### PR TITLE
Allow initializing Distance from angle-like parallax

### DIFF
--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -50,7 +50,7 @@ class Distance(u.SpecificTypeQuantity):
     distmod : float or `~astropy.units.Quantity`
         The distance modulus for this distance. Note that if ``unit`` is not
         provided, a guess will be made at the unit between AU, pc, kpc, and Mpc.
-    parallax : `~astropy.units.Quantity` or `~astropy.coordinates.Angle`
+    parallax : angle-like
         The parallax in angular units.
     dtype : `~numpy.dtype`, optional
         See `~astropy.units.Quantity`.
@@ -162,6 +162,7 @@ class Distance(u.SpecificTypeQuantity):
                     unit = u.pc
 
         elif parallax is not None:
+            parallax = u.Quantity(parallax, copy=False, subok=True)
             if unit is None:
                 unit = u.pc
             value = parallax.to_value(unit, equivalencies=u.parallax())

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -10,6 +10,7 @@ from numpy import testing as npt
 from astropy import units as u
 from astropy.coordinates import CartesianRepresentation, Distance, Latitude, Longitude
 from astropy.coordinates.builtin_frames import ICRS, Galactic
+from astropy.table import Column
 from astropy.units import allclose as quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyWarning
@@ -313,3 +314,19 @@ def test_distance_to_quantity_when_not_units_of_length():
 def test_distance_nan():
     # Check that giving NaNs to Distance doesn't emit a warning
     Distance([0, np.nan, 1] * u.m)
+
+
+def test_distance_parallax_angle_like():
+    """Test angle-like behavior of Distance.parallax for object with a unit attribute.
+
+    Adapted from #15693
+    """
+    assert quantity_allclose(
+        Distance(parallax=Column([1.0, 2.0, 4.0], unit=u.mas)),
+        [1000, 500, 250] * u.pc,
+    )
+
+    class FloatMas(float):
+        unit = u.mas
+
+    assert Distance(parallax=FloatMas(1.0)) == 1000 * u.pc

--- a/docs/changes/coordinates/15712.bugfix.rst
+++ b/docs/changes/coordinates/15712.bugfix.rst
@@ -1,0 +1,2 @@
+``Distance`` now accepts as ``parallax`` any angle-like value.
+This includes types like ``Column`` which have a unit but are not ``Quantity`` subclasses.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to allow initializing `Distance` from an angle-like `parallax` which is not a `Quantity`. In particular any numeric object with an angular `unit` will work.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15693

<!-- Optional opt-out -->

~~- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.~~
