### PR TITLE
Fix ruff violation in coordinates subpackage

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -163,7 +163,6 @@ lint.ignore = [
     "RET503",  # implicit-return
     "RET504",  # unnecessary-assign
     "RET505",  # superfluous-else-return
-    "RET506",  # superfluous-else-raise
     "RET507",  # superfluous-else-continue
 
     # flake8-raise (RSE)
@@ -238,21 +237,26 @@ lint.unfixable = [
 "astropy/config/*" = [
     "PTH114",  # os-path-islink
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/constants/*" = ["N817"]  # camelcase-imported-as-acronym
-"astropy/convolution/*" = []
+"astropy/convolution/*" = [
+    "RET506",  # superfluous-else-raise
+]
 "astropy/coordinates/*" = [
     "DTZ007",  # call-datetime-strptime-without-zone
 ]
 "astropy/cosmology/*" = [
     "C408",  # unnecessary-collection-call
     "PT019",   # pytest-fixture-param-without-value
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/io/*" = [
     "G001",  # logging-string-format
     "G004",  # logging-f-string
     "PTH116",  # os-stat
     "PTH117",  # os-path-isabs
+    "RET506",  # superfluous-else-raise
     "SLOT000",  # Subclasses of `str` should define `__slots__`
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception
@@ -260,13 +264,22 @@ lint.unfixable = [
 "astropy/logger.py" = ["C408"]
 "astropy/modeling/*" = [
     "C408",  # unnecessary-collection-call
+    "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
 ]
-"astropy/nddata/*" = ["C408"]
-"astropy/samp/*" = []
-"astropy/stats/*" = []
+"astropy/nddata/*" = [
+    "C408",
+    "RET506",  # superfluous-else-raise
+]
+"astropy/samp/*" = [
+    "RET506",  # superfluous-else-raise
+]
+"astropy/stats/*" = [
+    "RET506",  # superfluous-else-raise
+]
 "astropy/table/*" = [
     "C408",  # unnecessary-collection-call
+    "RET506",  # superfluous-else-raise
     "S605",  # Starting a process with a shell, possible injection detected
 ]
 "astropy/tests/*" = ["C408"]
@@ -274,24 +287,38 @@ lint.unfixable = [
     "C408",  # unnecessary-collection-call
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
+    "RET506",  # superfluous-else-raise
 ]
-"astropy/timeseries/*" = ["C408"]
+"astropy/timeseries/*" = [
+    "C408",
+    "RET506",  # superfluous-else-raise
+]
 "astropy/units/*" = [
     "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
+    "RET506",  # superfluous-else-raise
 ]
-"astropy/uncertainty/*" = ["C408"]
+"astropy/uncertainty/*" = [
+    "C408",
+    "RET506",  # superfluous-else-raise
+]
 "astropy/utils/*" = [
     "C408",  # unnecessary-collection-call
     "N811",  # constant-imported-as-non-constant
+    "RET506",  # superfluous-else-raise
     "S321",  # Suspicious-ftp-lib-usage
 ]
-"astropy/visualization/*" = ["B015", "C408"]
+"astropy/visualization/*" = [
+    "B015",
+    "C408",
+    "RET506",  # superfluous-else-raise
+]
 "astropy/wcs/*" = [
     "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
     "S608",  # Posslibe SQL injection
+    "RET506",  # superfluous-else-raise
     "SIM202",  # NegateNotEqualOp
 ]
 "docs/*" = []

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -161,7 +161,7 @@ class Angle(SpecificTypeQuantity):
                     "will be interpreted simply as a sequence with the given unit."
                 )
 
-            elif isinstance(angle, str):
+            if isinstance(angle, str):
                 angle, angle_unit = formats.parse_angle(angle, unit)
                 if angle_unit is None:
                     angle_unit = unit

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -311,8 +311,7 @@ class _AngleParser:
         except ValueError as e:
             if str(e):
                 raise ValueError(f"{e} in angle {angle!r}") from e
-            else:
-                raise ValueError(f"Syntax error parsing angle {angle!r}") from e
+            raise ValueError(f"Syntax error parsing angle {angle!r}") from e
 
         if unit is None and found_unit is None:
             raise u.UnitsError("No unit specified")

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -309,9 +309,9 @@ class _AngleParser:
                 angle, lexer=self._thread_local._lexer, debug=debug
             )
         except ValueError as e:
-            if str(e):
-                raise ValueError(f"{e} in angle {angle!r}") from e
-            raise ValueError(f"Syntax error parsing angle {angle!r}") from e
+            raise ValueError(
+                f"{str(e) or 'syntax error'} parsing angle {angle!r}"
+            ) from e
 
         if unit is None and found_unit is None:
             raise u.UnitsError("No unit specified")

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -2024,5 +2024,4 @@ class GenericFrame(BaseCoordinateFrame):
     def __setattr__(self, name, value):
         if name in self.frame_attributes:
             raise AttributeError(f"can't set frame attribute '{name}'")
-        else:
-            super().__setattr__(name, value)
+        super().__setattr__(name, value)

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -121,7 +121,7 @@ class Distance(u.SpecificTypeQuantity):
                 "none of `value`, `z`, `distmod`, or `parallax` "
                 "were given to Distance constructor"
             )
-        elif n_not_none > 1:
+        if n_not_none > 1:
             raise ValueError(
                 "more than one of `value`, `z`, `distmod`, or "
                 "`parallax` were given to Distance constructor"

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -81,9 +81,10 @@ def _get_json_result(url, err_str, use_google):
     except urllib.error.URLError as e:
         # This catches a timeout error, see:
         #   http://stackoverflow.com/questions/2712524/handling-urllib2s-timeout-python
-        if isinstance(e.reason, socket.timeout):
-            raise NameResolveError(err_str.format(msg="connection timed out")) from e
-        raise NameResolveError(err_str.format(msg=e.reason)) from e
+        msg = (
+            "connection timed out" if isinstance(e.reason, socket.timeout) else e.reason
+        )
+        raise NameResolveError(err_str.format(msg=msg)) from e
 
     except socket.timeout:
         # There are some cases where urllib2 does not catch socket.timeout

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -83,8 +83,7 @@ def _get_json_result(url, err_str, use_google):
         #   http://stackoverflow.com/questions/2712524/handling-urllib2s-timeout-python
         if isinstance(e.reason, socket.timeout):
             raise NameResolveError(err_str.format(msg="connection timed out")) from e
-        else:
-            raise NameResolveError(err_str.format(msg=e.reason)) from e
+        raise NameResolveError(err_str.format(msg=e.reason)) from e
 
     except socket.timeout:
         # There are some cases where urllib2 does not catch socket.timeout
@@ -901,8 +900,7 @@ class EarthLocation(u.Quantity):
     def __len__(self):
         if self.shape == ():
             raise IndexError("0-d EarthLocation arrays cannot be indexed")
-        else:
-            return super().__len__()
+        return super().__len__()
 
     def _to_value(self, unit, equivalencies=[]):
         """Helper method for to and to_value."""

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -812,7 +812,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         if not self.differentials and differential_class:
             raise ValueError("No differentials associated with this representation!")
 
-        elif (
+        if (
             len(self.differentials) == 1
             and isinstance(differential_class, type)
             and issubclass(differential_class, BaseDifferential)
@@ -841,8 +841,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                         "compatible with the desired "
                         f"representation class {new_rep.__class__}"
                     ) from err
-                else:
-                    raise
+                raise
 
         return new_diffs
 

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -454,8 +454,7 @@ class SphericalRepresentation(BaseRepresentation):
                         " must explicitly pass in a `Distance` object with the "
                         "argument 'allow_negative=True'."
                     ) from e
-                else:
-                    raise
+                raise
 
     @classproperty
     def _compatible_differentials(cls):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -2013,8 +2013,7 @@ class SkyCoord(ShapedLikeNDArray):
                     f'Found column "{v.name}" in table, but it was already provided as'
                     ' "{k}" keyword to guess_from_table function.'
                 )
-            else:
-                coord_kwargs[k] = v
+            coord_kwargs[k] = v
 
         return cls(**coord_kwargs)
 

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -112,8 +112,7 @@ def _get_frame_without_data(args, kwargs):
                             attr, getattr(frame, attr), kwargs[attr], "SkyCoord"
                         )
                     )
-                else:
-                    kwargs[attr] = getattr(frame, attr)
+                kwargs[attr] = getattr(frame, attr)
             frame = frame.frame
 
         if isinstance(frame, BaseCoordinateFrame):
@@ -129,7 +128,7 @@ def _get_frame_without_data(args, kwargs):
                         " Either pass a frame class, or modify the frame attributes of"
                         " the input frame instance."
                     )
-                elif not frame.is_frame_attr_default(attr):
+                if not frame.is_frame_attr_default(attr):
                     kwargs[attr] = getattr(frame, attr)
 
             frame_cls = frame.__class__
@@ -180,7 +179,7 @@ def _get_frame_without_data(args, kwargs):
                         f" {getattr(coord_frame_obj, attr)} =/= {kwargs[attr]}"
                     )
 
-                elif attr not in kwargs and not coord_frame_obj.is_frame_attr_default(
+                if attr not in kwargs and not coord_frame_obj.is_frame_attr_default(
                     attr
                 ):
                     kwargs[attr] = getattr(coord_frame_obj, attr)

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -359,8 +359,7 @@ class SpectralCoord(SpectralQuantity):
                 raise ValueError(
                     "Cannot specify value as a Quantity and also specify unit"
                 )
-            else:
-                value, unit = value.value, value.unit
+            value, unit = value.value, value.unit
 
         value = value if value is not None else self.value
         unit = unit or self.unit

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -1161,7 +1161,7 @@ class BaseAffineTransform(CoordinateTransform):
                 "transformation (representation class: {data.__class__})"
             )
 
-        elif (
+        if (
             has_velocity
             and (unit_vel_diff or rad_vel_diff)
             and offset is not None
@@ -1175,7 +1175,7 @@ class BaseAffineTransform(CoordinateTransform):
                 f" {data.differentials['s'].__class__})"
             )
 
-        elif len(data.differentials) > 1:
+        if len(data.differentials) > 1:
             # We should never get here because the frame initializer shouldn't
             # allow more differentials, but this just adds protection for
             # subclasses that somehow skip the checks


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the ruff lint violation 'superfluous-else-raise' (RET506) in the `coordinates` sub-package by eliminating unnecessary else blocks after raise statements. I make no claim as to the validity of this violation, I chose it because it was suggested in #14818.

> What it does
> Checks for else statements with a raise statement in the preceding if block.
> 
> Why is this bad?
> The else statement is not needed as the raise statement will always break out of the current scope. Removing the else will reduce nesting and make the code more readable.
> - https://docs.astral.sh/ruff/rules/superfluous-else-raise/

This PR also updates the ruff temporary configuration to prevent similar future issues in this sub-package.

> ...some of the rules have a large number of violations ... in such cases it is preferable to address the rules one sub-package per pull request.
> 
> If you are editing a single sub-package and the rule is in the global ignore list then remove it from there and add it to the ignore lists of sub-packages that are violating that rule, but not to the list of the sub-package you will be updating.
> - #14818 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


&nbsp;
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
