### PR TITLE
DEP: add a `[typing]` extra dependency target for type-check-only dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,12 @@ recommended = [
     "scipy>=1.5",
     "matplotlib>=3.3,!=3.4.0,!=3.5.2",
 ]
+typing = [
+    "typing_extensions>=4.0.0",
+]
 all = [
     "astropy[recommended]",  # installs the [recommended] dependencies
+    "astropy[typing]",
     "certifi",
     "dask[array]",
     "h5py",
@@ -84,7 +88,6 @@ all = [
     "bottleneck",
     "ipython>=4.2",
     "pytest>=7.0",
-    "typing_extensions>=3.10.0.1",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
     "pre-commit",


### PR DESCRIPTION
### Description
Following @nstarman's suggestion in https://github.com/astropy/astropy/pull/15686#issuecomment-1843690039

ping @hamogu

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
