### PR TITLE
Fix references to `file-like` objects in glossary

### DIFF
--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -192,7 +192,7 @@ def writeto(table, file, tabledata_format=None):
     ----------
     table : `~astropy.io.votable.tree.VOTableFile` or `~astropy.table.Table` instance.
 
-    file : str or writable file-like
+    file : str or :term:`file-like (writeable)`
         Path or file object to write to
 
     tabledata_format : str, optional

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -42,7 +42,7 @@ def convert_to_writable_filelike(fd, compressed=False):
 
     Returns
     -------
-    fd : writable file-like
+    fd : :term:`file-like (writeable)`
     """
     if isinstance(fd, str):
         fd = os.path.expanduser(fd)

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -322,7 +322,7 @@ def color_print(*args, end="\n", **kwargs):
         default, darkgrey, lightred, lightgreen, yellow, lightblue,
         lightmagenta, lightcyan, white, or '' (the empty string).
 
-    file : writable file-like, optional
+    file : :term:`file-like (writeable)`, optional
         Where to write to.  Defaults to `sys.stdout`.  If file is not
         a tty (as determined by calling its `isatty` member, if one
         exists), no coloring will be included.
@@ -506,7 +506,7 @@ class ProgressBar:
             If `True`, the progress bar will display as an IPython
             notebook widget.
 
-        file : writable file-like, optional
+        file : :term:`file-like (writeable)`, optional
             The file to write the progress bar to.  Defaults to
             `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any, or special case hacks
@@ -708,7 +708,7 @@ class ProgressBar:
             If `True`, the progress bar will display as an IPython
             notebook widget.
 
-        file : writable file-like, optional
+        file : :term:`file-like (writeable)`, optional
             The file to write the progress bar to.  Defaults to
             `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any), the scrollbar will
@@ -790,7 +790,7 @@ class ProgressBar:
             If `True`, the progress bar will display as an IPython
             notebook widget.
 
-        file : writable file-like, optional
+        file : :term:`file-like (writeable)`, optional
             The file to write the progress bar to.  Defaults to
             `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any), the scrollbar will
@@ -876,7 +876,7 @@ class Spinner:
             darkgrey, lightred, lightgreen, yellow, lightblue,
             lightmagenta, lightcyan, white.
 
-        file : writable file-like, optional
+        file : :term:`file-like (writeable)`, optional
             The file to write the spinner to.  Defaults to
             `sys.stdout`.  If ``file`` is not a tty (as determined by
             calling its `isatty` member, if any, or special case hacks
@@ -1022,7 +1022,7 @@ class ProgressBarOrSpinner:
             lightred, lightgreen, yellow, lightblue, lightmagenta,
             lightcyan, white.
 
-        file : writable file-like, optional
+        file : :term:`file-like (writeable)`, optional
             The file to write the to.  Defaults to `sys.stdout`.  If
             ``file`` is not a tty (as determined by calling its `isatty`
             member, if any), only ``msg`` will be displayed: the
@@ -1077,7 +1077,7 @@ def print_code_line(line, col=None, file=None, tabwidth=8, width=70):
         The character in the line to highlight.  ``col`` must be less
         than ``len(line)``.
 
-    file : writable file-like, optional
+    file : :term:`file-like (writeable)`, optional
         Where to write to.  Defaults to `sys.stdout`.
 
     tabwidth : int, optional

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -307,7 +307,7 @@ def get_readable_fileobj(
 
     Returns
     -------
-    file : readable file-like
+    file : :term:`file-like (readable)`
     """
     # close_fds is a list of file handles created by this function
     # that need to be closed.  We don't want to always just close the

--- a/astropy/utils/xml/iterparser.py
+++ b/astropy/utils/xml/iterparser.py
@@ -135,7 +135,7 @@ def get_xml_iterator(source, _debug_python_based_parser=False):
 
     Parameters
     ----------
-    source : path-like, readable file-like, or callable
+    source : path-like, :term:`file-like (readable)`, or callable
         Handle that contains the data or function that reads it.
         If a function or callable object, it must directly read from a stream.
         Non-callable objects must define a ``read`` method.
@@ -176,7 +176,7 @@ def get_xml_encoding(source):
 
     Parameters
     ----------
-    source : path-like, readable file-like, or callable
+    source : path-like, :term:`file-like (readable)`, or callable
         Handle that contains the data or function that reads it.
         If a function or callable object, it must directly read from a stream.
         Non-callable objects must define a ``read`` method.
@@ -201,7 +201,7 @@ def xml_readlines(source):
 
     Parameters
     ----------
-    source : path-like, readable file-like, or callable
+    source : path-like, :term:`file-like (readable)`, or callable
         Handle that contains the data or function that reads it.
         If a function or callable object, it must directly read from a stream.
         Non-callable objects must define a ``read`` method.

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -61,7 +61,7 @@ class XMLWriter:
         """
         Parameters
         ----------
-        file : writable file-like
+        file : :term:`file-like (writeable)`
         """
         self.write = file.write
         if hasattr(file, "flush"):


### PR DESCRIPTION
### Description

In 0ffdbb2fa019d2b33ed50038f28129283d51e8b0 the glossary was sorted alphabetically. The "writable file-like object" and "readable file-like object" entries were renamed so that they would be next to each other, but that broke some references to the old entries in some of the docstrings.

Note that #15705 was milestoned for 6.0.1, but despite that it was not backported, so I've milestoned this pull request for 6.1.0.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.