### PR TITLE
Remove an obsolete `PhysicalType` test

### DIFF
--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -497,18 +497,6 @@ class TestDefPhysType:
             )
 
 
-def test_missing_physical_type_attribute():
-    """
-    Test that a missing attribute raises an `AttributeError`.
-
-    This test should be removed when the deprecated option of calling
-    string methods on PhysicalType instances is removed from
-    `PhysicalType.__getattr__`.
-    """
-    with pytest.raises(AttributeError):
-        length.not_the_name_of_a_str_or_physical_type_attribute
-
-
 @pytest.mark.parametrize("ptype_name", ["length", "speed", "entropy"])
 def test_pickling(ptype_name):
     # Regression test for #11685


### PR DESCRIPTION
### Description

According to the suggestion in the test's docstring it should have been removed already in b62d7b21c337fb00b73b2ee212d8ce4421aa2dea, but nobody noticed it at the time. The test is harmless, so it doesn't have to be backported, but it is obsolete, so I think backporting is a good idea.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
