### PR TITLE
Ruff violation icn001 fix

### DIFF
--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 
 import erfa  # noqa: F401
-import matplotlib
+import matplotlib as mpl
 import pytest
 
 import astropy  # noqa: F401
@@ -86,7 +86,7 @@ shutil.copy2(
 
 # matplotlib hook in pyinstaller 5.0 and later no longer collects every backend, see
 # https://github.com/pyinstaller/pyinstaller/issues/6760
-matplotlib.use("svg")
+mpl.use("svg")
 
 # We skip a few tests, which are generally ones that rely on explicitly
 # checking the name of the current module (which ends up starting with

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -83,9 +83,6 @@ lint.ignore = [
     "FIX001",  # Line contains FIXME.  this should be fixed or at least FIXME replaced with TODO
     "FIX004",  # Line contains HACK. replace HACK with NOTE.
 
-    # flake8-import-conventions (ICN)  : use conventional import aliases
-    "ICN001",  # import-conventions
-
     # pep8-naming (N)
     # NOTE: some of these can/should be fixed, but this changes the API.
     "N801",  # invalid-class-name

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -40,7 +40,7 @@ if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
 if HAS_MATPLOTLIB:
-    import matplotlib
+    import matplotlib as mpl
 
 matplotlibrc_cache = {}
 
@@ -78,9 +78,9 @@ def pytest_configure(config):
     if HAS_MATPLOTLIB:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            matplotlibrc_cache.update(matplotlib.rcParams)
-            matplotlib.rcdefaults()
-            matplotlib.use("Agg")
+            matplotlibrc_cache.update(mpl.rcParams)
+            mpl.rcdefaults()
+            mpl.use("Agg")
 
     # Make sure we use temporary directories for the config and cache
     # so that the tests are insensitive to local configuration. Note that this
@@ -115,7 +115,7 @@ def pytest_unconfigure(config):
     if HAS_MATPLOTLIB:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            matplotlib.rcParams.update(matplotlibrc_cache)
+            mpl.rcParams.update(matplotlibrc_cache)
             matplotlibrc_cache.clear()
 
     if builtins._xdg_config_home_orig is None:

--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 C_CONVOLVE_PKGDIR = os.path.relpath(os.path.dirname(__file__))
@@ -24,7 +24,7 @@ def get_extensions():
         name="astropy.convolution._convolve",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         extra_compile_args=extra_compile_args,
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
         sources=sources,
     )
     return [_convolve_ext]

--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 C_CONVOLVE_PKGDIR = os.path.relpath(os.path.dirname(__file__))
@@ -24,7 +24,7 @@ def get_extensions():
         name="astropy.convolution._convolve",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         extra_compile_args=extra_compile_args,
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
         sources=sources,
     )
     return [_convolve_ext]

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -1189,13 +1189,13 @@ def test_astropy_convolution_against_scipy():
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="Requires pandas")
 def test_regression_6099():
-    import pandas
+    import pandas as pd
 
     wave = np.array(np.linspace(5000, 5100, 10))
     boxcar = 3
     nonseries_result = convolve(wave, np.ones((boxcar,)) / boxcar)
 
-    wave_series = pandas.Series(wave)
+    wave_series = pd.Series(wave)
     series_result = convolve(wave_series, np.ones((boxcar,)) / boxcar)
 
     assert_array_almost_equal(nonseries_result, series_result)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from contextlib import suppress
 from io import StringIO
 
-import numpy
+import numpy as np
 
 from astropy.table import Table
 from astropy.utils.data import get_readable_fileobj
@@ -158,7 +158,7 @@ class CsvWriter:
         return row_string
 
 
-class MaskedConstant(numpy.ma.core.MaskedConstant):
+class MaskedConstant(np.ma.core.MaskedConstant):
     """A trivial extension of numpy.ma.masked.
 
     We want to be able to put the generic term ``masked`` into a dictionary.
@@ -908,7 +908,7 @@ class BaseData:
         """READ: Replace string values in col.str_vals and set masks."""
         if self.fill_values:
             for col in (col for col in cols if col.fill_values):
-                col.mask = numpy.zeros(len(col.str_vals), dtype=bool)
+                col.mask = np.zeros(len(col.str_vals), dtype=bool)
                 for i, str_val in (
                     (i, x) for i, x in enumerate(col.str_vals) if x in col.fill_values
                 ):
@@ -1002,7 +1002,7 @@ def convert_numpy(numpy_type):
         the required type.
     """
     # Infer converter type from an instance of numpy_type.
