### PR TITLE
Edit a user-facing note in `coordinates`

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -6,6 +6,7 @@ ephemerides from jplephem.
 
 import os.path
 import re
+from inspect import cleandoc
 from urllib.parse import urlparse
 
 import erfa
@@ -13,7 +14,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.constants import c as speed_of_light
-from astropy.utils import indent
 from astropy.utils.data import download_file
 from astropy.utils.decorators import classproperty, deprecated
 from astropy.utils.state import ScienceState
@@ -62,25 +62,21 @@ PLAN94_BODY_NAME_TO_PLANET_INDEX = {
     "neptune": 8,
 }
 
-_EPHEMERIS_NOTE = """
-You can either give an explicit ephemeris or use a default, which is normally
-a built-in ephemeris that does not require ephemeris files.  To change
-the default to be the JPL ephemeris::
+_EPHEMERIS_NOTE = """You can either give an explicit ephemeris or use a default, which is normally
+    a built-in ephemeris that does not require ephemeris files.  To change
+    the default to be the JPL ephemeris::
 
-    >>> from astropy.coordinates import solar_system_ephemeris
-    >>> solar_system_ephemeris.set('jpl')  # doctest: +SKIP
+        >>> from astropy.coordinates import solar_system_ephemeris
+        >>> solar_system_ephemeris.set('jpl')  # doctest: +SKIP
 
-Use of any JPL ephemeris requires the jplephem package
-(https://pypi.org/project/jplephem/).
-If needed, the ephemeris file will be downloaded (and cached).
+    Use of any JPL ephemeris requires the jplephem package
+    (https://pypi.org/project/jplephem/).
+    If needed, the ephemeris file will be downloaded (and cached).
 
-One can check which bodies are covered by a given ephemeris using::
+    One can check which bodies are covered by a given ephemeris using::
 
-    >>> solar_system_ephemeris.bodies
-    ('earth', 'sun', 'moon', 'mercury', 'venus', 'earth-moon-barycenter', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune')
-"""[
-    1:-1
-]
+        >>> solar_system_ephemeris.bodies
+        ('earth', 'sun', 'moon', 'mercury', 'venus', 'earth-moon-barycenter', 'mars', 'jupiter', 'saturn', 'uranus', 'neptune')"""
 
 
 class solar_system_ephemeris(ScienceState):
@@ -236,7 +232,7 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None, get_velocity=True):
     try:
         if default_kernel:
             if solar_system_ephemeris.get() is None:
-                raise ValueError(_EPHEMERIS_NOTE)
+                raise ValueError(cleandoc(_EPHEMERIS_NOTE))
             kernel = solar_system_ephemeris.kernel
         else:
             kernel = _get_kernel(ephemeris)
@@ -542,4 +538,4 @@ for f in [
     for f in locals().values()
     if callable(f) and f.__doc__ is not None and "{_EPHEMERIS_NOTE}" in f.__doc__
 ]:
-    f.__doc__ = f.__doc__.format(_EPHEMERIS_NOTE=indent(_EPHEMERIS_NOTE)[4:])
+    f.__doc__ = f.__doc__.format(_EPHEMERIS_NOTE=_EPHEMERIS_NOTE)


### PR DESCRIPTION
### Description

There are two reasons for editing the note in question.

1) It is likely `astropy` will switch from using [Black](https://pypi.org/project/black/) to using [Ruff formatter](https://docs.astral.sh/ruff/formatter/). The note in question is one of the very few places in `astropy` where switching the formatter would necessitate a change in code, so we might as well edit it now. 

2) The update allows replacing importing `astropy.utils.indent()` with importing `inspect.cleandoc()`. Using the Python standard library is preferable over relying on our own functions if the replacement is as simple as it is in this case.

There are no changes to content of the note as displayed to the user.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
