### PR TITLE
make ParametersAttribute.attr_name a string

### DIFF
--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = []
+__all__: list[str] = []
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
@@ -31,8 +31,12 @@ class ParametersAttribute:
         The name of the class attribute containing the Parameter objects.
     """
 
-    attr_name: str | None = None
-    """The name of the class attribute containing the Parameter objects."""
+    attr_name: str
+    """The name of the class attribute containing the Parameter objects.
+
+    ``attr_name`` is different from the name of the descriptor on the containing class,
+    which is set by :meth:`__set_name__`.
+    """
 
     _name: str = field(init=False)
     """The name of the descriptor on the containing class."""
@@ -43,10 +47,10 @@ class ParametersAttribute:
     def __get__(
         self, instance: Cosmology | None, owner: type[Cosmology] | None
     ) -> MappingProxyType[str, Any]:
-        # called from the class
+        # Called from the class
         if instance is None:
             return getattr(owner, self.attr_name)
-        # called from the instance
+        # Called from the instance
         return MappingProxyType(
             {n: getattr(instance, n) for n in getattr(instance, self.attr_name)}
         )

--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -19,16 +19,44 @@ _dataclass_kwargs = {} if PYTHON_LT_3_10 else {"slots": True}
 
 @dataclass(frozen=True, **_dataclass_kwargs)
 class ParametersAttribute:
-    """Immutable mapping of the Parameters.
+    """Immutable mapping of the :class:`~astropy.cosmology.Parameter` objects or values.
 
-    If accessed from the class, this returns a mapping of the Parameter
-    objects themselves.  If accessed from an instance, this returns a
-    mapping of the values of the Parameters.
+    If accessed from the :class:`~astropy.cosmology.Cosmology` class, this returns a
+    mapping of the :class:`~astropy.cosmology.Parameter` objects themselves.  If
+    accessed from an instance, this returns a mapping of the values of the Parameters.
+
+    This class is used to implement the ``parameters`` attribute of
+    :class:`~astropy.cosmology.Cosmology`.
 
     Parameters
     ----------
     attr_name : str
         The name of the class attribute containing the Parameter objects.
+
+    Examples
+    --------
+    This class works as a descriptor on the containing class. When accessed from the
+    class, it returns the attribute specified by ``attr_name``. When accessed from an
+    instance, it returns a proxy mapping of the value for each key in ``attr_name``.
+
+    In the following example ``attr_name`` is set to ``_attr_map``, which is not a
+    dictionary, but a tuple of strings. When accessed from the class, the tuple is
+    returned. When accessed from an instance, a mapping of the values of the attributes
+    named in the tuple is returned.
+
+    >>> class Obj:
+    ...     a = 1
+    ...     b = 2
+    ...     c = 3
+    ...     _attr_map = ("a", "b", "c")
+    ...     attr = ParametersAttribute(attr_name="_attr_map")
+
+    >>> Obj.attr
+    ("a", "b", "c")
+
+    >>> obj = Obj()
+    >>> obj.attr
+    mappingproxy({'a': 1, 'b': 2, 'c': 3})
     """
 
     attr_name: str

--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -52,7 +52,7 @@ class ParametersAttribute:
     ...     attr = ParametersAttribute(attr_name="_attr_map")
 
     >>> Obj.attr
-    ("a", "b", "c")
+    ('a', 'b', 'c')
 
     >>> obj = Obj()
     >>> obj.attr

