### PR TITLE
Simplify some caching in `coordinates`

### DIFF
--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -1,4 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from functools import cache
+
 from astropy import units as u
 from astropy.coordinates.attributes import CoordinateAttribute, QuantityAttribute
 from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
@@ -8,9 +11,8 @@ from astropy.coordinates.transformations import (
     FunctionTransform,
 )
 
-_skyoffset_cache = {}
 
-
+@cache
 def make_skyoffset_cls(framecls):
     """
     Create a new class that is the sky offset frame for a specific class of
@@ -38,9 +40,6 @@ def make_skyoffset_cls(framecls):
     just that class, as well as ensuring that only one example of such a class
     actually gets created in any given python session.
     """
-    if framecls in _skyoffset_cache:
-        return _skyoffset_cache[framecls]
-
     # Create a new SkyOffsetFrame subclass for this frame class.
     name = "SkyOffset" + framecls.__name__
     _SkyOffsetFramecls = type(
@@ -91,7 +90,6 @@ def make_skyoffset_cls(framecls):
         # transpose is the inverse because R is a rotation matrix
         return matrix_transpose(R)
 
-    _skyoffset_cache[framecls] = _SkyOffsetFramecls
     return _SkyOffsetFramecls
 
 

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -11,8 +11,8 @@ from astropy.coordinates.representation import (
     REPRESENTATION_CLASSES,
     SphericalRepresentation,
     UnitSphericalRepresentation,
+    get_reprdiff_cls_hash,
 )
-from astropy.coordinates.representation.base import _invalidate_reprdiff_cls_hash
 from astropy.coordinates.transformations import FunctionTransform
 
 # Classes setup, borrowed from SunPy.
@@ -28,7 +28,7 @@ def setup_function(func):
 def teardown_function(func):
     REPRESENTATION_CLASSES.clear()
     REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
-    _invalidate_reprdiff_cls_hash()
+    get_reprdiff_cls_hash.cache_clear()
 
 
 def test_unit_representation_subclass():


### PR DESCRIPTION
### Description

By using the [`functools.cache` decorator](https://docs.python.org/3/library/functools.html#functools.cache) from the Python standard library it is possible to simplify caching of two functions in `coordinates`. The functions do not depend on each other in any way, but the changes are conceptually similar enough that submitting them together in the same pull request seems reasonable.

`get_reprdiff_cls_hash()` was added in #7949. Both @eteq (who wrote the code) and @adrn (who reviewed it) [said that they are not too happy with the way caching was implemented](https://github.com/astropy/astropy/pull/7949#discussion_r228027837). It is not clear to me why `functools.lru_cache(maxsize=None)` was not used. If there were any good reasons to avoid it they were not documented.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
