### PR TITLE
ENH: avoid importing optional dependencies just to know if they are installed

### DIFF
--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -41,6 +41,7 @@ _deps["PLT"] = "matplotlib"
 
 __all__ = [f"HAS_{pkg}" for pkg in _deps]
 
+
 def __getattr__(name):
     if name in __all__:
         return find_spec(_deps[name.removeprefix("HAS_")]) is not None

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -37,7 +37,7 @@ _optional_deps = [
 _deps = {k.upper(): k for k in _optional_deps}
 
 # Any subpackages that have different import behavior:
-_deps["PLT"] = "matplotlib.pyplot"
+_deps["PLT"] = "matplotlib"
 
 __all__ = [f"HAS_{pkg}" for pkg in _deps]
 

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -2,7 +2,7 @@
 """Checks for optional dependencies using lazy import from
 `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_.
 """
-import importlib
+from importlib.util import find_spec
 
 # First, the top-level packages:
 # TODO: This list is a duplicate of the dependencies in pyproject.toml "all", but
@@ -41,13 +41,8 @@ _deps["PLT"] = "matplotlib.pyplot"
 
 __all__ = [f"HAS_{pkg}" for pkg in _deps]
 
-
 def __getattr__(name):
     if name in __all__:
-        try:
-            importlib.import_module(_deps[name[4:]])
-        except (ImportError, ModuleNotFoundError):
-            return False
-        return True
+        return find_spec(_deps[name.removeprefix("HAS_")]) is not None
 
     raise AttributeError(f"Module {__name__!r} has no attribute {name!r}.")


### PR DESCRIPTION
### Description
Inspired by https://github.com/astropy/astropy/issues/13821#issuecomment-1861228534
I noticed that we could define `HAS_<optional_dep>` constant more lazily without breaking tests, though maybe this isn't desired in the overall context of #13821 ?

I bet @mhvk has opinions here.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
