### PR TITLE
Fix segfault with error report in FITS compression

### DIFF
--- a/astropy/io/fits/hdu/compressed/src/compression.c
+++ b/astropy/io/fits/hdu/compressed/src/compression.c
@@ -90,7 +90,10 @@ PyInit__compression(void)
 // cfitsio call.  In our wrapper functions we can then check if the Python error
 // state is set and then return NULL to raise the error.
 void ffpmsg(const char *err_message) {
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
     PyErr_SetString(CfitsioException, err_message);
+    PyGILState_Release(gstate);
 }
 
 /* PLIO/IRAF compression */

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from astropy.io import fits
 from astropy.io.fits.hdu.compressed._codecs import PLIO1
+from astropy.io.fits.hdu.compressed._compression import CfitsioException
 
 from .conftest import fitsio_param_to_astropy_param
 
@@ -165,7 +166,10 @@ def test_invalid_tile(tmp_path):
         f.write(b"\x00\x00\x00\x95")
         f.write(content[8644:])
 
-    hdulist = fits.open(tmp_path / "m13_corrupted.fits")
-
-    # Access the data to make sure we decompress it
-    hdulist[1].data.sum()
+    with fits.open(tmp_path / "m13_corrupted.fits") as hdulist:
+        # Access the data to make sure we decompress it
+        with pytest.raises(
+            CfitsioException,
+            match="decompression error: hit end of compressed byte stream",
+        ):
+            hdulist[1].data.sum()

--- a/docs/changes/io.fits/15489.bugfix.rst
+++ b/docs/changes/io.fits/15489.bugfix.rst
@@ -1,0 +1,1 @@
+Fix segfault with error report in tile decompression.


### PR DESCRIPTION
ffpmsg requires the GIL.

Fix #15482

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
