### PR TITLE
Add mypy configuration file that ignores existing errors on a per-file and per-error basis

### DIFF
--- a/docs/changes/15794.other.rst
+++ b/docs/changes/15794.other.rst
@@ -1,0 +1,2 @@
+Added a mypy configuration file that ignores existing typing errors on
+a per-file and per-error basis.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,1070 @@
+[mypy]
+python_version = 3.9
+pretty = false
+exclude = (?x)(
+          docs|
+          examples
+          )
+
+enable_error_code = ignore-without-code
+
+# We can get to passing mypy's strict mode by incrementally changing the
+# following global settings to true. This comes from mypy's documentation.
+
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+check_untyped_defs = false
+disallow_subclassing_any = false
+disallow_untyped_decorators = false
+disallow_any_generics = false
+disallow_untyped_calls = false
+disallow_incomplete_defs = false
+disallow_untyped_defs = false
+no_implicit_reexport = false
+warn_return_any = false
+extra_checks = false
+
+# The following sections specify configuration settings specific to
+# different subpackages and modules.
+
+# The disable_error_code configuration variable specifies that certain
+# typing errors should not be reported for specific modules. As we
+# gradually make Astropy consistent with mypy's strict mode, we can
+# remove the disabled error codes file-by-file.
+
+[mypy-astropy._dev.scm_version]
+disable_error_code = import-not-found
+
+[mypy-astropy.config.configuration]
+disable_error_code = var-annotated
+
+[mypy-astropy.config.paths]
+disable_error_code = assignment
+
+[mypy-astropy.config.tests.test_configs]
+disable_error_code = var-annotated
+
+[mypy-astropy.conftest]
+disable_error_code = arg-type,import-not-found
+
+[mypy-astropy.constants.codata2010]
+disable_error_code = var-annotated
+
+[mypy-astropy.constants.codata2014]
+disable_error_code = var-annotated
+
+[mypy-astropy.constants.codata2018]
+disable_error_code = var-annotated
+
+[mypy-astropy.constants.constant]
+disable_error_code = assignment,var-annotated
+
+[mypy-astropy.constants.iau2012]
+disable_error_code = var-annotated
+
+[mypy-astropy.constants.iau2015]
+disable_error_code = var-annotated
+
+[mypy-astropy.constants.tests.test_pickle]
+disable_error_code = attr-defined
+
+[mypy-astropy.constants.utils]
+disable_error_code = var-annotated
+
+[mypy-astropy.convolution.convolve]
+disable_error_code = import-untyped
+
+[mypy-astropy.convolution.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.convolution.tests.test_convolve]
+disable_error_code = import-untyped
+
+[mypy-astropy.convolution.tests.test_convolve_kernels]
+disable_error_code = arg-type
+
+[mypy-astropy.convolution.tests.test_convolve_models]
+disable_error_code = import-untyped
+
+[mypy-astropy.convolution.tests.test_kernel_class]
+disable_error_code = import-untyped
+
+[mypy-astropy.convolution.utils]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.angles.angle_lextab]
+disable_error_code = var-annotated
+
+[mypy-astropy.coordinates.angles.angle_parsetab]
+disable_error_code = var-annotated
+
+[mypy-astropy.coordinates.angles.core]
+disable_error_code = has-type
+
+[mypy-astropy.coordinates.baseframe]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.coordinates.builtin_frames.altaz]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.baseradec]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.cirs_observed_transforms]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.builtin_frames.ecliptic]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.ecliptic_transforms]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.builtin_frames.equatorial]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.galactic]
+disable_error_code = assignment,attr-defined
+
+[mypy-astropy.coordinates.builtin_frames.galactocentric]
+disable_error_code = assignment,attr-defined,return-value,var-annotated
+
+[mypy-astropy.coordinates.builtin_frames.hadec]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.icrs_observed_transforms]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.builtin_frames.intermediate_rotation_transforms]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.builtin_frames.itrs]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.itrs_observed_transforms]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.builtin_frames.lsr]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.skyoffset]
+disable_error_code = var-annotated
+
+[mypy-astropy.coordinates.builtin_frames.supergalactic]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.builtin_frames.utils]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.calculation]
+disable_error_code = import-untyped,var-annotated
+
+[mypy-astropy.coordinates.earth]
+disable_error_code = assignment
+
+[mypy-astropy.coordinates.earth_orientation]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.erfa_astrom]
+disable_error_code = import-untyped,var-annotated
+
+[mypy-astropy.coordinates.funcs]
+disable_error_code = attr-defined,import-untyped,var-annotated
+
+[mypy-astropy.coordinates.matching]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.coordinates.polarization]
+disable_error_code = arg-type,assignment,misc
+
+[mypy-astropy.coordinates.representation.base]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.coordinates.representation.cartesian]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.representation.geodetic]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.representation.spherical]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.sky_coordinate]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.coordinates.solar_system]
+disable_error_code = attr-defined,import-not-found,import-untyped
+
+[mypy-astropy.coordinates.spectral_coordinate]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.spectral_quantity]
+disable_error_code = assignment,attr-defined
+
+[mypy-astropy.coordinates.tests.accuracy.generate_ref_ast]
+disable_error_code = import-not-found
+
+[mypy-astropy.coordinates.tests.accuracy.generate_spectralcoord_ref]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.accuracy.test_altaz_icrs]
+disable_error_code = attr-defined,import-not-found
+
+[mypy-astropy.coordinates.tests.accuracy.test_ecliptic]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.accuracy.test_fk4_no_e_fk4]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.accuracy.test_fk4_no_e_fk5]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.accuracy.test_galactic_fk4]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.accuracy.test_icrs_fk5]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_angle_generators]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_angles]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_angular_separation]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_arrays]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_atc_replacements]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.tests.test_distance]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_earth]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_formatting]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_iau_fullstack]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.coordinates.tests.test_icrs_observed_transformations]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_intermediate_transformations]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.coordinates.tests.test_name_resolve]
+disable_error_code = import-not-found
+
+[mypy-astropy.coordinates.tests.test_pickle]
+disable_error_code = assignment,attr-defined
+
+[mypy-astropy.coordinates.tests.test_regression]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.coordinates.tests.test_representation]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_representation_arithmetic]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_representation_methods]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_shape_manipulation]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_sites]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_sky_coord]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.coordinates.tests.test_skyoffset_transformations]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_solar_system]
+disable_error_code = attr-defined,import-not-found
+
+[mypy-astropy.coordinates.tests.test_spectral_coordinate]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_unit_representation]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.tests.test_utils]
+disable_error_code = import-untyped
+
+[mypy-astropy.coordinates.tests.test_velocity_corrs]
+disable_error_code = attr-defined
+
+[mypy-astropy.coordinates.transformations]
+disable_error_code = import-not-found,index
+
+[mypy-astropy.cosmology._io.cosmology]
+disable_error_code = var-annotated
+
+[mypy-astropy.cosmology._io.mapping]
+disable_error_code = var-annotated
+
+[mypy-astropy.cosmology._io.model]
+disable_error_code = var-annotated
+
+[mypy-astropy.cosmology._io.yaml]
+disable_error_code = var-annotated
+
+[mypy-astropy.cosmology._utils]
+disable_error_code = var-annotated
+
+[mypy-astropy.cosmology.core]
+disable_error_code = arg-type,attr-defined,call-arg,misc,operator,type-var,var-annotated
+
+[mypy-astropy.cosmology.flrw.base]
+disable_error_code = attr-defined,import-untyped,no-redef,override,type-var
+
+[mypy-astropy.cosmology.flrw.lambdacdm]
+disable_error_code = attr-defined,import-untyped,misc
+
+[mypy-astropy.cosmology.flrw.tests.conftest]
+disable_error_code = type-arg
+
+[mypy-astropy.cosmology.flrw.tests.test_lambdacdm]
+disable_error_code = import-untyped,misc
+
+[mypy-astropy.cosmology.flrw.tests.test_w0cdm]
+disable_error_code = misc
+
+[mypy-astropy.cosmology.flrw.tests.test_w0wacdm]
+disable_error_code = misc
+
+[mypy-astropy.cosmology.flrw.tests.test_w0wzcdm]
+disable_error_code = misc
+
+[mypy-astropy.cosmology.flrw.tests.test_wpwazpcdm]
+disable_error_code = misc
+
+[mypy-astropy.cosmology.flrw.w0cdm]
+disable_error_code = attr-defined
+
+[mypy-astropy.cosmology.flrw.w0wacdm]
+disable_error_code = attr-defined
+
+[mypy-astropy.cosmology.flrw.w0wzcdm]
+disable_error_code = attr-defined
+
+[mypy-astropy.cosmology.flrw.wpwazpcdm]
+disable_error_code = attr-defined
+
+[mypy-astropy.cosmology.funcs.comparison]
+disable_error_code = assignment,attr-defined,var-annotated
+
+[mypy-astropy.cosmology.funcs.optimize]
+disable_error_code = import-untyped
+
+[mypy-astropy.cosmology.parameter._converter]
+disable_error_code = var-annotated
+
+[mypy-astropy.cosmology.parameter._core]
+disable_error_code = arg-type,attr-defined
+
+[mypy-astropy.cosmology.parameter._descriptors]
+disable_error_code = arg-type,var-annotated
+
+[mypy-astropy.cosmology.tests.test_units]
+disable_error_code = index
+
+[mypy-astropy.cosmology.utils]
+disable_error_code = var-annotated
+
+[mypy-astropy.extern._strptime]
+disable_error_code = import-not-found,no-redef,var-annotated
+
+[mypy-astropy.extern.configobj.configobj]
+disable_error_code = import-not-found
+
+[mypy-astropy.extern.configobj.validate]
+disable_error_code = truthy-function
+
+[mypy-astropy.extern.ply.cpp]
+disable_error_code = assignment,import-not-found,name-defined
+
+[mypy-astropy.extern.ply.lex]
+disable_error_code = attr-defined
+
+[mypy-astropy.extern.ply.yacc]
+disable_error_code = import-not-found
+
+[mypy-astropy.io.ascii.basic]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.cds]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.connect]
+disable_error_code = var-annotated
+
+[mypy-astropy.io.ascii.core]
+disable_error_code = assignment,var-annotated
+
+[mypy-astropy.io.ascii.daophot]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.ecsv]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.fastbasic]
+disable_error_code = attr-defined
+
+[mypy-astropy.io.ascii.fixedwidth]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.html]
+disable_error_code = assignment,import-untyped
+
+[mypy-astropy.io.ascii.ipac]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.latex]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.mrt]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.qdp]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.rst]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.ascii.sextractor]
+disable_error_code = assignment
+
+[mypy-astropy.io.ascii.tests.test_ecsv]
+disable_error_code = assignment,import-untyped
+
+[mypy-astropy.io.ascii.tests.test_html]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.ascii.tests.test_read]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.ascii.ui]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.io.fits.column]
+disable_error_code = assignment
+
+[mypy-astropy.io.fits.connect]
+disable_error_code = attr-defined
+
+[mypy-astropy.io.fits.convenience]
+disable_error_code = has-type
+
+[mypy-astropy.io.fits.file]
+disable_error_code = call-arg,operator
+
+[mypy-astropy.io.fits.hdu.base]
+disable_error_code = misc,var-annotated
+
+[mypy-astropy.io.fits.hdu.compressed._codecs]
+disable_error_code = import-not-found,import-untyped,no-redef
+
+[mypy-astropy.io.fits.hdu.compressed._quantization]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.fits.hdu.compressed.compressed]
+disable_error_code = no-redef
+
+[mypy-astropy.io.fits.hdu.compressed.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.fits.hdu.compressed.tests.test_fitsio]
+disable_error_code = import-not-found
+
+[mypy-astropy.io.fits.hdu.compressed.tests.test_tiled_compression]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.fits.hdu.groups]
+disable_error_code = assignment
+
+[mypy-astropy.io.fits.hdu.image]
+disable_error_code = import-not-found,no-redef
+
+[mypy-astropy.io.fits.hdu.table]
+disable_error_code = arg-type,assignment,no-redef
+
+[mypy-astropy.io.fits.header]
+disable_error_code = has-type,import-untyped
+
+[mypy-astropy.io.fits.tests.test_connect]
+disable_error_code = attr-defined
+
+[mypy-astropy.io.fits.tests.test_fsspec]
+disable_error_code = import-not-found
+
+[mypy-astropy.io.fits.tests.test_table]
+disable_error_code = import-not-found
+
+[mypy-astropy.io.fits.tests.test_util]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.fits.util]
+disable_error_code = import-not-found
+
+[mypy-astropy.io.misc.hdf5]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.misc.pandas.connect]
+disable_error_code = attr-defined,operator
+
+[mypy-astropy.io.misc.parquet]
+disable_error_code = import-not-found,var-annotated
+
+[mypy-astropy.io.misc.tests.test_hdf5]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.misc.tests.test_pandas]
+disable_error_code = operator
+
+[mypy-astropy.io.misc.tests.test_parquet]
+disable_error_code = attr-defined,operator
+
+[mypy-astropy.io.misc.tests.test_yaml]
+disable_error_code = attr-defined,operator
+
+[mypy-astropy.io.misc.yaml]
+disable_error_code = assignment,attr-defined,import-untyped
+
+[mypy-astropy.io.registry.tests.test_registries]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.io.tests.mixin_columns]
+disable_error_code = attr-defined,operator
+
+[mypy-astropy.io.votable.connect]
+disable_error_code = attr-defined
+
+[mypy-astropy.io.votable.converters]
+disable_error_code = assignment
+
+[mypy-astropy.io.votable.exceptions]
+disable_error_code = assignment
+
+[mypy-astropy.io.votable.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.io.votable.tree]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.logger]
+disable_error_code = misc,valid-type
+
+[mypy-astropy.modeling.bounding_box]
+disable_error_code = arg-type,assignment,comparison-overlap,return,var-annotated
+
+[mypy-astropy.modeling.convolution]
+disable_error_code = import-untyped
+
+[mypy-astropy.modeling.core]
+disable_error_code = arg-type,assignment,attr-defined,misc,no-redef
+
+[mypy-astropy.modeling.fitting]
+disable_error_code = import-untyped,var-annotated
+
+[mypy-astropy.modeling.functional_models]
+disable_error_code = import-untyped,misc
+
+[mypy-astropy.modeling.mappings]
+disable_error_code = misc
+
+[mypy-astropy.modeling.math_functions]
+disable_error_code = misc
+
+[mypy-astropy.modeling.optimizers]
+disable_error_code = import-untyped,var-annotated
+
+[mypy-astropy.modeling.physical_models]
+disable_error_code = assignment
+
+[mypy-astropy.modeling.polynomial]
+disable_error_code = assignment,misc
+
+[mypy-astropy.modeling.projections]
+disable_error_code = assignment,misc
+
+[mypy-astropy.modeling.rotations]
+disable_error_code = assignment,misc
+
+[mypy-astropy.modeling.spline]
+disable_error_code = assignment,import-untyped,var-annotated
+
+[mypy-astropy.modeling.tabular]
+disable_error_code = import-untyped,misc
+
+[mypy-astropy.modeling.tests.test_compound]
+disable_error_code = operator
+
+[mypy-astropy.modeling.tests.test_constraints]
+disable_error_code = import-untyped
+
+[mypy-astropy.modeling.tests.test_core]
+disable_error_code = misc
+
+[mypy-astropy.modeling.tests.test_fitters]
+disable_error_code = import-untyped,operator
+
+[mypy-astropy.modeling.tests.test_functional_models]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.modeling.tests.test_input]
+disable_error_code = attr-defined,operator
+
+[mypy-astropy.modeling.tests.test_models]
+disable_error_code = assignment,index
+
+[mypy-astropy.modeling.tests.test_parameters]
+disable_error_code = misc
+
+[mypy-astropy.modeling.tests.test_pickle]
+disable_error_code = attr-defined
+
+[mypy-astropy.modeling.tests.test_quantities_evaluation]
+disable_error_code = attr-defined
+
+[mypy-astropy.modeling.tests.test_quantities_fitting]
+disable_error_code = operator
+
+[mypy-astropy.modeling.tests.test_quantities_model]
+disable_error_code = attr-defined
+
+[mypy-astropy.modeling.tests.test_quantities_parameters]
+disable_error_code = attr-defined
+
+[mypy-astropy.modeling.tests.test_separable]
+disable_error_code = operator
+
+[mypy-astropy.modeling.tests.test_spline]
+disable_error_code = import-untyped
+
+[mypy-astropy.nddata.ccddata]
+disable_error_code = attr-defined
+
+[mypy-astropy.nddata.mixins.ndarithmetic]
+disable_error_code = arg-type
+
+[mypy-astropy.nddata.mixins.ndio]
+disable_error_code = arg-type
+
+[mypy-astropy.nddata.nddata]
+disable_error_code = import-not-found
+
+[mypy-astropy.nddata.tests.test_nddata]
+disable_error_code = import-not-found,misc
+
+[mypy-astropy.samp.standard_profile]
+disable_error_code = var-annotated
+
+[mypy-astropy.samp.web_profile]
+disable_error_code = var-annotated
+
+[mypy-astropy.stats.circstats]
+disable_error_code = import-untyped
+
+[mypy-astropy.stats.funcs]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.stats.histogram]
+disable_error_code = import-untyped
+
+[mypy-astropy.stats.jackknife]
+disable_error_code = import-untyped
+
+[mypy-astropy.stats.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.stats.sigma_clipping]
+disable_error_code = attr-defined,import-not-found,import-untyped
+
+[mypy-astropy.stats.tests.test_circstats]
+disable_error_code = import-untyped
+
+[mypy-astropy.stats.tests.test_funcs]
+disable_error_code = import-untyped
+
+[mypy-astropy.stats.tests.test_sigma_clipping]
+disable_error_code = import-untyped
+
+[mypy-astropy.table]
+disable_error_code = attr-defined,import-not-found
+
+[mypy-astropy.table.bst]
+disable_error_code = attr-defined
+
+[mypy-astropy.table.column]
+disable_error_code = assignment,import-untyped,misc
+
+[mypy-astropy.table.index]
+disable_error_code = var-annotated
+
+[mypy-astropy.table.jsviewer]
+disable_error_code = attr-defined
+
+[mypy-astropy.table.meta]
+disable_error_code = import-untyped
+
+[mypy-astropy.table.mixins.dask]
+disable_error_code = import-not-found
+
+[mypy-astropy.table.ndarray_mixin]
+disable_error_code = assignment
+
+[mypy-astropy.table.operations]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.table.pprint]
+disable_error_code = var-annotated
+
+[mypy-astropy.table.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.table.soco]
+disable_error_code = assignment,import-untyped
+
+[mypy-astropy.table.table]
+disable_error_code = arg-type
+
+[mypy-astropy.table.table_helpers]
+disable_error_code = assignment
+
+[mypy-astropy.table.tests.conftest]
+disable_error_code = attr-defined
+
+[mypy-astropy.table.tests.test_masked]
+disable_error_code = misc
+
+[mypy-astropy.tests.command]
+disable_error_code = import-not-found,import-untyped
+
+[mypy-astropy.tests.runner]
+disable_error_code = import-not-found,import-untyped
+
+[mypy-astropy.tests.test_logger]
+disable_error_code = misc,name-defined
+
+[mypy-astropy.time.core]
+disable_error_code = assignment,import-untyped,no-redef
+
+[mypy-astropy.time.formats]
+disable_error_code = assignment,attr-defined,call-arg,has-type,import-untyped,operator,var-annotated
+
+[mypy-astropy.time.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.time.tests.test_basic]
+disable_error_code = arg-type,import-untyped
+
+[mypy-astropy.time.tests.test_custom_formats]
+disable_error_code = import-untyped
+
+[mypy-astropy.time.tests.test_methods]
+disable_error_code = var-annotated
+
+[mypy-astropy.time.tests.test_precision]
+disable_error_code = arg-type,import-untyped
+
+[mypy-astropy.time.tests.test_sidereal]
+disable_error_code = import-untyped
+
+[mypy-astropy.time.tests.test_update_leap_seconds]
+disable_error_code = import-untyped
+
+[mypy-astropy.time.time_helper.function_helpers]
+disable_error_code = var-annotated
+
+[mypy-astropy.timeseries.binned]
+disable_error_code = assignment
+
+[mypy-astropy.timeseries.io.kepler]
+disable_error_code = attr-defined
+
+[mypy-astropy.timeseries.periodograms.bls.core]
+disable_error_code = assignment
+
+[mypy-astropy.timeseries.periodograms.bls.methods]
+disable_error_code = import-untyped
+
+[mypy-astropy.timeseries.periodograms.bls.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.timeseries.periodograms.lombscargle._statistics]
+disable_error_code = import-untyped
+
+[mypy-astropy.timeseries.periodograms.lombscargle.implementations.main]
+disable_error_code = import-untyped
+
+[mypy-astropy.timeseries.periodograms.lombscargle.implementations.scipy_impl]
+disable_error_code = import-untyped
+
+[mypy-astropy.timeseries.periodograms.lombscargle.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.timeseries.sampled]
+disable_error_code = assignment
+
+[mypy-astropy.uncertainty.core]
+disable_error_code = attr-defined,import-not-found,no-redef,var-annotated
+
+[mypy-astropy.uncertainty.function_helpers]
+disable_error_code = var-annotated
+
+[mypy-astropy.uncertainty.tests.test_containers]
+disable_error_code = attr-defined
+
+[mypy-astropy.uncertainty.tests.test_distribution]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.units.astrophys]
+disable_error_code = attr-defined,name-defined
+
+[mypy-astropy.units.cgs]
+disable_error_code = attr-defined,name-defined
+
+[mypy-astropy.units.core]
+disable_error_code = attr-defined
+
+[mypy-astropy.units.format.base]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.cds]
+disable_error_code = call-arg,operator
+
+[mypy-astropy.units.format.cds_lextab]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.cds_parsetab]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.generic]
+disable_error_code = call-arg,operator
+
+[mypy-astropy.units.format.generic_lextab]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.generic_parsetab]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.ogip_lextab]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.ogip_parsetab]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.format.vounit]
+disable_error_code = var-annotated
+
+[mypy-astropy.units.function.core]
+disable_error_code = no-redef
+
+[mypy-astropy.units.function.logarithmic]
+disable_error_code = attr-defined,has-type
+
+[mypy-astropy.units.imperial]
+disable_error_code = attr-defined,name-defined
+
+[mypy-astropy.units.misc]
+disable_error_code = attr-defined,name-defined
+
+[mypy-astropy.units.photometric]
+disable_error_code = attr-defined
+
+[mypy-astropy.units.physical]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.units.quantity]
+disable_error_code = assignment,call-arg,var-annotated
+
+[mypy-astropy.units.quantity_helper.erfa]
+disable_error_code = import-untyped
+
+[mypy-astropy.units.quantity_helper.function_helpers]
+disable_error_code = attr-defined,import-not-found,no-redef,var-annotated
+
+[mypy-astropy.units.quantity_helper.helpers]
+disable_error_code = assignment,attr-defined,no-redef
+
+[mypy-astropy.units.quantity_helper.scipy_special]
+disable_error_code = assignment,import-untyped
+
+[mypy-astropy.units.si]
+disable_error_code = attr-defined,name-defined
+
+[mypy-astropy.units.structured]
+disable_error_code = arg-type,index,union-attr
+
+[mypy-astropy.units.tests.test_format]
+disable_error_code = attr-defined,var-annotated
+
+[mypy-astropy.units.tests.test_physical]
+disable_error_code = attr-defined
+
+[mypy-astropy.units.tests.test_quantity_decorator]
+disable_error_code = misc,name-defined
+
+[mypy-astropy.units.tests.test_quantity_erfa_ufuncs]
+disable_error_code = call-overload,import-untyped
+
+[mypy-astropy.units.tests.test_quantity_non_ufuncs]
+disable_error_code = annotation-unchecked,index,var-annotated
+
+[mypy-astropy.units.tests.test_quantity_typing]
+disable_error_code = return-value
+
+[mypy-astropy.units.tests.test_quantity_ufuncs]
+disable_error_code = arg-type,assignment,import-untyped,name-defined,no-redef
+
+[mypy-astropy.units.tests.test_units]
+disable_error_code = attr-defined
+
+[mypy-astropy.utils.collections]
+disable_error_code = misc
+
+[mypy-astropy.utils.console]
+disable_error_code = import-not-found,import-untyped
+
+[mypy-astropy.utils.data]
+disable_error_code = assignment,import-not-found,var-annotated
+
+[mypy-astropy.utils.data_info]
+disable_error_code = var-annotated
+
+[mypy-astropy.utils.exceptions]
+disable_error_code = import-untyped
+
+[mypy-astropy.utils.iers.iers]
+disable_error_code = import-not-found,import-untyped
+
+[mypy-astropy.utils.iers.tests.test_iers]
+disable_error_code = import-not-found
+
+[mypy-astropy.utils.iers.tests.test_leap_second]
+disable_error_code = import-untyped
+
+[mypy-astropy.utils.masked.core]
+disable_error_code = assignment,var-annotated
+
+[mypy-astropy.utils.masked.function_helpers]
+disable_error_code = attr-defined,import-not-found,no-redef,var-annotated
+
+[mypy-astropy.utils.masked.tests.test_function_helpers]
+disable_error_code = var-annotated
+
+[mypy-astropy.utils.masked.tests.test_functions]
+disable_error_code = import-untyped
+
+[mypy-astropy.utils.masked.tests.test_masked]
+disable_error_code = assignment,attr-defined
+
+[mypy-astropy.utils.metadata.merge]
+disable_error_code = var-annotated
+
+[mypy-astropy.utils.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.utils.shapes]
+disable_error_code = attr-defined,has-type,import-not-found,no-redef
+
+[mypy-astropy.utils.tests.test_data]
+disable_error_code = import-not-found
+
+[mypy-astropy.utils.tests.test_introspection]
+disable_error_code = import-untyped
+
+[mypy-astropy.utils.xml.iterparser]
+disable_error_code = attr-defined
+
+[mypy-astropy.utils.xml.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.utils.xml.writer]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.visualization.mpl_normalize]
+disable_error_code = no-redef
+
+[mypy-astropy.visualization.tests.test_stretch]
+disable_error_code = index
+
+[mypy-astropy.visualization.tests.test_time]
+disable_error_code = import-untyped
+
+[mypy-astropy.visualization.tests.test_units]
+disable_error_code = attr-defined
+
+[mypy-astropy.visualization.wcsaxes.core]
+disable_error_code = import-untyped,misc
+
+[mypy-astropy.visualization.wcsaxes.formatter_locator]
+disable_error_code = attr-defined
+
+[mypy-astropy.visualization.wcsaxes.frame]
+disable_error_code = attr-defined
+
+[mypy-astropy.visualization.wcsaxes.grid_paths]
+disable_error_code = attr-defined
+
+[mypy-astropy.visualization.wcsaxes.helpers]
+disable_error_code = import-untyped
+
+[mypy-astropy.visualization.wcsaxes.patches]
+disable_error_code = union-attr
+
+[mypy-astropy.visualization.wcsaxes.tests.test_grid_paths]
+disable_error_code = attr-defined
+
+[mypy-astropy.visualization.wcsaxes.tests.test_utils]
+disable_error_code = attr-defined
+
+[mypy-astropy.visualization.wcsaxes.ticks]
+disable_error_code = attr-defined
+
+[mypy-astropy.wcs.setup_package]
+disable_error_code = import-untyped
+
+[mypy-astropy.wcs.tests.test_utils]
+disable_error_code = attr-defined
+
+[mypy-astropy.wcs.utils]
+disable_error_code = attr-defined,import-untyped
+
+[mypy-astropy.wcs.wcs]
+disable_error_code = misc,valid-type
+
+[mypy-astropy.wcs.wcsapi.fitswcs]
+disable_error_code = assignment,attr-defined,var-annotated
+
+[mypy-astropy.wcs.wcsapi.tests.test_fitswcs]
+disable_error_code = arg-type,import-untyped
+
+[mypy-conftest]
+disable_error_code = import-not-found
+
+[mypy-examples.coordinates.plot_sgr-coordinate-frame]
+disable_error_code = assignment
+
+[mypy-examples.io.split-jpeg-to-fits]
+disable_error_code = import-untyped
+
+[mypy-mypy_output_to_ini_format]
+disable_error_code = assignment,attr-defined
+
+[mypy-setup]
+disable_error_code = import-untyped

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 pretty = false
 exclude = (?x)(
           docs|


### PR DESCRIPTION
### Description

This prototype PR adds a [mypy](https://mypy.readthedocs.io/en/stable/) configuration file, `mypy.ini`, that ignores existing errors on a per-file and per-error basis. When I run `mypy .` in the top-level directory of this repo with this file, it passes using mypy v1.8.0!  🎉 🎂 🥳 🎈 🎆 🥦

The configuration file includes global settings near the top that can gradually be set to true in order to globally approach mypy's strict mode.

This PR does not add mypy to the suite of continuous integration tests, since doing so may require an Astropy Proposal for Enhancement (see https://github.com/astropy/astropy-APEs/issues/92).

### Motivation

Currently Astropy has no means to check that type hint annotations are correct, but there has been discussion over the last year or two about doing so, especially in #15170. If we want to methodically add *accurate* type hint annotations to Astropy, two steps that we'll need to take are:

 1. Get a static type checker like mypy to pass on the repo, such as by ignoring existing errors 
 2. Add the static type checker to the suite of CI tests 

This PR is a *possible* path forward for the first step, but there are other alternatives.  

### Backstory

This PR came about because I wrote a short script for https://github.com/PlasmaPy/PlasmaPy/pull/2424 that parses the output of mypy and creates the sections in `mypy.ini` to ignore existing errors on a per-file and per-error basis. Since it was pretty straightforward to run for Astropy too, I decided to submit a demo/prototype PR. 

### Consequences

 - This PR would give Astropy a mypy configuration that passes, which would enable contributors to make progress on typing certain portions of Astropy.
 - If mypy is added to CI after merging this PR, then we could ensure that each existing module would not get any new categories of typing errors. Similarly, we could ensure that new files would not have any unintended typing errors.
 - The fine-grained approach would let maintainers go file-by-file and error-by-error to improve typing in Astropy.
 - The sections specifying the per-file and per-error ignores were created mostly automatically which a script that I plan to share. It would require extra care to mix manual configuration settings on a per-subpackage or per-module basis.
 - The per-file configurations would be annoying to manage manually due to its size. Since mypy is still changing over time, new errors could crop up that would need to be added.

### Related issues

Closes #12970. This is similar to #12971, but this PR takes a much more fine-grained approach.  

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.