### PR TITLE
Move `position_angle()` from `SkyCoord` to `BaseCoordinateFrame`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -26,7 +26,7 @@ from astropy.utils.decorators import deprecated, format_doc, lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 
 from . import representation as r
-from .angles import Angle
+from .angles import Angle, position_angle
 from .attributes import Attribute
 from .transformations import TransformGraph
 
@@ -1776,6 +1776,39 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             .represent_as(r.UnitSphericalRepresentation)
         )
         return self_sph.lon, self_sph.lat, other_sph.lon, other_sph.lat
+
+    def position_angle(self, other: BaseCoordinateFrame | SkyCoord) -> Angle:
+        """Compute the on-sky position angle to another coordinate.
+
+        Parameters
+        ----------
+        other : `~astropy.coordinates.BaseCoordinateFrame` or `~astropy.coordinates.SkyCoord`
+            The other coordinate to compute the position angle to.  It is
+            treated as the "head" of the vector of the position angle.
+
+        Returns
+        -------
+        `~astropy.coordinates.Angle`
+            The (positive) position angle of the vector pointing from ``self``
+            to ``other``, measured East from North.  If either ``self`` or
+            ``other`` contain arrays, this will be an array following the
+            appropriate `numpy` broadcasting rules.
+
+        Examples
+        --------
+        >>> from astropy import units as u
+        >>> from astropy.coordinates import ICRS, SkyCoord
+        >>> c1 = SkyCoord(0*u.deg, 0*u.deg)
+        >>> c2 = ICRS(1*u.deg, 0*u.deg)
+        >>> c1.position_angle(c2).degree
+        90.0
+        >>> c2.position_angle(c1).degree
+        270.0
+        >>> c3 = SkyCoord(1*u.deg, 1*u.deg)
+        >>> c1.position_angle(c3).degree  # doctest: +FLOAT_CMP
+        44.995636455344844
+        """
+        return position_angle(*self._prepare_unit_sphere_coords(other))
 
     def separation(self, other):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -295,6 +295,7 @@ class SkyCoord(ShapedLikeNDArray):
     info = SkyCoordInfo()
 
     # Methods implemented by the underlying frame
+    position_angle: Callable[[BaseCoordinateFrame | SkyCoord], Angle]
     separation: Callable[[BaseCoordinateFrame | SkyCoord], Angle]
     separation_3d: Callable[[BaseCoordinateFrame | SkyCoord], Distance]
 
@@ -1182,7 +1183,7 @@ class SkyCoord(ShapedLikeNDArray):
         --------
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation` :
             for the *total* angular offset (not broken out into components).
-        position_angle :
+        :meth:`~astropy.coordinates.BaseCoordinateFrame.position_angle` :
             for the direction of the offset.
 
         """
@@ -1255,8 +1256,7 @@ class SkyCoord(ShapedLikeNDArray):
         -------
         newpoints : `~astropy.coordinates.SkyCoord`
             The coordinates for the location that corresponds to offsetting by
-            the given `position_angle` and
-            :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`.
+            the given ``position_angle`` and ``separation``.
 
         Notes
         -----
@@ -1273,8 +1273,10 @@ class SkyCoord(ShapedLikeNDArray):
 
         See Also
         --------
