### PR TITLE
Remove useless `Table` dunder methods

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3668,18 +3668,6 @@ class Table:
     def __copy__(self):
         return self.copy(False)
 
-    def __lt__(self, other):
-        return super().__lt__(other)
-
-    def __gt__(self, other):
-        return super().__gt__(other)
-
-    def __le__(self, other):
-        return super().__le__(other)
-
-    def __ge__(self, other):
-        return super().__ge__(other)
-
     def __eq__(self, other):
         return self._rows_equal(other)
 


### PR DESCRIPTION
### Description

The dunder methods this pull request removes were added in #828 to ensure that they would raise errors also in Python 2. They have served no purpose since support for Python 2 was dropped.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
