### PR TITLE
Misc Meta improvements

### DIFF
--- a/astropy/utils/metadata/core.py
+++ b/astropy/utils/metadata/core.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Classes for handling metadata."""
 
+__all__ = ["MetaData", "MetaAttribute"]
+
 import inspect
 from collections import OrderedDict
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import is_dataclass
-
-__all__ = ["MetaData", "MetaAttribute"]
 
 
 class MetaData:
@@ -146,8 +146,10 @@ class MetaAttribute:
     - Method or attribute of the "parent class", where the parent class is
       taken to be ``owner.__mro__[1]``.
 
-    :param default: default value
-
+    Parameters
+    ----------
+    default : Any, optional
+        Default value for the attribute, by default `None`.
     """
 
     def __init__(self, default=None):

--- a/astropy/utils/metadata/merge.py
+++ b/astropy/utils/metadata/merge.py
@@ -83,11 +83,10 @@ class MergeStrategy:
 
     def __init_subclass__(cls):
         members = vars(cls)
-
         # Wrap ``merge`` classmethod to catch any exception and re-raise as
         # MergeConflictError.
-        if "merge" in members and isinstance(members["merge"], classmethod):
-            orig_merge = members["merge"].__func__
+        if isinstance((merge_ := members.get("merge")), classmethod):
+            orig_merge = merge_.__func__
 
             @wraps(orig_merge)
             def merge(cls, left, right):
@@ -99,8 +98,7 @@ class MergeStrategy:
             cls.merge = classmethod(merge)
 
         # Register merging class (except for base MergeStrategy class)
-        if "types" in members:
-            types = members["types"]
+        if (types := members.get("types")) is not None:
             if isinstance(types, tuple):
                 types = [types]
             for left, right in reversed(types):

--- a/astropy/utils/metadata/utils.py
+++ b/astropy/utils/metadata/utils.py
@@ -10,6 +10,10 @@ from .exceptions import MergeConflictError
 __all__ = ["common_dtype"]
 
 
+def dtype(arr):
+    return getattr(arr, "dtype", np.dtype("O"))
+
+
 def common_dtype(arrs):
     """
     Use numpy to find the common dtype for a list of ndarrays.
@@ -27,10 +31,6 @@ def common_dtype(arrs):
     dtype_str : str
         String representation of dytpe (dtype ``str`` attribute)
     """
-
-    def dtype(arr):
-        return getattr(arr, "dtype", np.dtype("O"))
-
     np_types = (np.bool_, np.object_, np.number, np.character, np.void)
     uniq_types = {
         tuple(issubclass(dtype(arr).type, np_type) for np_type in np_types)


### PR DESCRIPTION
Various improvements:

1. Got rid of MetaStrategyMeta
2. Simplify ``enable_merge_strategies`` context manager

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
