### PR TITLE
BUG: fix a bug where inserting a row in an empty QTable would unexpectedly drop units

### DIFF
--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -766,7 +766,6 @@ def test_qtable_column_conversion():
     assert isinstance(qtab["f"], u.Dex)
 
 
-@pytest.mark.xfail
 def test_set_units_from_first_dynamic_row():
     # see https://github.com/astropy/astropy/issues/15964
     qt = table.QTable(names=["a", "b"])

--- a/docs/changes/table/15971.bugfix.rst
+++ b/docs/changes/table/15971.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where inserting a row in an empty ``QTable`` would unexpectedly drop units.


### PR DESCRIPTION
### Description
Fixes #15964

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
