### PR TITLE
Ensure cache coherence for views of time instances

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -25,6 +25,7 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray, lazyproperty
+from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
@@ -487,6 +488,13 @@ class TimeBase(ShapedLikeNDArray):
 
     def __getnewargs__(self):
         return (self._time,)
+
+    def __getstate__(self):
+        # For pickling, we remove the cache from what's pickled
+        state = (self.__dict__ if PYTHON_LT_3_11 else super().__getstate__()).copy()
+        state.pop("_id_cache", None)
+        state.pop("cache", None)
+        return state
 
     def _init_from_vals(
         self,

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from datetime import date, datetime, timezone
 from time import strftime
 from warnings import warn
+from weakref import WeakValueDictionary
 
 import erfa
 import numpy as np
@@ -23,9 +24,8 @@ from astropy import constants as const
 from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
-from astropy.utils import ShapedLikeNDArray
+from astropy.utils import ShapedLikeNDArray, lazyproperty
 from astropy.utils.data_info import MixinInfo, data_info_factory
-from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
 
@@ -1414,6 +1414,11 @@ class TimeBase(ShapedLikeNDArray):
         tm._format = new_format
         tm.SCALES = self.SCALES
 
+        # Finally, if we do not own our data, we link caches, so that
+        # those can be cleared as needed if any instance is written to.
+        if not (tm._time.jd1.base if tm.masked else tm._time.jd1).flags["OWNDATA"]:
+            tm._id_cache = self._id_cache
+
         return tm
 
     def __copy__(self):
@@ -1704,11 +1709,30 @@ class TimeBase(ShapedLikeNDArray):
         return result
 
     @lazyproperty
+    def _id_cache(self):
+        """Cache of all instances that share underlying data.
+
+        Helps to ensure all cached data can be deleted if the
+        underlying data is changed.
+        """
+        return WeakValueDictionary({id(self): self})
+
+    @_id_cache.setter
+    def _id_cache(self, _id_cache):
+        _id_cache[id(self)] = self
+        # lazyproperty will do the actual storing of the result.
+
+    @lazyproperty
     def cache(self):
         """
         Return the cache associated with this instance.
         """
         return defaultdict(dict)
+
+    @cache.deleter
+    def cache(self):
+        for instance in self._id_cache.values():
+            instance.cache.clear()
 
     def __getattr__(self, attr):
         """

--- a/astropy/time/tests/test_pickle.py
+++ b/astropy/time/tests/test_pickle.py
@@ -25,3 +25,17 @@ class TestPickle:
             t2d = pickle.dumps(t2, prot)
             t2l = pickle.loads(t2d)
             assert t2l == t2
+
+    def test_cache_not_shared(self):
+        t = Time(["2001:020", "2001:040", "2001:060", "2001:080"], out_subfmt="date")
+        # Ensure something is in the cache.
+        t.value
+        assert "format" in t.cache
+        td = pickle.dumps(t)
+        assert "format" in t.cache
+        tl = pickle.loads(td)
+        assert "format" in t.cache
+        assert "format" not in tl.cache
+        t[0] = "1999:099"
+        assert t.value[0] == "1999:099"
+        assert tl.value[0] == "2001:020"

--- a/docs/changes/time/15453.bugfix.rst
+++ b/docs/changes/time/15453.bugfix.rst
@@ -1,0 +1,5 @@
+Ensure that the ``Time`` caches of formats and scales do not get out
+of sync with the actual data, even if another instance, holding a view
+of the data is written to.  E.g., if one does ``t01 = t[:2]``, and
+sets ``t[0]`` after, it is now guaranteed that ``t01.value`` will
+correctly reflect that change in value.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request ensures that the ``Time`` caches of formats and scales do not get out of sync with the actual data, even if another instance, holding a view of the data is written to.  E.g., if one does ``t01 = t[:2]``, and sets ``t[0]`` after, it is now guaranteed that ``t01.value`` will correctly reflect that change in value.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15452

@taldcroft - this was considerably simpler than I thought! Though I think that perhaps the cache itself also needs to become a `WeakValueDictionary` so that, say, if one has `tt = t.tt` and later does `del tt`, the cache does not keep `tt` alive. But probably better as a separate PR since that would not be a bug fix. EDIT: on second thought, not sure `WeakValueDictionary` would work for "scale", since I think part of the original rationale was that one could do `jd1 = t.tt.jd1; jd2 = t.tt.jd2` and not have `tt` calculated twice. Anyway, that's orthogonal to this PR.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
