### PR TITLE
undeprecate fnunpickle/fnpickle

### DIFF
--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -11,7 +11,6 @@ from astropy.utils.decorators import deprecated
 __all__ = ["fnpickle", "fnunpickle"]
 
 
-@deprecated(since="6.0", message="Use pickle from standard library, if you must")
 def fnunpickle(fileorname, number=0):
     """Unpickle pickled objects from a specified file and return the contents.
 
@@ -71,7 +70,6 @@ def fnunpickle(fileorname, number=0):
     return res
 
 
-@deprecated(since="6.0", message="Use pickle from standard library, if you must")
 def fnpickle(object, fileorname, protocol=None, append=False):
     """Pickle an object to a specified file.
 

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -14,19 +14,16 @@ def test_fnpickling_simple(tmp_path):
     fn = str(tmp_path / "test1.pickle")
 
     obj1 = "astring"
-    with pytest.warns(
-        AstropyDeprecationWarning, match="Use pickle from standard library"
-    ):
-        fnpickle(obj1, fn)
-        res = fnunpickle(fn, 0)
-        assert obj1 == res
+    fnpickle(obj1, fn)
+    res = fnunpickle(fn, 0)
+    assert obj1 == res
 
-        # now try with a file-like object instead of a string
-        with open(fn, "wb") as f:
-            fnpickle(obj1, f)
-        with open(fn, "rb") as f:
-            res = fnunpickle(f)
-            assert obj1 == res
+    # now try with a file-like object instead of a string
+    with open(fn, "wb") as f:
+        fnpickle(obj1, f)
+    with open(fn, "rb") as f:
+        res = fnunpickle(f)
+        assert obj1 == res
 
 
 class ToBePickled:
@@ -49,11 +46,8 @@ def test_fnpickling_class(tmp_path):
 
     obj1 = "astring"
     obj2 = ToBePickled(obj1)
-    with pytest.warns(
-        AstropyDeprecationWarning, match="Use pickle from standard library"
-    ):
-        fnpickle(obj2, fn)
-        res = fnunpickle(fn)
+    fnpickle(obj2, fn)
+    res = fnunpickle(fn)
     assert res == obj2
 
 
@@ -69,11 +63,9 @@ def test_fnpickling_protocol(tmp_path):
 
     for p in range(pickle.HIGHEST_PROTOCOL + 1):
         fn = str(tmp_path / f"testp{p}.pickle")
-        with pytest.warns(
-            AstropyDeprecationWarning, match="Use pickle from standard library"
-        ):
-            fnpickle(obj2, fn, protocol=p)
-            res = fnunpickle(fn)
+        
+        fnpickle(obj2, fn, protocol=p)
+        res = fnunpickle(fn)
         assert res == obj2
 
 
@@ -88,20 +80,17 @@ def test_fnpickling_many(tmp_path):
     # now try multiples
     obj3 = 328.3432
     obj4 = "blahblahfoo"
-    with pytest.warns(
-        AstropyDeprecationWarning, match="Use pickle from standard library"
-    ):
-        fnpickle(obj3, fn)
-        fnpickle(obj4, fn, append=True)
+    fnpickle(obj3, fn)
+    fnpickle(obj4, fn, append=True)
 
-        res = fnunpickle(fn, number=-1)
-        assert len(res) == 2
-        assert res[0] == obj3
-        assert res[1] == obj4
+    res = fnunpickle(fn, number=-1)
+    assert len(res) == 2
+    assert res[0] == obj3
+    assert res[1] == obj4
 
-        fnpickle(obj4, fn, append=True)
-        res = fnunpickle(fn, number=2)
-        assert len(res) == 2
+    fnpickle(obj4, fn, append=True)
+    res = fnunpickle(fn, number=2)
+    assert len(res) == 2
 
-        with pytest.raises(EOFError):
-            fnunpickle(fn, number=5)
+    with pytest.raises(EOFError):
+        fnunpickle(fn, number=5)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR partially reverts #15418 - that PR was very quickly merged, due to an out-of-band miscommunication about whether or not there was consensus on deprecating this (i.e., someone thought I was ok with this but as this PR demonstrates I am not).  I am *not* in favor of this, so this PR is here to un-do the deprecation (although *not* the warning in the docs, which I am happy with and agree is a good change).

My case for this is as follows:  The original reason for these functions is to serve as a *convenience* to users who use pickle a lot and find it inconvenient to always have to add extra lines of code around opening files for a very straightoforward operation.  This is why it is never used elsewhere in astropy: it is *not* meant for library code, but rather for end-users who are writing scientific analysis code.  So to me it's a feature not a bug that it doesn't appear in other libraries nor astropy itself.  In a library you should follow stricter standards and *not* use these functions, but that's not the case for quick science code for data exploration, etc. 

I, for example, *do* use this code sometimes, especially for saving data to be used across multiple notebooks, etc.  I.e. cases where I know *I* made all the relevant pickle/unpickle code, and don't need to worry about cross-version compatibility.

Now there is a fair question here whether anyone other than me uses it, since not that many people go looking for this kind of functionality in `utils`.  The problem is: I don't think we have any good way to judge this, since it's likely hidden away on science users' laptops or the like.

So my stance is that we should leave it in, because taking it out *might* cause harm to users, and I see little clear benefit to taking it out.  The original justification from #15418 is simply that it's not used elsewhere, but the same argument could be made for, say, the end-user cosmology functions... but there it's obvious they are not *meant* to be used in the library, so we wouldn't expect that.  So I think it should be with these.

Caveat: if someone can demonstrate that there's a bigger advantage to removing it than I'm seeing here, I can just close the PR. But I don't see it yet!

cc @nstarman @mhvk @pllim @hamogu as participants in #15418

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
