### PR TITLE
Backport PR #15760: Support new additions to numpy (np.vecdot, np.matrix_transpose, etc.)

### DIFF
--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -34,9 +34,14 @@ def matrix_transpose(matrix):
     """Transpose a matrix or stack of matrices by swapping the last two axes.
 
     This function mostly exists for readability; seeing ``.swapaxes(-2, -1)``
-    it is not that obvious that one does a transpose.  Note that one cannot
-    use `~numpy.ndarray.T`, as this transposes all axes and thus does not
-    work for stacks of matrices.
+    it is not that obvious that one does a transpose.
+
+    Note that one cannot use `~numpy.ndarray.T`, as this transposes all axes
+    and thus does not work for stacks of matrices.  We also avoid
+    ``np.matrix_transpose`` (new in numpy 2.0), since it is slower, as it
+    first ensures the input is an array, while we ducktype, assuming the
+    input has a ``.swapaxes`` method.
+
     """
     return matrix.swapaxes(-2, -1)
 

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -109,7 +109,11 @@ if NUMPY_LT_2_0:
     SUBCLASS_SAFE_FUNCTIONS |= {np.msort, np.round_}  # noqa: NPY003
 else:
     # Array-API compatible versions (matrix axes always at end).
-    SUBCLASS_SAFE_FUNCTIONS |= {np.linalg.diagonal, np.linalg.trace}
+    SUBCLASS_SAFE_FUNCTIONS |= {
+        np.matrix_transpose, np.linalg.matrix_transpose,
+        np.linalg.diagonal, np.linalg.trace,
+        np.linalg.matrix_norm, np.linalg.vector_norm, np.linalg.vecdot,
+    }  # fmt: skip
 
     # these work out of the box (and are tested), because they
     # delegate to other, already wrapped functions from the np namespace
@@ -641,6 +645,7 @@ def dot_like(a, b, out=None):
         np.correlate,
         np.convolve,
     }
+    | (set() if NUMPY_LT_2_0 else {np.vecdot})
 )
 def cross_like(a, b, *args, **kwargs):
     a, b = _as_quantities(a, b)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -209,6 +209,11 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         assert type(a1) is np.ndarray
         assert type(a2) is np.ndarray
 
+    if not NUMPY_LT_2_0:
+
+        def test_matrix_transpose(self):
+            self.check(np.matrix_transpose)
+
 
 class TestArgFunctions(NoUnitTestSetup):
     def test_argmin(self):
@@ -1121,6 +1126,15 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
         q2 = np.array([4j, 5j, 6j]) / u.s
         o = np.vdot(q1, q2)
         assert o == (32.0 + 0j) * u.m / u.s
+
+    if not NUMPY_LT_2_0:
+
+        @needs_array_function
+        def test_vecdot(self):
+            q1 = np.array([1j, 2j, 3j]) * u.m
+            q2 = np.array([4j, 5j, 6j]) / u.s
+            o = np.vecdot(q1, q2)
+            assert o == (32.0 + 0j) * u.m / u.s
 
     @needs_array_function
     def test_tensordot(self):
@@ -2367,6 +2381,12 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             assert_allclose(res, ref, rtol=5e-16)
 
         @needs_array_function
+        def test_linalg_vecdot(self):
+            ref = (self.q * self.q).sum(-1)
+            res = np.linalg.vecdot(self.q, self.q)
+            assert_array_equal(res, ref)
+
+        @needs_array_function
         def test_linalg_tensordot(self):
             ref = np.tensordot(self.q, self.q)
             res = np.linalg.tensordot(self.q, self.q)
@@ -2378,6 +2398,32 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             ref = np.matmul(self.q, self.q)
             res = np.linalg.matmul(self.q, self.q)
             assert_array_equal(res, ref)
+
+        def test_linalg_matrix_transpose(self):
+            t = np.linalg.matrix_transpose(self.q)
+            assert_array_equal(t, self.q.swapaxes(-2, -1))
+
+        @needs_array_function
+        def test_matrix_norm(self):
+            n = np.linalg.matrix_norm(self.q)
+            expected = np.linalg.norm(self.q.value) << self.q.unit
+            assert_array_equal(n, expected)
+
+        @needs_array_function
+        def test_vector_norm(self):
+            n = np.linalg.vector_norm(self.q)
+            expected = np.linalg.norm(self.q.value.ravel()) << self.q.unit
+            assert_array_equal(n, expected)
+            # Special case: 1-D, ord=0.
+            n1 = np.linalg.vector_norm(self.q[0], ord=0)
+            expected1 = np.linalg.norm(self.q[0].value.ravel(), ord=0) << u.one
+            assert_array_equal(n1, expected1)
+            # Axis combo, just in case
+            n2 = np.linalg.vector_norm(self.q, axis=(-1, -2))
+            expected2 = (
+                np.linalg.vector_norm(self.q.value, axis=(-1, -2)) << self.q.unit
+            )
+            assert_array_equal(n2, expected2)
 
 
 class TestRecFunctions(metaclass=CoverageMeta):

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -149,6 +149,10 @@ IGNORED_FUNCTIONS |= {
     np.einsum, np.einsum_path,
 }  # fmt: skip
 
+if not NUMPY_LT_2_0:
+    # TODO, when also implementing np.dot, etc.; see above.
+    IGNORED_FUNCTIONS |= {np.vecdot}
+
 # Really should do these...
 if NUMPY_LT_2_0:
     from numpy.lib import arraysetops

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -107,6 +107,11 @@ class TestShapeManipulation(BasicTestSetup):
     def test_transpose(self):
         self.check(np.transpose)
 
+    if not NUMPY_LT_2_0:
+
+        def test_matrix_transpose(self):
+            self.check(np.matrix_transpose)
+
     def test_atleast_1d(self):
         self.check(np.atleast_1d)
         o, so = np.atleast_1d(self.mb[0], self.mc[0])


### PR DESCRIPTION
Backport PR #15760 onto v6.0.x