### PR TITLE
Updates following the removal of several np.ndarray methods.

### DIFF
--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -19,6 +19,7 @@ from astropy.coordinates import (
     Latitude,
     Longitude,
 )
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 
 def test_create_angles():
@@ -202,9 +203,11 @@ def test_angle_methods():
     a_var = a.var()
     assert type(a_var) is u.Quantity
     assert a_var == 1.0 * u.degree**2
-    a_ptp = a.ptp()
-    assert type(a_ptp) is Angle
-    assert a_ptp == 2.0 * u.degree
+    if NUMPY_LT_2_0:
+        # np.ndarray.ptp() method removed in numpy 2.0.
+        a_ptp = a.ptp()
+        assert type(a_ptp) is Angle
+        assert a_ptp == 2.0 * u.degree
     a_max = a.max()
     assert type(a_max) is Angle
     assert a_max == 2.0 * u.degree

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -61,7 +61,7 @@ class TestCompressedImage(FitsTestCase):
     )
     @pytest.mark.parametrize("byte_order", ["<", ">"])
     def test_comp_image(self, data, compression_type, quantize_level, byte_order):
-        data = data.newbyteorder(byte_order)
+        data = data.view(data.dtype.newbyteorder(byte_order))
         primary_hdu = fits.PrimaryHDU()
         ofd = fits.HDUList(primary_hdu)
         chdu = fits.CompImageHDU(

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3990,7 +3990,7 @@ class Table:
             if getattr(column.dtype, "isnative", True):
                 out[name] = column
             else:
-                out[name] = column.data.byteswap().newbyteorder("=")
+                out[name] = column.data.byteswap().view(column.dtype.newbyteorder("="))
 
             if isinstance(column, MaskedColumn) and np.any(column.mask):
                 if column.dtype.kind in ["i", "u"]:

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -168,7 +168,9 @@ MIXIN_COLS = {
         [0, 1, 2, 3] * u.mas / u.yr, [0, 1, 2, 3] * u.mas / u.yr, 10 * u.km / u.s
     ),
     "arraywrap": ArrayWrapper([0, 1, 2, 3]),
-    "arrayswap": ArrayWrapper(np.arange(4, dtype="i").byteswap().newbyteorder()),
+    "arrayswap": ArrayWrapper(
+        np.arange(4, dtype="i").byteswap().view(np.dtype("i").newbyteorder())
+    ),
     "ndarraylil": np.array(
         [(7, "a"), (8, "b"), (9, "c"), (9, "c")], dtype="<i4,|S1"
     ).view(table.NdarrayMixin),

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1938,7 +1938,7 @@ class TestPandas:
                 for byte in ["2", "4", "8"]:
                     dtype = np.dtype(endian + kind + byte)
                     x = np.array([1, 2, 3], dtype=dtype)
-                    t[endian + kind + byte] = x.newbyteorder(endian)
+                    t[endian + kind + byte] = x.view(x.dtype.newbyteorder(endian))
 
         t["u"] = ["a", "b", "c"]
         t["s"] = ["a", "b", "c"]
@@ -1958,7 +1958,7 @@ class TestPandas:
                 if t[column].dtype.isnative:
                     assert d[column].dtype == t[column].dtype
                 else:
-                    assert d[column].dtype == t[column].byteswap().newbyteorder().dtype
+                    assert d[column].dtype == t[column].dtype.newbyteorder()
 
         # Regression test for astropy/astropy#1156 - the following code gave a
         # ValueError: Big-endian buffer not supported on little-endian
@@ -1979,7 +1979,7 @@ class TestPandas:
             if t[column].dtype.isnative:
                 assert t[column].dtype == t2[column].dtype
             else:
-                assert t[column].byteswap().newbyteorder().dtype == t2[column].dtype
+                assert t[column].dtype.newbyteorder() == t2[column].dtype
 
     @pytest.mark.parametrize("unsigned", ["u", ""])
     @pytest.mark.parametrize("bits", [8, 16, 32, 64])
@@ -2195,7 +2195,7 @@ class TestPandas:
                 if column.dtype.byteorder in ("=", "|"):
                     assert column.dtype == t2[name].dtype
                 else:
-                    assert column.byteswap().newbyteorder().dtype == t2[name].dtype
+                    assert column.dtype.newbyteorder() == t2[name].dtype
 
     def test_units(self):
         import pandas as pd

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -12,6 +12,7 @@ from astropy.units import (
     dimensionless_unscaled,
     photometric,
 )
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 from .core import FunctionQuantity, FunctionUnitBase
 from .units import dB, dex, mag
@@ -390,9 +391,21 @@ class LogQuantity(FunctionQuantity):
         unit = self.unit._copy(dimensionless_unscaled)
         return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof, unit=unit)
 
