### PR TITLE
BUG: fix a spurious warning when calling sigma_clipped_stats on a MaskedColumn

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -429,7 +429,7 @@ class SigmaClip:
 
         # remove masked values and convert to ndarray
         if isinstance(filtered_data, np.ma.MaskedArray):
-            filtered_data = filtered_data.data[~filtered_data.mask]
+            filtered_data = filtered_data._data[~filtered_data.mask]
 
         # remove invalid values
         good_mask = np.isfinite(filtered_data)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy import units as u
 from astropy.stats import mad_std
 from astropy.stats.sigma_clipping import SigmaClip, sigma_clip, sigma_clipped_stats
+from astropy.table import MaskedColumn
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import NumpyRNGContext
@@ -161,6 +162,15 @@ def test_sigma_clipped_stats_ddof():
         assert median1 == median2
         assert_allclose(stddev1, 0.98156805711673156)
         assert_allclose(stddev2, 0.98161731654802831)
+
+
+def test_sigma_clipped_stats_masked_col():
+    # see https://github.com/astropy/astropy/issues/13281
+    arr = np.ma.masked_array([1, 2, 3], mask=[False, True, False])
+    sigma_clipped_stats(arr)
+
+    col = MaskedColumn(data=arr)
+    sigma_clipped_stats(col)
 
 
 def test_invalid_sigma_clip():

--- a/docs/changes/stats/15844.bugfix.rst
+++ b/docs/changes/stats/15844.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a spurious warning when calling ``sigma_clipped_stats`` on a ``MaskedColumn``.


### PR DESCRIPTION
### Description
Fixes #13281
Patch initially proposed by @mhvk 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
