### PR TITLE
TST [units]: restore consistent naming convention for array functions tests

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import inspect
 import itertools
+import re
+from types import FunctionType
 
 import numpy as np
 import numpy.lib.recfunctions as rfn
@@ -44,17 +46,11 @@ def get_wrapped_functions(*modules):
     else:
         from numpy.testing.overrides import allows_array_function_override
 
-    wrapped_functions = {}
+    wrapped_functions = {mod.__name__: {} for mod in modules}
     for mod in modules:
         for name, f in mod.__dict__.items():
             if callable(f) and allows_array_function_override(f):
-                # Indexing by just the name is easiest for test writing,
-                # but in numpy 2.0, there are 2 versions of diagonal and
-                # trace, one in the main namespace, and one in np.linalg.
-                # So, we distinguish those by adding the module name.
-                if name in wrapped_functions:
-                    name = mod.__name__.replace("numpy.", "") + "_" + name
-                wrapped_functions[name] = f
+                wrapped_functions[mod.__name__][name] = f
 
     return wrapped_functions
 
@@ -62,24 +58,42 @@ def get_wrapped_functions(*modules):
 all_wrapped_functions = get_wrapped_functions(
     np, np.fft, np.linalg, np.lib.recfunctions
 )
-all_wrapped = set(all_wrapped_functions.values())
+
+all_wrapped = set(
+    itertools.chain.from_iterable(_.values() for _ in all_wrapped_functions.values())
+)
+
+MOD_REGEXP = re.compile(r"((?P<module_name>[A-Z_]+)_)?(?P<function_name>[\w_]+)")
+
+
+def populate_covered_from_members(members, covered: set[FunctionType]) -> None:
+    for k, v in members.items():
+        if inspect.isfunction(v) and k.startswith("test_"):
+            if (m := MOD_REGEXP.fullmatch(k.removeprefix("test_"))) is None:
+                raise RuntimeError(f"failed to match {k=}")
+            function_name = m.group("function_name")
+            if (module_name := m.group("module_name")) is not None:
+                module_name = "numpy." + module_name.replace("_", ".").lower()
+            else:
+                module_name = "numpy"
+
+            if (
+                func := all_wrapped_functions[module_name].get(function_name)
+            ) is not None:
+                covered.add(func)
 
 
 class CoverageMeta(type):
     """Meta class that tracks which functions are covered by tests.
 
-    Assumes that a test is called 'test_<function_name>'.
+    Assumes that a test is called 'test_<MODULE_NAME>_<function_name>',
+    where MODULE_NAME (and its trailing '_') may be missing.
     """
 
     covered = set()
 
     def __new__(mcls, name, bases, members):
-        for k, v in members.items():
-            if inspect.isfunction(v) and k.startswith("test"):
-                f = k.replace("test_", "")
-                if f in all_wrapped_functions:
-                    mcls.covered.add(all_wrapped_functions[f])
-
+        populate_covered_from_members(members, mcls.covered)
         return super().__new__(mcls, name, bases, members)
 
 
@@ -2061,52 +2075,52 @@ class TestFFT(InvariantUnitTestSetup):
         # Use real input; gets turned into complex as needed.
         self.q = np.arange(128.0).reshape(8, -1) * u.s
 
-    def test_fft(self):
+    def test_FFT_fft(self):
         self.check(np.fft.fft)
 
-    def test_ifft(self):
+    def test_FFT_ifft(self):
         self.check(np.fft.ifft)
 
-    def test_rfft(self):
+    def test_FFT_rfft(self):
         self.check(np.fft.rfft)
 
-    def test_irfft(self):
+    def test_FFT_irfft(self):
         self.check(np.fft.irfft)
 
-    def test_fft2(self):
+    def test_FFT_fft2(self):
         self.check(np.fft.fft2)
 
-    def test_ifft2(self):
+    def test_FFT_ifft2(self):
         self.check(np.fft.ifft2)
 
-    def test_rfft2(self):
+    def test_FFT_rfft2(self):
         self.check(np.fft.rfft2)
 
-    def test_irfft2(self):
+    def test_FFT_irfft2(self):
         self.check(np.fft.irfft2)
 
