### PR TITLE
Make `AstropyDeprecationWarning` a `FutureWarning` subclass

### DIFF
--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -32,7 +32,7 @@ class AstropyUserWarning(UserWarning, AstropyWarning):
     """
 
 
-class AstropyDeprecationWarning(AstropyWarning):
+class AstropyDeprecationWarning(FutureWarning, AstropyWarning):
     """
     A warning class to indicate a deprecated feature.
     """

--- a/docs/changes/utils/15963.feature.rst
+++ b/docs/changes/utils/15963.feature.rst
@@ -1,0 +1,2 @@
+``AstropyDeprecationWarning`` is now a subclass of both ``FutureWarning`` and
+``AstropyWarning``.


### PR DESCRIPTION
### Description

[Starting from `pytest` 8.0](https://docs.pytest.org/en/latest/changelog.html#other-improvements) [`pytest.deprecated_call()`](https://docs.pytest.org/en/latest/reference/reference.html#pytest.deprecated_call) recognizes [`FutureWarning`](https://docs.python.org/3/library/exceptions.html#FutureWarning) instances, so `AstropyDeprecationWarning` being a subclass will allow reducing the amount of boilerplate code in tests. Compare:
```python
import pytest
...
from astropy.utils.exceptions import AstropyDeprecationWarning
...
    with pytest.warns(AstropyDeprecationWarning, match=...):
        ....
# -------------------------------------------------------------
import pytest
...
    with pytest.deprecated_call(match=...):
        ...
```

`astropy` currently supports `pytest` 7.0, so we cannot start using `deprecated_call()` immediately, but we should not prevent downstream developers from using it if they choose to drop support for `pytest` < 8.0 before we do.

An alternative would be to make `AstropyDeprecationWarning` a subclass of [`DeprecationWarning`](https://docs.python.org/3/library/exceptions.html#DeprecationWarning) instead, which would allow us to use `deprecated_call()` immediately. But doing that would not be entirely backwards compatible because by default it would also prevent users from seeing some  ([but not all](https://peps.python.org/pep-0565/)) deprecation warnings, so I've opened this pull request with the less disruptive implementation.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
