### PR TITLE
Remove duplicate `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
     hooks:
       - id: check-added-large-files
         # Prevent giant files from being committed.
-      - id: check-ast
-        # Simply check whether files parse as valid python.
       - id: check-case-conflict
         # Check for files with names that would conflict on a case-insensitive
         # filesystem like MacOS HFS+ or Windows FAT.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,9 +24,6 @@ repos:
       - id: check-yaml
         # Attempts to load all yaml files to verify syntax.
         exclude: ".*(.github.*)$"
-      - id: debug-statements
-        # Check for debugger imports and py37+ breakpoint() calls in python
-        # source.
       - id: detect-private-key
         # Checks for the existence of private keys.
       - id: end-of-file-fixer


### PR DESCRIPTION
### Description

`check-ast` verifies that Python files do not contain syntax errors, but that is also checked by Ruff and Black.

`debug-statements` duplicates [Ruff rule T100](https://docs.astral.sh/ruff/rules/#flake8-debugger-t10).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