--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -50,7 +50,7 @@ class ParametersAttribute:
     """
 
     attr_name: str
-    """Clas attribute name on Cosmology for the mapping of Parameter objects."""
+    """Class attribute name on Cosmology for the mapping of Parameter objects."""
 
     _name: str = field(init=False)
     """The name of the descriptor on the containing class."""

--- a/astropy/cosmology/parameter/_descriptors.py
+++ b/astropy/cosmology/parameter/_descriptors.py
@@ -25,46 +25,32 @@ class ParametersAttribute:
     mapping of the :class:`~astropy.cosmology.Parameter` objects themselves.  If
     accessed from an instance, this returns a mapping of the values of the Parameters.
 
-    This class is used to implement the ``parameters`` attribute of
-    :class:`~astropy.cosmology.Cosmology`.
+    This class is used to implement :obj:`astropy.cosmology.Cosmology.parameters`.
 
     Parameters
     ----------
     attr_name : str
-        The name of the class attribute containing the Parameter objects.
+        The name of the class attribute that is a `~types.MappingProxyType[str,
+        astropy.cosmology.Parameter]` of all the cosmology's parameters. When accessed
+        from the class, this attribute is returned. When accessed from an instance, a
+        mapping of the cosmology instance's values for each key is returned.
 
     Examples
     --------
-    This class works as a descriptor on the containing class. When accessed from the
-    class, it returns the attribute specified by ``attr_name``. When accessed from an
-    instance, it returns a proxy mapping of the value for each key in ``attr_name``.
+    The normal usage of this class is the ``parameters`` attribute of
+    :class:`~astropy.cosmology.Cosmology`.
 
-    In the following example ``attr_name`` is set to ``_attr_map``, which is not a
-    dictionary, but a tuple of strings. When accessed from the class, the tuple is
-    returned. When accessed from an instance, a mapping of the values of the attributes
-    named in the tuple is returned.
+        >>> from astropy.cosmology import FlatLambdaCDM, Planck18
 
-    >>> class Obj:
-    ...     a = 1
-    ...     b = 2
-    ...     c = 3
-    ...     _attr_map = ("a", "b", "c")
-    ...     attr = ParametersAttribute(attr_name="_attr_map")
+        >>> FlatLambdaCDM.parameters
+        mappingproxy({'H0': Parameter(...), ...})
 
-    >>> Obj.attr
-    ('a', 'b', 'c')
-
-    >>> obj = Obj()
-    >>> obj.attr
-    mappingproxy({'a': 1, 'b': 2, 'c': 3})
+        >>> Planck18.parameters
+        mappingproxy({'H0': <Quantity 67.66 km / (Mpc s)>, ...})
     """
 
     attr_name: str
-    """The name of the class attribute containing the Parameter objects.
-
-    ``attr_name`` is different from the name of the descriptor on the containing class,
-    which is set by :meth:`__set_name__`.
-    """
+    """Clas attribute name on Cosmology for the mapping of Parameter objects."""
 
     _name: str = field(init=False)
     """The name of the descriptor on the containing class."""

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -29,12 +29,12 @@ class TestParametersAttribute:
         return "attr"
 
     @pytest.fixture
-    def obj_class(self) -> type[Obj]:
+    def obj_cls(self) -> type[Obj]:
         return Obj
 
     @pytest.fixture
-    def obj(self, obj_class) -> Obj:
-        return obj_class()
+    def obj(self, obj_cls) -> Obj:
+        return obj_cls()
 
     # ===============================================================
 
@@ -43,9 +43,9 @@ class TestParametersAttribute:
         attr = ParametersAttribute("attr_name")
         assert attr.attr_name == "attr_name"
 
-    def test_get_from_class(self, obj_class):
+    def test_get_from_class(self, obj_cls):
         """Test the descriptor ``__get__``."""
-        assert obj_class.attr == ("a", "b", "c")
+        assert obj_cls.attr == ("a", "b", "c")
 
     def test_get_from_instance(self, obj):
         """Test the descriptor ``__get__``."""

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -3,15 +3,70 @@
 """Testing :mod:`astropy.cosmology.parameter._descriptor`."""
 
 from types import MappingProxyType
+from typing import ClassVar
 
 import pytest
 
 from astropy.cosmology._utils import all_cls_vars
 from astropy.cosmology.parameter import Parameter
+from astropy.cosmology.parameter._descriptors import ParametersAttribute
+
+
+class Obj:
+    a: ClassVar = 1
+    b: ClassVar = 2
+    c: ClassVar = 3
+    _attr_map: ClassVar = ("a", "b", "c")
+
+    attr = ParametersAttribute(attr_name="_attr_map")
+
+
+class TestParametersAttribute:
+    """Test the descriptor ``ParametersAttribute``."""
+
+    @pytest.fixture
+    def attr_name(self) -> str:
+        return "attr"
+
+    @pytest.fixture
+    def obj_class(self) -> type[Obj]:
+        return Obj
+
+    @pytest.fixture
+    def obj(self, obj_class) -> Obj:
+        return obj_class()
+
+    # ===============================================================
+
+    def test_init(self):
+        """Test constructing a ParametersAttribute."""
+        attr = ParametersAttribute("attr_name")
+        assert attr.attr_name == "attr_name"
+
+    def test_get_from_class(self, obj_class):
+        """Test the descriptor ``__get__``."""
+        assert obj_class.attr == ("a", "b", "c")
+
+    def test_get_from_instance(self, obj):
+        """Test the descriptor ``__get__``."""
+        assert isinstance(obj.attr, MappingProxyType)
+        assert tuple(obj.attr.keys()) == obj._attr_map
+
+    def test_set_from_instance(self, obj):
+        """Test the descriptor ``__set__``."""
+        with pytest.raises(AttributeError, match="cannot set 'attr' of"):
+            obj.attr = {}
+
+
+##############################################################################
 
 
 class ParametersAttributeTestMixin:
