### PR TITLE
Ensure mask calculation is correct also for multi-op ufunc with scalars

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -697,7 +697,9 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
                 np.copyto(out, masks[0], where=where)
                 return out
 
-        out = np.logical_or(masks[0], masks[1], out=out, where=where)
+        # [...] at the end to ensure we have an array, not a scalar, and
+        # thus can be used for in-place changes in the loop.
+        out = np.logical_or(masks[0], masks[1], out=out, where=where)[...]
         for mask in masks[2:]:
             np.logical_or(out, mask, out=out, where=where)
         return out

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -5,6 +5,7 @@ The tests here are fairly detailed but do not aim for complete
 coverage.  Complete coverage of all numpy functions is done
 with less detailed tests in test_function_helpers.
 """
+import erfa.ufunc as erfa_ufunc
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -150,6 +151,27 @@ class MaskedUfuncTests(MaskedArraySetup):
         expected_mask = self.mask_a
         assert_array_equal(ma_mb.unmasked, expected_data)
         assert_array_equal(ma_mb.mask, expected_mask)
+
+    def test_multi_op_ufunc(self):
+        mask = [True, False, False]
+        iy = Masked([2000, 2001, 2002], mask=mask)
+        im = Masked([1, 2, 3], mask=mask)
+        idy = Masked([10, 20, 25], mask=mask)
+        ihr = Masked([11, 12, 13], mask=[False, False, True])
+        imn = np.array([50, 51, 52])
+        isc = np.array([12.5, 13.6, 14.7])
+        result = erfa_ufunc.dtf2d("utc", iy, im, idy, ihr, imn, isc)
+        # Also test scalar
+        result0 = erfa_ufunc.dtf2d("utc", iy[0], im[0], idy[0], ihr[0], imn[0], isc[0])
+        expected = erfa_ufunc.dtf2d(
+            "utc", iy.unmasked, im.unmasked, idy.unmasked, ihr.unmasked, imn, isc
+        )
+        expected_mask = np.array([True, False, True])
+        for res, res0, exp in zip(result, result0, expected):
+            assert_array_equal(res.unmasked, exp)
+            assert_array_equal(res.mask, expected_mask)
+            assert res0.unmasked == exp[0]
+            assert res0.mask == expected_mask[0]
 
     @pytest.mark.parametrize("axis", (0, 1, None))
     def test_add_reduce(self, axis):

--- a/docs/changes/utils/15450.bugfix.rst
+++ b/docs/changes/utils/15450.bugfix.rst
@@ -1,0 +1,2 @@
+Ufuncs with more than 2 operands (such as ``erfa.dtf2d``) now work
+also if all inputs are scalars and more than two inputs have masks.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a small bug where if a ufunc with more than 2 scalar `Masked` arguments was used, the resulting mask could not be calculated.

Found in #15231

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
