### PR TITLE
MNT: Deprecate fnunpickle and fnpickle

### DIFF
--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -6,11 +6,16 @@ part of a larger framework or standard.
 
 import pickle
 
+from astropy.utils.decorators import deprecated
+
 __all__ = ["fnpickle", "fnunpickle"]
 
 
+@deprecated(since="6.0", message="Use pickle from standard library, if you must")
 def fnunpickle(fileorname, number=0):
     """Unpickle pickled objects from a specified file and return the contents.
+
+    .. warning:: The ``pickle`` module is not secure. Only unpickle data you trust.
 
     Parameters
     ----------
@@ -66,6 +71,7 @@ def fnunpickle(fileorname, number=0):
     return res
 
 
+@deprecated(since="6.0", message="Use pickle from standard library, if you must")
 def fnpickle(object, fileorname, protocol=None, append=False):
     """Pickle an object to a specified file.
 

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import warnings
-
 import pytest
 
 from astropy.io.misc import fnpickle, fnunpickle
@@ -16,8 +14,9 @@ def test_fnpickling_simple(tmp_path):
     fn = str(tmp_path / "test1.pickle")
 
     obj1 = "astring"
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+    with pytest.warns(
+        AstropyDeprecationWarning, match="Use pickle from standard library"
+    ):
         fnpickle(obj1, fn)
         res = fnunpickle(fn, 0)
         assert obj1 == res
@@ -50,8 +49,9 @@ def test_fnpickling_class(tmp_path):
 
     obj1 = "astring"
     obj2 = ToBePickled(obj1)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+    with pytest.warns(
+        AstropyDeprecationWarning, match="Use pickle from standard library"
+    ):
         fnpickle(obj2, fn)
         res = fnunpickle(fn)
     assert res == obj2
@@ -67,13 +67,14 @@ def test_fnpickling_protocol(tmp_path):
     obj1 = "astring"
     obj2 = ToBePickled(obj1)
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
-        for p in range(pickle.HIGHEST_PROTOCOL + 1):
-            fn = str(tmp_path / f"testp{p}.pickle")
+    for p in range(pickle.HIGHEST_PROTOCOL + 1):
+        fn = str(tmp_path / f"testp{p}.pickle")
+        with pytest.warns(
+            AstropyDeprecationWarning, match="Use pickle from standard library"
+        ):
             fnpickle(obj2, fn, protocol=p)
             res = fnunpickle(fn)
-            assert res == obj2
+        assert res == obj2
 
 
 def test_fnpickling_many(tmp_path):
@@ -87,8 +88,9 @@ def test_fnpickling_many(tmp_path):
     # now try multiples
     obj3 = 328.3432
     obj4 = "blahblahfoo"
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+    with pytest.warns(
+        AstropyDeprecationWarning, match="Use pickle from standard library"
+    ):
         fnpickle(obj3, fn)
         fnpickle(obj4, fn, append=True)
 

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import warnings
 
 import pytest
 
 from astropy.io.misc import fnpickle, fnunpickle
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_fnpickling_simple(tmp_path):
@@ -14,16 +16,18 @@ def test_fnpickling_simple(tmp_path):
     fn = str(tmp_path / "test1.pickle")
 
     obj1 = "astring"
-    fnpickle(obj1, fn)
-    res = fnunpickle(fn, 0)
-    assert obj1 == res
-
-    # now try with a file-like object instead of a string
-    with open(fn, "wb") as f:
-        fnpickle(obj1, f)
-    with open(fn, "rb") as f:
-        res = fnunpickle(f)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+        fnpickle(obj1, fn)
+        res = fnunpickle(fn, 0)
         assert obj1 == res
+
+        # now try with a file-like object instead of a string
+        with open(fn, "wb") as f:
+            fnpickle(obj1, f)
+        with open(fn, "rb") as f:
+            res = fnunpickle(f)
+            assert obj1 == res
 
 
 class ToBePickled:
@@ -46,8 +50,10 @@ def test_fnpickling_class(tmp_path):
 
     obj1 = "astring"
     obj2 = ToBePickled(obj1)
-    fnpickle(obj2, fn)
-    res = fnunpickle(fn)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+        fnpickle(obj2, fn)
+        res = fnunpickle(fn)
     assert res == obj2
 
 
@@ -61,11 +67,13 @@ def test_fnpickling_protocol(tmp_path):
     obj1 = "astring"
     obj2 = ToBePickled(obj1)
 
-    for p in range(pickle.HIGHEST_PROTOCOL + 1):
-        fn = str(tmp_path / f"testp{p}.pickle")
-        fnpickle(obj2, fn, protocol=p)
-        res = fnunpickle(fn)
-        assert res == obj2
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+        for p in range(pickle.HIGHEST_PROTOCOL + 1):
+            fn = str(tmp_path / f"testp{p}.pickle")
+            fnpickle(obj2, fn, protocol=p)
+            res = fnunpickle(fn)
+            assert res == obj2
 
 
 def test_fnpickling_many(tmp_path):
@@ -79,17 +87,19 @@ def test_fnpickling_many(tmp_path):
     # now try multiples
     obj3 = 328.3432
     obj4 = "blahblahfoo"
-    fnpickle(obj3, fn)
-    fnpickle(obj4, fn, append=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+        fnpickle(obj3, fn)
+        fnpickle(obj4, fn, append=True)
 
-    res = fnunpickle(fn, number=-1)
-    assert len(res) == 2
-    assert res[0] == obj3
-    assert res[1] == obj4
+        res = fnunpickle(fn, number=-1)
+        assert len(res) == 2
+        assert res[0] == obj3
+        assert res[1] == obj4
 
-    fnpickle(obj4, fn, append=True)
-    res = fnunpickle(fn, number=2)
-    assert len(res) == 2
+        fnpickle(obj4, fn, append=True)
+        res = fnunpickle(fn, number=2)
+        assert len(res) == 2
 
-    with pytest.raises(EOFError):
-        fnunpickle(fn, number=5)
+        with pytest.raises(EOFError):
+            fnunpickle(fn, number=5)

--- a/docs/changes/io.misc/15418.api.rst
+++ b/docs/changes/io.misc/15418.api.rst
@@ -1,0 +1,3 @@
+``fnunpickle`` and ``fnpickle`` are deprecated because they are not used anywhere within ``astropy``.
+If you must, use the module from Python standard library but be advised that pickle is insecure
+so you should only unpickle data that you trust.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to deprecate `fnunpickle` and `fnpickle` because they are not used anywhere in this repo.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
