### PR TITLE
Fix ruff error PTH124

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -170,7 +170,6 @@ ignore = [
     "PTH120",  # os-path-dirname
     "PTH122",  # os-path-splitext
     "PTH123",  # builtin-open
-    "PTH124",  # py-path
     "PTH202",  # `os.path.getsize` should be replaced by `Path.stat().st_size`
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
     "PTH207",  # Replace `glob` with `Path.glob` or `Path.rglob`

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -23,7 +23,6 @@ from contextlib import nullcontext
 from itertools import islice
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
-import py.path
 import pytest
 
 import astropy.utils.data
@@ -1600,12 +1599,6 @@ def test_cache_dir_is_actually_a_file(tmp_path, valid_urls):
 def test_get_fileobj_str(a_file):
     fn, c = a_file
     with get_readable_fileobj(str(fn)) as rf:
-        assert rf.read() == c
-
-
-def test_get_fileobj_localpath(a_file):
-    fn, c = a_file
-    with get_readable_fileobj(py.path.local(fn)) as rf:
         assert rf.read() == c
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ruff errors PTH124 ~and PLW0602~. I ran all the tests and there were no failures.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