-    def ptp(self, axis=None, out=None):
-        unit = self.unit._copy(dimensionless_unscaled)
-        return self._wrap_function(np.ptp, axis, out=out, unit=unit)
+    if NUMPY_LT_2_0:
+
+        def ptp(self, axis=None, out=None):
+            unit = self.unit._copy(dimensionless_unscaled)
+            return self._wrap_function(np.ptp, axis, out=out, unit=unit)
+
+    else:
+
+        def __array_function__(self, function, types, args, kwargs):
+            # TODO: generalize this to all supported functions!
+            if function is np.ptp:
+                unit = self.unit._copy(dimensionless_unscaled)
+                return self._wrap_function(np.ptp, *args[1:], unit=unit, **kwargs)
+            else:
+                return super().__array_function__(function, types, args, kwargs)
 
     def diff(self, n=1, axis=-1):
         unit = self.unit._copy(dimensionless_unscaled)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -17,6 +17,7 @@ import numpy as np
 
 # LOCAL
 from astropy import config as _config
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyWarning
@@ -1694,11 +1695,13 @@ class Quantity(np.ndarray):
             _value = _value.astype(self.dtype, copy=False)
         return _value
 
-    def itemset(self, *args):
-        if len(args) == 0:
-            raise ValueError("itemset must have at least one argument")
+    if NUMPY_LT_2_0:
 
-        self.view(np.ndarray).itemset(*(args[:-1] + (self._to_own_unit(args[-1]),)))
+        def itemset(self, *args):
+            if len(args) == 0:
+                raise ValueError("itemset must have at least one argument")
+
+            self.view(np.ndarray).itemset(*(args[:-1] + (self._to_own_unit(args[-1]),)))
 
     def tostring(self, order="C"):
         """Not implemented, use ``.value.tostring()`` instead."""

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -6,6 +6,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 
 class TestQuantityArrayCopy:
@@ -459,6 +460,18 @@ class TestArrayConversion:
     def test_item(self):
         q1 = u.Quantity(np.array([1, 2, 3]), u.m / u.km, dtype=int)
         assert q1.item(1) == 2 * q1.unit
+
+        q1[1] = 1
+        assert q1[1] == 1000 * u.m / u.km
+        q1[1] = 100 * u.cm / u.km
+        assert q1[1] == 1 * u.m / u.km
+        with pytest.raises(TypeError):
+            q1[1] = 1.5 * u.m / u.km
+
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="itemset method removed in numpy 2.0")
+    def test_itemset(self):
+        q1 = u.Quantity(np.array([1, 2, 3]), u.m / u.km, dtype=int)
+        assert q1.item(1) == 2 * q1.unit
         q1.itemset(1, 1)
         assert q1.item(1) == 1000 * u.m / u.km
         q1.itemset(1, 100 * u.cm / u.km)
@@ -467,13 +480,6 @@ class TestArrayConversion:
             q1.itemset(1, 1.5 * u.m / u.km)
         with pytest.raises(ValueError):
             q1.itemset()
-
-        q1[1] = 1
-        assert q1[1] == 1000 * u.m / u.km
-        q1[1] = 100 * u.cm / u.km
-        assert q1[1] == 1 * u.m / u.km
-        with pytest.raises(TypeError):
-            q1[1] = 1.5 * u.m / u.km
 
     def test_take_put(self):
         q1 = np.array([1, 2, 3]) * u.m / u.km

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -904,10 +904,11 @@ class TestReductionLikeFunctions(MaskedArraySetup):
         assert o2 is out
         assert_array_equal(o2.unmasked, expected.unmasked)
         assert_array_equal(o2.mask, expected.mask)
-        # Check method does the same thing.
-        o3 = self.ma.ptp(**kwargs)
-        assert_array_equal(o3.unmasked, expected.unmasked)
-        assert_array_equal(o3.mask, expected.mask)
+        if NUMPY_LT_2_0:
+            # Method is removed in numpy 2.0.
+            o3 = self.ma.ptp(**kwargs)
+            assert_array_equal(o3.unmasked, expected.unmasked)
+            assert_array_equal(o3.mask, expected.mask)
 
     def test_trace(self):
         o = np.trace(self.ma)

--- a/docs/changes/units/15378.api.rst
+++ b/docs/changes/units/15378.api.rst
@@ -1,0 +1,6 @@
+Like ``np.ndarray``, under numpy 2.0 ``Quantity`` and all its subclasses
+(``Angle``, ``Masked``, etc.) will no longer support the ``.ptp()`` method.
+Use ``np.ptp(...)`` instead.
+
+Similarly, support for the much less frequently used ``.newbyteorder()`` and
+``.itemset()`` methods has been removed.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address updates to numpy for 2.0, which removed the `.ptp()`, `.newbyteorder()` and `.itemset()` methods, causing `-dev` failures in current main.

Of these three methods, the latter two were basically not used, but the former is a little annoying, especially as we support it for `Time` as well. (Likely should be deprecated for `Time`, but keeping that as a separate issue [to be raised]).

I've simply removed the methods in `Quantity`, etc., as well; there are tests that the `np.ptp` function still works (adjusted for `Masked`).

Note I'm not backporting, as I think we already decided that we would not try to support numpy 2.0 for 5.3.

p.s. Review by commit may be handiest, as each commit deals with a different deprecated method.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
