### PR TITLE
MNT: Pin pyerfa maxversion in LTS

### DIFF
--- a/docs/changes/15483.other.rst
+++ b/docs/changes/15483.other.rst
@@ -1,0 +1,1 @@
+LTS is not compatible with pyerfa 2.0.1 or later.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ zip_safe = False
 tests_require = pytest-astropy
 install_requires =
     numpy>=1.18,<1.25
-    pyerfa>=2.0
+    pyerfa>=2.0,<2.0.1
     PyYAML>=3.13
     packaging>=19.0
 python_requires = >=3.8,<3.12


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to pin pyerfa maxversion in LTS because pyerfa 2.0.1 does not provide wheels for combo that is compatible with requirements in this branch and it cannot be built from source because it needs numpy>=1.25 to build because it dropped oldest-supported-numpy, but LTS here pinned numpy<1.25 for other reasons.

xref https://github.com/astropy/astropy/pull/15481

This makes https://github.com/astropy/astropy/pull/15478 kinda unnecessary but does not hurt to keep it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
