### PR TITLE
Remove duplicate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,6 @@ repos:
         # Detect mistake of inline code touching normal text in rst.
       - id: text-unicode-replacement-char
         # Forbid files which have a UTF-8 Unicode replacement character.
-      - id: python-check-blanket-noqa
-        # Enforce that all noqa annotations always occur with specific codes.
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,9 +38,6 @@ repos:
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      - id: python-check-mock-methods
-        # Prevent common mistakes of assert mck.not_called(), assert
-        # mck.called_once_with(...) and mck.assert_called.
       - id: rst-directive-colons
         # Detect mistake of rst directive not ending with double colon.
       - id: rst-inline-touching-normal


### PR DESCRIPTION
### Description

`python-check-mock-methods` is a duplicate of Ruff rule [PGH005](https://docs.astral.sh/ruff/rules/invalid-mock-access/).

`python-check-blanket-noqa` is a duplicate of Ruff rule [PGH004](https://docs.astral.sh/ruff/rules/blanket-noqa/).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
