### PR TITLE
Enable ruff preview for specific rules

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -54,7 +54,6 @@ lint.ignore = [
 
     # pycodestyle (E, W)
     "E501",  # line-too-long
-    "E721",  # type-comparison
     "E731",  # lambda-assignment
 
     # flake8-errmsg (EM)  : nicer error tracebacks
@@ -251,6 +250,7 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/io/*" = [
+    "E721",   # type-comparison
     "G001",  # logging-string-format
     "G004",  # logging-f-string
     "PLR0911",  # too-many-return-statements
@@ -268,6 +268,7 @@ lint.unfixable = [
     "ANN201",  # Public function without return type annotation
     "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
+    "E721",   # type-comparison
     "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
     "TRY300",  # Consider `else` block
@@ -288,12 +289,14 @@ lint.unfixable = [
 ]
 "astropy/table/*" = [
     "RET505",  # superfluous-else-return
+    "E721",   # type-comparison
     "RET506",  # superfluous-else-raise
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
 ]
 "astropy/tests/*" = ["C408", "RET505"]
 "astropy/time/*" = [
+    "E721",   # type-comparison
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
     "RET505",  # superfluous-else-return
@@ -302,6 +305,7 @@ lint.unfixable = [
 "astropy/timeseries/*" = [
     "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
+    "E721",   # type-comparison
     "RET506",  # superfluous-else-raise
 ]
 "astropy/units/*" = [
@@ -318,6 +322,7 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/utils/*" = [
+    "E721",   # type-comparison
     "N811",  # constant-imported-as-non-constant
     "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
@@ -333,6 +338,7 @@ lint.unfixable = [
 ]
 "astropy/wcs/*" = [
     "C408",  # unnecessary-collection-call
+    "E721",   # type-comparison
     "F821",  # undefined-name
     "S608",  # Posslibe SQL injection
     "RET505",  # superfluous-else-return

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -332,7 +332,7 @@ def concatenate_representations(reps):
         dif_type = type(reps[0].differentials["s"])
 
         if any(
-            "s" not in r.differentials or type(r.differentials["s"]) != dif_type
+            "s" not in r.differentials or type(r.differentials["s"]) is not dif_type
             for r in reps
         ):
             raise TypeError(

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1282,8 +1282,8 @@ def test_representation_subclass():
     frame = FK5(
         representation_type=r.SphericalRepresentation, ra=32 * u.deg, dec=20 * u.deg
     )
-    assert type(frame._data) == r.UnitSphericalRepresentation
-    assert frame.representation_type == r.SphericalRepresentation
+    assert type(frame._data) is r.UnitSphericalRepresentation
+    assert frame.representation_type is r.SphericalRepresentation
 
     # If using a SphericalRepresentation class this used to not work, so we
     # test here that this is now fixed.
@@ -1293,8 +1293,8 @@ def test_representation_subclass():
     frame = FK5(
         representation_type=NewSphericalRepresentation, lon=32 * u.deg, lat=20 * u.deg
     )
-    assert type(frame._data) == r.UnitSphericalRepresentation
-    assert frame.representation_type == NewSphericalRepresentation
+    assert type(frame._data) is r.UnitSphericalRepresentation
+    assert frame.representation_type is NewSphericalRepresentation
 
     # A similar issue then happened in __repr__ with subclasses of
     # SphericalRepresentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,13 +304,17 @@ exclude= [
         ]
 
 [tool.ruff]
-lint.select = ["ALL"]
 exclude=[
     "astropy/extern/*",
     "*_parsetab.py",
     "*_lextab.py"
 ]
-lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+select = ["ALL"]
+ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
 
     # flake8-builtins (A) : shadowing a Python built-in.
     # New ones should be avoided and is up to maintainers to enforce.


### PR DESCRIPTION
Should allow us to select specific rules for preview mode.

E.g. this will allow us to turn on E721 and still allow "Under [preview mode](https://docs.astral.sh/ruff/preview), this rule also allows for direct type comparisons using `is` and `is not`, to check for exact type equality (while still forbidding comparisons using `==` and `!=`)." We don't have E721 on because it doesn't allow `is`.

The one downside of adding this config is that *existing* rules will have ``—preview`` enabled. ``SIM910`` is the only case of that in Astropy. So IMO it appears fine to add.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
