### PR TITLE
Ensure Masked scalars print the same way as regular array scalars

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1053,9 +1053,21 @@ def array2string(
     return _array2string(a, options, separator, prefix)
 
 
+def _array_str_scalar(x):
+    # This wraps np.array_str for use as a format function in
+    # MaskedFormat. We cannot use it directly as format functions
+    # expect numpy scalars, while np.array_str expects an array.
+    return np.array_str(np.array(x))
+
+
 @dispatched_function
 def array_str(a, max_line_width=None, precision=None, suppress_small=None):
-    # Override to avoid special treatment of array scalars.
+    # Override to change special treatment of array scalars, since the numpy
+    # code turns the masked array scalar into a regular array scalar.
+    # By going through MaskedFormat, we can replace the string as needed.
+    if a.shape == () and a.dtype.names is None:
+        return MaskedFormat(_array_str_scalar)(a)
+
     return array2string(a, max_line_width, precision, suppress_small, " ", "")
 
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1294,17 +1294,44 @@ class TestMaskedArrayProductMethods(MaskedArraySetup):
         assert_array_equal(ma_sum.mask, expected_mask)
 
 
-def test_masked_str_explicit():
+def test_masked_str_repr_explicit_float():
+    sa = np.array([np.pi, 2 * np.pi])
+    msa = Masked(sa, [False, True])
+    # Test masking  the array works as expected, including truncating digits
+    assert str(msa) == "[3.14159265        ———]"
+    # Test the digits are kept for scalars.
+    assert str(msa[0]) == "3.141592653589793" == str(sa[0])
+    # And that the masked string has the same length.
+    assert str(msa[1]) == "              ———"
+    # Test temporary precision change (which does not affect scalars).
+    with np.printoptions(precision=3, floatmode="fixed"):
+        assert str(msa) == "[3.142   ———]"
+        assert str(msa[0]) == "3.141592653589793" == str(sa[0])
+    assert repr(msa) == "MaskedNDArray([3.14159265,        ———])"
+
+
+def test_masked_str_explicit_string():
+    sa = np.array(["2001-02-03", "2002-03-04"])
+    msa = Masked(sa, [False, True])
+    assert str(msa) == "['2001-02-03'          ———]"
+    assert str(msa[0]) == "2001-02-03" == str(sa[0])
+    assert str(msa[1]) == "       ———"
+    assert repr(msa) == "MaskedNDArray(['2001-02-03',          ———], dtype='<U10')"
+
+
+def test_masked_str_explicit_structured():
     sa = np.array([(1.0, 2.0), (3.0, 4.0)], dtype="f8,f8")
     msa = Masked(sa, [(False, True), (False, False)])
     assert str(msa) == "[(1., ——) (3., 4.)]"
     assert str(msa[0]) == "(1., ——)"
-    assert str(msa[1]) == "(3., 4.)"
+    assert str(msa[1]) == "(3., 4.)" == str(sa[1])
     with np.printoptions(precision=3, floatmode="fixed"):
         assert str(msa) == "[(1.000,   ———) (3.000, 4.000)]"
+        assert str(msa[0]) == "(1.000,   ———)"
+        assert str(msa[1]) == "(3.000, 4.000)" == str(sa[1])
 
 
-def test_masked_repr_explicit():
+def test_masked_repr_explicit_structured():
     # Use explicit endianness to ensure tests pass on all architectures
     sa = np.array([(1.0, 2.0), (3.0, 4.0)], dtype=">f8,>f8")
     msa = Masked(sa, [(False, True), (False, False)])

--- a/docs/changes/utils/15451.bugfix.rst
+++ b/docs/changes/utils/15451.bugfix.rst
@@ -1,0 +1,3 @@
+Ensured that ``str(masked_array)`` looks like ``str(unmasked_array)`` also for
+array scalars. Thus, like regular array scalars, the precision is ignored for
+float, and strings do not include extra quoting.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to ensured that `str(masked_array)` looks like `str(unmasked_array)` also for array scalars. Thus, like regular array scalars, the precision is ignored for float, and strings do not include extra quoting.

Found in #15231

I think this should not be backported, since it is not nice if `str(anything)` changes in a bug-fix release. But I do consider it more of a bug-fix than an API change (though happy to change it if need be).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
