### PR TITLE
Replace OrderedDict with dict in nddata module

### DIFF
--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -5,7 +5,6 @@ A module that provides functions for manipulating bit masks and data quality
 """
 import numbers
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 
@@ -86,7 +85,7 @@ class BitFlagNameMeta(type):
         attrl = list(map(str.lower, attr))
 
         if _ENABLE_BITFLAG_CACHING:
-            cache = OrderedDict()
+            cache = dict()
 
         for b in bases:
             for k, v in b.__dict__.items():

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-
 import numpy as np
 
 from astropy.utils.misc import isiterable

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from collections import OrderedDict
 
 import numpy as np
 
@@ -10,16 +9,16 @@ from astropy.utils.misc import isiterable
 __all__ = ["FlagCollection"]
 
 
-class FlagCollection(OrderedDict):
+class FlagCollection(dict):
     """
     The purpose of this class is to provide a dictionary for
     containing arrays of flags for the `NDData` class. Flags should be
     stored in Numpy arrays that have the same dimensions as the parent
-    data, so the `FlagCollection` class adds shape checking to an
-    ordered dictionary class.
+    data, so the `FlagCollection` class adds shape checking to a
+    dictionary.
 
-    The `FlagCollection` should be initialized like an
-    `~collections.OrderedDict`, but with the addition of a ``shape=``
+    The `FlagCollection` should be initialized like a
+    dict, but with the addition of a ``shape=``
     keyword argument used to pass the NDData shape.
     """
 
@@ -33,12 +32,12 @@ class FlagCollection(OrderedDict):
                 "FlagCollection should be initialized with the shape of the data"
             )
 
-        OrderedDict.__init__(self, *args, **kwargs)
+        super().__init__(self, *args, **kwargs)
 
     def __setitem__(self, item, value, **kwargs):
         if isinstance(value, np.ndarray):
             if value.shape == self.shape:
-                OrderedDict.__setitem__(self, item, value, **kwargs)
+                super().__setitem__(item, value)
             else:
                 raise ValueError(
                     "flags array shape {} does not match data shape {}".format(

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -69,7 +69,7 @@ class NDData(NDDataBase):
 
     meta : `dict`-like object, optional
         Additional meta information about the dataset. If no meta is provided
-        an empty `collections.OrderedDict` is created.
+        an empty dict is created.
         Default is ``None``.
 
     unit : unit-like, optional

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -370,7 +370,7 @@ def test_accepting_property_translated():
 
 
 def test_accepting_property_meta_empty():
-    # Meta is always set (OrderedDict) so it has a special case that it's
+    # Meta is always set (dict) so it has a special case that it's
     # ignored if it's empty but not None
     @support_nddata
     def test(data, meta=None):

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -3,7 +3,6 @@
 
 import pickle
 import textwrap
-from collections import OrderedDict
 from itertools import chain, permutations
 
 import numpy as np
@@ -356,7 +355,7 @@ def test_param_meta():
     nd = NDData([1, 2, 3], meta={})
     assert len(nd.meta) == 0
     nd = NDData([1, 2, 3])
-    assert isinstance(nd.meta, OrderedDict)
+    assert isinstance(nd.meta, dict)
     assert len(nd.meta) == 0
     # Test conflicting meta (other NDData)
     nd2 = NDData(nd, meta={"image": "sun"})


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


Following the discussion in issue #10888, this Pull Request is to replace the usage of `OrderedDict` with `dict` in the `nddata` module. This change is motivated by the fact that, starting from Python 3.7, the standard dictionary (`dict`) maintains the order of elements, rendering `OrderedDict` unnecessary.

I have made the necessary replacements and ensured that all functionalities continue to work as expected. Additionally, I have updated the tests to reflect this change.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes one of #10888 tasks.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
