### PR TITLE
Add field `default` to Parameter

### DIFF
--- a/astropy/cosmology/_io/tests/base.py
+++ b/astropy/cosmology/_io/tests/base.py
@@ -99,7 +99,7 @@ class IODirectTestBase(IOTestBase):
         """Setup and teardown for tests."""
 
         class CosmologyWithKwargs(Cosmology):
-            Tcmb0 = Parameter(unit=u.K)
+            Tcmb0 = Parameter(default=0, unit=u.K)
 
             def __init__(
                 self, Tcmb0=0, name="cosmology with kwargs", meta=None, **kwargs

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -170,18 +170,25 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         fvalidate="float",
     )
     Tcmb0 = Parameter(
+        default=0.0 * u.K,
         doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
         unit="Kelvin",
         fvalidate="scalar",
     )
     Neff = Parameter(
-        doc="Number of effective neutrino species.", fvalidate="non-negative"
+        default=3.04,
+        doc="Number of effective neutrino species.",
+        fvalidate="non-negative",
     )
     m_nu = Parameter(
-        doc="Mass of neutrino species.", unit="eV", equivalencies=u.mass_energy()
+        default=0.0 * u.eV,
+        doc="Mass of neutrino species.",
+        unit="eV",
+        equivalencies=u.mass_energy(),
     )
     Ob0 = Parameter(
-        doc="Omega baryon; baryonic matter density/critical density at z=0."
+        default=None,
+        doc="Omega baryon; baryonic matter density/critical density at z=0.",
     )
 
     def __init__(

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -20,7 +20,7 @@ import astropy.units as u
 from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Parameter, Planck18
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.flrw.base import _a_B_c2, _critdens_const, _H0units_to_invs, quad
-from astropy.cosmology.parameter._core import HASNODEFAULT
+from astropy.cosmology.parameter._core import MISSING
 from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.cosmology.tests.test_core import (
     CosmologyTest,
@@ -71,7 +71,7 @@ class ParameterH0TestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.H0, Parameter)
         assert "Hubble constant" in cosmo_cls.H0.__doc__
         assert cosmo_cls.H0.unit == unit
-        assert cosmo_cls.H0.default is HASNODEFAULT
+        assert cosmo_cls.H0.default is MISSING
 
         # validation
         assert cosmo_cls.H0.validate(cosmo, 1) == 1 * unit
@@ -114,7 +114,7 @@ class ParameterOm0TestMixin(ParameterTestMixin):
         # on the class
         assert isinstance(cosmo_cls.Om0, Parameter)
         assert "Omega matter" in cosmo_cls.Om0.__doc__
-        assert cosmo_cls.Om0.default is HASNODEFAULT
+        assert cosmo_cls.Om0.default is MISSING
 
         # validation
         assert cosmo_cls.Om0.validate(cosmo, 1) == 1
@@ -157,7 +157,7 @@ class ParameterOde0TestMixin(ParameterTestMixin):
         """Test Parameter ``Ode0`` on the class."""
         assert isinstance(cosmo_cls.Ode0, Parameter)
         assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
-        assert cosmo_cls.Ode0.default is HASNODEFAULT
+        assert cosmo_cls.Ode0.default is MISSING
 
     def test_Parameter_Ode0_validation(self, cosmo_cls, cosmo):
         """Test Parameter ``Ode0`` validation."""

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -71,6 +71,7 @@ class ParameterH0TestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.H0, Parameter)
         assert "Hubble constant" in cosmo_cls.H0.__doc__
         assert cosmo_cls.H0.unit == unit
+        assert cosmo_cls.H0.default is NotImplemented
 
         # validation
         assert cosmo_cls.H0.validate(cosmo, 1) == 1 * unit
@@ -113,6 +114,7 @@ class ParameterOm0TestMixin(ParameterTestMixin):
         # on the class
         assert isinstance(cosmo_cls.Om0, Parameter)
         assert "Omega matter" in cosmo_cls.Om0.__doc__
