### PR TITLE
Remove `if __name__ == "__main__":` block from a test file

### DIFF
--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -244,14 +244,3 @@ def test_cds_order():
     assert_equal(r.header.cols[5].description, "Catalogue Identification Number")
     assert_equal(r.header.cols[8].description, "Equivalent width (in mA)")
     assert_equal(r.header.cols[9].description, "Luminosity class codified (11)")
-
-
-if __name__ == "__main__":  # run from main directory; not from test/
-    test_header_from_readme()
-    test_multi_header()
-    test_glob_header()
-    test_description()
-    test_cds_units()
-    test_cds_ignore_nullable()
-    test_cds_no_whitespace()
-    test_cds_order()


### PR DESCRIPTION
### Description

It is possible to run tests in a single file by [passing that file to `pytest` as a command line parameter](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run). There is need to run the test file as a script, nor would doing so provide any benefits.

Grepping also reveals another file: https://github.com/astropy/astropy/blob/b2149fa539ba7c47bcd5d892581250c433e90a0f/astropy/convolution/tests/test_convolve_speeds.py#L9
However, despite its name that file does not contain anything for `pytest`, it is instead a script for benchmarking. 

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
