### PR TITLE
BUG: fix calling Table.group_by on an empty table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2073,7 +2073,7 @@ class Table:
             )
             out.meta = self.meta.copy()  # Shallow copy for meta
             return out
-        elif (isinstance(item, np.ndarray) and item.size == 0) or (
+        elif (isinstance(item, np.ndarray) and (item.size == 0 or len(self) == 0)) or (
             isinstance(item, (tuple, list)) and not item
         ):
             # If item is an empty array/list/tuple then return the table with no rows

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3178,6 +3178,13 @@ def test_rows_with_mixins():
     t.group_by("obs")
 
 
+@pytest.mark.xfail
+def test_group_by_empty_table():
+    # see https://github.com/astropy/astropy/issues/11884
+    t = Table(names=["a", "b"])
+    t.group_by("a")
+
+
 def test_iterrows():
     dat = [
         (1, 2, 3),

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3178,7 +3178,6 @@ def test_rows_with_mixins():
     t.group_by("obs")
 
 
-@pytest.mark.xfail
 def test_group_by_empty_table():
     # see https://github.com/astropy/astropy/issues/11884
     t = Table(names=["a", "b"])

--- a/docs/changes/table/15938.bugfix.rst
+++ b/docs/changes/table/15938.bugfix.rst
@@ -1,1 +1,1 @@
-Fix calling ``Table.group_by`` on an empty table.
+Calling ``Table.group_by`` on an empty table no longer raises an exception.

--- a/docs/changes/table/15938.bugfix.rst
+++ b/docs/changes/table/15938.bugfix.rst
@@ -1,0 +1,1 @@
+Fix calling ``Table.group_by`` on an empty table.


### PR DESCRIPTION
### Description
Fixes #11884

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
