### PR TITLE
Cosmo as a dataclass

### DIFF
--- a/astropy/cosmology/_io/ecsv.py
+++ b/astropy/cosmology/_io/ecsv.py
@@ -23,9 +23,10 @@ file:
     # ---
     # datatype:
     # - {name: name, datatype: string}
+    # - {name: H0, unit: km / (Mpc s), datatype: float64, description: Hubble ...}
     ...
-    # meta: !!omap
-    # - {Oc0: 0.2607}
+    # meta:
+    #   Oc0: 0.2607
     ...
     # schema: astropy-2.0
     name H0 Om0 Tcmb0 Neff m_nu Ob0
@@ -59,8 +60,8 @@ a column of the table using the ``cosmology_in_meta`` keyword argument.
     # - {name: cosmology, datatype: string}
     # - {name: name, datatype: string}
     ...
-    # meta: !!omap
-    # - {Oc0: 0.2607}
+    # meta:
+    #   Oc0: 0.2607
     ...
     # schema: astropy-2.0
     cosmology name H0 Om0 Tcmb0 Neff m_nu Ob0
@@ -121,17 +122,17 @@ useful when the files's column names do not match the class' parameter names.
     >>> file = Path(temp_dir.name) / "file4.ecsv"
     >>> Planck18.write(file, rename={"H0": "Hubble"})
     >>> with open(file) as f: print(f.read())
-     # %ECSV 1.0
+    # %ECSV 1.0
     # ---
     # datatype:
     # - {name: name, datatype: string}
     ...
-    # meta: !!omap
-    # - {Oc0: 0.2607}
+    # meta:
+    #   Oc0: 0.2607
     ...
     # schema: astropy-2.0
     name Hubble Om0 Tcmb0 Neff m_nu Ob0
-    ...
+    Planck18 67.66 0.30966 2.7255 3.046 [0.0,0.0,0.06] 0.04897
 
     >>> cosmo = Cosmology.read(file, rename={"Hubble": "H0"})
     >>> cosmo == Planck18
