### PR TITLE
Removed support for version = '1.0' on VOTable

### DIFF
--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -11,7 +11,6 @@ from astropy.io.votable.table import parse
 from astropy.io.votable.tree import MivotBlock, Resource, VOTableFile
 from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_check_astroyear_fail():

--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -93,18 +93,15 @@ def test_namespace_warning():
 
 def test_version():
     """
-    VOTableFile.__init__ allows versions of '1.0', '1.1', '1.2', '1.3' and '1.4'.
-    The '1.0' is curious since other checks in parse() and the version setter do not allow '1.0'.
-    This test confirms that behavior for now.  A future change may remove the '1.0'.
+    VOTableFile.__init__ allows versions of '1.1', '1.2', '1.3' and '1.4'.
+    VOTableFile.__init__ does not allow version of '1.0' anymore and now raises a ValueError as it does to other versions not supported.
     """
     # Exercise the checks in __init__
-    with pytest.warns(AstropyDeprecationWarning):
-        VOTableFile(version="1.0")
     for version in ("1.1", "1.2", "1.3", "1.4"):
         VOTableFile(version=version)
-    for version in ("0.9", "2.0"):
+    for version in ("0.9", "1.0", "2.0"):
         with pytest.raises(
-            ValueError, match=r"should be in \('1.0', '1.1', '1.2', '1.3', '1.4'\)."
+            ValueError, match=r"should be in \('1.1', '1.2', '1.3', '1.4'\)."
         ):
             VOTableFile(version=version)
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -9,7 +9,6 @@ import io
 import os
 import re
 import urllib.request
-import warnings
 
 # THIRD-PARTY
 import numpy as np
@@ -19,7 +18,6 @@ from numpy import ma
 from astropy import __version__ as astropy_version
 from astropy.io import fits
 from astropy.utils.collections import HomogeneousList
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.xml import iterparser
 from astropy.utils.xml.writer import XMLWriter
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3970,15 +3970,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         self._groups = HomogeneousList(Group)
 
         version = str(version)
-        if version == "1.0":
-            warnings.warn(
-                "VOTable 1.0 support is deprecated in astropy 4.3 and will be "
-                "removed in a future release",
-                AstropyDeprecationWarning,
-            )
-        elif (version != "1.0") and (version not in self._version_namespace_map):
+        if version not in self._version_namespace_map:
             allowed_from_map = "', '".join(self._version_namespace_map)
-            raise ValueError(f"'version' should be in ('1.0', '{allowed_from_map}').")
+            raise ValueError(f"'version' should be in ('{allowed_from_map}').")
 
         self._version = version
 

--- a/docs/changes/io.votable/15490.api.rst
+++ b/docs/changes/io.votable/15490.api.rst
@@ -1,0 +1,2 @@
+Fully removed support for version = '1.0' on ``VOTableFile__init__()`` and changed its tests to check correctly. 
+It was raising a ``DeprecationWarning`` and now is raising a ``ValueError``.

--- a/docs/changes/io.votable/15490.api.rst
+++ b/docs/changes/io.votable/15490.api.rst
@@ -1,2 +1,2 @@
-Fully removed support for version = '1.0' on ``VOTableFile__init__()`` and changed its tests to check correctly. 
+Fully removed support for version = '1.0' on ``VOTableFile__init__()`` and changed its tests to check correctly.
 It was raising a ``DeprecationWarning`` and now is raising a ``ValueError``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request removes support for '1.0' on VOTableFile__init__().

I basically removed a condition with version '1.0' specified and now '1.0' is treated like other versions which are not in `_version_namespace_map` dictionary. It means that now '1.0' raises a `ValueError` instead of a `DeprecationWarning`.

I also changed the test file to check if '1.0' is raising a ValueError as expected. It has passed the tests.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11669

<!-- Optional opt-out -->
