### PR TITLE
cosmo: make argument `verbose` to `z_at_value` keyword-only

### DIFF
--- a/astropy/cosmology/funcs/optimize.py
+++ b/astropy/cosmology/funcs/optimize.py
@@ -130,6 +130,7 @@ def z_at_value(
     maxfun=500,
     method="Brent",
     bracket=None,
+    *,
     verbose=False,
 ):
     """Find the redshift ``z`` at which ``func(z) = fval``.
@@ -192,10 +193,12 @@ def z_at_value(
 
         .. versionadded:: 4.3
 
-    verbose : bool, optional
+    verbose : bool, optional keyword-only
         Print diagnostic output from solver (default `False`).
 
         .. versionadded:: 4.3
+        .. versionchanged:: 6.1
+            Changed to keyword-only.
 
     Returns
     -------

--- a/docs/changes/cosmology/15855.api.rst
+++ b/docs/changes/cosmology/15855.api.rst
@@ -1,0 +1,1 @@
+The argument ``verbose`` in the function ``z_at_value`` is now keyword-only.


### PR DESCRIPTION
`z_at_value(..., verbose)` is now keyword-only.
See https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/