### PR TITLE
MAINT: Remove deprecated keywords args from io.ascii

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import io
 import locale
 import pathlib
 import platform
@@ -22,7 +21,7 @@ from astropy.units import Unit
 # NOTE: Python can be built without bz2.
 from astropy.utils.compat.optional_deps import HAS_BZ2
 from astropy.utils.data import get_pkg_data_path
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy.utils.exceptions import AstropyWarning
 
 # setup/teardown function to have the tests run in the correct directory
 from .common import (
@@ -2065,48 +2064,3 @@ def test_read_converters_simplified():
             t2 = Table.read(
                 out.getvalue(), format="ascii.basic", converters=converters, guess=False
             )
-
-
-def test_read_deprecations():
-    def check_warns(func, *args):
-        with pytest.warns(AstropyDeprecationWarning) as warns:
-            out = func(
-                *args,
-                Reader=ascii.Basic,
-                Inputter=ascii.BaseInputter,
-                Outputter=ascii.TableOutputter,
-                header_Splitter=ascii.DefaultSplitter,
-                data_Splitter=ascii.DefaultSplitter,
-            )
-            assert len(warns) == 5
-            for kwarg in (
-                "Reader",
-                "Inputter",
-                "Outputter",
-                "header_Splitter",
-                "data_Splitter",
-            ):
-                msg = f'"{kwarg}" was deprecated'
-                assert any(warn.message.args[0].startswith(msg) for warn in warns)
-            return out
-
-    tbl = check_warns(ascii.read, ["a b", "1 2"])
-    assert tbl.pformat_all() == [" a   b ", "--- ---", "  1   2"]
-
-    reader = check_warns(ascii.get_reader)
-    tbl = reader.read(["a b", "1 2"])
-    assert tbl.pformat_all() == [" a   b ", "--- ---", "  1   2"]
-
-
-def test_write_deprecations():
-    t = simple_table()
-    out = io.StringIO()
-    with pytest.warns(AstropyDeprecationWarning, match='"Writer" was deprecated'):
-        ascii.write(t, out, Writer=ascii.Csv)
-    assert out.getvalue().splitlines() == ["a,b,c", "1,1.0,c", "2,2.0,d", "3,3.0,e"]
-
-    with pytest.warns(AstropyDeprecationWarning, match='"Writer" was deprecated'):
-        writer = ascii.get_writer(Writer=ascii.Csv)
-    out = io.StringIO()
-    writer.write(t, out)
-    assert out.getvalue().splitlines() == ["a,b,c", "1,1.0,c", "2,2.0,d", "3,3.0,e"]

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -118,16 +118,6 @@ def set_guess(guess):
     _GUESS = guess
 
 
-# Make these changes in version 7.0 (hopefully!).
-@deprecated_renamed_argument("Reader", "reader_cls", "6.0")
-@deprecated_renamed_argument("Inputter", "inputter_cls", "6.0")
-@deprecated_renamed_argument("Outputter", "outputter_cls", "6.0")
-@deprecated_renamed_argument(
-    "header_Splitter", "header_splitter_cls", "6.0", arg_in_kwargs=True
-)
-@deprecated_renamed_argument(
-    "data_Splitter", "data_splitter_cls", "6.0", arg_in_kwargs=True
-)
 def get_reader(reader_cls=None, inputter_cls=None, outputter_cls=None, **kwargs):
     """
     Initialize a table reader allowing for common customizations.
@@ -293,18 +283,6 @@ def _expand_user_if_path(argument):
     return argument
 
 
-# Make these changes in version 7.0 (hopefully!).
-@deprecated_renamed_argument(
-    "Reader", None, "6.0", arg_in_kwargs=True, alternative='"format"'
-)
-@deprecated_renamed_argument("Inputter", "inputter_cls", "6.0", arg_in_kwargs=True)
-@deprecated_renamed_argument("Outputter", "outputter_cls", "6.0", arg_in_kwargs=True)
-@deprecated_renamed_argument(
-    "header_Splitter", "header_splitter_cls", "6.0", arg_in_kwargs=True
-)
-@deprecated_renamed_argument(
-    "data_Splitter", "data_splitter_cls", "6.0", arg_in_kwargs=True
-)
 def read(table, guess=None, **kwargs):
     # This the final output from reading. Static analysis indicates the reading
     # logic (which is indeed complex) might not define `dat`, thus do so here.
@@ -312,9 +290,8 @@ def read(table, guess=None, **kwargs):
 
     # Specifically block `reader_cls` kwarg, which will otherwise allow a backdoor from
     # read() to specify the reader class. Mostly for testing.
-    # For 7.0+, do the same check for `Reader`.
-    if "reader_cls" in kwargs:
-        raise TypeError("read() got an unexpected keyword argument 'reader_cls'")
+    if "Reader" in kwargs:
+        raise TypeError("read() got an unexpected keyword argument 'Reader'")
 
     # Docstring defined below
     del _read_trace[:]
@@ -348,9 +325,7 @@ def read(table, guess=None, **kwargs):
     kwargs["fast_reader"] = copy.deepcopy(fast_reader)
 
     # Get the Reader class based on possible format and reader_cls kwarg inputs.
-    reader_cls = _get_format_class(format, new_kwargs.pop("Reader", None), "Reader")
-    # For 7.0+ when `Reader` is removed:
-    # reader_cls = _get_format_class(format, None, "Reader")
+    reader_cls = _get_format_class(format, None, "Reader")
 
     if reader_cls is not None:
         new_kwargs["reader_cls"] = reader_cls
@@ -973,13 +948,8 @@ def write(
 
     # Specifically block `writer_cls` kwarg, which will otherwise allow a backdoor from
     # read() to specify the reader class. Mostly for testing.
-    # For 7.0+, do the same check for `Reader`.
-    if "writer_cls" in kwargs:
-        raise TypeError("write() got an unexpected keyword argument 'writer_cls'")
-
-    # For version 7.0+ (after Writer kwarg is removed):
-    # if "Writer" in kwargs:
-    #     raise TypeError("write() got an unexpected keyword argument 'Writer'")
+    if "Writer" in kwargs:
+        raise TypeError("write() got an unexpected keyword argument 'Writer'")
 
     _validate_read_write_kwargs(
         "write", format=format, fast_writer=fast_writer, overwrite=overwrite, **kwargs
@@ -1024,9 +994,7 @@ def write(
     if table.has_mixin_columns:
         fast_writer = False
 
-    writer_cls = _get_format_class(format, Writer, "Writer")
-    # For version 7.0+:
-    # writer_cls = _get_format_class(format, None, "Writer")
+    writer_cls = _get_format_class(format, None, "Writer")
     writer = get_writer(writer_cls=writer_cls, fast_writer=fast_writer, **kwargs)
     if writer._format_name in core.FAST_CLASSES:
         writer.write(table, output)

--- a/docs/changes/io.ascii/15758.api.rst
+++ b/docs/changes/io.ascii/15758.api.rst
@@ -1,0 +1,17 @@
+Remove all deprecated arguments from functions within ``astropy.io.ascii``.
+
+``read()``:
+- ``Reader`` is removed. Instead supply the equivalent ``format`` argument.
+- Use ``inputter_cls`` instead of ``Inputter``.
+- Use ``outputter_cls`` instead of ``Outputter``.
+
+``get_reader()``:
+- Use ``reader_cls`` instead of ``Reader``.
+- Use ``inputter_cls`` instead of ``Inputter``.
+- Use ``outputter_cls`` instead of ``Outputter``.
+
+``write()``:
+- ``Writer`` is removed. Instead supply the equivalent ``format`` argument.
+
+``get_writer()``:
+- Use ``writer_cls`` instead of ``Writer``.

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -211,13 +211,6 @@ Parameters for ``read()``
   This can be ``True`` or ``False``, and also be a ``dict`` with options.
   (see :ref:`fast_ascii_io`)
 
-**Reader** : Reader class (*deprecated* in favor of ``format``)
-  This specifies the top-level format of the ASCII table; for example,
-  if it is a basic character delimited table, fixed format table, or
-  a CDS-compatible table, etc. The value of this parameter must
-  be a Reader class. For basic usage this means one of the
-  built-in :ref:`extension_reader_classes`.
-
 Specifying Header and Data Location
 ===================================
 

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -221,15 +221,6 @@ details.
   to use the faster writer (described in :ref:`fast_ascii_io`) if possible.
   Specifying ``fast_writer=False`` disables this behavior.
 
-**Writer** : Writer class (*deprecated* in favor of ``format``)
-  This specifies the top-level format of the ASCII table to be written, such as
-  a basic character delimited table, fixed-format table, or a CDS-compatible
-  table, etc. The value of this parameter must be a Writer class. For basic
-  usage this means one of the built-in :ref:`extension_reader_classes`.
-  Note that Reader classes and Writer classes are synonymous; in other
-  words, Reader classes can also write, but for historical reasons they are
-  often called Reader classes.
-
 .. _cds_mrt_format:
 
 Machine-Readable Table Format


### PR DESCRIPTION
This removes the deprecated keywords args in https://github.com/astropy/astropy/pull/14914

Closes https://github.com/astropy/astropy/issues/15536
