### PR TITLE
BUG: fix a bug where columns with dtype=object wouldn't be properly deep-copied using copy.deepcopy

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -608,8 +608,7 @@ class Table:
     meta : dict, optional
         Metadata associated with the table.
     copy : bool, optional
-        Copy the input data. If the input is a Table the ``meta`` is always
-        copied regardless of the ``copy`` parameter.
+        Copy the input column data and make a deep copy of the input meta.
         Default is True.
     rows : numpy ndarray, list of list, optional
         Row-oriented data for table instead of ``data`` argument.
@@ -3777,9 +3776,9 @@ class Table:
         Parameters
         ----------
         copy_data : bool
-            If `True` (the default), copy the underlying data array.
-            Otherwise, use the same data array. The ``meta`` is always
-            deepcopied regardless of the value for ``copy_data``.
+            If `True` (the default), copy the underlying data array and make
+            a deep copy of the ``meta`` attribute. Otherwise, use the same
+            data array and make a shallow (key-only) copy of ``meta``.
         """
         out = self.__class__(self, copy=copy_data)
 
@@ -3791,7 +3790,11 @@ class Table:
         return out
 
     def __deepcopy__(self, memo=None):
-        return self.copy(True)
+        out = self.copy(False)
+        for name in out.colnames:
+            out.columns.__setitem__(name, deepcopy(self[name]), validated=True)
+        out.meta = deepcopy(self.meta)
+        return out
 
     def __copy__(self):
         return self.copy(False)

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import copy
 import operator
 import warnings
 
@@ -462,6 +463,24 @@ class TestColumn:
 
         with pytest.raises(AttributeError):
             t["a"].mask = [True, False]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [np.array([object()]), [object()]],
+)
+def test_deepcopy_object_column(data):
+    # see https://github.com/astropy/astropy/issues/13435
+    c1 = table.Column(data, meta={"test": object()})
+    c2 = copy.deepcopy(c1)
+    assert c2 is not c1
+    assert c2[0] is not c1[0]
+    assert c2.meta["test"] is not c1.meta["test"]
+
+    c3 = table.Column(c1, copy=True)
+    assert c3 is not c1
+    assert c3[0] is c1[0]
+    assert c3.meta["test"] is not c1.meta["test"]
 
 
 class TestAttrEqual:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2720,6 +2720,27 @@ def test_table_meta_copy_with_meta_arg():
     assert t.meta[1] is not meta[1]
 
 
+@pytest.mark.parametrize(
+    "data",
+    [np.array([object()]), [object()]],
+)
+def test_deepcopy_object_column(data):
+    # see https://github.com/astropy/astropy/issues/13435
+    t1 = Table({"a": data}, meta={"test": object()})
+    t2 = copy.deepcopy(t1)
+    c1 = t1["a"]
+    c2 = t2["a"]
+    assert c2 is not c1
+    assert c2[0] is not c1[0]
+    assert t2.meta["test"] is not t1.meta["test"]
+
+    t3 = Table(t1, copy=True)
+    c3 = t3["a"]
+    assert c3 is not c1
+    assert c3[0] is c1[0]
+    assert t3.meta["test"] is not t1.meta["test"]
+
+
 def test_replace_column_qtable():
     """Replace existing Quantity column with a new column in a QTable"""
     a = [1, 2, 3] * u.m

--- a/docs/changes/table/15871.bugfix.rst
+++ b/docs/changes/table/15871.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where columns with ``dtype=object`` wouldn't be properly deep-copied using ``copy.deepcopy``.


### PR DESCRIPTION
### Description
Fixes #13435

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