@@ -222,8 +223,8 @@ def read_ecsv(
         # datatype:
         # - {name: name, datatype: string}
         ...
-        # meta: !!omap
-        # - {Oc0: 0.2607}
+        # meta:
+        #   Oc0: 0.2607
         ...
         # schema: astropy-2.0
         name H0 Om0 Tcmb0 Neff m_nu Ob0
@@ -301,12 +302,12 @@ def read_ecsv(
         # datatype:
         # - {name: name, datatype: string}
         ...
-        # meta: !!omap
-        # - {Oc0: 0.2607}
+        # meta:
+        #   Oc0: 0.2607
         ...
         # schema: astropy-2.0
         name Hubble Om0 Tcmb0 Neff m_nu Ob0
-        ...
+        Planck18 67.66 0.30966 2.7255 3.046 [0.0,0.0,0.06] 0.04897
 
     Now we can read the Cosmology from the ECSV file, with the required renaming:
 
@@ -393,8 +394,8 @@ def write_ecsv(
         # datatype:
         # - {name: name, datatype: string}
         ...
-        # meta: !!omap
-        # - {Oc0: 0.2607}
+        # meta:
+        #   Oc0: 0.2607
         ...
         # schema: astropy-2.0
         name H0 Om0 Tcmb0 Neff m_nu Ob0
@@ -432,8 +433,8 @@ def write_ecsv(
         # - {name: cosmology, datatype: string}
         # - {name: name, datatype: string}
         ...
-        # meta: !!omap
-        # - {Oc0: 0.2607}
+        # meta:
+        #   Oc0: 0.2607
         ...
         # schema: astropy-2.0
         cosmology name H0 Om0 Tcmb0 Neff m_nu Ob0
@@ -451,12 +452,12 @@ def write_ecsv(
         # datatype:
         # - {name: name, datatype: string}
         ...
-        # meta: !!omap
-        # - {Oc0: 0.2607}
+        # meta:
         ...
         # schema: astropy-2.0
         name Hubble Om0 Tcmb0 Neff m_nu Ob0
-        ...
+        Planck18 67.66 0.30966 2.7255 3.046 [0.0,0.0,0.06] 0.04897
+        <BLANKLINE>
 
     Additional keyword arguments are passed to :attr:`astropy.table.QTable.write`.
 

--- a/astropy/cosmology/_io/mapping.py
+++ b/astropy/cosmology/_io/mapping.py
@@ -134,13 +134,14 @@ Lastly, the keys in the mapping may be renamed with the ``rename`` keyword.
      'cosmo_name': 'Planck18', ...
 """
 
+__all__ = []  # nothing is publicly scoped
+
 import copy
+import inspect
 from collections.abc import Mapping
 
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, Cosmology
-
-__all__ = []  # nothing is publicly scoped
 
 
 def _rename_map(map, /, renames):
@@ -273,15 +274,16 @@ def from_mapping(mapping, /, *, move_to_meta=False, cosmology=None, rename=None)
     cosmology = _get_cosmology_class(cosmology, params)
 
     # select arguments from mapping that are in the cosmo's signature.
-    ba = cosmology._init_signature.bind_partial()  # blank set of args
+    sig = inspect.signature(cosmology)
+    ba = sig.bind_partial()  # blank set of args
     ba.apply_defaults()  # fill in the defaults
-    for k in cosmology._init_signature.parameters.keys():
+    for k in sig.parameters.keys():
         if k in params:  # transfer argument, if in params
             ba.arguments[k] = params.pop(k)
 
     # deal with remaining params. If there is a **kwargs use that, else
     # allow to transfer to metadata. Raise TypeError if can't.
-    lastp = tuple(cosmology._init_signature.parameters.values())[-1]
+    lastp = next(reversed(sig.parameters.values()))
     if lastp.kind == 4:  # variable keyword-only
         ba.arguments[lastp.name] = params
     elif move_to_meta:  # prefers current meta, which was explicitly set

--- a/astropy/cosmology/_io/tests/base.py
+++ b/astropy/cosmology/_io/tests/base.py
@@ -1,11 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 import pytest
 
 import astropy.units as u
 from astropy.cosmology import Cosmology, Parameter, realizations
 from astropy.cosmology import units as cu
-from astropy.cosmology.core import _COSMOLOGY_CLASSES
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, dataclass_decorator
 from astropy.cosmology.realizations import available
 
 cosmo_instances = [getattr(realizations, name) for name in available]
@@ -98,8 +99,9 @@ class IODirectTestBase(IOTestBase):
     def setup(self):
         """Setup and teardown for tests."""
 
+        @dataclass_decorator
         class CosmologyWithKwargs(Cosmology):
-            Tcmb0 = Parameter(default=0, unit=u.K)
+            Tcmb0: Parameter = Parameter(default=0, unit=u.K)
 
             def __init__(
                 self, Tcmb0=0, name="cosmology with kwargs", meta=None, **kwargs

--- a/astropy/cosmology/_io/tests/base.py
+++ b/astropy/cosmology/_io/tests/base.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import pytest
 
 import astropy.units as u

--- a/astropy/cosmology/_io/tests/test_ecsv.py
+++ b/astropy/cosmology/_io/tests/test_ecsv.py
@@ -91,7 +91,7 @@ class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
         tbl.write(fp, format="ascii.ecsv", overwrite=True)
 
         # tests are different if the last argument is a **kwarg
-        if tuple(cosmo._init_signature.parameters.values())[-1].kind == 4:
+        if cosmo._init_has_kwargs:
             got = read(fp, format="ascii.ecsv")
 
             assert got.__class__ is cosmo_cls

--- a/astropy/cosmology/_io/tests/test_ecsv.py
+++ b/astropy/cosmology/_io/tests/test_ecsv.py
@@ -178,7 +178,7 @@ class ReadWriteECSVTestMixin(ReadWriteTestMixinBase):
 
         # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
-        assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
+        assert got.Tcmb0 == cosmo_cls.parameters["Tcmb0"].default
         assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta

--- a/astropy/cosmology/_io/tests/test_html.py
+++ b/astropy/cosmology/_io/tests/test_html.py
@@ -167,7 +167,7 @@ class ReadWriteHTMLTestMixin(ReadWriteTestMixinBase):
 
         # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
-        assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
+        assert got.Tcmb0 == cosmo_cls.parameters["Tcmb0"].default
         assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         # assert got.meta == cosmo.meta # metadata read not implemented

--- a/astropy/cosmology/_io/tests/test_html.py
+++ b/astropy/cosmology/_io/tests/test_html.py
@@ -79,7 +79,7 @@ class ReadWriteHTMLTestMixin(ReadWriteTestMixinBase):
         tbl.write(fp, format="ascii.html", overwrite=True)
 
         # tests are different if the last argument is a **kwarg
-        if tuple(cosmo._init_signature.parameters.values())[-1].kind == 4:
+        if cosmo._init_has_kwargs:
             got = read(fp, format="ascii.html")
 
             assert got.__class__ is cosmo_cls

--- a/astropy/cosmology/_io/tests/test_json.py
+++ b/astropy/cosmology/_io/tests/test_json.py
@@ -149,7 +149,7 @@ class ReadWriteJSONTestMixin(ReadWriteTestMixinBase):
 
         # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
-        assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
+        assert got.Tcmb0 == cosmo_cls.parameters["Tcmb0"].default
         assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta

--- a/astropy/cosmology/_io/tests/test_mapping.py
+++ b/astropy/cosmology/_io/tests/test_mapping.py
@@ -108,7 +108,7 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
         m["mismatching"] = "will error"
 
         # (Tests are different if the last argument is a **kwarg)
-        if tuple(cosmo._init_signature.parameters.values())[-1].kind == 4:
+        if cosmo._init_has_kwargs:
             got = from_format(m, format="mapping")
 
             assert got.name == cosmo.name

--- a/astropy/cosmology/_io/tests/test_mapping.py
+++ b/astropy/cosmology/_io/tests/test_mapping.py
@@ -209,7 +209,7 @@ class ToFromMappingTestMixin(ToFromTestMixinBase):
 
         # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
-        assert got.Tcmb0 == cosmo.__class__._init_signature.parameters["Tcmb0"].default
+        assert got.Tcmb0 == cosmo.__class__.parameters["Tcmb0"].default
         assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta

--- a/astropy/cosmology/_io/tests/test_row.py
+++ b/astropy/cosmology/_io/tests/test_row.py
@@ -57,7 +57,7 @@ class ToFromRowTestMixin(ToFromTestMixinBase):
         row.table["mismatching"] = "will error"
 
         # tests are different if the last argument is a **kwarg
-        if tuple(cosmo._init_signature.parameters.values())[-1].kind == 4:
+        if cosmo._init_has_kwargs:
             got = from_format(row, format="astropy.row")
 
             assert got.__class__ is cosmo.__class__

--- a/astropy/cosmology/_io/tests/test_table.py
+++ b/astropy/cosmology/_io/tests/test_table.py
@@ -97,7 +97,7 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
         tbl["mismatching"] = "will error"
 
         # tests are different if the last argument is a **kwarg
-        if tuple(cosmo._init_signature.parameters.values())[-1].kind == 4:
+        if cosmo._init_has_kwargs:
             got = from_format(tbl, format="astropy.table")
 
             assert got.__class__ is cosmo_cls

--- a/astropy/cosmology/_io/tests/test_table.py
+++ b/astropy/cosmology/_io/tests/test_table.py
@@ -157,7 +157,7 @@ class ToFromTableTestMixin(ToFromTestMixinBase):
 
         # not equal, because Tcmb0 is changed, which also changes m_nu
         assert got != cosmo
-        assert got.Tcmb0 == cosmo_cls._init_signature.parameters["Tcmb0"].default
+        assert got.Tcmb0 == cosmo_cls.parameters["Tcmb0"].default
         assert got.clone(name=cosmo.name, Tcmb0=cosmo.Tcmb0, m_nu=cosmo.m_nu) == cosmo
         # but the metadata is the same
         assert got.meta == cosmo.meta

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABCMeta, abstractmethod
-from dataclasses import KW_ONLY, dataclass
+from dataclasses import KW_ONLY, dataclass, replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
@@ -248,14 +248,7 @@ class Cosmology(metaclass=ABCMeta):
 
         # mix new meta into existing, preferring the former.
         meta = meta if meta is not None else {}
-        new_meta = {**self.meta, **meta}
-        # Mix kwargs into initial arguments, preferring the former.
-        new_init = {**self.parameters, "meta": new_meta, **kwargs}
-        # Create BoundArgument to handle args versus kwargs.
-        # This also handles all errors from mismatched arguments
-        ba = self._init_signature.bind_partial(**new_init)
-        # Instantiate, respecting args vs kwargs
-        cloned = type(self)(*ba.args, **ba.kwargs)
+        cloned = replace(self, meta=self.meta | meta, **kwargs)
 
         # Check if nothing has changed.
         # TODO! or should return self?

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -82,7 +82,7 @@ def dataclass_decorator(cls):
         The ``__eq__`` method is custom (``eq=False``).
         The signature is precomputed and added to the class.
     """
-    return _with_signature(dataclass(frozen=True, repr=False, eq=False, init=True)(cls))
+    return _with_signature(dataclass(frozen=True, repr=True, eq=False, init=True)(cls))
 
 
 ##############################################################################
@@ -432,10 +432,6 @@ class Cosmology(metaclass=ABCMeta):
         return eq
 
     # ---------------------------------------------------------------
-
-    def __repr__(self):
-        fmtps = (f"{k}={v!r}" for k, v in self.parameters.items())
-        return f"{type(self).__qualname__}(name={self.name!r}, {', '.join(fmtps)})"
 
     def __str__(self):
         """Return a string representation of the cosmology."""

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import abc
 import inspect
+from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from dataclasses import KW_ONLY, dataclass
 from types import MappingProxyType
@@ -83,7 +83,7 @@ class _NameField:
 
 
 @dataclass_decorator
-class Cosmology(metaclass=abc.ABCMeta):
+class Cosmology(metaclass=ABCMeta):
     """Base-class for all Cosmologies.
 
     Parameters
@@ -200,13 +200,11 @@ class Cosmology(metaclass=abc.ABCMeta):
 
     # ---------------------------------------------------------------
 
-    def __init__(self, name=None, meta=None):
-        all_vars = all_cls_vars(self)
-        all_vars["name"].__set__(self, name)
-        all_vars["meta"].__set__(self, OrderedDict(meta or {}))
+    def __post_init__(self):  # noqa: B027
+        """Post-initialization, for subclasses to override if they need."""
 
     @property
-    @abc.abstractmethod
+    @abstractmethod
     def is_flat(self):
         """Return bool; `True` if the cosmology is flat.
 
@@ -462,7 +460,7 @@ Cosmology.__dataclass_fields__["meta"].repr = False
 
 
 @dataclass_decorator
-class FlatCosmologyMixin(metaclass=abc.ABCMeta):
+class FlatCosmologyMixin(metaclass=ABCMeta):
     """Mixin class for flat cosmologies.
 
     Do NOT instantiate directly. Note that all instances of
@@ -547,7 +545,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
         return True
 
     @property
-    @abc.abstractmethod
+    @abstractmethod
     def nonflat(self: _FlatCosmoT) -> _CosmoT:
         """Return the equivalent non-flat-class instance of this cosmology."""
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -55,7 +55,7 @@ _CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _FlatCosmoT = TypeVar("_FlatCosmoT", bound="FlatCosmologyMixin")
 
 # dataclass
-dataclass_decorator = dataclass(frozen=False, repr=False, eq=False, init=False)
+dataclass_decorator = dataclass(frozen=True, repr=False, eq=False, init=False)
 
 ##############################################################################
 
@@ -272,7 +272,7 @@ class Cosmology(metaclass=ABCMeta):
         # Check if nothing has changed.
         # TODO! or should return self?
         if (cloned.name == _modname) and not meta and cloned.is_equivalent(self):
-            cloned._name = self.name
+            object.__setattr__(cloned, "name", self.name)
 
         return cloned
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1,9 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# ruff: noqa: RUF009
 
 from __future__ import annotations
 
 import abc
 import inspect
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
@@ -51,6 +53,9 @@ _COSMOLOGY_CLASSES = dict()
 _CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _FlatCosmoT = TypeVar("_FlatCosmoT", bound="FlatCosmologyMixin")
 
+# dataclass
+dataclass_decorator = dataclass(frozen=False, repr=False, eq=False, init=False)
+
 ##############################################################################
 
 
@@ -58,6 +63,7 @@ class CosmologyError(Exception):
     pass
 
 
+@dataclass_decorator
 class Cosmology(metaclass=abc.ABCMeta):
     """Base-class for all Cosmologies.
 
@@ -89,12 +95,12 @@ class Cosmology(metaclass=abc.ABCMeta):
     meta = MetaData()
 
     # Unified I/O object interchange methods
-    from_format = UnifiedReadWriteMethod(CosmologyFromFormat)
-    to_format = UnifiedReadWriteMethod(CosmologyToFormat)
+    from_format: ClassVar = UnifiedReadWriteMethod(CosmologyFromFormat)
+    to_format: ClassVar = UnifiedReadWriteMethod(CosmologyToFormat)
 
     # Unified I/O read and write methods
-    read = UnifiedReadWriteMethod(CosmologyRead)
-    write = UnifiedReadWriteMethod(CosmologyWrite)
+    read: ClassVar = UnifiedReadWriteMethod(CosmologyRead)
+    write: ClassVar = UnifiedReadWriteMethod(CosmologyWrite)
 
     # Parameters
     parameters = ParametersAttribute(attr_name="_parameters")
@@ -430,6 +436,7 @@ class Cosmology(metaclass=abc.ABCMeta):
         return self.to_format("astropy.table", cls=cls, **kwargs)
 
 
+@dataclass_decorator
 class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     """Mixin class for flat cosmologies.
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -15,7 +15,7 @@ from astropy.io.registry import UnifiedReadWriteMethod
 from astropy.utils.decorators import classproperty
 from astropy.utils.metadata import MetaData
 
-from ._utils import all_cls_vars
+from ._utils import all_parameters
 from .connect import (
     CosmologyFromFormat,
     CosmologyRead,
@@ -153,25 +153,14 @@ class Cosmology(metaclass=ABCMeta):
         # -------------------
         # Parameters
 
-        params = {}
-        derived_params = {}
-        for n, v in all_cls_vars(cls).items():
-            if not isinstance(v, Parameter):
-                continue
-            if v.derived:
-                derived_params[n] = v
-            else:
-                params[n] = v
-
-        # reorder to match signature, placing "unordered" at the end
-        ordered = {
-            n: params.pop(n)
-            for n in cls._init_signature.parameters.keys()
-            if n in params
-        }
-        cls._parameters = MappingProxyType(ordered | params)
-        cls._parameters_derived = MappingProxyType(derived_params)
-        cls._parameters_all = frozenset(cls._parameters).union(cls._parameters_derived)
+        all_params = all_parameters(cls)
+        cls._parameters = MappingProxyType(
+            {k: v for k, v in all_params.items() if not v.derived}
+        )
+        cls._derived_parameters = MappingProxyType(
+            {k: v for k, v in all_params.items() if v.derived}
+        )
+        cls._parameters_all = frozenset(all_params)
 
         # -------------------
         # Registration

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import inspect
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 from dataclasses import KW_ONLY, dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
@@ -55,7 +54,7 @@ _CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _FlatCosmoT = TypeVar("_FlatCosmoT", bound="FlatCosmologyMixin")
 
 # dataclass
-dataclass_decorator = dataclass(frozen=True, repr=False, eq=False, init=False)
+dataclass_decorator = dataclass(frozen=True, repr=False, eq=False, init=True)
 
 ##############################################################################
 
@@ -180,7 +179,7 @@ class Cosmology(metaclass=ABCMeta):
         if not inspect.isabstract(cls):  # skip abstract classes
             cls._register_cls()
 
-    @classproperty(lazy=True)
+    @classproperty(lazy=False)
     def _init_signature(cls):
         """Initialization signature (without 'self')."""
         # get signature, dropping "self" by taking arguments [1:]

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -296,6 +296,10 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         self._inv_efunc_scalar = self.inv_efunc
         self._inv_efunc_scalar_args = ()
 
+    def __post_init__(self):
+        """Post-initialization, for subclasses to override."""
+        super().__post_init__()
+
     # ---------------------------------------------------------------
     # Parameter details
 

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1,6 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# ruff: noqa: RUF009
 
 from __future__ import annotations
+
+__all__ = ["FLRW", "FlatFLRWMixin"]
 
 import warnings
 from abc import abstractmethod
@@ -14,7 +17,7 @@ from numpy import inf, sin
 import astropy.constants as const
 import astropy.units as u
 from astropy.cosmology._utils import aszarr, vectorize_redshift_method
-from astropy.cosmology.core import Cosmology, FlatCosmologyMixin
+from astropy.cosmology.core import Cosmology, FlatCosmologyMixin, dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.parameter._converter import (
     _validate_non_negative,
@@ -24,11 +27,6 @@ from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
-__all__ = ["FLRW", "FlatFLRWMixin"]
-
-__doctest_requires__ = {"*": ["scipy"]}
-
-
 # isort: split
 if HAS_SCIPY:
     from scipy.integrate import quad
@@ -36,6 +34,9 @@ else:
 
     def quad(*args, **kwargs):
         raise ModuleNotFoundError("No module named 'scipy.integrate'")
+
+
+__doctest_requires__ = {"*": ["scipy"]}
 
 
 ##############################################################################
@@ -101,6 +102,7 @@ ParameterOde0 = Parameter(
 )
 
 
+@dataclass_decorator
 class FLRW(Cosmology, _ScaleFactorMixin):
     """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
@@ -159,34 +161,34 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     documentation on :ref:`astropy-cosmology-fast-integrals`.
     """
 
-    H0 = Parameter(
+    H0: Parameter = Parameter(
         doc="Hubble constant as an `~astropy.units.Quantity` at z=0.",
         unit="km/(s Mpc)",
         fvalidate="scalar",
     )
-    Om0 = Parameter(
+    Om0: Parameter = Parameter(
         doc="Omega matter; matter density/critical density at z=0.",
         fvalidate="non-negative",
     )
-    Ode0 = ParameterOde0
-    Tcmb0 = Parameter(
+    Ode0: Parameter = ParameterOde0.clone()
+    Tcmb0: Parameter = Parameter(
         default=0.0 * u.K,
         doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
         unit="Kelvin",
         fvalidate="scalar",
     )
-    Neff = Parameter(
+    Neff: Parameter = Parameter(
         default=3.04,
         doc="Number of effective neutrino species.",
         fvalidate="non-negative",
     )
-    m_nu = Parameter(
+    m_nu: Parameter = Parameter(
         default=0.0 * u.eV,
         doc="Mass of neutrino species.",
         unit="eV",
         equivalencies=u.mass_energy(),
     )
-    Ob0 = Parameter(
+    Ob0: Parameter = Parameter(
         default=None,
         doc="Omega baryon; baryonic matter density/critical density at z=0.",
     )
@@ -1472,6 +1474,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         return _radian_in_arcsec / self.angular_diameter_distance(z).to(u.kpc)
 
 
+@dataclass_decorator
 class FlatFLRWMixin(FlatCosmologyMixin):
     """Mixin class for flat FLRW cosmologies.
 
@@ -1483,7 +1486,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     parameter values), but ``FlatLambdaCDM`` **will** be flat.
     """
 
-    Ode0 = ParameterOde0.clone(derived=True)  # same as FLRW, but derived.
+    Ode0: Parameter = ParameterOde0.clone(derived=True)  # same as FLRW, but derived.
 
     def __init_subclass__(cls):
         super().__init_subclass__()

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -221,7 +221,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         # Derived quantities:
         # Dark matter density; matter - baryons, if latter is not None.
         object.__setattr__(
-            self, "_Odm0", None if Ob0 is None else (self._Om0 - self._Ob0)
+            self, "_Odm0", (None if Ob0 is None else (self._Om0 - self._Ob0))
         )
 
         # 100 km/s/Mpc * h = H0 (so h is dimensionless)

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1491,6 +1491,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     Ode0: Parameter = field(  # now a derived param.
         default=ParameterOde0.clone(default=0, derived=True),
         init=False,
+        repr=False,
     )
 
     def __init_subclass__(cls):

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -11,7 +11,7 @@ from dataclasses import field
 from inspect import signature
 from math import exp, floor, log, pi, sqrt
 from numbers import Number
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np
 from numpy import inf, sin
@@ -28,6 +28,10 @@ from astropy.cosmology.parameter._converter import (
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Self
 
 # isort: split
 if HAS_SCIPY:
@@ -1548,3 +1552,11 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         return (
             1.0 if isinstance(z, (Number, np.generic)) else np.ones_like(z, subok=False)
         )
+
+    def clone(
+        self, *, meta: Mapping | None = None, to_nonflat: bool = False, **kwargs
+    ) -> Self:
+        if not to_nonflat and kwargs.get("Ode0", None) is not None:
+            msg = "Cannot set 'Ode0' in clone unless 'to_nonflat=True'. "
+            raise ValueError(msg)
+        return super().clone(meta=meta, to_nonflat=to_nonflat, **kwargs)

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 __all__ = ["FLRW", "FlatFLRWMixin"]
 
+import inspect
 import warnings
 from abc import abstractmethod
 from dataclasses import field
@@ -1520,7 +1521,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
     def nonflat(self: _FlatFLRWMixinT) -> _FLRWT:
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
-        ba = self.__nonflatclass__._init_signature.bind_partial(
+        ba = inspect.signature(self.__nonflatclass__).bind_partial(
             **dict(self.parameters), Ode0=self.Ode0, name=self.name
         )
         # Make new instance, respecting args vs kwargs

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -121,23 +121,25 @@ class LambdaCDM(FLRW):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0)
-            if self._Ok0 == 0:
-                self._optimize_flat_norad()
-            else:
-                self._comoving_distance_z1z2 = self._elliptic_comoving_distance_z1z2
+            inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_norel
+            inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0)
+            if self._Ok0 != 0:
+                object.__setattr__(
+                    self,
+                    "_comoving_distance_z1z2",
+                    self._elliptic_comoving_distance_z1z2,
+                )
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
                 self._Ogamma0 + self._Onu0,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -146,6 +148,11 @@ class LambdaCDM(FLRW):
                 self._nmasslessnu,
                 self._nu_y_list,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
+
+        if self._Tcmb0.value == 0 and self._Ok0 == 0:
+            self._optimize_flat_norad()
 
     def _optimize_flat_norad(self):
         """Set optimizations for flat LCDM cosmologies with no radiation."""
@@ -154,17 +161,21 @@ class LambdaCDM(FLRW):
         #    for Omega_M=0 would lead to an infinity in its argument.
         # The EdS case is three times faster than the hypergeometric.
         if self._Om0 == 0:
-            self._comoving_distance_z1z2 = self._dS_comoving_distance_z1z2
-            self._age = self._dS_age
-            self._lookback_time = self._dS_lookback_time
+            comoving_distance_z1z2 = self._dS_comoving_distance_z1z2
+            age = self._dS_age
+            lookback_time = self._dS_lookback_time
         elif self._Om0 == 1:
-            self._comoving_distance_z1z2 = self._EdS_comoving_distance_z1z2
-            self._age = self._EdS_age
-            self._lookback_time = self._EdS_lookback_time
+            comoving_distance_z1z2 = self._EdS_comoving_distance_z1z2
+            age = self._EdS_age
+            lookback_time = self._EdS_lookback_time
         else:
-            self._comoving_distance_z1z2 = self._hypergeometric_comoving_distance_z1z2
-            self._age = self._flat_age
-            self._lookback_time = self._flat_lookback_time
+            comoving_distance_z1z2 = self._hypergeometric_comoving_distance_z1z2
+            age = self._flat_age
+            lookback_time = self._flat_lookback_time
+
+        object.__setattr__(self, "_comoving_distance_z1z2", comoving_distance_z1z2)
+        object.__setattr__(self, "_age", age)
+        object.__setattr__(self, "_lookback_time", lookback_time)
 
     def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
@@ -697,22 +708,22 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
+            inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
+            inv_efunc_scalar_args = (self._Om0, self._Ode0)
             # Repeat the optimization reassignments here because the init
             # of the LambaCDM above didn't actually create a flat cosmology.
             # That was done through the explicit tweak setting self._Ok0.
             self._optimize_flat_norad()
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0 + self._Onu0,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0,
@@ -720,6 +731,8 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
                 self._nmasslessnu,
                 self._nu_y_list,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
     def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -113,6 +113,10 @@ class LambdaCDM(FLRW):
             name=name,
             meta=meta,
         )
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
@@ -685,6 +689,10 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
             name=name,
             meta=meta,
         )
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -6,7 +6,6 @@ from numbers import Number
 import numpy as np
 from numpy import log
 
-import astropy.units as u
 from astropy.cosmology._utils import aszarr
 from astropy.cosmology.core import dataclass_decorator
 from astropy.utils.compat.optional_deps import HAS_SCIPY
@@ -88,32 +87,6 @@ class LambdaCDM(FLRW):
     >>> z = 0.5
     >>> dc = cosmo.comoving_distance(z)
     """
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        Ode0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=Ode0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()
@@ -676,31 +649,6 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
     >>> print(cosmo.nonflat)
     LambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Ode0=0.7, ...
     """
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=0.0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -8,6 +8,7 @@ from numpy import log
 
 import astropy.units as u
 from astropy.cosmology._utils import aszarr
+from astropy.cosmology.core import dataclass_decorator
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 from . import scalar_inv_efuncs
@@ -30,6 +31,7 @@ __all__ = ["LambdaCDM", "FlatLambdaCDM"]
 __doctest_requires__ = {"*": ["scipy"]}
 
 
+@dataclass_decorator
 class LambdaCDM(FLRW):
     """FLRW cosmology with a cosmological constant and curvature.
 
@@ -600,6 +602,7 @@ class LambdaCDM(FLRW):
         )
 
 
+@dataclass_decorator
 class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
     """FLRW cosmology with a cosmological constant and no curvature.
 

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -11,7 +11,7 @@ import pytest
 import astropy.constants as const
 import astropy.units as u
 from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Parameter, Planck18
-from astropy.cosmology.core import _COSMOLOGY_CLASSES
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, dataclass_decorator
 from astropy.cosmology.flrw.base import _a_B_c2, _critdens_const, _H0units_to_invs, quad
 from astropy.cosmology.parameter._core import MISSING
 from astropy.cosmology.tests.helper import get_redshift_methods
@@ -31,6 +31,7 @@ from .conftest import filter_keys_from_items
 # SETUP / TEARDOWN
 
 
+@dataclass_decorator
 class SubFLRW(FLRW):
     def w(self, z):
         return super().w(z)
@@ -1015,6 +1016,7 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
 
         with pytest.raises(TypeError, match="subclasses of"):
 
+            @dataclass_decorator
             class HASOde0SubClass(cosmo_cls):
                 def __init__(self, Ode0):
                     pass

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -10,7 +10,14 @@ import pytest
 
 import astropy.constants as const
 import astropy.units as u
-from astropy.cosmology import FLRW, FlatLambdaCDM, LambdaCDM, Parameter, Planck18
+from astropy.cosmology import (
+    FLRW,
+    FlatFLRWMixin,
+    FlatLambdaCDM,
+    LambdaCDM,
+    Parameter,
+    Planck18,
+)
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, dataclass_decorator
 from astropy.cosmology.flrw.base import _a_B_c2, _critdens_const, _H0units_to_invs, quad
 from astropy.cosmology.parameter._core import MISSING
@@ -159,7 +166,10 @@ class ParameterOde0TestMixin(ParameterTestMixin):
         )
         assert isinstance(Ode0, Parameter)
         assert "Omega dark energy" in Ode0.__doc__
-        assert Ode0.default is MISSING
+        if issubclass(cosmo_cls, FlatFLRWMixin):
+            assert Ode0.default == 0
+        else:
+            assert Ode0.default is MISSING
 
     def test_Parameter_Ode0_validation(self, cosmo_cls, cosmo):
         """Test Parameter ``Ode0`` validation."""
@@ -277,7 +287,9 @@ class ParameterNeffTestMixin(ParameterTestMixin):
     def test_init_Neff(self, cosmo_cls, ba):
         """Test initialization for values of ``Neff``."""
         # test that it works with units
-        ba.arguments["Neff"] = ba.arguments["Neff"] << u.one  # ensure units
+        ba.arguments["Neff"] = (
+            cosmo_cls.parameters["Neff"].default << u.one
+        )  # ensure units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
         assert cosmo.Neff == ba.arguments["Neff"]
 
@@ -331,14 +343,16 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
         """
         # Test that it works when m_nu has units.
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
-        assert np.all(cosmo.m_nu == ba.arguments["m_nu"])  # (& checks len, unit)
+        np.testing.assert_array_equal(
+            cosmo.m_nu, cosmo_cls.parameters["m_nu"].default
+        )  # (& checks len, unit)
         assert not cosmo.has_massive_nu
         assert cosmo.m_nu.unit == u.eV  # explicitly check unit once.
 
         # And it works when m_nu doesn't have units.
-        ba.arguments["m_nu"] = ba.arguments["m_nu"].value  # strip units
+        ba.arguments["m_nu"] = cosmo_cls.parameters["m_nu"].default.value  # strip units
         cosmo = cosmo_cls(*ba.args, **ba.kwargs)
-        assert np.all(cosmo.m_nu.value == ba.arguments["m_nu"])
+        np.testing.assert_array_equal(cosmo.m_nu.value, ba.arguments["m_nu"])
         assert not cosmo.has_massive_nu
 
         # A negative m_nu raises an exception.
@@ -473,7 +487,7 @@ class ParameterOb0TestMixin(ParameterTestMixin):
             cosmo.Odm(1)
 
         # The default value is None
-        assert cosmo_cls._init_signature.parameters["Ob0"].default is None
+        assert cosmo_cls.parameters["Ob0"].default is None
 
 
 class FLRWTest(
@@ -1114,13 +1128,13 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
         assert flat.is_equivalent(cosmo)
         assert cosmo.is_equivalent(flat)
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """
         Test method ``.__repr__()``. Skip non-flat superclass test.
         e.g. `TestFlatLambdaCDDM` -> `FlatFLRWMixinTest`
         vs   `TestFlatLambdaCDDM` -> `TestLambdaCDDM` -> `FlatFLRWMixinTest`
         """
-        FLRWTest.test_repr(self, cosmo)
+        FLRWTest.test_repr(self, cosmo_cls, cosmo)
 
         # test eliminated Ode0 from parameters
         assert "Ode0" not in repr(cosmo)

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -1135,7 +1135,5 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
         e.g. `TestFlatLambdaCDDM` -> `FlatFLRWMixinTest`
         vs   `TestFlatLambdaCDDM` -> `TestLambdaCDDM` -> `FlatFLRWMixinTest`
         """
-        FLRWTest.test_repr(self, cosmo_cls, cosmo)
-
         # test eliminated Ode0 from parameters
         assert "Ode0" not in repr(cosmo)

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -1087,7 +1087,8 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
         super().test_clone_to_nonflat_change_param(cosmo)
 
         # change Ode0, without non-flat
-        with pytest.raises(TypeError):
+        msg = "Cannot set 'Ode0' in clone unless 'to_nonflat=True'. "
+        with pytest.raises(ValueError, match=msg):
             cosmo.clone(Ode0=1)
 
         # change to non-flat

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -1110,7 +1110,7 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
             Ode0=1.0 - cosmo.Om0 - cosmo.Ogamma0 - cosmo.Onu0,
             **self.cls_kwargs,
         )
-        flat._Ok0 = 0.0
+        object.__setattr__(flat, "_Ok0", 0.0)
         assert flat.is_equivalent(cosmo)
         assert cosmo.is_equivalent(flat)
 

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -94,12 +94,14 @@ class TestwCDM(FLRWTest, Parameterw0TestMixin):
         w = cosmo.w(z)
         assert u.allclose(w, self.cls_kwargs["w0"])
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
-            "wCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, Ode0=0.73,"
-            " w0=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
-            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            "wCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
+            "Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04, "
+            "m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03, w0=-0.5)"
         )
 
     # ===============================================================
@@ -147,12 +149,14 @@ class TestFlatwCDM(FlatFLRWMixinTest, TestwCDM):
         self.cls = FlatwCDM
         self.cls_kwargs.update(w0=-0.5)
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
-            "FlatwCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " w0=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
-            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            "FlatwCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
+            "Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>, "
+            "Ob0=0.03, w0=-0.5)"
         )
 
     # ===============================================================

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -96,8 +96,6 @@ class TestwCDM(FLRWTest, Parameterw0TestMixin):
 
     def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
         assert repr(cosmo) == (
             "wCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
             "Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04, "

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -100,8 +100,6 @@ class Testw0waCDM(FLRWTest, Parameterw0TestMixin, ParameterwaTestMixin):
 
     def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
         assert repr(cosmo) == (
             "w0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
             "Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04, "

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -98,12 +98,14 @@ class Testw0waCDM(FLRWTest, Parameterw0TestMixin, ParameterwaTestMixin):
             [-1, -1.16666667, -1.25, -1.3, -1.34848485],
         )
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
-            "w0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " Ode0=0.73, w0=-1.0, wa=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
-            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            "w0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
+            "Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04, "
+            "m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03, w0=-1.0, wa=-0.5)"
         )
 
     # ===============================================================
@@ -163,12 +165,14 @@ class TestFlatw0waCDM(FlatFLRWMixinTest, Testw0waCDM):
         self.cls = Flatw0waCDM
         self.cls_kwargs.update(w0=-1, wa=-0.5)
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
-            "Flatw0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " w0=-1.0, wa=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
-            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            "Flatw0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
+            "Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>, "
+            "Ob0=0.03, w0=-1.0, wa=-0.5)"
         )
 
     # ===============================================================

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -107,8 +107,6 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
 
     def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
         assert repr(cosmo) == (
             "w0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
             "Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04, "

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -105,12 +105,14 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
             cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]), [-1.0, -0.75, -0.5, -0.25, 0.15]
         )
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
-            "w0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " Ode0=0.73, w0=-1.0, wz=0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
-            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            "w0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
+            "Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04, "
+            "m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03, w0=-1.0, wz=0.5)"
         )
 
     # ---------------------------------------------------------------
@@ -199,12 +201,14 @@ class TestFlatw0wzCDM(FlatFLRWMixinTest, Testw0wzCDM):
         super().setup_class(self)
         self.cls = Flatw0wzCDM
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
-            "Flatw0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " w0=-1.0, wz=0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
-            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            "Flatw0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, "
+            "Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>, "
+            "Ob0=0.03, w0=-1.0, wz=0.5)"
         )
 
     # ---------------------------------------------------------------

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -147,13 +147,14 @@ class TestwpwaCDM(
             [-0.94848485, -0.93333333, -0.9, -0.84666667, -0.82380952, -0.78266667],
         )
 
-    def test_repr(self, cosmo):
+    def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
         assert repr(cosmo) == (
             "wpwaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " Ode0=0.73, wp=-0.9, wa=0.2, zp=<Quantity 0.5 redshift>,"
-            " Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>,"
-            " Ob0=0.03)"
+            " Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03, wp=-0.9, wa=0.2,"
+            " zp=<Quantity 0.5 redshift>)"
         )
 
     # ===============================================================
@@ -217,10 +218,12 @@ class TestFlatwpwaCDM(FlatFLRWMixinTest, TestwpwaCDM):
 
     def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
+        super().test_repr(cosmo_cls, cosmo)
+
         assert repr(cosmo) == (
             "FlatwpwaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
-            " wp=-0.9, wa=0.2, zp=<Quantity 0.5 redshift>, Tcmb0=<Quantity 3. K>,"
-            " Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
+            " Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>,"
+            " Ob0=0.03, wp=-0.9, wa=0.2, zp=<Quantity 0.5 redshift>)"
         )
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy required for this test.")

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -149,7 +149,6 @@ class TestwpwaCDM(
 
     def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
         assert repr(cosmo) == (
             "wpwaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
             " Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04,"

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -106,7 +106,7 @@ class wCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.w0 = w0
+        type(self).parameters["w0"].__set__(self, w0)
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -112,6 +112,11 @@ class wCDM(FLRW):
         )
         type(self).parameters["w0"].__set__(self, w0)
 
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
+
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
@@ -330,6 +335,10 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
             name=name,
             meta=meta,
         )
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -5,7 +5,6 @@
 import numpy as np
 from numpy import sqrt
 
-import astropy.units as u
 from astropy.cosmology._utils import aszarr
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
@@ -84,35 +83,6 @@ class wCDM(FLRW):
     w0: Parameter = Parameter(
         default=-1.0, doc="Dark energy equation of state.", fvalidate="float"
     )
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        Ode0,
-        w0=-1.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=Ode0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        type(self).parameters["w0"].__set__(self, w0)
-
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()
@@ -312,33 +282,6 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
     >>> print(cosmo.nonflat)
     wCDM(H0=70.0 km / (Mpc s), Om0=0.3, Ode0=0.7, ...
     """
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        w0=-1.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=0.0,
-            w0=w0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -120,11 +120,11 @@ class wCDM(FLRW):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0, self._w0)
+            inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_norel
+            inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0, self._w0)
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -132,8 +132,8 @@ class wCDM(FLRW):
                 self._w0,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -143,6 +143,9 @@ class wCDM(FLRW):
                 self._nu_y_list,
                 self._w0,
             )
+
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
     def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
@@ -343,19 +346,19 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0)
+            inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_norel
+            inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0)
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0 + self._Onu0,
                 self._w0,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0,