-    def test_fftn(self):
+    def test_FFT_fftn(self):
         self.check(np.fft.fftn)
 
-    def test_ifftn(self):
+    def test_FFT_ifftn(self):
         self.check(np.fft.ifftn)
 
-    def test_rfftn(self):
+    def test_FFT_rfftn(self):
         self.check(np.fft.rfftn)
 
-    def test_irfftn(self):
+    def test_FFT_irfftn(self):
         self.check(np.fft.irfftn)
 
-    def test_hfft(self):
+    def test_FFT_hfft(self):
         self.check(np.fft.hfft)
 
-    def test_ihfft(self):
+    def test_FFT_ihfft(self):
         self.check(np.fft.ihfft)
 
-    def test_fftshift(self):
+    def test_FFT_fftshift(self):
         self.check(np.fft.fftshift)
 
-    def test_ifftshift(self):
+    def test_FFT_ifftshift(self):
         self.check(np.fft.ifftshift)
 
 
@@ -2116,18 +2130,18 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             np.array([[1.0, -1.0, 2.0], [0.0, 3.0, -1.0], [-1.0, -1.0, 1.0]]) << u.m
         )
 
-    def test_cond(self):
+    def test_LINALG_cond(self):
         c = np.linalg.cond(self.q)
         expected = np.linalg.cond(self.q.value)
         assert c == expected
 
-    def test_matrix_rank(self):
+    def test_LINALG_matrix_rank(self):
         r = np.linalg.matrix_rank(self.q)
         x = np.linalg.matrix_rank(self.q.value)
         assert r == x
 
     @needs_array_function
-    def test_matrix_rank_with_tol(self):
+    def test_LINALG_matrix_rank_with_tol(self):
         # Use a matrix that is not so good, so tol=1 and tol=0.01 differ.
         q = np.arange(9.0).reshape(3, 3) / 4 * u.m
         tol = 1.0 * u.cm
@@ -2135,7 +2149,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         x2 = np.linalg.matrix_rank(q.value, tol.to_value(q.unit))
         assert r2 == x2
 
-    def test_matrix_power(self):
+    def test_LINALG_matrix_power(self):
         q1 = np.linalg.matrix_power(self.q, 1)
         assert_array_equal(q1, self.q)
         q2 = np.linalg.matrix_power(self.q, 2)
@@ -2144,7 +2158,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(q2, self.q @ self.q @ self.q @ self.q)
 
     @needs_array_function
-    def test_matrix_inv_power(self):
+    def test_LINALG_matrix_inv_power(self):
         qinv = np.linalg.inv(self.q.value) / self.q.unit
         qm1 = np.linalg.matrix_power(self.q, -1)
         assert_array_equal(qm1, qinv)
@@ -2152,7 +2166,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(qm3, qinv @ qinv @ qinv)
 
     @needs_array_function
-    def test_multi_dot(self):
+    def test_LINALG_multi_dot(self):
         q2 = np.linalg.multi_dot([self.q, self.q])
         q2x = self.q @ self.q
         assert_array_equal(q2, q2x)
@@ -2161,7 +2175,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(q3, q3x)
 
     @needs_array_function
-    def test_svd(self):
+    def test_LINALG_svd(self):
         m = np.arange(10.0) * np.arange(5.0)[:, np.newaxis] * u.m
         svd_u, svd_s, svd_vt = np.linalg.svd(m, full_matrices=False)
         svd_ux, svd_sx, svd_vtx = np.linalg.svd(m.value, full_matrices=False)
@@ -2176,13 +2190,13 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(s2, svd_s2x)
 
     @needs_array_function
-    def test_inv(self):
+    def test_LINALG_inv(self):
         inv = np.linalg.inv(self.q)
         expected = np.linalg.inv(self.q.value) / self.q.unit
         assert_array_equal(inv, expected)
 
     @needs_array_function
-    def test_pinv(self):
+    def test_LINALG_pinv(self):
         pinv = np.linalg.pinv(self.q)
         expected = np.linalg.pinv(self.q.value) / self.q.unit
         assert_array_equal(pinv, expected)
@@ -2194,13 +2208,13 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(pinv2, expected2)
 
     @needs_array_function
