### PR TITLE
Allow the use of Distribution in Representations and SkyCoord

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -605,8 +605,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
     info = RepresentationInfo()
 
     def __init_subclass__(cls, **kwargs):
-        # Register representation name (except for BaseRepresentation)
-        if cls.__name__ == "BaseRepresentation":
+        # Register representation name (except for bases on which other
+        # representations are built, but which cannot themselves be used).
+        if cls.__name__.startswith("Base"):
             return
 
         if not hasattr(cls, "attr_classes"):

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -268,7 +268,10 @@ class Distribution:
                 return self._not_implemented_or_raise(function, types)
 
             result = super().__array_function__(function, types, args, kwargs)
-            # Fall through to return section
+            # Fall through to return section, wrapping distributions, unless
+            # indicated otherwise.  TODO: use a less hacky solution?
+            if out is True:
+                return result
 
         else:  # pragma: no cover
             # By default, just pass it through for now.

--- a/astropy/uncertainty/tests/test_containers.py
+++ b/astropy/uncertainty/tests/test_containers.py
@@ -6,8 +6,44 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import astropy.units as u
-from astropy.coordinates import Angle, EarthLocation, Latitude, Longitude
+from astropy.coordinates import (
+    Angle,
+    CartesianDifferential,
+    CartesianRepresentation,
+    EarthLocation,
+    Latitude,
+    Longitude,
+    SphericalDifferential,
+    SphericalRepresentation,
+)
+from astropy.coordinates.representation import (
+    DIFFERENTIAL_CLASSES,
+    REPRESENTATION_CLASSES,
+)
+from astropy.coordinates.tests.test_representation import (
+    components_allclose,
+    representation_equal,
+)
 from astropy.uncertainty import Distribution
+
+
+def assert_representation_equal(rep1, rep2):
+    assert np.all(representation_equal(rep1, rep2))
+
+
+def assert_representation_allclose(rep1, rep2):
+    result = True
+    if type(rep1) is not type(rep2):
+        return False
+    if getattr(rep1, "_differentials", False):
+        if rep1._differentials.keys() != rep2._differentials.keys():
+            return False
+        for key, diff1 in rep1._differentials.items():
+            result &= components_allclose(diff1, rep2._differentials[key])
+    elif getattr(rep2, "_differentials", False):
+        return False
+
+    return np.all(result & components_allclose(rep1, rep2))
 
 
 class TestAngles:
@@ -93,3 +129,78 @@ class TestAngles:
 
         assert isinstance(deloc.x, Distribution)
         assert_array_equal(np.median(eloc.x, axis=1), deloc.x.pdf_median())
