### PR TITLE
Add missing dunder __all__ to star-imported modules

### DIFF
--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -40,6 +40,8 @@ from .settings import (
     DITHER_SEED_CLOCK,
 )
 
+__all__ = ["COMPRESSION_ENABLED", "CompImageHDU"]
+
 # This global variable is used e.g., when calling fits.open with
 # disable_image_compression which temporarily changes the global variable to
 # False. This should ideally be refactored to avoid relying on global module

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -11,6 +11,7 @@ from astropy.utils.shapes import simplify_basic_index
 
 __all__ = ["CompImageSection"]
 
+
 class CompImageSection:
     """
     Class enabling subsets of CompImageHDU data to be loaded lazily via slicing.

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -9,6 +9,7 @@ from astropy.io.fits.hdu.compressed._tiled_compression import (
 from astropy.io.fits.hdu.compressed.utils import _data_shape, _n_tiles, _tile_shape
 from astropy.utils.shapes import simplify_basic_index
 
+__all__ = ["CompImageSection"]
 
 class CompImageSection:
     """

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+__all__ = ["quantity_support"]
 __doctest_skip__ = ["quantity_support"]
 
 

--- a/docs/changes/15781.other.rst
+++ b/docs/changes/15781.other.rst
@@ -1,5 +1,0 @@
-Add missing ``__all__`` lists to star-imported modules
-Removes unintended exports from
-- ``astropy.io.fits.hdu.compressed`` (many unintended exports)
-- ``astropy.visualization`` (NumPy exported as ``np``)
-May break imports in rare cases that relied on these unintended exports.

--- a/docs/changes/15781.other.rst
+++ b/docs/changes/15781.other.rst
@@ -1,0 +1,5 @@
+Add missing ``__all__`` lists to star-imported modules
+Removes unintended exports from
+- ``astropy.io.fits.hdu.compressed`` (many unintended exports)
+- ``astropy.visualization`` (NumPy exported as ``np``)
+May break imports in rare cases that relied on these unintended exports.

--- a/docs/changes/io.fits/15781.api.rst
+++ b/docs/changes/io.fits/15781.api.rst
@@ -5,4 +5,4 @@ are now only available at the qualified names
 and ``astropy.io.fits.hdu.compressed._tiled_compression.decompress_image_data_section``.
 The rest of the removed exports are external modules or properly exported
 elsewhere in astropy. May break imports in rare cases that relied
-on these exports. 
+on these exports.

--- a/docs/changes/io.fits/15781.api.rst
+++ b/docs/changes/io.fits/15781.api.rst
@@ -1,27 +1,8 @@
-Add ``__all__`` lists to `~astropy.io.fits.hdu.compressed` submodules
-Removes the following unintended exports from `~astropy.io.fits.hdu.compressed`:
-- ``compress_image_data``
-- ``decompress_image_data_section``
-- ``lazyproperty``
-- ``ctypes``
-- ``DTYPE2BITPIX``
-- ``math``
-- ``BinTableHDU``
-- ``DELAYED``
-- ``BITPIX2DTYPE``
-- ``deprecated_renamed_argument``
-- ``np``
-- ``time``
-- ``FITS_rec``
-- ``ExtensionHDU``
-- ``conf``
-- ``simplify_basic_index``
-- ``suppress``
-- ``ImageHDU``
-May break imports in rare cases that relied on these unintended exports. The
-low-level functions ``compress_image_data`` and ``decompress_image_data_section``
+Remove many unintended exports from ``astropy.io.fits.hdu.compressed``.
+The low-level functions ``compress_image_data`` and ``decompress_image_data_section``
 are now only available at the qualified names
-`~astropy.io.fits.hdu.compressed._tiled_compression.compress_image_data`
-and `~astropy.io.fits.hdu.compressed._tiled_compression.decompress_image_data_section`.
+``astropy.io.fits.hdu.compressed._tiled_compression.compress_image_data``
+and ``astropy.io.fits.hdu.compressed._tiled_compression.decompress_image_data_section``.
 The rest of the removed exports are external modules or properly exported
-elsewhere in astropy.
+elsewhere in astropy. May break imports in rare cases that relied
+on these exports. 

--- a/docs/changes/io.fits/15781.api.rst
+++ b/docs/changes/io.fits/15781.api.rst
@@ -1,0 +1,27 @@
+Add ``__all__`` lists to `~astropy.io.fits.hdu.compressed` submodules
+Removes the following unintended exports from `~astropy.io.fits.hdu.compressed`:
+- ``compress_image_data``
+- ``decompress_image_data_section``
+- ``lazyproperty``
+- ``ctypes``
+- ``DTYPE2BITPIX``
+- ``math``
+- ``BinTableHDU``
+- ``DELAYED``
+- ``BITPIX2DTYPE``
+- ``deprecated_renamed_argument``
+- ``np``
+- ``time``
+- ``FITS_rec``
+- ``ExtensionHDU``
+- ``conf``
+- ``simplify_basic_index``
+- ``suppress``
+- ``ImageHDU``
+May break imports in rare cases that relied on these unintended exports. The
+low-level functions ``compress_image_data`` and ``decompress_image_data_section``
+are now only available at the qualified names
+`~astropy.io.fits.hdu.compressed._tiled_compression.compress_image_data`
+and `~astropy.io.fits.hdu.compressed._tiled_compression.decompress_image_data_section`.
+The rest of the removed exports are external modules or properly exported
+elsewhere in astropy.

--- a/docs/changes/visualization/15781.api.rst
+++ b/docs/changes/visualization/15781.api.rst
@@ -1,2 +1,1 @@
-Add ``__all__`` list to `~astropy.visualization.units` submodule
-Removes the unintended NumPy export at ``astropy.visualization.np``.
+Removes the unintended NumPy export previously at ``astropy.visualization.np``.

--- a/docs/changes/visualization/15781.api.rst
+++ b/docs/changes/visualization/15781.api.rst
@@ -1,0 +1,2 @@
+Add ``__all__`` list to `~astropy.visualization.units` submodule
+Removes the unintended NumPy export at ``astropy.visualization.np``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a couple of modules (`astropy.io.fits.hdu.compressed` and `astropy.visualization`) that currently have unintended exports because of star-imported modules without `__all__` defined.

Removes the following exports from `astropy.visualization`: `{'np'}`
Removes the following exports from `astropy.io.fits.hdu.compressed`: `{'lazyproperty', 'compress_image_data', 'ctypes', 'DTYPE2BITPIX', 'math', 'BinTableHDU', 'DELAYED', 'BITPIX2DTYPE', 'deprecated_renamed_argument', 'np', 'time', 'FITS_rec', 'ExtensionHDU', 'conf', 'simplify_basic_index', 'suppress', 'decompress_image_data_section', 'ImageHDU'}`

Represents a breaking change, though I hope no one is accessing NumPy as `astropy.visualization.np` or ctypes as `astropy.io.fits.hdu.compressed.ctypes`. Apart from external modules or names exported correctly at a different location, this makes `compress_image_data` and `decompress_image_data_section` "private". I don't think they're supposed to be accessible on `astropy.io.fits.hdu.compressed` since they're defined in `_tiled_compression.py`, but pinging @astrofrog to check.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