-    def test_tensorinv(self):
+    def test_LINALG_tensorinv(self):
         inv = np.linalg.tensorinv(self.q, ind=1)
         expected = np.linalg.tensorinv(self.q.value, ind=1) / self.q.unit
         assert_array_equal(inv, expected)
 
     @needs_array_function
-    def test_det(self):
+    def test_LINALG_det(self):
         det = np.linalg.det(self.q)
         expected = np.linalg.det(self.q.value)
         expected <<= self.q.unit ** self.q.shape[-1]
@@ -2211,14 +2225,14 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             np.linalg.det(self.q[:-1])  # Not square.
 
     @needs_array_function
-    def test_slogdet(self):
+    def test_LINALG_slogdet(self):
         # TODO: Could be supported if we had a natural logarithm unit.
         with pytest.raises(TypeError):
             logdet = np.linalg.slogdet(self.q)
             assert hasattr(logdet, "unit")
 
     @needs_array_function
-    def test_solve(self):
+    def test_LINALG_solve(self):
         b = np.array([1.0, 2.0, 4.0]) * u.m / u.s
         x = np.linalg.solve(self.q, b)
         xx = np.linalg.solve(self.q.value, b.value)
@@ -2227,7 +2241,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert u.allclose(self.q @ x, b)
 
     @needs_array_function
-    def test_tensorsolve(self):
+    def test_LINALG_tensorsolve(self):
         b = np.array([1.0, 2.0, 4.0]) * u.m / u.s
         x = np.linalg.tensorsolve(self.q, b)
         xx = np.linalg.tensorsolve(self.q.value, b.value)
@@ -2236,7 +2250,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert u.allclose(self.q @ x, b)
 
     @needs_array_function
-    def test_lstsq(self):
+    def test_LINALG_lstsq(self):
         b = np.array([1.0, 2.0, 4.0]) * u.m / u.s
         x, residuals, rank, s = np.linalg.lstsq(self.q, b, rcond=None)
         xx, residualsx, rankx, sx = np.linalg.lstsq(self.q.value, b.value, rcond=None)
@@ -2263,7 +2277,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             np.linalg.lstsq(m, b, rcond=1.0 * u.s)
 
     @needs_array_function
-    def test_norm(self):
+    def test_LINALG_norm(self):
         n = np.linalg.norm(self.q)
         expected = np.linalg.norm(self.q.value) << self.q.unit
         assert_array_equal(n, expected)
@@ -2273,7 +2287,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(n1, expected1)
 
     @needs_array_function
-    def test_cholesky(self):
+    def test_LINALG_cholesky(self):
         # Numbers from np.linalg.cholesky docstring.
         q = np.array([[1, -2j], [2j, 5]]) * u.m
         cd = np.linalg.cholesky(q)
@@ -2282,7 +2296,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert u.allclose(cd @ cd.T.conj(), q)
 
     @needs_array_function
-    def test_qr(self):
+    def test_LINALG_qr(self):
         # This is not exhaustive...
         a = np.array([[1, -2j], [2j, 5]]) * u.m
         q, r = np.linalg.qr(a)
@@ -2294,7 +2308,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert u.allclose(q @ r, a)
 
     @needs_array_function
-    def test_eig(self):
+    def test_LINALG_eig(self):
         w, v = np.linalg.eig(self.q)
         wx, vx = np.linalg.eig(self.q.value)
         wx <<= self.q.unit
@@ -2309,7 +2323,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(v, np.eye(3))
 
     @needs_array_function
-    def test_eigvals(self):
+    def test_LINALG_eigvals(self):
         w = np.linalg.eigvals(self.q)
         wx = np.linalg.eigvals(self.q.value) << self.q.unit
         assert_array_equal(w, wx)
@@ -2319,7 +2333,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(w, np.arange(1, 4) * u.m)
 
     @needs_array_function
-    def test_eigh(self):
+    def test_LINALG_eigh(self):
         w, v = np.linalg.eigh(self.q)
         wx, vx = np.linalg.eigh(self.q.value)
         wx <<= self.q.unit
@@ -2328,7 +2342,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         assert_array_equal(v, vx)
 
     @needs_array_function
