### PR TITLE
Let Pandas Series work as redshift inputs

### DIFF
--- a/astropy/cosmology/_utils.py
+++ b/astropy/cosmology/_utils.py
@@ -70,6 +70,11 @@ def aszarr(z):
     if isinstance(z, (Number, np.generic)):  # scalars
         return z
     elif hasattr(z, "shape"):  # ducktypes NumPy array
+        if getattr(z, "__module__", "").startswith("pandas"):
+            # See https://github.com/astropy/astropy/issues/15576. Pandas does not play
+            # well with others and will ignore unit-ful calculations so we need to
+            # convert to it's underlying value.
+            z = z.values
         if hasattr(z, "unit"):  # Quantity Column
             return (z << cu.redshift).value  # for speed only use enabled equivs
         return z

--- a/astropy/cosmology/tests/test_utils.py
+++ b/astropy/cosmology/tests/test_utils.py
@@ -3,8 +3,10 @@
 import numpy as np
 import pytest
 
+import astropy.units as u
 from astropy.cosmology import utils
 from astropy.cosmology._utils import all_cls_vars, aszarr, vectorize_redshift_method
+from astropy.utils.compat.optional_deps import HAS_PANDAS
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .test_core import invalid_zs, valid_zs, z_arr
@@ -73,6 +75,19 @@ class Test_aszarr:
         """Test :func:`astropy.cosmology._utils.aszarr`."""
         with pytest.raises(exc):
             aszarr(z)
+
+    @pytest.mark.skipif(not HAS_PANDAS, reason="requires pandas")
+    def test_pandas(self):
+        import pandas as pd
+
+        x = pd.Series([1, 2, 3, 4, 5])
+
+        # Demonstrate Pandas doesn't work with units
+        assert not isinstance(x * u.km, u.Quantity)
+
+        # Test aszarr works with Pandas
+        assert isinstance(aszarr(x), np.ndarray)
+        np.testing.assert_array_equal(aszarr(x), x.values)
 
 
 # -------------------------------------------------------------------

--- a/docs/changes/cosmology/15600.bugfix.rst
+++ b/docs/changes/cosmology/15600.bugfix.rst
@@ -1,0 +1,2 @@
+``pandas.Series`` are now uniformly converted to their underlying data type when given
+as an argument to a Cosmology method.


### PR DESCRIPTION
Fixes #15576 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
