### PR TITLE
Ensure mask is properly accounted for in Masked.ptp()

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -990,6 +990,11 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             axis=axis, out=out, **self._reduce_defaults(kwargs, np.nanmin)
         )
 
+    def ptp(self, axis=None, out=None, **kwargs):
+        result = self.max(axis=axis, out=out, **kwargs)
+        result -= self.min(axis=axis, **kwargs)
+        return result
+
     def nonzero(self):
         unmasked_nonzero = self.unmasked.nonzero()
         if self.ndim >= 1:

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -634,10 +634,6 @@ class TestMethodLikes(MaskedArraySetup):
     def test_cumproduct(self):
         self.check(np.cumproduct, method="cumprod")  # noqa: NPY003
 
-    def test_ptp(self):
-        self.check(np.ptp)
-        self.check(np.ptp, axis=0)
-
     def test_round(self):
         self.check(np.round, method="round")
 
@@ -896,6 +892,22 @@ class TestReductionLikeFunctions(MaskedArraySetup):
         expected_mask = (self.mask_a | self.mask_b).any(-1)
         assert_array_equal(o.unmasked, expected)
         assert_array_equal(o.mask, expected_mask)
+
+    @pytest.mark.parametrize("kwargs", [{}, {"axis": 0}])
+    def test_ptp(self, kwargs):
+        o = np.ptp(self.ma, **kwargs)
+        expected = self.ma.max(**kwargs) - self.ma.min(**kwargs)
+        assert_array_equal(o.unmasked, expected.unmasked)
+        assert_array_equal(o.mask, expected.mask)
+        out = np.zeros_like(expected)
+        o2 = np.ptp(self.ma, out=out, **kwargs)
+        assert o2 is out
+        assert_array_equal(o2.unmasked, expected.unmasked)
+        assert_array_equal(o2.mask, expected.mask)
+        # Check method does the same thing.
+        o3 = self.ma.ptp(**kwargs)
+        assert_array_equal(o3.unmasked, expected.unmasked)
+        assert_array_equal(o3.mask, expected.mask)
 
     def test_trace(self):
         o = np.trace(self.ma)

--- a/docs/changes/utils/15380.bugfix.rst
+++ b/docs/changes/utils/15380.bugfix.rst
@@ -1,0 +1,3 @@
+For ``Masked``, ``np.ptp`` and the ``.ptp()`` method now properly account for
+the mask, ensuring the result is identical to subtracting the maximum and
+minimum (with the same arguments).


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a bug in `Masked.ptp()`, which meant that if any element was masked, the result would be masked too. Now it is ensures that it is the same as `.max() - .min()`.

Found in #15378. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