@@ -364,6 +367,8 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
                 self._nu_y_list,
                 self._w0,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
     def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# ruff: noqa: RUF009
+
 
 import numpy as np
 from numpy import sqrt
 
 import astropy.units as u
 from astropy.cosmology._utils import aszarr
+from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
 from . import scalar_inv_efuncs
@@ -15,6 +18,7 @@ __all__ = ["wCDM", "FlatwCDM"]
 __doctest_requires__ = {"*": ["scipy"]}
 
 
+@dataclass_decorator
 class wCDM(FLRW):
     """FLRW cosmology with a constant dark energy EoS and curvature.
 
@@ -77,7 +81,7 @@ class wCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    w0 = Parameter(
+    w0: Parameter = Parameter(
         default=-1.0, doc="Dark energy equation of state.", fvalidate="float"
     )
 
@@ -236,6 +240,7 @@ class wCDM(FLRW):
         ) ** (-0.5)
 
 
+@dataclass_decorator
 class FlatwCDM(FlatFLRWMixin, wCDM):
     """FLRW cosmology with a constant dark energy EoS and no spatial curvature.
 

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -4,7 +4,6 @@
 
 from numpy import exp
 
-import astropy.units as u
 from astropy.cosmology._utils import aszarr
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
@@ -101,38 +100,6 @@ class w0waCDM(FLRW):
         doc="Negative derivative of dark energy equation of state w.r.t. a.",
         fvalidate="float",
     )
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        Ode0,
-        w0=-1.0,
-        wa=0.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=Ode0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        params = type(self).parameters
-        params["w0"].__set__(self, w0)
-        params["wa"].__set__(self, wa)
-
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()
@@ -305,35 +272,6 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
     .. [2] Linder, E. (2003). Exploring the Expansion History of the
            Universe. Phys. Rev. Lett., 90, 091301.
     """
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        w0=-1.0,
-        wa=0.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=0.0,
-            w0=w0,
-            wa=wa,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -132,6 +132,11 @@ class w0waCDM(FLRW):
         params["w0"].__set__(self, w0)
         params["wa"].__set__(self, wa)
 
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
+
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
@@ -326,6 +331,10 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
             name=name,
             meta=meta,
         )
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -140,8 +140,8 @@ class w0waCDM(FLRW):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_norel
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -149,8 +149,8 @@ class w0waCDM(FLRW):
                 self._wa,
             )
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -159,8 +159,8 @@ class w0waCDM(FLRW):
                 self._wa,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -171,6 +171,8 @@ class w0waCDM(FLRW):
                 self._w0,
                 self._wa,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
     def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
@@ -339,11 +341,11 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0, self._wa)
+            inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_norel
+            inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0, self._wa)
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0 + self._Onu0,
@@ -351,8 +353,8 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
                 self._wa,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0,
@@ -362,3 +364,5 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
                 self._w0,
                 self._wa,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# ruff: noqa: RUF009
+
 
 from numpy import exp
 
 import astropy.units as u
 from astropy.cosmology._utils import aszarr
+from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
 from . import scalar_inv_efuncs
@@ -14,6 +17,7 @@ __all__ = ["w0waCDM", "Flatw0waCDM"]
 __doctest_requires__ = {"*": ["scipy"]}
 
 
+@dataclass_decorator
 class w0waCDM(FLRW):
     r"""FLRW cosmology with a CPL dark energy EoS and curvature.
 
