### PR TITLE
Pin numpy<2.0 for v6.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=1.22",
+    "numpy>=1.22,<2",
     "pyerfa>=2.0",
     "astropy-iers-data>=0.2023.10.30.0.29.53",
     "PyYAML>=3.13",


### PR DESCRIPTION
Numpy is already pinned in our build requirements, we must do the same for runtime since to support Numpy 2.0 we will have to release a new version compiled with Numpy≥2.0.