### PR TITLE
Backport PR #15473: Ensure tables with masked and unmasked columns roundtrip properly (v5.0.x)

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -557,12 +557,13 @@ def table_to_hdu(table, character_as_bytes=False):
             # Binary FITS tables support TNULL *only* for integer data columns
             # TODO: Determine a schema for handling non-integer masked columns
             # with non-default fill values in FITS (if at all possible).
+            # Be careful that we do not set null for columns that were not masked!
             int_formats = ("B", "I", "J", "K")
-            if not (col.format in int_formats or col.format.p_format in int_formats):
-                continue
-
-            fill_value = tarray[col.name].fill_value
-            col.null = fill_value.astype(int)
+            if (
+                col.format in int_formats or col.format.p_format in int_formats
+            ) and hasattr(table[col.name], "mask"):
+                fill_value = tarray[col.name].fill_value
+                col.null = fill_value.astype(int)
     else:
         table_hdu = BinTableHDU.from_columns(
             tarray, header=hdr, character_as_bytes=character_as_bytes

--- a/docs/changes/io.fits/15473.bugfix.rst
+++ b/docs/changes/io.fits/15473.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that tables written to FITS with both masked and unmasked columns
+roundtrip properly (previously, all integer columns would become masked
+if any column was masked).


### PR DESCRIPTION
Manual backport of #15473 onto v5.0.x