### PR TITLE
BLD: fix compatibility issue with setuptools 69.0.0

### DIFF
--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -324,9 +324,6 @@ def get_extensions():
     # do the copying here then include the data in [tools.setuptools.package_data]
     # in the pyproject.toml file
 
-    def requires_update(source: Path, dest: Path) -> bool:
-        return not dest.is_file() or source.stat().st_mtime > dest.stat().st_mtime
-
     wcslib_headers = [
         "cel.h",
         "lin.h",
@@ -347,7 +344,7 @@ def get_extensions():
         for header in wcslib_headers:
             source = Path("cextern", "wcslib", "C", header)
             dest = Path("astropy", "wcs", "include", "wcslib", header)
-            if requires_update(source, dest):
+            if not dest.is_file() or source.stat().st_mtime > dest.stat().st_mtime:
                 shutil.copy(source, dest)
 
     return [Extension("astropy.wcs._wcs", **cfg)]

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -10,9 +10,15 @@ from os.path import join
 
 import numpy
 from setuptools import Extension
-from setuptools.dep_util import newer_group
 
 from extension_helpers import get_compiler, import_file, pkg_config, write_if_different
+
+try:
+    # requires setuptools 69.0.0 or newer
+    from setuptools.modified import newer_group
+except ModuleNotFoundError:
+    # setuptools<69 compatibility
+    from setuptools.dep_util import newer_group
 
 WCSROOT = os.path.relpath(os.path.dirname(__file__))
 WCSVERSION = "8.1"


### PR DESCRIPTION
Fix a surprise incompatibility with the newest setuptools (reported upstream as https://github.com/pypa/setuptools/issues/4126)
This should be enough to get CI working again.

Note that I'm using a `try/except` pattern here instead of checking on the version we have at runtime, because that would also require adding `packaging` as a build-time dependenc. For the recordI don't think it'd be a big deal but adding dependencies to manage other dependencies seemed to me like an overkill here. I'd be happy to change it if requested.
