### PR TITLE
exclude overload from coverage.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,7 +315,9 @@ exclude= [
             # Don't complain about IPython completion helper
             "def _ipython_key_completions_",
             # typing.TYPE_CHECKING is False at runtime
-            "if TYPE_CHECKING:"
+            "if TYPE_CHECKING:",
+            # Ignore type function overload
+            "@overload",
         ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,7 @@ exclude= [
             "def _ipython_key_completions_",
             # typing.TYPE_CHECKING is False at runtime
             "if TYPE_CHECKING:",
-            # Ignore type function overload
+            # Ignore typing overloads
             "@overload",
         ]
 


### PR DESCRIPTION
It's not used at runtime. Discovered we needed this in #15854 

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
