### PR TITLE
BUG: fix compat with numpy dev for numpy.linalg.lstsq's wrapper

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -1200,7 +1200,7 @@ def solve(a, b, *args, **kwargs):
 
 
 @function_helper(module=np.linalg)
-def lstsq(a, b, rcond="warn"):
+def lstsq(a, b, rcond="warn" if NUMPY_LT_2_0 else None):
     a, b = _as_quantities(a, b)
 
     if rcond not in (None, "warn", -1):


### PR DESCRIPTION
### Description
Last night, CI was green for a glorious 5 hours, and went back to red when numpy nightlies were updated. But this time, a really simple fix suffices, so we won't spend another week with red CI !
xref: https://github.com/numpy/numpy/pull/25721

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
