### PR TITLE
changed np.rollaxis with np.moveaxis in coordinates

### DIFF
--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -367,7 +367,7 @@ class TestShapeFunctions(ShapeSetup):
 
     def test_move_axis(self):
         # Goes via transpose so works without __array_function__ as well.
-        s0_10 = np.moveaxis(self.s0, 0, 1)
+        s0_10 = np.moveaxis(self.s0.data, 1, 0)
         assert s0_10.shape == (self.s0.shape[1], self.s0.shape[0])
         assert np.all(representation_equal(self.s0.T, s0_10))
         assert np.may_share_memory(s0_10.lon, self.s0.lon)

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -374,7 +374,7 @@ class TestShapeFunctions(ShapeSetup):
 
     def test_roll_axis(self):
         # Goes via transpose so works without __array_function__ as well.
-        s0_10 = np.rollaxis(self.s0, 1)
+        s0_10 = np.moveaxis(self.s0, 1)
         assert s0_10.shape == (self.s0.shape[1], self.s0.shape[0])
         assert np.all(representation_equal(self.s0.T, s0_10))
         assert np.may_share_memory(s0_10.lon, self.s0.lon)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Address `coordinates` portion for #15721

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
