### PR TITLE
DOC: Add branch protection rules to new release branch

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -118,6 +118,12 @@ The procedure for the feature freeze is as follows:
       $ git push upstream main:main
       $ git push upstream v<next_version>.dev:v<next_version>.dev
 
+#. Go into the branch protection rules page in the repo settings.
+   Add a rule for the new release branch you have just pushed out that only applies to that branch.
+   Check the "Require status checks to pass before merging" box.
+   Add the name of CI jobs that are required; these should be the same jobs that
+   required on ``main`` before the branching. Click "Save changes" at the bottom when done.
+
 #. Update the "Actual date" column of
    https://github.com/astropy/astropy/wiki/Release-Calendar with the current
    date for this version's feature freeze.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to update release instructions to include branch protection rules. This will allow the new release branch to take advantage of [auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) feature for backport PRs to that branch.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
