### PR TITLE
Fix marking in docstring to `astropy.stats.histogram`

### DIFF
--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -95,7 +95,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
     This is a histogram function that enables the use of more sophisticated
     algorithms for determining bins.  Aside from the ``bins`` argument allowing
     a string specified how bins are computed, the parameters are the same
-    as ``numpy.histogram()``.
+    as `numpy.histogram`.
 
     Parameters
     ----------
@@ -123,7 +123,8 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
         count of values. This argument does not affect determination of bin
         edges.
 
-    other keyword arguments are described in numpy.histogram().
+    **kwargs : dict, optional
+    Extra arguments are described in `numpy.histogram`.
 
     Returns
     -------

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -124,7 +124,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
         edges.
 
     **kwargs : dict, optional
-    Extra arguments are described in `numpy.histogram`.
+        Extra arguments are described in `numpy.histogram`.
 
     Returns
     -------


### PR DESCRIPTION
### Description

The markup did not generate correct links to cited numpy function before; this change fixes that.


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