-    """Test the descriptor for ``parameters`` on Cosmology classes."""
+    """Test the descriptor for ``parameters`` on Cosmology classes.
+
+    This is a mixin class and is mixed into
+    :class:`~astropy.cosmology.tests.test_core.CosmologyTest`.
+    """
 
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
     def test_parameters_from_class(self, cosmo_cls, name):

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -2,8 +2,10 @@
 
 """Testing :mod:`astropy.cosmology.parameter._descriptor`."""
 
+from __future__ import annotations
+
 from types import MappingProxyType
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -11,21 +13,24 @@ from astropy.cosmology._utils import all_cls_vars
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.parameter._descriptors import ParametersAttribute
 
+if TYPE_CHECKING:
+    from astropy.cosmology.core import Cosmology
+
 
 class Obj:
     """Example class with a ParametersAttribute."""
 
     # Attributes that will be accessed by ParametersAttribute when called an instance
     # of this class. On a Cosmology these would be the Parameter objects.
-    a: ClassVar = 1
-    b: ClassVar = 2
-    c: ClassVar = 3
+    a: ClassVar[int] = 1
+    b: ClassVar[int] = 2
+    c: ClassVar[int] = 3
     # The class attribute that is accessed by ParametersAttribute when called on the
     # class. On a Cosmology this would be the mapping of Parameter objects.
     # Here it is just the names of the attributes that will be accessed by the
     # ParametersAttribute to better distinguish between the class and instance
     # attributes.
-    _attr_map: ClassVar = ("a", "b", "c")
+    _attr_map: ClassVar[tuple[str, ...]] = ("a", "b", "c")
 
     # The ParametersAttribute descriptor. This will return a mapping of the values of
     # the attributes listed in ``_attr_map`` when called on an instance of this class.
@@ -36,7 +41,7 @@ class Obj:
 class TestParametersAttribute:
     """Test the descriptor ``ParametersAttribute``."""
 
-    def test_init(self):
+    def test_init(self) -> None:
         """Test constructing a ParametersAttribute."""
         # Proper construction
         attr = ParametersAttribute("attr_name")
@@ -45,33 +50,33 @@ class TestParametersAttribute:
         # Improper construction
         # There isn't type checking on the attr_name, so this is allowed, but will fail
         # later when the descriptor is used.
-        attr = ParametersAttribute(1)
+        attr = ParametersAttribute(1)  # type: ignore[arg-type]
         assert attr.attr_name == 1
 
-    def test_get_from_class(self):
+    def test_get_from_class(self) -> None:
         """Test the descriptor ``__get__`` from the class."""
         assert Obj.attr == ("a", "b", "c")
 
-    def test_get_from_instance(self):
+    def test_get_from_instance(self) -> None:
         """Test the descriptor ``__get__``."""
         obj = Obj()  # Construct an instance for the attribute `attr`.
         assert isinstance(obj.attr, MappingProxyType)
         assert tuple(obj.attr.keys()) == obj._attr_map
 
-    def test_set_from_instance(self):
+    def test_set_from_instance(self) -> None:
         """Test the descriptor ``__set__``."""
         obj = Obj()  # Construct an instance for the attribute `attr`.
         with pytest.raises(AttributeError, match="cannot set 'attr' of"):
             obj.attr = {}
 
-    def test_descriptor_attr_name_not_str(self):
+    def test_descriptor_attr_name_not_str(self) -> None:
         """Test when ``attr_name`` is not a string and used as a descriptor.
 
         This is a regression test for #15882.
         """
 
         class Obj2(Obj):
