### PR TITLE
DOC: Coordinates frames in dark mode

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -206,7 +206,7 @@ def make_transform_graph_docs(transform_graph):
     graph_legend = f"""
     .. raw:: html
 
-        <ul>
+        <ul class="cooframelegend">
             {nl.join(html_list_items)}
         </ul>
     """

--- a/docs/_static/astropy.css
+++ b/docs/_static/astropy.css
@@ -77,11 +77,9 @@ html[data-theme=dark] h3 {
 html[data-theme="dark"] div.graphviz > object.inheritance {
   filter: invert(0.82) brightness(0.8) contrast(1.2);
 }
-
-/* TODO: Enable this when someone figures out how to also invert
-   legend colors in coordinate/builtin_frames/__init__.py */
-/*
 html[data-theme="dark"] div.graphviz > object.graphviz {
   filter: invert(0.82) brightness(0.8) contrast(1.2);
 }
-*/
+html[data-theme="dark"] ul.cooframelegend {
+  filter: invert(0.82) brightness(0.8) contrast(1.2);
+}


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to also make coordinates frame be nice in dark mode. This is a follow-up of #15783 .

xref https://github.com/astropy/sphinx-automodapi/issues/167

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
