### PR TITLE
Create `units.typing` module with `QuantityLike`

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -47,7 +47,7 @@ from .utils import is_effectively_unity
 
 if TYPE_CHECKING:
     import sys
-    
+
     if sys.version_info >= (3, 11):
         from typing import Self
     else:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -5,12 +5,15 @@ associated units. `Quantity` objects support operations like ordinary numbers,
 but will deal with unit conversions internally.
 """
 
+from __future__ import annotations
+
 # STDLIB
 import numbers
 import operator
 import re
 import warnings
 from fractions import Fraction
+from typing import TYPE_CHECKING
 
 # THIRD PARTY
 import numpy as np
@@ -41,6 +44,11 @@ from .quantity_helper.function_helpers import (
 )
 from .structured import StructuredUnit, _structured_unit_like_dtype
 from .utils import is_effectively_unity
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from .typing import QuantityLike
 
 __all__ = [
     "Quantity",
@@ -419,15 +427,15 @@ class Quantity(np.ndarray):
         return Annotated[cls, unit]
 
     def __new__(
-        cls,
-        value,
+        cls: type[Self],
+        value: QuantityLike,
         unit=None,
         dtype=np.inexact,
         copy=True,
         order=None,
         subok=False,
         ndmin=0,
-    ):
+    ) -> Self:
         if unit is not None:
             # convert unit first, to avoid multiple string->unit conversions
             unit = Unit(unit)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -46,7 +46,12 @@ from .structured import StructuredUnit, _structured_unit_like_dtype
 from .utils import is_effectively_unity
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    import sys
+    
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
     from .typing import QuantityLike
 

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""Typing module for :mod:`~astropy.units`."""
+"""Typing module for supporting type annotations related to :mod:`~astropy.units`."""
 
 __all__ = ["QuantityLike"]
 

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Typing module for :mod:`~astropy.units`."""
+
+__all__ = ["QuantityLike"]
+
+
+import numpy.typing as npt
+from typing_extensions import TypeAlias
+
+from astropy.units import Quantity
+
+# Note: Quantity is technically covered by npt.ArrayLike, but we want to
+# explicitly include it here so that it is clear that we are also including
+# Quantity objects in the definition of QuantityLike.
+QuantityLike: TypeAlias = Quantity | npt.ArrayLike
+"""Type alias for a quantity-like object.
+
+This is an object that can be converted to a :class:`~astropy.units.Quantity` object
+using the :func:`~astropy.units.Quantity` constructor.
+
+Examples
+--------
+We assume the following imports:
+
+    >>> from astropy import units as u
+
+This is a non-exhaustive list of examples of quantity-like objects:
+
+Integers and floats:
+
+    >>> u.Quantity(1, u.meter)
+    <Quantity 1.0 m>
+
+    >>> u.Quantity(1.0, u.meter)
+    <Quantity 1.0 m>
+
+Tuples and lists:
+
+    >>> u.Quantity((1.0, 2.0), u.meter)
+    <Quantity [1., 2.] m>
+
+    >>> u.Quantity([1.0, 2.0], u.meter)
+    <Quantity [1., 2.] m>
+
+Numpy arrays:
+
+    >>> u.Quantity(np.array([1.0, 2.0]), u.meter)
+
+:class:`~astropy.units.Quantity` objects:
+
+    >>> u.Quantity(u.Quantity(1.0, u.meter))
+    <Quantity 1.0 m>
+
+Strings:
+
+    >>> u.Quantity('1.0 m')
+    <Quantity 1.0 m>
+
+For more examples see the :mod:`numpy.typing` definition of
+:obj:`numpy.typing.ArrayLike`.
+"""

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -39,12 +39,12 @@ Integers and floats:
     >>> u.Quantity(1.0, u.meter)
     <Quantity 1.0 m>
 
-Tuples and lists:
-
-    >>> u.Quantity((1.0, 2.0), u.meter)
-    <Quantity [1., 2.] m>
+Lists and tuples:
 
     >>> u.Quantity([1.0, 2.0], u.meter)
+    <Quantity [1., 2.] m>
+
+    >>> u.Quantity((1.0, 2.0), u.meter)
     <Quantity [1., 2.] m>
 
 Numpy arrays:

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -1,14 +1,18 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """Typing module for supporting type annotations related to :mod:`~astropy.units`."""
+
+from __future__ import annotations
 
 __all__ = ["QuantityLike"]
 
 
+from typing import TYPE_CHECKING
+
 import numpy.typing as npt
-from typing_extensions import TypeAlias
 
 from astropy.units import Quantity
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 # Note: Quantity is technically covered by npt.ArrayLike, but we want to
 # explicitly include it here so that it is clear that we are also including

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 __all__ = ["QuantityLike"]
 
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import numpy.typing as npt
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 # Note: Quantity is technically covered by npt.ArrayLike, but we want to
 # explicitly include it here so that it is clear that we are also including
 # Quantity objects in the definition of QuantityLike.
-QuantityLike: TypeAlias = Quantity | npt.ArrayLike
+QuantityLike: TypeAlias = Union[Quantity, npt.ArrayLike]
 """Type alias for a quantity-like object.
 
 This is an object that can be converted to a :class:`~astropy.units.Quantity` object

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 from astropy.units import Quantity
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 # Note: Quantity is technically covered by npt.ArrayLike, but we want to
 # explicitly include it here so that it is clear that we are also including

