### PR TITLE
Alphabetize units docs

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -54,6 +54,9 @@ __all__ += photometric.__all__
 __all__ += structured.__all__
 __all__ += equivalencies.__all__
 __all__ += function.__all__
+# We sort `__all__` for the docs. We use `globals` to avoid confusing any static
+# analysis tools.
+globals()["__all__"] = sorted(__all__)
 
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -56,7 +56,7 @@ __all__ += equivalencies.__all__
 __all__ += function.__all__
 # We sort `__all__` for the docs. We use `globals` to avoid confusing any static
 # analysis tools.
-globals()["__all__"] = sorted(__all__)
+globals()["__all__"].sort()
 
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.


### PR DESCRIPTION
@mhvk we can discuss the units docs here.

We have 3 considerations: the docs, static typing, convenience. For the 3rd we really don't want to manually specify imports in `units.__all__`. Therefore we need to be doing some type of sorting of the imports that are imported in a typing-compatible way.

I think we can define a `__init__.pyi` that is unsorted/ungrouped and have the runtime sorted for `sphinx`. Or maybe the reverse? Looks like we have options — https://github.com/readthedocs/sphinx-autoapi/issues/243.

Docs link: https://astropy--15891.org.readthedocs.build/en/15891/units/ref_api.html#reference-api

