### PR TITLE
Stop worrying about `matplotlib` default epoch

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -962,10 +962,9 @@ class TimePlotDate(TimeFromEpoch):
     def epoch(self):
         """Reference epoch time from which the time interval is measured."""
         try:
-            # Matplotlib >= 3.3 has a get_epoch() function
             from matplotlib.dates import get_epoch
         except ImportError:
-            # If no get_epoch() then the epoch is '0001-01-01'
+            # If matplotlib is not installed then the epoch is '0001-01-01'
             _epoch = self._epoch
         else:
             # Get the matplotlib date epoch as an ISOT string in UTC

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1057,11 +1057,9 @@ class TestSubFormat:
     def test_plot_date(self):
         """Test the plot_date format.
 
-        Depending on the situation with matplotlib, this can give different
-        results because the plot date epoch time changed in matplotlib 3.3. This
-        test tries to use the matplotlib date2num function to make the test
-        independent of version, but if matplotlib isn't available then the code
-        (and test) use the pre-3.3 epoch.
+        The plot date epoch time changed in matplotlib 3.3. This test
+        tries to use the matplotlib date2num function, but if matplotlib
+        isn't available then the code (and test) use the pre-3.3 epoch.
         """
         try:
             from matplotlib.dates import date2num

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -6,17 +6,11 @@ pytest.importorskip("matplotlib")
 
 from contextlib import nullcontext
 
-import matplotlib.dates
 import matplotlib.pyplot as plt
 from erfa import ErfaWarning
 
 from astropy.time import Time
 from astropy.visualization.time import time_support
-
-# Matplotlib 3.3 added a settable epoch for plot dates and changed the default
-# from 0000-12-31 to 1970-01-01. This can be checked by the existence of
-# get_epoch() in matplotlib.dates.
-MPL_EPOCH_1970 = hasattr(matplotlib.dates, "get_epoch")
 
 # Since some of the examples below use times/dates in the future, we use the
 # TAI time scale to avoid ERFA warnings about dubious years.
@@ -162,14 +156,7 @@ FORMAT_CASES = [
     ("jyear", ["2020", "2040", "2060"]),
     ("jyear_str", ["J2020.000", "J2040.000", "J2060.000"]),
     ("mjd", ["60000", "66000", "72000", "78000"]),
-    (
-        "plot_date",
-        (
-            ["18000", "24000", "30000", "36000"]
-            if MPL_EPOCH_1970
-            else ["738000", "744000", "750000", "756000"]
-        ),
-    ),
+    ("plot_date", (["18000", "24000", "30000", "36000"])),
     ("unix", ["1500000000", "2000000000", "2500000000", "3000000000"]),
     (
         "yday",


### PR DESCRIPTION
### Description

The default epoch `matplotlib` used for plot dates changed in version 3.3 (see #10876), but older versions have not been supported since 3b8b44be83defe3f5d5ca646d3a661cd4006514b.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
