### PR TITLE
BUG: fix write/read roundtrips with empty Table dumped to ECSV

### DIFF
--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -176,8 +176,13 @@ class EcsvHeader(basic.BasicHeader):
 
         # Read the first non-commented line of table and split to get the CSV
         # header column names.  This is essentially what the Basic reader does.
-        header_line = next(super().process_lines(raw_lines))
-        header_names = next(self.splitter([header_line]))
+        try:
+            header_line = next(super().process_lines(raw_lines))
+            header_names = next(self.splitter([header_line]))
+        except StopIteration:
+            # there are no non-commented lines
+            header_line = ""
+            header_names = []
 
         # Check for consistency of the ECSV vs. CSV header column names
         if header_names != self.names:

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -156,6 +156,15 @@ def test_write_read_roundtrip():
                 assert np.all(t[name] == t2[name])
 
 
+def test_write_read_roundtrip_empty_table(tmp_path):
+    # see https://github.com/astropy/astropy/issues/13191
+    sfile = tmp_path / "x.ecsv"
+    Table().write(sfile)
+    t = Table.read(sfile)
+    assert len(t) == 0
+    assert len(t.colnames) == 0
+
+
 def test_bad_delimiter():
     """
     Passing a delimiter other than space or comma gives an exception

--- a/docs/changes/units/15885.bugfix.rst
+++ b/docs/changes/units/15885.bugfix.rst
@@ -1,0 +1,1 @@
+Fix write/read roundtrips with empty ``Table`` dumped to ECSV.


### PR DESCRIPTION
### Description
Fixes #13191

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
