### PR TITLE
Remove `removestar` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,15 +106,6 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/asmeurer/removestar
-    rev: "1.5"
-    hooks:
-      - id: removestar
-        args: ["-iv"]  # in-place changes + verbose output
-        additional_dependencies:
-          - .
-          - sphinx_astropy
-
   - repo: local
     hooks:
       - id: changelogs-rst


### PR DESCRIPTION
### Description

Both [Ruff rule F403](https://docs.astral.sh/ruff/rules/undefined-local-with-import-star/) and [`removestar`](https://github.com/asmeurer/removestar) guard against `import *` statements, but only `removestar` can automatically replace them. However, `removestar` is noticeably slow (see e.g. https://github.com/astropy/astropy/pull/15365#issuecomment-1730258324 or https://github.com/astropy/astropy/issues/15270#issuecomment-1859176849) and in practice attempts to add new `import *` statements are not frequent enough to justify slowing down the pre-commit checks. Ruff will still guard against F403 violations, contributors will just have to fix them manually from now on.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
