### PR TITLE
BUG: Close Gzipfile in votable/utils properly

### DIFF
--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -76,10 +76,12 @@ def convert_to_writable_filelike(fd, compressed=False):
 
         if needs_wrapper:
             yield codecs.getwriter("utf-8")(fd)
-            fd.flush()
         else:
             yield fd
-            fd.flush()
+
+        fd.flush()
+        if isinstance(fd, gzip.GzipFile):
+            fd.close()
 
         return
     else:

--- a/docs/changes/io.votable/15359.bugfix.rst
+++ b/docs/changes/io.votable/15359.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in ``convert_to_writable_filelike`` where ``GzipFile`` was not closed properly.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to separate out the `io.votable` bugfix that Python 3.12 smoked out at #14784 because:

* the other PR just drags on, and
* this bug fix could potentially benefit LTS too.

Credit for this fix goes to @maxnoe , whom I credited as co-author.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
