### PR TITLE
units: remove vestigial cosmo imports

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -58,19 +58,3 @@ __all__ += function.__all__
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
 set_enabled_units([si, cgs, astrophys, function.units, misc, photometric])
-
-
-# -------------------------------------------------------------------------
-
-
-def __getattr__(attr):
-    if attr == "littleh":
-        from astropy.units.astrophys import littleh
-
-        return littleh
-    elif attr == "with_H0":
-        from astropy.units.equivalencies import with_H0
-
-        return with_H0
-
-    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")


### PR DESCRIPTION
It was already removed.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
