### PR TITLE
Start enforcing Ruff rule ANN201

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -6,7 +6,6 @@ lint.ignore = [
     # flake8-annotations (ANN) : static typing
     "ANN001",  # Function argument without type annotation
     "ANN003",  # `**kwargs` without type annotation
-    "ANN201",  # Public function without return type annotation
     "ANN202",  # Private function without return type annotation
     "ANN401",  # Use of `Any` type
 
@@ -266,6 +265,7 @@ lint.unfixable = [
 ]
 "astropy/logger.py" = ["C408", "RET505"]
 "astropy/modeling/*" = [
+    "ANN201",  # Public function without return type annotation
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -26,6 +26,8 @@ from .parameter._descriptors import ParametersAttribute
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from typing_extensions import Self
+
     from astropy.cosmology.funcs.comparison import _FormatType
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
@@ -516,7 +518,9 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
     def nonflat(self: _FlatCosmoT) -> _CosmoT:
         """Return the equivalent non-flat-class instance of this cosmology."""
 
-    def clone(self, *, meta: Mapping | None = None, to_nonflat: bool = False, **kwargs):
+    def clone(
+        self, *, meta: Mapping | None = None, to_nonflat: bool = False, **kwargs
+    ) -> Self:
         """Returns a copy of this object with updated parameters, as specified.
 
         This cannot be used to change the type of the cosmology, except for

--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -2,9 +2,12 @@
 
 """Testing :mod:`astropy.cosmology.core`."""
 
+from __future__ import annotations
+
 import abc
 import inspect
 import pickle
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -25,11 +28,14 @@ from astropy.cosmology.tests.test_connect import (
 from astropy.table import Column, QTable, Table
 from astropy.utils.compat import PYTHON_LT_3_11
 
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
 ##############################################################################
 # SETUP / TEARDOWN
 
 
-def make_valid_zs(max_z: float = 1e5):
+def make_valid_zs(max_z: float = 1e5) -> tuple[list, NDArray[float], list, list]:
     """Make a list of valid redshifts for testing."""
     # scalar
     scalar_zs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,6 +387,7 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "D411",  # sphinx treats spaced example sections as real sections
 ]
 "test_*.py" = [
+    "ANN201",  # Public function without return type annotation
     "B018",  # UselessExpression
     "D",  # pydocstyle
     "PGH001",  # No builtin eval() allowed


### PR DESCRIPTION
### Description

[ANN201](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/) checks for public functions without return type annotation. The permanent configuration is updated to ignore the rule in tests to avoid having to clutter them with the `-> None` return type annotation. The violations outside the tests are fixed.

Note that Ruff is configured to check this rule only for functions that already have type annotations in their signature.

NOTE: When this pull request was first opened it did not configure Ruff to ignore `ANN201` in tests and instead added the `-> None` annotations to some tests in `ŧable`, but the configuration update removed the need to edit that code.

A follow-up pull request will address ANN201 in `modeling`.

### Approvals by subpackage:

- [x] `cosmology` https://github.com/astropy/astropy/pull/15685#pullrequestreview-1822165615

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
