### PR TITLE
Increase auto_max_age from 30 to 300

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -173,7 +173,7 @@ class Conf(_config.ConfigNamespace):
         "out of date. Default is True.",
     )
     auto_max_age = _config.ConfigItem(
-        30.0,
+        300.0,
         "Maximum age (days) of predictive data before auto-downloading. "
         'See "Auto refresh behavior" in astropy.utils.iers documentation for details. '
         "Default is 30.",

--- a/docs/changes/utils/15436.api.rst
+++ b/docs/changes/utils/15436.api.rst
@@ -1,0 +1,1 @@
+``astropy.utils.iers.conf.auto_max_age`` default value is changed from 30 days to 300 days to prevent excessive network hit.

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -221,13 +221,13 @@ To see what configuration parameters are defined for a given ``conf``::
      ...,
      'ietf_leap_second_auto_url']
     >>> conf.auto_max_age
-    30.0
+    300.0
 
 You can also iterate through ``conf`` in a dictionary-like fashion::
 
     >>> list(conf.values())
     [<ConfigItem: name='auto_download' value=True at ...>,
-     <ConfigItem: name='auto_max_age' value=30.0 at ...>,
+     <ConfigItem: name='auto_max_age' value=300.0 at ...>,
      ...,
      <ConfigItem: name='ietf_leap_second_auto_url' value=...>]
     >>> for (key, cfgitem) in conf.items():
@@ -235,7 +235,7 @@ You can also iterate through ``conf`` in a dictionary-like fashion::
     ...         print(f'{cfgitem.description} Value is {cfgitem()}')
     Maximum age (days) of predictive data before auto-downloading. See "Auto
     refresh behavior" in astropy.utils.iers documentation for details. Default
-    is 30. Value is 30.0
+    is 300. Value is 300.0
 
 Upgrading ``astropy``
 ---------------------

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -102,7 +102,7 @@ important to consider are the following:
 
   auto_max_age:
     Maximum age of predictive data before auto-downloading (days).  See
-    next section for details. (default=30)
+    next section for details. (default=300)
 
   remote_timeout:
     Remote timeout downloading IERS file data (seconds)
@@ -140,7 +140,7 @@ polar motion values:
 
 The IERS Service provides the default online table
 (set by ``astropy.utils.iers.IERS_A_URL``) and updates the content
-once each 7 days.  The default value of ``auto_max_age`` is 30 days to avoid
+once each 7 days.  The default value of ``auto_max_age`` is 300 days to avoid
 unnecessary network access, but one can reduce this to as low as 10 days.
 
 .. _iers-working-offline:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to increase the default value of `auto_max_age` from 30 days to 300 days. The main goal is to reduce network hit from IERS related lookups.

I cannot tell if this needs updating (I did not touch it in the initial commit):

https://github.com/astropy/astropy/blob/e27b22432d1582f20dc15135afb116e5b3a1a165/astropy/utils/iers/iers.py#L1130

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14756 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
