### PR TITLE
Let Quantity accept Array-API compatible objects

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -21,7 +21,6 @@ from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyWarning
-from astropy.utils.misc import isiterable
 
 from .core import (
     Unit,
@@ -489,10 +488,9 @@ class Quantity(np.ndarray):
                     if unit is None:
                         unit = value_unit  # signal no conversion needed below.
 
-            elif isiterable(value) and len(value) > 0:
-                # Iterables like lists and tuples.
+            elif isinstance(value, (list, tuple)) and len(value) > 0:
                 if all(isinstance(v, Quantity) for v in value):
-                    # If a list/tuple containing only quantities, convert all
+                    # If a list/tuple contains only quantities, convert all
                     # to the same unit.
                     if unit is None:
                         unit = value[0].unit

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -640,3 +640,15 @@ class TestStructuredArray:
         assert qra[1].value == np.array((-1000.0, -2000.0, -3000.0), qra.dtype)
         # Ensure we do not override dtype names of value.
         assert value.dtype.names == ("x", "y", "z")
+
+
+@pytest.mark.filterwarnings(
+    "ignore: The numpy.array_api submodule is still experimental. See NEP 47."
+)
+def test_array_api_init():
+    import numpy.array_api as np_api
+
+    array = np_api.asarray([1, 2, 3])
+    quantity_array = u.Quantity(array, u.m)
+    assert type(quantity_array) is u.Quantity
+    assert_array_equal(quantity_array, [1, 2, 3] * u.m)

--- a/docs/changes/units/15752.api.rst
+++ b/docs/changes/units/15752.api.rst
@@ -1,0 +1,6 @@
+If any iterable such as a list of tuple was input to ``Quantity``, a check was
+done to see if they contained only quantities, and, if so, the quantities were
+concatenated.  This makes sense for list and tuple, but is not necessarily
+logical for all iterables and indeed was broken for those that do not have a
+length (such as ``array_api`` array instances). Hence, the check will now be
+done only for values where it makes sense, i.e., instances of list and tuple.


### PR DESCRIPTION
This is a hack to make the code block in https://github.com/astropy/astropy/issues/15071 work and I just wanted to test this out and see how things need to work/refactor inside `Quantity` to work. The changes here are minimal and it just casts any array-api compatible object to numpy array (as suggested in https://github.com/astropy/astropy/issues/15071#issuecomment-1638031396), like a `torch` tensor or `cupy` array will be able to use astropy to create a `Quantity` object.

The following code would work with this change.
``` python
>>> import torch
>>> import astropy.units as u
>>> array = torch.asarray([1, 2, 3])
>>> u.Quantity(array)
<Quantity [1., 2., 3.]>
```
The quantity value in the above case loses the torch tensor as it's wrapped by a numpy ndarray.
``` python
>>> u.Quantity(array).value == array
False
```
Would there be interest in refactoring `Quantity` and making it work natively with array-api compatible types?