### PR TITLE
Prevent using the legacy `tmpdir` fixture in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ addopts = [
     "--doctest-rst",
     "--strict-config",
     "--strict-markers",
+    "-p no:legacypath",
 ]
 log_cli_level = "info"
 xfail_strict = true

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ deps =
 
     image: latex
     image: scipy
-    image: pytest-mpl
+    image: pytest-mpl>=0.17
 
     # Some FITS tests use fitsio as a comparison
     fitsio: fitsio


### PR DESCRIPTION
### Description

[`pytest` recommends creating temporary directories with the `tmp_path` fixture instead of the legacy `tmpdir`](https://docs.pytest.org/en/latest/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures) and `astropy` follows that recommendation (see #13787). The update here ensures that `tmpdir` will not even work, which will prevent it from being reintroduced.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
