### PR TITLE
Remove an unneeded item from `pytest` `filterwarnings`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,6 @@ filterwarnings = [
     "ignore:unclosed transport <asyncio.sslproto",
     "ignore:numpy\\.ufunc size changed:RuntimeWarning",
     "ignore:numpy\\.ndarray size changed:RuntimeWarning",
-    "ignore:Unknown pytest\\.mark\\.mpl_image_compare:pytest.PytestUnknownMarkWarning",
     "ignore:matplotlibrc text\\.usetex:UserWarning:matplotlib",
     # Triggered by ProgressBar > ipykernel.iostream (revisit when we bump oldest deps versions)
     "ignore:the imp module is deprecated:DeprecationWarning",


### PR DESCRIPTION
### Description

The `mpl_image_compare` mark is [properly registered with `pytest`](https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks) since 1e634ee1c4c417bd8255225fe2000b40ffb5a9e4, so there is no need to ignore the warning about it being unknown anymore.

This should have been done already in #15367 but it wasn't, despite it [having been suggested in a review](https://github.com/astropy/astropy/pull/15367#discussion_r1377733562).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
