### PR TITLE
Allow structured data types in Distribution

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -21,8 +21,7 @@ SMAD_SCALE_FACTOR = 1.48260221850560203193936104071326553821563720703125
 
 
 class Distribution:
-    """
-    A scalar value or array values with associated uncertainty distribution.
+    """A scalar value or array values with associated uncertainty distribution.
 
     This object will take its exact type from whatever the ``samples`` argument
     is. In general this is expected to be an `~astropy.units.Quantity` or
@@ -34,9 +33,13 @@ class Distribution:
     Parameters
     ----------
     samples : array-like
-        The distribution, with sampling along the *leading* axis. If 1D, the
-        sole dimension is used as the sampling axis (i.e., it is a scalar
-        distribution).
+
+    The distribution, with sampling along the *trailing* axis. If 1D, the sole
+    dimension is used as the sampling axis (i.e., it is a scalar distribution).
+    If an |ndarray| or subclass, the data will not be copied unless it is not
+    possible to take a view (generally, only when the strides of the last axis
+    are negative).
+
     """
 
     _generated_subclasses = {}

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -47,32 +47,64 @@ class Distribution:
         if samples.shape == ():
             raise TypeError("Attempted to initialize a Distribution with a scalar")
 
+        # Do the view in two stages, since for viewing as a new class, it is good
+        # to have with the dtype in place (e.g., for Quantity.__array_finalize__,
+        # it is needed to create the correct StructuredUnit).
         new_dtype = np.dtype(
             {"names": ["samples"], "formats": [(samples.dtype, (samples.shape[-1],))]}
         )
-        samples_cls = type(samples)
+        self = samples.view(new_dtype)
+        # Get rid of trailing dimension of 1.
+        self.shape = samples.shape[:-1]
+
+        # Now view as the Distribution subclass.
+        new_cls = cls._get_distribution_cls(type(samples))
+        return self.view(new_cls)
+
+    @classmethod
+    def _get_distribution_cls(cls, samples_cls):
+        if issubclass(samples_cls, Distribution):
+            return samples_cls
+
         new_cls = cls._generated_subclasses.get(samples_cls)
         if new_cls is None:
-            # Make a new class with the combined name, inserting Distribution
-            # itself below the samples class since that way Quantity methods
-            # like ".to" just work (as .view() gets intercepted).  However,
-            # repr and str are problems, so we put those on top.
-            # TODO: try to deal with this at the lower level.  The problem is
-            # that array2string does not allow one to override how structured
-            # arrays are typeset, leading to all samples to be shown.  It may
-            # be possible to hack oneself out by temporarily becoming a void.
-            new_name = samples_cls.__name__ + cls.__name__
+            # Walk through MRO and find closest base data class.
+            # Note: right now, will basically always be ndarray, but
+            # one could imagine needing some special care for one subclass,
+            # which would then get its own entry.  E.g., if MaskedAngle
+            # defined something special, then MaskedLongitude should depend
+            # on it.
+            for mro_item in samples_cls.__mro__:
+                base_cls = cls._generated_subclasses.get(mro_item)
+                if base_cls is not None:
+                    break
+            else:
+                # Just hope that NdarrayDistribution can handle it.
+                # TODO: this covers the case where a user puts in a list or so,
+                # but for those one could just explicitly do something like
+                # _generated_subclasses[list] = NdarrayDistribution
+                return NdarrayDistribution
+
+            # We need to get rid of the top _DistributionRepr, since we add
+            # it again below (it should always be on top).
+            # TODO: remove the need for _DistributionRepr by defining
+            # __array_function__ and overriding array2string.
+            if base_cls.__mro__[1] is not _DistributionRepr:
+                # Sanity check. This should never happen!
+                raise RuntimeError(
+                    f"found {base_cls=}, which does not have _DistributionRepr at "
+                    "__mro__[1]. Please raise an issue."
+                )
+            # Create (and therefore register) new Distribution subclass for the
+            # given samples_cls.
             new_cls = type(
-                new_name,
-                (_DistributionRepr, samples_cls, ArrayDistribution),
+                samples_cls.__name__ + "Distribution",
+                (_DistributionRepr, samples_cls) + base_cls.__mro__[2:],
                 {"_samples_cls": samples_cls},
             )
             cls._generated_subclasses[samples_cls] = new_cls
 
-        self = samples.view(dtype=new_dtype, type=new_cls)
-        # Get rid of trailing dimension of 1.
-        self.shape = samples.shape[:-1]
-        return self
+        return new_cls
 
     @property
     def distribution(self):
@@ -288,26 +320,20 @@ class ArrayDistribution(Distribution, np.ndarray):
         ``dtype`` is allowed.
 
         """
-        if type is None and (
-            isinstance(dtype, builtins.type) and issubclass(dtype, np.ndarray)
-        ):
-            type = dtype
-            dtype = None
+        if type is None:
+            if isinstance(dtype, builtins.type) and issubclass(dtype, np.ndarray):
+                type = self._get_distribution_cls(dtype)
+                dtype = None
+            else:
+                type = self.__class__
+        else:
+            type = self._get_distribution_cls(type)
 
-        view_args = [item for item in (dtype, type) if item is not None]
-
-        if type is None or (
-            isinstance(type, builtins.type) and issubclass(type, Distribution)
-        ):
-            if dtype is not None and dtype != self.dtype:
-                raise ValueError(
-                    "cannot view as Distribution subclass with a new dtype."
-                )
-            return super().view(*view_args)
-
-        # View as the new non-Distribution class, but turn into a Distribution again.
-        result = self.distribution.view(*view_args)
-        return Distribution(result)
+        if dtype is None or dtype == self.dtype:
+            return super().view(type)
+        else:
+            # TODO: relax this constraint.
+            raise ValueError("cannot view as Distribution subclass with a new dtype.")
 
     # Override __getitem__ so that 'samples' is returned as the sample class.
     def __getitem__(self, item):

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -445,6 +445,10 @@ def test_distr_angle_view_as_quantity():
     assert isinstance(qd3, u.Quantity)
     assert isinstance(qd3, Distribution)
     assert_array_equal(qd3.distribution, qd.distribution)
