### PR TITLE
Relax restriction on AsinhStretch and SinhStretch parameter

### DIFF
--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -489,17 +489,17 @@ class AsinhStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  The value of
-        this parameter is where the asinh curve transitions from linear
-        to logarithmic behavior, expressed as a fraction of the
-        normalized image.  ``a`` must be greater than 0 and less than or
-        equal to 1 (0 < a <= 1).  Default is 0.1.
+        The ``a`` parameter used in the above formula. The value of this
+        parameter is where the asinh curve transitions from linear to
+        logarithmic behavior, expressed as a fraction of the normalized
+        image. The stretch becomes more linear as the ``a`` value is
+        increased. ``a`` must be greater than 0. Default is 0.1.
     """
 
     def __init__(self, a=0.1):
         super().__init__()
-        if a <= 0 or a > 1:
-            raise ValueError("a must be > 0 and <= 1")
+        if a <= 0:
+            raise ValueError("a must be > 0")
         self.a = a
 
     def __call__(self, values, clip=True, out=None):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -527,15 +527,15 @@ class SinhStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be
-        greater than 0 and less than or equal to 1 (0 < a <= 1).
-        Default is 1/3.
+        The ``a`` parameter used in the above formula. The stretch
+        becomes more linear as the ``a`` value is increased. ``a`` must
+        be greater than 0. Default is 1/3.
     """
 
     def __init__(self, a=1.0 / 3.0):
         super().__init__()
-        if a <= 0 or a > 1:
-            raise ValueError("a must be > 0 and <= 1")
+        if a <= 0:
+            raise ValueError("a must be > 0")
         self.a = a
 
     def __call__(self, values, clip=True, out=None):

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -138,9 +138,9 @@ def test_invalid_power_log_a(a):
         InvertedLogStretch(a=a)
 
 
-@pytest.mark.parametrize("a", [-2.0, -1, 0.0, 1.5])
+@pytest.mark.parametrize("a", [-2.0, -1, 0.0])
 def test_invalid_sinh_a(a):
-    match = "a must be > 0 and <= 1"
+    match = "a must be > 0"
     with pytest.raises(ValueError, match=match):
         AsinhStretch(a=a)
     with pytest.raises(ValueError, match=match):

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 
 from astropy.visualization.stretch import (
     AsinhStretch,
@@ -145,6 +145,13 @@ def test_invalid_sinh_a(a):
         AsinhStretch(a=a)
     with pytest.raises(ValueError, match=match):
         SinhStretch(a=a)
+
+
+def test_sinh_a():
+    a = 0.9
+    a_inv = 1.0 / np.arcsinh(1.0 / a)
+    z = AsinhStretch(a=a)
+    assert_allclose(z.inverse.a, a_inv)
 
 
 def test_histeqstretch_invalid():

--- a/docs/changes/visualization/15539.api.rst
+++ b/docs/changes/visualization/15539.api.rst
@@ -1,0 +1,2 @@
+Removed the maximum value of the ``a`` parameter in the ``AsinhStretch``
+and ``SinhStretch`` stretch classes.

--- a/docs/changes/visualization/15539.bugfix.rst
+++ b/docs/changes/visualization/15539.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug where a ``ValueError`` would be raised in the
+``AsinhStretch`` and ``SinhStretch`` classes for valid ``a`` parameter
+values.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR removes the maximum value of the ``a`` parameter in the ``AsinhStretch``
and ``SinhStretch`` stretch classes.  Restricting the maximum value of ``a`` is unnecessary.  As `a` gets larger, these stretches become more linear.

This is also a bugfix as the following fails even though `a=0.9` is currently allowed:
```python
>>> from astropy.visualization import ImageNormalize, AsinhStretch
>>> ImageNormalize(stretch=AsinhStretch(0.9))
ValueError: a must be > 0 and <= 1
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
