### PR TITLE
change convention for typing_extensions

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -17,15 +17,11 @@ from astropy.units import Quantity
 from astropy.utils import isiterable
 
 if TYPE_CHECKING:
-    import sys
     from typing import Any, Callable
 
-    from astropy.units import UnitBase
+    from typing_extensions import Self
 
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
+    from astropy.units import UnitBase
 
 __all__ = ["ModelBoundingBox", "CompoundBoundingBox"]
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -46,12 +46,7 @@ from .structured import StructuredUnit, _structured_unit_like_dtype
 from .utils import is_effectively_unity
 
 if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
+    from typing_extensions import Self
 
     from .typing import QuantityLike
 

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -12,10 +12,7 @@ import numpy.typing as npt
 from astropy.units import Quantity
 
 if TYPE_CHECKING:
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias
 
 # Note: Quantity is technically covered by npt.ArrayLike, but we want to
 # explicitly include it here so that it is clear that we are also including

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ recommended = [
     "matplotlib>=3.3,!=3.4.0,!=3.5.2",
 ]
 typing = [
-    "typing_extensions>=4.0.0 ; python_version < '3.11'",
+    "typing_extensions>=4.0.0"
 ]
 all = [
     "astropy[recommended]",  # installs the [recommended] dependencies


### PR DESCRIPTION
In a recent [PR](https://github.com/astropy/astropy/pull/15686) it was noted that `typing_extensions` is not a runtime dependency and as is consistent with our current policy we added a version check. That was good!
Now that we're starting to add type annotations, and `typing_extensions` is an integral part of that effort I think it's worth formalizing how we deal with `typing_extensions`. 

`typing_extensions` is developed within the core Python org (https://github.com/python/typing_extensions). *It is effectively core python*. Its mission is to provide backports of typing for use in earlier versions of Python. Internally `typing_extensions` does Python version checks to determine whether it should just re-export from `typing` or needs to define the official backport. **ALL** standard type checkers, like mypy, recognize `typing_extensions` since it is "core" python. Moreover, `ruff` has specific rules to **automatically** change our imports from `typing_extensions` to `typing` as we bump our minimum python version.

Putting all this together. Let's make our lives easier and reduce code clutter by trusting `typing_extensions` and our CI. *We don't need to do manual Python version checks.*
Let's make this our policy for `typing_extensions`!

Q: Why not make `typing_extensions` a runtime dependency?

Because we don't yet need it at runtime.

Q: is it really a lot of code clutter?

Heck yeah. This PR has one example. See also #15860 and https://github.com/astropy/astropy/pull/15853#discussion_r1448947674.
I suspect most files in Astropy will have this avoidable clutter.


