### PR TITLE
Cosmology: distinguish repr from str

### DIFF
--- a/astropy/cosmology/_io/cosmology.py
+++ b/astropy/cosmology/_io/cosmology.py
@@ -46,7 +46,7 @@ def from_cosmology(cosmo, /, **kwargs):
     Examples
     --------
     >>> from astropy.cosmology import Cosmology, Planck18
-    >>> Cosmology.from_format(Planck18)
+    >>> print(Cosmology.from_format(Planck18))
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
     """

--- a/astropy/cosmology/_io/ecsv.py
+++ b/astropy/cosmology/_io/ecsv.py
@@ -36,7 +36,7 @@ Now we can read the Cosmology from the ECSV file, constructing a new cosmologica
 instance identical to the ``Planck18`` cosmology from which it was generated.
 
     >>> cosmo = Cosmology.read(file)
-    >>> cosmo
+    >>> print(cosmo)
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                 Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
     >>> cosmo == Planck18
@@ -73,7 +73,7 @@ The ``cosmology`` information (column or metadata) may be omitted if the cosmolo
 data.
 
     >>> from astropy.cosmology import FlatLambdaCDM
-    >>> FlatLambdaCDM.read(file)
+    >>> print(FlatLambdaCDM.read(file))
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                     Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 
@@ -234,7 +234,7 @@ def read_ecsv(
     instance identical to the ``Planck18`` cosmology from which it was generated.
 
         >>> cosmo = Cosmology.read(file)
-        >>> cosmo
+        >>> print(cosmo)
         FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                     Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
         >>> cosmo == Planck18
@@ -246,7 +246,7 @@ def read_ecsv(
     data.
 
         >>> from astropy.cosmology import FlatLambdaCDM
-        >>> FlatLambdaCDM.read(file)
+        >>> print(FlatLambdaCDM.read(file))
         FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                       Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 

--- a/astropy/cosmology/_io/model.py
+++ b/astropy/cosmology/_io/model.py
@@ -22,7 +22,7 @@ evaluate``. Now you can fit cosmologies with data!
 
 The |Planck18| cosmology can be recovered with |Cosmology.from_format|.
 
-    >>> Cosmology.from_format(model)
+    >>> print(Cosmology.from_format(model))
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 """
@@ -172,7 +172,7 @@ def from_model(model):
     --------
     >>> from astropy.cosmology import Cosmology, Planck18
     >>> model = Planck18.to_format("astropy.model", method="lookback_time")
-    >>> Cosmology.from_format(model)
+    >>> print(Cosmology.from_format(model))
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
     """

--- a/astropy/cosmology/_io/yaml.py
+++ b/astropy/cosmology/_io/yaml.py
@@ -12,7 +12,7 @@ require YAML serialization.
     >>> yml  # doctest: +NORMALIZE_WHITESPACE
     "!astropy.cosmology...FlatLambdaCDM\nH0: !astropy.units.Quantity...
 
-    >>> Cosmology.from_format(yml, format="yaml")
+    >>> print(Cosmology.from_format(yml, format="yaml"))
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 """  # this is shown in the docs.
@@ -161,7 +161,7 @@ def from_yaml(yml, *, cosmology=None):
     --------
     >>> from astropy.cosmology import Cosmology, Planck18
     >>> yml = Planck18.to_format("yaml")
-    >>> Cosmology.from_format(yml, format="yaml")
+    >>> print(Cosmology.from_format(yml, format="yaml"))
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
     """

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import abc
 import inspect
-from itertools import chain
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
@@ -408,10 +407,10 @@ class Cosmology(metaclass=abc.ABCMeta):
                 if k != "name"
                 else f'name="{getattr(self, k)!s}"'  # name needs quotes
             )
-            for k in chain(("name",), self.__parameters__)
-            if (getattr(self, k) is not None if k == "name" else True)
+            for k in ("name", *self.__parameters__)
+            if k != "name" or getattr(self, k) is not None
         )
-        return f"{self.__class__.__name__}(" + ", ".join(fs) + ")"
+        return f"{type(self).__name__}({', '.join(fs)})"
 
     def __astropy_table__(self, cls, copy, **kwargs):
         """Return a `~astropy.table.Table` of type ``cls``.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -401,16 +401,9 @@ class Cosmology(metaclass=abc.ABCMeta):
 
     def __str__(self):
         """Return a string representation of the cosmology."""
