### PR TITLE
Consistent method to avoid FITSFixedWarning: END when using find_all_wcs

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -470,7 +470,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                     )
 
             if isinstance(header, fits.Header):
-                header_string = header.tostring().rstrip()
+                header_string = header.tostring(padding=False)
             else:
                 header_string = header
 
@@ -491,7 +491,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
             try:
                 tmp_header = fits.Header.fromstring(header_string)
                 self._remove_sip_kw(tmp_header)
-                tmp_header_bytes = tmp_header.tostring().rstrip()
+                tmp_header_bytes = tmp_header.tostring(padding=False)
                 if isinstance(tmp_header_bytes, str):
                     tmp_header_bytes = tmp_header_bytes.encode("ascii")
                 tmp_wcsprm = _wcs.Wcsprm(
@@ -524,8 +524,8 @@ class WCS(FITSWCSAPIMixin, WCSBase):
             sip = self._read_sip_kw(header, wcskey=key)
             self._remove_sip_kw(header)
 
-            header_string = header.tostring()
-            header_string = header_string.replace("END" + " " * 77, "")
+            header_string = header.tostring(padding=False)
+            header_string = header_string.replace("END", "")
 
             if isinstance(header_string, str):
                 header_bytes = header_string.encode("ascii")
@@ -3640,7 +3640,7 @@ def find_all_wcs(
     if isinstance(header, (str, bytes)):
         header_string = header
     elif isinstance(header, fits.Header):
-        header_string = header.tostring()
+        header_string = header.tostring(padding=False)
     else:
         raise TypeError("header must be a string or astropy.io.fits.Header object")
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
By giving an additional parameter (padding=False) in the tostring() method in wcs.py, we can avoid the FITSFixedWarning: END. This PR implements this change.
<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15814 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
