### PR TITLE
cosmo: add type annotations to `astropy.cosmology.units.py`

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -138,6 +138,7 @@ py:class DT
 py:class Equivalency
 py:class Quantity
 py:class Unit
+py:class UnitBase
 py:func astropy.units.Quantity
 py:obj CompositeUnit
 py:obj Equivalency

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -134,3 +134,17 @@ py:class ModuleType
 py:class NDArray
 # locally defined type variable for ndarray dtype
 py:class DT
+# astropy.units
+py:class Equivalency
+py:class Quantity
+py:class Unit
+py:func astropy.units.Quantity
+py:obj CompositeUnit
+py:obj Equivalency
+py:obj PhysicalType
+py:obj PrefixUnit
+py:obj Quantity
+py:obj StructuredUnit
+py:obj Unit
+py:obj UnitBase
+py:obj UnrecognizedUnit

--- a/docs/units/ref_api.rst
+++ b/docs/units/ref_api.rst
@@ -1,7 +1,7 @@
 Reference/API
 *************
 
-.. TODO: the :noindex: directive used below are necessary to avoid an issue related
+.. TODO: the :noindex: directives used below are necessary to avoid an issue related
    to type hints (see https://github.com/sphinx-doc/sphinx/issues/9813 and possibly
    https://github.com/sphinx-doc/sphinx/issues/11225) where the type hints are
    incorrectly interpreted as references, leading Sphinx to think that there are

--- a/docs/units/ref_api.rst
+++ b/docs/units/ref_api.rst
@@ -1,7 +1,15 @@
 Reference/API
 *************
 
+.. TODO: the :noindex: directive used below are necessary to avoid an issue related
+   to type hints (see https://github.com/sphinx-doc/sphinx/issues/9813 and possibly
+   https://github.com/sphinx-doc/sphinx/issues/11225) where the type hints are
+   incorrectly interpreted as references, leading Sphinx to think that there are
+   missing references. Resulting warnings are similar to
+   "WARNING: more than one target found for cross-reference 'Equivalency': astropy.units.Equivalency, astropy.units.equivalencies.Equivalency".
+
 .. automodapi:: astropy.units.quantity
+   :noindex:
 
 .. automodapi:: astropy.units
 
@@ -26,6 +34,7 @@ Reference/API
 .. automodapi:: astropy.units.physical
 
 .. automodapi:: astropy.units.equivalencies
+   :noindex:
 
 .. automodapi:: astropy.units.function.core
 


### PR DESCRIPTION
When I add type hints to `cosmology.funcs.optimize.py` then I'll be able to add better hints to the `atzkw` arguments, but for now these generic annotations are good.

Plz squash and cleanup merge message.