### PR TITLE
Remove `CompoundModel.both_inverses_exist()` again

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3263,27 +3263,6 @@ class CompoundModel(Model):
                 newnames.append(item)
         return tuple(newnames)
 
-    def both_inverses_exist(self):
-        """
-        if both members of this compound model have inverses return True.
-        """
-        import warnings
-
-        from astropy.utils.exceptions import AstropyDeprecationWarning
-
-        warnings.warn(
-            "CompoundModel.both_inverses_exist is deprecated. Use has_inverse instead.",
-            AstropyDeprecationWarning,
-        )
-
-        try:
-            self.left.inverse  # noqa: B018
-            self.right.inverse  # noqa: B018
-        except NotImplementedError:
-            return False
-
-        return True
-
     def _pre_evaluate(self, *args, **kwargs):
         """
         CompoundModel specific input setup that needs to occur prior to


### PR DESCRIPTION
### Description

The method was already removed in d65d668e3d64c5726705b05a9b4c2bc45b5e1c53, but then it was mysteriously reintroduced in 3b6f4df947c9963bf721abee842face70e8bb166. The change log entry about the removal of this method already exists, so I'm not adding a duplicate.
https://github.com/astropy/astropy/blob/b322c7621cc7d9214dbf1001c27c3f1ccc54d6b1/CHANGES.rst?plain=1#L2081-L2087

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
