### PR TITLE
Account for SOFA/ERFA bugfix in pvstar

### DIFF
--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -144,7 +144,11 @@ class TestPVUfuncs:
         assert px.unit == u.arcsec
         assert_quantity_allclose(px, 1 * u.radian)
         assert rv.unit == u.km / u.s
-        assert_array_equal(rv.value, np.zeros(self.pv.shape))
+        # RV is non-zero because proper motion induces a small redshift
+        # due to second order Doppler shift.
+        assert_quantity_allclose(
+            rv, np.zeros(self.pv.shape) << (u.km / u.s), atol=1 * u.m / u.s
+        )
 
     def test_starpv(self):
         ra, dec, pmr, pmd, px, rv, stat = erfa_ufunc.pvstar(self.pv)


### PR DESCRIPTION
This pull request changes a test so that it matches the output of `pvstar` in `pyerfa-dev` as well as of older `pyerfa`. `pyerfa-dev` was just updated to SOFA 19, which carried a bugfix for `pvstar` which includes the effect of proper motion on radial velocity (via second order Doppler). Here, the test is just adjusted to not fail - the idea being that in our quantity tests we really do not have to test that the output is exactly the same anyway, that is done in SOFA/ERFA (and, indirectly, in our coordinate tests); we should just test that quantities are propagated correctly.

cc @pllim: I asked you to review since the fix itself is trivial, but I want to be sure my order of operations makes sense: I committed the new erfa in `pyerfa` which means the existing test will start to fail on astropy-dev. The fix for that is here, and my logic was that once we merge this fix, `astropy-dev` will be happy again, and I can then release `pyerfa` 2.0.1 knowing that all regular CI should stay happy as well. Does this make sense?

Note: obviously should check `-dev` does not fail!

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
