### PR TITLE
RTD: Fix astropy version in v6.0.x doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
   jobs:
     post_checkout:
       - git fetch --shallow-since=2023-01-01  || true
+      - git fetch --tags || true
     pre_install:
       - git update-index --assume-unchanged docs/conf.py docs/rtd_environment.yaml
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,7 @@ build:
     python: "mambaforge-4.10"
   jobs:
     post_checkout:
-      - git fetch --shallow-since=2023-01-01  || true
-      - git fetch --tags || true
+      - git fetch --unshallow || true
     pre_install:
       - git update-index --assume-unchanged docs/conf.py docs/rtd_environment.yaml
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

RTD doc build on v6.0.x suddenly started failing. There has not been a change in RTD config (or anything doc related, really) since it last build successfully and when it first failed.

Last success: https://readthedocs.org/projects/astropy/builds/23235136/ (Completed Jan. 25, 2024. 7:38 p.m.)
First failure: https://readthedocs.org/projects/astropy/builds/23235619/ (Completed Jan. 25, 2024. 8:27 p.m.)

@jdavies-st thought maybe it is this line in the log that caused problem but the depth is not something we can set in the config:

`git fetch origin --force --prune --prune-tags --depth 50 refs/heads/v6.0.x:refs/remotes/origin/v6.0.x`

We have this set instead:

https://github.com/astropy/astropy/blob/75fbc4f7d0a0af53bea957eaf8aaff3bc0ad677f/.readthedocs.yaml#L8-L11

Want to see if https://github.com/readthedocs/readthedocs.org/issues/10715#issuecomment-1719693166 works.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
