### PR TITLE
BUG [table]: fix slicing logic for Row

### DIFF
--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -54,6 +54,9 @@ class Row:
             if self._table._is_list_or_tuple_of_str(item):
                 cols = [self._table[name] for name in item]
                 out = self._table.__class__(cols, copy=False)[self._index]
+            elif isinstance(item, slice):
+                # https://github.com/astropy/astropy/issues/14007
+                out = tuple(self.values())[item]
             else:
                 # This is only to raise an exception
                 out = self._table.columns[item][self._index]

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -378,3 +378,12 @@ def test_row_get():
     assert row.get("x") is None
     assert row.get("b", -1) == 3
     assert row.get("y", -1) == -1
+
+
+def test_table_row_slicing():
+    # see https://github.com/astropy/astropy/issues/14007
+    from numpy.testing import assert_array_equal
+
+    t = table.Table({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    first_row = t[0]
+    assert_array_equal(first_row[1:], [4, 7])

--- a/docs/changes/table/15733.bugfix.rst
+++ b/docs/changes/table/15733.bugfix.rst
@@ -1,0 +1,3 @@
+Fix slicing logic for Row.
+Previously, slicing a ``astropy.table.row.Row`` object would incorrectly return a column,
+now it correctly returns a list of values from that row.

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -40,6 +40,7 @@ to update the original table data or properties. See also the section on
   t['a'][1]    # Row 1 of column 'a'
   t[1]         # Row 1
   t[1]['a']    # Column 'a' of row 1
+  t[1][1:]     # Row 1, columns b and c
   t[2:5]       # Table object with rows 2:5
   t[[1, 3, 4]]  # Table object with rows 1, 3, 4 (copy)
   t[np.array([1, 3, 4])]  # Table object with rows 1, 3, 4 (copy)


### PR DESCRIPTION
### Description
Fixes #14007
Fixes #4068
ping @hamogu @taldcroft @astrofrog

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
