### PR TITLE
TMP pin matplotlib as it breaks the docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ docs =
     sphinx-astropy[confv2]>=1.9.1
     pytest>=7.0
     scipy>=1.3
-    matplotlib>=3.3,!=3.4.0,!=3.5.2
+    matplotlib>=3.3,!=3.4.0,!=3.5.2,<3.8
     sphinx-changelog>=1.2.0
     sphinx_design
     Jinja2>=3.0


### PR DESCRIPTION
### Description
We are currently seeing broken docs due to the matplotlib 3.8 release, see #15319 for details. This PR pins matplotlib < 3.8 for the docs as a temporary measure.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
