### PR TITLE
chore: bump repo-review and cleanup a bit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,10 +65,9 @@ repos:
         args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/scientific-python/cookie
-    rev: 2023.10.27
+    rev: 2023.11.17
     hooks:
       - id: sp-repo-review
-        additional_dependencies: ["repo-review[cli]"]
 
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,13 +316,13 @@ exclude= [
         ]
 
 [tool.ruff]
-select = ["ALL"]
+lint.select = ["ALL"]
 exclude=[
     "astropy/extern/*",
     "*_parsetab.py",
     "*_lextab.py"
 ]
-ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` instead.
+lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
 
     # flake8-builtins (A) : shadowing a Python built-in.
     # New ones should be avoided and is up to maintainers to enforce.
@@ -373,7 +373,7 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
     "RUF005",  # unpack-instead-of-concatenating-to-collection-literal -- it's not clearly faster.
 ]
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
 ".github/workflows/*.py" = ["INP001"]
 "astropy/modeling/models/__init__.py" = ["F405"]
@@ -399,14 +399,14 @@ ignore = [  # NOTE: non-permeanent exclusions should be added to `.ruff.toml` in
     "T203"    # pprint found
 ]
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 ignore-fully-untyped = true
 mypy-init-return = true
 
-[tool.ruff.isort]
-    known-first-party = ["astropy", "extension_helpers"]
+[tool.ruff.lint.isort]
+known-first-party = ["astropy", "extension_helpers"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.repo-review]
@@ -417,9 +417,6 @@ ignore = [
     "PC180", # ignore using `prettier` in pre-commit
     "PC901", # ignore using custom update message (we have many of the default ones in our history already)
     "PP308", # ignore requiring `-ra` flag for pytest, astropy's test suite is too large for this to be useful
-    "RF101", # See scientific-python/cookie#311 (bugbear must be selected)
-    "RF102", # See scientific-python/cookie#311 (isort must be selected)
-    "RF103", # See scientific-python/cookie#311 (pyupgrade must be selected)
 ]
 
 [tool.towncrier]


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


This is a follow-up to #15367, with a bump in sp-repo-review version. This allows a little bit of cleanup, and catches the part of the ruff config that didn't get a `.lint` added.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
