### PR TITLE
Use __array_wrap__ instead of __array_prepare__

### DIFF
--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -238,7 +238,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         else:
             return np.array(self.data)
 
-    def __array_prepare__(self, array, context=None):
+    def __array_wrap__(self, array, context=None):
         """
         This ensures that a masked array is returned if self is masked.
         """


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of `__array_prepare__` in numpy 2.0 (see https://github.com/numpy/numpy/pull/25105, where it was noticed that astropy uses it). Generally, `__array_wrap__` should be used; I think the use of `__array_prepare__` was just an oversight. Note that if I just remove `__array_prepare__`, the only thing that fails is
```
docs/nddata/ccddata.rst F                                                                                                             [100%]

================================================================= FAILURES ==================================================================
___________________________________________________________ [doctest] ccddata.rst ___________________________________________________________
076 
077 Getting Data Out
078 ++++++++++++++++
079 
080 A `~astropy.nddata.CCDData` object behaves like a ``numpy`` array (masked if the
081 `~astropy.nddata.CCDData` mask is set) in expressions, and the underlying
082 data (ignoring any mask) is accessed through the ``data`` attribute:
083 
084     >>> ccd_masked = CCDData([1, 2, 3], unit="adu", mask=[0, 0, 1])
085     >>> 2 * np.ones(3) * ccd_masked   # one return value will be masked
Expected:
    masked_array(data=[2.0, 4.0, --],
                 mask=[False, False,  True],
           fill_value=1e+20)
Got:
    array([2., 4., 6.])
```

It would probably be good to have more tests, but since `nddata` is not something I usually deal with, it would be better if one of the nddata maintainers were to add this - please feel free to push to this branch (or take it over).

p.s.  I noticed that the `__array__` definition just ahead of `__array_prepare__` does not include the usual `dtype` argument -- see https://numpy.org/doc/stable/reference/generated/numpy.ndarray.__array__.html -- probably nice to address this at some point.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
