### PR TITLE
DOC: edit out a reference to pylab (prefer matplotlib.pyplot)

### DIFF
--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -11,7 +11,7 @@ def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
     This is a histogram function that enables the use of more sophisticated
     algorithms for determining bins.  Aside from the ``bins`` argument allowing
     a string specified how bins are computed, the parameters are the same
-    as pylab.hist().
+    as matplotlib.pyplot.hist().
 
     This function was ported from astroML: https://www.astroml.org/
 


### PR DESCRIPTION
### Description

`pylab` isn't deprecated but discouraged. This is the only reference to it in the core library.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
