### PR TITLE
Make the `pre-commit.ci` job guard against large added files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,12 @@ repos:
     rev: v4.5.0
     hooks:
       - id: check-added-large-files
+        args: ["--enforce-all", "--maxkb=300"]
+        exclude: "^(\
+            cextern/wcslib/C/flexed/.*|\
+            CHANGES.rst|\
+            astropy/extern/jquery/data/js/jquery.dataTables.js|\
+        )$"
         # Prevent giant files from being committed.
       - id: check-case-conflict
         # Check for files with names that would conflict on a case-insensitive


### PR DESCRIPTION
### Description

Currently the `check-added-large-files` hook only checks staged files. When pushing changes to GitHub the commit has already been made, so nothing is staged, which in turn means that the hook does not check anything as a part of the `pre-commit.ci` job. This makes it possible for contributors who have not installed `pre-commit` locally to add large files to the repository without the CI jobs noticing (see e.g. c8cc533b8bee516dfceaea8bf2d208cf2bbdf975 in #15787). With the new configuration the hook still only checks staged files when run normally as a part of the commit procces, but does check all files when called with the `--all-files` option,  including in our `pre-commit.ci` job.

Furthermore, the maximum allowed file size is lowered from the default 500 KB to 300 KB. Explicitly configuring the limit instead of using the default clearly documents the value in the hook configuration. A few existing files would not be allowed by the hook, out of which all but 2 are in the same directory, so the hook exclusions have been configured accordingly.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
