### PR TITLE
TST: fix deprecation warnings from numpy dev's __array_wrap__ signature

### DIFF
--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -48,6 +48,9 @@ class Kernel:
     _is_bool = True
     _model = None
 
+    # numpy should not try to do any arithmetic
+    __array_ufunc__ = None
+
     def __init__(self, array):
         self._array = np.asanyarray(array)
 
@@ -179,12 +182,6 @@ class Kernel:
         Array representation of the kernel.
         """
         return self._array
-
-    def __array_wrap__(self, array, context=None, return_scalar=False):
-        """
-        Wrapper for multiplication with numpy arrays.
-        """
-        return NotImplemented if isinstance(context[0], np.ufunc) else array
 
 
 class Kernel1D(Kernel):

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -180,7 +180,7 @@ class Kernel:
         """
         return self._array
 
-    def __array_wrap__(self, array, context=None):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         """
         Wrapper for multiplication with numpy arrays.
         """

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -238,7 +238,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         else:
             return np.array(self.data)
 
-    def __array_wrap__(self, array, context=None):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         """
         This ensures that a masked array is returned if self is masked.
         """

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
+from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -721,7 +722,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         if "info" in getattr(obj, "__dict__", {}):
             self.info = obj.info
 
-    def __array_wrap__(self, out_arr, context=None):
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
         """
         __array_wrap__ is called at the end of every ufunc.
 
@@ -741,10 +742,16 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
            we also want to consistently return an array rather than a column
            (see #1446 and #1685)
         """
-        out_arr = super().__array_wrap__(out_arr, context)
-        if self.shape != out_arr.shape or (
-            isinstance(out_arr, BaseColumn)
-            and (context is not None and context[0] in _comparison_functions)
+        if NUMPY_LT_2_0:
+            out_arr = super().__array_wrap__(out_arr, context)
+        else:
+            out_arr = super().__array_wrap__(out_arr, context, return_scalar)
+        if (NUMPY_LT_2_0 or return_scalar) and (
+            self.shape != out_arr.shape
+            or (
+                isinstance(out_arr, BaseColumn)
+                and (context is not None and context[0] in _comparison_functions)
+            )
         ):
             return out_arr.data[()]
         else:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -602,7 +602,7 @@ class Quantity(np.ndarray):
             if "info" in obj.__dict__:
                 self.info = obj.info
 
-    def __array_wrap__(self, obj, context=None):
+    def __array_wrap__(self, obj, context=None, return_scalar=False):
         if context is None:
             # Methods like .squeeze() created a new `ndarray` and then call
             # __array_wrap__ to turn the array into self's subclass.


### PR DESCRIPTION
### Description
Fixes #15924
The discussion upstream is pretty rich so I haven't read it all, but the docstring says

> Subclasses may ignore the value, or return ``array[()]`` to behave more like NumPy.

I'm just going with the first option for now, but I don't think I understand the problem solved by this new argument deeply enough to make a call between the two proposed approaches. Since @mhvk served as a reviewer to https://github.com/numpy/numpy/pull/25409, I assume he's in a better position to make the call.



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
