### PR TITLE
Account for change in mask of end point in np.geomspace

### DIFF
--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1052,11 +1052,12 @@ class TestSpaceFunctions:
         expected_mask = np.broadcast_to(
             self.mask_a | self.mask_b, expected.shape
         ).copy()
-        # TODO: make implementation that also ensures start point mask is
-        # determined just by start point? (as for geomspace in numpy 1.20)?
-        expected_mask[-1] = self.mask_b
+        # TODO: make implementations that ensure both start and stop masks
+        # are determined just by their respective point?
         if function is np.geomspace:
             expected_mask[0] = self.mask_a
+        if NUMPY_LT_2_0 or function is not np.geomspace:
+            expected_mask[-1] = self.mask_b
 
         assert_array_equal(out.unmasked, expected)
         assert_array_equal(out.mask, expected_mask)


### PR DESCRIPTION
This pull request is to address a failure in numpy-dev for `np.geomspace`, in which the mask of the final point no longer is determined solely by the mask of `stop` given in `np.geomspace`. Since this behaviour was never particularly important, or indeed guaranteed (for `np.linspace` and `np.logspace` it does not currently work for `start`), simplest seemed to adjust the test.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15884

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