+
+
+class TestRepresentation:
+    @classmethod
+    def setup_class(cls):
+        cls.lon = Distribution(np.linspace(0.0, 360 * u.deg, 10, endpoint=False))
+        cls.lat = Angle([-45.0, 0.0, 45.0], u.deg)
+        cls.r = 6000 * u.km  # Sort of OK for Geodetic representations.
+        cls.sph = SphericalRepresentation(
+            cls.lon.distribution, cls.lat[:, np.newaxis], cls.r
+        )
+        cls.dsph = SphericalRepresentation(cls.lon, cls.lat, cls.r)
+
+    def get_distribution(self, rep):
+        return rep._apply(lambda x: getattr(x, "distribution", x[..., np.newaxis]))
+
+    def test_cartesian(self):
+        dcart = self.dsph.to_cartesian()
+        cart = self.sph.to_cartesian()
+        assert isinstance(dcart.x, Distribution)
+        assert_array_equal(dcart.x.distribution, cart.x)
+        assert_array_equal(dcart.y.distribution, cart.y)
+        assert_array_equal(dcart.z.distribution, cart.z)
+
+    def test_cartesian_roundtrip(self):
+        roundtrip = SphericalRepresentation.from_cartesian(self.dsph.to_cartesian())
+        assert_representation_allclose(self.get_distribution(roundtrip), self.sph)
+
+    @pytest.mark.parametrize("rep_cls", REPRESENTATION_CLASSES.values())
+    def test_other_reps(self, rep_cls):
+        drep = self.dsph.represent_as(rep_cls)
+        rep = self.sph.represent_as(rep_cls)
+        assert_representation_equal(self.get_distribution(drep), rep)
+
+
+class TestRepresentationWithDifferential(TestRepresentation):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.d_lon = Distribution(np.ones(10) << u.deg / u.hour)
+        cls.d_lat = np.ones(cls.lat.shape) << u.deg / u.hour
+        cls.d_r = 1 * u.m / u.s
+        cls.d_sph = SphericalDifferential(
+            cls.d_lon.distribution, cls.d_lat[:, np.newaxis], cls.d_r
+        )
+        cls.dd_sph = SphericalDifferential(cls.d_lon, cls.d_lat, cls.d_r)
+        cls.sph = cls.sph.with_differentials({"s": cls.d_sph})
+        cls.dsph = cls.dsph.with_differentials({"s": cls.dd_sph})
+
+    def test_cartesian(self):
+        dcart = self.dsph.represent_as(CartesianRepresentation, CartesianDifferential)
+        cart = self.sph.represent_as(CartesianRepresentation, CartesianDifferential)
+        assert isinstance(dcart.x, Distribution)
+        assert_array_equal(dcart.x.distribution, cart.x)
+        assert_array_equal(dcart.y.distribution, cart.y)
+        assert_array_equal(dcart.z.distribution, cart.z)
+        assert "s" in dcart._differentials
+        dd_cart = dcart._differentials["s"]
+        d_cart = cart._differentials["s"]
+        assert_array_equal(dd_cart.d_x.distribution, d_cart.d_x)
+        assert_array_equal(dd_cart.d_y.distribution, d_cart.d_y)
+        assert_array_equal(dd_cart.d_z.distribution, d_cart.d_z)
+
+    def test_cartesian_roundtrip(self):
+        roundtrip = self.dsph.represent_as(
+            CartesianRepresentation, CartesianDifferential
+        ).represent_as(SphericalRepresentation, SphericalDifferential)
+        assert_representation_allclose(self.get_distribution(roundtrip), self.sph)
+
+    @pytest.mark.parametrize("diff_cls", DIFFERENTIAL_CLASSES.values())
+    def test_other_reps(self, diff_cls):
+        repr_cls = diff_cls.base_representation
+        drep = self.dsph.represent_as(repr_cls, diff_cls)
+        rep = self.sph.represent_as(repr_cls, diff_cls)
+        assert_representation_equal(self.get_distribution(drep), rep)

