### PR TITLE
Backport PR #15848: Ensure names of Quantity and other mixin columns are propagated

### DIFF
--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -599,10 +599,10 @@ class MrtHeader(cds.CdsHeader):
             # Convert all other ``mixin`` columns to ``Column`` objects.
             # Parsing these may still lead to errors!
             elif not isinstance(col, Column):
-                col = Column(col)
+                col = Column(col, name=self.colnames[i])
                 # If column values are ``object`` types, convert them to string.
                 if np.issubdtype(col.dtype, np.dtype(object).type):
-                    col = Column([str(val) for val in col])
+                    col = Column([str(val) for val in col], name=col.name)
                 self.cols[i] = col
 
         # Delete original ``SkyCoord`` columns, if there were any.

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -13,7 +13,7 @@ import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import ascii
-from astropy.table import Column, MaskedColumn, Table
+from astropy.table import Column, MaskedColumn, QTable, Table
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyWarning
@@ -425,21 +425,22 @@ def test_write_mixin_and_broken_cols():
     """
     # fmt: off
     exp_output = [
-        '================================================================================',
-        'Byte-by-byte Description of file: table.dat',
-        '--------------------------------------------------------------------------------',
-        ' Bytes Format Units  Label     Explanations',
-        '--------------------------------------------------------------------------------',
-        '  1-  7  A7     ---    name    Description of name   ',
-        '  9- 74  A66    ---    Unknown Description of Unknown',
-        ' 76-114  A39    ---    Unknown Description of Unknown',
-        '116-138  A23    ---    Unknown Description of Unknown',
-        '--------------------------------------------------------------------------------',
-        'Notes:',
-        '--------------------------------------------------------------------------------',
-        'HD81809 <SkyCoord (ICRS): (ra, dec) in deg',
-        '    (330.564375, -61.65961111)> (0.41342785, -0.23329341, -0.88014294)  2019-01-01 00:00:00.000',
-        'random  12                                                                 (0.41342785, -0.23329341, -0.88014294)  2019-01-01 00:00:00.000',
+        "================================================================================",
+        "Byte-by-byte Description of file: table.dat",
+        "--------------------------------------------------------------------------------",
+        " Bytes Format Units  Label     Explanations",
+        "--------------------------------------------------------------------------------",
+        "  1-  7  A7     ---    name    Description of name       ",
+        "  9- 74  A66    ---    Unknown Description of Unknown    ",
+        " 76-114  A39    ---    cart    Description of cart       ",
+        "116-138  A23    ---    time    Description of time       ",
+        "140-142  F3.1   m      q       [1.0/1.0] Description of q",
+        "--------------------------------------------------------------------------------",
+        "Notes:",
+        "--------------------------------------------------------------------------------",
+        "HD81809 <SkyCoord (ICRS): (ra, dec) in deg",
+        "    (330.564375, -61.65961111)> (0.41342785, -0.23329341, -0.88014294)  2019-01-01 00:00:00.000 1.0",
+        "random  12                                                                 (0.41342785, -0.23329341, -0.88014294)  2019-01-01 00:00:00.000 1.0",
     ]
     # fmt: on
     t = Table()
@@ -449,6 +450,7 @@ def test_write_mixin_and_broken_cols():
     t.add_row(["random", 12])
     t["cart"] = coord.cartesian
     t["time"] = Time("2019-1-1")
+    t["q"] = u.Quantity(1.0, u.m)
     out = StringIO()
     t.write(out, format="ascii.mrt")
     lines = out.getvalue().splitlines()
@@ -552,3 +554,13 @@ def test_write_skycoord_with_format():
     lines = lines[i_bbb:]  # Select Byte-By-Byte section and following lines.
     # Check the written table.
     assert lines == exp_output
+
+
+def test_write_qtable():
+    # Regression test for gh-12804
+    qt = QTable([np.arange(4) * u.m, ["a", "b", "c", "ddd"]], names=["a", "b"])
+    out = StringIO()
+    qt.write(out, format="mrt")
+    result = out.getvalue()
+    assert "Description of a" in result
+    assert "Description of b" in result

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -555,6 +555,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
                     format = data.info.format
                 if meta is None:
                     meta = data.info.meta
+                if name is None:
+                    name = data.info.name
 
         else:
             if np.dtype(dtype).char == "S":

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -156,6 +156,19 @@ class TestColumn:
         assert np.all(c.data == np.array([100, 200, 300]))
         assert np.all(c.unit == u.cm)
 
+    def test_quantity_with_info_init(self, Column):
+        q = np.arange(3.0) * u.m
+        q.info.name = "q"
+        q.info.description = "an example"
+        q.info.meta = {"parrot": "dead"}
+        q.info.format = "3.1f"
+        c = Column(q)
+        assert c.name == "q"
+        assert c.description == "an example"
+        assert c.meta == q.info.meta
+        assert c.meta is not q.info.meta
+        assert c.pformat() == " q \n---\n0.0\n1.0\n2.0".splitlines()
+
     def test_quantity_comparison(self, Column):
         # regression test for gh-6532
         c = Column([1, 2100, 3], unit="Hz")

--- a/docs/changes/io.ascii/15848.bugfix.rst
+++ b/docs/changes/io.ascii/15848.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that the names of mixin columns are properly propagated as
+labels for the MRT format.

--- a/docs/changes/table/15848.bugfix.rst
+++ b/docs/changes/table/15848.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that if a ``Column`` is initialized with a ``Quantity`` it will use by
+default a possible name defined on the quantity's ``.info``.


### PR DESCRIPTION
Manual backport of #15848 onto v6.0.x