### PR TITLE
Address ruff's rule PIE790 in cosmology submodule

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -115,7 +115,6 @@ ignore = [
     "PERF401",  # Use a list comprehension to create a transformed list
 
     # flake8-pie (PIE)
-    "PIE790",  # unnecessary-pass
     "PIE794",  # duplicate-class-field-definition
 
     # pygrep-hooks (PGH)
@@ -274,20 +273,20 @@ unfixable = [
 "astropy/convolution/*" = []
 "astropy/coordinates/*" = ["C408"]
 "astropy/cosmology/*" = ["C408"]
-"astropy/io/*" = ["B015"]
+"astropy/io/*" = ["B015", "PIE790"]
 "astropy/logger.py" = ["C408"]
 "astropy/modeling/*" = ["C408"]
-"astropy/nddata/*" = ["C408"]
+"astropy/nddata/*" = ["C408", "PIE790"]
 "astropy/samp/*" = []
 "astropy/stats/*" = []
-"astropy/table/*" = ["C408"]
+"astropy/table/*" = ["C408", "PIE790"]
 "astropy/tests/*" = ["C408"]
-"astropy/time/*" = ["C408"]
+"astropy/time/*" = ["C408", "PIE790"]
 "astropy/timeseries/*" = ["C408"]
-"astropy/units/*" = ["C408", "F821"]
-"astropy/uncertainty/*" = ["C408"]
-"astropy/utils/*" = ["C408"]
-"astropy/visualization/*" = ["B015", "C408"]
-"astropy/wcs/*" = ["C408", "F821"]
+"astropy/units/*" = ["C408", "F821", "PIE790"]
+"astropy/uncertainty/*" = ["C408", "PIE790"]
+"astropy/utils/*" = ["C408", "PIE790"]
+"astropy/visualization/*" = ["B015", "C408", "PIE790"]
+"astropy/wcs/*" = ["C408", "F821", "PIE790"]
 "docs/*" = []
 "examples/coordinates/*" = []

--- a/astropy/cosmology/_io/tests/test_model.py
+++ b/astropy/cosmology/_io/tests/test_model.py
@@ -139,12 +139,13 @@ class ToFromModelTestMixin(ToFromTestMixinBase):
         assert got == cosmo
         assert set(cosmo.meta.keys()).issubset(got.meta.keys())
 
-    def test_fromformat_model_subclass_partial_info(self):
+    def test_fromformat_model_subclass_partial_info(self) -> None:
         """
         Test writing from an instance and reading from that class.
         This works with missing information.
+
+        There's no partial information with a Model
         """
-        pass  # there's no partial information with a Model
 
     @pytest.mark.parametrize("format", [True, False, None, "astropy.model"])
     def test_is_equivalent_to_model(self, cosmo, method_name, to_format, format):

--- a/astropy/cosmology/_io/tests/test_row.py
+++ b/astropy/cosmology/_io/tests/test_row.py
@@ -109,12 +109,13 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         got = from_format(row, rename=inv_rename)
         assert got == cosmo
 
-    def test_fromformat_row_subclass_partial_info(self, cosmo):
+    def test_fromformat_row_subclass_partial_info(self, cosmo: Cosmology) -> None:
         """
         Test writing from an instance and reading from that class.
         This works with missing information.
+
+        There are no partial info options
         """
-        pass  # there are no partial info options
 
     @pytest.mark.parametrize("format", [True, False, None, "astropy.row"])
     def test_is_equivalent_to_row(self, cosmo, to_format, format):

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -167,7 +167,6 @@ class CosmologyTest(
             @classmethod
             def _register_cls(cls):
                 """Override to not register."""
-                pass
 
         assert UnRegisteredSubclassTest.__parameters__ == cosmo_cls.__parameters__
         assert UnRegisteredSubclassTest.__qualname__ not in _COSMOLOGY_CLASSES

--- a/examples/template/example-template.py
+++ b/examples/template/example-template.py
@@ -77,9 +77,8 @@ plt.imshow(z, cmap=plt.cm.get_cmap('Spectral'), interpolation='none')
 # Comments in comment blocks remain nested in the text.
 
 
-def dummy():
+def dummy() -> None:
     """Dummy function to make sure docstrings don't get rendered as text"""
-    pass
 
 
 # Code comments not preceded by the hash splitter are left in code blocks.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address violations to Ruff's rule **PIE790**, which is listed explicitly in issue https://github.com/astropy/astropy/issues/14818. Only submodule `cosmolgy` is addressed.

The rule has been moved from global location in `.ruff.toml` to all submodules which are still not compliant with it. These violations will be fixed in following PRs dedicated to each submodule.

This is part of a series of PRs split from https://github.com/astropy/astropy/pull/15239, following suggestions by @nstarman.

Solves part of #14818.

