### PR TITLE
pytest 8.0 compat for test_all_masked_input_str

### DIFF
--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -235,12 +235,13 @@ def test_all_masked_input(masked_cls, val):
 
 
 @pytest.mark.parametrize("mask_cls", [np.ma.MaskedArray, Masked])
-@pytest.mark.parametrize("val", ["", [".."], b"", [b".."]])
-def test_all_masked_input_str(mask_cls, val):
-    dates = mask_cls(val, mask=True)
-    t = Time(dates, format="iso", in_subfmt="date")
-    assert np.all(t.mask)
-    assert np.all(t.unmasked == "2000-01-01")
+def test_all_masked_input_str(mask_cls):
+    # pytest 8.0 no longer allows parametrize to loop on empty string
+    for val in ("", [".."], b"", [b".."]):
+        dates = mask_cls(val, mask=True)
+        t = Time(dates, format="iso", in_subfmt="date")
+        assert np.all(t.mask)
+        assert np.all(t.unmasked == "2000-01-01")
 
 
 def test_some_masked_input_str_no_subfmt():


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a new failure seen in the "dev infra" job. I can reproduce this failure locally using pytest-dev so something must have changed in how pytest handles `parametrize` and empty strings. @nicoddemus , is this behavior change in pytest-dev intentional?

Without this patch, you will see this failure:

```
_ ERROR collecting .tox/py311-test-devinfra/lib/python3.11/site-packages/astropy/time/tests/test_mask.py _
...
_pytest/python.py:1338: in parametrize
    ids = self._resolve_parameter_set_ids(
_pytest/python.py:1461: in _resolve_parameter_set_ids
    return id_maker.make_unique_parameterset_ids()
_pytest/python.py:1006: in make_unique_parameterset_ids
    if id[-1].isdigit():
E   IndexError: string index out of range
```

Suspect:

* https://github.com/pytest-dev/pytest/pull/11489

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
