### PR TITLE
Backport PR #15929 on branch v6.0.x (BUG: fix compatibility with numpy 2.0 for ndarray suclasses overriding ndarray.sort and ndarray.argsort)

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1779,8 +1779,17 @@ class Quantity(np.ndarray):
         )
 
     # ensure we do not return indices as quantities
-    def argsort(self, axis=-1, kind="quicksort", order=None):
-        return self.view(np.ndarray).argsort(axis=axis, kind=kind, order=order)
+    if NUMPY_LT_2_0:
+
+        def argsort(self, axis=-1, kind=None, order=None):
+            return self.view(np.ndarray).argsort(axis=axis, kind=kind, order=order)
+
+    else:
+
+        def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
+            return self.view(np.ndarray).argsort(
+                axis=axis, kind=kind, order=order, stable=stable
+            )
 
     def searchsorted(self, v, *args, **kwargs):
         return np.searchsorted(

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1027,7 +1027,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         at_max = self == self.max(axis=axis, keepdims=True)
         return at_max.filled(False).argmax(axis=axis, out=out, keepdims=keepdims)
 
-    def argsort(self, axis=-1, kind=None, order=None):
+    def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
         """Returns the indices that would sort an array.
 
         Perform an indirect sort along the given axis on both the array
@@ -1045,6 +1045,8 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             second, etc.  A single field can be specified as a string, and not
             all fields need be specified, but unspecified fields will still be
             used, in dtype order, to break ties.
+        stable: bool, keyword-only, ignored
+            Sort stability. Present only to allow subclasses to work.
 
         Returns
         -------
@@ -1079,10 +1081,20 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
         return np.lexsort(keys, axis=axis)
 
-    def sort(self, axis=-1, kind=None, order=None):
-        """Sort an array in-place. Refer to `numpy.sort` for full documentation."""
+    def sort(self, axis=-1, kind=None, order=None, *, stable=False):
+        """Sort an array in-place. Refer to `numpy.sort` for full documentation.
+
+        Notes
+        -----
+        Masked items will be sorted to the end. The implementation
+        is via `numpy.lexsort` and thus ignores the ``kind`` and ``stable`` arguments;
+        they are present only so that subclasses can pass them on.
+        """
         # TODO: probably possible to do this faster than going through argsort!
-        indices = self.argsort(axis, kind=kind, order=order)
+        argsort_kwargs = dict(kind=kind, order=order)
+        if not NUMPY_LT_2_0:
+            argsort_kwargs["stable"] = stable
+        indices = self.argsort(axis, **argsort_kwargs)
         self[:] = np.take_along_axis(self, indices, axis=axis)
 
     def argpartition(self, kth, axis=-1, kind="introselect", order=None):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Manual attempt of https://github.com/astropy/astropy/pull/15952 to backport https://github.com/astropy/astropy/pull/15929 onto v6.0.x

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
