### PR TITLE
Remove `SkyCoord` separation methods

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1777,6 +1777,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             that ``self.separation(other)`` and ``other.separation(self)`` may
             not give the same answer in this case.
 
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`astropy:/coordinates/matchsep`.
+
         Parameters
         ----------
         other : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
@@ -1814,6 +1817,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         """
         Computes three dimensional separation between this coordinate
         and another.
+
+        For more on how to use this (and related) functionality, see the
+        examples in :doc:`astropy:/coordinates/matchsep`.
 
         Parameters
         ----------

--- a/docs/coordinates/common_errors.rst
+++ b/docs/coordinates/common_errors.rst
@@ -9,8 +9,9 @@ Object Separation
 -----------------
 
 When calculating the separation between objects, it is important to bear in mind that
-:meth:`astropy.coordinates.SkyCoord.separation` gives a different answer depending
-upon the order in which is used. For example::
+:meth:`~astropy.coordinates.BaseCoordinateFrame.separation` gives a different
+answer depending upon the order in which is used.
+For example::
 
     >>> import numpy as np
     >>> from astropy import units as u
@@ -26,11 +27,12 @@ upon the order in which is used. For example::
 
 Why do these give such different answers?
 
-The reason is that :meth:`astropy.coordinates.SkyCoord.separation` gives the separation as measured
-in the frame of the |SkyCoord| object. So ``star.separation(moon)`` gives the angular separation
-in the ICRS frame. This is the separation as it would appear from the Solar System Barycenter. For a
-geocentric observer, ``moon.separation(star)`` gives the correct answer, since ``moon`` is in a
-geocentric frame.
+The reason is that :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`
+gives the separation as measured in the frame of the |SkyCoord| object.
+So ``star.separation(moon)`` gives the angular separation in the ICRS frame.
+This is the separation as it would appear from the Solar System Barycenter.
+For a geocentric observer, ``moon.separation(star)`` gives the correct answer,
+since ``moon`` is in a geocentric frame.
 
 AltAz calculations for Earth-based objects
 ------------------------------------------

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -18,9 +18,8 @@ been executed::
 Separations
 ===========
 
-The on-sky separation can be computed with the
-:meth:`astropy.coordinates.BaseCoordinateFrame.separation` or
-:meth:`astropy.coordinates.SkyCoord.separation` methods,
+The on-sky separation can be computed with
+:meth:`~astropy.coordinates.BaseCoordinateFrame.separation`,
 which computes the great-circle distance (*not* the small-angle approximation)::
 
     >>> c1 = SkyCoord('5h23m34.5s', '-69d45m22s', frame='icrs')
@@ -48,8 +47,7 @@ though they are in different frames, the separation is determined
 consistently.
 
 In addition to the on-sky separation described above,
-:meth:`astropy.coordinates.BaseCoordinateFrame.separation_3d` or
-:meth:`astropy.coordinates.SkyCoord.separation_3d` methods will
+:meth:`~astropy.coordinates.BaseCoordinateFrame.separation_3d` will
 determine the 3D distance between two coordinates that have ``distance``
 defined::
 
@@ -80,8 +78,8 @@ astronomy convention (positive angles East of North)::
     >>> c1.position_angle(c2).to(u.deg)  # doctest: +FLOAT_CMP
     <Angle 44.97818294 deg>
 
-The combination of :meth:`~astropy.coordinates.SkyCoord.separation` and
-:meth:`~astropy.coordinates.SkyCoord.position_angle` thus give a set of
+The combination of :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`
+and :meth:`~astropy.coordinates.SkyCoord.position_angle` thus give a set of
 directional offsets. To do the inverse operation — determining the new
 "destination" coordinate given a separation and position angle — the
 :meth:`~astropy.coordinates.SkyCoord.directional_offset_by` method is provided::

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1134,7 +1134,7 @@ Matching Within Tolerance
 -------------------------
 
 To test if coordinates are within a certain angular distance of one other, use the
-`~astropy.coordinates.SkyCoord.separation` method::
+:meth:`~astropy.coordinates.BaseCoordinateFrame.separation` method::
 
   >>> sc1.icrs.fk4.separation(sc1).to(u.arcsec)  # doctest: +SKIP
   <Angle 7.98873629e-13 arcsec>
@@ -1251,8 +1251,8 @@ the available docstrings below:
 - `~astropy.coordinates.SkyCoord.match_to_catalog_sky`,
 - `~astropy.coordinates.SkyCoord.match_to_catalog_3d`,
 - `~astropy.coordinates.SkyCoord.position_angle`,
-- `~astropy.coordinates.SkyCoord.separation`,
-- `~astropy.coordinates.SkyCoord.separation_3d`
+- `~astropy.coordinates.BaseCoordinateFrame.separation`,
+- `~astropy.coordinates.BaseCoordinateFrame.separation_3d`
 - `~astropy.coordinates.SkyCoord.apply_space_motion`
 
 Additional information and examples can be found in the section on


### PR DESCRIPTION
### Description

The `SkyCoord` `separation()` and `separation_3d()` methods can be removed without loss of functionality because a `SkyCoord` instance exposes the equivalent methods implemented by its underlying frame.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
