### PR TITLE
Remove unused code from an `io.ascii` test helper file

### DIFF
--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -10,21 +10,10 @@ __all__ = [
     "assert_true",
     "setup_function",
     "teardown_function",
-    "has_isnan",
 ]
 
 CWD = os.getcwd()
 TEST_DIR = os.path.dirname(__file__)
-
-has_isnan = True
-try:
-    from math import isnan
-except ImportError:
-    try:
-        from numpy import isnan  # noqa: F401
-    except ImportError:
-        has_isnan = False
-        print("Tests requiring isnan will fail")
 
 
 def setup_function(function):
@@ -46,33 +35,3 @@ def assert_almost_equal(a, b, **kwargs):
 
 def assert_true(a):
     assert a
-
-
-def make_decorator(func):
-    """
-    Wraps a test decorator so as to properly replicate metadata
-    of the decorated function, including nose's additional stuff
-    (namely, setup and teardown).
-    """
-
-    def decorate(newfunc):
-        if hasattr(func, "compat_func_name"):
-            name = func.compat_func_name
-        else:
-            name = func.__name__
-        newfunc.__dict__ = func.__dict__
-        newfunc.__doc__ = func.__doc__
-        newfunc.__module__ = func.__module__
-        if not hasattr(newfunc, "compat_co_firstlineno"):
-            try:
-                newfunc.compat_co_firstlineno = func.func_code.co_firstlineno
-            except AttributeError:
-                newfunc.compat_co_firstlineno = func.__code__.co_firstlineno
-        try:
-            newfunc.__name__ = name
-        except TypeError:
-            # can't set func name in 2.3
-            newfunc.compat_func_name = name
-        return newfunc
-
-    return decorate


### PR DESCRIPTION
### Description

[`math.isnan` was introduced in Python 2.6](https://docs.python.org/2.6/library/math.html#math.isnan) so `has_isnan` has not been useful since support for Python 2.5 was dropped.

`make_decorator()` has not been used by anything since eabc51028fb6840ba07bac8fd083dbcd96fddc73.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