--- a/astropy/uncertainty/tests/test_functions.py
+++ b/astropy/uncertainty/tests/test_functions.py
@@ -1,0 +1,96 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test numpy functions and ufuncs on Distribution.
+
+The tests here are fairly detailed but do not aim for complete
+coverage.  Complete coverage of all numpy functions will be done
+in test_function_helpers.
+
+TODO: start test_function_helpers once more functions are supported.
+"""
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from astropy import units as u
+from astropy.uncertainty import Distribution
+
+
+class ArraySetup:
+    @classmethod
+    def setup_class(self):
+        self.a = (
+            np.array([[[0.0]], [[10.0]]])
+            + np.array([[0.0], [1.0], [2.0]])
+            + np.arange(4.0) / 10.0
+        )
+        self.b = -(np.arange(3.0, 6.0)[:, np.newaxis] + np.arange(4.0) / 10.0)
+        self.da = Distribution(self.a)
+        self.db = Distribution(self.b)
+        self.c = np.array([[200.0], [300.0]])
+
+
+class QuantitySetup(ArraySetup):
+    @classmethod
+    def setup_class(self):
+        super().setup_class()
+        self.a <<= u.m
+        self.b <<= u.km
+        self.da <<= u.m
+        self.db <<= u.km
+        self.c <<= u.Mm
+
+
+class TestConcatenation(ArraySetup):
+    def test_concatenate(self):
+        # Concatenate needs consistent shapes.
+        db = self.db[np.newaxis]
+        concat_a_b = np.concatenate((self.da, db), axis=0)
+        expected_distr = np.concatenate((self.a, self.b[np.newaxis]), axis=0)
+        assert_array_equal(concat_a_b.distribution, expected_distr)
+
+    def test_concatenate_not_all_distribution(self):
+        concat_c_a = np.concatenate((self.c, self.da), axis=1)
+        assert isinstance(concat_c_a, Distribution)
+        c_bcst = np.broadcast_to(
+            self.c[..., np.newaxis], self.c.shape + (self.da.n_samples,), subok=True
+        )
+
+        expected_distr = np.concatenate((c_bcst, self.a), axis=1)
+        assert_array_equal(concat_c_a.distribution, expected_distr)
+
+
+class TestQuantityDistributionConcatenation(TestConcatenation, QuantitySetup):
+    pass
+
+
+class TestBroadcast(ArraySetup):
+    def test_broadcast_to(self):
+        shape = self.da.shape
+        ba = np.broadcast_to(self.db, shape, subok=True)
+        assert ba.shape == shape
+        expected_distr = np.broadcast_to(self.b, self.a.shape, subok=True)
+        assert_array_equal(ba.distribution, expected_distr)
+
+    def test_broadcast_arrays(self):
+        bda, bdb, bdc = np.broadcast_arrays(self.da, self.db, self.c, subok=True)
+        assert type(bda) is type(bdb) is type(self.da)
+        assert type(bdc) is type(self.c)
+        ba, bb = np.broadcast_arrays(self.a, self.b, subok=True)
+        bc = np.broadcast_to(self.c, self.da.shape, subok=True)
+        assert_array_equal(bda.distribution, ba)
+        assert_array_equal(bdb.distribution, bb)
+        assert_array_equal(bdc, bc)
+
+    def test_broadcast_arrays_subok_false(self):
+        # subok affects ndarray subclasses but not distribution itself.
+        bda, bdb, bdc = np.broadcast_arrays(self.da, self.db, self.c, subok=False)
+        assert type(bda.distribution) is type(bdb.distribution) is np.ndarray
+        assert type(bdc) is np.ndarray
+        ba, bb = np.broadcast_arrays(self.a, self.b, subok=False)
+        bc = np.broadcast_to(self.c, self.da.shape, subok=False)
+        assert_array_equal(bda.distribution, ba)
+        assert_array_equal(bdb.distribution, bb)
+        assert_array_equal(bdc, bc)
+
+
+class TestQuantityDistributionBroadcast(TestBroadcast, QuantitySetup):
+    pass

--- a/docs/changes/uncertainty/15395.feature.rst
+++ b/docs/changes/uncertainty/15395.feature.rst
@@ -1,0 +1,4 @@
+Uncertainty ``Distribution`` can now be used inside representations, which
+also allows basic support in ``SkyCoord``. While most calculations work, there
+are remaining issues.  For instance, the ``repr`` does not show that the
+coordinates are distributions.


### PR DESCRIPTION
This pull request is updates the `Distribution` class to allow it to be used inside representations. After the PRs to get things to work with `EarthLocation`, the changes here are rather minimal: support `concatenate` and a small fix in how `broadcast_arrays` is dealt with (plus a very small change in registration of representations, just for the tests to work more easily); the bulk of this PR is extra tests.

Note that the support is not yet complete. E.g., the way representations do `__repr__` means that the `repr` gives no sign that distributions are used. I think the best way to fix this, though, is through support of `array2string` for representations, which is a bit beyond what I can do here (similarly, `Distribution.__repr__` should go via `array2string` so that one can indicate what are the samples more easily). There perhaps also is a more general question of whether things like `SkyCoord` should just allow `Distribution` to be used, or whether they should also gain a `.distribution` property.

Anyway, I think it makes sense to proceed in small steps, so just go with what is here first... 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
