### PR TITLE
ENH: implement a base comparison operator (__eq__) for NDData

### DIFF
--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -444,3 +444,26 @@ class NDData(NDDataBase):
                 # setter).
                 value.parent_nddata = self
         self._uncertainty = value
+
+    def __eq__(self, other) -> bool:
+        def is_sequence(a) -> bool:
+            try:
+                len(a)
+            except TypeError:
+                return False
+            else:
+                return True
+
+        def seqeq(a, b) -> bool:
+            # return True iff a==b
+            if is_sequence(a) and is_sequence(b):
+                return bool(np.all(np.asanyarray(a) == np.asanyarray(b)))
+            else:
+                return a == b
+
+        # checks are ordered from cheapest to most expensive
+        return other is self or (
+            self.unit == other.unit
+            and seqeq(self.mask, other.mask)
+            and seqeq(self.data, other.data)
+        )

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -707,3 +707,28 @@ def test_collapse(mask, unit, propagate_uncertainties, operation_ignores_mask):
             # as the data array, so we can just check for equality:
             if method in ext_methods and propagate_uncertainties:
                 assert np.ma.all(np.ma.equal(astropy_method, nddata_method))
+
+
+@pytest.mark.parametrize(
+    "nd1, nd2, expected",
+    [
+        (NDData([1]), None, True),
+        (NDData([1], mask=True), None, True),
+        (NDData([1], mask=False), None, True),
+        (NDData([1], unit=u.J), None, True),
+        (NDData([1]), NDData([1]), True),
+        (NDData([1]), NDData([1], mask=True), False),
+        (NDData([1]), NDData([1], unit=u.J), False),
+        (NDData([1], mask=True), NDData([1], mask=True, unit=u.J), False),
+        (NDData([1], mask=False, unit=u.J), NDData([1], mask=True, unit=u.J), False),
+        (NDData([1], mask=True, unit=u.K), NDData([1], mask=True, unit=u.J), False),
+        (NDData([1], mask=True, unit=u.J), NDData([1], mask=True, unit=u.J), True),
+    ],
+)
+def test_nddata_eq(nd1, nd2, expected):
+    if nd2 is None:
+        # special case to check that we don't break default comparison
+        # __eq__(self, other) = lambda self, other: self is other
+        nd2 = nd1
+    assert (nd1 == nd2) is expected
+    assert (nd1 != nd2) ^ expected

--- a/docs/changes/15903.other.rst
+++ b/docs/changes/15903.other.rst
@@ -1,0 +1,1 @@
+``NDData`` objects now supports comparison operators ``==`` and ``!=``.


### PR DESCRIPTION
### Description
This pull request is to address #11648

Actually it's not completely clear to me wether there's actually a consensus on doing this in any way or form:
- the issue didn't receive any attention (yet)
- APE7 explicitly warns that "The `NDDataBase` class should not define any arithmetic operations, which are impossible to generalize" (though it doesn't specify that `NDData` shouldn't get a `__eq__` so the possibility seems open)

I'm opening this at an early stage in hopes to get the discussion going, or that the PR be rejected before it consumes too much time.
I'm aware that *if* a consensus is to be reached, most likely we'll want to implement comparison on more than just `data`, `mask` and `unit`, but that's also open to discussion: are there any attributes in `NDData` that we should *not* compare in `__eq__` ?

If this is greenlit and more attributes indeed need to be compared, I'll probably need to upgrade the test using hypothesis to improve coverage.

Fixes #11648

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
