### PR TITLE
Numpy dev and nep 50 fixes

### DIFF
--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1103,6 +1103,32 @@ def test_str_repr_angles_nan(cls, input, expstr, exprepr):
 @pytest.mark.parametrize(
     "value,expected_value,dtype,expected_dtype",
     [
+        (np.pi * 2, 0.0, None, np.float64),
+        (np.pi * 2, 0.0, np.float64, np.float64),
+        (np.float32(2 * np.pi), np.float32(0.0), None, np.float32),
+        (np.float32(2 * np.pi), np.float32(0.0), np.float32, np.float32),
+    ],
+)
+def test_longitude_wrap(value, expected_value, dtype, expected_dtype, sign):
+    """
+    Test that the wrapping of the Longitude value range in radians works
+    in both float32 and float64.
+    """
+    # This prevents upcasting to float64 as sign * value would do.
+    if sign < 0:
+        value = -value
+        expected_value = -expected_value
+
+    result = Longitude(value, u.rad, dtype=dtype)
+    assert result.value == expected_value
+    assert result.dtype == expected_dtype
+    assert result.unit == u.rad
+
+
+@pytest.mark.parametrize("sign", (-1, 1))
+@pytest.mark.parametrize(
+    "value,expected_value,dtype,expected_dtype",
+    [
         (np.pi / 2, np.pi / 2, None, np.float64),
         (np.pi / 2, np.pi / 2, np.float64, np.float64),
         (np.float32(np.pi / 2), np.float32(np.pi / 2), None, np.float32),

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1149,7 +1149,8 @@ class FITS_rec(np.recarray):
                 if _number and (_scale or _zero) and column._physical_values:
                     dummy = field.copy()
                     if _zero:
-                        dummy -= bzero
+                        # Cast before subtracting to avoid overflow problems.
+                        dummy -= np.array(bzero).astype(dummy.dtype, casting="unsafe")
                     if _scale:
                         dummy /= bscale
                     # This will set the raw values in the recarray back to

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -183,7 +183,8 @@ def _check_compressed_header(header):
 
     for kw in ["ZVAL3"]:
         if kw in header:
-            if header[kw] > np.finfo(np.float32).max:
+            # float() below to avoid a NEP 50 warning about a cast to float32 inf.
+            if header[kw] > float(np.finfo(np.float32).max):
                 raise OverflowError(f"{kw} value {header[kw]} is too large")
 
     # Validate data types

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -548,7 +548,7 @@ class _ImageBaseHDU(_ValidHDU):
                 # We have to explicitly cast _zero to prevent numpy from raising an
                 # error when doing self.data -= zero, and we do this instead of
                 # self.data = self.data - zero to avoid doubling memory usage.
-                np.add(self.data, -_zero, out=self.data, casting="unsafe")
+                self.data -= np.array(_zero).astype(self.data.dtype, casting="unsafe")
             self._header["BZERO"] = _zero
         else:
             try:

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -360,6 +360,9 @@ UNSUPPORTED_UFUNCS |= {
     np.lcm,
 }
 
+if not NUMPY_LT_2_0:
+    UNSUPPORTED_UFUNCS |= {np.bitwise_count, np._core.umath.isalpha}
+
 # SINGLE ARGUMENT UFUNCS
 
 # ufuncs that do not care about the unit and do not return a Quantity


### PR DESCRIPTION
These fixes should get us up to date to numpy-dev for the changes in casting done in https://github.com/numpy/numpy/pull/23912 (following NEP 50). Also adds support (or, rather, indicate that we do not support) two string ufuncs for `Quantity`.

Will probably need to wait for the relevant numpy-dev wheels to come out, but at least one can test whether the tests still pass on regular numpy.

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