+        assert cosmo_cls.Om0.default is NotImplemented
 
         # validation
         assert cosmo_cls.Om0.validate(cosmo, 1) == 1
@@ -155,6 +157,7 @@ class ParameterOde0TestMixin(ParameterTestMixin):
         """Test Parameter ``Ode0`` on the class."""
         assert isinstance(cosmo_cls.Ode0, Parameter)
         assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
+        assert cosmo_cls.Ode0.default is NotImplemented
 
     def test_Parameter_Ode0_validation(self, cosmo_cls, cosmo):
         """Test Parameter ``Ode0`` validation."""
@@ -208,6 +211,7 @@ class ParameterTcmb0TestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.Tcmb0, Parameter)
         assert "Temperature of the CMB" in cosmo_cls.Tcmb0.__doc__
         assert cosmo_cls.Tcmb0.unit == u.K
+        assert cosmo_cls.Tcmb0.default == 0.0 * u.K
 
         # validation
         assert cosmo_cls.Tcmb0.validate(cosmo, 1) == 1 * u.K
@@ -250,6 +254,7 @@ class ParameterNeffTestMixin(ParameterTestMixin):
         # on the class
         assert isinstance(cosmo_cls.Neff, Parameter)
         assert "Number of effective neutrino species" in cosmo_cls.Neff.__doc__
+        assert cosmo_cls.Neff.default == 3.04
 
         # validation
         assert cosmo_cls.Neff.validate(cosmo, 1) == 1
@@ -294,6 +299,7 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
         assert "Mass of neutrino species" in cosmo_cls.m_nu.__doc__
         assert cosmo_cls.m_nu.unit == u.eV
         assert cosmo_cls.m_nu.equivalencies == u.mass_energy()
+        assert cosmo_cls.m_nu.default == 0.0 * u.eV
 
         # on the instance
         # assert cosmo.m_nu is cosmo._m_nu
@@ -400,6 +406,7 @@ class ParameterOb0TestMixin(ParameterTestMixin):
         # on the class
         assert isinstance(cosmo_cls.Ob0, Parameter)
         assert "Omega baryon;" in cosmo_cls.Ob0.__doc__
+        assert cosmo_cls.Ob0.default is None
 
         # validation
         assert cosmo_cls.Ob0.validate(cosmo, None) is None

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -17,10 +17,10 @@ import astropy.constants as const
 
 # LOCAL
 import astropy.units as u
-from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Planck18
+from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Parameter, Planck18
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.flrw.base import _a_B_c2, _critdens_const, _H0units_to_invs, quad
-from astropy.cosmology.parameter import Parameter
+from astropy.cosmology.parameter._core import HASNODEFAULT
 from astropy.cosmology.tests.helper import get_redshift_methods
 from astropy.cosmology.tests.test_core import (
     CosmologyTest,
@@ -71,7 +71,7 @@ class ParameterH0TestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.H0, Parameter)
         assert "Hubble constant" in cosmo_cls.H0.__doc__
         assert cosmo_cls.H0.unit == unit
-        assert cosmo_cls.H0.default is NotImplemented
+        assert cosmo_cls.H0.default is HASNODEFAULT
 
         # validation
         assert cosmo_cls.H0.validate(cosmo, 1) == 1 * unit
@@ -114,7 +114,7 @@ class ParameterOm0TestMixin(ParameterTestMixin):
         # on the class
         assert isinstance(cosmo_cls.Om0, Parameter)
         assert "Omega matter" in cosmo_cls.Om0.__doc__
-        assert cosmo_cls.Om0.default is NotImplemented
+        assert cosmo_cls.Om0.default is HASNODEFAULT
 
         # validation
         assert cosmo_cls.Om0.validate(cosmo, 1) == 1
