### PR TITLE
Add continuous CI benchmarking using astropy-benchmarks

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -1,0 +1,97 @@
+### Inspired from https://github.com/scikit-image/scikit-image/blob/main/.github/workflows/benchmarks.yml
+
+name: Benchmark
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    if: github.repository == 'astropy/astropy' && contains(github.event.pull_request.labels.*.name, 'benchmark')
+    name: "Compare asv with astropy main"
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_BASEDIR: "${{ github.workspace }}"
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_MAXSIZE: 400M
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.11"
+
+      - name: Setup some dependencies
+        shell: bash -l {0}
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y ccache
+          # Make gcc/gxx symlinks first in path
+          sudo /usr/sbin/update-ccache-symlinks
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+      - name: "Prepare ccache"
+        id: prepare-ccache
+        shell: bash -l {0}
+        run: |
+          echo "key=benchmark-$RUNNER_OS" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+          ccache -p
+          ccache -z
+
+      - name: "Restore ccache"
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-${{ secrets.CACHE_VERSION }}-${{ steps.prepare-ccache.outputs.key }}-${{ steps.prepare-ccache.outputs.timestamp }}
+          restore-keys: |
+            ccache-${{ secrets.CACHE_VERSION }}-${{ steps.prepare-ccache.outputs.key }}-
+
+      - name: Run benchmarks
+        shell: bash -l {0}
+        id: benchmark
+        env:
+          OPENBLAS_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OMP_NUM_THREADS: 1
+          ASV_FACTOR: 1.3
+          ASV_SKIP_SLOW: 1
+        run: |
+          set -x
+          python -m pip install asv virtualenv packaging
+
+          git clone -b main https://github.com/astropy/astropy-benchmarks.git --single-branch
+
+          # ID this runner
+          python -m asv machine --yes --conf asv.ci.conf.json
+
+          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
+          echo "Contender: ${GITHUB_SHA} (${{ github.event.pull_request.head.label }})"
+
+          # Run benchmarks for current commit against base
+          ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR --conf asv.ci.conf.json"
+          python -m asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
+              | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
+              | tee benchmarks.log
+
+      - name: "Check ccache performance"
+        shell: bash -l {0}
+        run: ccache -s
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: asv-benchmark-results
+          path: benchmarks.log

--- a/asv.ci.conf.json
+++ b/asv.ci.conf.json
@@ -1,0 +1,21 @@
+ {
+   "version": 1,
+   "project": "astropy",
+   "project_url": "http://www.astropy.org/",
+   "repo": ".",
+   "build_command": [
+     "python -m build --wheel -o {build_cache_dir} {build_dir}"
+   ],
+   "branches": ["main"],
+   "show_commit_url": "http://github.com/astropy/astropy/commit/",
+   "pythons": ["3.11"],
+   "matrix": {
+     "Cython": [],
+     "build": [],
+     "packaging": [],
+     "scipy": [],
+     "matplotlib": []
+   },
+   "environment_type": "virtualenv",
+   "benchmark_dir": "astropy-benchmarks/benchmarks"
+ }


### PR DESCRIPTION
~This PR moves astropy benchmarks from https://github.com/astropy/astropy-benchmarks to this repo~. This closes https://github.com/astropy/astropy/issues/12767 and https://github.com/astropy/astropy-benchmarks/issues/102. This also implements https://github.com/astropy/astropy-benchmarks/issues/106 (taken from scikit-image).

~Keeping this as draft for now to debug the CI (sorry for the notification noise 😅 )~

This PR implements a github action that will run a comparative ASV benchmark run between the head commit of the PR and the main branch when a maintainer of astropy labels the PR with something like `benchmark`. These benchmarks tests are running on shared infrastructure of github actions so it won't be the most precise ones but they *should* be enough to capture a regression/speed up that significantly affects astropy (it may pop up some false positives too).

If there is a significant performance change it will be "fail" the benchmark action and also upload the result log file to the action artefacts.

Anyone with triage permission on astropy should be able to test this PR by creating and adding `benchmark` label. The name is just a suggestion feel free to change it :)

