### PR TITLE
Remove explicit Ruff Python target version

### DIFF
--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -7,12 +7,15 @@ __all__ = []
 import copy
 from dataclasses import dataclass, field, fields, replace
 from enum import Enum, auto
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any
 
 import astropy.units as u
 from astropy.utils.compat import PYTHON_LT_3_10
 
 from ._converter import _REGISTRY_FVALIDATORS, FValidateCallable, _register_validator
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 if not PYTHON_LT_3_10:
     from dataclasses import KW_ONLY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,9 +319,6 @@ exclude= [
         ]
 
 [tool.ruff]
-# Our minimum Python version is 3.9 but we want to minimize backport issues, so
-# we use 3.8 as the target version.
-target-version = "py38"
 line-length = 88
 select = ["ALL"]
 exclude=[


### PR DESCRIPTION
### Description

Latest `astropy` requires Python 3.9 or newer, but LTS supports also 3.8. [Ruff has been configured to use Python 3.8 as its target version to minimize backporting complications caused by automatic code edits.](https://github.com/astropy/astropy/pull/14286#issuecomment-1448598385) A new version of `astropy` is about to be released and support for the current LTS is being dropped, so the Ruff Python target version should be made to match the actually required Python version to minimize backporting complications in the future. Note that [if the Python target version is not explicitly specified then Ruff tries to look up the `requires-python` value from `pyproject.toml`](https://docs.astral.sh/ruff/settings/#target-version) instead, so we don't have to configure the target version explicitly anymore.

Luckily for us the number of edits Ruff makes as a result of updating its Python target version is very small.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
