### PR TITLE
Remove aliases for `struct.pack` and `struct.unpack`

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -6,9 +6,8 @@ to/from TABLEDATA_ and BINARY_ formats.
 
 # STDLIB
 import re
+import struct
 import sys
-from struct import pack as _struct_pack
-from struct import unpack as _struct_unpack
 
 # THIRD-PARTY
 import numpy as np
@@ -55,10 +54,6 @@ files in the wild use them.
 _zero_int = b"\0\0\0\0"
 _empty_bytes = b""
 _zero_byte = b"\0"
-
-
-struct_unpack = _struct_unpack
-struct_pack = _struct_pack
 
 
 if sys.byteorder == "little":
@@ -154,7 +149,7 @@ def bool_to_bitarray(value):
     if bit_no != 7:
         bytes.append(byte)
 
-    return struct_pack(f"{len(bytes)}B", *bytes)
+    return struct.pack(f"{len(bytes)}B", *bytes)
 
 
 class Converter:
@@ -182,11 +177,11 @@ class Converter:
 
     @staticmethod
     def _parse_length(read):
-        return struct_unpack(">I", read(4))[0]
+        return struct.unpack(">I", read(4))[0]
 
     @staticmethod
     def _write_length(length):
-        return struct_pack(">I", int(length))
+        return struct.pack(">I", int(length))
 
     def supports_empty_values(self, config):
         """
@@ -379,7 +374,7 @@ class Char(Converter):
         return read(length).decode("ascii"), False
 
     def _binparse_fixed(self, read):
-        s = struct_unpack(self._struct_format, read(self.arraysize))[0]
+        s = struct.unpack(self._struct_format, read(self.arraysize))[0]
         end = s.find(_zero_byte)
         s = s.decode("ascii")
         if end != -1:
@@ -404,7 +399,7 @@ class Char(Converter):
                 value = value.encode("ascii")
             except ValueError:
                 vo_raise(E24, (value, self.field_name))
-        return struct_pack(self._struct_format, value)
+        return struct.pack(self._struct_format, value)
 
 
 class UnicodeChar(Converter):
@@ -453,7 +448,7 @@ class UnicodeChar(Converter):
         return read(length * 2).decode("utf_16_be"), False
 
     def _binparse_fixed(self, read):
-        s = struct_unpack(self._struct_format, read(self.arraysize * 2))[0]
+        s = struct.unpack(self._struct_format, read(self.arraysize * 2))[0]
         s = s.decode("utf_16_be")
         end = s.find("\0")
         if end != -1:
@@ -469,7 +464,7 @@ class UnicodeChar(Converter):
     def _binoutput_fixed(self, value, mask):
         if mask:
             value = ""
-        return struct_pack(self._struct_format, value.encode("utf_16_be"))
+        return struct.pack(self._struct_format, value.encode("utf_16_be"))
 
 
 class Array(Converter):


### PR DESCRIPTION
### Description

The aliases are a leftover from when the code needed to support both Python 2 and 3, see 602b5a2c92e8b496ab08384b605bd6daec586eb4

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
