### PR TITLE
Ensure tables with masked and unmasked columns roundtrip properly

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -541,12 +541,13 @@ def table_to_hdu(table, character_as_bytes=False):
             # Binary FITS tables support TNULL *only* for integer data columns
             # TODO: Determine a schema for handling non-integer masked columns
             # with non-default fill values in FITS (if at all possible).
+            # Be careful that we do not set null for columns that were not masked!
             int_formats = ("B", "I", "J", "K")
-            if not (col.format in int_formats or col.format.p_format in int_formats):
-                continue
-
-            fill_value = tarray[col.name].fill_value
-            col.null = fill_value.astype(int)
+            if (
+                col.format in int_formats or col.format.p_format in int_formats
+            ) and hasattr(table[col.name], "mask"):
+                fill_value = tarray[col.name].fill_value
+                col.null = fill_value.astype(int)
     else:
         table_hdu = BinTableHDU.from_columns(
             tarray, header=hdr, character_as_bytes=character_as_bytes

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -21,7 +21,7 @@ from astropy.io.fits.column import (
     python_to_tdisp,
 )
 from astropy.io.tests.mixin_columns import compare_attrs, mixin_cols, serialized_names
-from astropy.table import Column, QTable, Table
+from astropy.table import Column, MaskedColumn, QTable, Table
 from astropy.table.table_helpers import simple_table
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
@@ -1064,3 +1064,15 @@ def test_meta_not_modified(tmp_path):
 def test_is_fits_gh_14305():
     """Regression test for https://github.com/astropy/astropy/issues/14305"""
     assert not connect.is_fits("", "foo.bar", None)
+
+
+def test_keep_masked_state_integer_columns(tmp_path):
+    """Regression test for https://github.com/astropy/astropy/issues/15417"""
+    filename = tmp_path / "test_masked.fits"
+    t = Table([[1, 2], [1.5, 2.5]], names=["a", "b"])
+    t["c"] = MaskedColumn([1, 2], mask=[True, False])
+    t.write(filename)
+    tr = Table.read(filename)
+    assert not isinstance(tr["a"], MaskedColumn)
+    assert not isinstance(tr["b"], MaskedColumn)
+    assert isinstance(tr["c"], MaskedColumn)

--- a/docs/changes/io.fits/15473.bugfix.rst
+++ b/docs/changes/io.fits/15473.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that tables written to FITS with both masked and unmasked columns
+roundtrip properly (previously, all integer columns would become masked
+if any column was masked).


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address that when a table was written to FITS and read back, all integer columns would become masked if any column in the table was masked.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15417

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
