### PR TITLE
Removing deprecated code for _model_to_fit_params

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -32,7 +32,6 @@ from importlib.metadata import entry_points
 import numpy as np
 
 from astropy.units import Quantity
-from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .optimizers import DEFAULT_ACC, DEFAULT_EPS, DEFAULT_MAXITER, SLSQP, Simplex
@@ -2057,14 +2056,6 @@ def fitter_to_model_params(model, fps, use_min_max_bounds=True):
                 model._array_to_parameters()
 
 
-@deprecated(
-    since="5.1",
-    message="private method: _fitter_to_model_params has been made public now",
-)
-def _fitter_to_model_params(model, fps):
-    return fitter_to_model_params(model, fps)
-
-
 def model_to_fit_params(model):
     """
     Convert a model instance's parameter array to an array that can be used
@@ -2102,14 +2093,6 @@ def model_to_fit_params(model):
         model_bounds[idx] = (lower, upper)
     model_bounds = tuple(zip(*model_bounds))
     return model_params, fitparam_indices, model_bounds
-
-
-@deprecated(
-    since="5.1",
-    message="private method: _model_to_fit_params has been made public now",
-)
-def _model_to_fit_params(model):
-    return model_to_fit_params(model)
 
 
 def _validate_constraints(supported_constraints, model):

--- a/docs/changes/modeling/15461.api.rst
+++ b/docs/changes/modeling/15461.api.rst
@@ -1,0 +1,1 @@
+Removal of deprecated code ``_model_to_fit_params`` and ``_fitter_to_model_params`` from ``fitting.py``.

--- a/docs/modeling/new-fitter.rst
+++ b/docs/modeling/new-fitter.rst
@@ -45,7 +45,7 @@ necessary::
                     'Model is linear in parameters; '
                     'non-linear fitting methods should not be used.')
         model_copy = model.copy()
-        init_values, _ = _model_to_fit_params(model_copy)
+        init_values, _ = model_to_fit_params(model_copy)
         self.fitparams = optimize.fmin_slsqp(self.errorfunc, p0=init_values,
                                              args=(y, x),
                                              bounds=self.bounds,
@@ -93,8 +93,8 @@ The following import statements are needed::
 
     import numpy as np
     from astropy.modeling.fitting import (_validate_model,
-                                          _fitter_to_model_params,
-                                          _model_to_fit_params, Fitter,
+                                          fitter_to_model_params,
+                                          model_to_fit_params, Fitter,
                                           _convert_input)
     from astropy.modeling.optimizers import Simplex
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of deprecated code in the modeling subpackage for the fitting module.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Address one of #15455

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
