### PR TITLE
DEP: adjust requirements for extra dependency on typing-extensions

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -17,11 +17,15 @@ from astropy.units import Quantity
 from astropy.utils import isiterable
 
 if TYPE_CHECKING:
+    import sys
     from typing import Any, Callable
 
-    from typing_extensions import Self
-
     from astropy.units import UnitBase
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 __all__ = ["ModelBoundingBox", "CompoundBoundingBox"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ recommended = [
     "matplotlib>=3.3,!=3.4.0,!=3.5.2",
 ]
 typing = [
-    "typing_extensions>=4.0.0",
+    "typing_extensions>=4.0.0 ; python_version < '3.11'",
 ]
 all = [
     "astropy[recommended]",  # installs the [recommended] dependencies


### PR DESCRIPTION
### Description

@hamogu @eerovaher

While reviewing #15685, I noticed that requirements on `typing_extensions` needed slight adjustements:
- we use it only for the `Self` symbol, which was added in version 4.0.0
- this symbol is in the standard library (`typing.Self`) in Python 3.11 and newer, so I made this requirement py310- only

I also found a note in a doctoring that doesn't seem relevant now that support for Python 3.8 was dropped.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
