### PR TITLE
Fix bug setting items in bytes MaskedColumn

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1142,7 +1142,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
                 arr = np.char.encode(arr, encoding="utf-8")
                 if isinstance(value, np.ma.MaskedArray):
                     arr = np.ma.array(arr, mask=value.mask, copy=False)
-            value = arr
+                value = arr
 
         return value
 

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -651,3 +651,10 @@ def test_mask_slicing_count_array_finalize():
     # repr should need none (used to be 2!!)
     repr(c0)
     assert MyBaseColumn.counter == 2
+
+
+def test_set_masked_bytes_column():
+    mask = [True, False, True]
+    mc = MaskedColumn([b"a", b"b", b"c"], mask=mask)
+    mc[:] = mc
+    assert (mc.mask == mask).all()

--- a/docs/changes/table/15669.bugfix.rst
+++ b/docs/changes/table/15669.bugfix.rst
@@ -1,0 +1,4 @@
+Fix a Table bug when setting items (via slice or index list) in a ``bytes`` type
+``MaskedColumn`` would cause the column mask to be set to all ``False``. A common way to
+trigger this bug was reading a FITS file with masked string data and then sorting the
+table.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR fixes a Table bug when setting items (via slice or index list) in a `bytes` type `MaskedColumn` would cause the column mask to be set to all `False`. 

The problem was that when coercing the right hand side `value` to an appropriate `bytes` type in `_encode_str()`, it was using `np.asarray(value)` to check the data type of `value`. This converts a masked array `value` to a plain `ndarray` and drops the mask even if `value` is `bytes` type. The new logic ignores the converted array if the dtype is not `"U"`.

A common way to trigger this bug was reading a FITS file with masked string data and then sorting the table. (This was the original issue noted by a user).

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
