### PR TITLE
Fix ruff issue PLC0208.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -121,7 +121,6 @@ ignore = [
     "PGH001",  # eval
 
     # Pylint (PLC, PLE, PLR, PLW)
-    "PLC0208",  # Use a sequence type instead of a `set` when iterating over values
     "PLC1901",  # compare-to-empty-string
     "PLE0101",  # return-in-init
     "PLE0605",  # invalid-all-format

--- a/astropy/cosmology/funcs/tests/test_comparison.py
+++ b/astropy/cosmology/funcs/tests/test_comparison.py
@@ -110,7 +110,7 @@ class Test_parse_format(ComparisonFunctionTestBase):
     def test_shortcut(self, cosmo):
         """Test the already-a-cosmology shortcut."""
         # A Cosmology
-        for fmt in {None, True, False, "astropy.cosmology"}:
+        for fmt in (None, True, False, "astropy.cosmology"):
             assert _parse_format(cosmo, fmt) is cosmo, f"{fmt} failed"
 
         # A Cosmology, but improperly formatted


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->


<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a lint error reported by ruff. I followed the procedure in #14818 and picked an error that is reported only in once place. Since the rule is in global ignore section, I removed it from there.

This is my very first contribution to astropy so I picked what seems to be a simple fix. Please let me know if it looks good. I ran the tests in ``test_comparison.py`` and its result is same as before my change.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
