### PR TITLE
Improve automatically retrieved documentation of coordinate-frame attributes

### DIFF
--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # Dependencies
-from dataclasses import is_dataclass
-
 import numpy as np
 
 # Project
@@ -118,7 +116,7 @@ class Attribute:
 
     def __get__(self, instance, frame_cls=None):
         if instance is None:
-            return self.default if is_dataclass(frame_cls) else self
+            return self
         else:
             out = getattr(instance, "_" + self.name, self.default)
             if out is None:
@@ -150,19 +148,12 @@ class Attribute:
                 converted = True
 
             if converted:
-                # Use object.__setattr__() to be able to modify frozen dataclasses
-                object.__setattr__(instance, "_" + self.name, out)
+                setattr(instance, "_" + self.name, out)
 
         return out
 
     def __set__(self, instance, val):
-        if is_dataclass(instance):
-            # Use object.__setattr__() to be able to modify frozen dataclasses
-            object.__setattr__(
-                instance, "_" + self.name, self.default if val is self else val
-            )
-        else:
-            raise AttributeError("Cannot set frame attribute")
+        raise AttributeError("Cannot set frame attribute")
 
 
 class TimeAttribute(Attribute):

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -118,11 +118,14 @@ class Attribute:
 
     def __get__(self, instance, frame_cls=None):
         if instance is None:
+            # If this attribute is on a dataclass, follow the dataclass-field pattern of returning
+            # the default value.  Otherwise, follow the property pattern of returning itself (the
+            # actual descriptor object), which is important for stuff like accessing the docstring.
             return self.default if is_dataclass(frame_cls) else self
-        else:
-            out = getattr(instance, "_" + self.name, self.default)
-            if out is None:
-                out = getattr(instance, self.secondary_attribute, self.default)
+
+        out = getattr(instance, "_" + self.name, self.default)
+        if out is None:
+            out = getattr(instance, self.secondary_attribute, self.default)
 
         out, converted = self.convert_input(out)
         if instance is not None:

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-class Attribute:
+class Attribute(property):
     """A non-mutable data descriptor to hold a frame attribute.
 
     This class must be used to define frame attributes (e.g. ``equinox`` or
@@ -62,6 +62,8 @@ class Attribute:
     def __init__(self, default=None, secondary_attribute="", *, doc="A frame attribute"):
         self.default = default
         self.secondary_attribute = secondary_attribute
+
+        # Although Attribute inherits from property, setting `doc` in the constructor does not work
         super().__init__()
 
         # Replace the class docstring with the custom docstring

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-class Attribute(property):
+class Attribute:
     """A non-mutable data descriptor to hold a frame attribute.
 
     This class must be used to define frame attributes (e.g. ``equinox`` or
@@ -64,8 +64,6 @@ class Attribute(property):
     ):
         self.default = default
         self.secondary_attribute = secondary_attribute
-
-        # Although Attribute inherits from property, setting `doc` in the constructor does not work
         super().__init__()
 
         # Replace the class docstring with the custom docstring

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -53,7 +53,8 @@ class Attribute:
         Name of a secondary instance attribute which supplies the value if
         ``default is None`` and no value was supplied during initialization.
     doc : str