@@ -157,7 +157,7 @@ class ParameterOde0TestMixin(ParameterTestMixin):
         """Test Parameter ``Ode0`` on the class."""
         assert isinstance(cosmo_cls.Ode0, Parameter)
         assert "Omega dark energy" in cosmo_cls.Ode0.__doc__
-        assert cosmo_cls.Ode0.default is NotImplemented
+        assert cosmo_cls.Ode0.default is HASNODEFAULT
 
     def test_Parameter_Ode0_validation(self, cosmo_cls, cosmo):
         """Test Parameter ``Ode0`` validation."""

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -37,6 +37,7 @@ class Parameterw0TestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.w0, Parameter)
         assert "Dark energy equation of state" in cosmo_cls.w0.__doc__
         assert cosmo_cls.w0.unit is None
+        assert cosmo_cls.w0.default == -1.0
 
         # on the instance
         assert cosmo.w0 is cosmo._w0

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -38,6 +38,7 @@ class ParameterwaTestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.wa, Parameter)
         assert "Negative derivative" in cosmo_cls.wa.__doc__
         assert cosmo_cls.wa.unit is None
+        assert cosmo_cls.wa.default == 0.0
 
         # on the instance
         assert cosmo.wa is cosmo._wa

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -43,6 +43,7 @@ class ParameterwzTestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.wz, Parameter)
         assert "Derivative of the dark energy" in cosmo_cls.wz.__doc__
         assert cosmo_cls.wz.unit is None
+        assert cosmo_cls.wz.default == 0.0
 
         # on the instance
         assert cosmo.wz is cosmo._wz

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -43,6 +43,7 @@ class ParameterwpTestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.wp, Parameter)
         assert "at the pivot" in cosmo_cls.wp.__doc__
         assert cosmo_cls.wp.unit is None
+        assert cosmo_cls.wp.default == -1.0
 
         # on the instance
         assert cosmo.wp is cosmo._wp
@@ -80,6 +81,7 @@ class ParameterzpTestMixin(ParameterTestMixin):
         assert isinstance(cosmo_cls.zp, Parameter)
         assert "pivot redshift" in cosmo_cls.zp.__doc__
         assert cosmo_cls.zp.unit == cu.redshift
