### PR TITLE
cosmo: remove unneeded `__doctest_requires__`

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -37,8 +37,6 @@ if TYPE_CHECKING:
 
 __all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
 
-__doctest_requires__ = {}  # needed until __getattr__ removed
-
 
 ##############################################################################
 # Parameters


### PR DESCRIPTION
Removing a small extraneous test configuration.