### PR TITLE
Address ruff violations to rule C406 in submodule table

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -26,9 +26,6 @@ ignore = [
     # flake8-blind-except (BLE)
     "BLE001",  # blind-except
 
-    # flake8-comprehensions (C4)
-    "C406",  # unnecessary-literal-dict
-
     # mccabe (C90) : code complexity
     # TODO: configure maximum allowed complexity.
     "C901",  # McCabeComplexity
@@ -289,7 +286,7 @@ unfixable = [
 "astropy/timeseries/*" = ["C408"]
 "astropy/units/*" = ["C408", "F821"]
 "astropy/uncertainty/*" = ["C408"]
-"astropy/utils/*" = ["C408"]
+"astropy/utils/*" = ["C408","C406"]
 "astropy/visualization/*" = ["B015", "C408"]
 "astropy/wcs/*" = ["C408", "F821"]
 "docs/*" = []

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -52,7 +52,7 @@ class TestTableColumnsInit:
             assert col[0] in tc_tuple
             assert tc_tuple[col[0]] is col[1]
 
-        col_dict = dict([("x1", x1), ("x2", x2), ("x3", x3)])
+        col_dict = {"x1": x1, "x2": x2, "x3": x3}
         tc_dict = TableColumns(col_dict)
         for col in tc_dict.keys():
             assert col in tc_dict
@@ -307,13 +307,11 @@ class TestInitFromNdarrayStruct(BaseInitFromDictLike):
 @pytest.mark.usefixtures("table_type")
 class TestInitFromDict(BaseInitFromDictLike):
     def _setup(self, table_type):
-        self.data = dict(
-            [
-                ("a", Column([1, 3], name="x")),
-                ("b", [2, 4]),
-                ("c", np.array([3, 5], dtype="i8")),
-            ]
-        )
+        self.data = {
+            "a": Column([1, 3], name="x"),
+            "b": [2, 4],
+            "c": np.array([3, 5], dtype="i8"),
+        }
 
 
 @pytest.mark.usefixtures("table_type")
@@ -544,7 +542,7 @@ def test_init_and_ref_from_dict(table_type, copy):
     """
     x1 = np.arange(10.0)
     x2 = np.zeros(10)
-    col_dict = dict([("x1", x1), ("x2", x2)])
+    col_dict = {"x1": x1, "x2": x2}
     t = table_type(col_dict, copy=copy)
     assert set(t.colnames) == {"x1", "x2"}
     assert t["x1"].shape == (10,)
@@ -574,8 +572,8 @@ def test_init_from_row_OrderedDict(table_type):
     row1 = OrderedDict([("b", 1), ("a", 0)])
     row2 = {"a": 10, "b": 20}
     rows12 = [row1, row2]
-    row3 = dict([("b", 1), ("a", 0)])
-    row4 = dict([("b", 11), ("a", 10)])
+    row3 = {"b": 1, "a": 0}
+    row4 = {"b": 11, "a": 10}
     rows34 = [row3, row4]
     t1 = table_type(rows=rows12)
     t2 = table_type(rows=rows34)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address violations to Ruff's rule C406 listed explicitily in https://github.com/astropy/astropy/issues/14818. Only submodule `table` is addressed.

The rule has been moved from global location in `.ruff.toml` to submodule `utils`, where the only rule violation still lingers. This violation will be fixed in a following PR.

This is part of a series of PRs split from https://github.com/astropy/astropy/pull/15239, following suggestions by @_nstarman.

Solves part of issue#14818.

