### PR TITLE
cosmo: make derived_parameters private

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -96,7 +96,7 @@ class Cosmology(metaclass=abc.ABCMeta):
     write = UnifiedReadWriteMethod(CosmologyWrite)
 
     # Parameters
-    parameters = ParametersAttribute()
+    parameters = ParametersAttribute(attr_name="_parameters")
     """Immutable mapping of the Parameters.
 
     If accessed from the class, this returns a mapping of the Parameter
@@ -104,7 +104,7 @@ class Cosmology(metaclass=abc.ABCMeta):
     mapping of the values of the Parameters.
     """
 
-    derived_parameters = ParametersAttribute()
+    _derived_parameters = ParametersAttribute(attr_name="_parameters_derived")
     """Immutable mapping of the derived Parameters.
 
     If accessed from the class, this returns a mapping of the Parameter
@@ -113,7 +113,7 @@ class Cosmology(metaclass=abc.ABCMeta):
     """
 
     _parameters: ClassVar = MappingProxyType[str, Parameter]({})
-    _derived_parameters: ClassVar = MappingProxyType[str, Parameter]({})
+    _parameters_derived: ClassVar = MappingProxyType[str, Parameter]({})
     _parameters_all: ClassVar = frozenset[str]()
 
     # ---------------------------------------------------------------
@@ -141,8 +141,8 @@ class Cosmology(metaclass=abc.ABCMeta):
             if n in params
         }
         cls._parameters = MappingProxyType(ordered | params)
-        cls._derived_parameters = MappingProxyType(derived_params)
-        cls._parameters_all = frozenset(cls.parameters).union(cls.derived_parameters)
+        cls._parameters_derived = MappingProxyType(derived_params)
+        cls._parameters_all = frozenset(cls._parameters).union(cls._parameters_derived)
 
         # -------------------
         # Registration
@@ -440,7 +440,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     """
 
     _parameters: ClassVar[MappingProxyType[str, Parameter]]
-    _derived_parameters: ClassVar[MappingProxyType[str, Parameter]]
+    _parameters_derived: ClassVar[MappingProxyType[str, Parameter]]
 
     def __init_subclass__(cls: type[_FlatCosmoT]) -> None:
         super().__init_subclass__()

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -156,7 +156,7 @@ class ParameterOde0TestMixin(ParameterTestMixin):
     def test_Parameter_Ode0(self, cosmo_cls):
         """Test Parameter ``Ode0`` on the class."""
         Ode0 = cosmo_cls.parameters.get(
-            "Ode0", cosmo_cls.derived_parameters.get("Ode0")
+            "Ode0", cosmo_cls._derived_parameters.get("Ode0")
         )
         assert isinstance(Ode0, Parameter)
         assert "Omega dark energy" in Ode0.__doc__
@@ -165,7 +165,7 @@ class ParameterOde0TestMixin(ParameterTestMixin):
     def test_Parameter_Ode0_validation(self, cosmo_cls, cosmo):
         """Test Parameter ``Ode0`` validation."""
         Ode0 = cosmo_cls.parameters.get(
-            "Ode0", cosmo_cls.derived_parameters.get("Ode0")
+            "Ode0", cosmo_cls._derived_parameters.get("Ode0")
         )
         assert Ode0.validate(cosmo, 1.1) == 1.1
         assert Ode0.validate(cosmo, 10 * u.one) == 10.0
@@ -947,7 +947,7 @@ class ParameterFlatOde0TestMixin(ParameterOde0TestMixin):
     def test_Parameter_Ode0(self, cosmo_cls):
         """Test Parameter ``Ode0`` on the class."""
         super().test_Parameter_Ode0(cosmo_cls)
-        Ode0 = cosmo_cls.parameters.get("Ode0", cosmo_cls.derived_parameters["Ode0"])
+        Ode0 = cosmo_cls.parameters.get("Ode0", cosmo_cls._derived_parameters["Ode0"])
         assert Ode0.derived in (True, np.True_)
 
     def test_Ode0(self, cosmo):

--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -24,12 +24,21 @@ class ParametersAttribute:
     If accessed from the class, this returns a mapping of the Parameter
     objects themselves.  If accessed from an instance, this returns a
     mapping of the values of the Parameters.
+
+    Parameters
+    ----------
+    attr_name : str
+        The name of the class attribute containing the Parameter objects.
     """
 
-    attr_name: str = field(init=False)
+    attr_name: str | None = None
+    """The name of the class attribute containing the Parameter objects."""
 
-    def __set_name__(self, owner: type[Cosmology], name: str) -> None:
-        object.__setattr__(self, "attr_name", f"_{name}")
+    _name: str = field(init=False)
+    """The name of the descriptor on the containing class."""
+
+    def __set_name__(self, owner: Any, name: str) -> None:
+        object.__setattr__(self, "_name", name)
 
     def __get__(
         self, instance: Cosmology | None, owner: type[Cosmology] | None
@@ -43,5 +52,5 @@ class ParametersAttribute:
         )
 
     def __set__(self, instance: Any, value: Any) -> NoReturn:
-        msg = f"cannot set {self.attr_name.lstrip('_').rstrip('_')!r} of {instance!r}."
+        msg = f"cannot set {self._name!r} of {instance!r}."
         raise AttributeError(msg)

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -6,36 +6,39 @@ from types import MappingProxyType
 
 import pytest
 
