### PR TITLE
Enable Ruff `allow-dict-calls-with-keyword-arguments` setting

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -232,7 +232,6 @@ lint.unfixable = [
 # When a general exclusion is being fixed, but it affects many subpackages, it
 # is better to fix for subpackages individually. The general exclusion should be
 # copied to these subpackage sections and fixed there.
-"astropy/__init__.py" = ["C408"]
 "astropy/config/*" = [
     "PTH114",  # os-path-islink
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
@@ -270,7 +269,6 @@ lint.unfixable = [
 ]
 "astropy/logger.py" = ["C408", "RET505"]
 "astropy/modeling/*" = [
-    "C408",  # unnecessary-collection-call
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
@@ -289,21 +287,18 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/table/*" = [
-    "C408",  # unnecessary-collection-call
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "S605",  # Starting a process with a shell, possible injection detected
 ]
 "astropy/tests/*" = ["C408", "RET505"]
 "astropy/time/*" = [
-    "C408",  # unnecessary-collection-call
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
 "astropy/timeseries/*" = [
-    "C408",
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
@@ -320,7 +315,6 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/utils/*" = [
-    "C408",  # unnecessary-collection-call
     "N811",  # constant-imported-as-non-constant
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
@@ -328,7 +322,6 @@ lint.unfixable = [
 ]
 "astropy/visualization/*" = [
     "B015",
-    "C408",
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,6 +407,9 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 ignore-fully-untyped = true
 mypy-init-return = true
 
+[tool.ruff.lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true
+
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = []
 


### PR DESCRIPTION
### Description

[`allow-dict-calls-with-keyword-arguments`](https://docs.astral.sh/ruff/settings/#flake8-comprehensions-allow-dict-calls-with-keyword-arguments) configures Ruff rule [C408](https://docs.astral.sh/ruff/rules/unnecessary-collection-call/) to allow `dict` calls with keyword arguments (e.g. `dict(a=1, b=2)`). Ruff will still replace `dict()` with `{}`. C408 can now be enabled in several sub-packages.

This is in response to https://github.com/astropy/astropy/pull/15664#discussion_r1412317762

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.