### PR TITLE
Add note to time documentation on format vs internal values

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1777,7 +1777,8 @@ class Time(TimeBase):
         Value(s) to initialize the time or times.  Only used for numerical
         input, to help preserve precision.
     format : str, optional
-        Format of input value(s)
+        Format of input value(s), specifying how to interpret them (e.g., ISO, JD, or
+        Unix time). By default, the same format will be used for output representation.
     scale : str, optional
         Time scale of input value(s), must be one of the following:
         ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -48,9 +48,17 @@ To create a |Time| object:
   <Time object: scale='utc' format='isot' value=2010-01-01T00:00:00.000>
 
 The ``format`` argument specifies how to interpret the input values (e.g., ISO,
-JD, or Unix time). The ``scale`` argument specifies the `time scale`_ for the
-values (e.g., UTC, TT, or UT1). The ``scale`` argument is optional and defaults
-to UTC except for `Time from Epoch Formats`_.
+JD, or Unix time). By default, the same format will be used to represent the
+time for output. One can change this format later as needed, but because this
+is just for representation, that does not affect the internal representation
+(which is always by two 64-bit values, the ``jd1`` and ``jd2`` attributes), nor
+any computations with the object.
+
+The ``scale``  argument specifies the `time scale`_ for the values
+(e.g., UTC, TT, or UT1). The ``scale`` argument is optional and defaults
+to UTC except for `Time from Epoch Formats`_. It is possible to change
+it (e.g., from UTC to TDB), which will cause the internal values to be
+adjusted accordingly.
 
 .. EXAMPLE END
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address potential confusion about the difference between the time `format` and the internal 128-bit representation. This change clarifies early in the docs that the `format` is unrelated to the 128-bit value and any time computations.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Closes #15297 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