+from astropy.cosmology._utils import all_cls_vars
 from astropy.cosmology.parameter import Parameter
 
 
 class ParametersAttributeTestMixin:
     """Test the descriptor for ``parameters`` on Cosmology classes."""
 
-    @pytest.mark.parametrize("name", ["parameters", "derived_parameters"])
+    @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_from_class(self, cosmo_cls, name):
         """Test descriptor ``parameters`` accessed from the class."""
+        descriptor = all_cls_vars(cosmo_cls)[name]
         # test presence
         assert hasattr(cosmo_cls, name)
         # test Parameter is a MappingProxyType
         parameters = getattr(cosmo_cls, name)
         assert isinstance(parameters, MappingProxyType)
         # Test items
-        assert set(parameters.keys()) == set(getattr(cosmo_cls, f"_{name}"))
+        assert set(parameters.keys()) == set(getattr(cosmo_cls, descriptor.attr_name))
         assert all(isinstance(p, Parameter) for p in parameters.values())
 
-    @pytest.mark.parametrize("name", ["parameters", "derived_parameters"])
+    @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_from_instance(self, cosmo, name):
         """Test descriptor ``parameters`` accessed from the instance."""
+        descriptor = all_cls_vars(cosmo)[name]
         # test presence
         assert hasattr(cosmo, name)
         # test Parameter is a MappingProxyType
         parameters = getattr(cosmo, name)
         assert isinstance(parameters, MappingProxyType)
         # Test keys
-        assert set(parameters) == set(getattr(cosmo, f"_{name}"))
+        assert set(parameters) == set(getattr(cosmo, descriptor.attr_name))
 
-    @pytest.mark.parametrize("name", ["parameters", "derived_parameters"])
+    @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_cannot_set_on_instance(self, cosmo, name):
         """Test descriptor ``parameters`` cannot be set on the instance."""
         with pytest.raises(AttributeError, match=f"cannot set {name!r} of"):

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -95,7 +95,7 @@ class ParameterTestMixin:
         try:
             yield cosmo_cls.parameters[n]
         except KeyError:
-            yield cosmo_cls.derived_parameters[n]
+            yield cosmo_cls._derived_parameters[n]
 
     # ===============================================================
     # Method Tests
@@ -192,7 +192,7 @@ class ParameterTestMixin:
 
         # the reverse: check that if it is a Parameter, it's listed.
         if all_parameter.derived:
-            assert all_parameter.name in cosmo_cls.derived_parameters
+            assert all_parameter.name in cosmo_cls._derived_parameters
         else:
             assert all_parameter.name in cosmo_cls.parameters
 

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -360,7 +360,7 @@ class CosmologyTest(
         Test immutability of cosmologies.
         The metadata is mutable: see ``test_meta_mutable``.
         """
-        for n in (*cosmo.parameters, *cosmo.derived_parameters):
+        for n in (*cosmo.parameters, *cosmo._derived_parameters):
             with pytest.raises(AttributeError):
                 setattr(cosmo, n, getattr(cosmo, n))
 

--- a/docs/changes/cosmology/15168.feature.rst
+++ b/docs/changes/cosmology/15168.feature.rst
@@ -1,5 +1,4 @@
-The ``Cosmology`` class now has two new properties to access the parameters of the
-cosmology: ``.parameters`` and ``.derived_parameters``. These properties return a
-read-only dictionary of all the (derived) parameter values on the cosmology object.
-When accessed from the class (not an instance) the dictionary contains ``Parameter``
-objects, not the values.
+The ``Cosmology`` class now has a new property to access the parameters of the
+cosmology: ``.parameters``. This property return a read-only dictionary of all the
+(derived) parameter values on the cosmology object. When accessed from the class (not an
+instance) the dictionary contains ``Parameter`` objects, not the values.

--- a/docs/changes/cosmology/15168.feature.rst
+++ b/docs/changes/cosmology/15168.feature.rst
@@ -1,4 +1,4 @@
 The ``Cosmology`` class now has a new property to access the parameters of the
 cosmology: ``.parameters``. This property return a read-only dictionary of all the
-(derived) parameter values on the cosmology object. When accessed from the class (not an
-instance) the dictionary contains ``Parameter`` objects, not the values.
+non-derived parameter values on the cosmology object. When accessed from the class (not
+an instance) the dictionary contains ``Parameter`` instances, not the values.


### PR DESCRIPTION
- [ ] What's New entry directly in v6.0.x after merging this and backporting it to v6.0.x

I was working on a followup to #15484 (for v6.1) and realized there was a conceptual issue.

It’s unclear why `Ode0` should be “derived” but not `Ok0` or `Onu0` except that in the superclass it’s a Parameter object. It’s important for cosmology methods, eg. equality, to know this, but not the user. In fact it's confusing.

Therefore I think the new ``derived_parameters`` object should be made private. ``cosmology_class.Ode0`` still works so there's no API change yet.

As an aside I think the better solution is to have a "descriptors" (name not final) attribute that just collects all the descriptors that will be hidden from the user as proper dataclass descriptor objects are. That's for a future PR.

Sorry @eerovaher for the change right after #15168.