### PR TITLE
BUG: fix an unhelpful TypeError when attempting truediv, lshift/mul/truediv with a Unit for right operand and a numpy array with non-numerical dtype for left operand

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -861,6 +861,8 @@ class UnitBase:
             else:
                 return Quantity(m, self ** (-1))
         except TypeError:
+            if isinstance(m, np.ndarray):
+                raise
             return NotImplemented
 
     def __mul__(self, m):
@@ -899,6 +901,8 @@ class UnitBase:
             else:
                 return Quantity(m, unit=self)
         except TypeError:
+            if isinstance(m, np.ndarray):
+                raise
             return NotImplemented
 
     def __rlshift__(self, m):
@@ -907,6 +911,8 @@ class UnitBase:
 
             return Quantity(m, self, copy=False, subok=True)
         except Exception:
+            if isinstance(m, np.ndarray):
+                raise
             return NotImplemented
 
     def __rrshift__(self, m):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Regression tests for the units package."""
+import operator
 import pickle
 from fractions import Fraction
 
@@ -192,6 +193,15 @@ def test_unknown_unit3():
 def test_invalid_scale():
     with pytest.raises(TypeError):
         ["a", "b", "c"] * u.m
+
+
+@pytest.mark.parametrize("op", [operator.truediv, operator.lshift, operator.mul])
+def test_invalid_array_op(op):
+    # see https://github.com/astropy/astropy/issues/12836
+    with pytest.raises(
+        TypeError, match="The value must be a valid Python or Numpy numeric type"
+    ):
+        op(np.array(["cat"]), u.one)
 
 
 def test_cds_power():

--- a/docs/changes/units/15883.bugfix.rst
+++ b/docs/changes/units/15883.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an unhelpful ``TypeError`` when attempting truediv, ``lshift`` (``<<``) or ``mul`` (``*``) or ``truediv`` (``/``) with a ``Unit`` for right operand and a numpy array with non-numerical dtype for left operand.


### PR DESCRIPTION
### Description
Fixes #12836

In my humble opinion, this is the simplest fix possible here.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
