### PR TITLE
Backport PR #15892 on branch v6.0.x (units: remove vestigial cosmo imports)

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -49,19 +49,3 @@ del bases
 # Imperial units.
 
 set_enabled_units([si, cgs, astrophys, function_units, misc, photometric])
-
-
-# -------------------------------------------------------------------------
-
-
-def __getattr__(attr):
-    if attr == "littleh":
-        from astropy.units.astrophys import littleh
-
-        return littleh
-    elif attr == "with_H0":
-        from astropy.units.equivalencies import with_H0
-
-        return with_H0
-
-    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")


### PR DESCRIPTION
Backport PR #15892 on branch v6.0.x