### PR TITLE
`FlatCosmologyMixin.nonflat` is a property

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -512,6 +512,7 @@ class FlatCosmologyMixin(metaclass=abc.ABCMeta):
         """Return `True`, the cosmology is flat."""
         return True
 
+    @property
     @abc.abstractmethod
     def nonflat(self: _FlatCosmoT) -> _CosmoT:
         """Return the equivalent non-flat-class instance of this cosmology."""


### PR DESCRIPTION
Fixes the abstractmethod. This was never used / noticed because it was abstract.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
