### PR TITLE
Move error from init to using TableLoc, fixes #5973, #15911

### DIFF
--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -826,13 +826,14 @@ class TableLoc:
     def __init__(self, table):
         self.table = table
         self.indices = table.indices
-        if len(self.indices) == 0:
-            raise ValueError("Cannot create TableLoc object with no indices")
 
     def _get_rows(self, item):
         """
         Retrieve Table rows indexes by value slice.
         """
+        if len(self.indices) == 0:
+            raise ValueError("Can only use TableLoc for a table with indices")
+
         if isinstance(item, tuple):
             key, item = item
         else:
@@ -947,6 +948,9 @@ class TableILoc(TableLoc):
         super().__init__(table)
 
     def __getitem__(self, item):
+        if len(self.indices) == 0:
+            raise ValueError("Can only use TableILoc for a table with indices")
+
         if isinstance(item, tuple):
             key, item = item
         else:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3348,3 +3348,17 @@ def test_as_array_preserve_fill_value():
     assert tn["float"].fill_value == FLOAT_FILL
     assert tn["str"].fill_value == STR_FILL
     assert tn["cmplx"].fill_value == CMPLX_FILL
+
+
+def test_table_hasattr_iloc():
+    """Regression test for astropy issues #15911 and #5973"""
+    t = Table({"a": [1, 2, 3]})
+
+    assert hasattr(t, "iloc")
+    assert hasattr(t, "loc")
+
+    with pytest.raises(ValueError, match="for a table with indices"):
+        t.iloc[0]
+
+    with pytest.raises(ValueError, match="for a table with indices"):
+        t.loc[0]

--- a/docs/changes/table/15913.bugfix.rst
+++ b/docs/changes/table/15913.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``hasattr(Table, "iloc")`` raising an exception, preventing use of tables e.g. with scikit-learn.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address issues #5973 and #15911 by moving the error raising from the creation of the `TableLoc` to using of the `TableLoc` object.

Since these objects are basically never stored, but only used like:
```
table.loc[idx]
```
this shouldn't make any difference for any user code, but it fixes the issue that `hasattr(table, "loc")` raises an error.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #5973, fixes #15911

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
