### PR TITLE
Remove useless `**kwargs` from `quantity.isclose()` and `quantity.allclose()`

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -2111,7 +2111,7 @@ class SpecificTypeQuantity(Quantity):
         super()._set_unit(unit)
 
 
-def isclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False, **kwargs):
+def isclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False):
     """
     Return a boolean array where two arrays are element-wise equal
     within a tolerance.
@@ -2152,11 +2152,10 @@ def isclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False, **kwargs):
     --------
     allclose
     """
-    unquantified_args = _unquantify_allclose_arguments(a, b, rtol, atol)
-    return np.isclose(*unquantified_args, equal_nan=equal_nan, **kwargs)
+    return np.isclose(*_unquantify_allclose_arguments(a, b, rtol, atol), equal_nan)
 
 
-def allclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False, **kwargs) -> bool:
+def allclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False) -> bool:
     """
     Whether two arrays are element-wise equal within a tolerance.
 
@@ -2196,8 +2195,7 @@ def allclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False, **kwargs) -> bool:
     --------
     isclose
     """
-    unquantified_args = _unquantify_allclose_arguments(a, b, rtol, atol)
-    return np.allclose(*unquantified_args, equal_nan=equal_nan, **kwargs)
+    return np.allclose(*_unquantify_allclose_arguments(a, b, rtol, atol), equal_nan)
 
 
 def _unquantify_allclose_arguments(actual, desired, rtol, atol):


### PR DESCRIPTION
### Description

The `Quantity`-aware `isclose()` and `allclose()` functions accept `**kwargs` and pass them on to the corresponding `numpy` functions. The latter however do not accept `**kwargs` (see [`np.isclose()`](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html#numpy.isclose) and [`np.allclose()`](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html#numpy.allclose) documentation), so in practice the `astropy` functions do not accept them either, despite what the function signatures say. The new function signatures match actual code behaviour.

`**kwargs` was added to `quantity_allclose()` (as it was named at the time) in d64dae955eae12674f85458448a287687035f323 as a simple way to provide compatibility with different `numpy` versions. It would seem that f69fb8c9b860c37613e58209be6932cbacd5ac01 then simply ensured that `isclose()` has the same signature as `allclose()`, even though `isclose()` never needed `**kwargs`. When e004ef2c91de0bf6d4041301e5318460f56f86d9 added the `equal_nan` argument to the functions `**kwargs` could have been removed, but that was not done at the time.

The useless `**kwargs` were revealed by Ruff rule `ANN003` when I was working on #15354.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
