### PR TITLE
TST: Fix test_group_mixins_unsupported warning handling in pytest-dev

### DIFF
--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -10,7 +10,6 @@ from astropy import units as u
 from astropy.table import Column, NdarrayMixin, QTable, Table, table_helpers, unique
 from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.time import Time
-from astropy.time.core import TimeDeltaMissingUnitWarning
 from astropy.utils.compat import NUMPY_LT_1_22_1
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -732,15 +731,8 @@ def test_group_mixins_unsupported(col):
 
     t = Table([[1, 1], [3, 4], col], names=["a", "b", "mix"])
     tg = t.group_by("a")
-    if not PYTEST_LT_8_0 and isinstance(col, time.TimeDelta):
-        ctx = pytest.warns(
-            TimeDeltaMissingUnitWarning,
-            match="Numerical value without unit or explicit format",
-        )
-    else:
-        ctx = nullcontext()
 
-    with pytest.warns(AstropyUserWarning, match="Cannot aggregate column 'mix'"), ctx:
+    with pytest.warns(AstropyUserWarning, match="Cannot aggregate column 'mix'"):
         tg.groups.aggregate(np.sum)
 
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix `test_group_mixins_unsupported` when using pytest 8.0.dev because that test appears to no longer be emitting extra warning no matter what.

Example log with failure: https://github.com/astropy/astropy/actions/runs/6609359017/job/17949388707

Make sure the "devinfra" job passes. It is not one of the required checks.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