-            attr = ParametersAttribute(attr_name=None)
+            attr = ParametersAttribute(attr_name=None)  # type: ignore[arg-type]
 
         obj = Obj2()
 
@@ -92,7 +97,7 @@ class ParametersAttributeTestMixin:
     """
 
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
-    def test_parameters_from_class(self, cosmo_cls, name):
+    def test_parameters_from_class(self, cosmo_cls: type[Cosmology], name: str) -> None:
         """Test descriptor ``parameters`` accessed from the class."""
         descriptor = all_cls_vars(cosmo_cls)[name]
         # test presence
@@ -105,7 +110,7 @@ class ParametersAttributeTestMixin:
         assert all(isinstance(p, Parameter) for p in parameters.values())
 
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
-    def test_parameters_from_instance(self, cosmo, name):
+    def test_parameters_from_instance(self, cosmo: Cosmology, name: str) -> None:
         """Test descriptor ``parameters`` accessed from the instance."""
         descriptor = all_cls_vars(cosmo)[name]
         # test presence
@@ -117,7 +122,9 @@ class ParametersAttributeTestMixin:
         assert set(parameters) == set(getattr(cosmo, descriptor.attr_name))
 
     @pytest.mark.parametrize("name", ["parameters", "_derived_parameters"])
-    def test_parameters_cannot_set_on_instance(self, cosmo, name):
+    def test_parameters_cannot_set_on_instance(
+        self, cosmo: Cosmology, name: str
+    ) -> None:
         """Test descriptor ``parameters`` cannot be set on the instance."""
         with pytest.raises(AttributeError, match=f"cannot set {name!r} of"):
             setattr(cosmo, name, {})

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -13,11 +13,23 @@ from astropy.cosmology.parameter._descriptors import ParametersAttribute
 
 
 class Obj:
+    """Example class with a ParametersAttribute."""
+
+    # Attributes that will be accessed by ParametersAttribute when called an instance
+    # of this class. On a Cosmology these would be the Parameter objects.
     a: ClassVar = 1
     b: ClassVar = 2
     c: ClassVar = 3
+    # The class attribute that is accessed by ParametersAttribute when called on the
+    # class. On a Cosmology this would be the mapping of Parameter objects.
+    # Here it is just the names of the attributes that will be accessed by the
+    # ParametersAttribute to better distinguish between the class and instance
+    # attributes.
     _attr_map: ClassVar = ("a", "b", "c")
 
+    # The ParametersAttribute descriptor. This will return a mapping of the values of
+    # the attributes listed in ``_attr_map`` when called on an instance of this class.
+    # When called on the class, it will return ``_attr_map`` itself.
     attr = ParametersAttribute(attr_name="_attr_map")
 
 
@@ -25,15 +37,13 @@ class TestParametersAttribute:
     """Test the descriptor ``ParametersAttribute``."""
 
     @pytest.fixture
-    def attr_name(self) -> str:
-        return "attr"
-
-    @pytest.fixture
     def obj_cls(self) -> type[Obj]:
+        """The class with the ParametersAttribute."""
         return Obj
 
     @pytest.fixture
     def obj(self, obj_cls) -> Obj:
+        """An instance of the class with the ParametersAttribute."""
         return obj_cls()
 
     # ===============================================================

--- a/astropy/cosmology/parameter/tests/test_descriptors.py
+++ b/astropy/cosmology/parameter/tests/test_descriptors.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import re
+import sys
 from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar
 
@@ -80,9 +82,12 @@ class TestParametersAttribute:
 
         obj = Obj2()
 
-        with pytest.raises(
-            TypeError, match="attribute name must be string, not 'NoneType'"
-        ):
+        if sys.version_info < (3, 11):
+            msg = "getattr(): attribute name must be string"
+        else:
+            msg = "attribute name must be string, not 'NoneType'"
+
+        with pytest.raises(TypeError, match=re.escape(msg)):
             _ = obj.attr
 
 

--- a/docs/changes/cosmology/15882.bugfix.rst
+++ b/docs/changes/cosmology/15882.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where the attribute ``ParametersAttribute.attr_name`` could be None
+instead of a string.


### PR DESCRIPTION
It has to be one anyway since it’s used in `gettattr`.
