### PR TITLE
Fix minor gating in ruff update

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -107,7 +107,6 @@ ignore = [
     "PGH001",  # eval
 
     # Pylint (PLC, PLE, PLR, PLW)
-    "PLC1901",  # compare-to-empty-string
     "PLE0101",  # return-in-init
     "PLR0124",  # Name compared with itself
     "PLR0402",  # ConsiderUsingFromImport

--- a/astropy/uncertainty/function_helpers.py
+++ b/astropy/uncertainty/function_helpers.py
@@ -151,7 +151,7 @@ def concatenate(arrays, axis=0, out=None, dtype=None, casting="same_kind"):
 # Add any dispatched or helper function that has a docstring to __all__, so
 # they will be typeset by sphinx. The logic is that for those presumably the
 # way distributions are dealt with is not entirely obvious.
-__all__ += sorted(
+__all__ += sorted(  # noqa: PLE0605
     helper.__name__
     for helper in (set(FUNCTION_HELPERS.values()) | set(DISPATCHED_FUNCTIONS.values()))
     if helper.__doc__


### PR DESCRIPTION
Ruff's made some improvements w.r.t flaky tests and also expanded what it allows with ``__all__``. Somehow failures slipped through our regular update of pre-commit. This addresses these minor issues.

PRs will need to rebase to pick up the updated CI checks.