### PR TITLE
Ensure the cm unit is only defined once.

### DIFF
--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -12,7 +12,7 @@ from .core import UnitBase, def_unit
 
 _ns = globals()
 
-def_unit(["cm", "centimeter"], si.cm, namespace=_ns, prefixes=False)
+cm = si.cm
 g = si.g
 s = si.s
 C = si.C

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -29,11 +29,21 @@ def_unit(
 ###########################################################################
 # LENGTH
 
+# We exclude c as a prefix so we can define cm as a derived unit,
+# not a PrefixUnit. That way it can be used in cgs as a base unit.
 def_unit(
     ["m", "meter"],
     namespace=_ns,
     prefixes=True,
+    exclude_prefixes=["c"],
     doc="meter: base unit of length in SI",
+)
+def_unit(
+    ["cm", "centimeter"],
+    0.01 * m,
+    namespace=_ns,
+    prefixes=False,
+    doc="cm: 0.01 m in SI, base unit of length in cgs",
 )
 def_unit(
     ["micron"],

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -916,3 +916,9 @@ def test_si_prefixes(name, symbol, multiplying_factor):
     value_ratio = base.value / quantity_from_symbol.value
 
     assert u.isclose(value_ratio, multiplying_factor)
+
+
+def test_cm_uniqueness():
+    # Ensure we have defined cm only once; see gh-15200.
+    assert u.si.cm is u.cgs.cm is u.cm
+    assert str(u.si.cm / u.cgs.cm) == ""  # was cm / cm

--- a/docs/changes/units/15368.bugfix.rst
+++ b/docs/changes/units/15368.bugfix.rst
@@ -1,0 +1,3 @@
+We now ensure that the unit ``u.cgs.cm`` is just an alias of ``u.si.cm``,
+instead of a redefinition.  This ensures that ``u.Unit("cm") / u.cm``
+will reliably cancel to dimensionless (instead of some "cm / cm").


### PR DESCRIPTION
Make the unit ``u.cgs.cm`` an alias of ``u.si.cm``, instead of a redefinition.  This ensures that ``u.Unit("cm") / u.cm`` will reliably cancel to dimensionless (instead of some "cm / cm") -- in current main, `u.Unit("cm")` sometimes returns `u.cgs.cm` and then the ratio becomes "cm / cm".

This is all a bit more subtle than I'd like, but it solves the problem and all tests seem to pass... Given that it has not caused any issues since the definition in #579, I think we can forego backporting to 5.0. But happy to backport to 5.0 if that is thought better.

Fixes #15200

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