-        Description of the frame attribute for help and documentation
+        Description of the frame attribute for help and documentation.
+        Information on the default value will be appended to this description.
     """
 
     name = "<unbound>"
@@ -65,6 +66,14 @@ class Attribute:
 
         # Replace the class docstring with the custom docstring
         self.__doc__ = doc
+
+        # Add information on the default value
+        if self.default is not None:
+            self.__doc__ += f"\n\nDefaults to {self.default}"
+        elif self.secondary_attribute != "":
+            self.__doc__ += f"\n\nDefaults to the same value as the `{self.secondary_attribute}` frame attribute"
+        else:
+            self.__doc__ += "\n\nNo default value"
 
     def __set_name__(self, owner, name):
         self.name = name

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -73,7 +73,9 @@ class Attribute:
         if self.default is not None:
             self.__doc__ += f"\n\nDefault: {self.default}"
         elif self.secondary_attribute != "":
-            self.__doc__ += f"\n\nDefault: taken from `{self.secondary_attribute}` frame attribute"
+            self.__doc__ += (
+                f"\n\nDefault: taken from `{self.secondary_attribute}` frame attribute"
+            )
         else:
             self.__doc__ += "\n\nNo default value"
 
@@ -116,11 +118,12 @@ class Attribute:
 
     def __get__(self, instance, frame_cls=None):
         if instance is None:
+            # Return the descriptor instance to enable the retrieval of the docstring
             return self
-        else:
-            out = getattr(instance, "_" + self.name, self.default)
-            if out is None:
-                out = getattr(instance, self.secondary_attribute, self.default)
+
+        out = getattr(instance, "_" + self.name, self.default)
+        if out is None:
+            out = getattr(instance, self.secondary_attribute, self.default)
 
         out, converted = self.convert_input(out)
         if instance is not None:

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -52,14 +52,19 @@ class Attribute:
     secondary_attribute : str
         Name of a secondary instance attribute which supplies the value if
         ``default is None`` and no value was supplied during initialization.
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
     name = "<unbound>"
 
-    def __init__(self, default=None, secondary_attribute=""):
+    def __init__(self, default=None, secondary_attribute="", *, doc="A frame attribute"):
         self.default = default
         self.secondary_attribute = secondary_attribute
         super().__init__()
+
+        # Replace the class docstring with the custom docstring
+        self.__doc__ = doc
 
     def __set_name__(self, owner, name):
         self.name = name
@@ -153,6 +158,8 @@ class TimeAttribute(Attribute):
     secondary_attribute : str
         Name of a secondary instance attribute which supplies the value if
         ``default is None`` and no value was supplied during initialization.
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
     def convert_input(self, value):
@@ -212,10 +219,12 @@ class CartesianRepresentationAttribute(Attribute):
     unit : unit-like or None
         Name of a unit that the input will be converted into. If None, no
         unit-checking or conversion is performed
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
-    def __init__(self, default=None, secondary_attribute="", unit=None):
-        super().__init__(default, secondary_attribute)
+    def __init__(self, default=None, secondary_attribute="", unit=None, **kwargs):
+        super().__init__(default, secondary_attribute, **kwargs)
         self.unit = unit
 
     def convert_input(self, value):
@@ -290,9 +299,11 @@ class QuantityAttribute(Attribute):
         unit-checking or conversion is performed
     shape : tuple or None, optional
         If given, specifies the shape the attribute must be
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
-    def __init__(self, default=None, secondary_attribute="", unit=None, shape=None):
+    def __init__(self, default=None, secondary_attribute="", unit=None, shape=None, **kwargs):
         if default is None and unit is None:
             raise ValueError(
                 "Either a default quantity value must be provided, or a unit must "
@@ -305,7 +316,7 @@ class QuantityAttribute(Attribute):
         self.unit = unit
         self.shape = shape
         default = self.convert_input(default)[0]
-        super().__init__(default, secondary_attribute)
+        super().__init__(default, secondary_attribute, **kwargs)
 
     def convert_input(self, value):
         """
@@ -371,6 +382,8 @@ class EarthLocationAttribute(Attribute):
     secondary_attribute : str
         Name of a secondary instance attribute which supplies the value if
         ``default is None`` and no value was supplied during initialization.
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
     def convert_input(self, value):
@@ -429,11 +442,13 @@ class CoordinateAttribute(Attribute):
     secondary_attribute : str
         Name of a secondary instance attribute which supplies the value if
         ``default is None`` and no value was supplied during initialization.
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
-    def __init__(self, frame, default=None, secondary_attribute=""):
+    def __init__(self, frame, default=None, secondary_attribute="", **kwargs):
         self._frame = frame
-        super().__init__(default, secondary_attribute)
+        super().__init__(default, secondary_attribute, **kwargs)
 
     def convert_input(self, value):
         """
@@ -486,15 +501,17 @@ class DifferentialAttribute(Attribute):
     secondary_attribute : str
         Name of a secondary instance attribute which supplies the value if
         ``default is None`` and no value was supplied during initialization.
+    doc : str
+        Description of the frame attribute for help and documentation
     """
 
-    def __init__(self, default=None, allowed_classes=None, secondary_attribute=""):
+    def __init__(self, default=None, allowed_classes=None, secondary_attribute="", **kwargs):
         if allowed_classes is not None:
             self.allowed_classes = tuple(allowed_classes)
         else:
             self.allowed_classes = BaseDifferential
 
