### PR TITLE
Fix docstrings describing max_cut

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -253,7 +253,7 @@ def simple_norm(
 
     max_cut : float, optional
         The pixel value of the maximum cut level.  Data values greater
-        than ``min_cut`` will set to ``min_cut`` before stretching the
+        than ``max_cut`` will set to ``max_cut`` before stretching the
         image.  The default is the image maximum.  ``max_cut`` overrides
         ``max_percent``.
 

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -56,7 +56,7 @@ def fits2bitmap(
         ``min_percent``.
     max_cut : float, optional
         The pixel value of the maximum cut level.  Data values greater
-        than ``min_cut`` will set to ``min_cut`` before stretching the
+        than ``max_cut`` will set to ``max_cut`` before stretching the
         image.  The default is the image maximum.  ``max_cut`` overrides
         ``max_percent``.
     min_percent : float, optional


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes some typos in the docstrings describing the `max_cut` keyword to `simple_norm` and `fits2bitmap`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
