### PR TITLE
Added tox configuration for testing building of astropy with latest developer version of build-time dependencies

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -114,3 +114,7 @@ jobs:
         - name: (Allowed Failure) Python 3.11 with dev version of matplotlib
           linux: py311-test-mpldev
           posargs: --verbose
+
+        - name: (Allowed Failure) Building Astropy with developer version of build-time dependencies
+          linux: devbuild
+          posargs: --remote-data=any --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,22 @@ pip_pre =
     predeps: true
     !predeps: false
 
+# Test that we can build astropy with the latest developer versions of all
+# build-time dependencies,
+[testenv:devbuild]
+skip_install = true
+changedir = .tmp/{envname}
+setenv =
+    PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+deps =
+    numpy>=0.0.dev0
+    git+https://github.com/pypa/setuptools.git
+    git+https://github.com/pypa/setuptools_scm.git
+    git+https://github.com/cython/cython
+    git+https://github.com/astropy/extension-helpers
+commands =
+    pip install {toxinidir}"[test]" --no-build-isolation
+    pytest --pyargs astropy {posargs}
 
 # This lets developers use tox to build docs and ignores warnings.
 # This is not used in CI; For that, we have RTD PR builder.

--- a/tox.ini
+++ b/tox.ini
@@ -136,6 +136,8 @@ deps =
     git+https://github.com/astropy/extension-helpers
 commands =
     pip install {toxinidir}"[test]" --no-build-isolation
+    pip uninstall -y numpy cython extension-helpers
+    pip install numpy  # install stable numpy
     pytest --pyargs astropy {posargs}
 
 # This lets developers use tox to build docs and ignores warnings.


### PR DESCRIPTION
xref #15495

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
