### PR TITLE
Define `__all__` for `units`

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -10,7 +10,18 @@ Pontzen, who has granted the Astropy project permission to use the
 code under a BSD license.
 """
 
-from . import astrophys, cgs, misc, photometric, si
+from . import (
+    astrophys,
+    cgs,
+    core,
+    decorators,
+    misc,
+    photometric,
+    physical,
+    quantity,
+    si,
+    structured,
+)
 from .astrophys import *
 from .cgs import *
 from .core import *
@@ -25,17 +36,28 @@ from .structured import *
 
 # Import order matters here -- circular dependencies abound!
 # isort: split
+from . import equivalencies, function
 from .equivalencies import *
-from .function import units as function_units
-from .function.core import *
-from .function.logarithmic import *
-from .function.units import *
+from .function import *
 
-del bases
+__all__ = []
+__all__ += core.__all__
+__all__ += quantity.__all__
+__all__ += decorators.__all__
+__all__ += structured.__all__
+__all__ += si.__all__
+__all__ += cgs.__all__
+__all__ += astrophys.__all__
+__all__ += physical.__all__
+__all__ += misc.__all__
+__all__ += photometric.__all__
+__all__ += structured.__all__
+__all__ += equivalencies.__all__
+__all__ += function.__all__
 
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
-set_enabled_units([si, cgs, astrophys, function_units, misc, photometric])
+set_enabled_units([si, cgs, astrophys, function.units, misc, photometric])
 
 
 # -------------------------------------------------------------------------

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -16,13 +16,12 @@ code under a BSD license.
 # this also makes it easier to understand where most time is spent
 # (e.g., using python -X importtime).
 
-from .core import set_enabled_units
-
-# isort: off
+from . import astrophys, cgs, misc, photometric, si
 from .core import *
+from .core import set_enabled_units
 from .quantity import *
 
-from . import astrophys, cgs, misc, photometric, si
+# isort: off
 from .function import units as function_units
 
 from .si import *

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -10,43 +10,31 @@ Pontzen, who has granted the Astropy project permission to use the
 code under a BSD license.
 """
 
-# Import order matters here -- circular dependencies abound!
-# Lots of things to import - go from more basic to advanced, so that
-# whatever advanced ones need generally has been imported already;
-# this also makes it easier to understand where most time is spent
-# (e.g., using python -X importtime).
-
 from . import astrophys, cgs, misc, photometric, si
+from .astrophys import *
+from .cgs import *
 from .core import *
 from .core import set_enabled_units
-from .quantity import *
-
-# isort: off
-from .function import units as function_units
-
-from .si import *
-from .astrophys import *
-from .photometric import *
-from .cgs import *
-from .physical import *
-from .function.units import *
-from .misc import *
-
-from .equivalencies import *
-
-from .function.core import *
-from .function.logarithmic import *
-
 from .decorators import *
+from .misc import *
+from .photometric import *
+from .physical import *
+from .quantity import *
+from .si import *
 from .structured import *
 
-# isort: on
+# Import order matters here -- circular dependencies abound!
+# isort: split
+from .equivalencies import *
+from .function import units as function_units
+from .function.core import *
+from .function.logarithmic import *
+from .function.units import *
 
 del bases
 
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
-
 set_enabled_units([si, cgs, astrophys, function_units, misc, photometric])
 
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -16,6 +16,8 @@ set_enabled_units([si])
 
 import numpy as _np  # noqa: E402
 
+__all__: list[str] = []  #  Units are added at the end
+
 _ns = globals()
 
 ###########################################################################
@@ -216,15 +218,9 @@ def_unit(
 )
 
 ###########################################################################
-# CLEANUP
+# ALL & DOCSTRING
 
