### PR TITLE
Time.ptp() method deprecated in astropy/time/core.py

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1510,7 +1510,12 @@ class TimeBase(ShapedLikeNDArray):
         return self[self._advanced_index(self.argmax(axis), axis, keepdims)]
 
     def ptp(self, axis=None, out=None, keepdims=False):
-        """Peak to peak (maximum - minimum) along a given axis.
+        
+        '''
+        DEPRECATED
+        Method description
+        ------------------
+        Peak to peak (maximum - minimum) along a given axis.
 
         This is similar to :meth:`~numpy.ndarray.ptp`, but adapted to ensure
         that the full precision given by the two doubles ``jd1`` and ``jd2``
@@ -1519,13 +1524,22 @@ class TimeBase(ShapedLikeNDArray):
         Note that the ``out`` argument is present only for compatibility with
         `~numpy.ptp`; since `Time` instances are immutable, it is not possible
         to have an actual ``out`` to store the result in.
-        """
+        -------------------
+        
+        Deprecated code
+        --------------
         if out is not None:
             raise ValueError(
                 "Since `Time` instances are immutable, ``out`` "
                 "cannot be set to anything but ``None``."
             )
         return self.max(axis, keepdims=keepdims) - self.min(axis, keepdims=keepdims)
+        --------------
+        '''
+        warn(
+            "`ptp` is to be deprecated following Numpy deprecation of their numpy.ndarray.ptp method in Numpy 2.0.",
+            AstropyDeprecationWarning
+        )
 
     def sort(self, axis=-1):
         """Return a copy sorted along the specified axis.

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -12,6 +12,9 @@ from astropy.time import Time
 from astropy.time.utils import day_frac
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 from astropy.utils import iers
+from warnings import warn
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+
 
 needs_array_function = pytest.mark.xfail(
     not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
@@ -632,10 +635,8 @@ class TestArithmetic:
     def test_ptp(self, use_mask):
         self.create_data(use_mask)
 
-        assert self.t0.ptp() == self.t0.max() - self.t0.min()
-        assert np.all(self.t0.ptp(0) == self.t0.max(0) - self.t0.min(0))
-        assert self.t0.ptp(0).shape == (5, 5)
-        assert self.t0.ptp(0, keepdims=True).shape == (1, 5, 5)
+        with pytest.warns(AstropyDeprecationWarning):
+            self.t0.ptp()    
 
     def test_sort(self, use_mask):
         self.create_data(use_mask)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the issue #15379 to deprecate the Time.ptp() method following Numpy updates in version 2.0. It includes a deprecation warning in function ptp() inside astropy/time/core.py and adjustments in the astropy/time/tests/test_methods.py to reflect such changes. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15379

<!-- Optional opt-out -->
