### PR TITLE
DOC: Fix bad ref to tree.Table that has been renamed to tree.TableElement

### DIFF
--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -587,11 +587,11 @@ Now you have a MIVOT resource that you can add to an object Resource creating a 
    >>> r1.type = "results"
    >>> r1.resources.append(mivot_resource)
 
-You can add an `astropy.io.votable.tree.Table` to the resource:
+You can add an `astropy.io.votable.tree.TableElement` to the resource:
 
 .. code-block:: python
 
-   >>> table = tree.Table(votable)
+   >>> table = tree.TableElement(votable)
    >>> r1.tables.append(t1)
    >>> votable.resources.append(r1)
    >>> for resource in votable.resources:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix bad reference to `tree.Table` that has been renamed to `tree.TableElement` but not caught in #15372

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
