### PR TITLE
Added ability to define a private _validate_card method on Header subclasses

### DIFF
--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -304,6 +304,10 @@ class Header:
     def _ipython_key_completions_(self):
         return self.__iter__()
 
+    @classmethod
+    def _validate_card(cls, card):
+        return card
+
     @property
     def cards(self):
         """
@@ -1194,6 +1198,10 @@ class Header:
                 f"(keyword, value, [comment]) tuple; got: {card!r}"
             )
 
+        card = self._validate_card(card)
+        if card is None:
+            return
+
         if not end and card.is_blank:
             # Blank cards should always just be appended to the end
             end = True
@@ -1459,6 +1467,10 @@ class Header:
                 "The value inserted into a Header must be either a keyword or "
                 f"(keyword, value, [comment]) tuple; got: {card!r}"
             )
+
+        card = self._validate_card(card)
+        if card is None:
+            return
 
         self._cards.insert(idx, card)
 


### PR DESCRIPTION
This adds a way for header subclasses to define a private ``_validate_card`` method that can be used to e.g. emit warnings or errors depending on the card. It is intended for use in ``CompImageHeader`` in an upcoming refactor but I thought it would be easier to propose this as a standalone PR. It is private API so does not require a changelog entry.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
