### PR TITLE
Removed OrderedDict from tests

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -8,7 +8,6 @@ import shlex
 import sys
 import tempfile
 import warnings
-from collections import OrderedDict
 from functools import wraps
 from importlib.util import find_spec
 
@@ -103,7 +102,7 @@ class TestRunnerBase:
         # Sort all keywords based on the priority flag.
         sorted_keywords = sorted(keywords, key=lambda x: x[1]._priority, reverse=True)
 
-        cls.keywords = OrderedDict()
+        cls.keywords = {}
         doc_keywords = ""
         for name, func in sorted_keywords:
             # Here we test if the function has been overloaded to return


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request removes OrderedDict from file "runner" in tests.
The OrderedDict is normal dictionary now.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes part of #10888 

<!-- Optional opt-out -->