### PR TITLE
Address ruff's rule PIE790 in io submodule

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -249,7 +249,6 @@ unfixable = [
 "astropy/io/*" = [
     "G001",  # logging-string-format
     "G004",  # logging-f-string
-    "PIE790",  # unnecessary-pass
     "PTH116",  # os-stat
     "SLOT000",  # Subclasses of `str` should define `__slots__`
     "TD005",  # Missing issue description after `TODO`

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -112,14 +112,12 @@ class EcsvHeader(basic.BasicHeader):
         WRITE: Override the default write_comments to do nothing since this is handled
         in the custom write method.
         """
-        pass
 
     def update_meta(self, lines, meta):
         """
         READ: Override the default update_meta to do nothing.  This process is done
         in get_cols() for this reader.
         """
-        pass
 
     def get_cols(self, lines):
         """

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -84,8 +84,6 @@ for further documentation.
 class ExtensionNotFoundException(Exception):
     """Raised if an HDU extension requested by the user does not exist."""
 
-    pass
-
 
 class HeaderFormatter:
     """Class to format the header(s) of a FITS file for display by the

--- a/astropy/io/registry/base.py
+++ b/astropy/io/registry/base.py
@@ -14,8 +14,6 @@ __all__ = ["IORegistryError"]
 class IORegistryError(Exception):
     """Custom error for registry clashes."""
 
-    pass
-
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request is to address violations to Ruff's rule PIE790, which is listed explicitly in issue https://github.com/astropy/astropy/issues/14818. Only submodule io is addressed.

This is part of a series of PRs split from https://github.com/astropy/astropy/pull/15239, following suggestions by @nstarman.

Solves part of https://github.com/astropy/astropy/issues/14818.

This PR is directly connected to https://github.com/astropy/astropy/pull/15279. After some conflicts, I had the latter closed by mistake and GitHub won't allow reopening it.
