### PR TITLE
Remove deprecated kwarg and property names in stretches

### DIFF
--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -7,8 +7,6 @@ another set of [0:1] values with a transformation.
 
 import numpy as np
 
-from astropy.utils.decorators import deprecated_attribute
-
 from .transform import BaseTransform, CompositeTransform
 
 __all__ = [
@@ -210,8 +208,6 @@ class PowerStretch(BaseStretch):
         than 0.
     """
 
-    power = deprecated_attribute("power", "6.0", alternative="a")
-
     @property
     def _supports_invalid_kw(self):
         return True
@@ -290,8 +286,6 @@ class PowerDistStretch(BaseStretch):
         1000.
     """
 
-    exp = deprecated_attribute("exp", "6.0", alternative="a")
-
     def __init__(self, a=1000.0):
         if a < 0 or a == 1:  # singularity
             raise ValueError("a must be >= 0, but cannot be set to 1")
@@ -328,8 +322,6 @@ class InvertedPowerDistStretch(BaseStretch):
         greater than or equal to 0, but cannot be set to 1.  Default is
         1000.
     """
-
-    exp = deprecated_attribute("exp", "6.0", alternative="a")
 
     def __init__(self, a=1000.0):
         if a < 0 or a == 1:  # singularity
@@ -384,8 +376,6 @@ class LogStretch(BaseStretch):
         The ``a`` parameter used in the above formula.  ``a`` must be
         greater than 0.  Default is 1000.
     """
-
-    exp = deprecated_attribute("exp", "6.0", alternative="a")
 
     @property
     def _supports_invalid_kw(self):
@@ -465,8 +455,6 @@ class InvertedLogStretch(BaseStretch):
         The ``a`` parameter used in the above formula.  ``a`` must be
         greater than 0.  Default is 1000.
     """
-
-    exp = deprecated_attribute("exp", "6.0", alternative="a")
 
     def __init__(self, a):
         super().__init__()

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.stretch import (
     AsinhStretch,
     ContrastBiasStretch,
@@ -160,25 +159,3 @@ def test_histeqstretch_invalid():
     result = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0])
     assert_equal(HistEqStretch(data)(data), result)
     assert_equal(InvertedHistEqStretch(data)(data), result)
-
-
-def test_deprecated_attrs():
-    match = "The power attribute is deprecated"
-    with pytest.warns(AstropyDeprecationWarning, match=match):
-        stretch = PowerStretch(a=0.5)
-        assert stretch.power == stretch.a
-
-    match = "The exp attribute is deprecated"
-    with pytest.warns(AstropyDeprecationWarning, match=match):
-        stretch = PowerDistStretch(a=0.5)
-        assert stretch.exp == stretch.a
-    with pytest.warns(AstropyDeprecationWarning, match=match):
-        stretch = InvertedPowerDistStretch(a=0.5)
-        assert stretch.exp == stretch.a
-
-    with pytest.warns(AstropyDeprecationWarning, match=match):
-        stretch = LogStretch(a=0.5)
-        assert stretch.exp == stretch.a
-    with pytest.warns(AstropyDeprecationWarning, match=match):
-        stretch = InvertedLogStretch(a=0.5)
-        assert stretch.exp == stretch.a

--- a/docs/changes/visualization/15751.api.rst
+++ b/docs/changes/visualization/15751.api.rst
@@ -1,0 +1,5 @@
+Removed deprecated ``exp`` attribute in the ``LogStretch``,
+``InvertedLogStretch``, ``PowerDistStretch``, and
+``InvertedPowerDistStretch`` stretch classes, and the ``power``
+attribute in the ``PowerStretch``. Instead, use the ``a`` attribute,
+which matches the input keyword.


### PR DESCRIPTION
Fixes #15544

This PR removes the kwarg and property names in stretches deprecated in #15538

I should also add this to the changelog right?

PS: Keeping this as draft for now as it is slated for removal in `v7.0.0`

