### PR TITLE
Backport PR #15785 on branch v6.0.x (Update ufunc/linalg helpers to match numpy dev)

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -511,8 +511,9 @@ for ufunc in twoarg_invtrig_ufuncs:
 
 # ufuncs handled as special cases
 UFUNC_HELPERS[np.multiply] = helper_multiplication
-if isinstance(getattr(np, "matmul", None), np.ufunc):
-    UFUNC_HELPERS[np.matmul] = helper_multiplication
+UFUNC_HELPERS[np.matmul] = helper_multiplication
+if isinstance(getattr(np, "vecdot", None), np.ufunc):
+    UFUNC_HELPERS[np.vecdot] = helper_multiplication
 UFUNC_HELPERS[np.divide] = helper_division
 UFUNC_HELPERS[np.true_divide] = helper_division
 UFUNC_HELPERS[np.power] = helper_power

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1127,15 +1127,6 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
         o = np.vdot(q1, q2)
         assert o == (32.0 + 0j) * u.m / u.s
 
-    if not NUMPY_LT_2_0:
-
-        @needs_array_function
-        def test_vecdot(self):
-            q1 = np.array([1j, 2j, 3j]) * u.m
-            q2 = np.array([4j, 5j, 6j]) / u.s
-            o = np.vecdot(q1, q2)
-            assert o == (32.0 + 0j) * u.m / u.s
-
     @needs_array_function
     def test_tensordot(self):
         # From the docstring example
@@ -2206,6 +2197,9 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             np.linalg.pinv(self.q.value, rcond.to_value(self.q.unit)) / self.q.unit
         )
         assert_array_equal(pinv2, expected2)
+        if not NUMPY_LT_2_0:
+            pinv3 = np.linalg.pinv(self.q, rtol=rcond)
+            assert_array_equal(pinv3, expected2)
 
     @needs_array_function
     def test_tensorinv(self):
@@ -2381,7 +2375,7 @@ class TestLinAlg(InvariantUnitTestSetup, metaclass=CoverageMeta):
             assert_allclose(res, ref, rtol=5e-16)
 
         @needs_array_function
-        def test_linalg_vecdot(self):
+        def test_vecdot(self):
             ref = (self.q * self.q).sum(-1)
             res = np.linalg.vecdot(self.q, self.q)
             assert_array_equal(res, ref)

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -337,10 +337,6 @@ class TestQuantityMathFuncs:
             == np.arange(0, 6.0, 2.0) * u.m / u.s
         )
 
-    @pytest.mark.skipif(
-        not isinstance(getattr(np, "matmul", None), np.ufunc),
-        reason="np.matmul is not yet a gufunc",
-    )
     def test_matmul(self):
         q = np.arange(3.0) * u.m
         r = np.matmul(q, q)
@@ -360,6 +356,13 @@ class TestQuantityMathFuncs:
         ) / u.s  # fmt: skip
         r2 = np.matmul(q1, q2)
         assert np.all(r2 == np.matmul(q1.value, q2.value) * q1.unit * q2.unit)
+
+    @pytest.mark.skipif(NUMPY_LT_2_0, reason="vecdot only added in numpy 2.0")
+    def test_vecdot(self):
+        q1 = np.array([1j, 2j, 3j]) * u.m
+        q2 = np.array([4j, 5j, 6j]) / u.s
+        o = np.vecdot(q1, q2)
+        assert o == (32.0 + 0j) * u.m / u.s
 
     @pytest.mark.parametrize("function", (np.divide, np.true_divide))
     def test_divide_scalar(self, function):

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -149,10 +149,6 @@ IGNORED_FUNCTIONS |= {
     np.einsum, np.einsum_path,
 }  # fmt: skip
 
-if not NUMPY_LT_2_0:
-    # TODO, when also implementing np.dot, etc.; see above.
-    IGNORED_FUNCTIONS |= {np.vecdot}
-
 # Really should do these...
 if NUMPY_LT_2_0:
     from numpy.lib import arraysetops


### PR DESCRIPTION
np.vecdot is now a gufunc, np.linalg.pinv and np.linalg.cholesky got additional arguments.