### PR TITLE
Build nightly wheels against developer version of Numpy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,10 @@ jobs:
       anaconda_package: astropy
       anaconda_keep_n_latest: 10
 
+      env: |
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm cython numpy>=0.0.dev0 extension-helpers') || '' }}'
+        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'pip; args: --no-build-isolation') || 'build' }}'
+
       test_extras: test
       # FIXME: we exclude the test_data_out_of_range test since it
       # currently fails, see https://github.com/astropy/astropy/issues/10409

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
       anaconda_package: astropy
       anaconda_keep_n_latest: 10
 
+      # For nightly wheels as well as when building with the 'Build all wheels' label, we disable
+      # the build isolation and explicitly install the latest developer version of numpy as well as
+      # the latest stable versions of all other build-time dependencies.
       env: |
         CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm cython numpy>=0.0.dev0 extension-helpers') || '' }}'
         CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip; args: --no-build-isolation') || 'build' }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,8 @@ jobs:
       anaconda_keep_n_latest: 10
 
       env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm cython numpy>=0.0.dev0 extension-helpers') || '' }}'
-        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'pip; args: --no-build-isolation') || 'build' }}'
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm cython numpy>=0.0.dev0 extension-helpers') || '' }}'
+        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip; args: --no-build-isolation') || 'build' }}'
 
       test_extras: test
       # FIXME: we exclude the test_data_out_of_range test since it


### PR DESCRIPTION
This disables build isolation for nightly wheels in favor of installing dependencies by hand, and installs the latest developer version of numpy and the latest stable version of other build-time dependencies before doing the build. This also switches the regular builds from using ``pip wheel`` to ``python -m build`` by selecting the ``build`` framework (this is going to change by default in future, just anticipating the change).

I tested that the 'nightly' version works properly in my fork, e.g.:

https://github.com/astrofrog/astropy/actions/runs/6627003294/job/18001058641

Note the following in the cibuildwheel output:

```
before_build: pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools setuptools_scm cython numpy>=0.0.dev0 extension-helpers
build_frontend: 
  name: pip
  args: ['--no-build-isolation']
```

Once we merge this PR we can use the workflow dispatch to force a new nightly build to make sure it also works properly.

From the logs, it looks like this is working but what I can't tell is if there is a way to find out for a given wheel what version of Numpy it was built against, to double check.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
