### PR TITLE
Update `pyerfa` version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ keywords = [
 ]
 dependencies = [
     "numpy>=1.23",
-    "pyerfa>=2.0",
+    "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2024.1.1.0.33.39",
     "PyYAML>=3.13",
     "packaging>=19.0",


### PR DESCRIPTION
### Description

f3bd3b50102aef10be35dc3a9f9e7a8f3fbc33f2 added a test for a bug in `pyerfa` that was fixed in version 2.0.1.1. However, `astropy` also supports older versions of `pyerfa` with which the test predictably fails, as reported in #15788. We don't see failures in CI because the CI always uses the latest `pyerfa`, including in the `oldestdeps` job (!).

The simplest solution is to update the `pyerfa` version requirement. This also helps ensure all users benefit from the `pyerfa` bugfixes.

See also https://github.com/astropy/astropy/issues/15788#issuecomment-1869054337

Fixes the `coordinates` portion of #15788 (and resolves it if the `matplotlib` problems there are not our concern).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