-    type_name = numpy.array([], dtype=numpy_type).dtype.name
+    type_name = np.array([], dtype=numpy_type).dtype.name
     if "int" in type_name:
         converter_type = IntType
     elif "float" in type_name:
@@ -1020,26 +1020,26 @@ def convert_numpy(numpy_type):
         for any other string values.
         """
         if len(vals) == 0:
-            return numpy.array([], dtype=bool)
+            return np.array([], dtype=bool)
 
         # Try a smaller subset first for a long array
         if len(vals) > 10000:
-            svals = numpy.asarray(vals[:1000])
-            if not numpy.all(
+            svals = np.asarray(vals[:1000])
+            if not np.all(
                 (svals == "False") | (svals == "True") | (svals == "0") | (svals == "1")
             ):
                 raise ValueError('bool input strings must be False, True, 0, 1, or ""')
-        vals = numpy.asarray(vals)
+        vals = np.asarray(vals)
 
         trues = (vals == "True") | (vals == "1")
         falses = (vals == "False") | (vals == "0")
-        if not numpy.all(trues | falses):
+        if not np.all(trues | falses):
             raise ValueError('bool input strings must be only False, True, 0, 1, or ""')
 
         return trues
 
     def generic_converter(vals):
-        return numpy.array(vals, numpy_type)
+        return np.array(vals, numpy_type)
 
     converter = bool_converter if converter_type is BoolType else generic_converter
 
@@ -1068,7 +1068,7 @@ class BaseOutputter:
         try:
             # Don't allow list-like things that dtype accepts
             assert type(converters) is type
-            converters = [numpy.dtype(converters)]
+            converters = [np.dtype(converters)]
         except (AssertionError, TypeError):
             pass
 
@@ -1183,8 +1183,8 @@ class TableOutputter(BaseOutputter):
         self._convert_vals(cols)
 
         t_cols = [
-            numpy.ma.MaskedArray(x.data, mask=x.mask)
-            if hasattr(x, "mask") and numpy.any(x.mask)
+            np.ma.MaskedArray(x.data, mask=x.mask)
+            if hasattr(x, "mask") and np.any(x.mask)
             else x.data
             for x in cols
         ]

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -16,7 +16,7 @@ def get_extensions():
     ascii_ext = Extension(
         name="astropy.io.ascii.cparser",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
         sources=sources,
     )
     return [ascii_ext]

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -16,7 +16,7 @@ def get_extensions():
     ascii_ext = Extension(
         name="astropy.io.ascii.cparser",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
         sources=sources,
     )
     return [ascii_ext]

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -53,12 +53,12 @@ def import_html_libs():
 def _pandas_read(fmt, filespec, **kwargs):
     """Provide io Table connector to read table using pandas."""
     try:
-        import pandas
+        import pandas as pd
     except ImportError:
         raise ImportError("pandas must be installed to use pandas table reader")
 
     pandas_fmt = fmt[len(PANDAS_PREFIX) :]  # chop the 'pandas.' in front
-    read_func = getattr(pandas, "read_" + pandas_fmt)
+    read_func = getattr(pd, "read_" + pandas_fmt)
 
     # Get defaults and then override with user-supplied values
     read_kwargs = PANDAS_FMTS[pandas_fmt]["read"].copy()

--- a/astropy/stats/setup_package.py
+++ b/astropy/stats/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -15,14 +15,14 @@ def get_extensions():
         name="astropy.stats._fast_sigma_clip",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=SRCFILES,
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
         language="c",
     )
     _stats_ext = Extension(
         name="astropy.stats._stats",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[os.path.join(ROOT, "_stats.pyx")],
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
     )
 
     return [_sigma_clip_ext, _stats_ext]

--- a/astropy/stats/setup_package.py
+++ b/astropy/stats/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -15,14 +15,14 @@ def get_extensions():
         name="astropy.stats._fast_sigma_clip",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=SRCFILES,
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
         language="c",
     )
     _stats_ext = Extension(
         name="astropy.stats._stats",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[os.path.join(ROOT, "_stats.pyx")],
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
     )
 
     return [_sigma_clip_ext, _stats_ext]

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -10,7 +10,7 @@ ROOT = os.path.relpath(os.path.dirname(__file__))
 
 def get_extensions():
     sources = ["_np_utils.pyx", "_column_mixins.pyx"]
-    include_dirs = [np.get_include()]
+    include_dirs = [get_numpy_include()]
 
     exts = [
         Extension(

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -10,7 +10,7 @@ ROOT = os.path.relpath(os.path.dirname(__file__))
 
 def get_extensions():
     sources = ["_np_utils.pyx", "_column_mixins.pyx"]
-    include_dirs = [numpy.get_include()]
+    include_dirs = [np.get_include()]
 
     exts = [
         Extension(

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2150,10 +2150,10 @@ class TestPandas:
             # No warning with the default use_nullable_int=True
             d = t.to_pandas(use_nullable_int=use_nullable_int)
         else:
-            import pandas
+            import pandas as pd
             from packaging.version import Version
 
-            PANDAS_LT_2_0 = Version(pandas.__version__) < Version("2.0")
+            PANDAS_LT_2_0 = Version(pd.__version__) < Version("2.0")
             if PANDAS_LT_2_0:
                 if PYTEST_LT_8_0:
                     ctx = nullcontext()

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2150,10 +2150,9 @@ class TestPandas:
             # No warning with the default use_nullable_int=True
             d = t.to_pandas(use_nullable_int=use_nullable_int)
         else:
-            import pandas as pd
-            from packaging.version import Version
+            from astropy.utils.introspection import minversion
 
-            PANDAS_LT_2_0 = Version(pd.__version__) < Version("2.0")
+            PANDAS_LT_2_0 = not minversion("pandas", "2.0")
             if PANDAS_LT_2_0:
                 if PYTEST_LT_8_0:
                     ctx = nullcontext()

--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -4,7 +4,7 @@
 
 import os
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 C_TIME_PKGDIR = os.path.relpath(os.path.dirname(__file__))
@@ -20,7 +20,7 @@ def get_extensions():
     _time_ext = Extension(
         name="astropy.time._parse_times",
         sources=SRC_FILES,
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
         language="c",
     )
 

--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -4,7 +4,7 @@
 
 import os
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 C_TIME_PKGDIR = os.path.relpath(os.path.dirname(__file__))
@@ -20,7 +20,7 @@ def get_extensions():
     _time_ext = Extension(
         name="astropy.time._parse_times",
         sources=SRC_FILES,
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
         language="c",
     )
 

--- a/astropy/timeseries/periodograms/bls/setup_package.py
+++ b/astropy/timeseries/periodograms/bls/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 BLS_ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -16,6 +16,6 @@ def get_extensions():
             os.path.join(BLS_ROOT, "bls.c"),
             os.path.join(BLS_ROOT, "_impl.pyx"),
         ],
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
     )
     return [ext]

--- a/astropy/timeseries/periodograms/bls/setup_package.py
+++ b/astropy/timeseries/periodograms/bls/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 BLS_ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -16,6 +16,6 @@ def get_extensions():
             os.path.join(BLS_ROOT, "bls.c"),
             os.path.join(BLS_ROOT, "_impl.pyx"),
         ],
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
     )
     return [ext]

--- a/astropy/timeseries/periodograms/lombscargle/setup_package.py
+++ b/astropy/timeseries/periodograms/lombscargle/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -13,6 +13,6 @@ def get_extensions():
         "astropy.timeseries.periodograms.lombscargle.implementations.cython_impl",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[os.path.join(ROOT, "implementations", "cython_impl.pyx")],
-        include_dirs=[np.get_include()],
+        include_dirs=[get_numpy_include()],
     )
     return [ext]

--- a/astropy/timeseries/periodograms/lombscargle/setup_package.py
+++ b/astropy/timeseries/periodograms/lombscargle/setup_package.py
@@ -2,7 +2,7 @@
 
 import os
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 ROOT = os.path.relpath(os.path.dirname(__file__))
@@ -13,6 +13,6 @@ def get_extensions():
         "astropy.timeseries.periodograms.lombscargle.implementations.cython_impl",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[os.path.join(ROOT, "implementations", "cython_impl.pyx")],
-        include_dirs=[numpy.get_include()],
+        include_dirs=[np.get_include()],
     )
     return [ext]

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -5,6 +5,7 @@ This package defines the astrophysics-specific units.  They are also
 available in the `astropy.units` namespace.
 """
 
