### PR TITLE
MNT: Removed deprecated ConfigurationMissingWarning and update_default_config

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -22,15 +22,12 @@ from warnings import warn
 
 from astropy.extern.configobj import configobj, validate
 from astropy.utils import find_current_module, silence
-from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from astropy.utils.introspection import resolve_name
 
 from .paths import get_config_dir
 
 __all__ = (
     "InvalidConfigurationItemWarning",
-    "ConfigurationMissingWarning",
     "get_config",
     "reload_config",
     "ConfigNamespace",
@@ -44,17 +41,6 @@ class InvalidConfigurationItemWarning(AstropyWarning):
     """A Warning that is issued when the configuration value specified in the
     astropy configuration file does not match the type expected for that
     configuration value.
-    """
-
-
-# This was raised with Astropy < 4.3 when the configuration file was not found.
-# It is kept for compatibility and should be removed at some point.
-@deprecated("5.0")
-class ConfigurationMissingWarning(AstropyWarning):
-    """A Warning that is issued when the configuration directory cannot be
-    accessed (usually due to a permissions problem). If this warning appears,
-    configuration items will be set to their defaults rather than read from the
-    configuration file, and no configuration will persist across sessions.
     """
 
 
@@ -772,110 +758,6 @@ def is_unedited_config_file(content, template_content=None):
     raw_cfg = configobj.ConfigObj(buffer, interpolation=True)
     # If any of the items is set, return False
     return not any(len(v) > 0 for v in raw_cfg.values())
-
-
-# This function is no more used by astropy but it is kept for the other
-# packages that may use it (e.g. astroquery). It should be removed at some
-# point.
-# this is not in __all__ because it's not intended that a user uses it
-@deprecated("5.0")
-def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname="astropy"):
-    """
-    Checks if the configuration file for the specified package exists,
-    and if not, copy over the default configuration.  If the
-    configuration file looks like it has already been edited, we do
-    not write over it, but instead write a file alongside it named
-    ``pkg.version.cfg`` as a "template" for the user.
-
-    Parameters
-    ----------
-    pkg : str
-        The package to be updated.
-    default_cfg_dir_or_fn : str
-        The filename or directory name where the default configuration file is.
-        If a directory name, ``'pkg.cfg'`` will be used in that directory.
-    version : str, optional
-        The current version of the given package.  If not provided, it will
-        be obtained from ``pkg.__version__``.
-    rootname : str
-        Name of the root configuration directory.
-
-    Returns
-    -------
-    updated : bool
-        If the profile was updated, `True`, otherwise `False`.
-
-    Raises
-    ------
-    AttributeError
-        If the version number of the package could not determined.
-
-    """
-    if path.isdir(default_cfg_dir_or_fn):
-        default_cfgfn = path.join(default_cfg_dir_or_fn, pkg + ".cfg")
-    else:
-        default_cfgfn = default_cfg_dir_or_fn
-
-    if not path.isfile(default_cfgfn):
-        # There is no template configuration file, which basically
-        # means the affiliated package is not using the configuration
-        # system, so just return.
-        return False
-
-    cfgfn = get_config(pkg, rootname=rootname).filename
-
-    with open(default_cfgfn, encoding="latin-1") as fr:
-        template_content = fr.read()
-
-    doupdate = False
-    if cfgfn is not None:
-        if path.exists(cfgfn):
-            with open(cfgfn, encoding="latin-1") as fd:
-                content = fd.read()
-
-            identical = content == template_content
-
-            if not identical:
-                doupdate = is_unedited_config_file(content, template_content)
-        elif path.exists(path.dirname(cfgfn)):
-            doupdate = True
-            identical = False
-
-    if version is None:
-        version = resolve_name(pkg, "__version__")
-
-    # Don't install template files for dev versions, or we'll end up
-    # spamming `~/.astropy/config`.
-    if version and "dev" not in version and cfgfn is not None:
-        template_path = path.join(
-            get_config_dir(rootname=rootname), f"{pkg}.{version}.cfg"
-        )
-        needs_template = not path.exists(template_path)
-    else:
-        needs_template = False
-
-    if doupdate or needs_template:
-        if needs_template:
-            with open(template_path, "w", encoding="latin-1") as fw:
-                fw.write(template_content)
-            # If we just installed a new template file and we can't
-            # update the main configuration file because it has user
-            # changes, display a warning.
-            if not identical and not doupdate:
-                warn(
-                    f"The configuration options in {pkg} {version} may have changed, "
-                    "your configuration file was not updated in order to "
-                    "preserve local changes.  A new configuration template "
-                    f"has been saved to '{template_path}'.",
-                    ConfigurationChangedWarning,
-                )
-
-        if doupdate and not identical:
-            with open(cfgfn, "w", encoding="latin-1") as fw:
-                fw.write(template_content)
-            return True
-
-    return False
 
 
 def create_config_file(pkg, rootname="astropy", overwrite=False):

--- a/docs/changes/config/15466.api.rst
+++ b/docs/changes/config/15466.api.rst
@@ -1,0 +1,2 @@
+Removed deprecated ``ConfigurationMissingWarning`` class and ``update_default_config`` function;
+There are no replacements as they should no be used anymore.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address config portion of https://github.com/astropy/astropy/issues/15455 . Since `astroquery` is explicitly mentioned in the comment, I will ping astroquery maintainer to review as well.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
