### PR TITLE
Deprecate unused introspection functions

### DIFF
--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -312,6 +312,7 @@ def _get_module_from_frame(frm):
     return None
 
 
+@deprecated(since="6.1")
 def find_mod_objs(modname, onlylocals=False):
     """Returns all the public attributes of a module referenced by name.
 

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -11,6 +11,8 @@ from importlib import metadata
 
 from packaging.version import Version
 
+from .decorators import deprecated
+
 __all__ = ["resolve_name", "minversion", "find_current_module", "isinstancemethod"]
 
 __doctest_skip__ = ["find_current_module"]
@@ -377,6 +379,7 @@ def find_mod_objs(modname, onlylocals=False):
 
 # Note: I would have preferred call this is_instancemethod, but this naming is
 # for consistency with other functions in the `inspect` module
+@deprecated(since="6.1")
 def isinstancemethod(cls, obj):
     """
     Returns `True` if the given object is an instance method of the class
@@ -393,34 +396,7 @@ def isinstancemethod(cls, obj):
         A member of the provided class (the membership is not checked directly,
         but this function will always return `False` if the given object is not
         a member of the given class).
-
-    Examples
-    --------
-    >>> class MetaClass(type):
-    ...     def a_classmethod(cls): pass
-    ...
-    >>> class MyClass(metaclass=MetaClass):
-    ...     def an_instancemethod(self): pass
-    ...
-    ...     @classmethod
-    ...     def another_classmethod(cls): pass
-    ...
-    ...     @staticmethod
-    ...     def a_staticmethod(): pass
-    ...
-    >>> isinstancemethod(MyClass, MyClass.a_classmethod)
-    False
-    >>> isinstancemethod(MyClass, MyClass.another_classmethod)
-    False
-    >>> isinstancemethod(MyClass, MyClass.a_staticmethod)
-    False
-    >>> isinstancemethod(MyClass, MyClass.an_instancemethod)
-    True
     """
-    return _isinstancemethod(cls, obj)
-
-
-def _isinstancemethod(cls, obj):
     if not isinstance(obj, types.FunctionType):
         return False
 

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -9,7 +9,13 @@ import pytest
 import yaml
 
 from astropy.utils import introspection
-from astropy.utils.introspection import find_current_module, find_mod_objs, minversion
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.introspection import (
+    find_current_module,
+    find_mod_objs,
+    isinstancemethod,
+    minversion,
+)
 
 
 def test_pkg_finder():
@@ -95,3 +101,34 @@ def test_find_current_module_bundle():
         assert find_current_module(0).__name__ == mod1
         assert find_current_module(1).__name__ == mod2
         assert find_current_module(0, True).__name__ == mod3
+
+
+def test_deprecated_isinstancemethod():
+    class MetaClass(type):
+        def a_classmethod(cls):
+            pass
+
+    class MyClass(metaclass=MetaClass):
+        def an_instancemethod(self):
+            pass
+
+        @classmethod
+        def another_classmethod(cls):
+            pass
+
+        @staticmethod
+        def a_staticmethod():
+            pass
+
+    deprecation_message = (
+        "^The isinstancemethod function is deprecated and may be removed in "
+        r"a future version\.$"
+    )
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        assert isinstancemethod(MyClass, MyClass.a_classmethod) is False
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        assert isinstancemethod(MyClass, MyClass.another_classmethod) is False
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        assert isinstancemethod(MyClass, MyClass.a_staticmethod) is False
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        assert isinstancemethod(MyClass, MyClass.an_instancemethod) is True

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -49,7 +49,12 @@ def test_find_current_mod():
 
 
 def test_find_mod_objs():
-    lnms, fqns, objs = find_mod_objs("astropy")
+    deprecation_message = (
+        "^The find_mod_objs function is deprecated and may be removed in "
+        r"a future version\.$"
+    )
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        lnms, fqns, objs = find_mod_objs("astropy")
 
     # this import  is after the above call intentionally to make sure
     # find_mod_objs properly imports astropy on its own
@@ -60,12 +65,14 @@ def test_find_mod_objs():
     assert "test" in lnms
     assert astropy.test in objs
 
-    lnms, fqns, objs = find_mod_objs(__name__, onlylocals=False)
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        lnms, fqns, objs = find_mod_objs(__name__, onlylocals=False)
     assert "namedtuple" in lnms
     assert "collections.namedtuple" in fqns
     assert namedtuple in objs
 
-    lnms, fqns, objs = find_mod_objs(__name__, onlylocals=True)
+    with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
+        lnms, fqns, objs = find_mod_objs(__name__, onlylocals=True)
     assert "namedtuple" not in lnms
     assert "collections.namedtuple" not in fqns
     assert namedtuple not in objs

--- a/docs/changes/utils/15934.api.rst
+++ b/docs/changes/utils/15934.api.rst
@@ -1,1 +1,2 @@
-``introspection.isinstancemethod()`` is deprecated.
+``introspection.isinstancemethod()`` and ``introspection.find_mod_objs()`` are
+deprecated.

--- a/docs/changes/utils/15934.api.rst
+++ b/docs/changes/utils/15934.api.rst
@@ -1,0 +1,1 @@
+``introspection.isinstancemethod()`` is deprecated.


### PR DESCRIPTION
### Description

`astropy.utils.introspection.isinstancemethod()` isn't used anywhere (since 9bbdd645fb35f0e5716c1f65302e10af8b81c1a4) and should be safe to remove without replacement. Previously the function simply called a private function that contained the actual implementation. I have removed the private function to ensure that it doesn't stay in the code when the public function gets removed. I have also removed examples from the function docstring to avoid having to deal with deprecation warnings there.

`astropy.utils.introspection.find_mod_objs()` was used for automatically generating API listings for Sphinx, but that functionality has since been moved from `astropy` to a dedicated `sphinx-automodapi` package that has its own `find_mod_objs()`: https://github.com/astropy/sphinx-automodapi/blob/7c57ce13320e8b0448e75e4d8300748a914fa2cb/sphinx_automodapi/utils.py#L40. The implementation in `astropy` is no longer used anywhere and should be safe to remove without replacement.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