@@ -89,10 +93,10 @@ class w0waCDM(FLRW):
            Universe. Phys. Rev. Lett., 90, 091301.
     """
 
-    w0 = Parameter(
+    w0: Parameter = Parameter(
         default=-1.0, doc="Dark energy equation of state at z=0.", fvalidate="float"
     )
-    wa = Parameter(
+    wa: Parameter = Parameter(
         default=0.0,
         doc="Negative derivative of dark energy equation of state w.r.t. a.",
         fvalidate="float",
@@ -217,6 +221,7 @@ class w0waCDM(FLRW):
         return zp1 ** (3 * (1 + self._w0 + self._wa)) * exp(-3 * self._wa * z / zp1)
 
 
+@dataclass_decorator
 class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
     """FLRW cosmology with a CPL dark energy EoS and no curvature.
 

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -124,8 +124,9 @@ class w0waCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.w0 = w0
-        self.wa = wa
+        params = type(self).parameters
+        params["w0"].__set__(self, w0)
+        params["wa"].__set__(self, wa)
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -133,8 +133,8 @@ class w0wzCDM(FLRW):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_norel
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -142,8 +142,8 @@ class w0wzCDM(FLRW):
                 self._wz,
             )
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -152,8 +152,8 @@ class w0wzCDM(FLRW):
                 self._wz,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -164,6 +164,8 @@ class w0wzCDM(FLRW):
                 self._w0,
                 self._wz,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
     def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