--- a/docs/changes/units/15860.feature.rst
+++ b/docs/changes/units/15860.feature.rst
@@ -1,0 +1,2 @@
+Added a new module ``typing`` that provides support for type annotations related to
+``astropy.units``.

--- a/docs/changes/units/15860.feature.rst
+++ b/docs/changes/units/15860.feature.rst
@@ -1,2 +1,2 @@
-Added a new module ``typing`` that provides support for type annotations related to
+Added a new module ``astropy.units.typing`` that provides support for type annotations related to
 ``astropy.units``.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -57,9 +57,10 @@ Astropy Glossary
 
    quantity-like
       `~astropy.units.Quantity` (or subclass) instance, a number or `array-like
-      <https://numpy.org/doc/stable/glossary.html#term-array_like>`_ object with a
-      :term:`unit-like` ``unit`` attribute, or a string which is a valid initializer
-      for `~astropy.units.Quantity`.
+      <https://numpy.org/doc/stable/glossary.html#term-array_like>`_ object, or a string
+      which is a valid initializer for `~astropy.units.Quantity`.
+
+      For a formal definition see :obj:`~astropy.units.typing.QuantityLike`.
 
    table-like
       :class:`~astropy.table.Table` (or subclass) instance or valid initializer for

--- a/docs/units/type_hints.rst
+++ b/docs/units/type_hints.rst
@@ -1,3 +1,11 @@
+Type Annotations Module
+***********************
+
+.. automodule:: astropy.units.typing
+   :members:
+   :show-inheritance:
+
+
 Unit-Aware Type Annotations
 ***************************
 

--- a/docs/units/type_hints.rst
+++ b/docs/units/type_hints.rst
@@ -1,11 +1,3 @@
-Type Annotations Module
-***********************
-
-.. automodule:: astropy.units.typing
-   :members:
-   :show-inheritance:
-
-
 Unit-Aware Type Annotations
 ***************************
 
@@ -88,3 +80,12 @@ Multiple Quantity and unit-aware |Quantity| annotations are supported using
    >>> T.Union[Quantity[u.m], Quantity["time"]]
    typing.Union[typing.Annotated[astropy.units.quantity.Quantity, Unit("m")],
                 typing.Annotated[astropy.units.quantity.Quantity, PhysicalType('time')]]
+
+
+
+Type Annotations Module
+***********************
+
+.. automodule:: astropy.units.typing
+   :members:
+   :show-inheritance:


### PR DESCRIPTION
Create `units.typing` module with definition of `QuantityLike`.

`units` is a very fundamental part of Astropy and this definition will be used throughout Astropy by importing in a `typing.TYPE_CHECKING` block.