### PR TITLE
Remove obsolete known issues

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -189,18 +189,6 @@ means that an upstream fix in NumPy is required in order for
 To convert a dimensionless `~astropy.units.Quantity` to an integer, it is
 therefore recommended to use ``int(...)``.
 
-Inconsistent behavior when converting complex numbers to floats
----------------------------------------------------------------
-
-Attempting to use `float` or NumPy's ``numpy.float`` on a standard
-complex number (e.g., ``5 + 6j``) results in a `TypeError`.  In
-contrast, using `float` or ``numpy.float`` on a complex number from
-NumPy (e.g., ``numpy.complex128``) drops the imaginary component and
-issues a ``numpy.ComplexWarning``.  This inconsistency persists between
-`~astropy.units.Quantity` instances based on standard and NumPy
-complex numbers.  To get the real part of a complex number, it is
-recommended to use ``numpy.real``.
-
 Build/Installation/Test Issues
 ==============================
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -201,14 +201,6 @@ issues a ``numpy.ComplexWarning``.  This inconsistency persists between
 complex numbers.  To get the real part of a complex number, it is
 recommended to use ``numpy.real``.
 
-.. _structured_unit_deserialization_segfault:
-
-Structured units deserialization segfaults in big-endian
---------------------------------------------------------
-
-Structured units deserialization with ``pickle`` may cause segmentation
-fault in big-endian machine with ``numpy<1.21.1``.
-
 Build/Installation/Test Issues
 ==============================
 


### PR DESCRIPTION
### Description

The first commit here removes a known issues entry about `numpy<1.21.1` that was made obsolete by 3beb2f4c4f342dd97e4606831e194321ea0e78dc. Removing it is obviously the correct thing to do.

The second commit might be more controversial. The entry it removes describes possible unexpected behavior when converting a complex-valued `Quantity` to a `float`. However, trying to do that raises a very clear warning:
```python
>>> from astropy import units as u
>>> float((1j * u.m).value)
<stdin>:1: ComplexWarning: Casting complex values to real discards the imaginary part
0.0
```
It doesn't seem to me like the known issues entry is adding any useful information to what the warning message already contains, so I don't see a good reason for keeping it around. But I'll ping @namurphy, who authored 1a03364c56f9d74b04ecbff6e447744961d6feb9, and @bsipocz, who reviewed and merged it. Maybe they can point out something that I'm missing.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