+        assert cosmo_cls.zp.default == 0.0
 
         # on the instance
         assert cosmo.zp is cosmo._zp

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -77,7 +77,9 @@ class wCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    w0 = Parameter(doc="Dark energy equation of state.", fvalidate="float")
+    w0 = Parameter(
+        default=-1.0, doc="Dark energy equation of state.", fvalidate="float"
+    )
 
     def __init__(
         self,

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -89,8 +89,11 @@ class w0waCDM(FLRW):
            Universe. Phys. Rev. Lett., 90, 091301.
     """
 
-    w0 = Parameter(doc="Dark energy equation of state at z=0.", fvalidate="float")
+    w0 = Parameter(
+        default=-1.0, doc="Dark energy equation of state at z=0.", fvalidate="float"
+    )
     wa = Parameter(
+        default=0.0,
         doc="Negative derivative of dark energy equation of state w.r.t. a.",
         fvalidate="float",
     )

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -82,8 +82,11 @@ class w0wzCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    w0 = Parameter(doc="Dark energy equation of state at z=0.", fvalidate="float")
+    w0 = Parameter(
+        default=-1.0, doc="Dark energy equation of state at z=0.", fvalidate="float"
+    )
     wz = Parameter(
+        default=0.0,
         doc="Derivative of the dark energy equation of state w.r.t. z.",
         fvalidate="float",
     )

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -99,13 +99,20 @@ class wpwaCDM(FLRW):
     """
 
     wp = Parameter(
-        doc="Dark energy equation of state at the pivot redshift zp.", fvalidate="float"
+        default=-1.0,
+        doc="Dark energy equation of state at the pivot redshift zp.",
+        fvalidate="float",
     )
     wa = Parameter(
+        default=0.0,
         doc="Negative derivative of dark energy equation of state w.r.t. a.",
         fvalidate="float",
     )
-    zp = Parameter(doc="The pivot redshift, where w(z) = wp.", unit=cu.redshift)
+    zp = Parameter(
+        default=0.0 * cu.redshift,
+        doc="The pivot redshift, where w(z) = wp.",
+        unit=cu.redshift,
+    )
 
     def __init__(
         self,

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+__all__ = []
+
 import copy
 from dataclasses import dataclass, field, fields, replace
+from enum import Enum, auto
 from typing import Any, Sequence
 
 import astropy.units as u
@@ -11,13 +14,20 @@ from astropy.utils.compat import PYTHON_LT_3_10
 
 from ._converter import _REGISTRY_FVALIDATORS, FValidateCallable, _register_validator
 
-__all__ = []
-
-
 if not PYTHON_LT_3_10:
     from dataclasses import KW_ONLY
 else:
     KW_ONLY = Any
+
+
+class Sentinel(Enum):
+    """Sentinel values for Parameter fields."""
+
+    has_no_default = auto()
+    """Sentinel for values that have no default value."""
+
+
+HASNODEFAULT = Sentinel.has_no_default
 
 
 @dataclass(frozen=True)
@@ -71,7 +81,7 @@ class Parameter:
     Parameters
     ----------
     default : Any (optional, keyword-only)
-        Default value of the Parameter. If ``NotImplemented`` (default), the
+        Default value of the Parameter. If ``HASNODEFAULT`` (default), the
         Parameter must be set when initializing the cosmology.
     derived : bool (optional, keyword-only)
         Whether the Parameter is 'derived', default `False`.
@@ -103,10 +113,10 @@ class Parameter:
     if not PYTHON_LT_3_10:
         _: KW_ONLY
 
-    default: Any = NotImplemented
+    default: Any = HASNODEFAULT
     """Default value of the Parameter.
 
-    If `NotImplemented` (default), the Parameter must be set when initializing the
+    If ``HASNODEFAULT`` (default), the Parameter must be set when initializing the
     cosmology.
     """
 
@@ -139,7 +149,7 @@ class Parameter:
         def __init__(
             self,
             *,
-            default: Any | NotImplemented = NotImplemented,
+            default=HASNODEFAULT,
             derived=False,
             unit=None,
             equivalencies=[],
@@ -293,9 +303,7 @@ class Parameter:
             # Only show fields that should be displayed and are not sentinel values
             if (
                 f.repr
-                and (
-                    self.default is not NotImplemented if f.name == "default" else True
-                )
+                and (self.default is not HASNODEFAULT if f.name == "default" else True)
             )
         )
         return f"{self.__class__.__name__}({', '.join(fields_repr)})"

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -23,11 +23,14 @@ else:
 class Sentinel(Enum):
     """Sentinel values for Parameter fields."""
 
-    missing = auto()
+    MISSING = auto()
     """A sentinel value signifying a missing default."""
 
+    def __repr__(self):
+        return f"<{self.name}>"
 
-MISSING = Sentinel.missing
+
+MISSING = Sentinel.MISSING
 
 
 @dataclass(frozen=True)

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -84,7 +84,7 @@ class Parameter:
     Parameters
     ----------
     default : Any (optional, keyword-only)
-        Default value of the Parameter. If ``MISSING`` (default), the
+        Default value of the Parameter. If not given the
         Parameter must be set when initializing the cosmology.
     derived : bool (optional, keyword-only)
         Whether the Parameter is 'derived', default `False`.
@@ -119,8 +119,8 @@ class Parameter:
     default: Any = MISSING
     """Default value of the Parameter.
 
-    If ``MISSING`` (default), the Parameter must be set when initializing the
-    cosmology.
+    By default set to ``MISSING``, which indicates the parameter must be set
+    when initializing the cosmology.
     """
 
     derived: bool = False

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -199,6 +199,14 @@ class Parameter:
         if hasattr(cosmology, self._attr_name):
             raise AttributeError(f"can't set attribute {self.name} again")
 
+        # Change `self` to the default value if default is HASNODEFAULT.
+        # This is done for backwards compatibility only - so that Parameter can be used
+        # in a dataclass and still return `self` when accessed from a class.
+        # Accessing the Parameter object via `cosmo_cls.param_name` will be removed
+        # in favor of `cosmo_cls.parameters["param_name"]`.
+        if value is self and self.default is HASNODEFAULT:
+            value = self.default
+
         # Validate value, generally setting units if present
         value = self.validate(cosmology, copy.deepcopy(value))
 

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -23,11 +23,11 @@ else:
 class Sentinel(Enum):
     """Sentinel values for Parameter fields."""
 
-    has_no_default = auto()
-    """Sentinel for values that have no default value."""
+    missing = auto()
+    """A sentinel value signifying a missing default."""
 
 
-HASNODEFAULT = Sentinel.has_no_default
+MISSING = Sentinel.missing
 
 
 @dataclass(frozen=True)
@@ -81,7 +81,7 @@ class Parameter:
     Parameters
     ----------
     default : Any (optional, keyword-only)
-        Default value of the Parameter. If ``HASNODEFAULT`` (default), the
+        Default value of the Parameter. If ``MISSING`` (default), the
         Parameter must be set when initializing the cosmology.
     derived : bool (optional, keyword-only)
         Whether the Parameter is 'derived', default `False`.
@@ -113,10 +113,10 @@ class Parameter:
     if not PYTHON_LT_3_10:
         _: KW_ONLY
 
-    default: Any = HASNODEFAULT
+    default: Any = MISSING
     """Default value of the Parameter.
 
-    If ``HASNODEFAULT`` (default), the Parameter must be set when initializing the
+    If ``MISSING`` (default), the Parameter must be set when initializing the
     cosmology.
     """
 
@@ -149,7 +149,7 @@ class Parameter:
         def __init__(
             self,
             *,
-            default=HASNODEFAULT,
+            default=MISSING,
             derived=False,
             unit=None,
             equivalencies=[],
@@ -199,12 +199,12 @@ class Parameter:
         if hasattr(cosmology, self._attr_name):
             raise AttributeError(f"can't set attribute {self.name} again")
 
-        # Change `self` to the default value if default is HASNODEFAULT.
+        # Change `self` to the default value if default is MISSING.
         # This is done for backwards compatibility only - so that Parameter can be used
         # in a dataclass and still return `self` when accessed from a class.
         # Accessing the Parameter object via `cosmo_cls.param_name` will be removed
         # in favor of `cosmo_cls.parameters["param_name"]`.
-        if value is self and self.default is HASNODEFAULT:
+        if value is self and self.default is MISSING:
             value = self.default
 
         # Validate value, generally setting units if present
@@ -311,7 +311,7 @@ class Parameter:
             # Only show fields that should be displayed and are not sentinel values
             if (
                 f.repr
-                and (self.default is not HASNODEFAULT if f.name == "default" else True)
+                and (self.default is not MISSING if f.name == "default" else True)
             )
         )
         return f"{self.__class__.__name__}({', '.join(fields_repr)})"

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -312,9 +312,6 @@ class Parameter:
             f"{f.name}={(getattr(self, f.name if f.name != 'fvalidate' else '_fvalidate_in'))!r}"
             for f in fields(self)
             # Only show fields that should be displayed and are not sentinel values
-            if (
-                f.repr
-                and (self.default is not MISSING if f.name == "default" else True)
-            )
+            if (f.repr and (f.name != "default" or self.default is not MISSING))
         )
         return f"{self.__class__.__name__}({', '.join(fields_repr)})"

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -312,6 +312,6 @@ class Parameter:
             f"{f.name}={(getattr(self, f.name if f.name != 'fvalidate' else '_fvalidate_in'))!r}"
             for f in fields(self)
             # Only show fields that should be displayed and are not sentinel values
-            if (f.repr and (f.name != "default" or self.default is not MISSING))
+            if f.repr and (f.name != "default" or self.default is not MISSING)
         )
         return f"{self.__class__.__name__}({', '.join(fields_repr)})"

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -61,8 +61,8 @@ class SubCosmology(Cosmology):
     """Defined here to be serializable."""
 
     H0 = Parameter(unit="km/(s Mpc)")
