### PR TITLE
Fix support of custom WCS mapping.

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1623,8 +1623,8 @@ def test_custom_wcs_to_from_frame():
         wcs.wcs.ctype = [f"CSLN-{projection}", f"CSLT-{projection}"]
         return wcs
 
-    FRAME_WCS_MAPPINGS.append([custom_wcs_frame_mapping])
-    WCS_FRAME_MAPPINGS.append([custom_frame_wcs_mapping])
+    WCS_FRAME_MAPPINGS.append([custom_wcs_frame_mapping])
+    FRAME_WCS_MAPPINGS.append([custom_frame_wcs_mapping])
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.ctype = ["CSLN-TAN", "CSLT-TAN"]

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -158,13 +158,11 @@ def _wcs_to_celestial_frame_builtin(wcs):
                 representation_type=SphericalRepresentation,
                 obstime=wcs.wcs.dateobs or None,
             )
-        elif xcoord[2:4] in ("LN", "LT") and "H" not in xcoord and "CR" not in xcoord:
+        elif xcoord[2:4] in ("LN", "LT") and xcoord[:2] in SOLAR_SYSTEM_OBJ_DICT.keys():
             # Coordinates on a planetary body, as defined in
             # https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018EA000388
 
             object_name = SOLAR_SYSTEM_OBJ_DICT.get(xcoord[:2])
-            if object_name is None:
-                raise KeyError(f"unknown solar system object abbreviation {xcoord[:2]}")
 
             a_radius = wcs.wcs.aux.a_radius
             b_radius = wcs.wcs.aux.b_radius

--- a/docs/changes/wcs/15630.bugfix.rst
+++ b/docs/changes/wcs/15630.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a regression in custom WCS mapping due to the recent introduction of
+Solar System frames.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address issue #15625.
After the introduction of Solar System frames the creation of custom WCS frame with ctype yzLT, yzLN was no longer possible.
This pr reverts the previous behaviour.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15625

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
