### PR TITLE
BUG: fix comparing NaN quantity with TimeDelta object

### DIFF
--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -100,6 +100,35 @@ class TestTimeDelta:
         t2 = dt + self.t
         assert t2.iso == self.t2.iso
 
+    def test_time_delta_comp_num_quantity(self):
+        dt1 = TimeDelta(1, format="sec")
+        dt2 = 2 * u.s
+        assert dt1 < dt2
+        assert dt2 > dt1
+        assert dt1 <= dt2
+        assert dt2 >= dt1
+        assert not dt1 > dt2
+        assert not dt2 < dt1
+        assert not dt1 >= dt2
+        assert not dt2 <= dt1
+        assert dt1 != dt2
+        assert not dt1 == dt2
+
+    def test_time_delta_comp_nan_quantity(self):
+        # see https://github.com/astropy/astropy/issues/15230
+        dt1 = TimeDelta(1, format="sec")
+        dt2 = np.nan * u.s
+        assert not dt1 < dt2
+        assert not dt2 > dt1
+        assert not dt1 <= dt2
+        assert not dt2 >= dt1
+        assert not dt1 > dt2
+        assert not dt2 < dt1
+        assert not dt1 >= dt2
+        assert not dt2 <= dt1
+        assert dt1 != dt2
+        assert not dt1 == dt2
+
     def test_add_vector(self):
         """Check time arithmetic as well as properly keeping track of whether
         a time is a scalar or a vector"""

--- a/docs/changes/time/15830.bugfix.rst
+++ b/docs/changes/time/15830.bugfix.rst
@@ -1,0 +1,1 @@
+Fix comparing NaN ``Quantity`` with ``TimeDelta`` object.


### PR DESCRIPTION
### Description
Fixes #15230.
The patch is inspired from @mhvk's comment in https://github.com/astropy/astropy/issues/15230#issuecomment-1696150881

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
