### PR TITLE
Apply Ruff TCH rules to imports from `typing`

### DIFF
--- a/astropy/cosmology/_utils.py
+++ b/astropy/cosmology/_utils.py
@@ -7,13 +7,16 @@ __all__ = []  # nothing is publicly scoped
 import functools
 import operator
 from numbers import Number
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from astropy.units import Quantity
 
 from . import units as cu
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def vectorize_redshift_method(func=None, nin=1):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,6 +405,9 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 ignore-fully-untyped = true
 mypy-init-return = true
 
+[tool.ruff.lint.flake8-type-checking]
+exempt-modules = []
+
 [tool.ruff.lint.isort]
 known-first-party = ["astropy", "extension_helpers"]
 


### PR DESCRIPTION
### Description

The [Ruff TCH rules](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch) help ensure that imports only needed for type annotations are in an `if TYPE_CHECKING:` block, so that they are not executed at runtime, but [by default imports from `typing` are excluded from those rules](https://docs.astral.sh/ruff/settings/#flake8-type-checking). If we want to ensure all imports only needed for type checking are in an `if TYPE_CHECKING:` block then the Ruff configuration must be updated.

PS Should we have a `typing` label?

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
