### PR TITLE
TST: fix compatibility pytest 8.0 (episode 2)

### DIFF
--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -49,7 +49,8 @@ def test_angle_arrays():
             stack.enter_context(pytest.raises(TypeError))
             stack.enter_context(
                 pytest.warns(
-                    DeprecationWarning, match="automatic object dtype is deprecated"
+                    np.VisibleDeprecationWarning,
+                    match="Creating an ndarray from ragged nested sequences",
                 )
             )
         else:

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -1068,13 +1068,28 @@ def test_spectralcoord_accuracy(specsys):
 
     rest = 550 * u.nm
 
+    if PYTEST_LT_8_0:
+        ctx = nullcontext()
+    else:
+        ctx = pytest.warns(
+            NoVelocityWarning,
+            match=(
+                r"^No velocity defined on frame, assuming \(0\., 0\., 0\.\) km / s\.$"
+            ),
+        )
     with iers.conf.set_temp("auto_download", False):
         for row in reference_table:
             observer = EarthLocation.from_geodetic(
                 -row["obslon"], row["obslat"]
             ).get_itrs(obstime=row["obstime"])
 
-            with pytest.warns(AstropyUserWarning, match="No velocity defined on frame"):
+            with ctx, pytest.warns(
+                NoDistanceWarning,
+                match=(
+                    "^Distance on coordinate object is dimensionless, an arbitrary "
+                    r"distance value of 1000000\.0 kpc will be set instead\.$"
+                ),
+            ):
                 sc_topo = SpectralCoord(
                     545 * u.nm, observer=observer, target=row["target"]
                 )

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -23,7 +23,7 @@ __all__ = [
     "generic_recursive_equality_test",
 ]
 
-PYTEST_LT_8_0 = not minversion(pytest, "8.0.dev")
+PYTEST_LT_8_0 = not minversion(pytest, "8.0")
 
 # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
 CI = os.environ.get("CI", "false") == "true"

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1743,7 +1743,7 @@ def test_distortion_header(tmp_path):
     if PYTEST_LT_8_0:
         ctx = nullcontext()
     else:
-        ctx = pytest.raises(VerifyWarning)
+        ctx = pytest.warns(VerifyWarning)
 
     with fits.open(path) as hdulist:
         with ctx, pytest.warns(wcs.FITSFixedWarning):

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,9 @@ deps =
     oldestdeps: pandas==1.4.*
     # ipython did not pin traitlets, so we have to
     oldestdeps: traitlets<4.1
+    # see https://github.com/pytest-dev/pytest/issues/11872
+    # TODO: remove this line after PYTHON_LT_3_10 is dropped
+    oldestdeps: pytest<8.0
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.


### PR DESCRIPTION
### Description

A follow up to #15809
Fixes #15960 (🤞🏻)

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