-        super().__init__(default, secondary_attribute)
+        super().__init__(default, secondary_attribute, **kwargs)
 
     def convert_input(self, value):
         """

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -118,14 +118,11 @@ class Attribute:
 
     def __get__(self, instance, frame_cls=None):
         if instance is None:
-            # If this attribute is on a dataclass, follow the dataclass-field pattern of returning
-            # the default value.  Otherwise, follow the property pattern of returning itself (the
-            # actual descriptor object), which is important for stuff like accessing the docstring.
             return self.default if is_dataclass(frame_cls) else self
-
-        out = getattr(instance, "_" + self.name, self.default)
-        if out is None:
-            out = getattr(instance, self.secondary_attribute, self.default)
+        else:
+            out = getattr(instance, "_" + self.name, self.default)
+            if out is None:
+                out = getattr(instance, self.secondary_attribute, self.default)
 
         out, converted = self.convert_input(out)
         if instance is not None:

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -100,7 +100,7 @@ class Attribute:
 
     def __get__(self, instance, frame_cls=None):
         if instance is None:
-            out = self.default
+            return self
         else:
             out = getattr(instance, "_" + self.name, self.default)
             if out is None:

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -73,9 +73,9 @@ class Attribute:
 
         # Add information on the default value
         if self.default is not None:
-            self.__doc__ += f"\n\nDefaults to {self.default}"
+            self.__doc__ += f"\n\nDefault: {self.default}"
         elif self.secondary_attribute != "":
-            self.__doc__ += f"\n\nDefaults to the same value as the `{self.secondary_attribute}` frame attribute"
+            self.__doc__ += f"\n\nDefault: taken from `{self.secondary_attribute}` frame attribute"
         else:
             self.__doc__ += "\n\nNo default value"
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -59,7 +59,9 @@ class Attribute(property):
 
     name = "<unbound>"
 
-    def __init__(self, default=None, secondary_attribute="", *, doc="A frame attribute"):
+    def __init__(
+        self, default=None, secondary_attribute="", *, doc="A frame attribute"
+    ):
         self.default = default
         self.secondary_attribute = secondary_attribute
 
@@ -314,7 +316,9 @@ class QuantityAttribute(Attribute):
         Description of the frame attribute for help and documentation
     """
 
