### PR TITLE
BUG: fix a ValueError raised when calling table.join with large tables

### DIFF
--- a/astropy/table/_np_utils.pyx
+++ b/astropy/table/_np_utils.pyx
@@ -28,8 +28,8 @@ def join_inner(np.ndarray[DTYPE_t, ndim=1] idxs,
     Do the inner-loop cartesian product for np_utils.join() processing.
     (The "inner" is about the inner loop, not inner join).
     """
-    cdef int n_out = 0
-    cdef int max_key_idxs = 0
+    cdef DTYPE_t n_out = 0
+    cdef DTYPE_t max_key_idxs = 0
     cdef DTYPE_t ii, key_idxs, n_left, n_right, idx0, idx1, idx, i
     cdef DTYPE_t i_left, i_right, i_out
     cdef int masked

--- a/docs/changes/table/15734.bugfix.rst
+++ b/docs/changes/table/15734.bugfix.rst
@@ -1,0 +1,4 @@
+Fix a ``ValueError`` raised by ``table.join`` when fed with large tables.
+This would typically happen in situations when the result joined table would be
+too large to fit in memory. In those situations, the error message is now much more
+clearly about the necessary memory size.


### PR DESCRIPTION
### Description
Fixes #14167.
See [my comment therin](https://github.com/astropy/astropy/issues/14167#issuecomment-1855907737) for details

ping @hamogu @taldcroft

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
