### PR TITLE
Remove `fmt: off` instruction from `coordinates`

### DIFF
--- a/astropy/coordinates/tests/test_polarization.py
+++ b/astropy/coordinates/tests/test_polarization.py
@@ -36,13 +36,7 @@ def test_vector_list_init():
 
 def test_undefined():
     sk = StokesCoord(np.arange(-10, 7))
-    assert_equal(
-        sk.symbol,
-        # fmt: off
-        np.array(["?", "?", "YX", "XY", "YY", "XX", "LR", "RL",
-                  "LL", "RR", "?", "I", "Q", "U", "V", "?", "?"]),
-        # fmt: on
-    )
+    assert_equal(sk.symbol, "? ? YX XY YY XX LR RL LL RR ? I Q U V ? ?".split())
 
 
 def test_undefined_init():


### PR DESCRIPTION
### Description

#14235 removed all [Black `fmt: off` instructions from](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#code-style) `coordinates`, but 9f18ae6f16a9f87636d56c9db1a2c7693b06b1af added a new one. The `fmt: off` instructions are a code smell and should avoided if possible.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
