### PR TITLE
API/BUG: only output user-requested columns in votable.parse

### DIFF
--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -362,6 +362,20 @@ def test_select_columns_by_name():
             ["string test", "fixed string test"],
             id="two-cols-names-sameID",
         ),
+        # columns should be returned in the order they are found, which
+        # in the general case isn't the order they are requested
+        pytest.param(
+            ["unicode_test", "string_test"],
+            False,
+            ["string_test", "unicode_test"],
+            id="two-cols-ids-order-mismatch",
+        ),
+        pytest.param(
+            ["unicode_test", "string_test"],
+            True,
+            ["string test", "unicode_test"],
+            id="two-cols-names-order-mismatch",
+        ),
     ],
 )
 def test_select_columns_by_name_edge_cases(
@@ -374,14 +388,6 @@ def test_select_columns_by_name_edge_cases(
         vot1 = parse_single_table(filename, columns=column_ids)
     t1 = vot1.to_table(use_names_over_ids=use_names_over_ids)
     assert t1.colnames == expected_names
-
-    # columns should be returned in the order they are found, which
-    # in the general case isn't the order they are requested
-    with np.errstate(over="ignore"):
-        # https://github.com/astropy/astropy/issues/13341
-        vot2 = parse_single_table(filename, columns=list(reversed(column_ids)))
-    t2 = vot2.to_table(use_names_over_ids=use_names_over_ids)
-    assert t2.colnames == expected_names
 
 
 class TestParse:

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -793,7 +793,6 @@ class TestThroughBinary2(TestParse):
         pass
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("format_", ["binary", "binary2"])
 def test_select_columns_binary(format_):
     with np.errstate(over="ignore"):

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -285,7 +285,10 @@ def test_select_columns_by_index():
     columns = ["string_test", "unsignedByte", "bitarray"]
     for c in columns:
         assert not np.all(mask[c])
-    assert np.all(mask["unicode_test"])
+
+    # deselected columns shouldn't be present in the output
+    assert "unicode_test" not in array.dtype.fields
+    assert "unicode_test" not in mask.dtype.fields
 
 
 def test_select_columns_by_name():
@@ -298,7 +301,10 @@ def test_select_columns_by_name():
     assert array["string_test"][0] == "String & test"
     for c in columns:
         assert not np.all(mask[c])
-    assert np.all(mask["unicode_test"])
+
+    # deselected columns shouldn't be present in the output
+    assert "unicode_test" not in array.dtype.fields
+    assert "unicode_test" not in mask.dtype.fields
 
 
 @pytest.mark.xfail

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -307,7 +307,6 @@ def test_select_columns_by_name():
     assert "unicode_test" not in mask.dtype.fields
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "column_ids, use_names_over_ids, expected_names",
     [

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3030,8 +3030,6 @@ class TableElement(
         return careful_read
 
     def _parse_binary(self, mode, iterator, colnumbers, fields, config, pos):
-        fields = self.all_fields
-
         careful_read = self._get_binary_data_stream(iterator, config)
 
         # Need to have only one reference so that we can resize the
@@ -3086,11 +3084,11 @@ class TableElement(
             except EOFError:
                 break
 
-            row = [x.converter.default for x in fields]
-            row_mask = [False] * len(fields)
-            for i in colnumbers:
-                row[i] = row_data[i]
-                row_mask[i] = row_mask_data[i]
+            row = [x.converter.default for x in self.fields]
+            row_mask = [False] * len(self.fields)
+            for j, i in enumerate(colnumbers):
+                row[j] = row_data[i]
+                row_mask[j] = row_mask_data[i]
 
             array[numrows] = tuple(row)
             array.mask[numrows] = tuple(row_mask)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2607,9 +2607,12 @@ class TableElement(
         if colnumbers is None:
             colnumbers = list(range(len(self.all_fields)))
 
-        for i, field in enumerate(self.all_fields):
-            if i in colnumbers and field not in self.fields:
-                self.fields.append(field)
+        new_fields = HomogeneousList(
+            Field,
+            values=[f for i, f in enumerate(self.all_fields) if i in colnumbers],
+        )
+        if new_fields != self._fields:
+            self._fields = new_fields
 
         fields = self.all_fields
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # TODO: Test FITS parsing
 
-from __future__ import annotations
-
 # STDLIB
 import base64
 import codecs

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2535,7 +2535,9 @@ class TableElement(
         of the data columns. Contrary to ``fields``, this property should
         list every field that's available on disk, including deselected columns.
         """
-        # last minute update
+        # since we support extending self.fields directly via list.extend
+        # and list.append, self._all_fields may go out of sync.
+        # To remedy this issue, we sync back the public property upon access.
         for field in self._fields:
             if field not in self._all_fields:
                 self._all_fields.append(field)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2599,7 +2599,7 @@ class TableElement(
         Any data in the existing array will be lost.
 
         *nrows*, if provided, is the number of rows to allocate.
-        *colnumbers*, if provided, is the list of on-disk columns to select.
+        *colnumbers*, if provided, is the list of column indices to select.
         By default, all columns are selected.
         """
         if nrows is None:

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2653,6 +2653,7 @@ class TableElement(
 
     def add_field(self, field: Field) -> None:
         self.fields.append(field)
+        self.all_fields.append(field)
 
     def _register_field(self, iterator, tag, data, config, pos) -> None:
         field = Field(self._votable, config=config, pos=pos, **data)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2791,19 +2791,17 @@ class TableElement(
 
                 if tag == "TABLEDATA":
                     warn_unknown_attrs("TABLEDATA", data.keys(), config, pos)
-                    self.array = self._parse_tabledata(
-                        iterator, colnumbers, fields, config
-                    )
+                    self.array = self._parse_tabledata(iterator, colnumbers, config)
                 elif tag == "BINARY":
                     warn_unknown_attrs("BINARY", data.keys(), config, pos)
                     self.array = self._parse_binary(
-                        1, iterator, colnumbers, fields, config, pos
+                        1, iterator, colnumbers, config, pos
                     )
                 elif tag == "BINARY2":
                     if not config["version_1_3_or_later"]:
                         warn_or_raise(W52, W52, config["version"], config, pos)
                     self.array = self._parse_binary(
-                        2, iterator, colnumbers, fields, config, pos
+                        2, iterator, colnumbers, config, pos
                     )
                 elif tag == "FITS":
                     if config.get("columns") is not None:
@@ -2845,7 +2843,7 @@ class TableElement(
 
         return self
 
-    def _parse_tabledata(self, iterator, colnumbers, fields, config):
+    def _parse_tabledata(self, iterator, colnumbers, config):
         # Since we don't know the number of rows up front, we'll
         # reallocate the record array to make room as we go.  This
         # prevents the need to scan through the XML twice.  The
@@ -2857,6 +2855,7 @@ class TableElement(
         array = self.array
         del self.array
 
+        fields = self.all_fields
         parsers = [field.converter.parse for field in fields]
         binparsers = [field.converter.binparse for field in fields]
 
@@ -3029,7 +3028,7 @@ class TableElement(
 
         return careful_read
 
-    def _parse_binary(self, mode, iterator, colnumbers, fields, config, pos):
+    def _parse_binary(self, mode, iterator, colnumbers, config, pos):
         careful_read = self._get_binary_data_stream(iterator, config)
 
         # Need to have only one reference so that we can resize the
@@ -3037,6 +3036,7 @@ class TableElement(
         array = self.array
         del self.array
 
+        fields = self.all_fields
         binparsers = [field.converter.binparse for field in fields]
 
         numrows = 0

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2463,6 +2463,7 @@ class TableElement(
                 self._groups = table.groups
                 self._links = table.links
         else:
+            del self._fields[:]
             del self._all_fields[:]
             del self._params[:]
             del self._groups[:]

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2463,7 +2463,7 @@ class TableElement(
                 self._groups = table.groups
                 self._links = table.links
         else:
-            del self.all_fields[:]
+            del self._all_fields[:]
             del self._params[:]
             del self._groups[:]
             del self._links[:]

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2806,6 +2806,8 @@ class TableElement(
                         2, iterator, colnumbers, fields, config, pos
                     )
                 elif tag == "FITS":
+                    if config.get("columns") is not None:
+                        raise NotImplementedError
                     warn_unknown_attrs("FITS", data.keys(), config, pos, ["extnum"])
                     try:
                         extnum = int(data.get("extnum", 0))

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2532,7 +2532,7 @@ class TableElement(
         """
         A list of :class:`Field` objects describing the types of each
         of the data columns. Contrary to ``fields``, this property should
-        list every field that's available on disk, included deselected columns.
+        list every field that's available on disk, including deselected columns.
         """
         # last minute update
         for field in self._fields:

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2590,7 +2590,7 @@ class TableElement(
         nrows=0,
         config=None,
         *,
-        colnumbers: list[int] | None = None,
+        colnumbers=None,
     ):
         """
         Create a new array to hold the data based on the current set

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # TODO: Test FITS parsing
 
+from __future__ import annotations
+
 # STDLIB
 import base64
 import codecs
@@ -2413,6 +2415,7 @@ class TableElement(
         self.format = "tabledata"
 
         self._fields = HomogeneousList(Field)
+        self._all_fields = HomogeneousList(Field)
         self._params = HomogeneousList(Param)
         self._groups = HomogeneousList(Group)
         self._links = HomogeneousList(Link)
@@ -2457,11 +2460,12 @@ class TableElement(
                 ref = None
             else:
                 self._fields = table.fields
+                self._all_fields = table.all_fields
                 self._params = table.params
                 self._groups = table.groups
                 self._links = table.links
         else:
-            del self._fields[:]
+            del self.all_fields[:]
             del self._params[:]
             del self._groups[:]
             del self._links[:]
@@ -2526,6 +2530,20 @@ class TableElement(
         return self._fields
 
     @property
+    def all_fields(self):
+        """
+        A list of :class:`Field` objects describing the types of each
+        of the data columns. Contrary to ``fields``, this property should
+        list every field that's available on disk, included deselected columns.
+        """
+        # last minute update
+        for field in self._fields:
+            if field not in self._all_fields:
+                self._all_fields.append(field)
+
+        return self._all_fields
+
+    @property
     def params(self):
         """
         A list of parameters (constant-valued columns) for the
@@ -2567,18 +2585,32 @@ class TableElement(
         """
         return self._empty
 
-    def create_arrays(self, nrows=0, config=None):
+    def create_arrays(
+        self,
+        nrows=0,
+        config=None,
+        *,
+        colnumbers: list[int] | None = None,
+    ):
         """
         Create a new array to hold the data based on the current set
         of fields, and store them in the *array* and member variable.
         Any data in the existing array will be lost.
 
         *nrows*, if provided, is the number of rows to allocate.
+        *colnumbers*, if provided, is the list of on-disk columns to select.
+        By default, all columns are selected.
         """
         if nrows is None:
             nrows = 0
+        if colnumbers is None:
+            colnumbers = list(range(len(self.all_fields)))
 
-        fields = self.fields
+        for i, field in enumerate(self.all_fields):
+            if i in colnumbers and field not in self.fields:
+                self.fields.append(field)
+
+        fields = self.all_fields
 
         if len(fields) == 0:
             array = np.recarray((nrows,), dtype="O")
@@ -2588,7 +2620,9 @@ class TableElement(
             Field.uniqify_names(fields)
 
             dtype = []
-            for x in fields:
+            for i, x in enumerate(fields):
+                if i not in colnumbers:
+                    continue
                 if x._unique_name == x.ID:
                     id = x.ID
                 else:
@@ -2619,10 +2653,13 @@ class TableElement(
             return 512
         return int(np.ceil(size * RESIZE_AMOUNT))
 
-    def _add_field(self, iterator, tag, data, config, pos):
-        field = Field(self._votable, config=config, pos=pos, **data)
+    def add_field(self, field: Field) -> None:
         self.fields.append(field)
+
+    def _register_field(self, iterator, tag, data, config, pos) -> None:
+        field = Field(self._votable, config=config, pos=pos, **data)
         field.parse(iterator, config)
+        self._all_fields.append(field)
 
     def _add_param(self, iterator, tag, data, config, pos):
         param = Param(self._votable, config=config, pos=pos, **data)
@@ -2688,7 +2725,7 @@ class TableElement(
                         self.description = data or None
         else:
             tag_mapping = {
-                "FIELD": self._add_field,
+                "FIELD": self._register_field,
                 "PARAM": self._add_param,
                 "GROUP": self._add_group,
                 "LINK": self._add_link,
@@ -2699,7 +2736,7 @@ class TableElement(
             for start, tag, data, pos in iterator:
                 if start:
                     if tag == "DATA":
-                        if len(self.fields) == 0:
+                        if len(self.all_fields) == 0:
                             warn_or_raise(E25, E25, None, config, pos)
                         warn_unknown_attrs("DATA", data.keys(), config, pos)
                         break
@@ -2714,14 +2751,14 @@ class TableElement(
                         self.description = data or None
                     elif tag == "TABLE":
                         # For error checking purposes
-                        Field.uniqify_names(self.fields)
+                        Field.uniqify_names(self.all_fields)
                         # We still need to create arrays, even if the file
                         # contains no DATA section
                         self.create_arrays(nrows=0, config=config)
                         return self
 
-        self.create_arrays(nrows=self._nrows, config=config)
-        fields = self.fields
+        fields = self.all_fields
+        Field.uniqify_names(fields)
         names = [x.ID for x in fields]
         # Deal with a subset of the columns, if requested.
         if not columns:
@@ -2744,6 +2781,8 @@ class TableElement(
                     ) from None
             else:
                 raise TypeError("Invalid columns list")
+
+        self.create_arrays(nrows=self._nrows, config=config, colnumbers=colnumbers)
 
         if (not skip_table) and (len(fields) > 0):
             for start, tag, data, pos in iterator:
@@ -2822,8 +2861,8 @@ class TableElement(
         numrows = 0
         alloc_rows = len(array)
         colnumbers_bits = [i in colnumbers for i in range(len(fields))]
-        row_default = [x.converter.default for x in fields]
-        mask_default = [True] * len(fields)
+        row_default = [field.converter.default for field in self.fields]
+        mask_default = [True] * len(self.fields)
         array_chunk = []
         mask_chunk = []
         chunk_size = config.get("chunk_size", DEFAULT_CHUNK_SIZE)
@@ -2832,7 +2871,8 @@ class TableElement(
                 # Now parse one row
                 row = row_default[:]
                 row_mask = mask_default[:]
-                i = 0
+                i = 0  # index of the column being read from disk
+                j = 0  # index of the column being written in array (not necessarily == i)
                 for start, tag, data, pos in iterator:
                     if start:
                         binary = data.get("encoding", None) == "base64"
@@ -2879,8 +2919,9 @@ class TableElement(
                                     if invalid == "exception":
                                         vo_reraise(e, config, pos)
                                 else:
-                                    row[i] = value
-                                    row_mask[i] = mask_value
+                                    row[j] = value
+                                    row_mask[j] = mask_value
+                                    j += 1
                         elif tag == "TR":
                             break
                         else:
@@ -2987,7 +3028,7 @@ class TableElement(
         return careful_read
 
     def _parse_binary(self, mode, iterator, colnumbers, fields, config, pos):
-        fields = self.fields
+        fields = self.all_fields
 
         careful_read = self._get_binary_data_stream(iterator, config)
 
@@ -3378,7 +3419,7 @@ class TableElement(
 
         for colname in table.colnames:
             column = table[colname]
-            new_table.fields.append(Field.from_table_column(votable, column))
+            new_table.add_field(Field.from_table_column(votable, column))
 
         if table.mask is None:
             new_table.array = ma.array(np.asarray(table))
@@ -3393,7 +3434,7 @@ class TableElement(
         TABLE.
         """
         yield from self.params
-        yield from self.fields
+        yield from self.all_fields
         for group in self.groups:
             yield from group.iter_fields_and_params()
 

--- a/docs/changes/io.votable/15959.api.rst
+++ b/docs/changes/io.votable/15959.api.rst
@@ -1,3 +1,5 @@
 ``Table.read(..., format='votable')``, ``votable.parse`` and
 ``votable.parse_single_table`` now respect the ``columns`` argument and will only output
 selected columns. Previously, unselected columns would just be masked (and unallocated).
+``astropy.io.votable.tree.TableElement.create_arrays`` also gained a ``colnumbers``
+keyword argument to allow column selection.

--- a/docs/changes/io.votable/15959.api.rst
+++ b/docs/changes/io.votable/15959.api.rst
@@ -1,0 +1,3 @@
+``Table.read(..., format='votable')``, ``votable.parse`` and
+``votable.parse_single_table`` now respect the ``columns`` argument and will only output
+selected columns. Previously, unselected columns would just be masked (and unallocated).


### PR DESCRIPTION
### Description
Fixes #14943
I took me a couple hours to pass my test *and* all other tests locally, so I'm opening the PR while iron is hot, but I expect I'll probably want to refactor a bit before I open to review.

Since I needed to adjust existing tests which were actively checking for previous behaviour, I'm marking this as an API change, but in my opinion it's borderline a bug fix. In other words, I'm aiming astropy 6.1.0, not 6.0.1.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
