### PR TITLE
BUG: fix a bug where LaTeX formatter would return empty strings for unity (1) input

### DIFF
--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -60,10 +60,6 @@ def split_mantissa_exponent(v, format_spec=".8g"):
     mantissa, exponent : tuple of strings
     """
     x = format(v, format_spec).split("e")
-    if x[0] != "1." + "0" * (len(x[0]) - 2):
-        m = x[0]
-    else:
-        m = ""
 
     if len(x) == 2:
         ex = x[1].lstrip("0+")
@@ -71,6 +67,11 @@ def split_mantissa_exponent(v, format_spec=".8g"):
             ex = "-" + ex[1:].lstrip("0")
     else:
         ex = ""
+
+    if ex == "" or (x[0] != "1." + "0" * (len(x[0]) - 2)):
+        m = x[0]
+    else:
+        m = ""
 
     return m, ex
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -982,3 +982,23 @@ def test_function_format_styles(format_spec, string):
 def test_function_format_styles_non_default_fraction(format_spec, fraction, string):
     dbunit = u.decibel(u.m**-1)
     assert dbunit.to_string(format_spec, fraction=fraction) == string
+
+
+@pytest.mark.parametrize(
+    "format_spec, expected_mantissa",
+    [
+        ("", "1"),
+        (".1g", "1"),
+        (".3g", "1"),
+        (".1e", "1.0"),
+        (".1f", "1.0"),
+        (".3e", "1.000"),
+    ],
+)
+def test_format_latex_one(format_spec, expected_mantissa):
+    # see https://github.com/astropy/astropy/issues/12571
+    from astropy.units.format.utils import split_mantissa_exponent
+
+    m, ex = split_mantissa_exponent(1, format_spec)
+    assert ex == ""
+    assert m == expected_mantissa

--- a/docs/changes/units/15923.bugfix.rst
+++ b/docs/changes/units/15923.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where LaTeX formatter would return empty strings for unity (1) input.


### PR DESCRIPTION
### Description
This pull request is to address part of https://github.com/astropy/astropy/issues/12571


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
