### PR TITLE
Refactor CompImageHDU to inherit from ImageHDU

### DIFF
--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -528,7 +528,7 @@ def compress_image_data(
     for irow, tile_slices in _iter_array_tiles(data_shape, tile_shape):
         tile_data = image_data[tile_slices]
 
-        # FIXME: hack for now
+        # FIXME: determine whether the following needs to be dependent on the uint= option
         if tile_data.dtype.kind == "u":
             if tile_data.dtype.itemsize == 4:
                 tile_data = (tile_data.astype(np.int64) - 2**31).astype(np.int32)

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -528,7 +528,6 @@ def compress_image_data(
     for irow, tile_slices in _iter_array_tiles(data_shape, tile_shape):
         tile_data = image_data[tile_slices]
 
-        # FIXME: determine whether the following needs to be dependent on the uint= option
         if tile_data.dtype.kind == "u":
             if tile_data.dtype.itemsize == 4:
                 tile_data = (tile_data.astype(np.int64) - 2**31).astype(np.int32)

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -528,6 +528,13 @@ def compress_image_data(
     for irow, tile_slices in _iter_array_tiles(data_shape, tile_shape):
         tile_data = image_data[tile_slices]
 
+        # FIXME: hack for now
+        if tile_data.dtype.kind == "u":
+            if tile_data.dtype.itemsize == 4:
+                tile_data = (tile_data.astype(np.int64) - 2**31).astype(np.int32)
+            elif tile_data.dtype.itemsize == 2:
+                tile_data = (tile_data.astype(np.int32) - 2**15).astype(np.int16)
+
         settings = _update_tile_settings(settings, compression_type, tile_data.shape)
 
         quantize = "ZSCALE" in compressed_coldefs.dtype.names

--- a/astropy/io/fits/hdu/compressed/compbintable.py
+++ b/astropy/io/fits/hdu/compressed/compbintable.py
@@ -1,0 +1,17 @@
+from astropy.io.fits.hdu.table import BinTableHDU
+
+__all__ = ["_CompBinTableHDU"]
+
+
+class _CompBinTableHDU(BinTableHDU):
+    _load_variable_length_data = False
+    """
+    We don't want to always load all the tiles so by setting this option
+    we can then access the tiles as needed.
+    """
+
+    _manages_own_heap = True
+
+    @classmethod
+    def match_header(cls, header):
+        return False

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -755,7 +755,7 @@ class CompImageHDU(ImageHDU):
         if "SIMPLE" in self.header:
             errs_filtered = []
             for err in errs:
-                if err and err[1] in (
+                if len(err) >= 2 and err[1] in (
                     "'XTENSION' card does not exist.",
                     "'PCOUNT' card does not exist.",
                     "'GCOUNT' card does not exist.",

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -612,12 +612,15 @@ class CompImageHDU(ImageHDU):
         return self._bintable is None or self.header._modified or self._data_modified
 
     def _prewriteto(self, checksum=False, inplace=False):
-
         # In some cases the user might do hdu.data.shape = (...) to change the
         # shape of the data. In this case, we reset the data on the image HDU
         # to force the header to be updated and to set _data_modified since
         # the data will need to be recompressed from scratch.
-        if not self._data_modified and self._decompressed_data is not None and self._decompressed_data.shape != self._original_data_shape:
+        if (
+            not self._data_modified
+            and self._decompressed_data is not None
+            and self._decompressed_data.shape != self._original_data_shape
+        ):
             ImageHDU.data.fset(self, self.data)
 
         if inplace and not self._hdu_modified_from_disk:

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -63,13 +63,13 @@ class CompImageHDU(ImageHDU):
         data=None,
         header=None,
         name=None,
-        compression_type=None,
+        compression_type=DEFAULT_COMPRESSION_TYPE,
         tile_shape=None,
-        hcomp_scale=None,
-        hcomp_smooth=None,
-        quantize_level=None,
-        quantize_method=None,
-        dither_seed=None,
+        hcomp_scale=DEFAULT_HCOMP_SCALE,
+        hcomp_smooth=DEFAULT_HCOMP_SMOOTH,
+        quantize_level=DEFAULT_QUANTIZE_LEVEL,
+        quantize_method=DEFAULT_QUANTIZE_METHOD,
+        dither_seed=DEFAULT_DITHER_SEED,
         do_not_scale_image_data=False,
         uint=True,
         scale_back=None,
@@ -381,19 +381,17 @@ class CompImageHDU(ImageHDU):
                 if simple is not None:
                     self.header["SIMPLE"] = simple
 
-            self.compression_type = compression_type or DEFAULT_COMPRESSION_TYPE
+            self.compression_type = compression_type
             self.tile_shape = _validate_tile_shape(
                 tile_shape=tile_shape,
                 compression_type=self.compression_type,
                 image_header=self.header,
             )
-            self.hcomp_scale = hcomp_scale or DEFAULT_HCOMP_SCALE
-            self.hcomp_smooth = hcomp_smooth or DEFAULT_HCOMP_SMOOTH
-            self.quantize_level = (
-                quantize_level if quantize_level is not None else DEFAULT_QUANTIZE_LEVEL
-            )
-            self.quantize_method = quantize_method or DEFAULT_QUANTIZE_METHOD
-            self.dither_seed = dither_seed or DEFAULT_DITHER_SEED
+            self.hcomp_scale = hcomp_scale
+            self.hcomp_smooth = hcomp_smooth
+            self.quantize_level = quantize_level
+            self.quantize_method = quantize_method
+            self.dither_seed = dither_seed
 
             # TODO: just for parameter validation, e.g. tile shape - we shouldn't
             # ideally need this and should instead validate the values as they are

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -42,13 +42,7 @@ from .settings import (
 )
 from .utils import _validate_tile_shape
 
-__all__ = ["COMPRESSION_ENABLED", "CompImageHDU"]
-
-# This global variable is used e.g., when calling fits.open with
-# disable_image_compression which temporarily changes the global variable to
-# False. This should ideally be refactored to avoid relying on global module
-# variables.
-COMPRESSION_ENABLED = True
+__all__ = ["CompImageHDU"]
 
 
 class CompImageHDU(ImageHDU):
@@ -446,7 +440,7 @@ class CompImageHDU(ImageHDU):
         if "ZIMAGE" not in header or not header["ZIMAGE"]:
             return False
 
-        return COMPRESSION_ENABLED
+        return True
 
     @property
     def compression_type(self):

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -617,7 +617,7 @@ class CompImageHDU(ImageHDU):
         # shape of the data. In this case, we reset the data on the image HDU
         # to force the header to be updated and to set _data_modified since
         # the data will need to be recompressed from scratch.
-        if self._decompressed_data is not None and self._decompressed_data.shape != self._original_data_shape:
+        if not self._data_modified and self._decompressed_data is not None and self._decompressed_data.shape != self._original_data_shape:
             ImageHDU.data.fset(self, self.data)
 
         if inplace and not self._hdu_modified_from_disk:

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -607,16 +607,6 @@ class CompImageHDU(ImageHDU):
         return self._bintable is None or self.header._modified or self._data_modified
 
     def _prewriteto(self, checksum=False, inplace=False):
-        # In some cases the user might do hdu.data.shape = (...) to change the
-        # shape of the data. In this case, we reset the data on the image HDU
-        # to force the header to be updated and to set _data_modified since
-        # the data will need to be recompressed from scratch.
-        if (
-            not self._data_modified
-            and self._decompressed_data is not None
-            and self._decompressed_data.shape != self._original_data_shape
-        ):
-            ImageHDU.data.fset(self, self.data)
 
         if inplace and not self._hdu_modified_from_disk:
             self._tmp_bintable = None

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -14,7 +14,6 @@ from astropy.io.fits.hdu.compressed._tiled_compression import (
     _get_compression_setting,
     compress_image_data,
 )
-from astropy.io.fits.hdu.compressed.compbintable import _CompBinTableHDU
 from astropy.io.fits.hdu.compressed.utils import _tile_shape, _validate_tile_shape
 from astropy.io.fits.hdu.image import ImageHDU
 from astropy.io.fits.util import _is_int

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -580,36 +580,6 @@ class CompImageHDU(ImageHDU):
         # unambiguously
         return _bintable_header_to_image_header(self._bintable.header)
 
-    def _summary(self):
-        """
-        Summarize the HDU: name, dimensions, and formats.
-        """
-        class_name = self.__class__.__name__
-
-        # if data is touched, use data info.
-        if self._data_loaded:
-            if self.data is None:
-                _shape, _format = (), ""
-            else:
-                # the shape will be in the order of NAXIS's which is the
-                # reverse of the numarray shape
-                _shape = list(self.data.shape)
-                _format = self.data.dtype.name
-                _shape.reverse()
-                _shape = tuple(_shape)
-                _format = _format[_format.rfind(".") + 1 :]
-
-        # if data is not touched yet, use header info.
-        else:
-            _shape = ()
-
-            for idx in range(self.header["NAXIS"]):
-                _shape += (self.header["NAXIS" + str(idx + 1)],)
-
-            _format = BITPIX2DTYPE[self.header["BITPIX"]]
-
-        return (self.name, self.ver, class_name, len(self.header), _shape, _format)
-
     def _add_data_to_bintable(self, bintable):
         """
         Compress the image data so that it may be written to a file.

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -735,26 +735,6 @@ class CompImageHDU(ImageHDU):
         """
         return CompImageSection(self)
 
-    # FIXME: determine how we can simplify or avoid the following methods. These
-    # seem to be needed for the checksum calculations to work properly.
-
-    def _calculate_datasum(self):
-        return self._bintable._calculate_datasum()
-
-    def _calculate_checksum(self, datasum, checksum_keyword="CHECKSUM"):
-        return self._bintable._calculate_checksum(
-            datasum, checksum_keyword=checksum_keyword
-        )
-
-    def _verify_checksum_datasum(self):
-        return self._bintable._verify_checksum_datasum()
-
-    def verify_checksum(self):
-        return self._bintable.verify_checksum()
-
-    def verify_datasum(self):
-        return self._bintable.verify_datasum()
-
     def _verify(self, *args, **kwargs):
         if self._bintable is None:
             return super()._verify(*args, **kwargs)

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -738,24 +738,3 @@ class CompImageHDU(ImageHDU):
         :attr:`CompImageHDU.data`.
         """
         return CompImageSection(self)
-
-    @property
-    def tile_shape(self):
-        """
-        The tile shape used for the tiled compression.
-
-        This shape is given in Numpy/C order
-        """
-        return tuple(
-            [
-                self._header[f"ZTILE{idx + 1}"]
-                for idx in range(self._header["ZNAXIS"] - 1, -1, -1)
-            ]
-        )
-
-    @property
-    def compression_type(self):
-        """
-        The name of the compression algorithm.
-        """
-        return self._header.get("ZCMPTYPE", DEFAULT_COMPRESSION_TYPE)

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -641,10 +641,6 @@ class CompImageHDU(ImageHDU):
             self._bintable.data = self._tmp_bintable.data
             self._tmp_bintable = self._bintable
 
-        # FIXME: at the moment test_open_comp_image_in_update_mode fails because
-        # doing the above will result in the data always being written out again
-        # when in update mode even if no changes were made to the header or data
-
         return self._tmp_bintable._prewriteto(checksum=checksum, inplace=inplace)
 
     def _writeto(self, fileobj, inplace=False, copy=False):

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -567,7 +567,6 @@ class CompImageHDU(ImageHDU):
     def compressed_data(self):
         return self._bintable.data
 
-
     def _bintable_to_image_header(self):
         if self._bintable is None:
             raise ValueError("bintable is not set")

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -3,23 +3,16 @@
 import ctypes
 import math
 import time
-from contextlib import suppress
 
 import numpy as np
 
-from astropy.io.fits import conf
+from astropy.io.fits.hdu.compressed._quantization import DITHER_METHODS
+from astropy.io.fits.hdu.compressed._tiled_compression import compress_image_data, _get_compression_setting
 from astropy.io.fits.fitsrec import FITS_rec
-from astropy.io.fits.hdu.base import BITPIX2DTYPE, DELAYED, DTYPE2BITPIX, ExtensionHDU
-from astropy.io.fits.hdu.compressed._tiled_compression import compress_image_data
+from astropy.io.fits.hdu.base import BITPIX2DTYPE, DELAYED
 from astropy.io.fits.hdu.image import ImageHDU
 from astropy.io.fits.hdu.table import BinTableHDU
-from astropy.io.fits.util import (
-    _get_array_mmap,
-    _is_int,
-    _is_pseudo_integer,
-    _pseudo_zero,
-)
-from astropy.utils import lazyproperty
+from astropy.io.fits.util import _is_int
 from astropy.utils.decorators import deprecated_renamed_argument
 
 from .header import (

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -385,9 +385,6 @@ class CompImageHDU(ImageHDU):
             # set above.
             self._get_bintable_without_data()
 
-        # Keep track of whether the data has been modified
-        self._data_modified = False
-
     def _remove_unnecessary_default_extnames(self, header):
         """Remove default EXTNAME values if they are unnecessary.
 
@@ -533,7 +530,6 @@ class CompImageHDU(ImageHDU):
 
     @data.setter
     def data(self, data):
-        self._data_modified = True
         ImageHDU.data.fset(self, data)
         if (
             data is not None

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -651,9 +651,8 @@ class CompImageHDU(ImageHDU):
         del self._tmp_bintable
 
     def _close(self, closed=True):
-        # FIXME: need to determine how to keep memmap open if needed
-
-        return
+        if self._bintable is not None:
+            return self._bintable._close(closed=closed)
 
     def _generate_dither_seed(self, seed):
         if not _is_int(seed):

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -746,19 +746,20 @@ class CompImageHDU(ImageHDU):
         return CompImageSection(self)
 
     def _verify(self, *args, **kwargs):
-
         # The following is the default _verify for ImageHDU
         errs = super()._verify(*args, **kwargs)
 
         # However in some cases the decompressed header is actually like a
         # PrimaryHDU header rather than an ImageHDU header, in which case
         # there are certain errors we can ignore
-        if 'SIMPLE' in self.header:
+        if "SIMPLE" in self.header:
             errs_filtered = []
             for err in errs:
-                if err and err[1] in ("'XTENSION' card does not exist.",
-                                      "'PCOUNT' card does not exist.",
-                                      "'GCOUNT' card does not exist."):
+                if err and err[1] in (
+                    "'XTENSION' card does not exist.",
+                    "'PCOUNT' card does not exist.",
+                    "'GCOUNT' card does not exist.",
+                ):
                     continue
                 errs_filtered.append(err)
             return _ErrList(errs_filtered)

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -607,7 +607,6 @@ class CompImageHDU(ImageHDU):
         return self._bintable is None or self.header._modified or self._data_modified
 
     def _prewriteto(self, checksum=False, inplace=False):
-
         if inplace and not self._hdu_modified_from_disk:
             self._tmp_bintable = None
             return

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -278,7 +278,6 @@ class CompImageHDU(ImageHDU):
         This is particularly useful for software testing as it ensures that the
         same image will always use the same seed.
         """
-
         compression_type = CMTYPE_ALIASES.get(compression_type, compression_type)
 
         self._bintable = None

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -302,17 +302,21 @@ class CompImageHDU(ImageHDU):
                 scale_back=scale_back,
             )
 
-            if data is DELAYED:
-                # Reading the HDU from a file
-                self._bintable = _CompBinTableHDU(
-                    data=data, header=CompImageHeader(header)
-                )
-            else:
-                self._bintable = bintable
-                self._bintable._load_variable_length_data = False
-                self._bintable._manages_own_heap = True
-                self._bintable._new = False
-                self._bitpix = self._bintable.header["ZBITPIX"]
+            # NOTE: for now we don't ever read in CompImageHDU directly from
+            # files, instead we read in BinTableHDU and pass it in here. In
+            # future if we do want to read CompImageHDU in directly, we can
+            # use the following code.
+            # if data is DELAYED:
+            #     # Reading the HDU from a file
+            #     self._bintable = _CompBinTableHDU(data=data, header=header)
+            # else:
+
+            # If bintable is passed in, it should be a BinTableHDU
+            self._bintable = bintable
+            self._bintable._load_variable_length_data = False
+            self._bintable._manages_own_heap = True
+            self._bintable._new = False
+            self._bitpix = self._bintable.header["ZBITPIX"]
 
             self._header = self._bintable_to_image_header()
             self._header._modified = False

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -515,6 +515,13 @@ class CompImageHDU(ImageHDU):
         return self._bintable is None or self._bintable.data is not DELAYED
 
     @property
+    def _data_shape(self):
+        if self._decompression_active:
+            return tuple(reversed(self._axes))
+        else:
+            return self.data.shape
+
+    @property
     def data(self):
         """
         The decompressed data array.

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -748,8 +748,11 @@ class CompImageHDU(ImageHDU):
 
     @_data_offset.setter
     def _data_offset(self, value):
-        if self._bintable is not None:
-            self._bintable._data_offset = value
+        # We should never set _data_offset to a non-None value. We need to
+        # implement this setter as one of the parent classes sets _data_offset
+        # to None in __init__.
+        if value is not None:
+            raise RuntimeError('Cannot set CompImageHDU._data_offset')
 
     @property
     def _header_offset(self):
@@ -758,8 +761,11 @@ class CompImageHDU(ImageHDU):
 
     @_header_offset.setter
     def _header_offset(self, value):
-        if self._bintable is not None:
-            self._bintable._header_offset = value
+        # We should never set _data_offset to a non-None value. We need to
+        # implement this setter as one of the parent classes sets _data_offset
+        # to None in __init__.
+        if value is not None:
+            raise RuntimeError('Cannot set CompImageHDU._header_offset')
 
     @property
     def _data_size(self):
@@ -768,5 +774,8 @@ class CompImageHDU(ImageHDU):
 
     @_data_size.setter
     def _data_size(self, value):
-        if self._bintable is not None:
-            self._bintable._data_size = value
+        # We should never set _data_offset to a non-None value. We need to
+        # implement this setter as one of the parent classes sets _data_offset
+        # to None in __init__.
+        if value is not None:
+            raise RuntimeError('Cannot set CompImageHDU._data_size')

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -604,7 +604,11 @@ class CompImageHDU(ImageHDU):
 
         dtype = bintable.columns.dtype.newbyteorder(">")
         buf = np.frombuffer(heap, dtype=np.uint8)
-        data = buf[: bintable._theap].view(dtype=dtype, type=np.rec.recarray).view(FITS_rec)
+        data = (
+            buf[: bintable._theap]
+            .view(dtype=dtype, type=np.rec.recarray)
+            .view(FITS_rec)
+        )
         data._load_variable_length_data = False
         data._coldefs = bintable.columns
         data._heapoffset = bintable._theap

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -561,7 +561,7 @@ class CompImageHDU(ImageHDU):
 
     @property
     def compressed_data(self):
-        return self._bintable.data
+        return None if self._bintable is None else self._bintable.data
 
     def _bintable_to_image_header(self):
         if self._bintable is None:

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -311,7 +311,7 @@ class CompImageHDU(ImageHDU):
             if data is DELAYED:
                 # Reading the HDU from a file
                 self._bintable = _CompBinTableHDU(
-                    data=data, header=CompImageHeader(header.cards)
+                    data=data, header=CompImageHeader(header)
                 )
             else:
                 self._bintable = bintable
@@ -362,7 +362,7 @@ class CompImageHDU(ImageHDU):
 
             super().__init__(
                 data=data,
-                header=CompImageHeader() if header is None else CompImageHeader(header),
+                header=CompImageHeader(header or []),
                 name=name,
                 do_not_scale_image_data=do_not_scale_image_data,
                 uint=uint,
@@ -604,9 +604,7 @@ class CompImageHDU(ImageHDU):
 
         dtype = bintable.columns.dtype.newbyteorder(">")
         buf = np.frombuffer(heap, dtype=np.uint8)
-        compressed_data = buf[: bintable._theap].view(dtype=dtype, type=np.rec.recarray)
-
-        data = compressed_data.view(FITS_rec)
+        data = buf[: bintable._theap].view(dtype=dtype, type=np.rec.recarray).view(FITS_rec)
         data._load_variable_length_data = False
         data._coldefs = bintable.columns
         data._heapoffset = bintable._theap

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -668,6 +668,18 @@ class CompImageHDU(ImageHDU):
 
     def _writeto(self, fileobj, inplace=False, copy=False):
         if self._tmp_bintable is not None:
+            # Each time we assign the bintable data to the BinTableHDU, some of
+            # the blank keywords get removed, so at this point, just before
+            # writing, we should make sure that the number of blank cards in
+            # the final binary table to be written matches the number of blanks
+            # in the image header.
+
+            image_blanks = self.header._countblanks()
+            table_blanks = self._tmp_bintable.header._countblanks()
+
+            for _ in range(image_blanks - table_blanks):
+                self._tmp_bintable.header.append()
+
             return self._tmp_bintable._writeto(fileobj, inplace=inplace, copy=copy)
 
     def _postwriteto(self):

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -738,3 +738,53 @@ class CompImageHDU(ImageHDU):
         :attr:`CompImageHDU.data`.
         """
         return CompImageSection(self)
+
+    # FIXME: determine how we can simplify or avoid the following methods. These
+    # seem to be needed for the checksum calculations to work properly.
+
+    def _calculate_datasum(self):
+        return self._bintable._calculate_datasum()
+
+    def _calculate_checksum(self, datasum, checksum_keyword="CHECKSUM"):
+        return self._bintable._calculate_checksum(
+            datasum, checksum_keyword=checksum_keyword
+        )
+
+    def _verify_checksum_datasum(self):
+        return self._bintable._verify_checksum_datasum()
+
+    def verify_checksum(self):
+        return self._bintable.verify_checksum()
+
+    def verify_datasum(self):
+        return self._bintable.verify_datasum()
+
+    @property
+    def _data_offset(self):
+        if self._bintable is not None:
+            return self._bintable._data_offset
+
+    @_data_offset.setter
+    def _data_offset(self, value):
+        if self._bintable is not None:
+            self._bintable._data_offset = value
+
+    @property
+    def _header_offset(self):
+        if self._bintable is not None:
+            return self._bintable._header_offset
+
+    @_header_offset.setter
+    def _header_offset(self, value):
+        if self._bintable is not None:
+            self._bintable._header_offset = value
+
+    @property
+    def _data_size(self):
+        if self._bintable is not None:
+            return self._bintable._data_size
+
+    @_data_size.setter
+    def _data_size(self, value):
+        if self._bintable is not None:
+            self._bintable._data_size = value

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -15,7 +15,7 @@ from astropy.io.fits.hdu.compressed._tiled_compression import (
     compress_image_data,
 )
 from astropy.io.fits.hdu.compressed.compbintable import _CompBinTableHDU
-from astropy.io.fits.hdu.compressed.utils import _tile_shape
+from astropy.io.fits.hdu.compressed.utils import _tile_shape, _validate_tile_shape
 from astropy.io.fits.hdu.image import ImageHDU
 from astropy.io.fits.util import _is_int
 from astropy.io.fits.verify import _ErrList
@@ -40,7 +40,6 @@ from .settings import (
     DITHER_SEED_CHECKSUM,
     DITHER_SEED_CLOCK,
 )
-from .utils import _validate_tile_shape
 
 __all__ = ["CompImageHDU"]
 

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -750,7 +750,7 @@ class CompImageHDU(ImageHDU):
         # implement this setter as one of the parent classes sets _data_offset
         # to None in __init__.
         if value is not None:
-            raise RuntimeError('Cannot set CompImageHDU._data_offset')
+            raise RuntimeError("Cannot set CompImageHDU._data_offset")
 
     @property
     def _header_offset(self):
@@ -763,7 +763,7 @@ class CompImageHDU(ImageHDU):
         # implement this setter as one of the parent classes sets _data_offset
         # to None in __init__.
         if value is not None:
-            raise RuntimeError('Cannot set CompImageHDU._header_offset')
+            raise RuntimeError("Cannot set CompImageHDU._header_offset")
 
     @property
     def _data_size(self):
@@ -776,4 +776,4 @@ class CompImageHDU(ImageHDU):
         # implement this setter as one of the parent classes sets _data_offset
         # to None in __init__.
         if value is not None:
-            raise RuntimeError('Cannot set CompImageHDU._data_size')
+            raise RuntimeError("Cannot set CompImageHDU._data_size")

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -447,6 +447,7 @@ class CompImageHDU(ImageHDU):
 
     @compression_type.setter
     def compression_type(self, value):
+        value = CMTYPE_ALIASES.get(value, value)
         if value in COMPRESSION_TYPES:
             self._compression_type = value
         else:

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -745,10 +745,7 @@ class CompImageHDU(ImageHDU):
         return CompImageSection(self)
 
     def _verify(self, *args, **kwargs):
-        if self._bintable is None:
-            return super()._verify(*args, **kwargs)
-        else:
-            return self._bintable._verify(*args, **kwargs)
+        return super()._verify(*args, **kwargs)
 
     @property
     def _data_offset(self):

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -629,25 +629,6 @@ class CompImageHDU(ImageHDU):
                 BITPIX2DTYPE[self._orig_bitpix], blank=self._orig_blank
             )
 
-        # Shove the image header and data into a new ImageHDU and use that
-        # to compute the image checksum
-        image_hdu = ImageHDU(data=self.data, header=self.header.copy())
-        image_hdu._update_checksum(checksum)
-        if "CHECKSUM" in image_hdu.header:
-            # This will also pass through to the ZHECKSUM keyword and
-            # ZDATASUM keyword
-            self.header.set(
-                "CHECKSUM",
-                image_hdu.header["CHECKSUM"],
-                image_hdu.header.comments["CHECKSUM"],
-            )
-        if "DATASUM" in image_hdu.header:
-            self.header.set(
-                "DATASUM",
-                image_hdu.header["DATASUM"],
-                image_hdu.header.comments["DATASUM"],
-            )
-
         self._tmp_bintable = self._get_bintable_without_data()
 
         self._add_data_to_bintable(self._tmp_bintable)

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -328,17 +328,12 @@ def _image_header_to_empty_bintable(
     # added history or comments to.
 
     # Update the extension name in the table header
-    if name:
-        bintable.header["EXTNAME"] = name
-    else:
-        # Do not sync this with the image header since the default
-        # name is specific to the table header.
-        bintable.header.set(
-            "EXTNAME",
-            "COMPRESSED_IMAGE",
-            "name of this binary table extension",
-            after="TFIELDS",
-        )
+    bintable.header.set(
+        "EXTNAME",
+        name,
+        "name of this binary table extension",
+        after="TFIELDS",
+    )
 
     # Set the compression type in the table header.
     if compression_type:

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -187,6 +187,9 @@ def _bintable_header_to_image_header(bintable_header):
     # Start with a copy of the table header.
     image_header = bintable_header.copy()
 
+    # Strip out special keywords
+    image_header.strip()
+
     # Delete cards that are related to the table.  And move
     # the values of those cards that relate to the image from
     # their corresponding table cards.  These include
@@ -204,7 +207,6 @@ def _bintable_header_to_image_header(bintable_header):
         image_header.set(
             "SIMPLE", bintable_header["ZSIMPLE"], hcomments["ZSIMPLE"], before=0
         )
-        del image_header["XTENSION"]
     elif "ZTENSION" in bintable_header:
         if bintable_header["ZTENSION"] != "IMAGE":
             warnings.warn(

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -745,8 +745,8 @@ def _image_header_to_empty_bintable(
     # FIXME: don't use keyword_remaps, instead define an actual list to check
     # including regular expressions for NAXIS and other similar keywords
     for card in image_header.cards:
-        if card.keyword == "":  # BLANK
-            continue
+        if card.keyword == "":
+            bintable.header.add_blank()
         elif card.keyword == "COMMENT":
             bintable.header.add_comment(card.value)
         elif card.keyword == "HISTORY":

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -205,9 +205,9 @@ def _bintable_header_to_image_header(bintable_header):
             del image_header[keyword]
 
     if bscale:
-        image_header['BSCALE'] = bscale
+        image_header["BSCALE"] = bscale
     if bzero:
-        image_header['BZERO'] = bzero
+        image_header["BZERO"] = bzero
 
     hcomments = bintable_header.comments
 

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -187,6 +187,9 @@ def _bintable_header_to_image_header(bintable_header):
     # Start with a copy of the table header.
     image_header = bintable_header.copy()
 
+    bscale = image_header.get("BSCALE")
+    bzero = image_header.get("BZERO")
+
     # Strip out special keywords
     image_header.strip()
 
@@ -200,6 +203,11 @@ def _bintable_header_to_image_header(bintable_header):
     for keyword in set(image_header):
         if CompImageHeader._is_reserved_keyword(keyword, warn=False):
             del image_header[keyword]
+
+    if bscale:
+        image_header['BSCALE'] = bscale
+    if bzero:
+        image_header['BZERO'] = bzero
 
     hcomments = bintable_header.comments
 

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -198,7 +198,10 @@ def _bintable_header_to_image_header(bintable_header):
     # keywords, which there may be in some pathological cases:
     # https://github.com/astropy/astropy/issues/2750
     for keyword in set(image_header):
-        if CompImageHeader._is_reserved_keyword(keyword, warn=False):
+        if CompImageHeader._is_reserved_keyword(keyword, warn=False) or keyword in (
+            "CHECKSUM",
+            "DATASUM",
+        ):
             del image_header[keyword]
 
     if bscale:

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -407,7 +407,6 @@ def _image_header_to_empty_bintable(
     zbitpix = image_header["BITPIX"]
 
     if zbitpix < 0 and quantize_level != 0.0:
-
         # floating point image has 'COMPRESSED_DATA',
         # 'GZIP_COMPRESSED_DATA', 'ZSCALE', and 'ZZERO' columns (unless using
         # lossless compression, per CFITSIO)

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -407,18 +407,14 @@ def _image_header_to_empty_bintable(
     zbitpix = image_header["BITPIX"]
 
     if zbitpix < 0 and quantize_level != 0.0:
+
         # floating point image has 'COMPRESSED_DATA',
-        # 'UNCOMPRESSED_DATA', 'ZSCALE', and 'ZZERO' columns (unless using
+        # 'GZIP_COMPRESSED_DATA', 'ZSCALE', and 'ZZERO' columns (unless using
         # lossless compression, per CFITSIO)
         ncols = 4
 
-        # CFITSIO 3.28 and up automatically use the GZIP_COMPRESSED_DATA
-        # store floating point data that couldn't be quantized, instead
-        # of the UNCOMPRESSED_DATA column.  There's no way to control
-        # this behavior so the only way to determine which behavior will
-        # be employed is via the CFITSIO version
-
         ttype2 = "GZIP_COMPRESSED_DATA"
+
         # The required format for the GZIP_COMPRESSED_DATA is actually
         # missing from the standard docs, but CFITSIO suggests it
         # should be 1PB, which is logical.

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -45,9 +45,6 @@ class CompImageHeader(Header):
     regular `~astropy.io.fits.Header`.
     """
 
-    # TODO: The difficulty of implementing this screams a need to rewrite this
-    # module
-
     _keyword_remaps = {
         "SIMPLE": "ZSIMPLE",
         "XTENSION": "ZTENSION",
@@ -651,118 +648,84 @@ def _image_header_to_empty_bintable(
                 after="ZQUANTIZ",
             )
 
-    if image_header:
-        # Move SIMPLE card from the image header to the
-        # table header as ZSIMPLE card.
+    # Move SIMPLE card from the image header to the
+    # table header as ZSIMPLE card.
 
-        if "SIMPLE" in image_header:
-            bintable.header.set(
-                "ZSIMPLE",
-                image_header["SIMPLE"],
-                image_header.comments["SIMPLE"],
-                before="ZBITPIX",
-            )
+    if "SIMPLE" in image_header:
+        bintable.header.set(
+            "ZSIMPLE",
+            image_header["SIMPLE"],
+            image_header.comments["SIMPLE"],
+            before="ZBITPIX",
+        )
 
-        # Move EXTEND card from the image header to the
-        # table header as ZEXTEND card.
+    # Move EXTEND card from the image header to the
+    # table header as ZEXTEND card.
 
-        if "EXTEND" in image_header:
-            bintable.header.set(
-                "ZEXTEND", image_header["EXTEND"], image_header.comments["EXTEND"]
-            )
+    if "EXTEND" in image_header:
+        bintable.header.set(
+            "ZEXTEND", image_header["EXTEND"], image_header.comments["EXTEND"]
+        )
 
-        # Move BLOCKED card from the image header to the
-        # table header as ZBLOCKED card.
+    # Move BLOCKED card from the image header to the
+    # table header as ZBLOCKED card.
 
-        if "BLOCKED" in image_header:
-            bintable.header.set(
-                "ZBLOCKED",
-                image_header["BLOCKED"],
-                image_header.comments["BLOCKED"],
-            )
+    if "BLOCKED" in image_header:
+        bintable.header.set(
+            "ZBLOCKED",
+            image_header["BLOCKED"],
+            image_header.comments["BLOCKED"],
+        )
 
-        # Move XTENSION card from the image header to the
-        # table header as ZTENSION card.
+    # Move XTENSION card from the image header to the
+    # table header as ZTENSION card.
 
-        # Since we only handle compressed IMAGEs, ZTENSION should
-        # always be IMAGE, even if the caller has passed in a header
-        # for some other type of extension.
-        if "XTENSION" in image_header:
-            bintable.header.set(
-                "ZTENSION",
-                "IMAGE",
-                image_header.comments["XTENSION"],
-                before="ZBITPIX",
-            )
+    # Since we only handle compressed IMAGEs, ZTENSION should
+    # always be IMAGE, even if the caller has passed in a header
+    # for some other type of extension.
+    if "XTENSION" in image_header:
+        bintable.header.set(
+            "ZTENSION",
+            "IMAGE",
+            image_header.comments["XTENSION"],
+            before="ZBITPIX",
+        )
 
-        # Move PCOUNT and GCOUNT cards from image header to the table
-        # header as ZPCOUNT and ZGCOUNT cards.
+    # Move PCOUNT and GCOUNT cards from image header to the table
+    # header as ZPCOUNT and ZGCOUNT cards.
 
-        if "PCOUNT" in image_header:
-            bintable.header.set(
-                "ZPCOUNT",
-                image_header["PCOUNT"],
-                image_header.comments["PCOUNT"],
-                after=last_znaxis,
-            )
+    if "PCOUNT" in image_header:
+        bintable.header.set(
+            "ZPCOUNT",
+            image_header["PCOUNT"],
+            image_header.comments["PCOUNT"],
+            after=last_znaxis,
+        )
 
-        if "GCOUNT" in image_header:
-            bintable.header.set(
-                "ZGCOUNT",
-                image_header["GCOUNT"],
-                image_header.comments["GCOUNT"],
-                after="ZPCOUNT",
-            )
+    if "GCOUNT" in image_header:
+        bintable.header.set(
+            "ZGCOUNT",
+            image_header["GCOUNT"],
+            image_header.comments["GCOUNT"],
+            after="ZPCOUNT",
+        )
 
-        # Move CHECKSUM and DATASUM cards from the image header to the
-        # table header as XHECKSUM and XDATASUM cards.
+    # Move CHECKSUM and DATASUM cards from the image header to the
+    # table header as XHECKSUM and XDATASUM cards.
 
-        if "CHECKSUM" in image_header:
-            bintable.header.set(
-                "ZHECKSUM",
-                image_header["CHECKSUM"],
-                image_header.comments["CHECKSUM"],
-            )
+    if "CHECKSUM" in image_header:
+        bintable.header.set(
+            "ZHECKSUM",
+            image_header["CHECKSUM"],
+            image_header.comments["CHECKSUM"],
+        )
 
-        if "DATASUM" in image_header:
-            bintable.header.set(
-                "ZDATASUM",
-                image_header["DATASUM"],
-                image_header.comments["DATASUM"],
-            )
-    else:
-        # Move XTENSION card from the image header to the
-        # table header as ZTENSION card.
-
-        # Since we only handle compressed IMAGEs, ZTENSION should
-        # always be IMAGE, even if the caller has passed in a header
-        # for some other type of extension.
-        if "XTENSION" in image_header:
-            bintable.header.set(
-                "ZTENSION",
-                "IMAGE",
-                image_header.comments["XTENSION"],
-                before="ZBITPIX",
-            )
-
-        # Move PCOUNT and GCOUNT cards from image header to the table
-        # header as ZPCOUNT and ZGCOUNT cards.
-
-        if "PCOUNT" in image_header:
-            bintable.header.set(
-                "ZPCOUNT",
-                image_header["PCOUNT"],
-                image_header.comments["PCOUNT"],
-                after=last_znaxis,
-            )
-
-        if "GCOUNT" in image_header:
-            bintable.header.set(
-                "ZGCOUNT",
-                image_header["GCOUNT"],
-                image_header.comments["GCOUNT"],
-                after="ZPCOUNT",
-            )
+    if "DATASUM" in image_header:
+        bintable.header.set(
+            "ZDATASUM",
+            image_header["DATASUM"],
+            image_header.comments["DATASUM"],
+        )
 
     # When we have an image checksum we need to ensure that the same
     # number of blank cards exist in the table header as there were in
@@ -770,15 +733,10 @@ def _image_header_to_empty_bintable(
     # over to the image header when the hdu is uncompressed.
 
     if "ZHECKSUM" in bintable.header:
-        required_blanks = image_header._countblanks()
         image_blanks = image_header._countblanks()
         table_blanks = bintable.header._countblanks()
 
-        for _ in range(required_blanks - image_blanks):
-            image_header.append()
-            table_blanks += 1
-
-        for _ in range(required_blanks - table_blanks):
+        for _ in range(image_blanks - table_blanks):
             bintable.header.append()
 
     bintable.columns = cols
@@ -787,8 +745,8 @@ def _image_header_to_empty_bintable(
     # FIXME: don't use keyword_remaps, instead define an actual list to check
     # including regular expressions for NAXIS and other similar keywords
     for card in image_header.cards:
-        if card.keyword == "":
-            continue  # TODO: investigate why some cards have empty keyword
+        if card.keyword == "":  # BLANK
+            continue
         elif card.keyword == "COMMENT":
             bintable.header.add_comment(card.value)
         elif card.keyword == "HISTORY":

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -727,18 +727,6 @@ def _image_header_to_empty_bintable(
             image_header.comments["DATASUM"],
         )
 
-    # When we have an image checksum we need to ensure that the same
-    # number of blank cards exist in the table header as there were in
-    # the image header.  This allows those blank cards to be carried
-    # over to the image header when the hdu is uncompressed.
-
-    if "ZHECKSUM" in bintable.header:
-        image_blanks = image_header._countblanks()
-        table_blanks = bintable.header._countblanks()
-
-        for _ in range(image_blanks - table_blanks):
-            bintable.header.append()
-
     bintable.columns = cols
 
     # Add any keywords that are in the original header that are not already

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -54,7 +54,6 @@ class CompImageSection:
         return np.dtype(BITPIX2DTYPE[self.hdu._bintable.header["ZBITPIX"]])
 
     def __getitem__(self, index):
-
         if self.hdu._bintable is None:
             return self.hdu.data[index]
 

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -6,7 +6,7 @@ from astropy.io.fits.hdu.base import BITPIX2DTYPE
 from astropy.io.fits.hdu.compressed._tiled_compression import (
     decompress_image_data_section,
 )
-from astropy.io.fits.hdu.compressed.utils import _data_shape, _n_tiles, _tile_shape
+from astropy.io.fits.hdu.compressed.utils import _n_tiles
 from astropy.utils.shapes import simplify_basic_index
 
 __all__ = ["CompImageSection"]

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -60,7 +60,12 @@ class CompImageSection:
             first_tile_index = np.zeros(self._n_dim, dtype=int)
             last_tile_index = self._n_tiles - 1
             data = decompress_image_data_section(
-                self.hdu._bintable.data, self.hdu.compression_type, self.hdu._bintable.header, self.hdu._bintable, first_tile_index, last_tile_index,
+                self.hdu._bintable.data,
+                self.hdu.compression_type,
+                self.hdu._bintable.header,
+                self.hdu._bintable,
+                first_tile_index,
+                last_tile_index,
             )
             if self.hdu._do_not_scale_image_data:
                 return data
@@ -110,7 +115,12 @@ class CompImageSection:
                 )
 
         data = decompress_image_data_section(
-            self.hdu._bintable.data, self.hdu.compression_type, self.hdu._bintable.header, self.hdu._bintable, first_tile_index, last_tile_index,
+            self.hdu._bintable.data,
+            self.hdu.compression_type,
+            self.hdu._bintable.header,
+            self.hdu._bintable,
+            first_tile_index,
+            last_tile_index,
         )
 
         data = data[tuple(final_array_index)]

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -29,12 +29,8 @@ class CompImageSection:
     def __init__(self, hdu):
         self.hdu = hdu
 
-        if self.hdu._bintable is None:
-            self._data_shape = self.hdu.data.shape
-            self._tile_shape = self.hdu.tile_shape
-        else:
-            self._data_shape = _data_shape(self.hdu._bintable.header)
-            self._tile_shape = _tile_shape(self.hdu._bintable.header)
+        self._data_shape = self.hdu.shape
+        self._tile_shape = self.hdu.tile_shape
 
         self._n_dim = len(self._data_shape)
         self._n_tiles = np.array(
@@ -47,11 +43,11 @@ class CompImageSection:
 
     @property
     def ndim(self):
-        return self.hdu._bintable.header["ZNAXIS"]
+        return len(self.hdu.shape)
 
     @property
     def dtype(self):
-        return np.dtype(BITPIX2DTYPE[self.hdu._bintable.header["ZBITPIX"]])
+        return np.dtype(BITPIX2DTYPE[self.hdu._bitpix])
 
     def __getitem__(self, index):
         if self.hdu._bintable is None:

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -54,6 +54,10 @@ class CompImageSection:
         return np.dtype(BITPIX2DTYPE[self.hdu._bintable.header["ZBITPIX"]])
 
     def __getitem__(self, index):
+
+        if self.hdu._bintable is None:
+            return self.hdu.data[index]
+
         # Shortcut if the whole data is requested (this is used by the
         # data property, so we optimize it as it is frequently used)
         if index is Ellipsis:

--- a/astropy/io/fits/hdu/compressed/tests/test_checksum.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_checksum.py
@@ -12,17 +12,31 @@ class TestChecksumFunctions(BaseChecksumTests):
     def test_compressed_image_data(self):
         with fits.open(self.data("comp.fits")) as h1:
             h1.writeto(self.temp("tmp.fits"), overwrite=True, checksum=True)
+
+            with fits.open(
+                self.temp("tmp.fits"), checksum=True, disable_image_compression=True
+            ) as h2:
+                assert "CHECKSUM" in h2[0].header
+                assert h2[0].header["CHECKSUM"] == "D8iBD6ZAD6fAD6ZA"
+                assert "DATASUM" in h2[0].header
+                assert h2[0].header["DATASUM"] == "0"
+                assert "CHECKSUM" in h2[1].header
+                assert h2[1].header["CHECKSUM"] == "UAAaX40ZU97aU97Y"
+                assert "DATASUM" in h2[1].header
+                assert h2[1].header["DATASUM"] == "113055149"
+                assert h2[1].header._countblanks() == 78
+                assert "ZHECKSUM" not in h2[1].header
+                assert "ZDATASUM" not in h2[1].header
+
             with fits.open(self.temp("tmp.fits"), checksum=True) as h2:
                 assert np.all(h1[1].data == h2[1].data)
                 assert "CHECKSUM" in h2[0].header
                 assert h2[0].header["CHECKSUM"] == "D8iBD6ZAD6fAD6ZA"
                 assert "DATASUM" in h2[0].header
                 assert h2[0].header["DATASUM"] == "0"
-                assert "CHECKSUM" in h2[1].header
-                assert h2[1].header["CHECKSUM"] == "D2GXD29VD2EVD29V"
-                assert "DATASUM" in h2[1].header
-                assert h2[1].header["DATASUM"] == "2189405276"
-                assert h2[1].header._countblanks() == 76
+                assert "CHECKSUM" not in h2[1].header
+                assert "DATASUM" not in h2[1].header
+                assert h2[1].header._countblanks() == 78
 
     def test_failing_compressed_datasum(self):
         """
@@ -41,31 +55,47 @@ class TestChecksumFunctions(BaseChecksumTests):
         comp_hdu = fits.CompImageHDU(hdu.data, hdu.header)
         comp_hdu.writeto(self.temp("tmp.fits"), checksum=True)
         hdu.writeto(self.temp("uncomp.fits"), checksum=True)
-        with fits.open(self.temp("tmp.fits"), checksum=True) as hdul:
+
+        with (
+            fits.open(self.temp("tmp.fits"), checksum=True) as hdul,
+            fits.open(
+                self.temp("tmp.fits"), checksum=True, disable_image_compression=True
+            ) as hdul_comp,
+            fits.open(self.temp("uncomp.fits"), checksum=True) as hdul_uncomp,
+        ):
+            # Check that the data was decompressed properly
             assert np.all(hdul[1].data == comp_hdu.data)
             assert np.all(hdul[1].data == hdu.data)
+
+            # Check primary HDU checksums
             assert "CHECKSUM" in hdul[0].header
             assert hdul[0].header["CHECKSUM"] == "D8iBD6ZAD6fAD6ZA"
             assert "DATASUM" in hdul[0].header
             assert hdul[0].header["DATASUM"] == "0"
 
-            assert "CHECKSUM" in hdul[1].header
-            assert hdul[1].header["CHECKSUM"] == "ZE94eE91ZE91bE91"
-            assert "DATASUM" in hdul[1].header
-            assert hdul[1].header["DATASUM"] == "160565700"
-            assert "CHECKSUM" in hdul[1].header
+            # Check first HDU checksum in compressed data
+            assert "CHECKSUM" in hdul_comp[1].header
+            assert hdul_comp[1].header["CHECKSUM"] == "g4NEg2LEg2LEg2LE"
+            assert "DATASUM" in hdul_comp[1].header
+            assert hdul_comp[1].header["DATASUM"] == "2453673070"
+            assert "CHECKSUM" in hdul_comp[1].header
+            assert "ZHECKSUM" not in hdul_comp[1].header
+            assert "ZDATASUM" not in hdul_comp[1].header
 
-            with fits.open(self.temp("uncomp.fits"), checksum=True) as hdul2:
-                header_comp = hdul[1]._bintable.header
-                header_uncomp = hdul2[1].header
-                assert "ZHECKSUM" in header_comp
-                assert "CHECKSUM" in header_uncomp
-                assert header_uncomp["CHECKSUM"] == "ZE94eE91ZE91bE91"
-                assert header_comp["ZHECKSUM"] == header_uncomp["CHECKSUM"]
-                assert "ZDATASUM" in header_comp
-                assert "DATASUM" in header_uncomp
-                assert header_uncomp["DATASUM"] == "160565700"
-                assert header_comp["ZDATASUM"] == header_uncomp["DATASUM"]
+            # Check no checksums in decompressed data
+            assert "CHECKSUM" not in hdul[1].header
+            assert "DATASUM" not in hdul[1].header
+
+            # Check checksums in original image data
+            assert "CHECKSUM" in hdul_uncomp[1].header
+            assert hdul_uncomp[1].header["CHECKSUM"] == "ZE94eE91ZE91bE91"
+            assert "DATASUM" in hdul_uncomp[1].header
+            assert hdul_uncomp[1].header["DATASUM"] == "160565700"
+
+            # If in future we make it easy to compute the decompressed image
+            # checksum in CompImageHDU.header, the following test should pass
+            # assert header_comp["ZHECKSUM"] == header_uncomp["CHECKSUM"]
+            # assert header_comp["ZDATASUM"] == header_uncomp["DATASUM"]
 
     def test_compressed_image_data_float32(self):
         n = np.arange(100, dtype="float32")
@@ -73,31 +103,45 @@ class TestChecksumFunctions(BaseChecksumTests):
         comp_hdu = fits.CompImageHDU(hdu.data, hdu.header)
         comp_hdu.writeto(self.temp("tmp.fits"), checksum=True)
         hdu.writeto(self.temp("uncomp.fits"), checksum=True)
-        with fits.open(self.temp("tmp.fits"), checksum=True) as hdul:
+
+        with (
+            fits.open(self.temp("tmp.fits"), checksum=True) as hdul,
+            fits.open(
+                self.temp("tmp.fits"), checksum=True, disable_image_compression=True
+            ) as hdul_comp,
+            fits.open(self.temp("uncomp.fits"), checksum=True) as hdul_uncomp,
+        ):
+            # Check that the data was decompressed properly
             assert np.all(hdul[1].data == comp_hdu.data)
             assert np.all(hdul[1].data == hdu.data)
+
+            # Check primary HDU checksums
             assert "CHECKSUM" in hdul[0].header
             assert hdul[0].header["CHECKSUM"] == "D8iBD6ZAD6fAD6ZA"
             assert "DATASUM" in hdul[0].header
             assert hdul[0].header["DATASUM"] == "0"
 
-            assert "CHECKSUM" in hdul[1].header
-            assert "DATASUM" in hdul[1].header
+            # Check first HDU checksum in compressed data
+            assert "CHECKSUM" in hdul_comp[1].header
+            assert "DATASUM" in hdul_comp[1].header
 
             # The checksum ends up being different on Windows and s390/bigendian,
             # possibly due to slight floating point differences? See gh-10921.
             # TODO fix these so they work on all platforms; otherwise pointless.
-            # assert hdul[1]._header['CHECKSUM'] == 'eATIf3SHe9SHe9SH'
-            # assert hdul[1]._header['DATASUM'] == '1277667818'
+            # assert hdul_comp[1].header['CHECKSUM'] == 'eATIf3SHe9SHe9SH'
+            # assert hdul_comp[1].header['DATASUM'] == '1277667818'
 
-            with fits.open(self.temp("uncomp.fits"), checksum=True) as hdul2:
-                header_comp = hdul[1]._bintable.header
-                header_uncomp = hdul2[1].header
-                assert "ZHECKSUM" in header_comp
-                assert "CHECKSUM" in header_uncomp
-                assert header_uncomp["CHECKSUM"] == "Cgr5FZo2Cdo2CZo2"
-                assert header_comp["ZHECKSUM"] == header_uncomp["CHECKSUM"]
-                assert "ZDATASUM" in header_comp
-                assert "DATASUM" in header_uncomp
-                assert header_uncomp["DATASUM"] == "2393636889"
-                assert header_comp["ZDATASUM"] == header_uncomp["DATASUM"]
+            # Check no checksums in decompressed data
+            assert "CHECKSUM" not in hdul[1].header
+            assert "DATASUM" not in hdul[1].header
+
+            # Check checksums in original image data
+            assert "CHECKSUM" in hdul_uncomp[1].header
+            assert hdul_uncomp[1].header["CHECKSUM"] == "Cgr5FZo2Cdo2CZo2"
+            assert "DATASUM" in hdul_uncomp[1].header
+            assert hdul_uncomp[1].header["DATASUM"] == "2393636889"
+
+            # If in future we make it easy to compute the decompressed image
+            # checksum in CompImageHDU.header, the following test should pass
+            # assert header_comp["ZHECKSUM"] == header_uncomp["CHECKSUM"]
+            # assert header_comp["ZDATASUM"] == header_uncomp["DATASUM"]

--- a/astropy/io/fits/hdu/compressed/tests/test_checksum.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_checksum.py
@@ -22,6 +22,7 @@ class TestChecksumFunctions(BaseChecksumTests):
                 assert h2[1].header["CHECKSUM"] == "D2GXD29VD2EVD29V"
                 assert "DATASUM" in h2[1].header
                 assert h2[1].header["DATASUM"] == "2189405276"
+                assert h2[1].header._countblanks() == 76
 
     def test_failing_compressed_datasum(self):
         """

--- a/astropy/io/fits/hdu/compressed/tests/test_checksum.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_checksum.py
@@ -19,9 +19,9 @@ class TestChecksumFunctions(BaseChecksumTests):
                 assert "DATASUM" in h2[0].header
                 assert h2[0].header["DATASUM"] == "0"
                 assert "CHECKSUM" in h2[1].header
-                assert h2[1].header["CHECKSUM"] == "ZeAbdb8aZbAabb7a"
+                assert h2[1].header["CHECKSUM"] == "D2GXD29VD2EVD29V"
                 assert "DATASUM" in h2[1].header
-                assert h2[1].header["DATASUM"] == "113055149"
+                assert h2[1].header["DATASUM"] == "2189405276"
 
     def test_failing_compressed_datasum(self):
         """
@@ -49,13 +49,13 @@ class TestChecksumFunctions(BaseChecksumTests):
             assert hdul[0].header["DATASUM"] == "0"
 
             assert "CHECKSUM" in hdul[1].header
-            assert hdul[1]._header["CHECKSUM"] == "J5cCJ5c9J5cAJ5c9"
+            assert hdul[1].header["CHECKSUM"] == "ZE94eE91ZE91bE91"
             assert "DATASUM" in hdul[1].header
-            assert hdul[1]._header["DATASUM"] == "2453673070"
+            assert hdul[1].header["DATASUM"] == "160565700"
             assert "CHECKSUM" in hdul[1].header
 
             with fits.open(self.temp("uncomp.fits"), checksum=True) as hdul2:
-                header_comp = hdul[1]._header
+                header_comp = hdul[1]._bintable.header
                 header_uncomp = hdul2[1].header
                 assert "ZHECKSUM" in header_comp
                 assert "CHECKSUM" in header_uncomp
@@ -90,7 +90,7 @@ class TestChecksumFunctions(BaseChecksumTests):
             # assert hdul[1]._header['DATASUM'] == '1277667818'
 
             with fits.open(self.temp("uncomp.fits"), checksum=True) as hdul2:
-                header_comp = hdul[1]._header
+                header_comp = hdul[1]._bintable.header
                 header_uncomp = hdul2[1].header
                 assert "ZHECKSUM" in header_comp
                 assert "CHECKSUM" in header_uncomp

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -963,6 +963,17 @@ class TestCompressedImage(FitsTestCase):
         for line_actual, line_expected in zip(actual, expected, strict=True):
             assert line_actual.strip() == line_expected.strip()
 
+    def test_shape(self):
+
+        with fits.open(self.data("comp.fits")) as hdul:
+            assert hdul[1].header['NAXIS1'] == 440
+            assert hdul[1].header['NAXIS2'] == 300
+            assert hdul[1].shape == (300, 440)
+            hdul[1].data = np.ones((120, 150))
+            assert hdul[1].header['NAXIS1'] == 150
+            assert hdul[1].header['NAXIS2'] == 120
+            assert hdul[1].shape == (120, 150)
+
 
 class TestCompHDUSections:
     @pytest.fixture(autouse=True)

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -244,7 +244,14 @@ class TestCompressedImage(FitsTestCase):
 
         time.sleep(1)
 
-        fits.open(self.temp("scale.fits"), mode="update").close()
+        # Now open the file in update mode and close immediately. Note that we
+        # need to set do_not_scale_image_data otherwise the data is scaled upon
+        # being opened.
+        fits.open(
+            self.temp("scale.fits"),
+            mode="update",
+            do_not_scale_image_data=True,
+        ).close()
 
         # Ensure that no changes were made to the file merely by immediately
         # opening and closing it.

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1219,3 +1219,35 @@ def test_section_unwritten():
     hdu = fits.CompImageHDU(data, header, compression_type="RICE_1", tile_shape=(5, 6))
     assert_equal(hdu.section[...], data)
     assert hdu.section[3, 4] == data[3, 4]
+
+
+EXPECTED_HEADER = """
+XTENSION= 'IMAGE   '           / Image extension
+BITPIX  =                   16 / data type of original image
+NAXIS   =                    2 / dimension of original image
+NAXIS1  =                   10 / length of original image axis
+NAXIS2  =                   10 / length of original image axis
+PCOUNT  =                    0 / number of parameters
+GCOUNT  =                    1 / number of groups
+END
+""".lstrip()
+
+
+def test_header():
+    """
+    Check that the header is correct when reading in compressed images and
+    correctly shows the image dimensions.
+    """
+
+    filename = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "tests",
+        "data",
+        "compressed_image.fits",
+    )
+
+    with fits.open(filename) as hdulist:
+        assert hdulist[1].header == fits.Header.fromstring(EXPECTED_HEADER, sep="\n")

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import basic_indices
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from astropy.io import fits
 from astropy.io.fits.hdu.compressed import (
@@ -1083,3 +1083,24 @@ def test_image_write_readonly(tmp_path):
 
     with fits.open(filename) as hdulist:
         assert_equal(hdulist[1].data, [1.0, 2.0, 3.0])
+
+
+def test_uint_option(tmp_path):
+    """
+    Check that the uint= option works correctly
+    """
+
+    filename = tmp_path / "uint_test.fits"
+
+    data = (2 ** (1 + np.arange(16).reshape((4, 4))) - 1).astype(np.uint16)
+
+    hdu = fits.CompImageHDU(data)
+    hdu.writeto(filename)
+
+    with fits.open(filename) as hdulist:
+        assert hdulist[1].data.dtype == np.dtype("uint16")
+        assert_equal(hdulist[1].data, data)
+
+    with fits.open(filename, uint=False) as hdulist:
+        assert hdulist[1].data.dtype == np.dtype("float32")
+        assert_allclose(hdulist[1].data, data)

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -983,14 +983,13 @@ class TestCompressedImage(FitsTestCase):
             assert hdul[1].shape == (120, 150)
 
     def test_inplace_data_modify(self, tmp_path):
-
         self.copy_file("comp.fits")
 
-        with fits.open(self.temp('comp.fits'), mode="update") as hdul:
+        with fits.open(self.temp("comp.fits"), mode="update") as hdul:
             data = hdul[1].data
             data[0] = 0
 
-        with fits.open(self.temp('comp.fits')) as hdul:
+        with fits.open(self.temp("comp.fits")) as hdul:
             assert hdul[1].data[0, 0] == 0
 
     def test_summary_noload(self):
@@ -998,8 +997,21 @@ class TestCompressedImage(FitsTestCase):
         # does not cause the data to be loaded.
         with fits.open(self.data("comp.fits")) as hdul:
             summary = hdul.info(output=False)
-            assert summary == [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''), (1, 'COMPRESSED_IMAGE', 1, 'CompImageHDU', 105, (440, 300), 'int16', '')]
+            assert summary == [
+                (0, "PRIMARY", 1, "PrimaryHDU", 4, (), "", ""),
+                (
+                    1,
+                    "COMPRESSED_IMAGE",
+                    1,
+                    "CompImageHDU",
+                    105,
+                    (440, 300),
+                    "int16",
+                    "",
+                ),
+            ]
             assert not hdul[1]._data_loaded
+
 
 class TestCompHDUSections:
     @pytest.fixture(autouse=True)

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -759,6 +759,7 @@ class TestCompressedImage(FitsTestCase):
             hdul.writeto(self.temp("tmp.fits"), overwrite=True)
             with fits.open(self.temp("tmp.fits")) as hdul1:
                 hdu1 = hdul1[1]
+                assert len(hdu.header._keyword_indices["EXTNAME"]) == 1
                 assert hdu1.name == "NEW2"
 
             # Check that deleting EXTNAME will and setting the name will

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1258,3 +1258,10 @@ def test_header():
 
     with fits.open(filename) as hdulist:
         assert hdulist[1].header == fits.Header.fromstring(EXPECTED_HEADER, sep="\n")
+
+
+def test_rice_one_alias():
+    # Regression test for a bug that caused RICE_ONE (which we document as an
+    # acceptable alias) to no longer be recognized.
+    chdu = fits.CompImageHDU(np.zeros((3, 4, 5)))
+    chdu.compression_type = "RICE_ONE"

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1107,6 +1107,7 @@ def test_uint_option(tmp_path):
         assert_allclose(hdulist[1].data, data)
 
 
+@pytest.mark.xfail
 def test_incorrect_bzero(tmp_path):
     """
     Regression test for https://github.com/astropy/astropy/issues/5999 which is
@@ -1181,10 +1182,9 @@ def test_compression_settings_delayed_data(tmp_path):
     hdu1.writeto(tmp_path / "data1.fits")
     hdu2.writeto(tmp_path / "data2.fits")
 
-    hdu1_read = fits.open(tmp_path / "data1.fits")[1]
-    hdu2_read = fits.open(tmp_path / "data2.fits")[1]
-
-    assert_equal(hdu1_read.data, hdu2_read.data)
+    with fits.open(tmp_path / "data1.fits") as hdulist1_read:
+        with fits.open(tmp_path / "data2.fits") as hdulist2_read:
+            assert_equal(hdulist1_read[1].data, hdulist2_read[1].data)
 
 
 def test_header_assignment_issue(tmp_path):
@@ -1203,8 +1203,8 @@ def test_header_assignment_issue(tmp_path):
     assert ch.header["test"] == "right"
 
     ch.writeto(tmp_path / "test_header.fits")
-    chdl = fits.open(tmp_path / "test_header.fits")
-    assert chdl[1].header["test"] == "right"
+    with fits.open(tmp_path / "test_header.fits") as chdl:
+        assert chdl[1].header["test"] == "right"
 
 
 def test_section_unwritten():
@@ -1217,5 +1217,5 @@ def test_section_unwritten():
     data = np.arange(21 * 33).reshape((21, 33)).astype(np.int32)
     header = fits.Header()
     hdu = fits.CompImageHDU(data, header, compression_type="RICE_1", tile_shape=(5, 6))
-    assert_equal(hdu.section[...] == data)
+    assert_equal(hdu.section[...], data)
     assert hdu.section[3, 4] == data[3, 4]

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -993,6 +993,13 @@ class TestCompressedImage(FitsTestCase):
         with fits.open(self.temp('comp.fits')) as hdul:
             assert hdul[1].data[0, 0] == 0
 
+    def test_summary_noload(self):
+        # Make sure that calling info() (and therefore CompImageHDU.summary)
+        # does not cause the data to be loaded.
+        with fits.open(self.data("comp.fits")) as hdul:
+            summary = hdul.info(output=False)
+            assert summary == [(0, 'PRIMARY', 1, 'PrimaryHDU', 4, (), '', ''), (1, 'COMPRESSED_IMAGE', 1, 'CompImageHDU', 105, (440, 300), 'int16', '')]
+            assert not hdul[1]._data_loaded
 
 class TestCompHDUSections:
     @pytest.fixture(autouse=True)

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
+import io
 import math
 import os
 import re
@@ -940,6 +941,27 @@ class TestCompressedImage(FitsTestCase):
 
         with fits.open(tmp_path / "compressed.fits") as hdul:
             assert_equal(hdul[1].data, data)
+
+    def test_info(self):
+        """
+        Make sure .info() works correctly when CompImageHDUs are present
+        """
+        output = io.StringIO()
+        with fits.open(self.data("comp.fits")) as hdul:
+            hdul.info(output=output)
+        output.seek(0)
+
+        # Note: ignore the first line which just gives the filename
+        actual = output.read().splitlines()[1:]
+
+        expected = [
+            "No.    Name      Ver    Type      Cards   Dimensions   Format",
+            "0  PRIMARY       1 PrimaryHDU       4   ()",
+            "1  COMPRESSED_IMAGE    1 CompImageHDU    105   (440, 300)   int16",
+        ]
+
+        for line_actual, line_expected in zip(actual, expected, strict=True):
+            assert line_actual.strip() == line_expected.strip()
 
 
 class TestCompHDUSections:

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1295,8 +1295,5 @@ def test_header_order(tmp_path):
 
     hdulist.writeto(tmp_path / "test.fits", overwrite=True)
 
-    hdulist3 = fits.open(tmp_path / "test.fits", disable_image_compression=True)
-
-    hdulist2 = fits.open(tmp_path / "test.fits")
-
-    assert hdulist[1].header.tostring("\n") == hdulist2[1].header.tostring("\n")
+    with fits.open(tmp_path / "test.fits") as hdulist2:
+        assert hdulist[1].header.tostring("\n") == hdulist2[1].header.tostring("\n")

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -372,14 +372,14 @@ class TestCompressedImage(FitsTestCase):
             assert (hdul[1].data[0] == zero_point).all()
 
         with fits.open(self.temp("scale.fits")) as hdul:
-            assert (hdul[1].data[1:] == orig_data[1:]).all()
+            assert_equal(hdul[1].data[1:], orig_data[1:])
             # Extra test to ensure that after everything the data is still the
             # same as in the original uncompressed version of the image
             with fits.open(self.data("scale.fits")) as hdul2:
                 # Recall we made the same modification to the data in hdul
                 # above
                 hdul2[0].data[0] = 0
-                assert (hdul[1].data == hdul2[0].data).all()
+                assert_equal(hdul[1].data, hdul2[0].data)
 
     def test_lossless_gzip_compression(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/198"""
@@ -982,6 +982,17 @@ class TestCompressedImage(FitsTestCase):
             assert hdul[1].header["NAXIS2"] == 120
             assert hdul[1].shape == (120, 150)
 
+    def test_inplace_data_modify(self, tmp_path):
+
+        self.copy_file("comp.fits")
+
+        with fits.open(self.temp('comp.fits'), mode="update") as hdul:
+            data = hdul[1].data
+            data[0] = 0
+
+        with fits.open(self.temp('comp.fits')) as hdul:
+            assert hdul[1].data[0, 0] == 0
+
 
 class TestCompHDUSections:
     @pytest.fixture(autouse=True)
@@ -1004,6 +1015,7 @@ class TestCompHDUSections:
         hdulist.writeto(tmp_path / "sections.fits")
 
         self.hdul = fits.open(tmp_path / "sections.fits")
+        self.hdul2 = fits.open(tmp_path / "sections.fits")
 
     def teardown_method(self):
         self.hdul.close()

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -964,14 +964,13 @@ class TestCompressedImage(FitsTestCase):
             assert line_actual.strip() == line_expected.strip()
 
     def test_shape(self):
-
         with fits.open(self.data("comp.fits")) as hdul:
-            assert hdul[1].header['NAXIS1'] == 440
-            assert hdul[1].header['NAXIS2'] == 300
+            assert hdul[1].header["NAXIS1"] == 440
+            assert hdul[1].header["NAXIS2"] == 300
             assert hdul[1].shape == (300, 440)
             hdul[1].data = np.ones((120, 150))
-            assert hdul[1].header['NAXIS1'] == 150
-            assert hdul[1].header['NAXIS2'] == 120
+            assert hdul[1].header["NAXIS1"] == 150
+            assert hdul[1].header["NAXIS2"] == 120
             assert hdul[1].shape == (120, 150)
 
 

--- a/astropy/io/fits/hdu/compressed/tests/test_compression_failures.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compression_failures.py
@@ -40,6 +40,7 @@ class TestCompressionFunction(FitsTestCase):
     def test_data_none(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
         hdu.data = None
+        hdu.tile_shape = None
         bintable = hdu._get_bintable_without_data()
         with pytest.raises(TypeError) as exc:
             compress_image_data(

--- a/astropy/io/fits/hdu/compressed/tests/test_compression_failures.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compression_failures.py
@@ -19,120 +19,123 @@ class TestCompressionFunction(FitsTestCase):
 
     def test_unknown_compression_type(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header["ZCMPTYPE"] = "fun"
+        bintable = hdu._get_bintable_without_data()
+        bintable.header["ZCMPTYPE"] = "fun"
         with pytest.raises(ValueError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert "Unrecognized compression type: fun" in str(exc.value)
 
     def test_zbitpix_unknown(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header["ZBITPIX"] = 13
+        bintable = hdu._get_bintable_without_data()
+        bintable.header["ZBITPIX"] = 13
         with pytest.raises(ValueError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert "Invalid value for BITPIX: 13" in str(exc.value)
 
     def test_data_none(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
         hdu.data = None
+        bintable = hdu._get_bintable_without_data()
         with pytest.raises(TypeError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert "Image data must be a numpy.ndarray" in str(exc.value)
 
-    def test_missing_internal_header(self):
-        hdu = fits.CompImageHDU(np.ones((10, 10)))
-        del hdu._header
-        with pytest.raises(AttributeError) as exc:
-            compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
-            )
-        assert "_header" in str(exc.value)
-
     def test_invalid_tform(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header["TFORM1"] = "TX"
+        bintable = hdu._get_bintable_without_data()
+        bintable.header["TFORM1"] = "TX"
         with pytest.raises(RuntimeError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert "TX" in str(exc.value) and "TFORM" in str(exc.value)
 
     def test_invalid_zdither(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)), quantize_method=1)
-        hdu._header["ZDITHER0"] = "a"
+        bintable = hdu._get_bintable_without_data()
+        bintable.header["ZDITHER0"] = "a"
         with pytest.raises(TypeError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["ZNAXIS", "ZBITPIX"])
     def test_header_missing_keyword(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        del hdu._header[kw]
+        bintable = hdu._get_bintable_without_data()
+        del bintable.header[kw]
         with pytest.raises(KeyError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert kw in str(exc.value)
 
     @pytest.mark.parametrize("kw", ["ZNAXIS", "ZVAL1", "ZVAL2", "ZBLANK", "BLANK"])
     def test_header_value_int_overflow(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = MAX_INT + 1
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = MAX_INT + 1
         with pytest.raises(OverflowError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["ZTILE1", "ZNAXIS1"])
     def test_header_value_long_overflow(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = MAX_LONG + 1
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = MAX_LONG + 1
         with pytest.raises(OverflowError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["NAXIS1", "NAXIS2", "TNULL1", "PCOUNT", "THEAP"])
     def test_header_value_longlong_overflow(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = MAX_LONGLONG + 1
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = MAX_LONGLONG + 1
         with pytest.raises(OverflowError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["ZVAL3"])
     def test_header_value_float_overflow(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = 1e300
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = 1e300
         with pytest.raises(OverflowError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["NAXIS1", "NAXIS2", "TFIELDS", "PCOUNT"])
     def test_header_value_negative(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = -1
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = -1
         with pytest.raises(ValueError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert f"{kw} should not be negative." in str(exc.value)
 
     @pytest.mark.parametrize(("kw", "limit"), [("ZNAXIS", 999), ("TFIELDS", 999)])
     def test_header_value_exceeds_custom_limit(self, kw, limit):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = limit + 1
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = limit + 1
         with pytest.raises(ValueError) as exc:
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
         assert kw in str(exc.value)
 
@@ -141,26 +144,29 @@ class TestCompressionFunction(FitsTestCase):
     )
     def test_header_value_no_string(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = 1
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = 1
         with pytest.raises(TypeError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["TZERO1", "TSCAL1"])
     def test_header_value_no_double(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
-        hdu._header[kw] = "1"
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = "1"
         with pytest.raises(TypeError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )
 
     @pytest.mark.parametrize("kw", ["ZSCALE", "ZZERO"])
     def test_header_value_no_double_int_image(self, kw):
         hdu = fits.CompImageHDU(np.ones((10, 10), dtype=np.int32))
-        hdu._header[kw] = "1"
+        bintable = hdu._get_bintable_without_data()
+        bintable.header[kw] = "1"
         with pytest.raises(TypeError):
             compress_image_data(
-                hdu.data, hdu.compression_type, hdu._header, hdu.columns
+                hdu.data, hdu.compression_type, bintable.header, bintable.columns
             )

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -185,10 +185,11 @@ def test_decompress(
 ):
     compression_type, param, dtype = comp_param_dtype
 
+    with fits.open(fitsio_compressed_file_path, disable_image_compression=True) as hdul:
+        assert hdul[1].header["ZCMPTYPE"].replace("ONE", "1") == compression_type
+
     with fits.open(fitsio_compressed_file_path) as hdul:
         data = hdul[1].data
-
-        assert hdul[1]._header["ZCMPTYPE"].replace("ONE", "1") == compression_type
         assert hdul[1].data.dtype.kind == np.dtype(dtype).kind
         assert hdul[1].data.dtype.itemsize == np.dtype(dtype).itemsize
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1587,9 +1587,23 @@ class HDUList(list, _Verify):
 
         Side effect of setting the objects _resize attribute.
         """
+
+        # Avoid circular import
+        from astropy.io.fits import CompImageHDU
+
         if not self._resize:
+
             # determine if any of the HDU is resized
             for hdu in self:
+
+                # for CompImageHDU, we need to handle things a little differently
+                # because the HDU matching the header/data on disk is hdu._bintable
+                if isinstance(hdu, CompImageHDU):
+                    if hdu._hdu_modified_from_disk:
+                        self._resize = True
+                        self._truncate = False
+                    continue
+
                 # Header:
                 nbytes = len(str(hdu._header))
                 if nbytes != (hdu._data_offset - hdu._header_offset):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1332,10 +1332,14 @@ class HDUList(list, _Verify):
                     if isinstance(hdu, BinTableHDU) and CompImageHDU.match_header(
                         hdu.header
                     ):
-                        kwargs_comp = {}
-                        for key in ("scale_back", "uint", "do_not_scale_image_data"):
-                            if key in kwargs:
-                                kwargs_comp[key] = kwargs[key]
+                        kwargs_comp = {
+                            key: kwargs[key]
+                            for key in {
+                                "scale_back",
+                                "uint",
+                                "do_not_scale_image_data",
+                            }.intersection(kwargs)
+                        }
                         hdu = CompImageHDU(bintable=hdu, **kwargs_comp)
 
                 super().append(hdu)

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1587,15 +1587,12 @@ class HDUList(list, _Verify):
 
         Side effect of setting the objects _resize attribute.
         """
-
         # Avoid circular import
         from astropy.io.fits import CompImageHDU
 
         if not self._resize:
-
             # determine if any of the HDU is resized
             for hdu in self:
-
                 # for CompImageHDU, we need to handle things a little differently
                 # because the HDU matching the header/data on disk is hdu._bintable
                 if isinstance(hdu, CompImageHDU):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1333,12 +1333,9 @@ class HDUList(list, _Verify):
                         hdu.header
                     ):
                         kwargs_comp = {
-                            key: kwargs[key]
-                            for key in {
-                                "scale_back",
-                                "uint",
-                                "do_not_scale_image_data",
-                            }.intersection(kwargs)
+                            key: val
+                            for key, val in kwargs.items()
+                            if key in ("scale_back", "uint", "do_not_scale_image_data")
                         }
                         hdu = CompImageHDU(bintable=hdu, **kwargs_comp)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -31,7 +31,6 @@ from astropy.utils.compat.optional_deps import HAS_BZ2
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .base import ExtensionHDU, _BaseHDU, _NonstandardHDU, _ValidHDU
-from .compressed import compressed
 from .groups import GroupsHDU
 from .image import ImageHDU, PrimaryHDU
 
@@ -1333,7 +1332,11 @@ class HDUList(list, _Verify):
                     if isinstance(hdu, BinTableHDU) and CompImageHDU.match_header(
                         hdu.header
                     ):
-                        hdu = CompImageHDU(bintable=hdu)
+                        kwargs_comp = {}
+                        for key in ("scale_back", "uint", "do_not_scale_image_data"):
+                            if key in kwargs:
+                                kwargs_comp[key] = kwargs[key]
+                        hdu = CompImageHDU(bintable=hdu, **kwargs_comp)
 
                 super().append(hdu)
                 if len(self) == 1:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -319,6 +319,10 @@ class _ImageBaseHDU(_ValidHDU):
         # setting self.__dict__['data']
         return data
 
+    @property
+    def _data_shape(self):
+        return self.data.shape
+
     def update_header(self):
         """
         Update the header keywords to agree with the data.
@@ -326,7 +330,7 @@ class _ImageBaseHDU(_ValidHDU):
         if not (
             self._modified
             or self._header._modified
-            or (self._has_data and self.shape != self.data.shape)
+            or (self._has_data and self.shape != self._data_shape)
         ):
             # Not likely that anything needs updating
             return
@@ -345,8 +349,8 @@ class _ImageBaseHDU(_ValidHDU):
         # If the data's shape has changed (this may have happened without our
         # noticing either via a direct update to the data.shape attribute) we
         # need to update the internal self._axes
-        if self._has_data and self.shape != self.data.shape:
-            self._axes = list(self.data.shape)
+        if self._has_data and self.shape != self._data_shape:
+            self._axes = list(self._data_shape)
             self._axes.reverse()
 
         # Update the NAXIS keyword and ensure it's in the correct location in

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -811,7 +811,6 @@ class _ImageBaseHDU(_ValidHDU):
         return self._scale_data(raw_data)
 
     def _scale_data(self, raw_data):
-
         if self._do_not_scale_image_data or (
             self._orig_bzero == 0 and self._orig_bscale == 1 and self._blank is None
         ):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -527,7 +527,10 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
             for idx in range(self.data._nfields):
                 format = self.data._coldefs._recformats[idx]
                 if isinstance(format, _FormatP):
-                    _max = self.data.field(idx).max
+                    if self.data._load_variable_length_data:
+                        _max = self.data.field(idx).max
+                    else:
+                        _max = self.data.field(idx)[:, 0].max()
                     # May be either _FormatP or _FormatQ
                     format_cls = format.__class__
                     format = format_cls(format.dtype, repeat=format.repeat, max=_max)

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -68,6 +68,7 @@ import numpy as np
 
 from astropy import __version__, log
 from astropy.io import fits
+from astropy.io.fits import CompImageHDU
 
 DESCRIPTION = """
 Print the header(s) of a FITS file. Optional arguments allow the desired
@@ -200,10 +201,10 @@ class HeaderFormatter:
         """
         # First we obtain the desired header
         try:
-            if compressed:
+            if compressed and isinstance(self._hdulist[hdukey], CompImageHDU):
                 # In the case of a compressed image, return the header before
                 # decompression (not the default behavior)
-                header = self._hdulist[hdukey]._header
+                header = self._hdulist[hdukey]._bintable.header
             else:
                 header = self._hdulist[hdukey].header
         except (IndexError, KeyError):

--- a/docs/changes/io.fits/15474.api.rst
+++ b/docs/changes/io.fits/15474.api.rst
@@ -1,0 +1,6 @@
+The ``CompImageHDU`` class has been refactored to inherit from ``ImageHDU``
+instead of ``BinTableHDU``. This change should be for the most part preserve the
+API, but any calls to ``isinstance(hdu, BinTableHDU)`` will now return ``False``
+if ``hdu`` is a ``CompImageHDU`` whereas before it would have returned ``True``.
+In addition, the ``uint`` keyword argument to ``CompImageHDU`` now defaults to
+``True`` for consistency with ``ImageHDU``.

--- a/docs/changes/io.fits/15474.bugfix.rst
+++ b/docs/changes/io.fits/15474.bugfix.rst
@@ -1,0 +1,11 @@
+Fix a number of bugs in ``CompImageHDU``:
+
+* Fix the ability to pickle ``CompImageHDU`` objects
+* Ensure that compression settings are not lost if initializing ``CompImageHDU``
+  without data but with compression settings and setting the data later
+* Make sure that keywords are properly updated when setting the header of a
+  ``CompImageHDU`` to an existing image header.
+* Fix the ability to use ``CompImageHDU.section`` on instances that have not yet
+  been written to disk
+* Fix the image checksum/datasum in ``CompImageHDU.header`` to be those for the
+  image HDU instead of for the underlying binary table.

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -474,16 +474,6 @@ and "Registered FITS Convention, Tiled Image Compression Convention":
 
     https://fits.gsfc.nasa.gov/registry/tilecompression.html
 
-Compressed image data is accessed, in ``astropy``, using the optional
-``astropy.io.fits.compression`` module contained in a C shared library
-(compression.so). If an attempt is made to access an HDU containing compressed
-image data when the compression module is not available, the user is notified
-of the problem and the HDU is treated like a standard binary table HDU. This
-notification will only be made the first time compressed image data is
-encountered. In this way, the compression module is not required in order for
-``astropy`` to work.
-
-
 Header and Summary
 ------------------
 
@@ -492,7 +482,7 @@ any image header. The actual header stored in the FITS file is that of a binary
 table HDU with a set of special keywords, defined by the convention, to
 describe the structure of the compressed image. The conversion between binary
 table HDU header and image HDU header is all performed behind the scenes.
-Since the HDU is actually a binary table, it may not appear as a primary HDU in
+Since the HDU is actually a binary table, it will never appear as a primary HDU in
 a FITS file.
 
 Example
@@ -502,7 +492,7 @@ Example
   EXAMPLE START
   Accessing Compressed FITS Image HDU Headers
 
-The content of the HDU header may be accessed using the ``.header`` attribute::
+The content of the decompressed HDU header may be accessed using the ``.header`` attribute::
 
     >>> filename = fits.util.get_testdata_filepath('compressed_image.fits')
 
@@ -515,38 +505,6 @@ The content of the HDU header may be accessed using the ``.header`` attribute::
     NAXIS2  =                   10 / length of original image axis
     PCOUNT  =                    0 / number of parameters
     GCOUNT  =                    1 / number of groups
-
-The contents of the corresponding binary table HDU may be accessed using the
-hidden ``._header`` attribute. However, all user interface with the HDU header
-should be accomplished through the image header (the ``.header`` attribute)::
-
-    >>> hdul[1]._header
-    XTENSION= 'BINTABLE'           / binary table extension
-    BITPIX  =                    8 / array data type
-    NAXIS   =                    2 / number of array dimensions
-    NAXIS1  =                    8 / width of table in bytes
-    NAXIS2  =                   10 / number of rows in table
-    PCOUNT  =                   60 / number of group parameters
-    GCOUNT  =                    1 / number of groups
-    TFIELDS =                    1 / number of fields in each row
-    TTYPE1  = 'COMPRESSED_DATA'    / label for field 1
-    TFORM1  = '1PB(6)  '           / data format of field: variable length array
-    ZIMAGE  =                    T / extension contains compressed image
-    ZTENSION= 'IMAGE   '           / Image extension
-    ZBITPIX =                   16 / data type of original image
-    ZNAXIS  =                    2 / dimension of original image
-    ZNAXIS1 =                   10 / length of original image axis
-    ZNAXIS2 =                   10 / length of original image axis
-    ZPCOUNT =                    0 / number of parameters
-    ZGCOUNT =                    1 / number of groups
-    ZTILE1  =                   10 / size of tiles to be compressed
-    ZTILE2  =                    1 / size of tiles to be compressed
-    ZCMPTYPE= 'RICE_1  '           / compression algorithm
-    ZNAME1  = 'BLOCKSIZE'          / compression block size
-    ZVAL1   =                   32 / pixels per block
-    ZNAME2  = 'BYTEPIX '           / bytes per pixel (1, 2, 4, or 8)
-    ZVAL2   =                    2 / bytes per pixel (1, 2, 4, or 8)
-    EXTNAME = 'COMPRESSED_IMAGE'   / name of this binary table extension
 
 The contents of the HDU can be summarized by using either the :func:`info`
 convenience function or method::
@@ -571,15 +529,15 @@ Data
 
 As with the header, the data of a compressed image HDU appears to the user as
 standard uncompressed image data. The actual data is stored in the FITS file
-as Binary Table data containing at least one column (COMPRESSED_DATA). Each
+as binary table data containing at least one column (COMPRESSED_DATA). Each
 row of this variable length column contains the byte stream that was generated
 as a result of compressing the corresponding image tile. Several optional
-columns may also appear. These include UNCOMPRESSED_DATA to hold the
-uncompressed pixel values for tiles that cannot be compressed, ZSCALE and ZZERO
-to hold the linear scale factor and zero point offset which may be needed to
-transform the raw uncompressed values back to the original image pixel values,
-and ZBLANK to hold the integer value used to represent undefined pixels (if
-any) in the image.
+columns may also appear. These include GZIP_COMPRESSED_DATA to hold the
+gzip-compressed data for tiles that cannot be compressed by the selected
+algorithm, as well as ZSCALE and ZZERO to hold the linear scale factor and zero
+point offset which may be needed to transform the raw uncompressed values back
+to the original image pixel values, and ZBLANK to hold the integer value used to
+represent undefined pixels (if any) in the image.
 
 Example
 ^^^^^^^


### PR DESCRIPTION
This pull request addresses https://github.com/astropy/astropy/issues/9238 by refactoring ``CompImageHDU`` to inherit from ``ImageHDU`` instead of ``BinTableHDU``. This includes some subtle API changes that cannot be warned about in advance using deprecation warnings or future warnings, so this PR, if accepted, would definitely warrant a major version bump. Ideally this would go in v6.0 but it depends on whether we can achieve consensus and stamp out remaining issues.

This PR isn't 100% ready (see 'Outstanding issues' below and FIXME comments in code) but I wanted to try and open this now in case it is something we can consider getting in before the v6.0 feature freeze. I doubt that the outstanding issues would cause significant code changes so it should be safe to already review things as-is.

### Background

Compressed image HDUs are stored in FITS files as binary tables. The ``CompImageHDU`` was therefore developed as a a subclass of ``BinTableHDU``. However, that implementation is quite complex because it tries to look to users like an ``ImageHDU`` - for example ``.header`` is meant to be the image header, and ``.data`` is meant to be the decompressed image data. To quote comments from the code:

```
# TODO: The difficulty of implementing this screams a need to rewrite this module
```

```
Bypasses `BinTableHDU._writeheader()` which updates the header with
metadata about the data that is meaningless here; another reason
why this class maybe shouldn't inherit directly from BinTableHDU...
```

Issue https://github.com/astropy/astropy/issues/9238 by @mhvk also suggested that ``CompImageHDU`` would be simpler if it inherited from ``ImageHDU``.

This PR does that refactoring, and represents ``CompImageHDU`` as an ``ImageHDU`` subclass that internally stores a ``BinTableHDU`` representing the compressed data. Instead of always keeping the image and table header in sync, headers are only converted at I/O time which should in principle make things faster.

Overall, this results in a few hundred lines of code being removed. For now ``CompImageHeader`` is kept to avoid breaking API so that warnings about reserved keywords are emitted as soon as they are set. However, if we would be happy to 'break' this behavior and only warn at I/O time or when calling ``verify``, we could get rid of the custom header subclass. If we want to keep the behavior, we can nevertheless try and avoid code duplication with the ``Header`` class by ssimplifying the header validation (see https://github.com/astropy/astropy/pull/15293).

### API changes/fixes

I have tried to minimize API changes as much as possible. However, it is impossible to not have any changes at all:

* With this PR, a compressed image HDU ``chdu`` will no longer return ``True`` for ``isinstance(chdu, BinTableHDU)``. There's no way to avoid this and also no way to do this with a gradual deprecation. However, I would hope that this is rare and that if anything people would do ``isinstance(chdu, CompImageHDU)`` which will still be ``True``.

* The following options have changed defaults in the ``CompImageHDU`` initializer to match ``ImageHDU``:

    * ``uint=True`` replaces ``uint=False`` (I need to check if I can come up with an example that shows the difference here)
    * ``scale_back=None`` replaces ``scale_back=False`` (in practice I think this won't change anything)

* The checksum on the main header is now the image checksum not the binary table checksum (I believe this was a bug: https://github.com/astropy/astropy/issues/14753)

Fixes:
* https://github.com/astropy/astropy/issues/9238
* https://github.com/astropy/astropy/issues/10512
* https://github.com/astropy/astropy/issues/12216
* https://github.com/astropy/astropy/issues/14081
* https://github.com/astropy/astropy/issues/14611
* https://github.com/astropy/astropy/issues/14753

Repeating for auto-close in less readable format:

Fixes https://github.com/astropy/astropy/issues/9238
Fixes https://github.com/astropy/astropy/issues/10512
Fixes https://github.com/astropy/astropy/issues/12216
Fixes https://github.com/astropy/astropy/issues/14081
Fixes https://github.com/astropy/astropy/issues/14611
Fixes https://github.com/astropy/astropy/issues/14753

### Modified tests

I've tried to change tests as little as possible but there were some unavoidable changes:

* Many tests (probably non-optimally) were checking the contents of ``chdu._header`` which no longer exists (the equivalent is ``chdu._bintable.header``.
* ``test_compressed_header_missing_znaxis`` has been removed - this checked that removing ``ZNAXIS`` or ``ZBITPIX`` from the internal binary table caused accessing the compressed data property to fail. This doesn't seem needed because it relies on modifying private attributes on ``CompImageHDU`` and we now also generate the compressed header on-the-fly so there is no opportunity to remove the keywords before the data is compressed.
* ``test_compressed_header_double_extname`` - included some lines checking state of internal/private properties. Those checks have been removed as the test is no longer relevant for this API.

### Outstanding issues/open questions

* [x] Add back support for accessing ``CompImageHDU.shape`` (should be simple)
* [x] Make sure that we don't write out anything when in ``mode='update'`` if a file is simply opened and closed (``test_open_comp_image_in_update_mode`` failure). For now I have xfailed the test to make sure the rest of the CI works properly.

### For future

* Not critical for this PR, but currently this preserves the ``CompImageHeader`` class - as noted higher up we could potentially consider removing or simplifying this in future.
* This keeps the ``compressed_data`` property on ``CompImageHDU``. It might be better to deprecate it and encourage people to open the file with ``disable_image_compression``? I doubt this property is used much. We can do this in a follow-up though.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
