### PR TITLE
TST: Removed deprecated raises within io.ascii test helper

### DIFF
--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -4,8 +4,6 @@ import os
 
 import numpy as np
 
-from astropy.utils.decorators import deprecated
-
 __all__ = [
     "assert_equal",
     "assert_almost_equal",
@@ -75,41 +73,6 @@ def make_decorator(func):
         except TypeError:
             # can't set func name in 2.3
             newfunc.compat_func_name = name
-        return newfunc
-
-    return decorate
-
-
-@deprecated("5.1", alternative="pytest.raises")
-def raises(*exceptions):
-    """Test must raise one of expected exceptions to pass.
-
-    Example use::
-
-      @raises(TypeError, ValueError)
-      def test_raises_type_error():
-          raise TypeError("This test passes")
-
-      @raises(Exception)
-      def test_that_fails_by_passing():
-          pass
-
-    """
-    valid = " or ".join([e.__name__ for e in exceptions])
-
-    def decorate(func):
-        name = func.__name__
-
-        def newfunc(*arg, **kw):
-            try:
-                func(*arg, **kw)
-            except exceptions:
-                pass
-            else:
-                message = f"{name}() did not raise {valid}"
-                raise AssertionError(message)
-
-        newfunc = make_decorator(func)(newfunc)
         return newfunc
 
     return decorate

--- a/docs/changes/io.ascii/15470.api.rst
+++ b/docs/changes/io.ascii/15470.api.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``astropy.io.ascii.tests.common.raises`` test helper; use ``pytest.raises`` instead.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the io.ascii portion of https://github.com/astropy/astropy/issues/15455 . I originally didn't think we wanted a change log but I changed my mind because it is documented in a conversion guide in dev docs along with other test helpers we removed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
