### PR TITLE
BUG: fix an unintended exception being raised when attempting to compare two unequal ``Table`` instances.

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3729,7 +3729,7 @@ class Table:
 
         whitelist = (TypeError, ValueError if not NUMPY_LT_1_25 else DeprecationWarning)
         # One table is masked and the other is not
-        if self_is_masked != other_is_masked:
+        if self_is_masked ^ other_is_masked:
             # remap variables to a and b where a is masked and b isn't
             a, b = (
                 (self.as_array(), other) if self_is_masked else (other, self.as_array())

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3699,7 +3699,11 @@ class Table:
 
         This is actual implementation for __eq__.
 
-        Returns a 1-D boolean numpy array showing result of row-wise comparison.
+        Returns a 1-D boolean numpy array showing result of row-wise comparison,
+        or a bool (False) in cases where comparison isn't possible (uncomparable dtypes
+        or unbroadcastable shapes). Intended to follow legacy numpy's elementwise
+        comparison rules.
+
         This is the same as the ``==`` comparison for tables.
 
         Parameters
@@ -3740,12 +3744,12 @@ class Table:
                 # numpy may complain that structured array are not comparable (TypeError)
                 # or that operands are not brodcastable (ValueError)
                 # see https://github.com/astropy/astropy/issues/13421
-                result = np.array([False])
+                result = False
         else:
             try:
                 result = self.as_array() == other
             except whitelist:
-                result = np.array([False])
+                result = False
 
         return result
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3727,7 +3727,10 @@ class Table:
         self_is_masked = self.has_masked_columns
         other_is_masked = isinstance(other, np.ma.MaskedArray)
 
-        whitelist = (TypeError, ValueError if not NUMPY_LT_1_25 else DeprecationWarning)
+        allowed_numpy_exceptions = (
+            TypeError,
+            ValueError if not NUMPY_LT_1_25 else DeprecationWarning,
+        )
         # One table is masked and the other is not
         if self_is_masked ^ other_is_masked:
             # remap variables to a and b where a is masked and b isn't
@@ -3740,7 +3743,7 @@ class Table:
             false_mask = np.zeros(1, dtype=[(n, bool) for n in a.dtype.names])
             try:
                 result = (a.data == b) & (a.mask == false_mask)
-            except whitelist:
+            except allowed_numpy_exceptions:
                 # numpy may complain that structured array are not comparable (TypeError)
                 # or that operands are not brodcastable (ValueError)
                 # see https://github.com/astropy/astropy/issues/13421
@@ -3748,7 +3751,7 @@ class Table:
         else:
             try:
                 result = self.as_array() == other
-            except whitelist:
+            except allowed_numpy_exceptions:
                 result = False
 
         return result

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3684,7 +3684,14 @@ class Table:
         return self._rows_equal(other)
 
     def __ne__(self, other):
-        return ~self.__eq__(other)
+        eq = self.__eq__(other)
+        if isinstance(eq, bool):
+            # bitwise operators on bool values not reliable (e.g. `bool(~True) == True`)
+            # and are deprecated in Python 3.12
+            # see https://github.com/python/cpython/pull/103487
+            return not eq
+        else:
+            return ~eq
 
     def _rows_equal(self, other):
         """

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -2468,7 +2468,19 @@ def test_mixin_join_regression():
 )
 def test_table_comp(t1, t2):
     # see https://github.com/astropy/astropy/issues/13421
-    assert not any(t1 == t2)
-    assert not any(t2 == t1)
-    assert all(t1 != t2)
-    assert all(t2 != t1)
+    try:
+        np.result_type(t1.dtype, t2.dtype)
+        np.broadcast_shapes((len(t1),), (len(t2),))
+    except (TypeError, ValueError):
+        # dtypes are not comparable or arrays can't be broadcasted:
+        # a simple bool should be returned
+        assert not t1 == t2
+        assert not t2 == t1
+        assert t1 != t2
+        assert t2 != t1
+    else:
+        # otherwise, the general case is to return a 1D array with dtype=bool
+        assert not any(t1 == t2)
+        assert not any(t2 == t1)
+        assert all(t1 != t2)
+        assert all(t2 != t1)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -2424,3 +2424,51 @@ def test_mixin_join_regression():
     t12 = table.join(t1, t2, keys=("index", "flux1", "flux2"), join_type="outer")
 
     assert len(t12) == 6
+
+
+@pytest.mark.parametrize(
+    "t1, t2",
+    [
+        # different names
+        (
+            Table([np.array([1])], names=["a"]),
+            Table([np.array([1])], names=["b"]),
+        ),
+        # different data (broadcastable)
+        (
+            Table([np.array([])], names=["a"]),
+            Table([np.array([1])], names=["a"]),
+        ),
+        # different data (not broadcastable)
+        (
+            Table([np.array([1, 2])], names=["a"]),
+            Table([np.array([1, 2, 3])], names=["a"]),
+        ),
+        # different names and data (broadcastable)
+        (
+            Table([np.array([])], names=["a"]),
+            Table([np.array([1])], names=["b"]),
+        ),
+        # different names and data (not broadcastable)
+        (
+            Table([np.array([1, 2])], names=["a"]),
+            Table([np.array([1, 2, 3])], names=["b"]),
+        ),
+        # different data and array type (broadcastable)
+        (
+            Table([np.array([])], names=["a"]),
+            Table([np.ma.MaskedArray([1])], names=["a"]),
+        ),
+        # different data and array type (not broadcastable)
+        (
+            Table([np.array([1, 2])], names=["a"]),
+            Table([np.ma.MaskedArray([1, 2, 3])], names=["a"]),
+        ),
+    ],
+)
+def test_table_comp(t1, t2):
+    # see https://github.com/astropy/astropy/issues/13421
+    assert not any(t1 == t2)
+    assert not any(t2 == t1)
+    assert all(t1 != t2)
+    assert all(t2 != t1)

--- a/docs/changes/table/15845.bugfix.rst
+++ b/docs/changes/table/15845.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an unintended exception being raised when attempting to compare two unequal ``Table`` instances.

--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -351,12 +351,18 @@ Table Equality
 
 We can check table data equality using two different methods:
 
-- The ``==`` comparison operator. This returns a `True` or `False` for
-  each row if the *entire row* matches. This is the same as the behavior of
-  ``numpy`` structured arrays.
+- The ``==`` comparison operators. In the general case, this returns a 1D array
+  with ``dtype=bool`` mapping each row to ``True`` if and only if the *entire row*
+  matches. For incomparable data (different ``dtype`` or unbroacastable lengths),
+  a boolean ``False`` is returned.
+  This is in contrast to the behavior of ``numpy`` where trying to compare
+  structured arrays might raise exceptions.
 - Table :meth:`~astropy.table.Table.values_equal` to compare table values
   element-wise. This returns a boolean `True` or `False` for each table
   *element*, so you get a `~astropy.table.Table` of values.
+
+.. note:: both methods will report equality *after* broadcasting, which
+  matches ``numpy`` array comparison.
 
 Examples
 ^^^^^^^^


### PR DESCRIPTION
### Description
Will fix #13421

The essence of the patch is to wrap existing logic in a `try/except` block as discussed in the issue, but I also tried to reduce code duplication, which resulted in a larger diff.

The test is also incomplete at the moment (see embedded comment). I'll come back to it when I'm confident that the current state survives CI.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
