### PR TITLE
Use manylinux2014 for all linux LTS wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,6 @@ write_to = "astropy/_version.py"
 test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-musllinux_x86_64"
 
 [[tool.cibuildwheel.overrides]]
-# Python 3.11 and later is not available in manylinux2010 so we only
-# set this for Python<=3.10.
-select = "cp3{8,9,10}-*"
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
-
-[[tool.cibuildwheel.overrides]]
 # Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version
 # that does - this pin can be removed once we drop support for 32-bit wheels.
 select = "cp3{8,9}-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ write_to = "astropy/_version.py"
 # - MacOS X ARM (no native hardware, tests are skipped anyway, this avoids a warning)
 # - Linux AArch64 (no native hardware, tests take too long)
 # - MuslLinux (tests hang non-deterministically)
-test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-musllinux_x86_64"
+# - Python 3.9 32-bit Linux wheel (issue compiling recent Numpy versions)
+test-skip = "*-macosx_arm64 *-manylinux_aarch64 *-musllinux_x86_64 cp39-manylinux_i686"
 
 [[tool.cibuildwheel.overrides]]
 # Numpy 1.22 doesn't have wheels for i386, so we pin Numpy to an older version


### PR DESCRIPTION
This should fix issues with the wheel builds on LTS. The small impact to users is that users using OSes that are quite old who could previously install manylinux2010 wheels may no longer be able to install astropy wheels if they specifically care about LTS (we already crossed that bridge a while back on `main`). Such users will end up installing astropy from source.

EDIT: Alternative to https://github.com/astropy/astropy/pull/15483