### PR TITLE
MNT: fix labeler.yml for labeler v5 (again)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,152 +1,230 @@
 Docs:
-  - docs/*
-  - docs/_static/*
-  - docs/_templates/*
-  - docs/development/**/*
-  - docs/whatsnew/*
-  - examples/**/*
-  - licenses/*
-  - CITATION
-  - .mailmap
-  - .readthedocs.yaml
-  - '*.md'
-  - any:
-    - changed-files:
-      - any-glob-to-any-file: ['*.rst', '!CHANGES.rst']
+- changed-files:
+  - any-glob-to-any-file:
+    - docs/*
+    - docs/_static/*
+    - docs/_templates/*
+    - docs/development/**/*
+    - docs/whatsnew/*
+    - examples/**/*
+    - licenses/*
+    - CITATION
+    - .mailmap
+    - .readthedocs.yaml
+    - '*.md'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '*.rst'
+      - '!CHANGES.rst'
 
 testing:
-  - astropy/tests/**/*
-  - codecov.yml
-  - conftest.py
-  - '**/conftest.py'
-  - tox.ini
-  - .circleci/*
-  - .github/**/*.yml
-  - .pyinstaller/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/tests/**/*
+    - codecov.yml
+    - conftest.py
+    - '**/conftest.py'
+    - tox.ini
+    - .circleci/*
+    - .github/**/*.yml
+    - .pyinstaller/**/*
 
 external:
-  - astropy/extern/**/*
-  - cextern/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/extern/**/*
+    - cextern/**/*
 
 installation:
-  - docs/install.rst
-  - MANIFEST.in
-  - pyproject.toml
-  - setup.*
+- changed-files:
+  - any-glob-to-any-file:
+    - docs/install.rst
+    - MANIFEST.in
+    - pyproject.toml
+    - setup.*
 
 Release:
-  - docs/development/releasing.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - docs/development/releasing.rst
 
 config:
-  - '**/config/**/*'
-  - astropy/extern/configobj/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/config/**/*'
+    - astropy/extern/configobj/**/*
 
 constants:
-  - '**/constants/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/constants/**/*'
 
 convolution:
-  - '**/convolution/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/convolution/**/*'
 
 coordinates:
-  - '**/coordinates/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/coordinates/**/*'
 
 cosmology:
-  - '**/cosmology/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/cosmology/**/*'
 
 io.ascii:
-  - '**/io/ascii/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/io/ascii/**/*'
 
 io.fits:
-  - '**/io/fits/**/*'
-  - cextern/cfitsio/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/io/fits/**/*'
+    - cextern/cfitsio/**/*
 
 io.misc:
-  - astropy/io/misc/*
-  - astropy/io/misc/pandas/**/*
-  - astropy/io/misc/tests/**/*
-  - docs/io/misc.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/io/misc/*
+    - astropy/io/misc/pandas/**/*
+    - astropy/io/misc/tests/**/*
+    - docs/io/misc.rst
 
 io.registry:
-  - astropy/io/*
-  - astropy/io/tests/*
-  - docs/io/registry.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/io/*
+    - astropy/io/tests/*
+    - docs/io/registry.rst
 
 io.votable:
-  - '**/io/votable/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/io/votable/**/*'
 
 logging:
-  - astropy/logger.py
-  - astropy/tests/test_logger.py
-  - docs/logging.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/logger.py
+    - astropy/tests/test_logger.py
+    - docs/logging.rst
 
 modeling:
-  - '**/modeling/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/modeling/**/*'
 
 nddata:
-  - '**/nddata/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/nddata/**/*'
 
 samp:
-  - '**/samp/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/samp/**/*'
 
 stats:
-  - '**/stats/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/stats/**/*'
 
 table:
-  - '**/table/**/*'
-  - astropy/extern/jquery/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/table/**/*'
+    - astropy/extern/jquery/**/*
 
 time:
-  - '**/time/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/time/**/*'
 
 timeseries:
-  - '**/timeseries/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/timeseries/**/*'
 
 uncertainty:
-  - '**/uncertainty/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/uncertainty/**/*'
 
 unified-io:
-  - docs/io/unified.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - docs/io/unified.rst
 
 units:
-  - '**/units/**/*'
-  - astropy/extern/ply/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/units/**/*'
+    - astropy/extern/ply/**/*
 
 utils:
-  - cextern/expat/**/*
-  - any:
-    - changed-files:
-      - any-glob-to-any-file: ['**/utils/**/*',
-          '!astropy/utils/iers/**/*', '!docs/utils/iers.rst',
-          '!astropy/utils/masked/**/*', '!docs/utils/masked/**/*']
+- changed-files:
+  - any-glob-to-any-file:
+    - cextern/expat/**/*
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/utils/**/*'
+      - '!astropy/utils/iers/**/*'
+      - '!docs/utils/iers.rst'
+      - '!astropy/utils/masked/**/*'
+      - '!docs/utils/masked/**/*'
 
 utils.iers:
-  - astropy/utils/iers/**/*
-  - docs/utils/iers.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/utils/iers/**/*
+    - docs/utils/iers.rst
 
 utils.masked:
-  - astropy/utils/masked/**/*
-  - docs/utils/masked/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/utils/masked/**/*
+    - docs/utils/masked/**/*
 
 visualization:
-  - any:
-    - changed-files:
-      - any-glob-to-any-file: ['**/visualization/**/*', '!**/visualization/wcsaxes/**/*']
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/visualization/**/*'
+      - '!**/visualization/wcsaxes/**/*'
 
 visualization.wcsaxes:
-  - '**/visualization/wcsaxes/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/visualization/wcsaxes/**/*'
 
 wcs:
-  - cextern/wcslib/**/*
-  - any:
-    - changed-files:
-      - any-glob-to-any-file: ['**/wcs/**/*', '!astropy/wcs/wcsapi/**/*', '!docs/wcs/wcsapi.rst']
+- changed-files:
+  - any-glob-to-any-file:
+    - cextern/wcslib/**/*
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/wcs/**/*'
+      - '!astropy/wcs/wcsapi/**/*'
+      - '!docs/wcs/wcsapi.rst'
 
 wcs.wcsapi:
-  - astropy/wcs/wcsapi/**/*
-  - docs/wcs/wcsapi.rst
+- changed-files:
+  - any-glob-to-any-file:
+    - astropy/wcs/wcsapi/**/*
+    - docs/wcs/wcsapi.rst
 
 dev-automation:
-  - .pre-commit-config.yaml
+- changed-files:
+  - any-glob-to-any-file:
+    - .pre-commit-config.yaml
 
 skip-changelog-checks:
-  - .pre-commit-config.yaml
+- changed-files:
+  - any-glob-to-any-file:
+    - .pre-commit-config.yaml


### PR DESCRIPTION
### Description
Seeing that #15723 didn't achieve the fix,

This time, I went the extra mile and actually *checked* that I really fixed the labeler workflow by iterating with noop pull requests on my fork, see the latest (successful) attempt https://github.com/neutrinoceros/astropy/pull/7

Follow-up to #15708 and #15723, which were both backported, so should this.

ping @pllim


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
