### PR TITLE
Ignore Ruff rules in single sub-packages

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -49,7 +49,6 @@ ignore = [
     # flake8-datetimez (DTZ)
     "DTZ001",  # call-datetime-without-tzinfo
     "DTZ005",  # call-datetime-now-without-tzinfo
-    "DTZ007",  # call-datetime-strptime-without-zone
 
     # pycodestyle (E, W)
     "E501",  # line-too-long
@@ -79,12 +78,7 @@ ignore = [
 
     # flake8-fixme (FIX)
     "FIX001",  # Line contains FIXME.  this should be fixed or at least FIXME replaced with TODO
-    "FIX003",  # Line contains XXX.  replace XXX with TODO
     "FIX004",  # Line contains HACK. replace HACK with NOTE.
-
-    # flake8-logging-format (G)
-    "G001",  # logging-string-format
-    "G004",  # logging-f-string
 
     # flake8-import-conventions (ICN)  : use conventional import aliases
     "ICN001",  # import-conventions
@@ -97,12 +91,9 @@ ignore = [
     "N804",  # invalid-first-argument-name-for-class-method
     "N805",  # invalid-first-argument-name-for-method
     "N807",  # dunder-function-name
-    "N811",  # constant-imported-as-non-constant
-    "N812",  # lowercase-imported-as-non-lowercase
     "N813",  # camelcase-imported-as-lowercase
     "N815",  # mixed-case-variable-in-class-scope
     "N816",  # mixed-case-variable-in-global-scope
-    "N817",  # camelcase-imported-as-acronym
     "N818",  # error-suffix-on-exception-name
 
     # NumPy-specific rules (NPY)
@@ -111,9 +102,6 @@ ignore = [
     # Perflint (PERF)
     "PERF203",  # `try`-`except` within a loop incurs performance overhead
     "PERF401",  # Use a list comprehension to create a transformed list
-
-    # flake8-pie (PIE)
-    "PIE794",  # duplicate-class-field-definition
 
     # pygrep-hooks (PGH)
     "PGH001",  # eval
@@ -143,7 +131,6 @@ ignore = [
     "PT012",   # pytest-raises-with-multiple-statements
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion
-    "PT019",   # pytest-fixture-param-without-value
     "PT022",   # pytest-useless-yield-fixture
     "PT023",   # pytest-incorrect-mark-parentheses-style
 
@@ -160,15 +147,12 @@ ignore = [
     "PTH111",  # os-path-expanduser
     "PTH112",  # os-path-isdir
     "PTH113",  # os-path-isfile
-    "PTH114",  # os-path-islink
-    "PTH116",  # os-stat
     "PTH118",  # os-path-join
     "PTH119",  # os-path-basename
     "PTH120",  # os-path-dirname
     "PTH122",  # os-path-splitext
     "PTH123",  # builtin-open
     "PTH202",  # `os.path.getsize` should be replaced by `Path.stat().st_size`
-    "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
     "PTH207",  # Replace `glob` with `Path.glob` or `Path.rglob`
 
     # flake8-return (RET)
@@ -200,11 +184,8 @@ ignore = [
     "S324",  # hashlib-insecure-hash-function
     "S506",  # UnsafeYAMLLoad
     "S310",  # Suspicious-url-open-usage
-    "S321",  # Suspicious-ftp-lib-usage
     "S603",  # `subprocess` call: check for execution of untrusted input
-    "S605",  # Starting a process with a shell, possible injection detected  (2023-05-03)
     "S607",  # Starting a process with a partial executable path
-    "S608",  # Posslibe SQL injection
 
     # flake8-simplify (SIM)
     "SIM102",  # NestedIfStatements
@@ -215,12 +196,7 @@ ignore = [
     "SIM117",  # MultipleWithStatements
     "SIM118",  # KeyInDict
     "SIM201",  # NegateEqualOp
-    "SIM202",  # NegateNotEqualOp
     "SIM300",  # yoda condition
-
-    # flake8-slots (SLOT)
-    "SLOT000",  # Subclasses of `str` should define `__slots__`
-    "SLOT001",  # Subclasses of `tuple` should define `__slots__`
 
     # flake8-print (T20)
     "T201",  # PrintUsed
@@ -229,7 +205,6 @@ ignore = [
     "TD001",  # Invalid TODO tag
     "TD003",  # Missing issue link on the line following this TODO
     "TD004",  # Missing colon in TODO
-    "TD005",  # Missing issue description after `TODO`
     "TD007",  # Missing space after colon in TODO
 
     # tryceratops (TRY)
@@ -240,7 +215,6 @@ ignore = [
     "TRY201",  # verbose-raise
     "TRY300",  # Consider `else` block
     "TRY301",  # raise-within-try
-    "TRY400",  # error-instead-of-exception
 
     # flake8-quotes (Q)
     "Q000",  # use double quotes
@@ -259,25 +233,70 @@ unfixable = [
 # is better to fix for subpackages individually. The general exclusion should be
 # copied to these subpackage sections and fixed there.
 "astropy/__init__.py" = ["C408"]
-"astropy/config/*" = []
-"astropy/constants/*" = []
+"astropy/config/*" = [
+    "PTH114",  # os-path-islink
+    "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
+]
+"astropy/constants/*" = ["N817"]  # camelcase-imported-as-acronym
 "astropy/convolution/*" = []
-"astropy/coordinates/*" = ["C408"]
-"astropy/cosmology/*" = ["C408"]
-"astropy/io/*" = ["PIE790"]
+"astropy/coordinates/*" = [
+    "C408",  # unnecessary-collection-call
+    "DTZ007",  # call-datetime-strptime-without-zone
+]
+"astropy/cosmology/*" = [
+    "C408",  # unnecessary-collection-call
+    "PT019",   # pytest-fixture-param-without-value
+]
+"astropy/io/*" = [
+    "G001",  # logging-string-format
+    "G004",  # logging-f-string
+    "PIE790",  # unnecessary-pass
+    "PTH116",  # os-stat
+    "SLOT000",  # Subclasses of `str` should define `__slots__`
+    "TD005",  # Missing issue description after `TODO`
+    "TRY400",  # error-instead-of-exception
+]
 "astropy/logger.py" = ["C408"]
-"astropy/modeling/*" = ["C408"]
+"astropy/modeling/*" = [
+    "C408",  # unnecessary-collection-call
+    "SLOT001",  # Subclasses of `tuple` should define `__slots__`
+]
 "astropy/nddata/*" = ["C408"]
 "astropy/samp/*" = []
 "astropy/stats/*" = []
-"astropy/table/*" = ["C408", "PIE790"]
+"astropy/table/*" = [
+    "C408",  # unnecessary-collection-call
+    "PIE790",  # unnecessary-pass
+    "S605",  # Starting a process with a shell, possible injection detected
+]
 "astropy/tests/*" = ["C408"]
-"astropy/time/*" = ["C408", "PIE790"]
+"astropy/time/*" = [
+    "C408",  # unnecessary-collection-call
+    "FIX003",  # Line contains XXX.  replace XXX with TODO
+    "PIE790",  # unnecessary-pass
+    "PIE794",  # duplicate-class-field-definition
+]
 "astropy/timeseries/*" = ["C408"]
-"astropy/units/*" = ["C408", "F821", "PIE790"]
+"astropy/units/*" = [
+    "C408",  # unnecessary-collection-call
+    "F821",  # undefined-name
+    "N812",  # lowercase-imported-as-non-lowercase
+    "PIE790",  # unnecessary-pass
+]
 "astropy/uncertainty/*" = ["C408", "PIE790"]
-"astropy/utils/*" = ["C408", "PIE790"]
+"astropy/utils/*" = [
+    "C408",  # unnecessary-collection-call
+    "N811",  # constant-imported-as-non-constant
+    "PIE790",  # unnecessary-pass
+    "S321",  # Suspicious-ftp-lib-usage
+]
 "astropy/visualization/*" = ["B015", "C408", "PIE790"]
-"astropy/wcs/*" = ["C408", "F821", "PIE790"]
+"astropy/wcs/*" = [
+    "C408",  # unnecessary-collection-call
+    "F821",  # undefined-name
+    "PIE790",  # unnecessary-pass
+    "S608",  # Posslibe SQL injection
+    "SIM202",  # NegateNotEqualOp
+]
 "docs/*" = []
 "examples/coordinates/*" = []


### PR DESCRIPTION
### Description

`astropy` is globally ignoring many Ruff rules that are violated only in a single sub-package. Such rules can be identified by running once
```shell
ruff check --select=ALL --statistics . | sed "s/^\s*//" > all_stats
```
and then for each sub-package (e.g. `time`)
```shell
cat all_stats <(ruff --select=ALL --statistics astropy/time/ | sed "s/\s*//") \
    | sort \
    | uniq --repeated
```
The updated Ruff configuration prevents violations of the relevant rules from entering sub-packages that currently do not fail the rules.

Note that this pull request only updates Ruff configuration, so most of the CI tests are not relevant and the only one that matters is the `pre-commit.ci` job.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
