### PR TITLE
TST: require matplotlib binaries in devdeps so that nightlies take priority over pre-releases without wheels

### DIFF
--- a/devdeps_constraints.txt
+++ b/devdeps_constraints.txt
@@ -1,0 +1,1 @@
+matplotlib>=0.0.dev0 --only-binary matplotlib

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ deps =
     # or nightly wheel of key dependencies.
     devdeps: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
-    devdeps: matplotlib>=0.0.dev0
+    devdeps: -c devdeps_constraints.txt
     devdeps: git+https://github.com/astropy/asdf-astropy.git#egg=asdf-astropy
     devdeps: git+https://github.com/liberfa/pyerfa.git#egg=pyerfa
 
@@ -109,7 +109,7 @@ extras =
     alldeps: test_all
 
 commands =
-    mpldev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib
+    mpldev: pip install -U --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib --only-binary matplotlib
 
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}


### PR DESCRIPTION
This tentatively fix #15283

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
