### PR TITLE
Add pandas-stubs to typing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,9 @@ test_all = [
     "sgp4>=2.3",
     "array-api-strict",
 ]
-typing = []
+typing = [
+    "pandas-stubs>=2.0",
+]
 docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies
     "sphinx",


### PR DESCRIPTION
We have pandas as an optional dependency. This PR ensures type checkers understand Pandas + Astropy.
All the contents of `typing` are NOT runtime dependencies. The only cost this dependency incurs is when installing with `astropy[all]`, which picks up on all dependencies, not just runtime ones. Since we have Pandas already and this stubs package is maintained by Pandas, this is a very safe type-checking dependency to add.

Found when testing #15794.

If you run `mypy` then it notices that there are a number of missing stubs dependencies. I think that we should at minimum have type-check level dependencies for our runtime packages (followup PR for `types-PyYAML`) but also for  important optional dependencies. Chances are good that users who care about typing will have these stubs installed already (using e.g. `mypy --install-types` for automatic discovery) but it's good to be explicit.

~Requires #15603~