-del UnitBase
-del def_unit
-del si
-
-
-###########################################################################
-# DOCSTRING
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -34,6 +34,10 @@ you have a string that uses CDS units:
 <Quantity 0.95992119 bar>
 """
 
+__all__ = ["enable"]  #  Units are added at the end
+
+from .core import UnitBase
+
 _ns = globals()
 
 
@@ -179,7 +183,9 @@ _initialize_module()
 
 
 ###########################################################################
-# DOCSTRING
+# ALL & DOCSTRING
+
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -10,6 +10,8 @@ from fractions import Fraction
 from . import si
 from .core import UnitBase, def_unit
 
+__all__: list[str] = []  #  Units are added at the end
+
 _ns = globals()
 
 cm = si.cm
@@ -169,16 +171,9 @@ bases = {cm, g, s, rad, cd, K, mol}
 
 
 ###########################################################################
-# CLEANUP
+# ALL & DOCSTRING
 
-del UnitBase
-del def_unit
-del si
-del Fraction
-
-
-###########################################################################
-# DOCSTRING
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/function/__init__.py
+++ b/astropy/units/function/__init__.py
@@ -5,5 +5,13 @@ This subpackage contains classes and functions for defining and converting
 between different function units and quantities, i.e., using units which
 are some function of a physical unit, such as magnitudes and decibels.
 """
+
+from . import core, logarithmic, units
 from .core import *
 from .logarithmic import *
+from .units import *
+
+__all__: list[str] = []
+__all__ += core.__all__
+__all__ += logarithmic.__all__
+__all__ += units.__all__

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -5,9 +5,11 @@ If called, their arguments are used to initialize the corresponding function
 unit (e.g., ``u.mag(u.ct/u.s)``).  Note that the prefixed versions cannot be
 called, as it would be unclear what, e.g., ``u.mmag(u.ct/u.s)`` would mean.
 """
-from astropy.units.core import _add_prefixes
+from astropy.units.core import UnitBase, _add_prefixes
 
 from .mixin import IrreducibleFunctionUnit, RegularFunctionUnit
+
+__all__: list[str] = []  #  Units are added at the end
 
 _ns = globals()
 
@@ -37,14 +39,11 @@ mag = RegularFunctionUnit(
 
 _add_prefixes(mag, namespace=_ns, prefixes=True)
 
-###########################################################################
-# CLEANUP
-
-del RegularFunctionUnit
-del IrreducibleFunctionUnit
 
 ###########################################################################
 # DOCSTRING
+
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -17,6 +17,7 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
     >>> u.imperial.enable()  # doctest: +SKIP
 """
 
+__all__: list[str] = []  #  Units are added at the end
 
 from . import si
 from .core import UnitBase, def_unit
@@ -148,16 +149,10 @@ def_unit(
     doc="Rankine scale: absolute scale of thermodynamic temperature",
 )
 
-
 ###########################################################################
-# CLEANUP
+# ALL & DOCSTRING
 
-del UnitBase
-del def_unit
-
-
-###########################################################################
-# DOCSTRING
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -16,6 +16,8 @@ set_enabled_units([si])
 
 import numpy as _np  # noqa: E402
 
+__all__: list[str] = []  #  Units are added at the end
+
 _ns = globals()
 
 ###########################################################################
@@ -130,16 +132,11 @@ def_unit(
     prefixes=True,
 )
 
-
 ###########################################################################
-# CLEANUP
+# ALL & DOCSTRING
 
-del UnitBase
-del def_unit
-del si
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
-###########################################################################
-# DOCSTRING
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -15,6 +15,8 @@ from astropy.constants import si as _si
 from . import astrophys, cgs, si
 from .core import Unit, UnitBase, def_unit
 
+__all__ = ["zero_point_flux"]  #  Units are added at the end
+
 _ns = globals()
 
 def_unit(
@@ -78,14 +80,10 @@ def zero_point_flux(flux0):
 
 
 ###########################################################################
-# CLEANUP
+# ALL & DOCSTRING
 
-del UnitBase
-del def_unit
-del cgs, si, astrophys
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
-###########################################################################
-# DOCSTRING
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -11,6 +11,8 @@ from astropy.constants import si as _si
 
 from .core import Unit, UnitBase, def_unit
 
+__all__: list[str] = []  #  Units are added at the end
+
 _ns = globals()
 
 
@@ -444,15 +446,9 @@ bases = {m, s, kg, A, cd, rad, K, mol}
 
 
 ###########################################################################
-# CLEANUP
+# ALL & DOCSTRING
 
-del UnitBase
-del Unit
-del def_unit
-
-
-###########################################################################
-# DOCSTRING
+__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the


### PR DESCRIPTION
This PR: 
1. Sorts `units.__init__.py`.
2. Expands the arguments to `def_unit` to add the units to `__all__` if it exists.
3. Adds `__all__` to `units`.

Plz squash.