### PR TITLE
Handle ruff rule B033.

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -19,7 +19,6 @@ ignore = [
     "B007",  # UnusedLoopControlVariable
     "B023",  # FunctionUsesLoopVariable
     "B028",  # No-explicit-stacklevel
-    "B033",  # Sets should not contain duplicate item
     "B904",  # RaiseWithoutFromInsideExcept
     "B905",  # ZipWithoutExplicitStrict   # requires 3.10+
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -280,7 +280,7 @@ class TestHeaderFunctions(FitsTestCase):
 
         header.update(NAXIS1=100, NAXIS2=100)
         assert set(header.keys()) == {"FOO", "A", "B", "HELLO", "NAXIS1", "NAXIS2"}
-        assert set(header.values()) == {"BAR", 1, 2, 100, 100}
+        assert tuple(header.values()) == ("BAR", 1, 2, 1, 100, 100)
 
     def test_update_comment(self):
         hdul = fits.open(self.data("arange.fits"))

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -83,7 +83,7 @@ def test_JsonCustomEncoder():
 
     assert json.dumps(np.arange(3), cls=misc.JsonCustomEncoder) == "[0, 1, 2]"
     assert json.dumps(1 + 2j, cls=misc.JsonCustomEncoder) == "[1.0, 2.0]"
-    assert json.dumps({1, 2, 1}, cls=misc.JsonCustomEncoder) == "[1, 2]"
+    assert json.dumps({1, 2}, cls=misc.JsonCustomEncoder) == "[1, 2]"
     assert (
         json.dumps(b"hello world \xc3\x85", cls=misc.JsonCustomEncoder)
         == '"hello world \\u00c5"'


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ruff error B033. Please see #15332 for previous discussion in this regard.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