-        position_angle : inverse operation for the ``position_angle`` component
-        :meth:`~astropy.coordinates.BaseCoordinateFrame.separation` : inverse operation for the ``separation`` component
+        :meth:`~astropy.coordinates.BaseCoordinateFrame.position_angle` :
+            inverse operation for the ``position_angle`` component
+        :meth:`~astropy.coordinates.BaseCoordinateFrame.separation` :
+            inverse operation for the ``separation`` component
 
         """
         from .angles import offset_by
@@ -1540,39 +1542,6 @@ class SkyCoord(ShapedLikeNDArray):
         return search_around_3d(
             searcharoundcoords, self, distlimit, storekdtree="_kdtree_3d"
         )
-
-    def position_angle(self, other):
-        """
-        Computes the on-sky position angle (East of North) between this
-        SkyCoord and another.
-
-        Parameters
-        ----------
-        other : |SkyCoord|
-            The other coordinate to compute the position angle to.  It is
-            treated as the "head" of the vector of the position angle.
-
-        Returns
-        -------
-        pa : `~astropy.coordinates.Angle`
-            The (positive) position angle of the vector pointing from ``self``
-            to ``other``.  If either ``self`` or ``other`` contain arrays, this
-            will be an array following the appropriate `numpy` broadcasting
-            rules.
-
-        Examples
-        --------
-        >>> c1 = SkyCoord(0*u.deg, 0*u.deg)
-        >>> c2 = SkyCoord(1*u.deg, 0*u.deg)
-        >>> c1.position_angle(c2).degree
-        90.0
-        >>> c3 = SkyCoord(1*u.deg, 1*u.deg)
-        >>> c1.position_angle(c3).degree  # doctest: +FLOAT_CMP
-        44.995636455344844
-        """
-        from .angles import position_angle
-
-        return position_angle(*self.frame._prepare_unit_sphere_coords(other))
 
     def skyoffset_frame(self, rotation=None):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1572,21 +1572,7 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from .angles import position_angle
 
-        if not self.is_equivalent_frame(other):
-            try:
-                other = other.transform_to(self, merge_attributes=False)
-            except TypeError:
-                raise TypeError(
-                    "Can only get position_angle to another "
-                    "SkyCoord or a coordinate frame with data"
-                )
-
-        slat = self.represent_as(UnitSphericalRepresentation).lat
-        slon = self.represent_as(UnitSphericalRepresentation).lon
-        olat = other.represent_as(UnitSphericalRepresentation).lat
-        olon = other.represent_as(UnitSphericalRepresentation).lon
-
-        return position_angle(slon, slat, olon, olat)
+        return position_angle(*self.frame._prepare_unit_sphere_coords(other))
 
     def skyoffset_frame(self, rotation=None):
         """

--- a/astropy/coordinates/tests/test_frame_skycoord_common_methods.py
+++ b/astropy/coordinates/tests/test_frame_skycoord_common_methods.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Tests for methods that are implemented in `BaseCoordinateFrame`,
+but are also exposed by `SkyCoord` instances.
+"""
+
+import pytest
+
+from astropy import units as u
+from astropy.coordinates import FK5, ICRS, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
+
+
+@pytest.mark.parametrize("self_class", [SkyCoord, ICRS])
+@pytest.mark.parametrize("other_class", [SkyCoord, ICRS])
+def test_position_angle_array(self_class, other_class):
+    c1 = self_class(0 * u.deg, [0, 1, 2] * u.deg)
+    c2 = other_class([-1, -2, -3] * u.deg, [0.1, 1.1, 2.1] * u.deg)
+    assert_quantity_allclose(
+        c1.position_angle(c2), [275.710887, 272.880921, 271.963607] * u.deg
+    )
+
+
+@pytest.mark.parametrize("self_class", [SkyCoord, ICRS])
+@pytest.mark.parametrize(
+    "other_coord,value",
+    [
+        (SkyCoord(1 * u.deg, 0 * u.deg), 90 * u.deg),
+        (SkyCoord(1 * u.deg, 0.1 * u.deg), 84.289113 * u.deg),
+        (SkyCoord(1 * u.deg, 1 * u.deg), 44.995636455344844 * u.deg),
+        (ICRS(0 * u.deg, 1 * u.deg), 0 * u.deg),
+        (FK5(1 * u.deg, 0 * u.deg), 90.000139 * u.deg),
+    ],
+)
+def test_position_angle_scalar(self_class, other_coord, value):
+    assert_quantity_allclose(
+        self_class(0 * u.deg, 0 * u.deg).position_angle(other_coord), value
+    )

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -853,33 +853,6 @@ def test_none_transform():
     npt.assert_array_equal(sc_arr5.ra, sc_arr2.transform_to("fk5").ra)
 
 
-def test_position_angle():
-    c1 = SkyCoord(0 * u.deg, 0 * u.deg)
-
-    c2 = SkyCoord(1 * u.deg, 0 * u.deg)
-    assert_allclose(c1.position_angle(c2) - 90.0 * u.deg, 0 * u.deg)
-
-    c3 = SkyCoord(1 * u.deg, 0.1 * u.deg)
-    assert c1.position_angle(c3) < 90 * u.deg
-
-    c4 = SkyCoord(0 * u.deg, 1 * u.deg)
-    assert_allclose(c1.position_angle(c4), 0 * u.deg)
-
-    carr1 = SkyCoord(0 * u.deg, [0, 1, 2] * u.deg)
-    carr2 = SkyCoord([-1, -2, -3] * u.deg, [0.1, 1.1, 2.1] * u.deg)
-
-    res = carr1.position_angle(carr2)
-    assert res.shape == (3,)
-    assert np.all(res < 360 * u.degree)
-    assert np.all(res > 270 * u.degree)
-
-    cicrs = SkyCoord(0 * u.deg, 0 * u.deg, frame="icrs")
-    cfk5 = SkyCoord(1 * u.deg, 0 * u.deg, frame="fk5")
-    # because of the frame transform, it's just a *bit* more than 90 degrees
-    assert cicrs.position_angle(cfk5) > 90.0 * u.deg
-    assert cicrs.position_angle(cfk5) < 91.0 * u.deg
-
-
 def test_position_angle_directly():
     """Regression check for #3800: position_angle should accept floats."""
     from astropy.coordinates import position_angle