-    def test_eigvalsh(self):
+    def test_LINALG_eigvalsh(self):
         w = np.linalg.eigvalsh(self.q)
         wx = np.linalg.eigvalsh(self.q.value) << self.q.unit
         assert_array_equal(w, wx)
@@ -2338,43 +2352,39 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
         # diagonal and trace to np.linalg. Since these have
         # name conflicts with the main numpy namespace, they
         # are tracked as linalg_diagonal and linalg_trace.
-        def test_linalg_diagonal(self):
+        def test_LINALG_diagonal(self):
             self.check(np.linalg.diagonal)
 
-        def test_linalg_trace(self):
+        def test_LINALG_trace(self):
             self.check(np.trace)
 
         @needs_array_function
-        def test_linalg_cross(self):
+        def test_LINALG_cross(self):
             q1 = np.array([1, 2, 3]) << u.m
             q2 = np.array([4, 5, 6]) << u.s
             assert_array_equal(np.linalg.cross(q1, q2), np.cross(q1, q2))
             assert_array_equal(np.linalg.cross(q1, q2.value), np.cross(q1, q2.value))
 
         @needs_array_function
-        def test_linalg_outer(self):
+        def test_LINALG_outer(self):
             q = self.q.flatten()
             assert_array_equal(np.linalg.outer(q, q), np.outer(q, q))
             assert_array_equal(np.linalg.outer(q, q.value), np.outer(q, q.value))
 
         @needs_array_function
-        def test_svdvals(self):
-            # TODO: this function should be named test_linalg_svdvals
-            # but at the moment this breaks the completion test
-            # see https://github.com/astropy/astropy/issues/15692
+        def test_LINALG_svdvals(self):
             _, ref, _ = np.linalg.svd(self.q)
             res = np.linalg.svdvals(self.q)
             assert_allclose(res, ref, rtol=5e-16)
 
         @needs_array_function
-        def test_linalg_tensordot(self):
+        def test_LINALG_tensordot(self):
             ref = np.tensordot(self.q, self.q)
             res = np.linalg.tensordot(self.q, self.q)
             assert_array_equal(res, ref)
 
         @needs_array_function
-        def test_matmul(self):
-            # see https://github.com/astropy/astropy/issues/15692
+        def test_LINALG_matmul(self):
             ref = np.matmul(self.q, self.q)
             res = np.linalg.matmul(self.q, self.q)
             assert_array_equal(res, ref)
@@ -2399,7 +2409,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
         self.q_pv = self.pv << self.pv_unit
         self.q_pv_t = self.pv_t << self.pv_t_unit
 
-    def test_structured_to_unstructured(self):
+    def test_LIB_RECFUNCTIONS_structured_to_unstructured(self):
         # can't unstructure something with incompatible units
         with pytest.raises(u.UnitConversionError, match="'m'"):
             rfn.structured_to_unstructured(u.Quantity((0, 0.6), u.Unit("(eV, m)")))
@@ -2427,7 +2437,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
         # For the other tests of ``structured_to_unstructured``, see
         # ``test_structured.TestStructuredQuantityFunctions.test_structured_to_unstructured``
 
-    def test_unstructured_to_structured(self):
+    def test_LIB_RECFUNCTIONS_unstructured_to_structured(self):
         unstruct = [1, 2, 3] * u.m
         dtype = np.dtype([("f1", float), ("f2", float), ("f3", float)])
 
@@ -2443,7 +2453,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
         # For the other tests of ``structured_to_unstructured``, see
         # ``test_structured.TestStructuredQuantityFunctions.test_unstructured_to_structured``
 
-    def test_merge_arrays_repeat_dtypes(self):
+    def test_LIB_RECFUNCTIONS_merge_arrays_repeat_dtypes(self):
         # Cannot merge things with repeat dtypes.
         q1 = u.Quantity([(1,)], dtype=[("f1", float)])
         q2 = u.Quantity([(1,)], dtype=[("f1", float)])
@@ -2452,7 +2462,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
             rfn.merge_arrays((q1, q2))
 
     @pytest.mark.parametrize("flatten", [True, False])
-    def test_merge_arrays(self, flatten):
+    def test_LIB_RECFUNCTIONS_merge_arrays(self, flatten):
         """Test `numpy.lib.recfunctions.merge_arrays`."""
         # Merge single normal array.
         arr = rfn.merge_arrays(self.q_pv["p"], flatten=flatten)
