### PR TITLE
TST: Fix test_ignore_sigint for pytest 8

### DIFF
--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -32,7 +32,10 @@ class TestUtils(FitsTestCase):
                 os.kill(pid, signal.SIGINT)
             assert len(warning_lines) == 2
             for w in warning_lines:
-                assert str(w.message) == "KeyboardInterrupt ignored until test is complete!"
+                assert (
+                    str(w.message)
+                    == "KeyboardInterrupt ignored until test is complete!"
+                )
 
         pytest.raises(KeyboardInterrupt, runme)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Maybe because maybe you cannot use pytest.warns inside a function sent to pytest.raises anymore in some cases; not sure. After merge, devdeps that was failing in #15809 no longer fails (though it still picks up pytest 8.0rc) but predeps still fails. This is all very confusing.

Locally, I had to install `[all]` and `[test_all]`, pytest 8.0rc, and run `pytest astropy/io/fits/tests/ --remote-data` for the error to show up. Running `pytest astropy/io/fits/tests/test_util.py -k test_ignore_sigint --remote-data` does not trigger the error.

I guess this is what happens when we play with fire that is called `os.kill`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is a direct follow-up of https://github.com/astropy/astropy/pull/15809 to fix https://github.com/astropy/astropy/issues/15807 .

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
