### PR TITLE
Fix inconsistent kwarg and property names in stretches

### DIFF
--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -27,7 +27,8 @@ __all__ = [
 
 def _logn(n, x, out=None):
     """Calculate the log base n of x."""
-    # We define this because numpy.lib.scimath.logn doesn't support out=
+    # We define this because numpy.emath.logn doesn't support the out
+    # keyword.
     if out is None:
         return np.log(x) / np.log(n)
     else:
@@ -53,8 +54,8 @@ def _prepare(values, clip=True, out=None):
 
 class BaseStretch(BaseTransform):
     """
-    Base class for the stretch classes, which, when called with an array
-    of values in the range [0:1], return an transformed array of values,
+    Base class for the stretch classes, which when called with an array
+    of values in the range [0:1], returns an transformed array of values
     also in the range [0:1].
     """
 
@@ -99,7 +100,7 @@ class LinearStretch(BaseStretch):
     The stretch is given by:
 
     .. math::
-        y = slope x + intercept
+        y = slope * x + intercept
 
     Parameters
     ----------

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -466,24 +466,26 @@ class InvertedLogStretch(BaseStretch):
         greater than 0.  Default is 1000.
     """
 
+    exp = deprecated_attribute("exp", "6.0", alternative="a")
+
     def __init__(self, a):
         super().__init__()
         if a <= 0:  # singularity
             raise ValueError("a must be > 0")
-        self.exp = a
+        self.a = a
 
     def __call__(self, values, clip=True, out=None):
         values = _prepare(values, clip=clip, out=out)
-        np.multiply(values, np.log(self.exp + 1.0), out=values)
+        np.multiply(values, np.log(self.a + 1.0), out=values)
         np.exp(values, out=values)
         np.subtract(values, 1.0, out=values)
-        np.true_divide(values, self.exp, out=values)
+        np.true_divide(values, self.a, out=values)
         return values
 
     @property
     def inverse(self):
         """A stretch object that performs the inverse operation."""
-        return LogStretch(self.exp)
+        return LogStretch(self.a)
 
 
 class AsinhStretch(BaseStretch):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -290,23 +290,25 @@ class PowerDistStretch(BaseStretch):
         1000.
     """
 
+    exp = deprecated_attribute("exp", "6.0", alternative="a")
+
     def __init__(self, a=1000.0):
         if a < 0 or a == 1:  # singularity
             raise ValueError("a must be >= 0, but cannot be set to 1")
         super().__init__()
-        self.exp = a
+        self.a = a
 
     def __call__(self, values, clip=True, out=None):
         values = _prepare(values, clip=clip, out=out)
-        np.power(self.exp, values, out=values)
+        np.power(self.a, values, out=values)
         np.subtract(values, 1, out=values)
-        np.true_divide(values, self.exp - 1.0, out=values)
+        np.true_divide(values, self.a - 1.0, out=values)
         return values
 
     @property
     def inverse(self):
         """A stretch object that performs the inverse operation."""
-        return InvertedPowerDistStretch(a=self.exp)
+        return InvertedPowerDistStretch(a=self.a)
 
 
 class InvertedPowerDistStretch(BaseStretch):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -329,23 +329,25 @@ class InvertedPowerDistStretch(BaseStretch):
         1000.
     """
 
+    exp = deprecated_attribute("exp", "6.0", alternative="a")
+
     def __init__(self, a=1000.0):
         if a < 0 or a == 1:  # singularity
             raise ValueError("a must be >= 0, but cannot be set to 1")
         super().__init__()
-        self.exp = a
+        self.a = a
 
     def __call__(self, values, clip=True, out=None):
         values = _prepare(values, clip=clip, out=out)
-        np.multiply(values, self.exp - 1.0, out=values)
+        np.multiply(values, self.a - 1.0, out=values)
         np.add(values, 1, out=values)
-        _logn(self.exp, values, out=values)
+        _logn(self.a, values, out=values)
         return values
 
     @property
     def inverse(self):
         """A stretch object that performs the inverse operation."""
-        return PowerDistStretch(a=self.exp)
+        return PowerDistStretch(a=self.a)
 
 
 class SquaredStretch(PowerStretch):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -385,6 +385,8 @@ class LogStretch(BaseStretch):
         greater than 0.  Default is 1000.
     """
 
+    exp = deprecated_attribute("exp", "6.0", alternative="a")
+
     @property
     def _supports_invalid_kw(self):
         return True
@@ -393,7 +395,7 @@ class LogStretch(BaseStretch):
         super().__init__()
         if a <= 0:  # singularity
             raise ValueError("a must be > 0")
-        self.exp = a
+        self.a = a
 
     def __call__(self, values, clip=True, out=None, invalid=None):
         """
@@ -429,10 +431,10 @@ class LogStretch(BaseStretch):
         with np.errstate(invalid="ignore"):
             if replace_invalid:
                 idx = values < 0
-            np.multiply(values, self.exp, out=values)
+            np.multiply(values, self.a, out=values)
             np.add(values, 1.0, out=values)
             np.log(values, out=values)
-            np.true_divide(values, np.log(self.exp + 1.0), out=values)
+            np.true_divide(values, np.log(self.a + 1.0), out=values)
 
         if replace_invalid:
             # Assign new NaN (i.e., NaN not in the original input
@@ -444,7 +446,7 @@ class LogStretch(BaseStretch):
     @property
     def inverse(self):
         """A stretch object that performs the inverse operation."""
-        return InvertedLogStretch(self.exp)
+        return InvertedLogStretch(self.a)
 
 
 class InvertedLogStretch(BaseStretch):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -7,6 +7,8 @@ another set of [0:1] values with a transformation.
 
 import numpy as np
 
+from astropy.utils.decorators import deprecated_attribute
+
 from .transform import BaseTransform, CompositeTransform
 
 __all__ = [
@@ -208,6 +210,8 @@ class PowerStretch(BaseStretch):
         than 0.
     """
 
+    power = deprecated_attribute("power", "6.0", alternative="a")
+
     @property
     def _supports_invalid_kw(self):
         return True
@@ -216,7 +220,7 @@ class PowerStretch(BaseStretch):
         super().__init__()
         if a <= 0:
             raise ValueError("a must be > 0")
-        self.power = a
+        self.a = a
 
     def __call__(self, values, clip=True, out=None, invalid=None):
         """
@@ -249,14 +253,12 @@ class PowerStretch(BaseStretch):
         """
         values = _prepare(values, clip=clip, out=out)
         replace_invalid = (
-            not clip
-            and invalid is not None
-            and ((-1 < self.power < 0) or (0 < self.power < 1))
+            not clip and invalid is not None and ((-1 < self.a < 0) or (0 < self.a < 1))
         )
         with np.errstate(invalid="ignore"):
             if replace_invalid:
                 idx = values < 0
-            np.power(values, self.power, out=values)
+            np.power(values, self.a, out=values)
 
         if replace_invalid:
             # Assign new NaN (i.e., NaN not in the original input
@@ -268,7 +270,7 @@ class PowerStretch(BaseStretch):
     @property
     def inverse(self):
         """A stretch object that performs the inverse operation."""
-        return PowerStretch(1.0 / self.power)
+        return PowerStretch(1.0 / self.a)
 
 
 class PowerDistStretch(BaseStretch):

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.stretch import (
     AsinhStretch,
     ContrastBiasStretch,
@@ -152,3 +153,25 @@ def test_histeqstretch_invalid():
     result = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0])
     assert_equal(HistEqStretch(data)(data), result)
     assert_equal(InvertedHistEqStretch(data)(data), result)
+
+
+def test_deprecated_attrs():
+    match = "The power attribute is deprecated"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        stretch = PowerStretch(a=0.5)
+        assert stretch.power == stretch.a
+
+    match = "The exp attribute is deprecated"
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        stretch = PowerDistStretch(a=0.5)
+        assert stretch.exp == stretch.a
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        stretch = InvertedPowerDistStretch(a=0.5)
+        assert stretch.exp == stretch.a
+
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        stretch = LogStretch(a=0.5)
+        assert stretch.exp == stretch.a
+    with pytest.warns(AstropyDeprecationWarning, match=match):
+        stretch = InvertedLogStretch(a=0.5)
+        assert stretch.exp == stretch.a

--- a/docs/changes/visualization/15538.api.rst
+++ b/docs/changes/visualization/15538.api.rst
@@ -1,0 +1,5 @@
+Deprecated the ``exp`` attribute in the ``LogStretch``,
+``InvertedLogStretch``, ``PowerDistStretch``, and
+``InvertedPowerDistStretch`` stretch classes, and the ``power``
+attribute in the ``PowerStretch``. Instead, use the ``a`` attribute,
+which matches the input keyword.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Fixes #15534.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
