### PR TITLE
Remove needless `fmt: off` instructions from `utils`

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1144,12 +1144,10 @@ def test_read_unicode(filename):
     contents = get_pkg_data_contents(os.path.join("data", filename), encoding="binary")
     assert isinstance(contents, bytes)
     x = contents.splitlines()[1]
-    # fmt: off
     assert x == (
         b"\xff\xd7\x94\xd7\x90\xd7\xa1\xd7\x98\xd7\xa8\xd7\x95\xd7\xa0\xd7\x95"
         b"\xd7\x9e\xd7\x99 \xd7\xa4\xd7\x99\xd7\x99\xd7\xaa\xd7\x95\xd7\x9f"[1:]
     )
-    # fmt: on
 
 
 def test_compressed_stream():

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -49,14 +49,11 @@ def test_diff_types():
     b = "1.0"
     identical = report_diff_values(a, b, fileobj=f)
     assert not identical
-    out = f.getvalue()
-    # fmt: off
-    assert out == (
-        "  (float) a> 1.0\n"
-        "    (str) b> '1.0'\n"
-        "           ? +   +\n"
-    )
-    # fmt: on
+    assert f.getvalue().splitlines() == [
+        "  (float) a> 1.0",
+        "    (str) b> '1.0'",
+        "           ? +   +",
+    ]
 
 
 def test_diff_numeric_scalar_types():


### PR DESCRIPTION
### Description

I had a look at the [Black `fmt:` instructions](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#code-style) in `utils` and found two uses of `fmt: off` that are not needed. A handful of `fmt: skip` instructions are used to help organize long lists of functions. Their use seems justified so I've left them as they are.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
