### PR TITLE
Regression test for non-contiguous transformation matrices

### DIFF
--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1223,6 +1223,13 @@ class TestCartesianRepresentation:
         assert ds2.d_y.unit == u.km / u.s
         assert ds2.d_z.unit == u.km / u.s
 
+    def test_transform_non_contiguous_matrix(self):
+        # Regression test for gh-15503 (due to pyerfa gh-123)
+        r = CartesianRepresentation([1, 2, 3] * u.kpc)
+        m = np.array([[1, 0, 0, 5], [0, 1, 0, 6], [0, 0, 1, 7]], dtype="f8")[:, :3]
+        assert_array_equal(m, np.eye(3))
+        assert representation_equal(r.transform(m), r)
+
 
 class TestCylindricalRepresentation:
     def test_name(self):


### PR DESCRIPTION
This PR doesn't fix anything -- the fix is https://github.com/liberfa/pyerfa/pull/124 -- but it adds a regression test, since really we should have tested earlier that using a non-contiguous matrix in `repr.transform()` worked.

Does not need a changelog or backport, since the fix itself relies on using latest pyerfa -- which should be in by now (i.e., all tests should pass, which isn't the case with pyerfa 2.0.1)

Fixes #15503

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