-    Tcmb0 = Parameter(unit=u.K)
-    m_nu = Parameter(unit=u.eV)
+    Tcmb0 = Parameter(default=0 * u.K, unit=u.K)
+    m_nu = Parameter(default=0 * u.eV, unit=u.eV)
 
     def __init__(self, H0, Tcmb0=0 * u.K, m_nu=0 * u.eV, name=None, meta=None):
         super().__init__(name=name, meta=meta)

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -70,6 +70,7 @@ class ParameterTestMixin:
         """Test :class:`astropy.cosmology.Parameter` instantiation."""
         # defaults
         parameter = Parameter()
+        assert parameter.default is NotImplemented
         assert parameter.fvalidate is _validate_with_unit
         assert parameter.unit is None
         assert parameter.equivalencies == []
@@ -78,12 +79,14 @@ class ParameterTestMixin:
 
         # setting all kwargs
         parameter = Parameter(
+            default=1.0,
             fvalidate="float",
             doc="DOCSTRING",
             unit="km",
             equivalencies=[u.mass_energy()],
             derived=True,
         )
+        assert parameter.default == 1.0
         assert parameter.fvalidate is _validate_to_float
         assert parameter.unit is u.km
         assert parameter.equivalencies == [u.mass_energy()]
@@ -139,6 +142,13 @@ class ParameterTestMixin:
             all_parameter.name not in cosmo_cls.__parameters__
         )
 
