### PR TITLE
Remove needless Black and Ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,6 @@ archs = ["x86_64", "arm64"]
 archs = ["auto", "aarch64"]
 
 [tool.black]
-line-length = 88
 force-exclude = """
 ^/(
   (
@@ -309,7 +308,6 @@ exclude= [
         ]
 
 [tool.ruff]
-line-length = 88
 select = ["ALL"]
 exclude=[
     "astropy/extern/*",
@@ -390,9 +388,7 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
 ]
 
 [tool.ruff.isort]
-    known-third-party = ["erfa", "PyYAML", "packaging", "pytest", "scipy", "matplotlib"]
     known-first-party = ["astropy", "extension_helpers"]
-    force-sort-within-sections = false
 
 [tool.ruff.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
### Description

Our `pyproject.toml` contains a few settings which specify values that would be the defaults anyways and can therefore be removed to declutter the file:
~[`setuptools` `include-package-data`](https://setuptools.pypa.io/en/stable/userguide/pyproject_config.html#setuptools-specific-configuration)~ (see #15422 instead),
[Black line length](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#l-line-length),
[Ruff line length](https://docs.astral.sh/ruff/settings/#line-length),
[Ruff `isort` `known-third-party`](https://docs.astral.sh/ruff/settings/#isort-known-third-party) has a non-default value, but this has no effect in practice,
[Ruff `isort` `force-sort-within-sections`](https://docs.astral.sh/ruff/settings/#isort-force-sort-within-sections),
~[`towncrier.type` `showcontent`](https://towncrier.readthedocs.io/en/stable/configuration.html#use-a-toml-array-defined-order)~ (these appear to have caused the RTD build to fail, not worth the effort to debug).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
