### PR TITLE
BUG: avoid a segfault when calling astropy.convolution.convolve on an empty array

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -296,6 +296,8 @@ def convolve(
         )
     elif array_internal.ndim != kernel_internal.ndim:
         raise Exception("array and kernel have differing number of dimensions.")
+    elif array_internal.size == 0:
+        raise Exception("cannot convolve empty array")
 
     array_shape = np.array(array_internal.shape)
     kernel_shape = np.array(kernel_internal.shape)

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -289,15 +289,15 @@ def convolve(
 
     # Check dimensionality
     if array_internal.ndim == 0:
-        raise Exception("cannot convolve 0-dimensional arrays")
+        raise ValueError("cannot convolve 0-dimensional arrays")
     elif array_internal.ndim > 3:
         raise NotImplementedError(
             "convolve only supports 1, 2, and 3-dimensional arrays at this time"
         )
     elif array_internal.ndim != kernel_internal.ndim:
-        raise Exception("array and kernel have differing number of dimensions.")
+        raise ValueError("array and kernel have differing number of dimensions.")
     elif array_internal.size == 0:
-        raise Exception("cannot convolve empty array")
+        raise ValueError("cannot convolve empty array")
 
     array_shape = np.array(array_internal.shape)
     kernel_shape = np.array(kernel_internal.shape)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -439,6 +439,28 @@ class TestConvolve1D:
 
         assert_array_almost_equal_nulp(z, (8 / 3.0, 4, 8, 12, 8), 10)
 
+    @pytest.mark.parametrize(
+        "array, exc_type, match",
+        [
+            (0, Exception, "cannot convolve 0-dimensional arrays"),
+            (
+                [[1]],
+                Exception,
+                r"array and kernel have differing number of dimensions\.",
+            ),
+            ([], Exception, "cannot convolve empty array"),
+            (
+                np.ones((1, 1, 1, 1)),
+                NotImplementedError,
+                "convolve only supports 1, 2, and 3-dimensional arrays at this time",
+            ),
+        ],
+    )
+    def test_exceptions(self, array, exc_type, match):
+        kernel = [1]
+        with pytest.raises(exc_type, match=match):
+            convolve(array, kernel)
+
 
 class TestConvolve2D:
     def test_list(self):

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -442,13 +442,13 @@ class TestConvolve1D:
     @pytest.mark.parametrize(
         "array, exc_type, match",
         [
-            (0, Exception, "cannot convolve 0-dimensional arrays"),
+            (0, ValueError, "cannot convolve 0-dimensional arrays"),
             (
                 [[1]],
-                Exception,
+                ValueError,
                 r"array and kernel have differing number of dimensions\.",
             ),
-            ([], Exception, "cannot convolve empty array"),
+            ([], ValueError, "cannot convolve empty array"),
             (
                 np.ones((1, 1, 1, 1)),
                 NotImplementedError,

--- a/docs/changes/convolution/15840.bugfix.rst
+++ b/docs/changes/convolution/15840.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid a segfault when calling ``astropy.convolution.convolve`` on an empty array.
+An exception is now raised instead.


### PR DESCRIPTION
### Description

Fixes #10048


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
