### PR TITLE
Handle ImageNormalize cases when vmin >= vmax

### DIFF
--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 from numpy import ma
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB, HAS_PLT
 from astropy.visualization.interval import ManualInterval, PercentileInterval
@@ -32,6 +32,11 @@ class TestNormalize:
         with pytest.raises(TypeError):
             ImageNormalize(vmin=2.0, vmax=10.0, interval=ManualInterval, clip=True)
 
+    def test_invalid_vmin_vmax(self):
+        with pytest.raises(ValueError):
+            norm = ImageNormalize(vmin=10.0, vmax=2.0)
+            norm(10)
+
     def test_invalid_stretch(self):
         with pytest.raises(TypeError):
             ImageNormalize(vmin=2.0, vmax=10.0, stretch=SqrtStretch, clip=True)
@@ -47,6 +52,11 @@ class TestNormalize:
         )
         assert_allclose(norm(6), 0.70710678)
         assert_allclose(norm(6), norm2(6))
+
+    def test_vmin_vmax_equal(self):
+        norm = ImageNormalize(vmin=2.0, vmax=2.0)
+        data = np.arange(10) - 5.0
+        assert_array_equal(norm(data), 0)
 
     def test_clip(self):
         norm = ImageNormalize(vmin=2.0, vmax=10.0, stretch=SqrtStretch(), clip=True)

--- a/docs/changes/visualization/15622.api.rst
+++ b/docs/changes/visualization/15622.api.rst
@@ -1,0 +1,3 @@
+If ``vmin == vmax``, the ``ImageNormalize`` class now maps the input
+data to 0. If ``vmin > vmax``, the ``ImageNormalize`` class now raises a
+``ValueError``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

With this PR, if ``vmin == vmax``, the ``ImageNormalize`` class now maps the input
data to 0.  That is what the matplotlib `Normalize` class does.  Currently a divide-by-zero `RuntimeWarning` is issued and the output data are (+/-) np.inf.

Also if ``vmin > vmax``, the ``ImageNormalize`` class now raises a ``ValueError`` instead of returning invalid results.  This also matches the matplotlib `Normalize` behavior.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
