### PR TITLE
Adjust indentation in a LaTeX writing test

### DIFF
--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -6,6 +6,7 @@ import pathlib
 from contextlib import nullcontext
 from io import StringIO
 from itertools import chain
+from string import Template
 
 import numpy as np
 import pytest
@@ -672,28 +673,28 @@ def test_latex_units():
     latexdict = copy.deepcopy(ascii.latexdicts["AA"])
     latexdict["units"] = {"NUV exp.time": "s"}
     out = StringIO()
-    expected = """\
-\\begin{table}{cc}
-\\tablehead{\\colhead{date} & \\colhead{NUV exp.time}\\\\ \\colhead{ } & \\colhead{s}}
-\\startdata
-a & 1 \\\\
-b & 2
-\\enddata
-\\end{table}
-""".replace(
-        "\n", os.linesep
+    tablehead = Template(
+        r"\tablehead{\colhead{date} & \colhead{NUV exp.time}\\ \colhead{$u1} & \colhead{$u2}}"
     )
-
+    expected = [
+        r"\begin{table}{cc}",
+        tablehead.substitute(u1=" ", u2="s"),
+        r"\startdata",
+        r"a & 1 \\",
+        "b & 2",
+        r"\enddata",
+        r"\end{table}",
+        "",
+    ]
     ascii.write(t, out, format="aastex", latexdict=latexdict)
-    assert out.getvalue() == expected
+    assert out.getvalue() == os.linesep.join(expected)
     # use unit attribute instead
     t["NUV exp.time"].unit = u.s
     t["date"].unit = u.yr
     out = StringIO()
     ascii.write(t, out, format="aastex", latexdict=ascii.latexdicts["AA"])
-    assert out.getvalue() == expected.replace(
-        "colhead{s}", r"colhead{$\mathrm{s}$}"
-    ).replace("colhead{ }", r"colhead{$\mathrm{yr}$}")
+    expected[1] = tablehead.substitute(u1=r"$\mathrm{yr}$", u2=r"$\mathrm{s}$")
+    assert out.getvalue() == os.linesep.join(expected)
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])


### PR DESCRIPTION
### Description

The expected output in one of the tests is written as a multi-line string which is underindented relative to the function it is in. Although it is valid Python code, it is confusing both for humans and for any text editor or IDE that might use indentation for code folding.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
