### PR TITLE
TST: Skip test_ignore_sigint in predeps job

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -50,7 +50,7 @@ jobs:
             python: '3.11'
             toxenv: py311-test-alldeps-predeps
             toxargs: -v
-            toxposargs: --remote-data=any -k 'not test_ignore_sigint'
+            toxposargs: --remote-data=any
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -50,7 +50,7 @@ jobs:
             python: '3.11'
             toxenv: py311-test-alldeps-predeps
             toxargs: -v
-            toxposargs: --remote-data=any
+            toxposargs: --remote-data=any -k 'not test_ignore_sigint'
 
     steps:
     - name: Checkout code

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -4,6 +4,7 @@ import gzip
 import os
 import signal
 import sys
+import threading
 
 import numpy as np
 import pytest
@@ -21,7 +22,10 @@ from .conftest import FitsTestCase
 
 
 class TestUtils(FitsTestCase):
-    @pytest.mark.skipif(sys.platform.startswith("win"), reason="Cannot test on Windows")
+    @pytest.mark.skipif(
+        sys.platform.startswith("win") or threading.active_count() > 1,
+        reason="Cannot test on Windows or on multiple threads"
+    )
     def test_ignore_sigint(self):
         @ignore_sigint
         def runme():

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -22,11 +22,11 @@ from .conftest import FitsTestCase
 
 
 class TestUtils(FitsTestCase):
-    @pytest.mark.skipif(
-        sys.platform.startswith("win") or threading.active_count() > 1,
-        reason="Cannot test on Windows or on multiple threads"
-    )
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="Cannot test on Windows")
     def test_ignore_sigint(self):
+        if threading.active_count() > 1:  # Only check when test starts.
+            pytest.skip("Cannot test when multiple threads are active")
+
         @ignore_sigint
         def runme():
             with pytest.warns(AstropyUserWarning) as w:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Because I do not know how to fix it for all the jobs all at once. See #15817 for failed attempt.

This is a direct follow-up of https://github.com/astropy/astropy/pull/15809 to fix https://github.com/astropy/astropy/issues/15807 . One way we can fix #15827 .

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
