### PR TITLE
cosmo: add type annotations for realizations

### DIFF
--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -22,12 +22,16 @@ __all__ = [  # noqa: F822 (undefined name)
 
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 
 from astropy.utils.data import get_pkg_data_path
 from astropy.utils.state import ScienceState
 
 from . import _io  # Ensure IO methods are registered, to read realizations # noqa: F401
 from .core import Cosmology
+
+if TYPE_CHECKING:
+    from typing import ClassVar
 
 __doctest_requires__ = {"*": ["scipy"]}
 
@@ -46,7 +50,7 @@ available = (
 )
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Cosmology:
     """Make specific realizations from data files with lazy import from ``PEP 562``.
 
     Raises
@@ -71,7 +75,7 @@ def __getattr__(name):
     return cosmo
 
 
-def __dir__():
+def __dir__() -> list[str]:
     """Directory, including lazily-imported objects."""
     return __all__
 
@@ -104,8 +108,8 @@ class default_cosmology(ScienceState):
                       Om0=0.30966, ...
     """
 
-    _default_value = "Planck18"
-    _value = "Planck18"
+    _default_value: ClassVar[str] = "Planck18"
+    _value: ClassVar[str | Cosmology] = "Planck18"
 
     @classmethod
     def validate(cls, value: Cosmology | str | None) -> Cosmology | None:


### PR DESCRIPTION
Add type annotations to `astropy.cosmology.realizations`.