@@ -2469,7 +2479,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
         assert np.array_equal(arr, self.q_pv)
         assert arr.unit == (u.km, u.km / u.s)
 
-    def test_merge_array_nested_structure(self):
+    def test_LIB_RECFUNCTIONS_merge_array_nested_structure(self):
         # Merge 2-element tuples without flattening.
         arr = rfn.merge_arrays((self.q_pv, self.q_pv_t))
         assert_array_equal(arr["f0"], self.q_pv)
@@ -2481,7 +2491,7 @@ class TestRecFunctions(metaclass=CoverageMeta):
         assert_array_equal(arr.value, expected_value)
         assert arr.unit == u.Unit((self.q_pv["p"].unit, (u.one, u.one)))
 
-    def test_merge_arrays_flatten_nested_structure(self):
+    def test_LIB_RECFUNCTIONS_merge_arrays_flatten_nested_structure(self):
         # Merge 2-element tuple, flattening it.
         arr = rfn.merge_arrays((self.q_pv, self.q_pv_t), flatten=True)
         assert_array_equal(arr["p"], self.q_pv["p"])
@@ -2498,16 +2508,16 @@ class TestRecFunctions(metaclass=CoverageMeta):
         assert_array_equal(arr.value, expected_value)
         assert arr.unit == u.Unit((self.q_pv["p"].unit, u.one, u.one))
 
-    def test_merge_arrays_asrecarray(self):
+    def test_LIB_RECFUNCTIONS_merge_arrays_asrecarray(self):
         with pytest.raises(ValueError, match="asrecarray=True is not supported."):
             rfn.merge_arrays(self.q_pv, asrecarray=True)
 
-    def test_merge_arrays_usemask(self):
+    def test_LIB_RECFUNCTIONS_merge_arrays_usemask(self):
         with pytest.raises(ValueError, match="usemask=True is not supported."):
             rfn.merge_arrays(self.q_pv, usemask=True)
 
     @pytest.mark.parametrize("flatten", [True, False])
-    def test_merge_arrays_str(self, flatten):
+    def test_LIB_RECFUNCTIONS_merge_arrays_str(self, flatten):
         with pytest.raises(
             TypeError, match="the Quantity implementation cannot handle"
         ):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -66,7 +66,8 @@ all_wrapped = set(
 MOD_REGEXP = re.compile(r"((?P<module_name>[A-Z_]+)_)?(?P<function_name>[\w_]+)")
 
 
-def populate_covered_from_members(members, covered: set[FunctionType]) -> None:
+def get_covered_from_members(members) -> set[FunctionType]:
+    covered = set()
     for k, v in members.items():
         if inspect.isfunction(v) and k.startswith("test_"):
             if (m := MOD_REGEXP.fullmatch(k.removeprefix("test_"))) is None:
@@ -81,6 +82,7 @@ def populate_covered_from_members(members, covered: set[FunctionType]) -> None:
                 func := all_wrapped_functions[module_name].get(function_name)
             ) is not None:
                 covered.add(func)
+    return covered
 
 
 class CoverageMeta(type):
@@ -93,7 +95,7 @@ class CoverageMeta(type):
     covered = set()
 
     def __new__(mcls, name, bases, members):