+    def test_Parameter_default(self, cosmo_cls, all_parameter):
+        """Test :attr:`astropy.cosmology.Parameter.default`."""
+        assert hasattr(all_parameter, "default")
+        assert isinstance(
+            all_parameter.default, (type(NotImplemented), type(None), float, u.Quantity)
+        )
+
     # -------------------------------------------
     # descriptor methods
 
@@ -146,8 +156,7 @@ class ParameterTestMixin:
         """Test :attr:`astropy.cosmology.Parameter.__get__`."""
         # from class
         parameter = getattr(cosmo_cls, all_parameter.name)
-        assert isinstance(parameter, Parameter)
-        assert parameter is all_parameter
+        assert np.all(parameter.default == all_parameter.default)
 
         # from instance
         parameter = getattr(cosmo, all_parameter.name)

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -22,7 +22,7 @@ from astropy.cosmology.parameter._converter import (
     _validate_to_float,
     _validate_with_unit,
 )
-from astropy.cosmology.parameter._core import HASNODEFAULT, Sentinel
+from astropy.cosmology.parameter._core import MISSING, Sentinel
 
 ##############################################################################
 # TESTS
@@ -70,7 +70,7 @@ class ParameterTestMixin:
         """Test :class:`astropy.cosmology.Parameter` instantiation."""
         # defaults
         parameter = Parameter()
-        assert parameter.default is HASNODEFAULT
+        assert parameter.default is MISSING
         assert parameter.fvalidate is _validate_with_unit
         assert parameter.unit is None
         assert parameter.equivalencies == []

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -37,6 +37,42 @@ def test_registry_validators():
     assert all(callable(v) for v in _REGISTRY_FVALIDATORS.values())
 
 