-        fs = (  # name + fields
-            (
-                f"{k!s}={getattr(self, k)!s}"
-                if k != "name"
-                else f'name="{getattr(self, k)!s}"'  # name needs quotes
-            )
-            for k in ("name", *self.__parameters__)
-            if k != "name" or getattr(self, k) is not None
-        )
-        return f"{type(self).__name__}({', '.join(fs)})"
+        name_str = "" if self.name is None else f'name="{self.name}", '
+        param_strs = (f"{k!s}={getattr(self, k)!s}" for k in self.__parameters__)
+        return f"{type(self).__name__}({name_str}{', '.join(param_strs)})"
 
     def __astropy_table__(self, cls, copy, **kwargs):
         """Return a `~astropy.table.Table` of type ``cls``.

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -657,8 +657,8 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
     To get an equivalent cosmology, but of type `astropy.cosmology.LambdaCDM`,
     use :attr:`astropy.cosmology.FlatFLRWMixin.nonflat`.
 
-    >>> cosmo.nonflat
-    LambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
+    >>> print(cosmo.nonflat)
+    LambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Ode0=0.7, ...
     """
 
     def __init__(

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -1086,13 +1086,13 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
         assert flat.is_equivalent(cosmo)
         assert cosmo.is_equivalent(flat)
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """
         Test method ``.__repr__()``. Skip non-flat superclass test.
         e.g. `TestFlatLambdaCDDM` -> `FlatFLRWMixinTest`
         vs   `TestFlatLambdaCDDM` -> `TestLambdaCDDM` -> `FlatFLRWMixinTest`
         """
-        FLRWTest.test_repr(self, cosmo_cls, cosmo)
+        FLRWTest.test_repr(self, cosmo)
 
         # test eliminated Ode0 from parameters
         assert "Ode0" not in repr(cosmo)

--- a/astropy/cosmology/flrw/tests/test_lambdacdm.py
+++ b/astropy/cosmology/flrw/tests/test_lambdacdm.py
@@ -77,16 +77,20 @@ class TestLambdaCDM(FLRWTest):
         w = cosmo.w(z)
         assert u.allclose(w, -1.0)
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'LambdaCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27,'
-            " Ode0=0.73, Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
-            " Ob0=0.03)"
+        assert repr(cosmo) == (
+            "LambdaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " Ode0=0.73, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
+
+    def test_str(self, cosmo):
+        """Test method ``.__str__()``."""
+        assert str(cosmo) == (
+            'LambdaCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27, Ode0=0.73,'
+            " Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        )
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize(
@@ -139,16 +143,20 @@ class TestFlatLambdaCDM(FlatFLRWMixinTest, TestLambdaCDM):
     # ===============================================================
     # Method & Attribute Tests
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'FlatLambdaCDM(name="ABCMeta", H0=70.0 km / (Mpc s),'
-            " Om0=0.27, Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
+        assert repr(cosmo) == (
+            "FlatLambdaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>,"
             " Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
+
+    def test_str(self, cosmo):
+        """Test method ``.__str__()``."""
+        assert str(cosmo) == (
+            'FlatLambdaCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27, '
+            "Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        )
 
     # ===============================================================
     # Usage Tests

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -98,16 +98,13 @@ class TestwCDM(FLRWTest, Parameterw0TestMixin):
         w = cosmo.w(z)
         assert u.allclose(w, self.cls_kwargs["w0"])
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'wCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27,'
-            " Ode0=0.73, w0=-0.5, Tcmb0=3.0 K, Neff=3.04,"
-            " m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "wCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27, Ode0=0.73,"
+            " w0=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ===============================================================
     # Usage Tests
@@ -154,16 +151,13 @@ class TestFlatwCDM(FlatFLRWMixinTest, TestwCDM):
         self.cls = FlatwCDM
         self.cls_kwargs.update(w0=-0.5)
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'FlatwCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27,'
-            " w0=-0.5, Tcmb0=3.0 K, Neff=3.04, m_nu=[0. 0. 0.] eV,"
-            " Ob0=0.03)"
+        assert repr(cosmo) == (
+            "FlatwCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " w0=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ===============================================================
     # Usage Tests

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -102,16 +102,13 @@ class Testw0waCDM(FLRWTest, Parameterw0TestMixin, ParameterwaTestMixin):
             [-1, -1.16666667, -1.25, -1.3, -1.34848485],
         )
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'w0waCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27,'
-            " Ode0=0.73, w0=-1.0, wa=-0.5, Tcmb0=3.0 K, Neff=3.04,"
-            " m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "w0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " Ode0=0.73, w0=-1.0, wa=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ===============================================================
     # Usage Tests
@@ -170,16 +167,13 @@ class TestFlatw0waCDM(FlatFLRWMixinTest, Testw0waCDM):
         self.cls = Flatw0waCDM
         self.cls_kwargs.update(w0=-1, wa=-0.5)
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'Flatw0waCDM(name="ABCMeta", H0=70.0 km / (Mpc s),'
-            " Om0=0.27, w0=-1.0, wa=-0.5, Tcmb0=3.0 K, Neff=3.04,"
-            " m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "Flatw0waCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " w0=-1.0, wa=-0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ===============================================================
     # Usage Tests

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -106,16 +106,13 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
             cosmo.w([0.0, 0.5, 1.0, 1.5, 2.3]), [-1.0, -0.75, -0.5, -0.25, 0.15]
         )
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'w0wzCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27,'
-            " Ode0=0.73, w0=-1.0, wz=0.5, Tcmb0=3.0 K, Neff=3.04,"
-            " m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "w0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " Ode0=0.73, w0=-1.0, wz=0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ---------------------------------------------------------------
 
@@ -203,16 +200,13 @@ class TestFlatw0wzCDM(FlatFLRWMixinTest, Testw0wzCDM):
         super().setup_class(self)
         self.cls = Flatw0wzCDM
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'Flatw0wzCDM(name="ABCMeta", H0=70.0 km / (Mpc s),'
-            " Om0=0.27, w0=-1.0, wz=0.5, Tcmb0=3.0 K,"
-            " Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "Flatw0wzCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " w0=-1.0, wz=0.5, Tcmb0=<Quantity 3. K>, Neff=3.04,"
+            " m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ---------------------------------------------------------------
 

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -148,16 +148,14 @@ class TestwpwaCDM(
             [-0.94848485, -0.93333333, -0.9, -0.84666667, -0.82380952, -0.78266667],
         )
 
-    def test_repr(self, cosmo_cls, cosmo):
+    def test_repr(self, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'wpwaCDM(name="ABCMeta", H0=70.0 km / (Mpc s), Om0=0.27,'
-            " Ode0=0.73, wp=-0.9, wa=0.2, zp=0.5 redshift, Tcmb0=3.0 K,"
-            " Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "wpwaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " Ode0=0.73, wp=-0.9, wa=0.2, zp=<Quantity 0.5 redshift>,"
+            " Tcmb0=<Quantity 3. K>, Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>,"
+            " Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     # ===============================================================
     # Usage Tests
@@ -220,14 +218,11 @@ class TestFlatwpwaCDM(FlatFLRWMixinTest, TestwpwaCDM):
 
     def test_repr(self, cosmo_cls, cosmo):
         """Test method ``.__repr__()``."""
-        super().test_repr(cosmo_cls, cosmo)
-
-        expected = (
-            'FlatwpwaCDM(name="ABCMeta", H0=70.0 km / (Mpc s),'
-            " Om0=0.27, wp=-0.9, wa=0.2, zp=0.5 redshift, Tcmb0=3.0 K,"
-            " Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.03)"
+        assert repr(cosmo) == (
+            "FlatwpwaCDM(name='ABCMeta', H0=<Quantity 70. km / (Mpc s)>, Om0=0.27,"
+            " wp=-0.9, wa=0.2, zp=<Quantity 0.5 redshift>, Tcmb0=<Quantity 3. K>,"
+            " Neff=3.04, m_nu=<Quantity [0., 0., 0.] eV>, Ob0=0.03)"
         )
-        assert repr(cosmo) == expected
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy required for this test.")
     @pytest.mark.parametrize(

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -296,8 +296,8 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
     To get an equivalent cosmology, but of type `astropy.cosmology.wCDM`,
     use :attr:`astropy.cosmology.FlatFLRWMixin.nonflat`.
 
-    >>> cosmo.nonflat
-    wCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
+    >>> print(cosmo.nonflat)
+    wCDM(H0=70.0 km / (Mpc s), Om0=0.3, Ode0=0.7, ...
     """
 
     def __init__(

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -281,8 +281,8 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
     To get an equivalent cosmology, but of type `astropy.cosmology.w0waCDM`,
     use :attr:`astropy.cosmology.FlatFLRWMixin.nonflat`.
 
-    >>> cosmo.nonflat
-    w0waCDM(H0=70.0 km / (Mpc s), Om0=0.3, ...
+    >>> print(cosmo.nonflat)
+    w0waCDM(H0=70.0 km / (Mpc s), Om0=0.3, Ode0=0.7, ...
 
     References
     ----------

--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -102,7 +102,8 @@ class default_cosmology(ScienceState):
     To get the default cosmology:
 
         >>> default_cosmology.get()
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966, ...
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>,
+                      Om0=0.30966, ...
     """
 
     _default_value = "Planck18"

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -315,14 +315,14 @@ class CosmologyTest(
 
         # name in string rep
         if cosmo.name is not None:
-            assert f'name="{cosmo.name}"' in r
+            assert f"name={cosmo.name!r}" in r
             assert r.index("name=") == 0
             r = r[6 + len(cosmo.name) + 3 :]  # remove
 
         # parameters in string rep
         ps = {k: getattr(cosmo, k) for k in cosmo.__parameters__}
         for k, v in ps.items():
-            sv = f"{k}={v}"
+            sv = f"{k}={v!r}"
             assert sv in r
             assert r.index(k) == 0
             r = r[len(sv) + 2 :]  # remove

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -227,8 +227,8 @@ describe the cosmology::
   >>> from astropy.cosmology import FlatwCDM
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
   >>> print(cosmo)
-  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262, Tcmb0=0.0 K,
-           Neff=3.04, m_nu=None, Ob0=None, w0=-1.016)
+  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262, w0=-1.016,
+           Tcmb0=0.0 K, Neff=3.04, m_nu=None, Ob0=None)
 
 ..
   EXAMPLE END

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -79,7 +79,7 @@ classes::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
-  >>> cosmo  # doctest: +FLOAT_CMP
+  >>> print(cosmo)  # doctest: +FLOAT_CMP
   FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
                 Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)
 
@@ -131,7 +131,7 @@ parameter and Omega matter (both at z=0)::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-  >>> cosmo
+  >>> print(cosmo)
   FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=0.0 K,
                 Neff=3.04, m_nu=None, Ob0=None)
 
@@ -203,7 +203,7 @@ instantiation by passing the keyword argument ``Ob0``::
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
-  >>> cosmo
+  >>> print(cosmo)
   FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=0.0 K,
                 Neff=3.04, m_nu=None, Ob0=0.05)
 
@@ -226,9 +226,9 @@ describe the cosmology::
 
   >>> from astropy.cosmology import FlatwCDM
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
-  >>> cosmo
-  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262,
-           w0=-1.016, Tcmb0=0.0 K, Neff=3.04, m_nu=None, Ob0=None)
+  >>> print(cosmo)
+  FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262, Tcmb0=0.0 K,
+           Neff=3.04, m_nu=None, Ob0=None, w0=-1.016)
 
 ..
   EXAMPLE END

--- a/docs/cosmology/io/index.rst
+++ b/docs/cosmology/io/index.rst
@@ -110,7 +110,7 @@ the |Planck18| cosmology from which it was created.
 .. code-block::
 
     >>> cosmo = Cosmology.from_format(ct, format="astropy.table")
-    >>> cosmo
+    >>> print(cosmo)
     FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 


### PR DESCRIPTION
Cosmology's repr was built a bit incorrectly, using the string representation for fields, not the actual representation. I've made the current `repr` into the new `__str__` so that the more succinct string form can be accessed by `print(cosmo)`.
`repr(cosmo)` now uses `repr` all the way down.


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
