### PR TITLE
TST: Skip TestStandardProfile and TestWebProfile

### DIFF
--- a/astropy/samp/tests/test_standard_profile.py
+++ b/astropy/samp/tests/test_standard_profile.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 # By default, tests should not use the internet.
@@ -8,11 +10,14 @@ from astropy.samp.integrated_client import SAMPIntegratedClient
 
 from .test_helpers import TEST_REPLY, Receiver, assert_output, random_params
 
+CI = os.environ.get("CI", "false") == "true"
+
 
 def setup_module(module):
     conf.use_internet = False
 
 
+@pytest.mark.skipif(CI, reason="flaky in CI")
 class TestStandardProfile:
     @property
     def hub_init_kwargs(self):

--- a/astropy/samp/tests/test_web_profile.py
+++ b/astropy/samp/tests/test_web_profile.py
@@ -4,6 +4,7 @@ web client. We can only put a single test here because only one hub can run
 with the web profile active, and the user might want to run the tests in
 parallel.
 """
+import os
 import threading
 from urllib.request import Request, urlopen
 
@@ -19,11 +20,14 @@ from .web_profile_test_helpers import (
     SAMPIntegratedWebClient,
 )
 
+CI = os.environ.get("CI", "false") == "true"
+
 
 def setup_module(module):
     conf.use_internet = False
 
 
+@pytest.mark.skipif(CI, reason="flaky in CI")
 class TestWebProfile(BaseTestStandardProfile):
     @pytest.fixture(autouse=True)
     def setup_method(self, tmp_path):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to skip `TestStandardProfile` and `TestWebProfile` tests for `astropy.samp` in CI due to their flakiness that is almost always failing the OSX job now.

This is a much more localized change than #15475 for old backport branches.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
