### PR TITLE
cosmo: type annotate `cosmology…connect.py`

### DIFF
--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -1,8 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from astropy.cosmology import units as cu
 from astropy.io import registry as io_registry
 from astropy.units import add_enabled_units
+
+if TYPE_CHECKING:
+    from astropy.cosmology import Cosmology
 
 __all__ = [
     "CosmologyRead",
@@ -62,10 +69,10 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
     -----
     """
 
-    def __init__(self, instance, cosmo_cls):
+    def __init__(self, instance: Cosmology, cosmo_cls: type[Cosmology]) -> None:
         super().__init__(instance, cosmo_cls, "read", registry=readwrite_registry)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Cosmology:
         from astropy.cosmology.core import Cosmology
 
         # so subclasses can override, also pass the class as a kwarg.
@@ -119,10 +126,10 @@ class CosmologyWrite(io_registry.UnifiedReadWrite):
     -----
     """
 
-    def __init__(self, instance, cls):
+    def __init__(self, instance: Cosmology, cls: type[Cosmology]) -> None:
         super().__init__(instance, cls, "write", registry=readwrite_registry)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
         self.registry.write(self._instance, *args, **kwargs)
 
 
@@ -178,10 +185,12 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
         `~astropy.cosmology.Cosmology` corresponding to ``obj`` contents.
     """
 
-    def __init__(self, instance, cosmo_cls):
+    def __init__(self, instance: Cosmology, cosmo_cls: type[Cosmology]) -> None:
         super().__init__(instance, cosmo_cls, "read", registry=convert_registry)
 
-    def __call__(self, obj, *args, format=None, **kwargs):
+    def __call__(
+        self, obj: object, *args: Any, format: str | None = None, **kwargs: Any
+    ) -> Cosmology:
         from astropy.cosmology.core import Cosmology
 
         # so subclasses can override, also pass the class as a kwarg.
@@ -237,8 +246,8 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
         Keyword arguments passed through to data writer.
     """
 
-    def __init__(self, instance, cls):
+    def __init__(self, instance: Cosmology, cls: type[Cosmology]):
         super().__init__(instance, cls, "write", registry=convert_registry)
 
-    def __call__(self, format, *args, **kwargs):
+    def __call__(self, format: str, *args: Any, **kwargs: Any) -> object:
         return self.registry.write(self._instance, None, *args, format=format, **kwargs)

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -246,7 +246,7 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
         Keyword arguments passed through to data writer.
     """
 
-    def __init__(self, instance: Cosmology, cls: type[Cosmology]):
+    def __init__(self, instance: Cosmology, cls: type[Cosmology]) -> None:
         super().__init__(instance, cls, "write", registry=convert_registry)
 
     def __call__(self, format: str, *args: Any, **kwargs: Any) -> object:

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypeVar, overload
 
 from astropy.cosmology import units as cu
 from astropy.io import registry as io_registry
 from astropy.units import add_enabled_units
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any, Literal
+
     from astropy.cosmology import Cosmology
+    from astropy.cosmology._io.model import _CosmologyModel
+    from astropy.table import Row, Table
 
 __all__ = [
     "CosmologyRead",
@@ -18,6 +23,10 @@ __all__ = [
     "CosmologyToFormat",
 ]
 __doctest_skip__ = __all__
+
+
+_CosmoT = TypeVar("_CosmoT", bound="Cosmology")  # NOTE: private b/c RTD error
+_MT = TypeVar("_MT", bound="Mapping")  # type: ignore[type-arg]
 
 
 # ==============================================================================
@@ -188,8 +197,70 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
     def __init__(self, instance: Cosmology, cosmo_cls: type[Cosmology]) -> None:
         super().__init__(instance, cosmo_cls, "read", registry=convert_registry)
 
+    # ===============================================================
+    # __call__ overloads
+    # note: format: ... | None means the format can be auto-detected from the input.
+
+    @overload
     def __call__(
-        self, obj: object, *args: Any, format: str | None = None, **kwargs: Any
+        self,
+        obj: _CosmoT,
+        *args: Any,
+        format: Literal["astropy.cosmology"] | None,
+        **kwargs: Any,
+    ) -> _CosmoT:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        obj: _CosmologyModel,
+        *args: Any,
+        format: Literal["astropy.model"] | None,
+        **kwargs: Any,
+    ) -> Cosmology:
+        ...
+
+    @overload
+    def __call__(
+        self, obj: Row, *args: Any, format: Literal["astropy.row"] | None, **kwargs: Any
+    ) -> Cosmology:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        obj: Table,
+        *args: Any,
+        format: Literal["astropy.table"] | None,
+        **kwargs: Any,
+    ) -> Cosmology:
+        ...
+
+    @overload
+    def __call__(
+        self,
+        obj: Mapping[str, Any],
+        *args: Any,
+        format: Literal["mapping"] | None,
+        **kwargs: Any,
+    ) -> Cosmology:
+        ...
+
+    @overload
+    def __call__(
+        self, obj: str, *args: Any, format: Literal["yaml"], **kwargs: Any
+    ) -> Cosmology:
+        ...
+
+    @overload
+    def __call__(
+        self, obj: Any, *args: Any, format: str | None = None, **kwargs: Any
+    ) -> Cosmology:
+        ...
+
+    def __call__(
+        self, obj: Any, *args: Any, format: str | None = None, **kwargs: Any
     ) -> Cosmology:
         from astropy.cosmology.core import Cosmology
 
@@ -249,5 +320,52 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
     def __init__(self, instance: Cosmology, cls: type[Cosmology]) -> None:
         super().__init__(instance, cls, "write", registry=convert_registry)
 
-    def __call__(self, format: str, *args: Any, **kwargs: Any) -> object:
+    # ===============================================================
+    # __call__ overloads
+
+    @overload
+    def __call__(
+        self, format: Literal["astropy.cosmology"], *args: Any, **kwargs: Any
+    ) -> Cosmology:
+        ...
+
+    @overload
+    def __call__(
+        self, format: Literal["astropy.model"], *args: Any, **kwargs: Any
+    ) -> _CosmologyModel:
+        ...
+
+    @overload
+    def __call__(
+        self, format: Literal["astropy.row"], *args: Any, **kwargs: Any
+    ) -> Row:
+        ...
+
+    @overload
+    def __call__(
+        self, format: Literal["astropy.table"], *args: Any, **kwargs: Any
+    ) -> Table:
+        ...
+
+    @overload  # specific mapping option, where the mapping class is specified.
+    def __call__(
+        self, format: Literal["mapping"], *args: Any, cls: _MT, **kwargs: Any
+    ) -> _MT:
+        ...
+
+    @overload
+    def __call__(
+        self, format: Literal["mapping"], *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        ...
+
+    @overload
+    def __call__(self, format: Literal["yaml"], *args: Any, **kwargs: Any) -> str:
+        ...
+
+    @overload
+    def __call__(self, format: str, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+    def __call__(self, format: str, *args: Any, **kwargs: Any) -> Any:
         return self.registry.write(self._instance, None, *args, format=format, **kwargs)

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -25,7 +25,8 @@ __all__ = [
 __doctest_skip__ = __all__
 
 
-_CosmoT = TypeVar("_CosmoT", bound="Cosmology")  # NOTE: private b/c RTD error
+# NOTE: private b/c RTD error
+_CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _MT = TypeVar("_MT", bound="Mapping")  # type: ignore[type-arg]
 
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -45,7 +45,8 @@ __all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
 _COSMOLOGY_CLASSES = dict()
 
 # typing
-_CosmoT = TypeVar("_CosmoT", bound="Cosmology")  # NOTE: private b/c RTD error
+# NOTE: private b/c RTD error
+_CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _FlatCosmoT = TypeVar("_FlatCosmoT", bound="FlatCosmologyMixin")
 
 ##############################################################################

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -45,7 +45,7 @@ __all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
 _COSMOLOGY_CLASSES = dict()
 
 # typing
-_CosmoT = TypeVar("_CosmoT", bound="Cosmology")
+_CosmoT = TypeVar("_CosmoT", bound="Cosmology")  # NOTE: private b/c RTD error
 _FlatCosmoT = TypeVar("_FlatCosmoT", bound="FlatCosmologyMixin")
 
 ##############################################################################


### PR DESCRIPTION
These are all quite generic functions that cannot be specialized wrt their type annotations.

Plz squash.
