### PR TITLE
BUG [table]: fix a bug where column names would be lost when instanciating Table from a list of Row objects

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -209,9 +209,9 @@ def _get_names_from_list_of_dict(rows):
     if rows is None:
         return None
 
-    names = set()
+    names = {}
     for row in rows:
-        if not isinstance(row, Mapping):
+        if not isinstance(row, (Mapping, Row)):
             return None
         names.update(row)
     return list(names)
@@ -1189,17 +1189,7 @@ class Table:
         MISSING = object()
 
         # Gather column names that exist in the input `data`.
-        names_from_data = set()
-        for row in data:
-            names_from_data.update(row)
-
-        if set(data[0].keys()) == names_from_data:
-            names_from_data = list(data[0].keys())
-        else:
-            names_from_data = sorted(names_from_data)
-
-        # Note: if set(data[0].keys()) != names_from_data, this will give an
-        # exception later, so NO need to catch here.
+        names_from_data = _get_names_from_list_of_dict(data)
 
         # Convert list of dict into dict of list (cols), keep track of missing
         # indexes and put in MISSING placeholders in the `cols` lists.

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -197,6 +197,7 @@ class TestInitFromListOfDicts(BaseInitFromListLike):
     def _setup(self, table_type):
         self.data = [{"a": 1, "b": 2, "c": 3}, {"a": 3, "b": 4, "c": 5}]
         self.data_ragged = [{"a": 1, "b": 2}, {"a": 2, "c": 4}]
+        self.data_acb = [{"a": 2, "c": 4}, {"a": 1, "b": 2}]
 
     def test_names(self, table_type):
         self._setup(table_type)
@@ -207,6 +208,14 @@ class TestInitFromListOfDicts(BaseInitFromListLike):
         self._setup(table_type)
         t = table_type(self.data, names=("c", "b", "a"))
         assert t.colnames == ["c", "b", "a"]
+
+    def test_rows_without_names_args(self, table_type):
+        # see https://github.com/astropy/astropy/pull/15735
+        self._setup(table_type)
+        t1 = table_type(rows=self.data)
+        assert t1.colnames == ["a", "b", "c"]
+        t2 = table_type(rows=self.data_acb)
+        assert t2.colnames == ["a", "c", "b"]
 
     def test_missing_data_init_from_dict(self, table_type):
         self._setup(table_type)
@@ -252,6 +261,7 @@ class TestInitFromListOfMapping(TestInitFromListOfDicts):
     def _setup(self, table_type):
         self.data = [DictLike(a=1, b=2, c=3), DictLike(a=3, b=4, c=5)]
         self.data_ragged = [DictLike(a=1, b=2), DictLike(a=2, c=4)]
+        self.data_acb = [DictLike(a=2, c=4), DictLike(a=1, b=2)]
         # Make sure data rows are not a dict subclass
         assert not isinstance(self.data[0], dict)
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1784,6 +1784,17 @@ def test_rows_equal():
     )
 
 
+def test_table_from_rows():
+    # see https://github.com/astropy/astropy/issues/5923
+    t1 = Table()
+    t1["a"] = [1, 2, 3]
+    t1["b"] = [2.0, 3.0, 4.0]
+
+    rows = [row for row in t1]  # noqa: C416
+    t2 = Table(rows=rows)
+    assert_array_equal(t2.colnames, t1.colnames)
+
+
 def test_equality_masked():
     t = table.Table.read(
         [

--- a/docs/changes/table/15735.bugfix.rst
+++ b/docs/changes/table/15735.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where column names would be lost when instantiating ``Table`` from a list of ``Row`` objects.

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -258,26 +258,17 @@ You can specify the column order with the ``names`` argument::
    10   5
    20  15
 
-If ``names`` are not provided then column ordering will be determined by the
-first :class:`dict` if it contains values for all the columns, or by sorting
-the column names alphabetically if it doesn't::
+If ``names`` are not provided then column ordering will be determined by
+order in which they appear as the :class:`list` of :class:`dict` is iterated over.
 
-  >>> data = [{'b': 10, 'c': 7, 'a': 5},
+  >>> data = [{'b': 10, 'c': 7, },
   ...         {'a': 15, 'c': 35, 'b': 20}]
   >>> t = Table(rows=data)
   >>> print(t)
    b   c   a
   --- --- ---
-   10   7   5
+   10   7  --
    20  35  15
-  >>> data = [{'b': 10, 'c': 7, },
-  ...         {'a': 15, 'c': 35, 'b': 20}]
-  >>> t = Table(rows=data)
-  >>> print(t)
-   a   b   c
-  --- --- ---
-   --  10   7
-   15  20  35
 
 **Single row**
 

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -15,6 +15,7 @@ In particular, this release includes:
 * :ref:`whatsnew-7.0-table-masked-quantity`
 * :ref:`whatsnew-7.0-table-frames`
 * :ref:`whatsnew-7.0-table-notebook-backends`
+* :ref:`whatsnew-7.0-table-init-columns-order`
 * :ref:`whatsnew_7_0_quantity_to_string_formatter`
 * :ref:`whatsnew_7_0_numpy_constructors_like_quantity`
 * :ref:`whatsnew_7_0_ecsv_meta_default_dict`
@@ -76,6 +77,43 @@ backends for rendering Astropy tables in Jupyter notebooks.
 .. image:: https://raw.githubusercontent.com/jupyter-widgets/ipydatagrid/main/static/ipydatagrid_1.gif
    :width: 450px
    :alt: Animated DataGrid usage example from ipydatagrid
+
+.. _whatsnew-7.0-table-init-columns-order:
+
+Ordering of table columns constructed from rows
+===============================================
+
+The column order in a `~astropy.table.Table` constructed from a `list` or rows (`dict`
+or `~astropy.table.Row`) may change using ``astropy`` version ``7.0`` *if the
+first row has missing values*.
+
+Before ``7.0``, the column ordering was determined from the first row if it contained
+values for all the columns, or by sorting the final column names alphabetically if it
+did not. Starting with ``7.0``, columns are always added in the order they appear
+when iterating over  the `list` of rows.
+
+For example, create a table as shown below:
+
+    >>> from astropy.table import Table
+    >>> data = [{'b': 10, 'c': 7, },
+    ...         {'a': 15, 'c': 35, 'b': 20}]
+    >>> t = Table(data)  # or Table(rows=data), which is equivalent
+
+
+Before ``7.0`` the table would look like this::
+
+     a   b   c
+    --- --- ---
+     --  10   7
+     15  20  35
+
+
+Starting with ``7.0`` the table would instead look like this::
+
+     b   c   a
+    --- --- ---
+     10   7  --
+     20  35  15
 
 .. _whatsnew_7_0_quantity_to_string_formatter:
 
@@ -316,6 +354,7 @@ now supports version 1.5 of the VOTable standard.  The main new feature is that 
 
 At this writing, version 1.5 is a proposed standard, but it is expected to be approved as an
 official recommendation soon.
+
 
 Full change log
 ===============


### PR DESCRIPTION
### Description

Fixes #5923
This is a somewhat inelegant minimal patch; I'll be happy to iterate over it to improve quality if requested !

ping @hamogu @taldcroft

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
