### PR TITLE
Start enforcing Ruff `flake8-annotations (ANN)` ruleset  

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -4,8 +4,14 @@ ignore = [
     # ruff --select="ALL" --statistics astropy/<subpackage>
 
     # flake8-annotations (ANN) : static typing
-    # TODO: revisit this when Astropy implements typing.
-    "ANN",
+    "ANN001",  # Function argument without type annotation
+    "ANN003",  # `**kwargs` without type annotation
+    "ANN201",  # Public function without return type annotation
+    "ANN202",  # Private function without return type annotation
+    "ANN204",  # Dunder method without return type annotation
+    "ANN205",  # Static method without return type annotation
+    "ANN206",  # Class method without return type annotation
+    "ANN401",  # Use of `Any` type
 
     # flake8-unused-arguments (ARG)
     "ARG001",  # unused-function-argument

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,7 +9,6 @@ ignore = [
     "ANN201",  # Public function without return type annotation
     "ANN202",  # Private function without return type annotation
     "ANN204",  # Dunder method without return type annotation
-    "ANN205",  # Static method without return type annotation
     "ANN206",  # Class method without return type annotation
     "ANN401",  # Use of `Any` type
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,7 +8,6 @@ ignore = [
     "ANN003",  # `**kwargs` without type annotation
     "ANN201",  # Public function without return type annotation
     "ANN202",  # Private function without return type annotation
-    "ANN204",  # Dunder method without return type annotation
     "ANN206",  # Class method without return type annotation
     "ANN401",  # Use of `Any` type
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,7 +8,6 @@ ignore = [
     "ANN003",  # `**kwargs` without type annotation
     "ANN201",  # Public function without return type annotation
     "ANN202",  # Private function without return type annotation
-    "ANN206",  # Class method without return type annotation
     "ANN401",  # Use of `Any` type
 
     # flake8-unused-arguments (ARG)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from __future__ import annotations
+
 import copy
 from collections.abc import MappingView
 from types import MappingProxyType
@@ -228,7 +230,7 @@ class galactocentric_frame_defaults(ScienceState):
         return cls._references
 
     @classmethod
-    def get_from_registry(cls, name: str):
+    def get_from_registry(cls, name: str) -> dict[str, dict]:
         """
         Return Galactocentric solar parameters and metadata given string names
         for the parameter sets. This method ensures the returned state is a
@@ -318,7 +320,9 @@ class galactocentric_frame_defaults(ScienceState):
         return parameters
 
     @classmethod
-    def register(cls, name: str, parameters: dict, references=None, **meta: dict):
+    def register(
+        cls, name: str, parameters: dict, references=None, **meta: dict
+    ) -> None:
         """Register a set of parameters.
 
         Parameters

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -20,7 +20,7 @@ from .connect import (
 )
 from .parameter import Parameter
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from astropy.cosmology.funcs.comparison import _FormatType

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -19,6 +19,8 @@ from astropy.utils import isiterable
 if TYPE_CHECKING:
     from typing import Any, Callable
 
+    from typing_extensions import Self
+
     from astropy.units import UnitBase
 
 __all__ = ["ModelBoundingBox", "CompoundBoundingBox"]
@@ -1120,7 +1122,9 @@ class _SelectorArguments(tuple):
 
     _kept_ignore = None
 
-    def __new__(cls, input_: tuple[_SelectorArgument], kept_ignore: list | None = None):
+    def __new__(
+        cls, input_: tuple[_SelectorArgument], kept_ignore: list | None = None
+    ) -> Self:
         self = super().__new__(cls, input_)
 
         if kept_ignore is None:

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 import abc
 import copy
 import warnings
-from typing import Any, Callable, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import isiterable
+
+if TYPE_CHECKING:
+    from typing import Any, Callable
+
+    from astropy.units import UnitBase
 
 __all__ = ["ModelBoundingBox", "CompoundBoundingBox"]
 
@@ -428,7 +433,7 @@ class _BoundingDomain(abc.ABC):
         )
 
     @staticmethod
-    def _get_valid_outputs_unit(valid_outputs, with_units: bool):
+    def _get_valid_outputs_unit(valid_outputs, with_units: bool) -> UnitBase | None:
         """
         Get the unit for outputs if one is required.
 

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -788,7 +788,7 @@ class ModelBoundingBox(_BoundingDomain):
         order: str = "C",
         _preserve_ignore: bool = False,
         **kwargs,
-    ):
+    ) -> Self:
         """
         Construct a valid bounding box for a model.
 
@@ -989,7 +989,7 @@ class _SelectorArgument(_BaseSelectorArgument):
         return self
 
     @classmethod
-    def validate(cls, model, argument, ignored: bool = True):
+    def validate(cls, model, argument, ignored: bool = True) -> Self:
         """
         Construct a valid selector argument for a CompoundBoundingBox.
 
@@ -1164,7 +1164,7 @@ class _SelectorArguments(tuple):
         return self._kept_ignore
 
     @classmethod
-    def validate(cls, model, arguments, kept_ignore: list | None = None):
+    def validate(cls, model, arguments, kept_ignore: list | None = None) -> Self:
         """
         Construct a valid Selector description for a CompoundBoundingBox.
 
@@ -1463,7 +1463,7 @@ class CompoundBoundingBox(_BoundingDomain):
         order: str = "C",
         _preserve_ignore: bool = False,
         **kwarg,
-    ):
+    ) -> Self:
         """
         Construct a valid compound bounding box for a model.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,9 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
     "T203"    # pprint found
 ]
 
+[tool.ruff.flake8-annotations]
+ignore-fully-untyped = true
+
 [tool.ruff.isort]
     known-third-party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]
     known-first-party = ["astropy", "extension_helpers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
     # New ones should be avoided and is up to maintainers to enforce.
     "A00",
 
+    # flake8-annotations (ANN)
+    "ANN101",  # No annotation for `self`.
+    "ANN102",  # No annotation for `cls`.
+
     # flake8-bugbear (B)
     "B008",  # FunctionCallArgumentDefault
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ exclude= [
             "pragma: py{ignore_python_version}",
             # Don't complain about IPython completion helper
             "def _ipython_key_completions_",
+            # typing.TYPE_CHECKING is False at runtime
+            "if TYPE_CHECKING:"
         ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
 
 [tool.ruff.flake8-annotations]
 ignore-fully-untyped = true
+mypy-init-return = true
 
 [tool.ruff.isort]
     known-third-party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]


### PR DESCRIPTION
### Description

The Ruff [`flake8-annotations (ANN)`](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann) ruleset provides several checks related to type annotations. Currently `astropy` ignores these rules entirely, but the changes in this pull request enable gradually adopting type annotations in `astropy`. Note however that Ruff is a linter, not a type checker. It can check that type annotations follow a few simple rules, but it does not check that the annotations are correct.

### New settings and permanent ignores

The most important new setting is [`ignore-fully-untyped`](https://docs.astral.sh/ruff/settings/#flake8-annotations-ignore-fully-untyped). It ensures that Ruff only checks for the `ANN` rules in functions that actually use type annotations. __Functions with no type annotations at all will not cause any `ANN` rule failures.__ This allows adding type annotations to `astropy` one function at a time without having to update Ruff configuration.

The [`mypy-init-return`](https://docs.astral.sh/ruff/settings/#flake8-annotations-mypy-init-return) setting tells Ruff that `__init__()` methods do not need a return annotation because `-> None` is the only valid annotation and writing it out in every `__init__()` is therefore not informative.

The rules `ANN101` (no annotation for `self`) and `ANN102` (no annotation for `cls`) should be permanently ignored because writing type annotations for those arguments is not helpful for type checkers and might even be lying if the methods are called from a subclass.

### Addressing temporarily ignored rules

`ANN001` (function argument without type annotation) and `ANN202` (private function without return type annotation) violations are numerous enough (66 and 46 respectively) that they are best addressed in separate pull requests, perhaps even multiple pull requests for different sub-packages.

`ANN401` (use of `Any` type) could be addressed by more detailed type annotations, [`noqa` comments](https://docs.astral.sh/ruff/configuration/#error-suppression) or by turning on the [`allow-star-arg-any`](https://docs.astral.sh/ruff/settings/#flake8-annotations-allow-star-arg-any) setting. This can be discussed in a separate issue.

In some cases `ANN003` (`**kwargs` without type annotation) and `ANN201` (public function without return type annotation) might be better addressed by editing `astropy` code rather than adding annotations, so they are best dealt with in follow-up pull requests.

The rest of the `ANN` rules have a very small number of violations and are addressed in this pull request.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.