### PR TITLE
BUG: fix an incompatibility with numpy 2.0 (np.round_ was removed)

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -94,14 +94,16 @@ SUBCLASS_SAFE_FUNCTIONS |= {
 }  # fmt: skip
 SUBCLASS_SAFE_FUNCTIONS |= {  # Deprecated
     np.product, np.cumproduct,  # noqa: NPY003
-    np.round_,  # noqa: NPY003  # Alias for np.round in NUMPY_LT_1_25
 }  # fmt: skip
 
 SUBCLASS_SAFE_FUNCTIONS |= {np.median}
 
 if NUMPY_LT_2_0:
     # functions removed in numpy 2.0
-    SUBCLASS_SAFE_FUNCTIONS |= {np.msort}
+    SUBCLASS_SAFE_FUNCTIONS |= {
+        np.msort,
+        np.round_,  # noqa: NPY003  # Alias for np.round in NUMPY_LT_1_25
+    }
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -692,6 +692,7 @@ class TestUfuncLike(InvariantUnitTestSetup):
         self.check(np.round)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ was removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):
         self.check(np.round_)  # noqa: NPY003

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -642,6 +642,7 @@ class TestMethodLikes(MaskedArraySetup):
         self.check(np.round, method="round")
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ was removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):
         self.check(np.round_, method="round")  # noqa: NPY003


### PR DESCRIPTION
see https://github.com/numpy/numpy/pull/24477

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
