### PR TITLE
ENH: add support for 3D convolution kernels

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -14,7 +14,7 @@ from astropy.utils.console import human_file_size
 from astropy.utils.exceptions import AstropyUserWarning
 
 from ._convolve import _convolveNd_c
-from .core import MAX_NORMALIZATION, Kernel, Kernel1D, Kernel2D
+from .core import MAX_NORMALIZATION, Kernel, Kernel1D, Kernel2D, Kernel3D
 from .utils import KernelSizeError, has_even_axis
 
 # np.unique([scipy.fft.next_fast_len(i, real=True) for i in range(10000)])
@@ -444,8 +444,10 @@ def convolve(
             new_result = Kernel1D(array=result)
         elif isinstance(passed_array, Kernel2D):
             new_result = Kernel2D(array=result)
+        elif isinstance(passed_array, Kernel3D):
+            new_result = Kernel3D(array=result)
         else:
-            raise TypeError("Only 1D and 2D Kernels are supported.")
+            raise TypeError("Only 1D, 2D and 3D Kernels are supported.")
         new_result._is_bool = False
         new_result._separable = passed_array._separable
         if isinstance(passed_kernel, Kernel):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -26,6 +26,7 @@ from .utils import (
     KernelArithmeticError,
     add_kernel_arrays_1D,
     add_kernel_arrays_2D,
+    add_kernel_arrays_3D,
     discretize_model,
 )
 
@@ -453,8 +454,23 @@ def kernel_arithmetics(kernel, value, operation):
         new_kernel._separable = kernel._separable and value._separable
         new_kernel._is_bool = kernel._is_bool or value._is_bool
 
+    # 3D kernels
+    elif isinstance(kernel, Kernel3D) and isinstance(value, Kernel3D):
+        if operation == "add":
+            new_array = add_kernel_arrays_3D(kernel.array, value.array)
+        elif operation == "sub":
+            new_array = add_kernel_arrays_3D(kernel.array, -value.array)
+        elif operation == "mul":
+            raise KernelArithmeticError(
+                "Kernel operation not supported. Maybe you want "
+                "to use convolve(kernel1, kernel2) instead."
+            )
+        new_kernel = Kernel3D(array=new_array)
+        new_kernel._separable = kernel._separable and value._separable
+        new_kernel._is_bool = kernel._is_bool or value._is_bool
+
     # kernel and number
-    elif isinstance(kernel, (Kernel1D, Kernel2D)) and np.isscalar(value):
+    elif isinstance(kernel, (Kernel1D, Kernel2D, Kernel3D)) and np.isscalar(value):
         if operation != "mul":
             raise KernelArithmeticError("Kernel operation not supported.")
         new_kernel = copy.copy(kernel)

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -5,9 +5,9 @@ import math
 import numpy as np
 
 from astropy.modeling import models
-from astropy.modeling.core import Fittable1DModel, Fittable2DModel
+from astropy.modeling.core import Fittable1DModel, Fittable2DModel, Fittable3DModel
 
-from .core import Kernel, Kernel1D, Kernel2D
+from .core import Kernel, Kernel1D, Kernel2D, Kernel3D
 from .utils import KernelSizeError, has_even_axis
 
 __all__ = [
@@ -24,6 +24,7 @@ __all__ = [
     "Moffat2DKernel",
     "Model1DKernel",
     "Model2DKernel",
+    "Model3DKernel",
     "TrapezoidDisk2DKernel",
     "Ring2DKernel",
 ]
@@ -881,6 +882,7 @@ class Model1DKernel(Kernel1D):
     See Also
     --------
     Model2DKernel : Create kernel from `~astropy.modeling.Fittable2DModel`
+    Model3DKernel : Create kernel from `~astropy.modeling.Fittable3DModel`
     CustomKernel : Create kernel from list or array
 
     Examples
@@ -949,6 +951,7 @@ class Model2DKernel(Kernel2D):
     See Also
     --------
     Model1DKernel : Create kernel from `~astropy.modeling.Fittable1DModel`
+    Model3DKernel : Create kernel from `~astropy.modeling.Fittable3DModel`
     CustomKernel : Create kernel from list or array
 
     Examples
@@ -978,6 +981,64 @@ class Model2DKernel(Kernel2D):
         super().__init__(**kwargs)
 
 
+class Model3DKernel(Kernel3D):
+    """
+    Create kernel from 3D model.
+
+    The model has to be centered on x = 0 and y = 0.
+
+    Parameters
+    ----------
+    model : `~astropy.modeling.Fittable2DModel`
+        Kernel response function model
+    x_size : int, optional
+        Size in x direction of the kernel array. Default = ⌊8*width +1⌋.
+        Must be odd.
+    y_size : int, optional
+        Size in y direction of the kernel array. Default = ⌊8*width +1⌋.
+    z_size : int, optional
+        Size in z direction of the kernel array. Default = ⌊8*width +1⌋.
+    mode : {'center', 'linear_interp', 'oversample', 'integrate'}, optional
+        One of the following discretization modes:
+            * 'center' (default)
+                Discretize model by taking the value
+                at the center of the bin.
+            * 'linear_interp'
+                Discretize model by performing a bilinear interpolation
+                between the values at the corners of the bin.
+            * 'oversample'
+                Discretize model by taking the average
+                on an oversampled grid.
+            * 'integrate'
+                Discretize model by integrating the
+                model over the bin.
+    factor : number, optional
+        Factor of oversampling. Default factor = 10.
+
+    Raises
+    ------
+    TypeError
+        If model is not an instance of `~astropy.modeling.Fittable2DModel`
+
+    See Also
+    --------
+    Model1DKernel : Create kernel from `~astropy.modeling.Fittable1DModel`
+    Model2DKernel : Create kernel from `~astropy.modeling.Fittable2DModel`
+    CustomKernel : Create kernel from list or array
+    """
+
+    _is_bool = False
+    _separable = False
+
+    def __init__(self, model, **kwargs):
+        self._separable = False
+        if isinstance(model, Fittable3DModel):
+            self._model = model
+        else:
+            raise TypeError("Must be Fittable2DModel")
+        super().__init__(**kwargs)
+
+
 class CustomKernel(Kernel):
     """
     Create filter kernel from list or array.
@@ -996,7 +1057,9 @@ class CustomKernel(Kernel):
 
     See Also
     --------
-    Model2DKernel, Model1DKernel
+    Model1DKernel : Create kernel from `~astropy.modeling.Fittable1DModel`
+    Model2DKernel : Create kernel from `~astropy.modeling.Fittable2DModel`
+    Model3DKernel : Create kernel from `~astropy.modeling.Fittable3DModel`
 
     Examples
     --------

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -85,6 +85,43 @@ def add_kernel_arrays_2D(array_1, array_2):
     return array_2 + array_1
 
 
+def add_kernel_arrays_3D(array_1, array_2):
+    """
+    Add two 3D kernel arrays of different size.
+
+    The arrays are added with the centers lying upon each other.
+    """
+    if array_1.size > array_2.size:
+        new_array = array_1.copy()
+        center = [axes_size // 2 for axes_size in array_1.shape]
+        slice_x = slice(
+            center[2] - array_2.shape[2] // 2, center[2] + array_2.shape[2] // 2 + 1
+        )
+        slice_y = slice(
+            center[1] - array_2.shape[1] // 2, center[1] + array_2.shape[1] // 2 + 1
+        )
+        slice_z = slice(
+            center[0] - array_2.shape[0] // 2, center[0] + array_2.shape[0] // 2 + 1
+        )
+        new_array[slice_z, slice_y, slice_x] += array_2
+        return new_array
+    elif array_2.size > array_1.size:
+        new_array = array_2.copy()
+        center = [axes_size // 2 for axes_size in array_2.shape]
+        slice_x = slice(
+            center[2] - array_1.shape[2] // 2, center[2] + array_1.shape[2] // 2 + 1
+        )
+        slice_y = slice(
+            center[1] - array_1.shape[1] // 2, center[1] + array_1.shape[1] // 2 + 1
+        )
+        slice_z = slice(
+            center[0] - array_1.shape[0] // 2, center[0] + array_1.shape[0] // 2 + 1
+        )
+        new_array[slice_z, slice_y, slice_x] += array_1
+        return new_array
+    return array_2 + array_1
+
+
 def discretize_model(
     model, x_range, y_range=None, z_range=None, *, mode="center", factor=10
 ):

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -222,7 +222,7 @@ def discretize_model(
         model = custom_model(model)()
     ndim = model.n_inputs
     if ndim > 3:
-        raise ValueError("discretize_model supports only 1D, 2D and 3D models.")
+        raise ValueError("discretize_model supports only 1D, 2D, and 3D models.")
 
     dxrange = np.diff(x_range)[0]
     if dxrange != int(dxrange):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -57,6 +57,7 @@ __all__ = [
     "FittableModel",
     "Fittable1DModel",
     "Fittable2DModel",
+    "Fittable3DModel",
     "CompoundModel",
     "fix_inputs",
     "custom_model",
@@ -3023,6 +3024,17 @@ class Fittable2DModel(FittableModel):
     """
 
     n_inputs = 2
+    n_outputs = 1
+
+
+class Fittable3DModel(FittableModel):
+    """
+    Base class for three-dimensional fittable models.
+
+    This class provides an easier interface to defining new models.
+    """
+
+    n_inputs = 3
     n_outputs = 1
 
 


### PR DESCRIPTION
### Description
This pull request is to fix #13511
For now I'm just laying out the foundation to allow users to implement 3D kernels.
At first, I'm doing this in a purely additive fashion, naturally leading to a large amount of code duplication (as there's already many repetitions between the 1D and the 2D code).
At a minimum, I still need to add tests and documentation, but I'd like to gather feedback early on the following questions.

To be discussed
- should repetitions be avoided ? in other word, is it worth it to generalize the repeated logic in a refactor ?
- `discretize_model` is public API, which makes the change in signature I need to support 3D models a *breaking* one, however it would only affect user code that rely on the `mode` argument being accepted positionally. Is this acceptable as is or should I think of a smoother deprecation path ?
- Should it be a goal for this PR to actually implement a 3D kernel or should this be purely left to users ?

TODO
- [ ] tests
- [ ] documentation

ping @hamogu 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