+    # Simple view with no arguments
+    qd4 = qd3.view()
+    assert qd4.__class__ is qd3.__class__
+    assert np.may_share_memory(qd4, qd3)
 
 
 def test_distr_cannot_view_new_dtype():
@@ -462,7 +466,7 @@ def test_distr_cannot_view_new_dtype():
         ad.view(np.dtype("f8"))
 
     with pytest.raises(ValueError, match="with a new dtype"):
-        ad.view(np.dtype("f8"), Distribution)
+        ad.view(np.dtype("f8"), distr.__class__)
 
 
 def test_scalar_quantity_distribution():

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -513,3 +513,50 @@ class TestSetItemWithSelection:
         d = Distribution([90.0, 30.0, 0.0])
         d[d > 50] *= -1.0
         assert_array_equal(d, Distribution([-90.0, 30.0, 0.0]))
+
+
+ADVANCED_INDICES = [
+    (np.array([[1, 2], [0, 1]]), np.array([[1, 3], [0, 2]])),
+    # Same advanced index, but also using negative numbers
+    (np.array([[-2, -1], [0, -2]]), np.array([[1, -1], [-4, -2]])),
+]
+
+
+class TestGetSetItemAdvancedIndex:
+    @classmethod
+    def setup_class(self):
+        self.distribution = np.arange(60.0).reshape(3, 4, 5)
+        self.d = Distribution(self.distribution)
+
+    def test_setup(self):
+        ai1, ai2 = ADVANCED_INDICES[:2]
+        # Check that the first two indices produce the same output.
+        assert_array_equal(self.distribution[ai1], self.distribution[ai2])
+
+    @pytest.mark.parametrize("item", ADVANCED_INDICES)
+    def test_getitem(self, item):
+        v = self.d[item]
+        assert v.shape == item[0].shape
+        assert_array_equal(v.distribution, self.distribution[item])
+
+    @pytest.mark.parametrize("item", [([0, 4],), ([0], [0], [0])])
+    def test_getitem_bad(self, item):
+        with pytest.raises(IndexError):
+            self.d[item]
+
+    @pytest.mark.parametrize("item", ADVANCED_INDICES)
+    def test_setitem(self, item):
+        d = self.d.copy()
+        d[item] = 0.0
+        distribution = self.distribution.copy()
+        distribution[item] = 0.0
+        assert_array_equal(d.distribution, distribution)
+        d[item] = self.d[item]
+        assert_array_equal(d.distribution, self.distribution)
+
+
+class TestQuantityDistributionGetSetItemAdvancedIndex(TestGetSetItemAdvancedIndex):
+    @classmethod
+    def setup_class(self):
+        self.distribution = np.arange(60.0).reshape(3, 4, 5) << u.m
+        self.d = Distribution(self.distribution)

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -458,15 +458,15 @@ def test_distr_cannot_view_new_dtype():
     # TODO: with a lot of thought, this restriction can likely be relaxed.
     distr = Distribution([2.0, 3.0, 4.0])
     with pytest.raises(ValueError, match="with a new dtype"):
-        distr.view(np.dtype("f8"))
+        distr.view(np.dtype("i8"))
 
     # Check subclass just in case.
     ad = Angle(distr, "deg")
     with pytest.raises(ValueError, match="with a new dtype"):
-        ad.view(np.dtype("f8"))
+        ad.view(np.dtype("i8"))
 
     with pytest.raises(ValueError, match="with a new dtype"):
-        ad.view(np.dtype("f8"), distr.__class__)
+        ad.view(np.dtype("i8"), distr.__class__)
 
 
 def test_scalar_quantity_distribution():

--- a/docs/changes/uncertainty/15296.api.rst
+++ b/docs/changes/uncertainty/15296.api.rst
@@ -1,0 +1,16 @@
+The ``.dtype`` attribute exposed by ``Distribution`` is now that of
+the samples, rather than one that has a "samples" entry.  This makes
+quantities with structured data types and units easier to support, and
+generally makes the ``Distribution`` appear more similar to regular
+arrays.  It should have little effect on code.  For instance,
+``distribution["samples"]`` still will return the actual distribution.
+
+As a consequence of this refactoring, most arrays that are not
+C-contiguous can now be viewed and will thus not be copied on input
+any more.  The only exceptions are arrays for which the strides are
+negative.
+
+Note that the true data type is considered an implementation detail.
+But for reference, it now is a structured data type with a single
+field, "samples", which itself is an array of "sample" fields, which
+contain the actual data.

--- a/docs/changes/uncertainty/15296.feature.rst
+++ b/docs/changes/uncertainty/15296.feature.rst
@@ -1,0 +1,1 @@
+Uncertainty ``Distribution`` now support structured data types.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to allow structured data types for `Distribution`, so that classes like `EarthLocation` can be made into `Distribution` as well (though that will need some changes in `EarthLocation` itself).

To make this possible, an API change was necessary, where the `.dtype` exposed by the distribution now equals the `.dtype` of the samples (rather than the structured dtype used internally). I could not get `QuantityDistribution` to work without changes to `Quantity` and `StructuredUnit` that I felt were not warranted. And arguably, it is more logical for the distribution to look as much as possible like a regular array, so to expose the regular `dtype`.

Note that this builds on #15295; it may be best to get that in first. Otherwise, reviewing by commit may be helpful.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
