### PR TITLE
Add `default_factory` to MetaData

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -3,6 +3,7 @@
 import itertools
 import warnings
 import weakref
+from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
@@ -500,7 +501,9 @@ class ColumnInfo(BaseColumnInfo):
 
 
 class BaseColumn(_ColumnGetitemShim, np.ndarray):
-    meta = MetaData()
+    meta = MetaData(default_factory=OrderedDict)
+    # It's important that the metadata is an OrderedDict so that the order of
+    # the metadata is preserved when the column is YAML serialized.
 
     def __new__(
         cls,

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 
 import numpy as np
@@ -94,6 +94,20 @@ class ExampleFrozenDataclass:
 class TestMetaExampleFrozenDataclass(MetaBaseTest):
     test_class = ExampleFrozenDataclass
     args = ()
+
+
+def test_metadata_default_factory():
+    """Test the default_factory argument to MetaData."""
+
+    class ExampleData:
+        meta = MetaData(default_factory=defaultdict)
+
+        def __init__(self, meta=None):
+            self.meta = meta
+
+    data = ExampleData()
+    assert isinstance(data.meta, defaultdict)
+    assert len(data.meta) == 0
 
 
 def test_metadata_merging_conflict_exception():

--- a/docs/changes/utils/15265.feature.rst
+++ b/docs/changes/utils/15265.feature.rst
@@ -1,0 +1,2 @@
+The ``astropy.utils.metadata.MetaData`` default dictionary can now be
+set with the ``default_factory`` keyword argument.


### PR DESCRIPTION
Followup to #15237 

MetaData defaults to an OrderedDict, but `dict` is now ordered. This enables MetaData to use other mapping types as the default.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
