### PR TITLE
BUG: fix a crash when retrieving rows from a multiple-index table

### DIFF
--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -31,12 +31,18 @@ Notes
     array.view(Column) -> no indices
 """
 
+from __future__ import annotations
+
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from .bst import MaxValue, MinValue
 from .sorted_array import SortedArray
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class QueryError(ValueError):
@@ -826,21 +832,27 @@ class TableLoc:
         self.table = table
         self.indices = table.indices
 
-    def _get_rows(self, item):
+    def _get_rows(
+        self,
+        item: int | Iterable[int] | slice | tuple[str, slice],
+    ) -> list[np.int64]:
         """
         Retrieve Table rows indexes by value slice.
         """
         if len(self.indices) == 0:
             raise ValueError("Can only use TableLoc for a table with indices")
 
-        if isinstance(item, tuple):
+        if (
+            isinstance(item, tuple)
+            and len(item) == 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], slice)
+        ):
             key, item = item
         else:
             key = self.table.primary_key
 
         index = self.indices[key]
-        if len(index.columns) > 1:
-            raise ValueError("Cannot use .loc on multi-column indices")
 
         if isinstance(item, slice):
             # None signifies no upper/lower bound
@@ -853,7 +865,7 @@ class TableLoc:
             # item should be a list or ndarray of values
             rows = []
             for key in item:
-                p = index.find((key,))
+                p = index.find(key if isinstance(key, tuple) else (key,))
                 if len(p) == 0:
                     raise KeyError(f"No matches found for key {key}")
                 else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1051,8 +1051,7 @@ class Table:
     def loc(self):
         """
         Return a TableLoc object that can be used for retrieving
-        rows by index in a given data range. Note that both loc
-        and iloc work only with single-column indices.
+        rows by index in a given data range.
         """
         return TableLoc(self)
 

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -623,3 +623,65 @@ def test_nd_columun_as_index(masked):
         ValueError, match="Multi-dimensional column 'arr' cannot be used as an index."
     ):
         t.add_index("arr")
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "col_a_constructor, expected_row_repr_lines, expected_table_pformat",
+    [
+        pytest.param(
+            lambda vals: vals,
+            [
+                "<Row index=0>",
+                "  c     b     a  ",
+                "int64 int64 int64",
+                "----- ----- -----",
+                "    0     1     3",
+            ],
+            [
+                " c   b   a ",
+                "--- --- ---",
+                "  2   2   2",
+                "  3   2   2",
+            ],
+            id="list",
+        ),
+        pytest.param(
+            lambda vals: Time(vals, format="cxcsec"),
+            [
+                "<Row index=0>",
+                "  c     b    a  ",
+                "int64 int64 Time",
+                "----- ----- ----",
+                "    0     1  3.0",
+            ],
+            [
+                " c   b   a ",
+                "--- --- ---",
+                "  2   2 2.0",
+                "  3   2 2.0",
+            ],
+            id="Time",
+        ),
+    ],
+)
+def test_multi_index(
+    col_a_constructor, expected_row_repr_lines, expected_table_pformat
+):
+    # see https://github.com/astropy/astropy/issues/13176
+    # forcing dtype to int64 for portability
+    # (Windows + numpy 1.x uses int32 by default)
+    vals_a = np.array([3, 3, 2, 2, 1], dtype="int64")
+    vals_b = np.array([1, 2, 2, 2, 1], dtype="int64")
+    vals_c = np.array([0, 1, 2, 3, 4], dtype="int64")
+
+    col_a = col_a_constructor(vals_a)
+    t = QTable([vals_c, vals_b, col_a], names=("c", "b", "a"))
+    t.add_index(["a", "b"])
+    res1 = t.loc[t["a"][0], t["b"][0]]
+    assert isinstance(res1, Row)
+    assert repr(res1).splitlines() == expected_row_repr_lines
+
+    res2 = t.loc[t["a"][2], t["b"][2]]
+    assert isinstance(res2, Table)
+    assert res2.pformat() == expected_table_pformat

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -625,7 +625,6 @@ def test_nd_columun_as_index(masked):
         t.add_index("arr")
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "col_a_constructor, expected_row_repr_lines, expected_table_pformat",
     [

--- a/docs/changes/table/15826.bugfix.rst
+++ b/docs/changes/table/15826.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash when retrieving rows from a multiple-index table.


### PR DESCRIPTION
### Description
Fixes #13176
I need to refine the test, it's currently run 3 times with no variations because of how I introduced it in a heavily parametrized test class.
Opening as a draft for now to see if it already survives full CI.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
