### PR TITLE
Try to fix example plot not working with matplotlib 3.8

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -2084,7 +2084,7 @@ class Ellipse2D(Fittable2DModel):
         y, x = np.mgrid[0:50, 0:50]
         fig, ax = plt.subplots(1, 1)
         ax.imshow(e(x, y), origin='lower', interpolation='none', cmap='Greys_r')
-        e2 = mpatches.Ellipse((x0, y0), 2*a, 2*b, theta.degree, edgecolor='red',
+        e2 = mpatches.Ellipse((x0, y0), 2*a, 2*b, angle=theta.degree, edgecolor='red',
                               facecolor='none')
         ax.add_patch(e2)
         plt.show()

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -723,7 +723,7 @@ class Cutout2D:
         height, width = self.shape
         hw, hh = width / 2.0, height / 2.0
         pos_xy = self.position_original - np.array([hw, hh])
-        patch = mpatches.Rectangle(pos_xy, width, height, 0.0, **kwargs)
+        patch = mpatches.Rectangle(pos_xy, width, height, angle=0.0, **kwargs)
         ax.add_patch(patch)
         return ax
 

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -63,6 +63,8 @@ py:obj AbstractPathEffect
 py:obj ScaleBase
 py:obj matplotlib.axis.Axes.get_window_extent
 py:obj matplotlib.spines.get_window_extent
+py:obj N
+py:obj cycler.Cycler
 
 # astropy.wcs
 py:class astropy.wcs.wcsapi.fitswcs.FITSWCSAPIMixin

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -140,7 +140,7 @@ m33altazs_July12_to_13 = m33.transform_to(frame_July12_to_13)
 plt.plot(delta_midnight, sunaltazs_July12_to_13.alt, color='r', label='Sun')
 plt.plot(delta_midnight, moonaltazs_July12_to_13.alt, color=[0.75]*3, ls='--', label='Moon')
 plt.scatter(delta_midnight, m33altazs_July12_to_13.alt,
-            c=m33altazs_July12_to_13.az, label='M33', lw=0, s=8,
+            c=m33altazs_July12_to_13.az.value, label='M33', lw=0, s=8,
             cmap='viridis')
 plt.fill_between(delta_midnight, 0*u.deg, 90*u.deg,
                  sunaltazs_July12_to_13.alt < -0*u.deg, color='0.5', zorder=0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ docs =
     sphinx-astropy[confv2]>=1.9.1
     pytest>=7.0
     scipy>=1.3
-    matplotlib>=3.3,!=3.4.0,!=3.5.2,<3.8
+    matplotlib>=3.3,!=3.4.0,!=3.5.2
     sphinx-changelog>=1.2.0
     sphinx_design
     Jinja2>=3.0


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the `plot_obs-planning` not working with matplotlib 3.8, because it passes a `Quantity` to the color entry in `plt.scatter` -- see #15319.

Obviously, if readthedocs does not work, this was not good enough!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15319

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
