### PR TITLE
TST: do not ignore numpy warnings in votable tests

### DIFF
--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -56,9 +56,7 @@ def home_is_tmpdir(monkeypatch, tmp_path):
 
 def test_table(tmp_path):
     # Read the VOTABLE
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        votable = parse(get_pkg_data_filename("data/regression.xml"))
+    votable = parse(get_pkg_data_filename("data/regression.xml"))
     table = votable.get_first_table()
     astropy_table = table.to_table()
 
@@ -115,17 +113,13 @@ def test_table(tmp_path):
 def test_read_from_tilde_path(home_is_data):
     # Just test that these run without error for tilde-paths
     path = os.path.join("~", "regression.xml")
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        votable = parse(path)
-        Table.read(path, format="votable", table_id="main_table")
+    votable = parse(path)
+    Table.read(path, format="votable", table_id="main_table")
 
 
 def test_read_through_table_interface(tmp_path):
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        with get_pkg_data_fileobj("data/regression.xml", encoding="binary") as fd:
-            t = Table.read(fd, format="votable", table_id="main_table")
+    with get_pkg_data_fileobj("data/regression.xml", encoding="binary") as fd:
+        t = Table.read(fd, format="votable", table_id="main_table")
 
     assert len(t) == 5
 
@@ -145,10 +139,8 @@ def test_read_through_table_interface(tmp_path):
 
 
 def test_read_through_table_interface2():
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        with get_pkg_data_fileobj("data/regression.xml", encoding="binary") as fd:
-            t = Table.read(fd, format="votable", table_id="last_table")
+    with get_pkg_data_fileobj("data/regression.xml", encoding="binary") as fd:
+        t = Table.read(fd, format="votable", table_id="last_table")
 
     assert len(t) == 0
 

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -43,19 +43,15 @@ def assert_validate_schema(filename, version):
 
 
 def test_parse_single_table():
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        table = parse_single_table(get_pkg_data_filename("data/regression.xml"))
+    table = parse_single_table(get_pkg_data_filename("data/regression.xml"))
     assert isinstance(table, tree.TableElement)
     assert len(table.array) == 5
 
 
 def test_parse_single_table2():
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        table2 = parse_single_table(
-            get_pkg_data_filename("data/regression.xml"), table_number=1
-        )
+    table2 = parse_single_table(
+        get_pkg_data_filename("data/regression.xml"), table_number=1
+    )
     assert isinstance(table2, tree.TableElement)
     assert len(table2.array) == 1
     assert len(table2.array.dtype.names) == 28
@@ -199,11 +195,9 @@ def test_regression_binary2(tmp_path):
 
 class TestFixups:
     def setup_class(self):
-        with np.errstate(over="ignore"):
-            # https://github.com/astropy/astropy/issues/13341
-            self.table = parse(
-                get_pkg_data_filename("data/regression.xml")
-            ).get_first_table()
+        self.table = parse(
+            get_pkg_data_filename("data/regression.xml")
+        ).get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
 
@@ -213,9 +207,7 @@ class TestFixups:
 
 class TestReferences:
     def setup_class(self):
-        with np.errstate(over="ignore"):
-            # https://github.com/astropy/astropy/issues/13341
-            self.votable = parse(get_pkg_data_filename("data/regression.xml"))
+        self.votable = parse(get_pkg_data_filename("data/regression.xml"))
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -281,9 +273,7 @@ def test_select_columns_by_name():
 
 class TestParse:
     def setup_class(self):
-        with np.errstate(over="ignore"):
-            # https://github.com/astropy/astropy/issues/13341
-            self.votable = parse(get_pkg_data_filename("data/regression.xml"))
+        self.votable = parse(get_pkg_data_filename("data/regression.xml"))
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -600,9 +590,7 @@ class TestParse:
 
 class TestThroughTableData(TestParse):
     def setup_class(self):
-        with np.errstate(over="ignore"):
-            # https://github.com/astropy/astropy/issues/13341
-            votable = parse(get_pkg_data_filename("data/regression.xml"))
+        votable = parse(get_pkg_data_filename("data/regression.xml"))
 
         self.xmlout = bio = io.BytesIO()
         # W39: Bit values can not be masked
@@ -634,9 +622,7 @@ class TestThroughTableData(TestParse):
 
 class TestThroughBinary(TestParse):
     def setup_class(self):
-        with np.errstate(over="ignore"):
-            # https://github.com/astropy/astropy/issues/13341
-            votable = parse(get_pkg_data_filename("data/regression.xml"))
+        votable = parse(get_pkg_data_filename("data/regression.xml"))
         votable.get_first_table().format = "binary"
 
         self.xmlout = bio = io.BytesIO()
@@ -665,9 +651,7 @@ class TestThroughBinary(TestParse):
 
 class TestThroughBinary2(TestParse):
     def setup_class(self):
-        with np.errstate(over="ignore"):
-            # https://github.com/astropy/astropy/issues/13341
-            votable = parse(get_pkg_data_filename("data/regression.xml"))
+        votable = parse(get_pkg_data_filename("data/regression.xml"))
         votable.version = "1.3"
         votable.get_first_table()._config["version_1_3_or_later"] = True
         votable.get_first_table().format = "binary2"
@@ -724,8 +708,6 @@ def table_from_scratch():
     votable.to_xml(out)
 
 
-# https://github.com/astropy/astropy/issues/13341
-@np.errstate(over="ignore")
 def test_open_files():
     for filename in get_pkg_data_filenames("data", pattern="*.xml"):
         if not filename.endswith(
@@ -842,9 +824,7 @@ def test_validate_path_object():
 
 
 def test_gzip_filehandles(tmp_path):
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        votable = parse(get_pkg_data_filename("data/regression.xml"))
+    votable = parse(get_pkg_data_filename("data/regression.xml"))
 
     # W39: Bit values can not be masked
     with pytest.warns(W39):

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -1,7 +1,6 @@
 import os
 import re
 
-import numpy as np
 import pytest
 
 from astropy.table.scripts import showtable
@@ -130,17 +129,15 @@ def test_ascii_delimiter(capsys):
 
 
 def test_votable(capsys):
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        showtable.main(
-            [
-                os.path.join(VOTABLE_ROOT, "data/regression.xml"),
-                "--table-id",
-                "main_table",
-                "--max-width",
-                "50",
-            ]
-        )
+    showtable.main(
+        [
+            os.path.join(VOTABLE_ROOT, "data/regression.xml"),
+            "--table-id",
+            "main_table",
+            "--max-width",
+            "50",
+        ]
+    )
     out, err = capsys.readouterr()
     assert out.splitlines() == [
         "   string_test    string_test_2 ...   bitarray2  ",


### PR DESCRIPTION
### Description
I was curious to see if reverting #13343 was safe now (it seems to, at least locally). Let's see if CI explodes if I remove those context managers...


note: even if it does work, I'll need to finish the cleanup. For now I just did that one file.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
