### PR TITLE
Remove deprecated functionality from `units`

### DIFF
--- a/astropy/cosmology/tests/test_units.py
+++ b/astropy/cosmology/tests/test_units.py
@@ -10,34 +10,10 @@ import astropy.units as u
 from astropy.cosmology import Planck13, default_cosmology
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 ##############################################################################
 # TESTS
 ##############################################################################
-
-
-def test_has_expected_units():
-    """
-    Test that this module has the expected set of units. Some of the units are
-    imported from :mod:`astropy.units`, or vice versa. Here we test presence,
-    not usage. Units from :mod:`astropy.units` are tested in that module. Units
-    defined in :mod:`astropy.cosmology` will be tested subsequently.
-    """
-    with pytest.warns(AstropyDeprecationWarning, match="`littleh`"):
-        assert u.astrophys.littleh is cu.littleh
-
-
-def test_has_expected_equivalencies():
-    """
-    Test that this module has the expected set of equivalencies. Many of the
-    equivalencies are imported from :mod:`astropy.units`, so here we test
-    presence, not usage. Equivalencies from :mod:`astropy.units` are tested in
-    that module. Equivalencies defined in :mod:`astropy.cosmology` will be
-    tested subsequently.
-    """
-    with pytest.warns(AstropyDeprecationWarning, match="`with_H0`"):
-        assert u.equivalencies.with_H0 is cu.with_H0
 
 
 def test_littleh():

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -232,25 +232,3 @@ if __doc__ is not None:
     from .utils import generate_unit_summary as _generate_unit_summary
 
     __doc__ += _generate_unit_summary(globals())
-
-
-# -------------------------------------------------------------------------
-
-
-def __getattr__(attr):
-    if attr == "littleh":
-        import warnings
-
-        from astropy.cosmology.units import littleh
-        from astropy.utils.exceptions import AstropyDeprecationWarning
-
-        warnings.warn(
-            "`littleh` is deprecated from module `astropy.units.astrophys` "
-            "since astropy 5.0 and may be removed in a future version. "
-            "Use `astropy.cosmology.units.littleh` instead.",
-            AstropyDeprecationWarning,
-        )
-
-        return littleh
-
-    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -884,25 +884,3 @@ def plate_scale(platescale):
         "plate_scale",
         {"platescale": platescale},
     )
-
-
-# -------------------------------------------------------------------------
-
-
-def __getattr__(attr):
-    if attr == "with_H0":
-        import warnings
-
-        from astropy.cosmology.units import with_H0
-        from astropy.utils.exceptions import AstropyDeprecationWarning
-
-        warnings.warn(
-            "`with_H0` is deprecated from `astropy.units.equivalencies` "
-            "since astropy 5.0 and may be removed in a future version. "
-            "Use `astropy.cosmology.units.with_H0` instead.",
-            AstropyDeprecationWarning,
-        )
-
-        return with_H0
-
-    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """A set of standard astronomical equivalencies."""
 
-import warnings
 from collections import UserList
 
 # THIRD-PARTY
@@ -9,7 +8,6 @@ import numpy as np
 
 # LOCAL
 from astropy.constants import si as _si
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import isiterable
 
 from . import astrophys, cgs, dimensionless_unscaled, misc, si
@@ -647,19 +645,6 @@ def brightness_temperature(frequency, beam_area=None):
         >>> surf_brightness.to(u.K, equivalencies=u.brightness_temperature(500*u.GHz)) # doctest: +FLOAT_CMP
         <Quantity 130.1931904778803 K>
     """
-    if frequency.unit.is_equivalent(si.sr):
-        if not beam_area.unit.is_equivalent(si.Hz):
-            raise ValueError(
-                "The inputs to `brightness_temperature` are frequency and angular area."
-            )
-        warnings.warn(
-            "The inputs to `brightness_temperature` have changed. "
-            "Frequency is now the first input, and angular area "
-            "is the second, optional input.",
-            AstropyDeprecationWarning,
-        )
-        frequency, beam_area = beam_area, frequency
-
     nu = frequency.to(si.GHz, spectral())
     factor_Jy = (2 * _si.k_B * si.K * nu**2 / _si.c**2).to(astrophys.Jy).value
     factor_K = (astrophys.Jy / (2 * _si.k_B * nu**2 / _si.c**2)).to(si.K).value

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -3,9 +3,6 @@
 """Defines the physical types that correspond to different units."""
 
 import numbers
-import warnings
-
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import (
     astrophys,
@@ -323,26 +320,6 @@ class PhysicalType:
 
     def __iter__(self):
         yield from self._physical_type_list
-
-    def __getattr__(self, attr):
-        # TODO: remove this whole method when accessing str attributes from
-        # physical types is no longer supported
-
-        # short circuit attribute accessed in __str__ to prevent recursion
-        if attr == "_physical_type_list":
-            super().__getattribute__(attr)
-
-        self_str_attr = getattr(str(self), attr, None)
-        if hasattr(str(self), attr):
-            warning_message = (
-                f"support for accessing str attributes such as {attr!r} "
-                "from PhysicalType instances is deprecated since 4.3 "
-                "and will be removed in a subsequent release."
-            )
-            warnings.warn(warning_message, AstropyDeprecationWarning)
-            return self_str_attr
-        else:
-            super().__getattribute__(attr)  # to get standard error message
 
     def __eq__(self, other):
         """

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -12,7 +12,6 @@ from astropy import constants
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units.equivalencies import Equivalency
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_dimensionless_angles():
@@ -698,22 +697,6 @@ def test_brightness_temperature():
             u.Jy, equivalencies=u.brightness_temperature(nu, beam_area=omega_B)
         ),
     )
