### PR TITLE
Remove the last `SkyCoord` separation method references

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1167,7 +1167,8 @@ class SkyCoord(ShapedLikeNDArray):
         ------
         ValueError
             If the ``tocoord`` is not in the same frame as this one. This is
-            different from the behavior of the `separation`/`separation_3d`
+            different from the behavior of the
+            :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`/:meth:`~astropy.coordinates.BaseCoordinateFrame.separation_3d`
             methods because the offset components depend critically on the
             specific choice of frame.
 
@@ -1254,7 +1255,8 @@ class SkyCoord(ShapedLikeNDArray):
         -------
         newpoints : `~astropy.coordinates.SkyCoord`
             The coordinates for the location that corresponds to offsetting by
-            the given `position_angle` and `separation`.
+            the given `position_angle` and
+            :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`.
 
         Notes
         -----
@@ -1272,7 +1274,7 @@ class SkyCoord(ShapedLikeNDArray):
         See Also
         --------
         position_angle : inverse operation for the ``position_angle`` component
-        separation : inverse operation for the ``separation`` component
+        :meth:`~astropy.coordinates.BaseCoordinateFrame.separation` : inverse operation for the ``separation`` component
 
         """
         from .angles import offset_by


### PR DESCRIPTION
### Description

The methods were removed in da730d01e2e7dd41bd12859f873fbcb555e3674f because at runtime `SkyCoord` instances expose the equivalent methods of their underlying frames, but a handful of references in docstrings escaped detection and are currently breaking the documentation build on RTD.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