@@ -323,11 +325,11 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0, self._wz)
+            inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_norel
+            inv_efunc_scalar_args = (self._Om0, self._Ode0, self._w0, self._wz)
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0 + self._Onu0,
@@ -335,8 +337,8 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
                 self._wz,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0,
@@ -346,3 +348,5 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
                 self._w0,
                 self._wz,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -4,7 +4,6 @@
 
 from numpy import exp
 
-import astropy.units as u
 from astropy.cosmology._utils import aszarr
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
@@ -94,38 +93,6 @@ class w0wzCDM(FLRW):
         doc="Derivative of the dark energy equation of state w.r.t. z.",
         fvalidate="float",
     )
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        Ode0,
-        w0=-1.0,
-        wz=0.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=Ode0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        params = type(self).parameters
-        params["w0"].__set__(self, w0)
-        params["wz"].__set__(self, wz)
-
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()
@@ -289,35 +256,6 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
     >>> cosmo.comoving_distance(0.5)
     <Quantity 1849.74726272 Mpc>
     """
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        w0=-1.0,
-        wz=0.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=0.0,
-            w0=w0,
-            wz=wz,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -125,6 +125,11 @@ class w0wzCDM(FLRW):
         params["w0"].__set__(self, w0)
         params["wz"].__set__(self, wz)
 
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
+
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         if self._Tcmb0.value == 0:
@@ -310,6 +315,10 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
             name=name,
             meta=meta,
         )
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -117,8 +117,9 @@ class w0wzCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.w0 = w0
-        self.wz = wz
+        params = type(self).parameters
+        params["w0"].__set__(self, w0)
+        params["wz"].__set__(self, wz)
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# ruff: noqa: RUF009
+
 
 from numpy import exp
 
 import astropy.units as u
 from astropy.cosmology._utils import aszarr
+from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
 from . import scalar_inv_efuncs
@@ -14,6 +17,7 @@ __all__ = ["w0wzCDM", "Flatw0wzCDM"]
 __doctest_requires__ = {"*": ["scipy"]}
 
 
+@dataclass_decorator
 class w0wzCDM(FLRW):
     """FLRW cosmology with a variable dark energy EoS and curvature.
 
@@ -82,10 +86,10 @@ class w0wzCDM(FLRW):
     >>> dc = cosmo.comoving_distance(z)
     """
 
-    w0 = Parameter(
+    w0: Parameter = Parameter(
         default=-1.0, doc="Dark energy equation of state at z=0.", fvalidate="float"
     )
-    wz = Parameter(
+    wz: Parameter = Parameter(
         default=0.0,
         doc="Derivative of the dark energy equation of state w.r.t. z.",
         fvalidate="float",
@@ -214,6 +218,7 @@ class w0wzCDM(FLRW):
         )
 
 
+@dataclass_decorator
 class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
     """FLRW cosmology with a variable dark energy EoS and no curvature.
 

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# ruff: noqa: RUF009
+
 
 from numpy import exp
 
 import astropy.units as u
 from astropy.cosmology import units as cu
 from astropy.cosmology._utils import aszarr
+from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
 from . import scalar_inv_efuncs
@@ -15,6 +18,7 @@ __all__ = ["wpwaCDM", "FlatwpwaCDM"]
 __doctest_requires__ = {"*": ["scipy"]}
 
 
+@dataclass_decorator
 class wpwaCDM(FLRW):
     r"""FLRW cosmology with a CPL dark energy EoS, a pivot redshift, and curvature.
 
@@ -98,17 +102,17 @@ class wpwaCDM(FLRW):
            of Merit Science Working Group. arXiv e-prints, arXiv:0901.0721.
     """
 
