### PR TITLE
Ensure `BaseCoordinateFrame` separation methods work with `SkyCoord` input

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1779,7 +1779,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Parameters
         ----------
-        other : `~astropy.coordinates.BaseCoordinateFrame`
+        other : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
             The coordinate to get the separation to.
 
         Returns
@@ -1798,8 +1798,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         from .angles import Angle, angular_separation
 
         self_unit_sph = self.represent_as(r.UnitSphericalRepresentation)
-        other_transformed = other.transform_to(self)
-        other_unit_sph = other_transformed.represent_as(r.UnitSphericalRepresentation)
+        other_unit_sph = (
+            getattr(other, "frame", other)
+            .transform_to(self)
+            .represent_as(r.UnitSphericalRepresentation)
+        )
 
         # Get the separation as a Quantity, convert to Angle in degrees
         sep = angular_separation(
@@ -1814,7 +1817,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         Parameters
         ----------
-        other : `~astropy.coordinates.BaseCoordinateFrame`
+        other : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
             The coordinate system to get the distance to.
 
         Returns
@@ -1835,7 +1838,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             )
 
         # do this first just in case the conversion somehow creates a distance
-        other_in_self_system = other.transform_to(self)
+        other_in_self_system = getattr(other, "frame", other).transform_to(self)
 
         if issubclass(other_in_self_system.__class__, r.UnitSphericalRepresentation):
             raise ValueError(

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -736,6 +736,21 @@ def test_sep():
         i7.separation_3d(i3)
 
 
+@pytest.mark.parametrize(
+    "method,expectation",
+    [
+        pytest.param("separation", 0.69815121 * u.deg, id="separation"),
+        pytest.param("separation_3d", 0.12184962 * u.pc, id="separation_3d"),
+    ],
+)
+def test_seps_with_skycoord(method, expectation):
+    coords = (1 * u.deg, 2 * u.deg, 10 * u.pc)
+    assert_allclose(
+        getattr(FK5(*coords), method)(SkyCoord(*coords, frame=FK5, equinox="B1950")),
+        expectation,
+    )
+
+
 def test_time_inputs():
     """
     Test validation and conversion of inputs for equinox and obstime attributes.

--- a/docs/changes/coordinates/15659.bugfix.rst
+++ b/docs/changes/coordinates/15659.bugfix.rst
@@ -1,0 +1,4 @@
+Previously passing a ``SkyCoord`` instance to the ``BaseCoordinateFrame``
+``separation()`` or ``separation_3d()`` methods could produce wrong results,
+depending on what additional frame attributes were defined on the ``SkyCoord``,
+but now ``SkyCoord`` input can be used safely.


### PR DESCRIPTION
### Description

The first commit here adds a test which demonstrates that it is possible to get wrong results from `BaseCoordinateFrame` `separation()` and `separation_3d()` methods if the input to those methods is a `SkyCoord` instance. These methods do not claim to support `SkyCoord` input, but if they don't work with `SkyCoord` they should fail in an obvious manner. The current behavior is therefore a bug and the second commit here fixes it.

~The third commit removes the `SkyCoord` `separation()` and `separation_3d()` methods. This can be removed without loss of functionality after fixing the bug because a `SkyCoord` instance then exposes the separation methods of its underlying frame.~
EDIT: there will be a separate pull request for the third commit.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
