### PR TITLE
Ensure TimeDelta can be initialized with empty quantity.

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -582,10 +582,12 @@ class TimeBase(ShapedLikeNDArray):
         """
         if format is None:
             # If val and val2 broadcasted shape is (0,) (i.e. empty array input) then we
-            # cannot guess format from the input values.  Instead use the default
-            # format.
+            # cannot guess format from the input values. But a quantity is fine (as
+            # long as it has time units, but that will be checked later).
             empty_array = val.size == 0 and (val2 is None or val2.size == 0)
-            if empty_array or np.all(mask):
+            if not (isinstance(self, TimeDelta) and isinstance(val, u.Quantity)) and (
+                empty_array or np.all(mask)
+            ):
                 raise ValueError(
                     "cannot guess format from input values with zero-size array"
                     " or all elements masked"

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2872,3 +2872,16 @@ def test_to_string():
 def test_format_typeerror():
     with pytest.raises(TypeError, match="format must be a string"):
         Time("2020-01-01", format=1)
+
+
+def test_timedelta_empty_quantity():
+    # Regression test for gh-15601.
+    td = TimeDelta([] * u.s)
+    assert td.shape == (0,)
+
+    # This should work, even if it is perhaps not so useful.
+    t = Time.now() + [] * u.s
+    assert t.shape == (0,)
+
+    with pytest.raises(ValueError, match="only quantities with time units"):
+        TimeDelta([] * u.m)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a small regression introduced by #15264, where `TimeDelta([] * u.s)` no longer works. Would be nice to include in 6.0 to avoid a regression in released astropy versions.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15601

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
