### PR TITLE
MAINT: ensure deprecated/removed functions in numpy 2.0 are accounted for

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -84,7 +84,8 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.nanmax, np.nanmin, np.nanargmin, np.nanargmax, np.nanmean,
     np.nansum, np.nancumsum, np.nanstd, np.nanvar,
     np.nanprod, np.nancumprod,
-    np.einsum_path, np.trapz, np.linspace,
+    np.einsum_path, np.linspace,
+    np.trapz,  # deprecated in not NUMPY_LT_2_0
     np.sort, np.partition, np.meshgrid,
     np.common_type, np.result_type, np.can_cast, np.min_scalar_type,
     np.iscomplexobj, np.isrealobj,
@@ -919,7 +920,7 @@ def twosetop(ar1, ar2, *args, **kwargs):
     return (ar1, ar2) + args, kwargs, unit, None
 
 
-@function_helper(helps=(np.isin, np.in1d))
+@function_helper(helps=(np.isin, np.in1d))  # np.in1d deprecated in not NUMPY_LT_2_0.
 def setcheckop(ar1, ar2, *args, **kwargs):
     # This tests whether ar1 is in ar2, so we should change the unit of
     # a1 to that of a2.

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1154,6 +1154,7 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
 
 
 class TestIntDiffFunctions(metaclass=CoverageMeta):
+    @pytest.mark.filterwarnings("ignore:`trapz` is deprecated. Use `scipy.*")
     def test_trapz(self):
         y = np.arange(9.0) * u.m / u.s
         out = np.trapz(y)
@@ -1947,6 +1948,7 @@ class TestSetOpsFcuntions(metaclass=CoverageMeta):
         self.check2(np.setdiff1d)
 
     @needs_array_function
+    @pytest.mark.filterwarnings("ignore:`in1d` is deprecated. Use `np.isin` instead.")
     def test_in1d(self):
         self.check2(np.in1d, unit=None)
         # Check zero is treated as having any unit.

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -94,12 +94,13 @@ MASKED_SAFE_FUNCTIONS |= {
     # np.core.shape_base
     np.atleast_1d, np.atleast_2d, np.atleast_3d, np.stack, np.hstack, np.vstack,
     # np.lib._function_base_impl
-    np.average, np.diff, np.extract, np.meshgrid, np.trapz, np.gradient,
+    np.average, np.diff, np.extract, np.meshgrid, np.gradient,
+    np.trapz,  # deprecated in not NUMPY_LT_2_0
     # np.lib.index_tricks
     np.diag_indices_from, np.triu_indices_from, np.tril_indices_from,
     np.fill_diagonal,
     # np.lib.shape_base
-    np.column_stack, np.row_stack, np.dstack,
+    np.column_stack, np.dstack,
     np.array_split, np.split, np.hsplit, np.vsplit, np.dsplit,
     np.expand_dims, np.apply_along_axis, np.kron, np.tile,
     np.take_along_axis, np.put_along_axis,
@@ -111,6 +112,13 @@ MASKED_SAFE_FUNCTIONS |= {
     # np.lib._function_base_impl
     np.angle, np.i0,
 }  # fmt: skip
+
+
+if NUMPY_LT_2_0:
+    # Removed in numpy 2.0.  Just an alias to vstack.
+    MASKED_SAFE_FUNCTIONS |= {np.row_stack}
+
+
 IGNORED_FUNCTIONS = {
     # I/O - useless for Masked, since no way to store the mask.
     np.save, np.savez, np.savetxt, np.savez_compressed,

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -981,6 +981,7 @@ class TestIntDiffFunctions(MaskedArraySetup):
         assert_array_equal(out.unmasked, expected)
         assert_array_equal(out.mask, expected_mask)
 
+    @pytest.mark.filterwarnings("ignore:`trapz` is deprecated. Use `scipy.*")
     def test_trapz(self):
         ma = self.ma.copy()
         ma.mask[1] = False


### PR DESCRIPTION
As noted by @pllim in https://github.com/astropy/astropy/pull/14784#issuecomment-1710393339, numpy has deprecated `np.trapz` and `np.in1d` and removed `np.row_stack`. This adjusts the tests and function helpers accordingly.