### PR TITLE
Add new (2.0) string ufuncs in np.char to UNSUPPORTED_UFUNCS

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -361,7 +361,19 @@ UNSUPPORTED_UFUNCS |= {
 }
 
 if not NUMPY_LT_2_0:
-    UNSUPPORTED_UFUNCS |= {np.bitwise_count, np._core.umath.isalpha}
+    # string utilities - make no sense for Quantity.
+    UNSUPPORTED_UFUNCS |= {
+        np.bitwise_count,
+        np._core.umath.isalpha,
+        np._core.umath.isdigit,
+        np._core.umath.isspace,
+        np._core.umath.isnumeric,
+        np._core.umath.isdecimal,
+        np._core.umath.startswith,
+        np._core.umath.endswith,
+        np._core.umath.find,
+        np._core.umath.rfind,
+    }
 
 # SINGLE ARGUMENT UFUNCS
 

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -364,6 +364,7 @@ if not NUMPY_LT_2_0:
     # string utilities - make no sense for Quantity.
     UNSUPPORTED_UFUNCS |= {
         np.bitwise_count,
+        np._core.umath.count,
         np._core.umath.isalpha,
         np._core.umath.isdigit,
         np._core.umath.isspace,
@@ -373,6 +374,13 @@ if not NUMPY_LT_2_0:
         np._core.umath.endswith,
         np._core.umath.find,
         np._core.umath.rfind,
+        np._core.umath.str_len,
+        np._core.umath._strip_chars,
+        np._core.umath._lstrip_chars,
+        np._core.umath._rstrip_chars,
+        np._core.umath._strip_whitespace,
+        np._core.umath._lstrip_whitespace,
+        np._core.umath._rstrip_whitespace,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
### Description
Additional ufuncs in `np.char` not yet covered by `units.quantity_helpers`; added to `UNSUPPORTED_UFUNCS` as none of them make sense for quantities.

Fixes part of #15690 – actually the above were not mentioned there or showed up in any test agains numpy-2.0 since `TestUfuncHelpers.test_coverage` is skipped with scipy installed.

Tagging @neutrinoceros

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
