### PR TITLE
BUG: fix compatibility with numpy 2.0 for np.broadcast_arrays (now returns a tuple)

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -543,15 +543,16 @@ def broadcast_arrays(*args, subok=True):
     ]
     results = np.broadcast_arrays(*data, subok=subok)
 
-    shape = results[0].shape if isinstance(results, list) else results.shape
+    return_type = list if NUMPY_LT_2_0 else tuple
+    shape = results[0].shape if isinstance(results, return_type) else results.shape
     masks = [
         (np.broadcast_to(arg.mask, shape, subok=subok) if is_masked else None)
         for arg, is_masked in zip(args, are_masked)
     ]
-    results = [
+    results = return_type(
         (Masked(result, mask) if mask is not None else result)
         for (result, mask) in zip(results, masks)
-    ]
+    )
     return results if len(results) > 1 else results[0]
 
 


### PR DESCRIPTION
### Description
This pull request is to address part of #15926
~Currently based atop #15925~

xref https://github.com/numpy/numpy/pull/25570

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
