### PR TITLE
Avoid needlessly using `itertools.chain()`

### DIFF
--- a/astropy/constants/cgs.py
+++ b/astropy/constants/cgs.py
@@ -3,14 +3,10 @@
 Astronomical and physics constants in cgs units.  See :mod:`astropy.constants`
 for a complete listing of constants defined in Astropy.
 """
-import itertools
-
 from .config import codata, iaudata
 from .constant import Constant
 
-for _nm, _c in itertools.chain(
-    sorted(vars(codata).items()), sorted(vars(iaudata).items())
-):
+for _nm, _c in (*sorted(vars(codata).items()), *sorted(vars(iaudata).items())):
     if (
         isinstance(_c, Constant)
         and _c.abbrev not in locals()

--- a/astropy/constants/si.py
+++ b/astropy/constants/si.py
@@ -3,13 +3,9 @@
 Astronomical and physics constants in SI units.  See :mod:`astropy.constants`
 for a complete listing of constants defined in Astropy.
 """
-import itertools
-
 from .config import codata, iaudata
 from .constant import Constant
 
-for _nm, _c in itertools.chain(
-    sorted(vars(codata).items()), sorted(vars(iaudata).items())
-):
+for _nm, _c in (*sorted(vars(codata).items()), *sorted(vars(iaudata).items())):
     if isinstance(_c, Constant) and _c.abbrev not in locals() and _c.system == "si":
         locals()[_c.abbrev] = _c

--- a/astropy/constants/utils.py
+++ b/astropy/constants/utils.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utility functions for ``constants`` sub-package."""
-import itertools
-
 __all__ = []
 
 
@@ -29,9 +27,7 @@ def _get_c(codata, iaudata, module, not_in_module_only=True):
     """
     from .constant import Constant
 
-    for _nm, _c in itertools.chain(
-        sorted(vars(codata).items()), sorted(vars(iaudata).items())
-    ):
+    for _nm, _c in (*sorted(vars(codata).items()), *sorted(vars(iaudata).items())):
         if not isinstance(_c, Constant):
             continue
         elif (not not_in_module_only) or (_c.abbrev not in module.__dict__):

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 from contextlib import nullcontext
 from io import StringIO
-from itertools import chain
 from string import Template
 
 import numpy as np
@@ -850,9 +849,10 @@ def test_write_overwrite_ascii(
         assert not os.path.exists(filename)
 
 
-fmt_name_classes = list(
-    chain(ascii.core.FAST_CLASSES.items(), ascii.core.FORMAT_CLASSES.items())
-)
+fmt_name_classes = [
+    *ascii.core.FAST_CLASSES.items(),
+    *ascii.core.FORMAT_CLASSES.items(),
+]
 
 
 @pytest.mark.parametrize("fmt_name_class", fmt_name_classes)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -17,11 +17,9 @@ import abc
 import copy
 import functools
 import inspect
-import itertools
 import operator
 from collections import defaultdict, deque
 from inspect import signature
-from itertools import chain
 
 import numpy as np
 
@@ -971,7 +969,7 @@ class Model(metaclass=_ModelMeta):
         parameters = self._param_sets(raw=True, units=True)
 
         def evaluate(_inputs):
-            return self.evaluate(*chain(_inputs, parameters))
+            return self.evaluate(*_inputs, *parameters)
 
         return evaluate, inputs, broadcasted_shapes, kwargs
 
@@ -3222,7 +3220,7 @@ class CompoundModel(Model):
                 for ind, inp in enumerate(left_inputs)
             ]
 
-        leftval = self.left.evaluate(*itertools.chain(left_inputs, left_params))
+        leftval = self.left.evaluate(*left_inputs, *left_params)
 
         if op == "fix_inputs":
             return leftval
@@ -3232,11 +3230,11 @@ class CompoundModel(Model):
 
         if op == "|":
             if isinstance(leftval, tuple):
-                return self.right.evaluate(*itertools.chain(leftval, right_params))
+                return self.right.evaluate(*leftval, *right_params)
             else:
                 return self.right.evaluate(leftval, *right_params)
         else:
-            rightval = self.right.evaluate(*itertools.chain(right_inputs, right_params))
+            rightval = self.right.evaluate(*right_inputs, *right_params)
 
         return self._apply_operators_to_value_lists(leftval, rightval, **kw)
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2627,7 +2627,7 @@ class TestFunctionHelpersCompleteness:
 @pytest.mark.parametrize(
     "target, helper",
     sorted(
-        itertools.chain(FUNCTION_HELPERS.items(), DISPATCHED_FUNCTIONS.items()),
+        (*FUNCTION_HELPERS.items(), *DISPATCHED_FUNCTIONS.items()),
         key=lambda items: items[0].__name__,
     ),
     ids=lambda func: func.__name__,

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -3,7 +3,6 @@
 
 
 import inspect
-import itertools
 import keyword
 import os
 import re
@@ -56,7 +55,7 @@ def make_function_with_signature(
         iter_kwargs = iter(kwargs)
 
     # Check that all the argument names are valid
-    for item in itertools.chain(args, iter_kwargs):
+    for item in (*args, *iter_kwargs):
         if isinstance(item, tuple):
             argname = item[0]
             key_args.append(item)


### PR DESCRIPTION
### Description

It is better to use iterable unpacking where possible because that does not require importing `itertools`.

### Approvals by sub-package

- [x] `constants`
- [x] `io/ascii`
- [ ] `modeling`
- [x] `units`
- [x] `utils`


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