--- a/docs/changes/coordinates/15737.feature.rst
+++ b/docs/changes/coordinates/15737.feature.rst
@@ -1,0 +1,2 @@
+``BaseCoordinateFrame`` now has a ``position_angle()`` method, which is the
+same as the ``position_angle`` method of ``SkyCoord`` instances.

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -68,8 +68,8 @@ rather than the single scalar angular offset of a separation.
 offsets encountered in astronomy.
 
 The first piece of such functionality is the
-:meth:`~astropy.coordinates.SkyCoord.position_angle` method. This method
-computes the position angle between one
+:meth:`~astropy.coordinates.BaseCoordinateFrame.position_angle` method.
+This method computes the position angle between one
 |SkyCoord| instance and another (passed as the argument) following the
 astronomy convention (positive angles East of North)::
 
@@ -79,8 +79,9 @@ astronomy convention (positive angles East of North)::
     <Angle 44.97818294 deg>
 
 The combination of :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`
-and :meth:`~astropy.coordinates.SkyCoord.position_angle` thus give a set of
-directional offsets. To do the inverse operation — determining the new
+and :meth:`~astropy.coordinates.BaseCoordinateFrame.position_angle` thus give a
+set of directional offsets.
+To do the inverse operation — determining the new
 "destination" coordinate given a separation and position angle — the
 :meth:`~astropy.coordinates.SkyCoord.directional_offset_by` method is provided::
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1256,7 +1256,7 @@ the available docstrings below:
 
 - `~astropy.coordinates.SkyCoord.match_to_catalog_sky`,
 - `~astropy.coordinates.SkyCoord.match_to_catalog_3d`,
-- `~astropy.coordinates.SkyCoord.position_angle`,
+- `~astropy.coordinates.BaseCoordinateFrame.position_angle`,
 - `~astropy.coordinates.BaseCoordinateFrame.separation`,
 - `~astropy.coordinates.BaseCoordinateFrame.separation_3d`
 - `~astropy.coordinates.SkyCoord.apply_space_motion`


### PR DESCRIPTION
### Description

The first commit implements a new private method in `BaseCoordinateFrame` that simplifies the implementation of `separation()` and `position_angle()` methods.

The second commit moves `position_angle()` from `SkyCoord` to `BaseCoordinateFrame`. The method remains accessible for `SkyCoord` instances because they have access to methods defined both in `SkyCoord` and in their underlying frame.

I felt it appropriate to create a new file for testing methods that are implemented in `BaseCoordinateFrame`, but are exposed also by `SkyCoord` instances. That file should also include tests for `separation()` and `separation_3d()`, but moving those tests over would be beyond the scope of this pull request, which is large enough as it is.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