-    wp = Parameter(
+    wp: Parameter = Parameter(
         default=-1.0,
         doc="Dark energy equation of state at the pivot redshift zp.",
         fvalidate="float",
     )
-    wa = Parameter(
+    wa: Parameter = Parameter(
         default=0.0,
         doc="Negative derivative of dark energy equation of state w.r.t. a.",
         fvalidate="float",
     )
-    zp = Parameter(
+    zp: Parameter = Parameter(
         default=0.0 * cu.redshift,
         doc="The pivot redshift, where w(z) = wp.",
         unit=cu.redshift,
@@ -141,9 +145,10 @@ class wpwaCDM(FLRW):
             name=name,
             meta=meta,
         )
-        self.wp = wp
-        self.wa = wa
-        self.zp = zp
+        params = self.__class__.parameters
+        params["wp"].__set__(self, wp)
+        params["wa"].__set__(self, wa)
+        params["zp"].__set__(self, zp)
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
@@ -243,6 +248,7 @@ class wpwaCDM(FLRW):
         )
 
 
+@dataclass_decorator
 class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
     r"""FLRW cosmology with a CPL dark energy EoS, a pivot redshift, and no curvature.
 

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -159,8 +159,8 @@ class wpwaCDM(FLRW):
         # about what is being done here.
         apiv = 1.0 / (1.0 + self._zp.value)
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_norel
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -169,8 +169,8 @@ class wpwaCDM(FLRW):
                 self._wa,
             )
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -180,8 +180,8 @@ class wpwaCDM(FLRW):
                 self._wa,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ok0,
@@ -193,6 +193,8 @@ class wpwaCDM(FLRW):
                 apiv,
                 self._wa,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
     def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
@@ -371,8 +373,8 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
         # about what is being done here.
         apiv = 1.0 / (1.0 + self._zp)
         if self._Tcmb0.value == 0:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_norel
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_norel
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._wp,
@@ -380,8 +382,8 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
                 self._wa,
             )
         elif not self._massivenu:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_nomnu
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_nomnu
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0 + self._Onu0,
@@ -390,8 +392,8 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
                 self._wa,
             )
         else:
-            self._inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc
-            self._inv_efunc_scalar_args = (
+            inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc
+            inv_efunc_scalar_args = (
                 self._Om0,
                 self._Ode0,
                 self._Ogamma0,
@@ -402,3 +404,5 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
                 apiv,
                 self._wa,
             )
+        object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
+        object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -150,6 +150,11 @@ class wpwaCDM(FLRW):
         params["wa"].__set__(self, wa)
         params["zp"].__set__(self, zp)
 
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
+
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.
         apiv = 1.0 / (1.0 + self._zp.value)
@@ -357,6 +362,10 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
             name=name,
             meta=meta,
         )
+        self.__post_init__()
+
+    def __post_init__(self):
+        super().__post_init__()
 
         # Please see :ref:`astropy-cosmology-fast-integrals` for discussion
         # about what is being done here.

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -4,7 +4,6 @@
 
 from numpy import exp
 
-import astropy.units as u
 from astropy.cosmology import units as cu
 from astropy.cosmology._utils import aszarr
 from astropy.cosmology.core import dataclass_decorator
@@ -117,40 +116,6 @@ class wpwaCDM(FLRW):
         doc="The pivot redshift, where w(z) = wp.",
         unit=cu.redshift,
     )
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        Ode0,
-        wp=-1.0,
-        wa=0.0,
-        zp=0.0 * cu.redshift,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=Ode0,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        params = self.__class__.parameters
-        params["wp"].__set__(self, wp)
-        params["wa"].__set__(self, wa)
-        params["zp"].__set__(self, zp)
-
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()
@@ -334,37 +299,6 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
         Nichol, R. (2009). Findings of the Joint Dark Energy Mission Figure
         of Merit Science Working Group. arXiv e-prints, arXiv:0901.0721.
     """
-
-    def __init__(
-        self,
-        H0,
-        Om0,
-        wp=-1.0,
-        wa=0.0,
-        zp=0.0,
-        Tcmb0=0.0 * u.K,
-        Neff=3.04,
-        m_nu=0.0 * u.eV,
-        Ob0=None,
-        *,
-        name=None,
-        meta=None,
-    ):
-        super().__init__(
-            H0=H0,
-            Om0=Om0,
-            Ode0=0.0,
-            wp=wp,
-            wa=wa,
-            zp=zp,
-            Tcmb0=Tcmb0,
-            Neff=Neff,
-            m_nu=m_nu,
-            Ob0=Ob0,
-            name=name,
-            meta=meta,
-        )
-        self.__post_init__()
 
     def __post_init__(self):
         super().__post_init__()

--- a/astropy/cosmology/funcs/tests/test_funcs.py
+++ b/astropy/cosmology/funcs/tests/test_funcs.py
@@ -419,7 +419,7 @@ def test_z_at_value_roundtrip(cosmo):
         assert allclose(got, z, rtol=2e-11), f"Round-trip testing {name} failed"
 
     # Test distance functions between two redshifts; only for realizations
-    if isinstance(cosmo.name, str):
+    if isinstance(getattr(cosmo, "name", None), str):
         z2 = 2.0
         func_z1z2 = [
             lambda z1: cosmo._comoving_distance_z1z2(z1, z2),

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -175,7 +175,7 @@ class Parameter:
         """
         # Raise error if setting 2nd time.
         if hasattr(cosmology, self._attr_name):
-            raise AttributeError(f"can't set attribute {self.name} again")
+            raise AttributeError(f"cannot assign to field {self.name!r}")
 
         # Change `self` to the default value if default is MISSING.
         # This is done for backwards compatibility only - so that Parameter can be used

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -191,7 +191,7 @@ class Parameter:
         # in a dataclass and still return `self` when accessed from a class.
         # Accessing the Parameter object via `cosmo_cls.param_name` will be removed
         # in favor of `cosmo_cls.parameters["param_name"]`.
-        if value is self and self.default is MISSING:
+        if value is self:
             value = self.default
 
         # Validate value, generally setting units if present

--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -193,7 +193,7 @@ class Parameter:
             value.setflags(write=False)
 
         # Set the value on the cosmology
-        setattr(cosmology, self._attr_name, value)
+        object.__setattr__(cosmology, self._attr_name, value)
 
     # -------------------------------------------
     # validate value

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -131,5 +131,5 @@ class ParametersAttributeTestMixin:
         self, cosmo: Cosmology, name: str
     ) -> None:
         """Test descriptor ``parameters`` cannot be set on the instance."""
-        with pytest.raises(AttributeError, match=f"cannot set {name!r} of"):
+        with pytest.raises(AttributeError, match=f"cannot assign to field {name!r}"):
             setattr(cosmo, name, {})

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -104,27 +104,33 @@ class ParametersAttributeTestMixin:
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_from_class(self, cosmo_cls: type[Cosmology], name: str) -> None:
         """Test descriptor ``parameters`` accessed from the class."""
-        descriptor = all_cls_vars(cosmo_cls)[name]
         # test presence
         assert hasattr(cosmo_cls, name)
         # test Parameter is a MappingProxyType
         parameters = getattr(cosmo_cls, name)
         assert isinstance(parameters, MappingProxyType)
         # Test items
-        assert set(parameters.keys()) == set(getattr(cosmo_cls, descriptor.attr_name))
         assert all(isinstance(p, Parameter) for p in parameters.values())
+        assert set(parameters) == {
+            k
+            for k, v in all_cls_vars(cosmo_cls).items()
+            if (isinstance(v, Parameter) and (v.derived == ("derived" in name)))
+        }
 
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_from_instance(self, cosmo: Cosmology, name: str) -> None:
         """Test descriptor ``parameters`` accessed from the instance."""
-        descriptor = all_cls_vars(cosmo)[name]
         # test presence
         assert hasattr(cosmo, name)
         # test Parameter is a MappingProxyType
         parameters = getattr(cosmo, name)
         assert isinstance(parameters, MappingProxyType)
         # Test keys
-        assert set(parameters) == set(getattr(cosmo, descriptor.attr_name))
+        assert set(parameters) == {
+            k
+            for k, v in all_cls_vars(cosmo).items()
+            if (isinstance(v, Parameter) and (v.derived == ("derived" in name)))
+        }
 
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_cannot_set_on_instance(

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -10,7 +10,7 @@ import pytest
 import astropy.units as u
 from astropy.cosmology import Cosmology, Parameter
 from astropy.cosmology._utils import all_cls_vars
-from astropy.cosmology.core import _COSMOLOGY_CLASSES
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, dataclass_decorator
 from astropy.cosmology.parameter._converter import (
     _REGISTRY_FVALIDATORS,
     _validate_with_unit,
@@ -189,22 +189,6 @@ class ParameterTestMixin:
         else:
             assert all_parameter.name in cosmo_cls.parameters
 
-    def test_Parameters_reorder_by_signature(self, cosmo_cls, clean_registry):
-        """Test parameters are reordered."""
-
-        class Example(cosmo_cls):
-            param = Parameter()
-
-            def __init__(self, param, *, name=None, meta=None):
-                pass  # never actually initialized
-
-        # param should be 1st, all other parameters next
-        assert next(iter(Example.parameters)) == "param"
-        # Check the other parameters are as expected.
-        # only run this test if "param" is not already on the cosmology
-        if next(iter(cosmo_cls.parameters)) != "param":
-            assert set(tuple(Example.parameters)[1:]) == set(cosmo_cls.parameters)
-
 
 # ========================================================================
 
@@ -222,6 +206,7 @@ class TestParameter(ParameterTestMixin):
             equivalencies=u.mass_energy(),
         )
 
+        @dataclass_decorator
         class Example1(Cosmology):
             param = Param
 
@@ -233,6 +218,7 @@ class TestParameter(ParameterTestMixin):
                 return super().is_flat()
 
         # with validator
+        @dataclass_decorator
         class Example2(Example1):
             def __init__(self, param=15 * u.m):
                 self.param = param

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -9,6 +9,7 @@ import pytest
 
 import astropy.units as u
 from astropy.cosmology import Cosmology, Parameter
+from astropy.cosmology._utils import all_cls_vars
 from astropy.cosmology.core import _COSMOLOGY_CLASSES
 from astropy.cosmology.parameter._converter import (
     _REGISTRY_FVALIDATORS,
@@ -16,8 +17,6 @@ from astropy.cosmology.parameter._converter import (
 )
 from astropy.cosmology.parameter._core import MISSING
 
-##############################################################################
-# TESTS
 ##############################################################################
 
 
@@ -247,7 +246,7 @@ class TestParameter(ParameterTestMixin):
 
     def teardown_class(self):
         for cls in self.classes.values():
-            _COSMOLOGY_CLASSES.pop(cls.__qualname__)
+            _COSMOLOGY_CLASSES.pop(cls.__qualname__, None)
 
     @pytest.fixture(scope="class", params=["Example1", "Example2"])
     def cosmo_cls(self, request):
@@ -279,7 +278,7 @@ class TestParameter(ParameterTestMixin):
         assert param.__doc__ == "Description of example parameter."
 
         # custom from init
-        assert param._unit == u.m
+        assert param.unit == u.m
         assert param.equivalencies == u.mass_energy()
         assert param.derived == np.False_
 
@@ -458,8 +457,8 @@ class TestParameter(ParameterTestMixin):
         class Example(cosmo_cls):
             param = Parameter(unit=u.eV, equivalencies=u.mass_energy())
 
-            def __init__(self, param, *, name=None, meta=None):
-                self.param = param
+            def __init__(self, param, *args, **kwargs):
+                all_cls_vars(self)["param"].__set__(self, param)
 
             @property
             def is_flat(self):

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -168,7 +168,9 @@ class ParameterTestMixin:
         assert hasattr(cosmo, all_parameter._attr_name)
 
         # and raises an error if set again
-        with pytest.raises(AttributeError, match="can't set attribute"):
+        with pytest.raises(
+            AttributeError, match=f"cannot assign to field {all_parameter.name!r}"
+        ):
             setattr(cosmo, all_parameter.name, None)
 
     # -------------------------------------------

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -64,9 +64,11 @@ def __getattr__(name: str) -> Cosmology:
     cosmo = Cosmology.read(
         str(_COSMOLOGY_DATA_DIR / name) + ".ecsv", format="ascii.ecsv"
     )
-    cosmo.__doc__ = (
+    object.__setattr__(
+        cosmo,
+        "__doc__",
         f"{name} instance of {cosmo.__class__.__qualname__} "
-        f"cosmology\n(from {cosmo.meta['reference']})"
+        f"cosmology\n(from {cosmo.meta['reference']})",
     )
 
     # Cache in this module so `__getattr__` is only called once per `name`.

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -15,9 +15,8 @@ import pytest
 
 import astropy.cosmology.units as cu
 import astropy.units as u
-from astropy.cosmology import Cosmology, FlatCosmologyMixin
+from astropy.cosmology import Cosmology, FlatCosmologyMixin, Parameter
 from astropy.cosmology.core import _COSMOLOGY_CLASSES, dataclass_decorator
-from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.parameter.tests.test_descriptors import (
     ParametersAttributeTestMixin,
 )
@@ -215,7 +214,6 @@ class CosmologyTest(
 
     def test_name(self, cosmo):
         """Test property ``name``."""
-        assert cosmo.name is cosmo._name  # accesses private attribute
         assert cosmo.name is None or isinstance(cosmo.name, str)  # type
         assert cosmo.name == self.cls_kwargs["name"]  # test has expected value
 
@@ -229,6 +227,10 @@ class CosmologyTest(
 
         with pytest.raises(AttributeError, match=match):
             cosmo.name = None
+
+    def test_name_on_cls(self, cosmo_cls):
+        """Test accessing :attr:`~astropy.cosmology.Cosmology.name` from the class."""
+        assert cosmo_cls.name is None
 
     @abc.abstractmethod
     def test_is_flat(self, cosmo_cls, cosmo):

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -282,34 +282,6 @@ class CosmologyTest(
         assert (cosmo != newcosmo) and (newcosmo != cosmo)
         assert cosmo.__equiv__(newcosmo) and newcosmo.__equiv__(cosmo)
 
-    # ---------------------------------------------------------------
-
-    def test_repr(self, cosmo_cls, cosmo):
-        """Test method ``.__repr__()``.
-
-        This is a very general test and it is probably good to have a
-        hard-coded comparison.
-        """
-        r = repr(cosmo)
-
-        # class in string rep
-        assert cosmo_cls.__qualname__ in r
-        assert r.index(cosmo_cls.__qualname__) == 0  # it's the first thing
-        r = r[len(cosmo_cls.__qualname__) + 1 :]  # remove
-
-        # name in string rep
-        if cosmo.name is not None:
-            assert f"name={cosmo.name!r}" in r
-            assert r.index("name=") == 0
-            r = r[6 + len(cosmo.name) + 3 :]  # remove
-
-        # parameters in string rep
-        for k, v in cosmo.parameters.items():
-            sv = f"{k}={v!r}"
-            assert sv in r
-            assert r.index(k) == 0
-            r = r[len(sv) + 2 :]  # remove
-
     # ------------------------------------------------
 
     @pytest.mark.parametrize("in_meta", [True, False])

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -16,7 +16,7 @@ import pytest
 import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology import Cosmology, FlatCosmologyMixin
-from astropy.cosmology.core import _COSMOLOGY_CLASSES
+from astropy.cosmology.core import _COSMOLOGY_CLASSES, dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.parameter.tests.test_descriptors import (
     ParametersAttributeTestMixin,
@@ -68,12 +68,13 @@ invalid_zs = [
 ]
 
 
+@dataclass_decorator
 class SubCosmology(Cosmology):
     """Defined here to be serializable."""
 
-    H0 = Parameter(unit="km/(s Mpc)")
-    Tcmb0 = Parameter(default=0 * u.K, unit=u.K)
-    m_nu = Parameter(default=0 * u.eV, unit=u.eV)
+    H0: Parameter = Parameter(unit="km/(s Mpc)")
+    Tcmb0: Parameter = Parameter(default=0 * u.K, unit=u.K)
+    m_nu: Parameter = Parameter(default=0 * u.eV, unit=u.eV)
 
     def __init__(self, H0, Tcmb0=0 * u.K, m_nu=0 * u.eV, name=None, meta=None):
         super().__init__(name=name, meta=meta)
@@ -544,6 +545,7 @@ def test__nonflatclass__multiple_nonflat_inheritance():
     """
 
     # Define a non-operable minimal subclass of Cosmology.
+    @dataclass_decorator
     class SubCosmology2(Cosmology):
         def __init__(self, H0, Tcmb0=0 * u.K, m_nu=0 * u.eV, name=None, meta=None):
             super().__init__(name=name, meta=meta)

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -130,14 +130,14 @@ class CosmologyTest(
     @pytest.fixture(scope="function")  # ensure not cached.
     def ba(self):
         """Return filled `inspect.BoundArguments` for cosmology."""
-        ba = self.cls._init_signature.bind(*self.cls_args, **self.cls_kwargs)
+        ba = inspect.signature(self.cls).bind(*self.cls_args, **self.cls_kwargs)
         ba.apply_defaults()
         return ba
 
     @pytest.fixture(scope="class")
     def cosmo(self, cosmo_cls):
         """The cosmology instance with which to test."""
-        ba = self.cls._init_signature.bind(*self.cls_args, **self.cls_kwargs)
+        ba = inspect.signature(self.cls).bind(*self.cls_args, **self.cls_kwargs)
         ba.apply_defaults()
         return cosmo_cls(*ba.args, **ba.kwargs)
 
@@ -173,23 +173,6 @@ class CosmologyTest(
 
         assert UnRegisteredSubclassTest.parameters == cosmo_cls.parameters
         assert UnRegisteredSubclassTest.__qualname__ not in _COSMOLOGY_CLASSES
-
-    def test_init_signature(self, cosmo_cls, cosmo):
-        """Test class-property ``_init_signature``."""
-        # test presence
-        assert hasattr(cosmo_cls, "_init_signature")
-        assert hasattr(cosmo, "_init_signature")
-
-        # test internal consistency, so following tests can use either cls or instance.
-        assert cosmo_cls._init_signature == cosmo._init_signature
-
-        # test matches __init__, but without 'self'
-        sig = inspect.signature(cosmo.__init__)  # (instances don't have self)
-        assert set(sig.parameters) == set(cosmo._init_signature.parameters)
-        assert all(
-            np.all(sig.parameters[k].default == p.default)
-            for k, p in cosmo._init_signature.parameters.items()
-        )
 
     # ---------------------------------------------------------------
     # instance-level

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -74,13 +74,6 @@ class SubCosmology(Cosmology):
     Tcmb0: Parameter = Parameter(default=0 * u.K, unit=u.K)
     m_nu: Parameter = Parameter(default=0 * u.eV, unit=u.eV)
 
-    def __init__(self, H0, Tcmb0=0 * u.K, m_nu=0 * u.eV, name=None, meta=None):
-        super().__init__(name=name, meta=meta)
-        params = self.__class__.parameters
-        params["H0"].__set__(self, H0)
-        params["Tcmb0"].__set__(self, Tcmb0)
-        params["m_nu"].__set__(self, m_nu)
-
     @property
     def is_flat(self):
         return super().is_flat()
@@ -544,9 +537,6 @@ def test__nonflatclass__multiple_nonflat_inheritance():
     # Define a non-operable minimal subclass of Cosmology.
     @dataclass_decorator
     class SubCosmology2(Cosmology):
-        def __init__(self, H0, Tcmb0=0 * u.K, m_nu=0 * u.eV, name=None, meta=None):
-            super().__init__(name=name, meta=meta)
-
         @property
         def is_flat(self):
             return False

--- a/docs/changes/cosmology/15484.api.rst
+++ b/docs/changes/cosmology/15484.api.rst
@@ -1,1 +1,1 @@
-``Cosmology`` is now a ``dataclass``.
+``Cosmology`` and its subclasses are now frozen ``dataclass`` objects.

--- a/docs/changes/cosmology/15484.api.rst
+++ b/docs/changes/cosmology/15484.api.rst
@@ -1,0 +1,1 @@
+``Cosmology`` is now a ``dataclass``.

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -59,7 +59,7 @@ and tips and tricks to building a performant cosmology class.
 
     from astropy.cosmology import FLRW
 
-    @dataclass(repr=False, eq=False, init=False)
+    @dataclass(frozen=True, repr=False, eq=False, init=False)
     class CustomCosmology(FLRW):
         ...  # [details discussed below]
 
@@ -87,7 +87,7 @@ the definition of |FLRW|.
 
 .. code-block:: python
 
-    @dataclass(repr=False, eq=False, init=False)
+    @dataclass(frozen=True, repr=False, eq=False, init=False)
     class FLRW(Cosmology):
 
         H0: Parameter = Parameter(doc="Hubble constant as an `~astropy.units.Quantity` at z=0",
@@ -148,7 +148,7 @@ parameter and change any constructor argument. For example, see
 
 .. code-block:: python
 
-    @dataclass(repr=False, eq=False, init=False)
+    @dataclass(frozen=True, repr=False, eq=False, init=False)
     class FlatFLRWMixin(FlatCosmologyMixin):
         ...
 

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -59,7 +59,7 @@ and tips and tricks to building a performant cosmology class.
 
     from astropy.cosmology import FLRW
 
-    @dataclass(frozen=True, repr=False, eq=False)
+    @dataclass(frozen=True, eq=False)
     class CustomCosmology(FLRW):
         ...  # [details discussed below]
 
@@ -87,7 +87,7 @@ the definition of |FLRW|.
 
 .. code-block:: python
 
-    @dataclass(frozen=True, repr=False, eq=False)
+    @dataclass(frozen=True, eq=False)
     class FLRW(Cosmology):
 
         H0: Parameter = Parameter(doc="Hubble constant as an `~astropy.units.Quantity` at z=0",
@@ -143,7 +143,7 @@ parameter and change any constructor argument. For example, see
 
 .. code-block:: python
 
-    @dataclass(frozen=True, repr=False, eq=False)
+    @dataclass(frozen=True, eq=False)
     class FlatFLRWMixin(FlatCosmologyMixin):
         ...
 

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -59,6 +59,7 @@ and tips and tricks to building a performant cosmology class.
 
     from astropy.cosmology import FLRW
 
+    @dataclass(repr=False, eq=False, init=False)
     class CustomCosmology(FLRW):
         ...  # [details discussed below]
 
@@ -86,24 +87,27 @@ the definition of |FLRW|.
 
 .. code-block:: python
 
+    @dataclass(repr=False, eq=False, init=False)
     class FLRW(Cosmology):
 
-        H0 = Parameter(doc="Hubble constant as an `~astropy.units.Quantity` at z=0",
-                       unit="km/(s Mpc)", fvalidate="scalar")
-        Om0 = Parameter(doc="Omega matter; matter density/critical density at z=0",
-                        fvalidate="non-negative")
-        Ode0 = Parameter(doc="Omega dark energy; dark energy density/critical density at z=0.",
-                         fvalidate="float")
-        Tcmb0 = Parameter(doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
-                  unit="Kelvin", fmt="0.4g", fvalidate="scalar")
-        Neff = Parameter(doc="Number of effective neutrino species.", fvalidate="non-negative")
-        m_nu = Parameter(doc="Mass of neutrino species.",
-                 unit="eV", equivalencies=u.mass_energy(), fmt="")
-        Ob0 = Parameter(doc="Omega baryon; baryonic matter density/critical density at z=0.")
+        H0: Parameter = Parameter(doc="Hubble constant as an `~astropy.units.Quantity` at z=0",
+                                  unit="km/(s Mpc)", fvalidate="scalar")
+        Om0: Parameter = Parameter(doc="Omega matter; matter density/critical density at z=0",
+                                   fvalidate="non-negative")
+        Ode0: Parameter = Parameter(doc="Omega dark energy; dark energy density/critical density at z=0.",
+                                    fvalidate="float")
+        Tcmb0: Parameter = Parameter(doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
+                                     default=0.0 * u.K, unit="Kelvin", fmt="0.4g", fvalidate="scalar")
+        Neff: Parameter = Parameter(doc="Number of effective neutrino species.",
+                                    default=3.04, fvalidate="non-negative")
+        m_nu: Parameter = Parameter(doc="Mass of neutrino species.",
+                                    unit="eV", equivalencies=u.mass_energy())
+        Ob0: Parameter = Parameter(doc="Omega baryon; baryonic matter density/critical density at z=0.")
 
         def __init__(self, H0, Om0, Ode0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,
                      Ob0=None, *, name=None, meta=None):
-            self.H0 = H0
+            params = self.__class__.parameters
+            params["H0"].__set__(self, H0)
             ...  # for each Parameter in turn
 
         @Ob0.validator
@@ -144,10 +148,11 @@ parameter and change any constructor argument. For example, see
 
 .. code-block:: python
 
+    @dataclass(repr=False, eq=False, init=False)
     class FlatFLRWMixin(FlatCosmologyMixin):
         ...
 
-        Ode0 = FLRW.parameters["Ode0"].clone(derived=True)
+        Ode0: Parameter = FLRW.parameters["Ode0"].clone(derived=True)
 
 Mixins
 ------

--- a/docs/cosmology/dev.rst
+++ b/docs/cosmology/dev.rst
@@ -59,7 +59,7 @@ and tips and tricks to building a performant cosmology class.
 
     from astropy.cosmology import FLRW
 
-    @dataclass(frozen=True, repr=False, eq=False, init=False)
+    @dataclass(frozen=True, repr=False, eq=False)
     class CustomCosmology(FLRW):
         ...  # [details discussed below]
 
@@ -87,7 +87,7 @@ the definition of |FLRW|.
 
 .. code-block:: python
 
-    @dataclass(frozen=True, repr=False, eq=False, init=False)
+    @dataclass(frozen=True, repr=False, eq=False)
     class FLRW(Cosmology):
 
         H0: Parameter = Parameter(doc="Hubble constant as an `~astropy.units.Quantity` at z=0",
@@ -101,14 +101,9 @@ the definition of |FLRW|.
         Neff: Parameter = Parameter(doc="Number of effective neutrino species.",
                                     default=3.04, fvalidate="non-negative")
         m_nu: Parameter = Parameter(doc="Mass of neutrino species.",
-                                    unit="eV", equivalencies=u.mass_energy())
-        Ob0: Parameter = Parameter(doc="Omega baryon; baryonic matter density/critical density at z=0.")
-
-        def __init__(self, H0, Om0, Ode0, Tcmb0=0.0*u.K, Neff=3.04, m_nu=0.0*u.eV,
-                     Ob0=None, *, name=None, meta=None):
-            params = self.__class__.parameters
-            params["H0"].__set__(self, H0)
-            ...  # for each Parameter in turn
+                                    default=0.0*u.eV, unit="eV", equivalencies=u.mass_energy(), fmt="")
+        Ob0: Parameter = Parameter(doc="Omega baryon; baryonic matter density/critical density at z=0.",
+                                   default=None)
 
         @Ob0.validator
         def Ob0(self, param, value):
@@ -148,7 +143,7 @@ parameter and change any constructor argument. For example, see
 
 .. code-block:: python
 
-    @dataclass(frozen=True, repr=False, eq=False, init=False)
+    @dataclass(frozen=True, repr=False, eq=False)
     class FlatFLRWMixin(FlatCosmologyMixin):
         ...
 

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -227,8 +227,8 @@ describe the cosmology::
   >>> from astropy.cosmology import FlatwCDM
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
   >>> print(cosmo)
-  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262, w0=-1.016,
-           Tcmb0=0.0 K, Neff=3.04, m_nu=None, Ob0=None)
+  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262, Tcmb0=0.0 K, Neff=3.04,
+           m_nu=None, Ob0=None, w0=-1.016)
 
 ..
   EXAMPLE END

--- a/docs/whatsnew/6.1.rst
+++ b/docs/whatsnew/6.1.rst
@@ -43,6 +43,24 @@ columns with any long integers which overflowed the 32-bit integer would be retu
 as string columns. The new default behavior is consistent with ``numpy`` v2 and ``pandas``.
 
 
+Updates to `~astropy.cosmology`
+===============================
+
+|Cosmology| as a :func:`~dataclasses.dataclass`
+-----------------------------------------------
+
+The :class:`~astropy.cosmology.Cosmology` class is
+now a :func:`~dataclasses.dataclass`. This means that the :mod:`dataclasses` machinery
+can be used to work with :class:`~astropy.cosmology.Cosmology` objects. For example::
+
+    >>> from dataclasses import make_dataclass, field, fields
+    >>> from astropy.cosmology import Cosmology
+    >>> NewC = make_dataclass("NewC", [("newfield", float, field(default=None))],
+    ...                       bases=(Cosmology,), frozen=True, eq=False)
+    >>> [f.name for f in fields(NewC)]
+    ['name', 'meta', 'newfield']
+
+
 Full change log
 ===============
 

--- a/docs/whatsnew/6.1.rst
+++ b/docs/whatsnew/6.1.rst
@@ -53,6 +53,18 @@ The :class:`~astropy.cosmology.Cosmology` class is
 now a :func:`~dataclasses.dataclass`. This means that the :mod:`dataclasses` machinery
 can be used to work with :class:`~astropy.cosmology.Cosmology` objects. For example::
 
+    >>> from dataclasses import asdict, fields, replace
+    >>> from astropy.cosmology import Planck18
+    >>> replace(Planck18, name="modified", Ob0=0.05)
+    FlatLambdaCDM(name='modified', ..., Ob0=0.05)
+    >>> asdict(Planck18)
+    {'name': 'Planck18', 'meta': ..., 'H0': <Quantity 67.66 km / (Mpc s)>, ...
+    >>> [f.name for f in fields(Planck18)]
+    ['name', 'meta', 'H0', 'Om0', 'Ode0', 'Tcmb0', 'Neff', 'm_nu', 'Ob0']
+
+Also, it is now possible to create new :class:`~astropy.cosmology.Cosmology` subclasses
+using :func:`~dataclasses.make_dataclass`::
+
     >>> from dataclasses import make_dataclass, field, fields
     >>> from astropy.cosmology import Cosmology
     >>> NewC = make_dataclass("NewC", [("newfield", float, field(default=None))],


### PR DESCRIPTION
This PR changes `Cosmology` and its subclasses to `dataclasses.dataclass` objects for versions py3.10+.

**Why change?**

Well, this has long been the intended plan. `Cosmology` is structured very similarly to the dataclass paradigm (see `cosmology.Parameter`) but small differences meant that they were not compatible.

Dataclasses bring a number of advantages over normal classes, particularly for classes that are defined by their attributes (so not `dict`-like things).

1. straightforward declaration of the fields / attributes
2. no need to define most dunder methods.
3. built in static typing compatibility
4. support for match statements
5. easy to make immutable structures
6. introspection tools like `fields` and `asdict`, etc.
7. easier to dynamically define subclasses
8. deep support in transpilation / compilation libraries, e.g. mypyc.
9. ...

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
