### PR TITLE
TST: fix compatibility pytest 8.0

### DIFF
--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_equal
 from astropy.io.fits import util
 from astropy.io.fits.util import _rstrip_inplace, ignore_sigint
 from astropy.utils.compat.optional_deps import HAS_PIL
+from astropy.utils.exceptions import AstropyUserWarning
 
 if HAS_PIL:
     from PIL import Image
@@ -23,8 +24,8 @@ class TestUtils(FitsTestCase):
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="Cannot test on Windows")
     def test_ignore_sigint(self):
         @ignore_sigint
-        def test():
-            with pytest.warns(UserWarning) as w:
+        def runme():
+            with pytest.warns(AstropyUserWarning) as w:
                 pid = os.getpid()
                 os.kill(pid, signal.SIGINT)
                 # One more time, for good measure
@@ -34,7 +35,7 @@ class TestUtils(FitsTestCase):
                 str(w[0].message) == "KeyboardInterrupt ignored until test is complete!"
             )
 
-        pytest.raises(KeyboardInterrupt, test)
+        pytest.raises(KeyboardInterrupt, runme)
 
     def test_realign_dtype(self):
         """

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -167,14 +167,59 @@ def test_io_time_write_fits_standard(tmp_path, table_types):
     filename = tmp_path / "table-tmp"
 
     # Show that FITS format succeeds
-    with pytest.warns(
-        AstropyUserWarning,
-        match=(
-            'Time Column "btai" has no specified location, '
-            "but global Time Position is present"
-        ),
-    ):
+    with pytest.warns(AstropyUserWarning) as record:
         t.write(filename, format="fits", overwrite=True)
+
+    # The exact sequence probably
+    # does not matter too much, so we'll just try to match the *set* of warnings
+    warnings = {wm.message.args[0] for wm in record}
+
+    expected = {
+        (
+            'Time Column "btai" has no specified location, '
+            "but global Time Position is present, "
+            "which will be the default for this column in FITS specification."
+        ),
+        (
+            'Time Column "btdb" has no specified location, '
+            "but global Time Position is present, "
+            "which will be the default for this column in FITS specification."
+        ),
+        (
+            'Time Column "btcg" has no specified location, '
+            "but global Time Position is present, "
+            "which will be the default for this column in FITS specification."
+        ),
+        (
+            'Time Column "btt" has no specified location, '
+            "but global Time Position is present, which will be the default "
+            "for this column in FITS specification."
+        ),
+        (
+            'Time Column "butc" has no specified location, '
+            "but global Time Position is present, "
+            "which will be the default for this column in FITS specification."
+        ),
+        (
+            'Earth Location "TOPOCENTER" for Time Column "atdb"'
+            ' is incompatible with scale "TDB".'
+        ),
+        (
+            'Earth Location "TOPOCENTER" for Time Column "atcb"'
+            ' is incompatible with scale "TCB".'
+        ),
+        (
+            'Time Column "but1" has no specified location, '
+            "but global Time Position is present, "
+            "which will be the default for this column in FITS specification."
+        ),
+        (
+            'Time Column "btcb" has no specified location, '
+            "but global Time Position is present, "
+            "which will be the default for this column in FITS specification."
+        ),
+    }
+    assert warnings == expected, f"Got some unexpected warnings\n{warnings - expected}"
     with pytest.warns(
         AstropyUserWarning,
         match='Time column reference position "TRPOSn" is not specified',

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1098,10 +1098,14 @@ def test_data_noastropy_fallback(monkeypatch):
     assert os.path.isfile(fnout)
 
     # clearing the cache should be a no-up that doesn't affect fnout
-    with pytest.warns(
-        CacheMissingWarning, match=r".*Not clearing data cache - cache inaccessible.*"
-    ):
+    with pytest.warns(CacheMissingWarning) as record:
         clear_download_cache(TESTURL)
+    assert len(record) == 2
+    assert (
+        record[0].message.args[0]
+        == "Remote data cache could not be accessed due to OSError"
+    )
+    assert "Not clearing data cache - cache inaccessible" in record[1].message.args[0]
     assert os.path.isfile(fnout)
 
     # now remove it so tests don't clutter up the temp dir this should get


### PR DESCRIPTION
### Description
This pull request is to address issues seen with pytest 8.0.0rc1, which makes previously hidden warnings visible in tests that use `pytest.warns`
Fixes #15807

I went with the simplest approach (besides straightforwardly *ignoring* newly discovered warnings) of blessing each warning as "expected", and just reject anything new that would appear in the future, but maybe in some cases these "new" warnings should be regarded as bugs, in which case it's not *just* a matter of adjusting tests, but I'll leave that up to be discussed by subpackages maintainers.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