+class test_Parameter:
+    """Test :class:`astropy.cosmology.Parameter` not on a cosmology."""
+
+    def test_Parameter_init(self):
+        """Test :class:`astropy.cosmology.Parameter` instantiation."""
+        # defaults
+        parameter = Parameter()
+        assert parameter.default is MISSING
+        assert parameter.fvalidate is _validate_with_unit
+        assert parameter.unit is None
+        assert parameter.equivalencies == []
+        assert parameter.derived is False
+        assert parameter.name is None
+
+        # setting all kwargs
+        parameter = Parameter(
+            default=1.0,
+            fvalidate="float",
+            doc="DOCSTRING",
+            unit="km",
+            equivalencies=[u.mass_energy()],
+            derived=True,
+        )
+        assert parameter.default == 1.0
+        assert parameter.fvalidate is _validate_to_float
+        assert parameter.unit is u.km
+        assert parameter.equivalencies == [u.mass_energy()]
+        assert parameter.derived is True
+
+    def test_Parameter_default(self):
+        """Test :attr:`astropy.cosmology.Parameter.default`."""
+        parameter = Parameter()
+        assert parameter.default is MISSING
+        assert repr(parameter.default) == "<MISSING>"
+
+
 class ParameterTestMixin:
     """Tests for a :class:`astropy.cosmology.Parameter` on a Cosmology.
 
@@ -65,32 +101,6 @@ class ParameterTestMixin:
 
     # ===============================================================
     # Method Tests
-
-    def test_Parameter_init(self):
-        """Test :class:`astropy.cosmology.Parameter` instantiation."""
-        # defaults
-        parameter = Parameter()
-        assert parameter.default is MISSING
-        assert parameter.fvalidate is _validate_with_unit
-        assert parameter.unit is None
-        assert parameter.equivalencies == []
-        assert parameter.derived is False
-        assert parameter.name is None
-
-        # setting all kwargs
-        parameter = Parameter(
-            default=1.0,
-            fvalidate="float",
-            doc="DOCSTRING",
-            unit="km",
-            equivalencies=[u.mass_energy()],
-            derived=True,
-        )
-        assert parameter.default == 1.0
-        assert parameter.fvalidate is _validate_to_float
-        assert parameter.unit is u.km
-        assert parameter.equivalencies == [u.mass_energy()]
-        assert parameter.derived is True
 
     def test_Parameter_instance_attributes(self, all_parameter):
         """Test :class:`astropy.cosmology.Parameter` attributes from init."""

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -15,14 +15,14 @@ import pytest
 
 # LOCAL
 import astropy.units as u
-from astropy.cosmology import Cosmology
+from astropy.cosmology import Cosmology, Parameter
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
-from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.parameter._converter import (
     _REGISTRY_FVALIDATORS,
     _validate_to_float,
     _validate_with_unit,
 )
+from astropy.cosmology.parameter._core import HASNODEFAULT, Sentinel
 
 ##############################################################################
 # TESTS
@@ -70,7 +70,7 @@ class ParameterTestMixin:
         """Test :class:`astropy.cosmology.Parameter` instantiation."""
         # defaults
         parameter = Parameter()
-        assert parameter.default is NotImplemented
+        assert parameter.default is HASNODEFAULT
         assert parameter.fvalidate is _validate_with_unit
         assert parameter.unit is None
         assert parameter.equivalencies == []
@@ -146,7 +146,7 @@ class ParameterTestMixin:
         """Test :attr:`astropy.cosmology.Parameter.default`."""
         assert hasattr(all_parameter, "default")
         assert isinstance(
-            all_parameter.default, (type(NotImplemented), type(None), float, u.Quantity)
+            all_parameter.default, (Sentinel, type(None), float, u.Quantity)
         )
 
     # -------------------------------------------

--- a/astropy/cosmology/tests/test_parameter.py
+++ b/astropy/cosmology/tests/test_parameter.py
@@ -21,7 +21,7 @@ from astropy.cosmology.parameter._converter import (
     _REGISTRY_FVALIDATORS,
     _validate_with_unit,
 )
-from astropy.cosmology.parameter._core import MISSING, Sentinel
+from astropy.cosmology.parameter._core import MISSING
 
 ##############################################################################
 # TESTS
@@ -157,8 +157,8 @@ class ParameterTestMixin:
     def test_Parameter_default(self, cosmo_cls, all_parameter):
         """Test :attr:`astropy.cosmology.Parameter.default`."""
         assert hasattr(all_parameter, "default")
-        assert isinstance(
-            all_parameter.default, (Sentinel, type(None), float, u.Quantity)
+        assert all_parameter.default is MISSING or isinstance(
+            all_parameter.default, (type(None), float, u.Quantity)
         )
 
     # -------------------------------------------

--- a/docs/changes/cosmology/15400.feature.rst
+++ b/docs/changes/cosmology/15400.feature.rst
@@ -1,0 +1,2 @@
+The field ``default`` has been added to ``Parameter``. This can be used to introspect
+the default value of a parameter on a cosmology class ``e.g. LambdaCDM.H0.default``.

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -140,7 +140,7 @@ This means that the :mod:`dataclasses` machinery can be used to work with
 
     >>> from dataclasses import asdict
     >>> asdict(H0)
-    {'default': NotImplemented, 'derived': False, 'unit': Unit("km / (Mpc s)"), 'equivalencies': [], ...
+    {'default': ..., 'derived': False, 'unit': Unit("km / (Mpc s)"), 'equivalencies': [], ...
 
 
 It's also much easier to create new :class:`~astropy.cosmology.Parameter` subclasses

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -140,7 +140,7 @@ This means that the :mod:`dataclasses` machinery can be used to work with
 
     >>> from dataclasses import asdict
     >>> asdict(H0)
-    {'derived': False, 'unit': Unit("km / (Mpc s)"), 'equivalencies': [], ...
+    {'default': NotImplemented, 'derived': False, 'unit': Unit("km / (Mpc s)"), 'equivalencies': [], ...
 
 
 It's also much easier to create new :class:`~astropy.cosmology.Parameter` subclasses

--- a/docs/whatsnew/6.0.rst
+++ b/docs/whatsnew/6.0.rst
@@ -132,15 +132,15 @@ This means that the :mod:`dataclasses` machinery can be used to work with
 
     >>> from dataclasses import replace
     >>> from astropy.cosmology import FlatLambdaCDM
-    >>> H0 = FlatLambdaCDM.H0
-    >>> H0
-    Parameter(derived=False, unit=Unit("km / (Mpc s)"), equivalencies=[], ...)
-    >>> replace(H0, derived=True)
-    Parameter(derived=True, unit=Unit("km / (Mpc s)"), equivalencies=[], ...)
+    >>> m_nu = FlatLambdaCDM.m_nu
+    >>> m_nu
+    Parameter(default=<Quantity 0. eV>, derived=False, unit=Unit("eV"), ...)
+    >>> replace(m_nu, derived=True)
+    Parameter(default=<Quantity 0. eV>, derived=True, unit=Unit("eV"), ...)
 
     >>> from dataclasses import asdict
-    >>> asdict(H0)
-    {'default': ..., 'derived': False, 'unit': Unit("km / (Mpc s)"), 'equivalencies': [], ...
+    >>> asdict(m_nu)
+    {'default': <Quantity 0. eV>, 'derived': False, 'unit': Unit("eV"), ...}
 
 
 It's also much easier to create new :class:`~astropy.cosmology.Parameter` subclasses


### PR DESCRIPTION
Split off from #15168. This adds the field `default` to Parameter. Currently it doesn't do anything since the default value is specified on `__init__()`, but it is useful for introspecting a cosmology class e.g. `LambdaCDM.H0.default` and it will also replace `__init__()` when `Cosmology` is a dataclass for v6.