### PR TITLE
typing cosmology's io

### DIFF
--- a/astropy/cosmology/_io/cosmology.py
+++ b/astropy/cosmology/_io/cosmology.py
@@ -35,14 +35,12 @@ def from_cosmology(
     ----------
     cosmo : `~astropy.cosmology.Cosmology`
         The cosmology to return.
-    cosmology : `~astropy.cosmology.Cosmology` | str | None, optional
+    cosmology : type[`~astropy.cosmology.Cosmology`] | str | None, optional
         The |Cosmology| class to check against. If not `None`, ``cosmo`` is checked
         for correctness.
     **kwargs
         This argument is required for compatibility with the standard set of
-        keyword arguments in format `~astropy.cosmology.Cosmology.from_format`,
-        e.g. "cosmology". If "cosmology" is included and is not `None`,
-        ``cosmo`` is checked for correctness.
+        keyword arguments in format |Cosmology.from_format|.
 
     Returns
     -------
@@ -104,7 +102,7 @@ def cosmology_identify(
 ) -> bool:
     """Identify if object is a `~astropy.cosmology.Cosmology`.
 
-    This checks is the 2nd argument is a |Cosmology| instance and the format is
+    This checks if the 2nd argument is a |Cosmology| instance and the format is
     "astropy.cosmology" or `None`.
 
     Returns

--- a/astropy/cosmology/_io/ecsv.py
+++ b/astropy/cosmology/_io/ecsv.py
@@ -216,7 +216,7 @@ def read_ecsv(
         any non-mandatory arguments missing in 'table'.
 
     rename : dict or None (optional, keyword-only)
-        A dictionary mapping columns in 'table' to fields of the
+        A dictionary mapping column names in 'table' to fields of the
         `~astropy.cosmology.Cosmology` class.
 
     **kwargs
@@ -314,8 +314,8 @@ def read_ecsv(
 
     Fields of the table in the file can be renamed to match the
     `~astropy.cosmology.Cosmology` class' signature using the ``rename`` argument. This
-    is useful when the files's column names do not match the class' parameter names. For
-    this example we need to make a new file with renamed columns:
+    is useful when the files's column names do not match the class' parameter names.
+    For this example we need to make a new file with renamed columns:
 
         >>> file = Path(temp_dir.name) / "file3.ecsv"
         >>> renamed_table = Planck18.to_format("astropy.table", rename={"H0": "Hubble"})

--- a/astropy/cosmology/_io/html.py
+++ b/astropy/cosmology/_io/html.py
@@ -85,6 +85,10 @@ enable this, set ``latex_names=True``.
     >>> temp_dir.cleanup()
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
 import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology.connect import readwrite_registry
@@ -93,6 +97,13 @@ from astropy.cosmology.parameter import Parameter
 from astropy.table import QTable
 
 from .table import from_table, to_table
+
+if TYPE_CHECKING:
+    from astropy.cosmology._typing import _CosmoT
+    from astropy.io.typing import PathLike, ReadableFileLike, WriteableFileLike
+    from astropy.table import Table
+
+    _TableT = TypeVar("_TableT", "Table")
 
 # Format look-up for conversion, {original_name: new_name}
 # TODO! move this information into the Parameters themselves
@@ -113,14 +124,14 @@ _FORMAT_TABLE = {
 
 
 def read_html_table(
-    filename,
-    index=None,
+    filename: PathLike | ReadableFileLike[Table],
+    index: int | str | None = None,
     *,
-    move_to_meta=False,
-    cosmology=None,
-    latex_names=True,
-    **kwargs,
-):
+    move_to_meta: bool = False,
+    cosmology: str | type[_CosmoT] | None = None,
+    latex_names: bool = True,
+    **kwargs: Any,
+) -> _CosmoT:
     r"""Read a |Cosmology| from an HTML file.
 
     Parameters
@@ -188,14 +199,20 @@ def read_html_table(
 
 
 def write_html_table(
-    cosmology, file, *, overwrite=False, cls=QTable, latex_names=False, **kwargs
-):
+    cosmology: Cosmology,
+    file: PathLike | WriteableFileLike[_TableT],
+    *,
+    overwrite: bool = False,
+    cls: type[_TableT] = QTable,
+    latex_names: bool = False,
+    **kwargs: Any,
+) -> None:
     r"""Serialize the |Cosmology| into a HTML table.
 
     Parameters
     ----------
-    cosmology : |Cosmology| subclass instance file : path-like or file-like
-        Location to save the serialized cosmology.
+    cosmology : |Cosmology| subclass instance
+        The cosmology to serialize.
     file : path-like or file-like
         Where to write the html table.
 
@@ -325,20 +342,20 @@ def write_html_table(
     table.write(file, overwrite=overwrite, format="ascii.html", **kwargs)
 
 
-def html_identify(origin, filepath, fileobj, *args, **kwargs):
+def html_identify(
+    origin: object, filepath: object, *args: object, **kwargs: object
+) -> bool:
     """Identify if an object uses the HTML Table format.
 
     Parameters
     ----------
-    origin : Any
+    origin : object
         Not used.
-    filepath : str or Any
+    filepath : str | object
         From where to read the Cosmology.
-    fileobj : Any
+    *args : object
         Not used.
-    *args : Any
-        Not used.
-    **kwargs : Any
+    **kwargs : object
         Not used.
 
     Returns

--- a/astropy/cosmology/_io/html.py
+++ b/astropy/cosmology/_io/html.py
@@ -351,7 +351,7 @@ def html_identify(
     ----------
     origin : object
         Not used.
-    filepath : str | object
+    filepath : object
         From where to read the Cosmology.
     *args : object
         Not used.

--- a/astropy/cosmology/_io/latex.py
+++ b/astropy/cosmology/_io/latex.py
@@ -54,6 +54,10 @@ By default the parameter names are converted to LaTeX format. To disable this, s
     >>> temp_dir.cleanup()
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
 import astropy.units as u
 from astropy.cosmology.connect import readwrite_registry
 from astropy.cosmology.core import Cosmology
@@ -61,6 +65,12 @@ from astropy.cosmology.parameter import Parameter
 from astropy.table import QTable
 
 from .table import to_table
+
+if TYPE_CHECKING:
+    from astropy.io.typing import PathLike, WriteableFileLike
+    from astropy.table import Table
+
+    _TableT = TypeVar("_TableT", Table)
 
 _FORMAT_TABLE = {
     "H0": "$H_0$",
@@ -79,8 +89,14 @@ _FORMAT_TABLE = {
 
 
 def write_latex(
-    cosmology, file, *, overwrite=False, cls=QTable, latex_names=True, **kwargs
-):
+    cosmology: Cosmology,
+    file: PathLike | WriteableFileLike[_TableT],
+    *,
+    overwrite: bool = False,
+    cls: type[_TableT] = QTable,
+    latex_names: bool = True,
+    **kwargs: Any,
+) -> None:
     r"""Serialize the |Cosmology| into a LaTeX.
 
     Parameters
@@ -184,7 +200,9 @@ def write_latex(
     table.write(file, overwrite=overwrite, format="ascii.latex", **kwargs)
 
 
-def latex_identify(origin, filepath, fileobj, *args, **kwargs):
+def latex_identify(
+    origin: object, filepath: str | None, *args: object, **kwargs: object
+) -> bool:
     """Identify if object uses the Table format.
 
     Returns

--- a/astropy/cosmology/_io/mapping.py
+++ b/astropy/cosmology/_io/mapping.py
@@ -203,7 +203,7 @@ def from_mapping(
         the case of a merge conflict (e.g. for ``Cosmology(meta={'key':10}, key=42)``,
         the ``Cosmology.meta`` will be ``{'key': 10}``).
 
-    cosmology : str, `~astropy.cosmology.Cosmology` class, or None (optional, keyword-only)
+    cosmology : str, |Cosmology| class, or None (optional, keyword-only)
         The cosmology class (or string name thereof) to use when constructing the
         cosmology instance. The class also provides default parameter values, filling in
         any non-mandatory arguments missing in 'map'.

--- a/astropy/cosmology/_io/row.py
+++ b/astropy/cosmology/_io/row.py
@@ -31,8 +31,11 @@ to the ``Planck18`` cosmology from which it was generated.
 For more information on the argument options, see :ref:`cosmology_io_builtin-table`.
 """
 
+from __future__ import annotations
+
 import copy
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from astropy.cosmology.connect import convert_registry
 from astropy.cosmology.core import Cosmology
@@ -40,8 +43,20 @@ from astropy.table import QTable, Row
 
 from .mapping import from_mapping
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
-def from_row(row, *, move_to_meta=False, cosmology=None, rename=None):
+    from astropy.cosmology._typing import _CosmoT
+    from astropy.table import Table
+
+
+def from_row(
+    row: Row,
+    *,
+    move_to_meta: bool = False,
+    cosmology: str | type[_CosmoT] | None = None,
+    rename: Mapping[str, str] | None = None,
+) -> _CosmoT:
     """Instantiate a `~astropy.cosmology.Cosmology` from a `~astropy.table.Row`.
 
     Parameters
@@ -62,8 +77,8 @@ def from_row(row, *, move_to_meta=False, cosmology=None, rename=None):
         the cosmology instance. The class also provides default parameter values,
         filling in any non-mandatory arguments missing in 'table'.
 
-    rename : dict or None (optional, keyword-only)
-        A dictionary mapping columns in the row to fields of the `~astropy.cosmology.Cosmology`.
+    rename : Mapping[str, str] or None (optional, keyword-only)
+        A mapping of column names in the row to field names of the |Cosmology|.
 
     Returns
     -------
@@ -163,7 +178,13 @@ def from_row(row, *, move_to_meta=False, cosmology=None, rename=None):
     )
 
 
-def to_row(cosmology, *args, cosmology_in_meta=False, table_cls=QTable, rename=None):
+def to_row(
+    cosmology: Cosmology,
+    *args: object,
+    cosmology_in_meta: bool = False,
+    table_cls: type[Table] = QTable,
+    rename: Mapping[str, str] | None = None,
+) -> Row:
     """Serialize the cosmology into a `~astropy.table.Row`.
 
     Parameters
@@ -179,6 +200,8 @@ def to_row(cosmology, *args, cosmology_in_meta=False, table_cls=QTable, rename=N
     cosmology_in_meta : bool
         Whether to put the cosmology class in the Table metadata (if `True`) or as the
         first column (if `False`, default).
+    rename : Mapping[str, str] or None (optional, keyword-only)
+        A mapping of field names of the |Cosmology| to column names in the row.
 
     Returns
     -------
@@ -247,7 +270,9 @@ def to_row(cosmology, *args, cosmology_in_meta=False, table_cls=QTable, rename=N
     return table[0]  # extract row from table
 
 
-def row_identify(origin, format, *args, **kwargs):
+def row_identify(
+    origin: str, format: str | None, *args: object, **kwargs: object
+) -> bool:
     """Identify if object uses the `~astropy.table.Row` format.
 
     Returns

--- a/astropy/cosmology/_io/table.py
+++ b/astropy/cosmology/_io/table.py
@@ -154,6 +154,10 @@ not match the class' parameter names.
     True
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from astropy.cosmology.connect import convert_registry
@@ -164,8 +168,23 @@ from .mapping import to_mapping
 from .row import from_row
 from .utils import convert_parameter_to_column
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import TypeVar
 
-def from_table(table, index=None, *, move_to_meta=False, cosmology=None, rename=None):
+    from astropy.cosmology._typing import _CosmoT
+
+    _TableT = TypeVar("_TableT", Table)
+
+
+def from_table(
+    table: Table,
+    index: int | str | None = None,
+    *,
+    move_to_meta: bool = False,
+    cosmology: str | type[_CosmoT] | None = None,
+    rename: Mapping[str, str] | None = None,
+) -> _CosmoT:
     """Instantiate a `~astropy.cosmology.Cosmology` from a |QTable|.
 
     Parameters
@@ -191,9 +210,8 @@ def from_table(table, index=None, *, move_to_meta=False, cosmology=None, rename=
         cosmology instance. The class also provides default parameter values, filling in
         any non-mandatory arguments missing in 'table'.
 
-    rename : dict or None (optional, keyword-only)
-        A dictionary mapping columns in 'table' to fields of the
-        `~astropy.cosmology.Cosmology` class.
+    rename : Mapping[str, str] or None (optional, keyword-only)
+        A mapping of column names in 'table' to field names of the |Cosmology| class.
 
     Returns
     -------
@@ -332,14 +350,20 @@ def from_table(table, index=None, *, move_to_meta=False, cosmology=None, rename=
     return from_row(row, move_to_meta=move_to_meta, cosmology=cosmology, rename=rename)
 
 
-def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True, rename=None):
+def to_table(
+    cosmology: Cosmology,
+    *args: object,
+    cls: type[_TableT] = QTable,
+    cosmology_in_meta: bool = True,
+    rename: Mapping[str, str] | None = None,
+) -> _TableT:
     """Serialize the cosmology into a `~astropy.table.QTable`.
 
     Parameters
     ----------
     cosmology : `~astropy.cosmology.Cosmology`
         The cosmology instance to convert to a table.
-    *args
+    *args : object
         Not used. Needed for compatibility with
         `~astropy.io.registry.UnifiedReadWriteMethod`
     cls : type (optional, keyword-only)
@@ -348,6 +372,9 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True, rename=None):
     cosmology_in_meta : bool (optional, keyword-only)
         Whether to put the cosmology class in the Table metadata (if `True`,
         default) or as the first column (if `False`).
+    rename : Mapping[str, str] or None (optional, keyword-only)
+        A mapping of field names of the |Cosmology| class to column names in the
+        |Table|.
 
     Returns
     -------
@@ -448,7 +475,9 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True, rename=None):
     return tbl
 
 
-def table_identify(origin, format, *args, **kwargs):
+def table_identify(
+    origin: str, format: str | None, *args: object, **kwargs: object
+) -> bool:
     """Identify if object uses the Table format.
 
     Returns

--- a/astropy/cosmology/_io/yaml.py
+++ b/astropy/cosmology/_io/yaml.py
@@ -17,6 +17,10 @@ require YAML serialization.
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 """  # this is shown in the docs.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology.connect import convert_registry
@@ -26,7 +30,14 @@ from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 from .mapping import from_mapping
 from .utils import FULLQUALNAME_SUBSTITUTIONS as QNS
 
-__all__ = []  # nothing is publicly scoped
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from yaml import MappingNode
+
+    from astropy.cosmology._typing import _CosmoT
+
+__all__: list[str] = []  # nothing is publicly scoped
 
 
 ##############################################################################
@@ -36,7 +47,21 @@ __all__ = []  # nothing is publicly scoped
 # that calls these functions.
 
 
-def yaml_representer(tag):
+_representer_doc = """Cosmology yaml representer function for {}.
+
+Parameters
+----------
+dumper : `~astropy.io.misc.yaml.AstropyDumper`
+obj : `~astropy.cosmology.Cosmology`
+
+Returns
+-------
+str
+    :mod:`yaml` representation of |Cosmology| object.
+"""
+
+
+def yaml_representer(tag: str) -> Callable[[AstropyDumper, Cosmology], str]:
     """`yaml <https://yaml.org>`_ representation of |Cosmology| object.
 
     Parameters
@@ -50,19 +75,7 @@ def yaml_representer(tag):
         Function to construct :mod:`yaml` representation of |Cosmology| object.
     """
 
-    def representer(dumper, obj):
-        """Cosmology yaml representer function for {}.
-
-        Parameters
-        ----------
-        dumper : `~astropy.io.misc.yaml.AstropyDumper`
-        obj : `~astropy.cosmology.Cosmology`
-
-        Returns
-        -------
-        str
-            :mod:`yaml` representation of |Cosmology| object.
-        """
+    def representer(dumper: AstropyDumper, obj: Cosmology) -> str:
         # convert to mapping
         map = obj.to_format("mapping")
         # remove the cosmology class info. It's already recorded in `tag`
@@ -72,12 +85,14 @@ def yaml_representer(tag):
 
         return dumper.represent_mapping(tag, map)
 
-    representer.__doc__ = representer.__doc__.format(tag)
+    representer.__doc__ = _representer_doc.format(tag)
 
     return representer
 
 
-def yaml_constructor(cls):
+def yaml_constructor(
+    cls: type[_CosmoT],
+) -> Callable[[AstropyLoader, MappingNode], _CosmoT]:
     """Cosmology| object from :mod:`yaml` representation.
 
     Parameters
@@ -91,7 +106,7 @@ def yaml_constructor(cls):
         Function to construct |Cosmology| object from :mod:`yaml` representation.
     """
 
-    def constructor(loader, node):
+    def constructor(loader: AstropyLoader, node: MappingNode) -> _CosmoT:
         """Cosmology yaml constructor function.
 
         Parameters
@@ -116,7 +131,7 @@ def yaml_constructor(cls):
     return constructor
 
 
-def register_cosmology_yaml(cosmo_cls):
+def register_cosmology_yaml(cosmo_cls: type[Cosmology]) -> None:
     """Register :mod:`yaml` for Cosmology class.
 
     Parameters
@@ -136,14 +151,14 @@ def register_cosmology_yaml(cosmo_cls):
 # Unified-I/O Functions
 
 
-def from_yaml(yml, *, cosmology=None):
+def from_yaml(yml: str, *, cosmology: type[_CosmoT] | None = None) -> _CosmoT:
     """Load `~astropy.cosmology.Cosmology` from :mod:`yaml` object.
 
     Parameters
     ----------
     yml : str
         :mod:`yaml` representation of |Cosmology| object
-    cosmology : str, `~astropy.cosmology.Cosmology` class, or None (optional, keyword-only)
+    cosmology : str, `~astropy.cosmology.Cosmology` class or None (optional, keyword-only)
         The expected cosmology class (or string name thereof). This argument is
         is only checked for correctness if not `None`.
 
@@ -178,14 +193,14 @@ def from_yaml(yml, *, cosmology=None):
     return cosmo
 
 
-def to_yaml(cosmology, *args):
+def to_yaml(cosmology: Cosmology, *args: object) -> str:
     r"""Return the cosmology class, parameters, and metadata as a :mod:`yaml` object.
 
     Parameters
     ----------
     cosmology : `~astropy.cosmology.Cosmology` subclass instance
         The cosmology to serialize.
-    *args
+    *args : Any
         Not used. Needed for compatibility with
         `~astropy.io.registry.UnifiedReadWriteMethod`
 

--- a/astropy/cosmology/_io/yaml.py
+++ b/astropy/cosmology/_io/yaml.py
@@ -51,8 +51,10 @@ _representer_doc = """Cosmology yaml representer function for {}.
 
 Parameters
 ----------
-dumper : `~astropy.io.misc.yaml.AstropyDumper`
-obj : `~astropy.cosmology.Cosmology`
+dumper : :class:`~astropy.io.misc.yaml.AstropyDumper`
+    The dumper object with which to serialize the |Cosmology| object.
+obj : :class:`~astropy.cosmology.Cosmology`
+    The |Cosmology| object to serialize.
 
 Returns
 -------
@@ -158,7 +160,7 @@ def from_yaml(yml: str, *, cosmology: type[_CosmoT] | None = None) -> _CosmoT:
     ----------
     yml : str
         :mod:`yaml` representation of |Cosmology| object
-    cosmology : str, `~astropy.cosmology.Cosmology` class or None (optional, keyword-only)
+    cosmology : str, |Cosmology| class, or None (optional, keyword-only)
         The expected cosmology class (or string name thereof). This argument is
         is only checked for correctness if not `None`.
 

--- a/astropy/cosmology/_typing.py
+++ b/astropy/cosmology/_typing.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Static typing for :mod:`astropy.cosmology`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from astropy.cosmology import Cosmology
+
+_CosmoT = TypeVar("_CosmoT", bound="Cosmology")  # noqa: PYI018
+"""Type variable for :class:`~astropy.cosmology.Cosmology` and subclasses."""

--- a/astropy/cosmology/connect.py
+++ b/astropy/cosmology/connect.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
     from astropy.cosmology import Cosmology
     from astropy.cosmology._io.model import _CosmologyModel
+    from astropy.cosmology._typing import _CosmoT
     from astropy.table import Row, Table
 
 __all__ = [
@@ -26,7 +27,6 @@ __doctest_skip__ = __all__
 
 
 # NOTE: private b/c RTD error
-_CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _MT = TypeVar("_MT", bound="Mapping")  # type: ignore[type-arg]
 
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -46,7 +46,7 @@ __all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
 # Parameters
 
 # registry of cosmology classes with {key=name : value=class}
-_COSMOLOGY_CLASSES = dict()
+_COSMOLOGY_CLASSES: dict[str, type[Cosmology]] = dict()
 
 # typing
 # NOTE: private b/c RTD error

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from typing import Self
 
+    from astropy.cosmology._typing import _CosmoT
     from astropy.cosmology.funcs.comparison import _FormatType
 
 # Originally authored by Andrew Becker (becker@astro.washington.edu),
@@ -49,7 +50,6 @@ _COSMOLOGY_CLASSES = dict()
 
 # typing
 # NOTE: private b/c RTD error
-_CosmoT = TypeVar("_CosmoT", bound="Cosmology")
 _FlatCosmoT = TypeVar("_FlatCosmoT", bound="FlatCosmologyMixin")
 
 


### PR DESCRIPTION
~Requires #15916 (currently based on that PR. will need a rebase when it's merged).~

I'm looking to minimally type cosmology's I/O module. In doing the types I've noticed a number of places where improving the code will enable us to replace ``All`` annotations. Let's do code changes in followup PRs. I modified one docstring to get Mypy to be happy.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
