### PR TITLE
Fix vounit formatting of fractions and powers

### DIFF
--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -201,6 +201,20 @@ class VOUnit(generic.Generic):
         return super().format_exponential_notation(val, format_spec)
 
     @classmethod
+    def _format_fraction(cls, scale, numerator, denominator, *, fraction="inline"):
+        if not (fraction is True or fraction == "inline"):
+            raise ValueError(
+                "format {cls.name!r} only supports inline fractions,"
+                f"not fraction={fraction!r}."
+            )
+
+        if cls._space in denominator:
+            denominator = f"({denominator})"
+        if scale and numerator == "1":
+            return f"{scale}/{denominator}"
+        return f"{scale}{numerator}/{denominator}"
+
+    @classmethod
     def to_string(cls, unit, fraction=False):
         from astropy.units import core
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -194,7 +194,7 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def _format_superscript(cls, number):
-        return f"({number})" if "/" in number or "." in number else f"**{number}"
+        return f"**({number})" if "/" in number or "." in number else f"**{number}"
 
     @classmethod
     def format_exponential_notation(cls, val, format_spec=".8g"):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -712,6 +712,37 @@ def test_vounit_scale_factor(unit, vounit, number, scale, voscale):
     assert x.to_string(format="vounit") == voscale + vounit
 
 
+@pytest.mark.parametrize(
+    "unit, vounit",
+    [
+        ("m s^-1", "m/s"),
+        ("s^-1", "1/s"),
+        ("100 s^-2", "100/s**2"),
+        ("kg m-1 s-2", "kg/(m.s**2)"),
+    ],
+)
+@pytest.mark.parametrize("fraction", [True, "inline"])
+def test_vounit_fraction(unit, vounit, fraction):
+    x = u.Unit(unit)
+    assert x.to_string(format="vounit", fraction=fraction) == vounit
+
+
+@pytest.mark.parametrize(
+    "unit, vounit",
+    [
+        ("m^2", "m**2"),
+        ("s^-1", "s**-1"),
+        ("s(0.333)", "s**(0.333)"),
+        ("s(-0.333)", "s**(-0.333)"),
+        ("s(1/3)", "s**(1/3)"),
+        ("s(-1/3)", "s**(-1/3)"),
+    ],
+)
+def test_vounit_power(unit, vounit):
+    x = u.Unit(unit)
+    assert x.to_string(format="vounit") == vounit
+
+
 def test_vounit_custom():
     x = u.Unit("'foo' m", format="vounit")
     x_vounit = x.to_string("vounit")

--- a/docs/changes/units/15282.bugfix.rst
+++ b/docs/changes/units/15282.bugfix.rst
@@ -1,0 +1,1 @@
+In VOUnit, the spaces around the slash were removed in the formatting of fractions, and fractional powers now also use the "**" operator.


### PR DESCRIPTION
### Description

Issue https://github.com/astropy/astropy/issues/15074#issuecomment-1706222742 shows that there are two bugs in the vounit formatte that produce output not compliant to the [VOUnits standard](https://www.ivoa.net/documents/VOUnits/20140523/VOUnits-REC-1.0-20140523.pdf). If fractions are used, the formatter adds a space around the slash, and for fractional power exponents the power sign (`**`) is omitted:

```Python
>>> import astropy.units as u
>>> (u.km/u.h).to_string(format="vounit", fraction=True)  # expected: 'km/h'
'km / h'
>>> (u.Hz**0.5).to_string(format="vounit")  # expected: 'Hz**(1/2)'
'Hz(1/2)'
>>> (u.Hz**-0.5).to_string(format="vounit", fraction=True)  # expected: '1/Hz**(1/2)'
'1 / Hz(1/2)'
```

This PR addresses both, and adds unit tests for them.
