### PR TITLE
MNT: cleanup fiduciary comments that are unneeded since Python 3.8 was dropped

### DIFF
--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -46,23 +46,18 @@ def test_api():
     "kwargs",
     [
         POSITION_ON_SKY,
-        # In Python 3.9 we could write `POSITION_ON_SKY | DISTANCE`
-        {**POSITION_ON_SKY, **DISTANCE},
-        {**POSITION_ON_SKY, **PROPER_MOTION},
-        {**POSITION_ON_SKY, **DISTANCE, **PROPER_MOTION},
-        {**POSITION_ON_SKY, **RADIAL_VELOCITY},
-        {**POSITION_ON_SKY, **DISTANCE, **RADIAL_VELOCITY},
-        {**POSITION_ON_SKY, **PROPER_MOTION, **RADIAL_VELOCITY},
-        {**POSITION_ON_SKY, **DISTANCE, **PROPER_MOTION, **RADIAL_VELOCITY},
+        POSITION_ON_SKY | DISTANCE,
+        POSITION_ON_SKY | PROPER_MOTION,
+        POSITION_ON_SKY | DISTANCE | PROPER_MOTION,
+        POSITION_ON_SKY | RADIAL_VELOCITY,
+        POSITION_ON_SKY | DISTANCE | RADIAL_VELOCITY,
+        POSITION_ON_SKY | PROPER_MOTION | RADIAL_VELOCITY,
+        POSITION_ON_SKY | DISTANCE | PROPER_MOTION | RADIAL_VELOCITY,
         # Now test other representation/differential types:
         CARTESIAN_POSITION,
-        {**CARTESIAN_POSITION, **CARTESIAN_REPRESENTATION_KEYWORD_STR},
-        {**CARTESIAN_POSITION, **CARTESIAN_VELOCITY},
-        {
-            **CARTESIAN_POSITION,
-            **CARTESIAN_VELOCITY,
-            **CARTESIAN_DIFFERENTIAL_KEYWORD_STR,
-        },
+        CARTESIAN_POSITION | CARTESIAN_REPRESENTATION_KEYWORD_STR,
+        CARTESIAN_POSITION | CARTESIAN_VELOCITY,
+        CARTESIAN_POSITION | CARTESIAN_VELOCITY | CARTESIAN_DIFFERENTIAL_KEYWORD_STR,
     ],
 )
 def test_all_arg_options(kwargs):
@@ -185,12 +180,12 @@ def test_xhip_galactic(
     "kwargs,expect_success",
     (
         (POSITION_ON_SKY, False),
-        ({**POSITION_ON_SKY, **DISTANCE}, True),
-        ({**POSITION_ON_SKY, **PROPER_MOTION}, False),
-        ({**POSITION_ON_SKY, **RADIAL_VELOCITY}, False),
-        ({**POSITION_ON_SKY, **DISTANCE, **RADIAL_VELOCITY}, False),
-        ({**POSITION_ON_SKY, **PROPER_MOTION, **RADIAL_VELOCITY}, False),
-        ({**POSITION_ON_SKY, **DISTANCE, **PROPER_MOTION, **RADIAL_VELOCITY}, True),
+        (POSITION_ON_SKY | DISTANCE, True),
+        (POSITION_ON_SKY | PROPER_MOTION, False),
+        (POSITION_ON_SKY | RADIAL_VELOCITY, False),
+        (POSITION_ON_SKY | DISTANCE | RADIAL_VELOCITY, False),
+        (POSITION_ON_SKY | PROPER_MOTION | RADIAL_VELOCITY, False),
+        (POSITION_ON_SKY | DISTANCE | PROPER_MOTION | RADIAL_VELOCITY, True),
     ),
 )
 def test_frame_affinetransform(kwargs, expect_success):
@@ -305,7 +300,7 @@ def test_shorthand_attributes():
 
 
 @pytest.mark.parametrize(
-    "icrs_coords", [POSITION_ON_SKY, {**POSITION_ON_SKY, **PROPER_MOTION}]
+    "icrs_coords", [POSITION_ON_SKY, POSITION_ON_SKY | PROPER_MOTION]
 )
 def test_negative_distance(icrs_coords):
     """Regression test: #7408

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -1013,11 +1013,9 @@ class TestColumnsShowHide:
             out = t.pformat_all()
         assert out == exp
 
-        # Mixture (not common in practice but possible). Note, the trailing
-        # backslash instead of parens is needed for Python < 3.9. See:
-        # https://bugs.python.org/issue12782.
-        with t.pprint_include_names.set(["b", "c", "d"]), t.pprint_exclude_names.set(
-            ["c"]
+        with (
+            t.pprint_include_names.set(["b", "c", "d"]),
+            t.pprint_exclude_names.set(["c"]),
         ):
             out = t.pformat_all()
         assert out == exp

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -388,8 +388,7 @@ class Quantity(np.ndarray):
 
         Notes
         -----
-        With Python 3.9+ or :mod:`typing_extensions`, |Quantity| types are also
-        static-type compatible.
+        |Quantity| types are also static-type compatible.
         """
         from typing import Annotated
 


### PR DESCRIPTION
### Description

ping @hamogu and @nstarman

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