+import numpy as np
 
 from astropy.constants import si as _si
 
@@ -14,7 +15,6 @@ from .core import UnitBase, def_unit, set_enabled_units
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
 
-import numpy as np  # noqa: E402
 
 __all__: list[str] = []  #  Units are added at the end
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -14,7 +14,7 @@ from .core import UnitBase, def_unit, set_enabled_units
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
 
-import numpy as _np  # noqa: E402
+import numpy as np  # noqa: E402
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -156,7 +156,7 @@ def_unit(
 )
 def_unit(
     ["R", "Rayleigh", "rayleigh"],
-    (1e10 / (4 * _np.pi)) * ph * si.m**-2 * si.s**-1 * si.sr**-1,
+    (1e10 / (4 * np.pi)) * ph * si.m**-2 * si.s**-1 * si.sr**-1,
     namespace=_ns,
     prefixes=True,
     doc="Rayleigh: photon flux",

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -14,7 +14,7 @@ from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_pre
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
 
-import numpy as _np  # noqa: E402
+import numpy as np  # noqa: E402
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -37,14 +37,14 @@ def_unit(
 
 def_unit(
     ["cycle", "cy"],
-    2.0 * _np.pi * si.rad,
+    2.0 * np.pi * si.rad,
     namespace=_ns,
     prefixes=False,
     doc="cycle: angular measurement, a full turn or rotation",
 )
 def_unit(
     ["spat", "sp"],
-    4.0 * _np.pi * si.sr,
+    4.0 * np.pi * si.sr,
     namespace=_ns,
     prefixes=False,
     doc="spat: the solid angle of the sphere, 4pi sr",

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -5,6 +5,7 @@ This package defines miscellaneous units. They are also
 available in the `astropy.units` namespace.
 """
 
+import numpy as np
 
 from astropy.constants import si as _si
 
@@ -14,7 +15,6 @@ from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_pre
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
 
-import numpy as np  # noqa: E402
 
 __all__: list[str] = []  #  Units are added at the end
 

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -8,7 +8,7 @@ The corresponding magnitudes are given in the description of each unit
 """
 
 
-import numpy as _numpy
+import numpy as np
 
 from astropy.constants import si as _si
 
@@ -31,7 +31,7 @@ def_unit(
 )
 def_unit(
     ["bol", "f_bol"],
-    _si.L_bol0 / (4 * _numpy.pi * (10.0 * astrophys.pc) ** 2),
+    _si.L_bol0 / (4 * np.pi * (10.0 * astrophys.pc) ** 2),
     namespace=_ns,
     prefixes=False,
     doc=(

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -5,7 +5,7 @@ This package defines the SI units.  They are also available in the
 
 """
 
-import numpy as _numpy
+import numpy as np
 
 from astropy.constants import si as _si
 
@@ -91,7 +91,7 @@ def_unit(
 )
 def_unit(
     ["deg", "degree"],
-    _numpy.pi / 180.0 * rad,
+    np.pi / 180.0 * rad,
     namespace=_ns,
     prefixes=True,
     doc="degree: angular measurement 1/360 of full rotation",

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -66,15 +66,15 @@ def test_find_mod_objs():
 
 
 def test_minversion():
-    import numpy
+    import numpy as np
 
     good_versions = ["1.16", "1.16.1", "1.16.0.dev", "1.16dev"]
     bad_versions = ["100000", "100000.2rc1"]
     for version in good_versions:
-        assert minversion(numpy, version)
+        assert minversion(np, version)
         assert minversion("numpy", version)
     for version in bad_versions:
-        assert not minversion(numpy, version)
+        assert not minversion(np, version)
         assert not minversion("numpy", version)
 
     assert minversion(yaml, "3.1")

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -28,7 +28,6 @@ from .stretch import (
 )
 
 try:
-    import matplotlib as mpl  # noqa: F401
     from matplotlib import pyplot as plt
     from matplotlib.colors import Normalize
 except ImportError:

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -28,7 +28,7 @@ from .stretch import (
 )
 
 try:
-    import matplotlib  # noqa: F401
+    import matplotlib as mpl  # noqa: F401
     from matplotlib import pyplot as plt
     from matplotlib.colors import Normalize
 except ImportError:

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -80,7 +80,7 @@ def fits2bitmap(
     cmap : str
         The matplotlib color map name. The default is 'Greys_r'.
     """
-    import matplotlib
+    import matplotlib as mpl
     import matplotlib.image as mimg
 
     from astropy.utils.introspection import minversion
@@ -110,8 +110,8 @@ def fits2bitmap(
     out_format = os.path.splitext(out_fn)[1][1:]
 
     try:
-        if minversion(matplotlib, "3.5"):
-            matplotlib.colormaps[cmap]
+        if minversion(mpl, "3.5"):
+            mpl.colormaps[cmap]
         else:
             from matplotlib import cm
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -2,7 +2,7 @@
 import warnings
 from contextlib import nullcontext
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -24,14 +24,14 @@ from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import HighLevelWCSWrapper, SlicedLowLevelWCS
 
-ft_version = Version(matplotlib.ft2font.__freetype_version__)
+ft_version = Version(mpl.ft2font.__freetype_version__)
 FREETYPE_261 = ft_version == Version("2.6.1")
 
 # We cannot use matplotlib.checkdep_usetex() anymore, see
 # https://github.com/matplotlib/matplotlib/issues/23244
 TEX_UNAVAILABLE = True
 
-MATPLOTLIB_LT_3_7 = Version(matplotlib.__version__) < Version("3.7")
+MATPLOTLIB_LT_3_7 = Version(mpl.__version__) < Version("3.7")
 
 
 def teardown_function(function):

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 
 from astropy import units as u
@@ -14,7 +14,7 @@ __all__ = [
     "transform_contour_set_inplace",
 ]
 
-MATPLOTLIB_LT_3_8 = not minversion(matplotlib, "3.8.dev")
+MATPLOTLIB_LT_3_8 = not minversion(mpl, "3.8.dev")
 
 
 def select_step_degree(dv):

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import matplotlib as mpl
 import numpy as np
 

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from os.path import join
 from pathlib import Path
 
-import numpy as np
+from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
 from extension_helpers import get_compiler, import_file, pkg_config, write_if_different
@@ -184,7 +184,7 @@ MSVC, do not support string literals greater than 256 characters.
 def get_wcslib_cfg(cfg, wcslib_files, include_paths):
     debug = "--debug" in sys.argv
 
-    cfg["include_dirs"].append(np.get_include())
+    cfg["include_dirs"].append(get_numpy_include())
     cfg["define_macros"].extend(
         [
             ("ECHO", None),

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from os.path import join
 from pathlib import Path
 
-import numpy
+import numpy as np
 from setuptools import Extension
 
 from extension_helpers import get_compiler, import_file, pkg_config, write_if_different
@@ -184,7 +184,7 @@ MSVC, do not support string literals greater than 256 characters.
 def get_wcslib_cfg(cfg, wcslib_files, include_paths):
     debug = "--debug" in sys.argv
 
-    cfg["include_dirs"].append(numpy.get_include())
+    cfg["include_dirs"].append(np.get_include())
     cfg["define_macros"].extend(
         [
             ("ECHO", None),

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -203,8 +203,9 @@ Coding Style/Conventions
     import numpy as np
     import matplotlib as mpl
     import matplotlib.pyplot as plt
+    import pandas as pd
 
-  should be used wherever relevant. On the other hand::
+  should be used wherever relevant. The complete list of conventional aliases can be found `here <https://docs.astral.sh/ruff/settings/#flake8-import-conventions-aliases>`_ . On the other hand::
 
     from packagename import *
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
This PR fixes the violation of RUFF rule ICN001
# unconventional-import-alias (ICN001)

Derived from the **flake8-import-conventions** linter.

Fix is sometimes available.

## What it does
Checks for imports that are typically imported using a common convention,
like `import pandas as pd`, and enforces that convention.

## Why is this bad?
Consistency is good. Use a common convention for imports to make your code
more readable and idiomatic.

For example, `import pandas as pd` is a common
convention for importing the `pandas` library, and users typically expect
Pandas to be aliased as `pd`.

## Example
```python
import pandas
```

Use instead:
```python
import pandas as pd
```
<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14818

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
