### PR TITLE
TST: fix incorrect skipif marker

### DIFF
--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -738,7 +738,9 @@ class FLRWTest(
         """Test :meth:`astropy.cosmology.FLRW.scale_factor`."""
         assert np.allclose(cosmo.scale_factor(z), 1 / (1 + np.array(z)))
 
-    @pytest.mark.skipif(not HAS_PANDAS, reason="requires pandas")
+    @pytest.mark.skipif(
+        not (HAS_PANDAS and HAS_SCIPY), reason="requires pandas and scipy"
+    )
     def test_luminosity_distance_pandas(self, cosmo):
         """Test :meth:`astropy.cosmology.FLRW.luminosity_distance`.
 


### PR DESCRIPTION
### Description
Running all test in my env, where I happen to have pandas installed but not scipy, I discovered that this test wasn't properly skipped despite implicitely requiring scipy.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
