### PR TITLE
BUG: list np._core.umath._replace as unsupported by Quantity

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -381,6 +381,7 @@ if not NUMPY_LT_2_0:
         np._core.umath._strip_whitespace,
         np._core.umath._lstrip_whitespace,
         np._core.umath._rstrip_whitespace,
+        np._core.umath._replace,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
### Description

This pull request is to address a failure in `astropy/units/tests/test_quantity_ufuncs.py::TestUfuncHelpers::test_coverage` with numpy dev (after #15797 is fixed by https://github.com/numpy/numpy/issues/25513)
At the time of writing, this is the only failure with numpy dev that can be adressed on our side.

ping @mhvk 

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
