### PR TITLE
DEPR: deprecate importing ErfaError and ErfaWarning from astropy.utils.exceptions

### DIFF
--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -5,11 +5,6 @@ astropy. Exceptions that are specific to a given subpackage should *not* be
 here, but rather in the particular subpackage.
 """
 
-# TODO: deprecate these.  This cannot be trivially done with
-# astropy.utils.decorators.deprecate, since that module needs the exceptions
-# here, leading to circular import problems.
-from erfa import ErfaError, ErfaWarning  # noqa: F401
-
 __all__ = [
     "AstropyWarning",
     "AstropyUserWarning",
@@ -78,3 +73,22 @@ class _NoValue:
 
 
 NoValue = _NoValue()
+
+
+def __getattr__(name: str):
+    if name in ("ErfaError", "ErfaWarning"):
+        import warnings
+
+        warnings.warn(
+            f"Importing {name} from astropy.utils.exceptions was deprecated "
+            "in version 6.1 and will stop working in a future version. "
+            f"Instead, please use\nfrom erfa import {name}\n\n",
+            category=AstropyDeprecationWarning,
+            stacklevel=1,
+        )
+
+        import erfa
+
+        return getattr(erfa, name)
+
+    raise AttributeError(f"Module {__name__!r} has no attribute {name!r}.")

--- a/docs/changes/utils/15777.api.rst
+++ b/docs/changes/utils/15777.api.rst
@@ -1,0 +1,2 @@
+Deprecate importing ``ErfaError`` and ``ErfaWarning`` from ``astropy.utils.exceptions``.
+They should be imported directly from ``erfa`` instead.


### PR DESCRIPTION
### Description
Follow up to #10329, and in response to https://github.com/astropy/astropy/issues/13821#issuecomment-1859631785

This feels a bit too easy, so perhaps I'm missing something ? I'm considering that maybe it wasn't done 3 years ago because [PEP 562](https://peps.python.org/pep-0562/) wasn't usable yet. This reasoning seems plausible since #10329 went into astropy 4.1, which was the last version to support Python 3.6 (PEP 562 landed in 3.7)

ping @mhvk 


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
