### PR TITLE
TST: tox option to exclude scipy

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -43,16 +43,16 @@ jobs:
           # that gives too many false positives due to URL timeouts. We also
           # install all dependencies via pip here so we pick up the latest
           # releases.
-          - name: Python 3.11 with dev version of key dependencies
-            os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-devdeps
-
-          # https://github.com/astropy/astropy/issues/15701
-          - name: Python 3.10 with dev version of key dependencies without scipy
+          - name: Python 3.10 with dev version of key dependencies
             os: ubuntu-latest
             python: '3.10'
-            toxenv: py310-test-devdeps-noscipy
+            toxenv: py310-test-devdeps
+
+          # https://github.com/astropy/astropy/issues/15701
+          - name: Python 3.11 with dev version of key dependencies without scipy
+            os: ubuntu-latest
+            python: '3.11'
+            toxenv: py311-test-devdeps-noscipy
 
           - name: Python 3.11 with dev version of infrastructure dependencies
             os: ubuntu-latest

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -48,6 +48,12 @@ jobs:
             python: '3.11'
             toxenv: py311-test-devdeps
 
+          # https://github.com/astropy/astropy/issues/15701
+          - name: Python 3.10 with dev version of key dependencies without scipy
+            os: ubuntu-latest
+            python: '3.10'
+            toxenv: py310-test-devdeps-noscipy
+
           - name: Python 3.11 with dev version of infrastructure dependencies
             os: ubuntu-latest
             python: '3.11'
@@ -55,9 +61,10 @@ jobs:
 
           - name: Documentation link check
             os: ubuntu-latest
-            python: '3.10'
+            python: '3.x'
             toxenv: linkcheck
 
+          # This is sensitive to Python version.
           - name: Run flynt to check string formatting
             os: ubuntu-latest
             python: '3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-mpldev,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl334}{,-cov}{,-clocale}{,-fitsio}
+    py{39,310,311,312,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-mpldev,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl334}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py39-test-image-mpl334-cov
     py39-test-image-mpldev-cov
@@ -52,6 +52,7 @@ description =
     mpl334: with matplotlib 3.3.4
     mpldev: with the latest developer version of matplotlib
     double: twice in a row to check for global state changes
+    noscipy: without scipy-dev
 
 deps =
     numpy123: numpy==1.23.*
@@ -82,7 +83,7 @@ deps =
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
-    devdeps: scipy>=0.0.dev0
+    devdeps-!noscipy: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to add tox option to exclude scipy so we can test devdeps without scipy-dev. I opted to run this combo in weekly cron. The setup and cadence are all negotiable.

Also cc @neutrinoceros 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15701

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
