### PR TITLE
Bump jinja2 for security reasons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ docs = [
     "pytest>=7.0",
     "sphinx-changelog>=1.2.0",
     "sphinx_design",
-    "Jinja2>=3.0",
+    "Jinja2>=3.1.3",
     "tomli; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
In Stingray, we received a dependabot alert about jinja2 versions below 3.1.3. I can send privately the details. Anyhow, for us, this simple version bump was sufficient to solve the vulnerability. Hope this helps