### PR TITLE
Raise a value error when dumping or loading numpy object arrays with yaml

### DIFF
--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -293,3 +293,26 @@ def test_ecsv_astropy_objects_in_meta():
     compare_time(tm, t2.meta["tm"])
     compare_coord(c, t2.meta["c"])
     assert t2.meta["unit"] == unit
+
+
+def test_yaml_dump_of_object_arrays_fail():
+    """Test that dumping and loading object arrays fails."""
+    with pytest.raises(TypeError, match="cannot serialize"):
+        dump(np.array([1, 2, 3], dtype=object))
+
+
+def test_yaml_load_of_object_arrays_fail():
+    """Test that dumping and loading object arrays fails.
+
+    The string to load was obtained by suppressing the exception and dumping
+    ``np.array([1, 2, 3], dtype=object)`` to a yaml file.
+    """
+    with pytest.raises(TypeError, match="cannot load numpy array"):
+        load(
+            """!numpy.ndarray
+            buffer: !!binary |
+              WndBQUFISUFBQUJwQUFBQQ==
+            dtype: object
+            order: C
+            shape: !!python/tuple [3]"""
+        )

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -110,6 +110,9 @@ def _timedelta_constructor(loader, node):
 
 
 def _ndarray_representer(dumper, obj):
+    if obj.dtype.hasobject:
+        raise TypeError(f"cannot serialize numpy object array: {obj}")
+
     if not (obj.flags["C_CONTIGUOUS"] or obj.flags["F_CONTIGUOUS"]):
         obj = np.ascontiguousarray(obj)
 
@@ -138,6 +141,9 @@ def _ndarray_constructor(loader, node):
     # construct_sequence.
     map = loader.construct_mapping(node, deep=True)
     map["buffer"] = base64.b64decode(map["buffer"])
+
+    if map["dtype"] == "object":
+        raise TypeError("cannot load numpy array with dtype object")
     return np.ndarray(**map)
 
 

--- a/docs/changes/io.misc/15373.bugfix.rst
+++ b/docs/changes/io.misc/15373.bugfix.rst
@@ -1,0 +1,1 @@
+Updated ``astropy.io.misc.yaml`` so ``dump()` with a numpy object array or ``load()`` with YAML representing a numpy object array both raise ``TypeError``. This prevents problems like a segmentation fault.

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -1008,6 +1008,10 @@ As of ``astropy`` 3.0, by specifying ``serialize_meta=True`` one can also store
 to HDF5 tables that contain :ref:`mixin_columns` such as `~astropy.time.Time` or
 `~astropy.coordinates.SkyCoord` columns.
 
+.. note::
+    Certain kind of metadata (e.g., numpy object arrays) cannot be serialized correctly
+    using YAML.
+
 .. _table_io_parquet:
 
 Parquet


### PR DESCRIPTION

### Description
This pull request is to address issue #14748. From now on, trying to dump a numpy object array to YAML (e.g. as metadata from a Table) or loading it will rise a `TypeError`. This will avoid more worrisome behavior such as segmentation faults.


Fixes #14748 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
