### PR TITLE
Address RET505 in astropy/convolution

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -162,7 +162,6 @@ lint.ignore = [
     "RET502",  # implicit-return-value
     "RET503",  # implicit-return
     "RET504",  # unnecessary-assign
-    "RET505",  # superfluous-else-return
     "RET507",  # superfluous-else-continue
 
     # flake8-raise (RSE)
@@ -238,18 +237,23 @@ lint.unfixable = [
     "PTH114",  # os-path-islink
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
+
 ]
 "astropy/constants/*" = ["N817"]  # camelcase-imported-as-acronym
 "astropy/convolution/*" = [
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/coordinates/*" = [
     "DTZ007",  # call-datetime-strptime-without-zone
+    "RET505",  # superfluous-else-return
 ]
 "astropy/cosmology/*" = [
     "C408",  # unnecessary-collection-call
     "PT019",   # pytest-fixture-param-without-value
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/io/*" = [
     "G001",  # logging-string-format
@@ -260,59 +264,71 @@ lint.unfixable = [
     "SLOT000",  # Subclasses of `str` should define `__slots__`
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception
+    "RET505",  # superfluous-else-return
 ]
-"astropy/logger.py" = ["C408"]
+"astropy/logger.py" = ["C408", "RET505"]
 "astropy/modeling/*" = [
     "C408",  # unnecessary-collection-call
     "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
+    "RET505",  # superfluous-else-return
 ]
 "astropy/nddata/*" = [
     "C408",
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/samp/*" = [
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/stats/*" = [
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/table/*" = [
     "C408",  # unnecessary-collection-call
     "RET506",  # superfluous-else-raise
     "S605",  # Starting a process with a shell, possible injection detected
+    "RET505",  # superfluous-else-return
 ]
-"astropy/tests/*" = ["C408"]
+"astropy/tests/*" = ["C408", "RET505"]
 "astropy/time/*" = [
     "C408",  # unnecessary-collection-call
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/timeseries/*" = [
     "C408",
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/units/*" = [
     "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/uncertainty/*" = [
     "C408",
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/utils/*" = [
     "C408",  # unnecessary-collection-call
     "N811",  # constant-imported-as-non-constant
     "RET506",  # superfluous-else-raise
     "S321",  # Suspicious-ftp-lib-usage
+    "RET505",  # superfluous-else-return
 ]
 "astropy/visualization/*" = [
     "B015",
     "C408",
     "RET506",  # superfluous-else-raise
+    "RET505",  # superfluous-else-return
 ]
 "astropy/wcs/*" = [
     "C408",  # unnecessary-collection-call
@@ -320,6 +336,7 @@ lint.unfixable = [
     "S608",  # Posslibe SQL injection
     "RET506",  # superfluous-else-raise
     "SIM202",  # NegateNotEqualOp
+    "RET505",  # superfluous-else-return
 ]
 "docs/*" = []
 "examples/coordinates/*" = []

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -236,14 +236,16 @@ lint.unfixable = [
 "astropy/config/*" = [
     "PTH114",  # os-path-islink
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
-
+    "RET506",  # superfluous-else-raise
 ]
-"astropy/constants/*" = ["N817"]  # camelcase-imported-as-acronym
-"astropy/convolution/*" = [
-    "RET506",  # superfluous-else-raise
+"astropy/constants/*" = [
+    "N817",  # camelcase-imported-as-acronym
     "RET505",  # superfluous-else-return
+]
+"astropy/convolution/*" = [
+    "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/coordinates/*" = [
     "DTZ007",  # call-datetime-strptime-without-zone
@@ -252,91 +254,91 @@ lint.unfixable = [
 "astropy/cosmology/*" = [
     "C408",  # unnecessary-collection-call
     "PT019",   # pytest-fixture-param-without-value
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/io/*" = [
     "G001",  # logging-string-format
     "G004",  # logging-f-string
     "PTH116",  # os-stat
     "PTH117",  # os-path-isabs
+    "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "SLOT000",  # Subclasses of `str` should define `__slots__`
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception
-    "RET505",  # superfluous-else-return
 ]
 "astropy/logger.py" = ["C408", "RET505"]
 "astropy/modeling/*" = [
     "C408",  # unnecessary-collection-call
+    "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
-    "RET505",  # superfluous-else-return
 ]
 "astropy/nddata/*" = [
     "C408",
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/samp/*" = [
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/stats/*" = [
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/table/*" = [
     "C408",  # unnecessary-collection-call
+    "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "S605",  # Starting a process with a shell, possible injection detected
-    "RET505",  # superfluous-else-return
 ]
 "astropy/tests/*" = ["C408", "RET505"]
 "astropy/time/*" = [
     "C408",  # unnecessary-collection-call
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/timeseries/*" = [
     "C408",
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/units/*" = [
     "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/uncertainty/*" = [
     "C408",
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/utils/*" = [
     "C408",  # unnecessary-collection-call
     "N811",  # constant-imported-as-non-constant
+    "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "S321",  # Suspicious-ftp-lib-usage
-    "RET505",  # superfluous-else-return
 ]
 "astropy/visualization/*" = [
     "B015",
     "C408",
-    "RET506",  # superfluous-else-raise
     "RET505",  # superfluous-else-return
+    "RET506",  # superfluous-else-raise
 ]
 "astropy/wcs/*" = [
     "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
     "S608",  # Posslibe SQL injection
+    "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "SIM202",  # NegateNotEqualOp
-    "RET505",  # superfluous-else-return
 ]
 "docs/*" = []
 "examples/coordinates/*" = []

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -453,7 +453,7 @@ def convolve(
         if isinstance(passed_kernel, Kernel):
             new_result._separable = new_result._separable and passed_kernel._separable
         return new_result
-    elif array_dtype.kind == "f":
+    if array_dtype.kind == "f":
         # Try to preserve the input type if it's a floating point type
         # Avoid making another copy if possible
         try:
@@ -947,8 +947,7 @@ def convolve_fft(
     if crop:
         result = rifft[arrayslices].real
         return result
-    else:
-        return rifft.real
+    return rifft.real
 
 
 def interpolate_replace_nans(array, kernel, convolve=convolve, **kwargs):

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -944,10 +944,7 @@ def convolve_fft(
     if preserve_nan:
         rifft[arrayslices][nanmaskarray] = np.nan
 
-    if crop:
-        result = rifft[arrayslices].real
-        return result
-    return rifft.real
+    return rifft[arrayslices].real if crop else rifft.real
 
 
 def interpolate_replace_nans(array, kernel, convolve=convolve, **kwargs):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -184,9 +184,7 @@ class Kernel:
         """
         Wrapper for multiplication with numpy arrays.
         """
-        if type(context[0]) == np.ufunc:
-            return NotImplemented
-        return array
+        return NotImplemented if type(context[0]) == np.ufunc else array
 
 
 class Kernel1D(Kernel):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -186,8 +186,7 @@ class Kernel:
         """
         if type(context[0]) == np.ufunc:
             return NotImplemented
-        else:
-            return array
+        return array
 
 
 class Kernel1D(Kernel):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -184,7 +184,7 @@ class Kernel:
         """
         Wrapper for multiplication with numpy arrays.
         """
-        return NotImplemented if type(context[0]) == np.ufunc else array
+        return NotImplemented if isinstance(context[0], np.ufunc) else array
 
 
 class Kernel1D(Kernel):

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -33,8 +33,7 @@ def _round_up_to_odd_integer(value):
     i = math.ceil(value)
     if i % 2 == 0:
         return i + 1
-    else:
-        return i
+    return i
 
 
 class Gaussian1DKernel(Kernel1D):

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -31,9 +31,7 @@ __all__ = [
 
 def _round_up_to_odd_integer(value):
     i = math.ceil(value)
-    if i % 2 == 0:
-        return i + 1
-    return i
+    return i + 1 if i % 2 == 0 else i
 
 
 class Gaussian1DKernel(Kernel1D):

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -264,11 +264,9 @@ def discretize_bilinear_2D(model, x_range, y_range):
     values_intermediate_grid = model(x, y)
 
     # Mean in y direction
-    values_y = 0.5 * (
-        values_intermediate_grid[1:, :] + values_intermediate_grid[:-1, :]
-    )
+    values = 0.5 * (values_intermediate_grid[1:, :] + values_intermediate_grid[:-1, :])
     # Mean in x direction
-    return 0.5 * (values_y[:, 1:] + values_y[:, :-1])
+    return 0.5 * (values[:, 1:] + values[:, :-1])
 
 
 def discretize_oversample_1D(model, x_range, factor=10):

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -30,8 +30,7 @@ class KernelArithmeticError(KernelError):
 def has_even_axis(array):
     if isinstance(array, (list, tuple)):
         return not len(array) % 2
-    else:
-        return any(not axes_size % 2 for axes_size in array.shape)
+    return any(not axes_size % 2 for axes_size in array.shape)
 
 
 def add_kernel_arrays_1D(array_1, array_2):
@@ -46,7 +45,7 @@ def add_kernel_arrays_1D(array_1, array_2):
         slice_ = slice(center - array_2.size // 2, center + array_2.size // 2 + 1)
         new_array[slice_] += array_2
         return new_array
-    elif array_2.size > array_1.size:
+    if array_2.size > array_1.size:
         new_array = array_2.copy()
         center = array_2.size // 2
         slice_ = slice(center - array_1.size // 2, center + array_1.size // 2 + 1)
@@ -72,7 +71,7 @@ def add_kernel_arrays_2D(array_1, array_2):
         )
         new_array[slice_y, slice_x] += array_2
         return new_array
-    elif array_2.size > array_1.size:
+    if array_2.size > array_1.size:
         new_array = array_2.copy()
         center = [axes_size // 2 for axes_size in array_2.shape]
         slice_x = slice(
@@ -205,7 +204,7 @@ def discretize_model(model, x_range, y_range=None, mode="center", factor=10):
     if mode == "center":
         if ndim == 1:
             return discretize_center_1D(model, x_range)
-        elif ndim == 2:
+        if ndim == 2:
             return discretize_center_2D(model, x_range, y_range)
     elif mode == "linear_interp":
         if ndim == 1:
@@ -265,10 +264,11 @@ def discretize_bilinear_2D(model, x_range, y_range):
     values_intermediate_grid = model(x, y)
 
     # Mean in y direction
-    values = 0.5 * (values_intermediate_grid[1:, :] + values_intermediate_grid[:-1, :])
+    values_y = 0.5 * (
+        values_intermediate_grid[1:, :] + values_intermediate_grid[:-1, :]
+    )
     # Mean in x direction
-    values = 0.5 * (values[:, 1:] + values[:, :-1])
-    return values
+    return 0.5 * (values_y[:, 1:] + values_y[:, :-1])
 
 
 def discretize_oversample_1D(model, x_range, factor=10):


### PR DESCRIPTION
### Description:

This PR addresses Ruff rule RET505 violations in ``astropy/convolution`` (as said in #14818).

> If you are editing a single sub-package and the rule is in the global ignore list then remove it from there and add it to the ignore lists of sub-packages that are violating that rule, but not to the list of the sub-package you will be updating.

I have addressed the violations as well as updated the [``.ruff.toml``](https://github.com/astropy/astropy/blob/main/.ruff.toml) file.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
