### PR TITLE
TST: fix CI weekly

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -150,6 +150,7 @@ jobs:
             echo "LONG_BIT="$(getconf LONG_BIT)
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
+            pip3 list
             ASTROPY_USE_SYSTEM_ALL=1 pip3 install -e .[test]
             pip3 list
             python3 -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython==0.29.34",
-            "numpy>=1.25,<2",
+            # A prebuilt numpy 1.25+ version is only currently available on x86_64, aarch64, arm64
+            "numpy>=1.25,<2; platform_machine=='x86_64' or platform_machine=='aarch64' or platform_machine=='arm64'",
+            "numpy>=1.24,<1.25; platform_machine!='x86_64' and platform_machine!='aarch64' and platform_machine!='arm64'",
             "extension-helpers"]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
### Description

Debugging/testing to figure out why the recent `numpy` 1.26 release has broken the weekly CI on exotic arcs

Fix #15333

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