-    def __init__(self, default=None, secondary_attribute="", unit=None, shape=None, **kwargs):
+    def __init__(
+        self, default=None, secondary_attribute="", unit=None, shape=None, **kwargs
+    ):
         if default is None and unit is None:
             raise ValueError(
                 "Either a default quantity value must be provided, or a unit must "
@@ -516,7 +520,9 @@ class DifferentialAttribute(Attribute):
         Description of the frame attribute for help and documentation
     """
 
-    def __init__(self, default=None, allowed_classes=None, secondary_attribute="", **kwargs):
+    def __init__(
+        self, default=None, allowed_classes=None, secondary_attribute="", **kwargs
+    ):
         if allowed_classes is not None:
             self.allowed_classes = tuple(allowed_classes)
         else:

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -150,19 +150,24 @@ class Attribute:
                 converted = True
 
             if converted:
-                # Use object.__setattr__() to be able to modify frozen dataclasses
-                object.__setattr__(instance, "_" + self.name, out)
+                self._force_set(instance, out)
 
         return out
 
     def __set__(self, instance, val):
-        if is_dataclass(instance):
-            # Use object.__setattr__() to be able to modify frozen dataclasses
-            object.__setattr__(
-                instance, "_" + self.name, self.default if val is self else val
-            )
-        else:
+        # Unless the attribute is in a dataclass, do not allow setting
+        if not is_dataclass(instance):
             raise AttributeError("Cannot set frame attribute")
+
+        # When instantiating a dataclass with defaults, val is self rather than a "normal" value
+        self._force_set(instance, self.default if val is self else val)
+
+    def _force_set(self, instance, val):
+        if is_dataclass(instance) and instance.__dataclass_params__.frozen:
+            # Use object.__setattr__() to be able to modify frozen dataclasses
+            object.__setattr__(instance, "_" + self.name, val)
+        else:
+            setattr(instance, "_" + self.name, val)
 
 
 class TimeAttribute(Attribute):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -731,7 +731,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @classmethod
     def get_frame_attr_defaults(cls):
         """Return a dict with the defaults for each frame attribute."""
-        return {name: getattr(cls, name) for name in cls.frame_attributes}
+        return {name: getattr(cls, name).default for name in cls.frame_attributes}
 
     @deprecated(
         "5.2",

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -103,12 +103,12 @@ class AltAz(BaseCoordinateFrame):
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
 
-    obstime = TimeAttribute(default=None)
-    location = EarthLocationAttribute(default=None)
-    pressure = QuantityAttribute(default=0, unit=u.hPa)
-    temperature = QuantityAttribute(default=0, unit=u.deg_C)
-    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled)
-    obswl = QuantityAttribute(default=1 * u.micron, unit=u.micron)
+    obstime = TimeAttribute(default=None, doc="The reference time (e.g., time of observation)")
+    location = EarthLocationAttribute(default=None, doc="The location on Earth of the observer")
+    pressure = QuantityAttribute(default=0, unit=u.hPa, doc="The atmospheric pressure")
+    temperature = QuantityAttribute(default=0, unit=u.deg_C, doc="The ground-level temperature")
+    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled, doc="The relative humidity")
+    obswl = QuantityAttribute(default=1 * u.micron, unit=u.micron, doc="The average wavelength of observations")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -103,12 +103,24 @@ class AltAz(BaseCoordinateFrame):
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
 
-    obstime = TimeAttribute(default=None, doc="The reference time (e.g., time of observation)")
-    location = EarthLocationAttribute(default=None, doc="The location on Earth of the observer")
+    obstime = TimeAttribute(
+        default=None, doc="The reference time (e.g., time of observation)"
+    )
+    location = EarthLocationAttribute(
+        default=None, doc="The location on Earth of the observer"
+    )
     pressure = QuantityAttribute(default=0, unit=u.hPa, doc="The atmospheric pressure")
-    temperature = QuantityAttribute(default=0, unit=u.deg_C, doc="The ground-level temperature")
-    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled, doc="The relative humidity")
-    obswl = QuantityAttribute(default=1 * u.micron, unit=u.micron, doc="The average wavelength of observations")
+    temperature = QuantityAttribute(
+        default=0, unit=u.deg_C, doc="The ground-level temperature"
+    )
+    relative_humidity = QuantityAttribute(
+        default=0, unit=u.dimensionless_unscaled, doc="The relative humidity"
+    )
+    obswl = QuantityAttribute(
+        default=1 * u.micron,
+        unit=u.micron,
+        doc="The average wavelength of observations",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -32,8 +32,12 @@ class CIRS(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation")
-    location = EarthLocationAttribute(default=EARTH_CENTER, doc="The location on Earth of the observer")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation"
+    )
+    location = EarthLocationAttribute(
+        default=EARTH_CENTER, doc="The location on Earth of the observer"
+    )
 
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -32,8 +32,8 @@ class CIRS(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    location = EarthLocationAttribute(default=EARTH_CENTER)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation")
+    location = EarthLocationAttribute(default=EARTH_CENTER, doc="The location on Earth of the observer")
 
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -93,7 +93,9 @@ class GeocentricMeanEcliptic(BaseEclipticFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
 
 
 @format_doc(
@@ -114,7 +116,9 @@ class GeocentricTrueEcliptic(BaseEclipticFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
 
 
 doc_footer_bary = """
@@ -195,7 +199,9 @@ class HeliocentricMeanEcliptic(BaseEclipticFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
 
 
 @format_doc(
@@ -219,7 +225,9 @@ class HeliocentricTrueEcliptic(BaseEclipticFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
 
 
 @format_doc(base_doc, components=doc_components_ecl.format("sun's center"), footer="")
@@ -239,7 +247,9 @@ class HeliocentricEclipticIAU76(BaseEclipticFrame):
 
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
 
 
 @format_doc(base_doc, components=doc_components_ecl.format("barycenter"), footer="")
@@ -254,4 +264,6 @@ class CustomBarycentricEcliptic(BaseEclipticFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obliquity = QuantityAttribute(default=84381.448 * u.arcsec, unit=u.arcsec, doc="The obliquity of the ecliptic")
+    obliquity = QuantityAttribute(
+        default=84381.448 * u.arcsec, unit=u.arcsec, doc="The obliquity of the ecliptic"
+    )

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -92,8 +92,8 @@ class GeocentricMeanEcliptic(BaseEclipticFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
 
 
 @format_doc(
@@ -113,8 +113,8 @@ class GeocentricTrueEcliptic(BaseEclipticFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
 
 
 doc_footer_bary = """
@@ -141,7 +141,7 @@ class BarycentricMeanEcliptic(BaseEclipticFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
 
 
 @format_doc(
@@ -158,7 +158,7 @@ class BarycentricTrueEcliptic(BaseEclipticFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
 
 
 doc_footer_helio = """
@@ -194,8 +194,8 @@ class HeliocentricMeanEcliptic(BaseEclipticFrame):
 
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
 
 
 @format_doc(
@@ -218,8 +218,8 @@ class HeliocentricTrueEcliptic(BaseEclipticFrame):
 
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
 
 
 @format_doc(base_doc, components=doc_components_ecl.format("sun's center"), footer="")
@@ -239,7 +239,7 @@ class HeliocentricEclipticIAU76(BaseEclipticFrame):
 
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
 
 
 @format_doc(base_doc, components=doc_components_ecl.format("barycenter"), footer="")
@@ -254,4 +254,4 @@ class CustomBarycentricEcliptic(BaseEclipticFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obliquity = QuantityAttribute(default=84381.448 * u.arcsec, unit=u.arcsec)
+    obliquity = QuantityAttribute(default=84381.448 * u.arcsec, unit=u.arcsec, doc="The obliquity of the ecliptic")

--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -79,8 +79,12 @@ class TETE(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
-    location = EarthLocationAttribute(default=EARTH_CENTER, doc="The location on Earth of the observer")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
+    location = EarthLocationAttribute(
+        default=EARTH_CENTER, doc="The location on Earth of the observer"
+    )
 
 
 # Self transform goes through ICRS and is defined in icrs_cirs_transforms.py

--- a/astropy/coordinates/builtin_frames/equatorial.py
+++ b/astropy/coordinates/builtin_frames/equatorial.py
@@ -79,8 +79,8 @@ class TETE(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    location = EarthLocationAttribute(default=EARTH_CENTER)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    location = EarthLocationAttribute(default=EARTH_CENTER, doc="The location on Earth of the observer")
 
 
 # Self transform goes through ICRS and is defined in icrs_cirs_transforms.py
@@ -106,7 +106,7 @@ class TEME(BaseCoordinateFrame):
     default_representation = CartesianRepresentation
     default_differential = CartesianDifferential
 
-    obstime = TimeAttribute()
+    obstime = TimeAttribute(doc="The reference time (e.g., time of observation)")
 
 
 # Transformation functions for getting to/from TEME and ITRS are in

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -46,7 +46,11 @@ class FK4(BaseRADecFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_B1950, doc="The equinox time")
-    obstime = TimeAttribute(default=None, secondary_attribute="equinox", doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=None,
+        secondary_attribute="equinox",
+        doc="The reference time (e.g., time of observation)",
+    )
 
 
 # the "self" transform
@@ -71,7 +75,11 @@ class FK4NoETerms(BaseRADecFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_B1950, doc="The equinox time")
-    obstime = TimeAttribute(default=None, secondary_attribute="equinox", doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=None,
+        secondary_attribute="equinox",
+        doc="The reference time (e.g., time of observation)",
+    )
 
     @staticmethod
     def _precession_matrix(oldequinox, newequinox):

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -45,8 +45,8 @@ class FK4(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_B1950)
-    obstime = TimeAttribute(default=None, secondary_attribute="equinox")
+    equinox = TimeAttribute(default=EQUINOX_B1950, doc="The equinox time")
+    obstime = TimeAttribute(default=None, secondary_attribute="equinox", doc="The reference time (e.g., time of observation)")
 
 
 # the "self" transform
@@ -70,8 +70,8 @@ class FK4NoETerms(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_B1950)
-    obstime = TimeAttribute(default=None, secondary_attribute="equinox")
+    equinox = TimeAttribute(default=EQUINOX_B1950, doc="The equinox time")
+    obstime = TimeAttribute(default=None, secondary_attribute="equinox", doc="The reference time (e.g., time of observation)")
 
     @staticmethod
     def _precession_matrix(oldequinox, newequinox):

--- a/astropy/coordinates/builtin_frames/fk5.py
+++ b/astropy/coordinates/builtin_frames/fk5.py
@@ -31,7 +31,7 @@ class FK5(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
 
     @staticmethod
     def _precession_matrix(oldequinox, newequinox):

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -464,13 +464,24 @@ class Galactocentric(BaseCoordinateFrame):
     default_differential = r.CartesianDifferential
 
     # frame attributes
-    galcen_coord = CoordinateAttribute(frame=ICRS, doc="The coordinates of the Galactic center")
-    galcen_distance = QuantityAttribute(unit=u.kpc, doc="The distance from the Sun to the Galactic center")
+    galcen_coord = CoordinateAttribute(
+        frame=ICRS, doc="The coordinates of the Galactic center"
+    )
+    galcen_distance = QuantityAttribute(
+        unit=u.kpc, doc="The distance from the Sun to the Galactic center"
+    )
 
-    galcen_v_sun = DifferentialAttribute(allowed_classes=[r.CartesianDifferential], doc="The velocity of the Sun in the Galactocentric frame")
+    galcen_v_sun = DifferentialAttribute(
+        allowed_classes=[r.CartesianDifferential],
+        doc="The velocity of the Sun in the Galactocentric frame",
+    )
 
-    z_sun = QuantityAttribute(unit=u.pc, doc="The distance from the Sun to the Galactic midplane")
-    roll = QuantityAttribute(unit=u.deg, doc="The rotation angle relative to the orientation for Galactic")
+    z_sun = QuantityAttribute(
+        unit=u.pc, doc="The distance from the Sun to the Galactic midplane"
+    )
+    roll = QuantityAttribute(
+        unit=u.deg, doc="The rotation angle relative to the orientation for Galactic"
+    )
 
     def __init__(self, *args, **kwargs):
         # Set default frame attribute values based on the ScienceState instance

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -464,13 +464,13 @@ class Galactocentric(BaseCoordinateFrame):
     default_differential = r.CartesianDifferential
 
     # frame attributes
-    galcen_coord = CoordinateAttribute(frame=ICRS)
-    galcen_distance = QuantityAttribute(unit=u.kpc)
+    galcen_coord = CoordinateAttribute(frame=ICRS, doc="The coordinates of the Galactic center")
+    galcen_distance = QuantityAttribute(unit=u.kpc, doc="The distance from the Sun to the Galactic center")
 
-    galcen_v_sun = DifferentialAttribute(allowed_classes=[r.CartesianDifferential])
+    galcen_v_sun = DifferentialAttribute(allowed_classes=[r.CartesianDifferential], doc="The velocity of the Sun in the Galactocentric frame")
 
-    z_sun = QuantityAttribute(unit=u.pc)
-    roll = QuantityAttribute(unit=u.deg)
+    z_sun = QuantityAttribute(unit=u.pc, doc="The distance from the Sun to the Galactic midplane")
+    roll = QuantityAttribute(unit=u.deg, doc="The rotation angle relative to the orientation for Galactic")
 
     def __init__(self, *args, **kwargs):
         # Set default frame attribute values based on the ScienceState instance

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -54,9 +54,19 @@ class GCRS(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m, doc="The observer location relative to Earth center")
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m / u.s, doc="The observer velocity relative to Earth center")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
+    obsgeoloc = CartesianRepresentationAttribute(
+        default=[0, 0, 0],
+        unit=u.m,
+        doc="The observer location relative to Earth center",
+    )
+    obsgeovel = CartesianRepresentationAttribute(
+        default=[0, 0, 0],
+        unit=u.m / u.s,
+        doc="The observer velocity relative to Earth center",
+    )
 
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
@@ -99,6 +109,16 @@ class PrecessedGeocentric(BaseRADecFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m, doc="The observer location relative to Earth center")
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m / u.s, doc="The observer velocity relative to Earth center")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
+    obsgeoloc = CartesianRepresentationAttribute(
+        default=[0, 0, 0],
+        unit=u.m,
+        doc="The observer location relative to Earth center",
+    )
+    obsgeovel = CartesianRepresentationAttribute(
+        default=[0, 0, 0],
+        unit=u.m / u.s,
+        doc="The observer velocity relative to Earth center",
+    )

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -54,9 +54,9 @@ class GCRS(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m)
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m / u.s)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m, doc="The observer location relative to Earth center")
+    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m / u.s, doc="The observer velocity relative to Earth center")
 
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
@@ -98,7 +98,7 @@ class PrecessedGeocentric(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**
     """
 
-    equinox = TimeAttribute(default=EQUINOX_J2000)
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m)
-    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m / u.s)
+    equinox = TimeAttribute(default=EQUINOX_J2000, doc="The equinox time")
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m, doc="The observer location relative to Earth center")
+    obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m / u.s, doc="The observer velocity relative to Earth center")

--- a/astropy/coordinates/builtin_frames/hadec.py
+++ b/astropy/coordinates/builtin_frames/hadec.py
@@ -99,12 +99,24 @@ class HADec(BaseCoordinateFrame):
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
 
-    obstime = TimeAttribute(default=None, doc="The reference time (e.g., time of observation)")
-    location = EarthLocationAttribute(default=None, doc="The location on Earth of the observer")
+    obstime = TimeAttribute(
+        default=None, doc="The reference time (e.g., time of observation)"
+    )
+    location = EarthLocationAttribute(
+        default=None, doc="The location on Earth of the observer"
+    )
     pressure = QuantityAttribute(default=0, unit=u.hPa, doc="The atmospheric pressure")
-    temperature = QuantityAttribute(default=0, unit=u.deg_C, doc="The ground-level temperature")
-    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled, doc="The relative humidity")
-    obswl = QuantityAttribute(default=1 * u.micron, unit=u.micron, doc="The average wavelength of observations")
+    temperature = QuantityAttribute(
+        default=0, unit=u.deg_C, doc="The ground-level temperature"
+    )
+    relative_humidity = QuantityAttribute(
+        default=0, unit=u.dimensionless_unscaled, doc="The relative humidity"
+    )
+    obswl = QuantityAttribute(
+        default=1 * u.micron,
+        unit=u.micron,
+        doc="The average wavelength of observations",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/hadec.py
+++ b/astropy/coordinates/builtin_frames/hadec.py
@@ -99,12 +99,12 @@ class HADec(BaseCoordinateFrame):
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
 
-    obstime = TimeAttribute(default=None)
-    location = EarthLocationAttribute(default=None)
-    pressure = QuantityAttribute(default=0, unit=u.hPa)
-    temperature = QuantityAttribute(default=0, unit=u.deg_C)
-    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled)
-    obswl = QuantityAttribute(default=1 * u.micron, unit=u.micron)
+    obstime = TimeAttribute(default=None, doc="The reference time (e.g., time of observation)")
+    location = EarthLocationAttribute(default=None, doc="The location on Earth of the observer")
+    pressure = QuantityAttribute(default=0, unit=u.hPa, doc="The atmospheric pressure")
+    temperature = QuantityAttribute(default=0, unit=u.deg_C, doc="The ground-level temperature")
+    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled, doc="The relative humidity")
+    obswl = QuantityAttribute(default=1 * u.micron, unit=u.micron, doc="The average wavelength of observations")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -40,7 +40,7 @@ class HCRS(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
 
 
 # Transformations are defined in icrs_circ_transforms.py

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -40,7 +40,9 @@ class HCRS(BaseRADecFrame):
     The frame attributes are listed under **Other Parameters**.
     """
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
 
 
 # Transformations are defined in icrs_circ_transforms.py

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -67,8 +67,12 @@ class ITRS(BaseCoordinateFrame):
     default_representation = CartesianRepresentation
     default_differential = CartesianDifferential
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
-    location = EarthLocationAttribute(default=EARTH_CENTER, doc="The location on Earth of the observer")
+    obstime = TimeAttribute(
+        default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)"
+    )
+    location = EarthLocationAttribute(
+        default=EARTH_CENTER, doc="The location on Earth of the observer"
+    )
 
     @property
     def earth_location(self):

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -67,8 +67,8 @@ class ITRS(BaseCoordinateFrame):
     default_representation = CartesianRepresentation
     default_differential = CartesianDifferential
 
-    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-    location = EarthLocationAttribute(default=EARTH_CENTER)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME, doc="The reference time (e.g., time of observation)")
+    location = EarthLocationAttribute(default=EARTH_CENTER, doc="The location on Earth of the observer")
 
     @property
     def earth_location(self):

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -63,8 +63,9 @@ class LSR(BaseRADecFrame):
 
     # frame attributes:
     v_bary = DifferentialAttribute(
-        default=v_bary_Schoenrich2010, allowed_classes=[r.CartesianDifferential],
-        doc="The relative velocity of the solar-system barycenter"
+        default=v_bary_Schoenrich2010,
+        allowed_classes=[r.CartesianDifferential],
+        doc="The relative velocity of the solar-system barycenter",
     )
 
 
@@ -149,7 +150,10 @@ class GalacticLSR(BaseCoordinateFrame):
     default_differential = r.SphericalCosLatDifferential
 
     # frame attributes:
-    v_bary = DifferentialAttribute(default=v_bary_Schoenrich2010, doc="The relative velocity of the solar-system barycenter")
+    v_bary = DifferentialAttribute(
+        default=v_bary_Schoenrich2010,
+        doc="The relative velocity of the solar-system barycenter",
+    )
 
 
 @frame_transform_graph.transform(AffineTransform, Galactic, GalacticLSR)

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -63,7 +63,8 @@ class LSR(BaseRADecFrame):
 
     # frame attributes:
     v_bary = DifferentialAttribute(
-        default=v_bary_Schoenrich2010, allowed_classes=[r.CartesianDifferential]
+        default=v_bary_Schoenrich2010, allowed_classes=[r.CartesianDifferential],
+        doc="The relative velocity of the solar-system barycenter"
     )
 
 
@@ -148,7 +149,7 @@ class GalacticLSR(BaseCoordinateFrame):
     default_differential = r.SphericalCosLatDifferential
 
     # frame attributes:
-    v_bary = DifferentialAttribute(default=v_bary_Schoenrich2010)
+    v_bary = DifferentialAttribute(default=v_bary_Schoenrich2010, doc="The relative velocity of the solar-system barycenter")
 
 
 @frame_transform_graph.transform(AffineTransform, Galactic, GalacticLSR)

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -46,7 +46,9 @@ def make_skyoffset_cls(framecls):
         name,
         (SkyOffsetFrame, framecls),
         {
-            "origin": CoordinateAttribute(frame=framecls, default=None, doc="The origin of the offset frame"),
+            "origin": CoordinateAttribute(
+                frame=framecls, default=None, doc="The origin of the offset frame"
+            ),
             # The following two have to be done because otherwise we use the
             # defaults of SkyOffsetFrame set by BaseCoordinateFrame.
             "_default_representation": framecls._default_representation,
@@ -133,8 +135,12 @@ class SkyOffsetFrame(BaseCoordinateFrame):
     of ``origin``.
     """
 
-    rotation = QuantityAttribute(default=0, unit=u.deg, doc="The rotation angle for the frame orientation")
-    origin = CoordinateAttribute(default=None, frame=None, doc="The origin of the offset frame")
+    rotation = QuantityAttribute(
+        default=0, unit=u.deg, doc="The rotation angle for the frame orientation"
+    )
+    origin = CoordinateAttribute(
+        default=None, frame=None, doc="The origin of the offset frame"
+    )
 
     def __new__(cls, *args, **kwargs):
         # We don't want to call this method if we've already set up

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -46,7 +46,7 @@ def make_skyoffset_cls(framecls):
         name,
         (SkyOffsetFrame, framecls),
         {
-            "origin": CoordinateAttribute(frame=framecls, default=None),
+            "origin": CoordinateAttribute(frame=framecls, default=None, doc="The origin of the offset frame"),
             # The following two have to be done because otherwise we use the
             # defaults of SkyOffsetFrame set by BaseCoordinateFrame.
             "_default_representation": framecls._default_representation,
@@ -133,8 +133,8 @@ class SkyOffsetFrame(BaseCoordinateFrame):
     of ``origin``.
     """
 
-    rotation = QuantityAttribute(default=0, unit=u.deg)
-    origin = CoordinateAttribute(default=None, frame=None)
+    rotation = QuantityAttribute(default=0, unit=u.deg, doc="The rotation angle for the frame orientation")
+    origin = CoordinateAttribute(default=None, frame=None, doc="The origin of the offset frame")
 
     def __new__(cls, *args, **kwargs):
         # We don't want to call this method if we've already set up


### PR DESCRIPTION
This PR improves the automatically retrieved documentation of coordinate-frame attributes (via Sphinx auto-documentation, `help()`, `?` in IPython, etc.) by setting the docstrings on the descriptors and appending information on the default values.  See below for an example of what we currently have.

This PR includes a few (minor) breaking changes:

- Accessing a frame attribute on a frame class (e.g., `HCRS.obstime`) returns the descriptor instance (e.g., the instance of `TimeAttribute`) rather than the default value of the frame attribute.  This is important so that code will pull up the descriptor docstring rather than the docstring of the default value.
- ~`Attribute` (and hence all of its subclasses) is now subclassed from `property`.  No aspect of `property` is being used here, but making it a subclass of `property` is a signal for programs like IPython that the documentation of a frame attribute on a frame instance (as opposed to a frame class) will be pulled from the descriptor docstring.~ Removed following discussion

This approach of descriptor docstrings is partially redundant with the existing documentation (under "Other Parameters").  We could choose to move all of existing documentation to these descriptor docstrings, and then remove the "Other Parameters" documentation.

---

The current documentation of coordinate-frame attributes is somewhat lacking.  Let's use [the page for FK4](https://docs.astropy.org/en/latest/api/astropy.coordinates.FK4.html) as an example, and `FK4` has the frame attributes `equinox` and `obstime`.  While these frame attributes are manually documented under "Other Parameters" in the docstring for the frame class:
<img width="690" alt="Screen Shot 2023-08-31 at 12 40 11 PM" src="https://github.com/astropy/astropy/assets/991759/b3890b74-cbe0-4f93-9b9e-1331eb2bb28c">
the frame attributes are also auto-documented under "Attributes Summary", with no description:
<img width="698" alt="Screen Shot 2023-08-31 at 12 42 23 PM" src="https://github.com/astropy/astropy/assets/991759/c586f7f6-0aef-45c2-9fad-76f8f87db2bd">
and under "Attributes Documentation", showing the default values as if they were class constants:
<img width="637" alt="Screen Shot 2023-08-31 at 12 44 32 PM" src="https://github.com/astropy/astropy/assets/991759/348ecf71-5b1e-44b1-b3ff-e76956884193">