### PR TITLE
Remove unnecessary `FlatFLRWMixin.clone()`

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -548,13 +548,12 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
             'Planck13 (modified)'
 
         The keyword 'to_nonflat' can be used to clone on the non-flat equivalent
-        cosmology.
+        cosmology. For :class:`~astropy.cosmology.FLRW` cosmologies this means
+        ``Ode0`` can be modified:
 
-            >>> Planck13.clone(to_nonflat=True)
-            LambdaCDM(name="Planck13", ...
-
-            >>> Planck13.clone(H0=70, to_nonflat=True)
-            LambdaCDM(name="Planck13 (modified)", H0=70.0 km / (Mpc s), ...
+            >>> Planck13.clone(to_nonflat=True, Ode0=1)
+            LambdaCDM(name="Planck13 (modified)", H0=67.77 km / (Mpc s),
+                      Om0=0.30712, Ode0=1.0, ...
         """
         if to_nonflat:
             return self.nonflat.clone(meta=meta, **kwargs)

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -6,7 +6,7 @@ import warnings
 from abc import abstractmethod
 from math import exp, floor, log, pi, sqrt
 from numbers import Number
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TypeVar
 
 import numpy as np
 from numpy import inf, sin
@@ -28,9 +28,6 @@ __all__ = ["FLRW", "FlatFLRWMixin"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 # isort: split
 if HAS_SCIPY:
@@ -1505,68 +1502,6 @@ class FlatFLRWMixin(FlatCosmologyMixin):
             setattr(inst, "_" + n, getattr(self, n))
 
         return inst
-
-    def clone(
-        self,
-        *,
-        meta: Mapping | None = None,
-        to_nonflat: bool | None = None,
-        **kwargs: Any,
-    ):
-        """Returns a copy of this object with updated parameters, as specified.
-
-        This cannot be used to change the type of the cosmology, except for
-        changing to the non-flat version of this cosmology.
-
-        Parameters
-        ----------
-        meta : mapping or None (optional, keyword-only)
-            Metadata that will update the current metadata.
-        to_nonflat : bool or None, optional keyword-only
-            Whether to change to the non-flat version of this cosmology.
-        **kwargs
-            Cosmology parameter (and name) modifications. If any parameter is
-            changed and a new name is not given, the name will be set to "[old
-            name] (modified)".
-
-        Returns
-        -------
-        newcosmo : `~astropy.cosmology.Cosmology` subclass instance
-            A new instance of this class with updated parameters as specified.
-            If no arguments are given, then a reference to this object is
-            returned instead of copy.
-
-        Examples
-        --------
-        To make a copy of the ``Planck13`` cosmology with a different matter
-        density (``Om0``), and a new name:
-
-            >>> from astropy.cosmology import Planck13
-            >>> Planck13.clone(name="Modified Planck 2013", Om0=0.35)
-            FlatLambdaCDM(name="Modified Planck 2013", H0=67.77 km / (Mpc s),
-              Om0=0.35, ...
-
-        If no name is specified, the new name will note the modification.
-
-            >>> Planck13.clone(Om0=0.35).name
-            'Planck13 (modified)'
-
-        The keyword 'to_nonflat' can be used to clone on the non-flat equivalent
-        cosmology.
-
-            >>> Planck13.clone(to_nonflat=True)
-            LambdaCDM(name="Planck13", ...
-
-            >>> Planck13.clone(H0=70, to_nonflat=True)
-            LambdaCDM(name="Planck13 (modified)", H0=70.0 km / (Mpc s), ...
-
-        With 'to_nonflat' `True`, ``Ode0`` can be modified.
-
-            >>> Planck13.clone(to_nonflat=True, Ode0=1)
-            LambdaCDM(name="Planck13 (modified)", H0=67.77 km / (Mpc s),
-                      Om0=0.30712, Ode0=1.0, ...
-        """
-        return super().clone(meta=meta, to_nonflat=to_nonflat, **kwargs)
 
     @property
     def Otot0(self):


### PR DESCRIPTION
### Description

The removed method used `super()` to always call its parent class `clone()` method without modifying any arguments. Removing the method makes `FlatFLRWMixin` inherit `clone()` from the parent class, resulting in exactly the same behavior. There were minor differences in the docstrings of the two `clone()` methods, but there was no good reason not to have a common docstring.

I found this duplicated method when I was working on #15354, but the two pull requests are independent of each other and can be merged in any order.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
