### PR TITLE
Use relative path for source files

### DIFF
--- a/astropy/io/fits/hdu/compressed/setup_package.py
+++ b/astropy/io/fits/hdu/compressed/setup_package.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import Extension
 
-SRC_DIR = os.path.join(os.path.dirname(__file__), "src")
+SRC_DIR = os.path.relpath(os.path.join(os.path.dirname(__file__), "src"))
 
 
 def get_extensions():


### PR DESCRIPTION
Since https://github.com/astropy/extension-helpers/pull/67 in extension-helpers, I'm seeing the following error when trying to build astropy:

```
      writing manifest file 'astropy.egg-info/SOURCES.txt'
      error: Error: setup script specifies an absolute path:
      
          /Users/tom/Code/Astropy/astropy/./astropy/io/fits/hdu/compressed/src/compression.c
      
      setup() arguments must *always* be /-separated paths relative to the
      setup.py directory, *never* absolute paths.
```

I think this is a real issue that should be fixed here, as all other extension modules specify relative paths.

I think this will also require a fix in extension-helpers to ensure backward-compatibility, otherwise packages specifying extension-helpers in pyproject without pinning (such as astropy itself) won't be able to be compiled with a new release of extension-helpers.