### PR TITLE
Avoid importing both `inspect` and `types`

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -19,7 +19,6 @@ import functools
 import inspect
 import itertools
 import operator
-import types
 from collections import defaultdict, deque
 from inspect import signature
 from itertools import chain
@@ -1479,7 +1478,7 @@ class Model(metaclass=_ModelMeta):
             # This typically implies a hard-coded bounding box.  This will
             # probably be rare, but it is an option
             return self._bounding_box
-        elif isinstance(self._bounding_box, types.MethodType):
+        elif inspect.ismethod(self._bounding_box):
             return ModelBoundingBox.validate(self, self._bounding_box())
         else:
             # The only other allowed possibility is that it's a ModelBoundingBox

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,7 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import annotations
+
 import inspect
 import itertools
-from types import FunctionType, ModuleType
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.lib.recfunctions as rfn
@@ -23,6 +26,10 @@ from astropy.utils.compat import (
     NUMPY_LT_1_25,
     NUMPY_LT_2_0,
 )
+
+if TYPE_CHECKING:
+    from types import FunctionType, ModuleType
+
 
 VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -6,7 +6,6 @@ import importlib
 import inspect
 import os
 import sys
-import types
 from importlib import metadata
 
 from packaging.version import Version
@@ -128,7 +127,7 @@ def minversion(module, version, inclusive=True):
     >>> minversion(astropy, '0.4.4')
     True
     """
-    if isinstance(module, types.ModuleType):
+    if inspect.ismodule(module):
         module_name = module.__name__
         module_version = getattr(module, "__version__", None)
     elif isinstance(module, str):
@@ -398,7 +397,7 @@ def isinstancemethod(cls, obj):
         but this function will always return `False` if the given object is not
         a member of the given class).
     """
-    if not isinstance(obj, types.FunctionType):
+    if not inspect.isfunction(obj):
         return False
 
     # Unfortunately it seems the easiest way to get to the original


### PR DESCRIPTION
### Description

In _some_ cases checking if an object is an instance of some specific type can be done either by importing the type from `types` and using `isinstance()` (e.g. `isinstance(..., types.MethodType)` or by importing an appropriate function from `inspect` (e.g. `inspect.ismethod(...)`. Either of these is fine to use, but using both in a single file necessitates importing both modules, which should be avoided if possible.

### Approvals by sub-package

- [ ] `modeling`
- [x] `units` https://github.com/astropy/astropy/pull/15950#pullrequestreview-1844242284
- [x] `utils` https://github.com/astropy/astropy/pull/15950#issuecomment-1910650653

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