-
-
-def test_swapped_args_brightness_temperature():
-    """
-    #5173 changes the order of arguments but accepts the old (deprecated) args
-    """
-    omega_B = np.pi * (50 * u.arcsec) ** 2
-    nu = u.GHz * 5
-    tb = 7.052587837212582 * u.K
-
-    with pytest.warns(AstropyDeprecationWarning) as w:
-        result = (1 * u.Jy).to(u.K, equivalencies=u.brightness_temperature(omega_B, nu))
-        roundtrip = result.to(u.Jy, equivalencies=u.brightness_temperature(omega_B, nu))
-    assert len(w) == 2
-    np.testing.assert_almost_equal(tb.value, result.value)
-    np.testing.assert_almost_equal(roundtrip.value, 1)
 
 
 def test_surfacebrightness():

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -10,7 +10,6 @@ import pytest
 from astropy import units as u
 from astropy.constants import hbar
 from astropy.units import physical
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 unit_physical_type_pairs = [
     (u.m, "length"),
@@ -496,20 +495,6 @@ class TestDefPhysType:
                 f"the physical type for {unit}, which was added for"
                 "testing, was not deleted."
             )
-
-
-@pytest.mark.parametrize(
-    "method, expected",
-    [("title", "Length"), ("isalpha", True), ("isnumeric", False), ("upper", "LENGTH")],
-)
-def test_that_str_methods_work_with_physical_types(method, expected):
-    """
-    Test that str methods work for `PhysicalType` instances while issuing
-    a deprecation warning.
-    """
-    with pytest.warns(AstropyDeprecationWarning, match="PhysicalType instances"):
-        result_of_method_call = getattr(length, method)()
-    assert result_of_method_call == expected
 
 
 def test_missing_physical_type_attribute():

--- a/docs/changes/units/15514.api.rst
+++ b/docs/changes/units/15514.api.rst
@@ -1,0 +1,4 @@
+The following deprecated functionality has been removed:
+
+  * ``littleh`` unit and ``with_H0`` equivalency. They are still available from
+    ``cosmology.units``.

--- a/docs/changes/units/15514.api.rst
+++ b/docs/changes/units/15514.api.rst
@@ -4,3 +4,4 @@ The following deprecated functionality has been removed:
     ``cosmology.units``.
   * ``brightness_temperature`` equivalency no longer automatically swaps the
     order of its arguments if it does not match the expectation.
+  * ``PhysicalType`` no longer supports ``str`` methods and attributes.

--- a/docs/changes/units/15514.api.rst
+++ b/docs/changes/units/15514.api.rst
@@ -2,3 +2,5 @@ The following deprecated functionality has been removed:
 
   * ``littleh`` unit and ``with_H0`` equivalency. They are still available from
     ``cosmology.units``.
+  * ``brightness_temperature`` equivalency no longer automatically swaps the
+    order of its arguments if it does not match the expectation.


### PR DESCRIPTION
### Description

The first commit ends the deprecation period during which `littleh` and `with_H0` could be imported from both `units` and `cosmology.units` (#12092).

The second commit finalizes the `brightness_temperature` equivalency argument order reversal (#5173).

The third commit completes transitioning the `physical_type` attribute of a unit from being a `str` to being a `PhysicalType` (#11204 and #11625).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