-        populate_covered_from_members(members, mcls.covered)
+        mcls.covered |= get_covered_from_members(members)
         return super().__new__(mcls, name, bases, members)
 
 

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -17,7 +17,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from astropy.units.tests.test_quantity_non_ufuncs import get_wrapped_functions
+from astropy.units.tests.test_quantity_non_ufuncs import (
+    get_wrapped_functions,
+    populate_covered_from_members,
+)
 from astropy.utils.compat import (
     NUMPY_LT_1_23,
     NUMPY_LT_1_24,
@@ -36,7 +39,10 @@ from astropy.utils.masked.function_helpers import (
 from .test_masked import MaskedArraySetup, assert_masked_equal
 
 all_wrapped_functions = get_wrapped_functions(np)
-all_wrapped = set(all_wrapped_functions.values())
+
+all_wrapped = set(
+    itertools.chain.from_iterable(_.values() for _ in all_wrapped_functions.values())
+)
 
 
 class BasicTestSetup(MaskedArraySetup):
@@ -1462,11 +1468,7 @@ untested_functions |= poly_functions
 # Get covered functions
 tested_functions = set()
 for cov_cls in list(filter(inspect.isclass, locals().values())):
-    for k, v in cov_cls.__dict__.items():
-        if inspect.isfunction(v) and k.startswith("test"):
-            f = k.replace("test_", "")
-            if f in all_wrapped_functions:
-                tested_functions.add(all_wrapped_functions[f])
+    populate_covered_from_members(members=cov_cls.__dict__, covered=tested_functions)
 
 
 def test_basic_testing_completeness():

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -10,7 +10,6 @@ TODO: finish full coverage (see also `~astropy.utils.masked.function_helpers`)
 - np.fft (is there any point?)
 
 """
-import inspect
 import itertools
 
 import numpy as np
@@ -18,7 +17,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy.units.tests.test_quantity_non_ufuncs import (
-    get_covered_from_members,
+    get_covered_functions,
     get_wrapped_functions,
 )
 from astropy.utils.compat import (
@@ -37,12 +36,6 @@ from astropy.utils.masked.function_helpers import (
 )
 
 from .test_masked import MaskedArraySetup, assert_masked_equal
-
-all_wrapped_functions = get_wrapped_functions(np)
-
-all_wrapped = set(
-    itertools.chain.from_iterable(_.values() for _ in all_wrapped_functions.values())
-)
 
 
 class BasicTestSetup(MaskedArraySetup):
@@ -1444,6 +1437,10 @@ class TestNaNFunctions:
         self.check(np.nanpercentile, q=50)
 
 
+# Get wrapped and covered functions.
+all_wrapped_functions = get_wrapped_functions(np)
+tested_functions = get_covered_functions(locals())
+# Create set of untested functions.
 untested_functions = set()
 
 if NUMPY_LT_1_23:
@@ -1465,20 +1462,16 @@ poly_functions = {
 untested_functions |= poly_functions
 
 
-# Get covered functions
-tested_functions = set()
-for cov_cls in list(filter(inspect.isclass, locals().values())):
-    tested_functions |= get_covered_from_members(cov_cls.__dict__)
-
-
 def test_basic_testing_completeness():
-    assert all_wrapped == (tested_functions | IGNORED_FUNCTIONS | UNSUPPORTED_FUNCTIONS)
+    assert all_wrapped_functions == (
+        tested_functions | IGNORED_FUNCTIONS | UNSUPPORTED_FUNCTIONS
+    )
 
 
 @pytest.mark.xfail(reason="coverage not completely set up yet")
 def test_testing_completeness():
     assert not tested_functions.intersection(untested_functions)
-    assert all_wrapped == (tested_functions | untested_functions)
+    assert all_wrapped_functions == (tested_functions | untested_functions)
 
 
 class TestFunctionHelpersCompleteness:
@@ -1504,7 +1497,7 @@ class TestFunctionHelpersCompleteness:
             | set(APPLY_TO_BOTH_FUNCTIONS.keys())
             | set(DISPATCHED_FUNCTIONS.keys())
         )
-        assert all_wrapped == included_in_helpers
+        assert all_wrapped_functions == included_in_helpers
 
     @pytest.mark.xfail(reason="coverage not completely set up yet")
     def test_ignored_are_untested(self):

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -18,8 +18,8 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy.units.tests.test_quantity_non_ufuncs import (
+    get_covered_from_members,
     get_wrapped_functions,
-    populate_covered_from_members,
 )
 from astropy.utils.compat import (
     NUMPY_LT_1_23,
@@ -1468,7 +1468,7 @@ untested_functions |= poly_functions
 # Get covered functions
 tested_functions = set()
 for cov_cls in list(filter(inspect.isclass, locals().values())):
-    populate_covered_from_members(members=cov_cls.__dict__, covered=tested_functions)
+    tested_functions |= get_covered_from_members(cov_cls.__dict__)
 
 
 def test_basic_testing_completeness():


### PR DESCRIPTION
### Description
Fixes #15692

ping @hamogu @mhvk 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
