### PR TITLE
Don't upload to PyPI on workflow dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
     with:
 
       # We upload to PyPI for all tags starting with v but not ones ending in .dev
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && (github.event_name == 'push') }}
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
       anaconda_package: astropy


### PR DESCRIPTION
Just a small tweak to the publish workflow - now that when we do workflow_dispatch we default to building against Numpy dev, I don't think we want to upload to PyPI also when using workflow_dispatch. I think it makes sense to keep workflow_dispatch as a developer thing anyway, and not to make actual stable releases.