### PR TITLE
Address ruff violations to rule PIE810

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -120,7 +120,6 @@ ignore = [
     # flake8-pie (PIE)
     "PIE790",  # unnecessary-pass
     "PIE794",  # duplicate-class-field-definition
-    "PIE810",  # single-starts-ends-with
 
     # pygrep-hooks (PGH)
     "PGH001",  # eval

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -728,9 +728,8 @@ def table_from_scratch():
 @np.errstate(over="ignore")
 def test_open_files():
     for filename in get_pkg_data_filenames("data", pattern="*.xml"):
-        if filename.endswith(("custom_datatype.xml", "timesys_errors.xml")):
-            continue
-        parse(filename)
+        if not filename.endswith(("custom_datatype.xml", "timesys_errors.xml")):
+            parse(filename)
 
 
 def test_too_many_columns():

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -728,9 +728,7 @@ def table_from_scratch():
 @np.errstate(over="ignore")
 def test_open_files():
     for filename in get_pkg_data_filenames("data", pattern="*.xml"):
-        if filename.endswith("custom_datatype.xml") or filename.endswith(
-            "timesys_errors.xml"
-        ):
+        if filename.endswith(("custom_datatype.xml", "timesys_errors.xml")):
             continue
         parse(filename)
 


### PR DESCRIPTION
This pull request is to address violations to Ruff's rule **PIE810** listed explicitly in https://github.com/astropy/astropy/issues/14818.

The sole violation still unadressed was present in submodule io.

The rule has been moved from `.ruff.toml` entirely.

This is part of a series of PRs split from https://github.com/astropy/astropy/pull/15239, following suggestions by @nstarman.

Solves part of issue https://github.com/astropy/astropy/issues/14818.