### PR TITLE
BUG: fix a crash when calling `Column.pprint` on a scalar column

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -463,7 +463,13 @@ class TableFormatter:
 
         max_lines -= n_header
         n_print2 = max_lines // 2
-        n_rows = len(col)
+        try:
+            n_rows = len(col)
+        except TypeError:
+            is_scalar = True
+            n_rows = 1
+        else:
+            is_scalar = False
 
         # This block of code is responsible for producing the function that
         # will format values for this column.  The ``format_func`` function
@@ -501,17 +507,15 @@ class TableFormatter:
         auto_format_func = get_auto_format_func(col, pssf)
         format_func = col.info._format_funcs.get(col_format, auto_format_func)
 
-        if len(col) > max_lines:
+        if n_rows > max_lines:
             if show_length is None:
                 show_length = True
             i0 = n_print2 - (1 if show_length else 0)
             i1 = n_rows - n_print2 - max_lines % 2
-            indices = np.concatenate(
-                [np.arange(0, i0 + 1), np.arange(i1 + 1, len(col))]
-            )
+            indices = np.concatenate([np.arange(0, i0 + 1), np.arange(i1 + 1, n_rows)])
         else:
             i0 = -1
-            indices = np.arange(len(col))
+            indices = np.arange(n_rows)
 
         def format_col_str(idx):
             if multidims:
@@ -527,6 +531,8 @@ class TableFormatter:
                     left = format_func(col_format, col[(idx,) + multidim0])
                     right = format_func(col_format, col[(idx,) + multidim1])
                     return f"{left} .. {right}"
+            elif is_scalar:
+                return format_func(col_format, col)
             else:
                 return format_func(col_format, col[idx])
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -464,6 +464,18 @@ class TestColumn:
         with pytest.raises(AttributeError):
             t["a"].mask = [True, False]
 
+    @pytest.mark.parametrize("scalar", [1, u.Quantity(0.6, "eV")])
+    def test_access_scalar(self, scalar):
+        # see https://github.com/astropy/astropy/pull/15749#issuecomment-1867561072
+        c = table.Column(scalar)
+        if isinstance(scalar, u.Quantity):
+            assert c.item() == scalar.value
+        else:
+            assert c.item() == scalar
+
+        with pytest.raises(IndexError):
+            c[0]
+
 
 @pytest.mark.parametrize(
     "data",

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -10,7 +10,7 @@ import pytest
 from astropy import conf, table
 from astropy import units as u
 from astropy.io import ascii
-from astropy.table import QTable, Table
+from astropy.table import Column, QTable, Table
 from astropy.table.table_helpers import simple_table
 
 BIG_WIDE_ARR = np.arange(2000, dtype=np.float64).reshape(100, 20)
@@ -314,6 +314,40 @@ class TestPprint:
         (out, err) = capsys.readouterr()
         # +3 accounts for the three header lines in this  table
         assert len(out.splitlines()) == BIG_WIDE_ARR.shape[0] + 3
+
+
+class TestPprintColumn:
+    @pytest.mark.parametrize(
+        "scalar, exp",
+        [
+            (
+                1,
+                [
+                    "None",
+                    "----",
+                    "   1",
+                ],
+            ),
+            (
+                u.Quantity(0.6, "eV"),
+                [
+                    "None",
+                    "----",
+                    " 0.6",
+                ],
+            ),
+        ],
+    )
+    def test_pprint_scalar(self, scalar, exp):
+        # see https://github.com/astropy/astropy/issues/12584
+        c = Column(scalar)
+
+        # Make sure pprint() does not raise an exception
+        c.pprint()
+
+        # Check actual output
+        out = c.pformat()
+        assert out == exp
 
 
 @pytest.mark.usefixtures("table_type")

--- a/docs/changes/table/15749.bugfix.rst
+++ b/docs/changes/table/15749.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash when calling ``Column.pprint`` on a scalar column.


### PR DESCRIPTION
### Description
Fixes #12584

This is a proof of concept fix because it breaks another regression test, however I haven't been able to find a general solution that passes all tests yet, so instead of going in circles I'd rather open this to early feedback.

ping @hamogu @mhvk @taldcroft and @nstarman 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
