### PR TITLE
Enforce Ruff rule E402 in tests

### DIFF
--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -18,6 +18,7 @@ from astropy.nddata.nduncertainty import StdDevUncertainty
 from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_DASK
 from astropy.utils.masked import Masked
+from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS, HighLevelWCSWrapper, SlicedLowLevelWCS
 
@@ -439,9 +440,6 @@ def test_pickle_nddata_without_uncertainty():
 # Check that the meta descriptor is working as expected. The MetaBaseTest class
 # takes care of defining all the tests, and we simply have to define the class
 # and any minimal set of args to pass.
-from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
-
-
 class TestMetaNDData(MetaBaseTest):
     test_class = NDData
     args = np.array([[1.0]])

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -29,6 +29,7 @@ import astropy.utils.data
 from astropy import units as _u  # u is taken
 from astropy.config import paths
 from astropy.tests.helper import CI, IS_CRON, PYTEST_LT_8_0
+from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA
 from astropy.utils.data import (
     CacheDamaged,
     CacheMissingWarning,
@@ -64,9 +65,6 @@ TESTURL = "http://www.astropy.org"
 TESTURL2 = "http://www.astropy.org/about.html"
 TESTURL_SSL = "https://www.astropy.org"
 TESTLOCAL = get_pkg_data_filename(os.path.join("data", "local.dat"))
-
-# NOTE: Python can be built without bz2 or lzma.
-from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA
 
 # For when we need "some" test URLs
 FEW = 5

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+# ruff: noqa: E402
+
 import pytest
 
 pytest.importorskip("matplotlib")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,7 +384,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 "test_*.py" = [
     "B018",  # UselessExpression
     "D",  # pydocstyle
-    "E402",  # Module level import not at top of file
     "PGH001",  # No builtin eval() allowed
     "S101",  # Use of assert detected
 ]


### PR DESCRIPTION
### Description

[E402](https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/) checks for module-level imports that are not at the top of the file. Even though `astropy` currently configures Ruff to ignore this in all tests, the rule is violated in only three test files. In two of them it is simple to enforce the rule. The third uses [`pytest.importorskip()`](https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-on-a-missing-import-dependency) to stop executing the file if `matplotlib` is not installed, which means a [module-level `noqa` instruction](https://docs.astral.sh/ruff/linter/#error-suppression) is appropriate.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
