### PR TITLE
MetaData compatibility with frozen dataclasses

### DIFF
--- a/astropy/utils/metadata/core.py
+++ b/astropy/utils/metadata/core.py
@@ -5,6 +5,7 @@ import inspect
 from collections import OrderedDict
 from collections.abc import Mapping
 from copy import deepcopy
+from dataclasses import is_dataclass
 
 __all__ = ["MetaData", "MetaAttribute"]
 
@@ -100,18 +101,23 @@ class MetaData:
         return instance._meta
 
     def __set__(self, instance, value):
-        # The 'default' value is `None`, but we want to set it to an empty `OrderedDict`
+        # The 'default' value is `None`, but we want to set it to an empty `Mapping`
         # if it is `None` so that we can always assume it is a `Mapping` and not have
         # to check for `None` everywhere.
         if value is None:
-            instance._meta = self.default_factory()
+            value = self.default_factory()
         # We don't want to allow setting the meta attribute to a non-dict-like object.
         # NOTE: with mypyc compilation this can be removed.
         elif not isinstance(value, Mapping):
             raise TypeError("meta attribute must be dict-like")
         # This is called when the dataclass is instantiated with a `meta` argument.
         else:
-            instance._meta = deepcopy(value) if self.copy else value
+            value = deepcopy(value) if self.copy else value
+
+        if is_dataclass(instance) and instance.__dataclass_params__.frozen:
+            object.__setattr__(instance, "_meta", value)
+        else:
+            instance._meta = value
 
 
 class MetaAttribute:

--- a/astropy/utils/metadata/tests/test_metadata.py
+++ b/astropy/utils/metadata/tests/test_metadata.py
@@ -90,7 +90,6 @@ class ExampleFrozenDataclass:
     meta: MetaData = MetaData()  # noqa: RUF009
 
 
-@pytest.mark.xfail(reason="Frozen dataclasses aren't yet supported", strict=False)
 class TestMetaExampleFrozenDataclass(MetaBaseTest):
     test_class = ExampleFrozenDataclass
     args = ()

--- a/docs/changes/utils/15404.api.rst
+++ b/docs/changes/utils/15404.api.rst
@@ -1,0 +1,2 @@
+The ``astropy.utils.metadata.MetaData`` class, which is used throughout astropy
+to carry metadata on tables, columns, etc., can now also be used on frozen dataclasses.


### PR DESCRIPTION
Using `setattr(instance, …)` calls the ``instance.__setattr__()`` method. However this can be ‘frozen’ like in `@dataclass(frozen=True)` and therefore fail. Changing to `object.__setattr__(instance, …)` is standard practice to ensure mutability in assignment.

