### PR TITLE
Add clarification on the xy coordinates in fit_wcs_from_points

### DIFF
--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -1098,7 +1098,8 @@ def fit_wcs_from_points(
     Parameters
     ----------
     xy : (`numpy.ndarray`, `numpy.ndarray`) tuple
-        x & y pixel coordinates.
+        x & y pixel coordinates.  These should be in FITS convention, starting
+        from (1,1) as the center of the bottom-left pixel.
     world_coords : `~astropy.coordinates.SkyCoord`
         Skycoord object with world coordinates.
     proj_point : 'center' or ~astropy.coordinates.SkyCoord`


### PR DESCRIPTION
Replacement for https://github.com/astropy/astropy/pull/15739, which was mistakenly branched in `upstream`.

This is a minor clarification in the documentation of fit_wcs_from_points: it looks like the xy coordinates should be 1-indexed. I've tested this empirically in one case, but not systematically - it would be helpful to have additional expert eyes on this.