### PR TITLE
Backport PR #15986 on branch v6.0.x (TST: adjustments to np.trapz->np.trapezoid renaming)

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -90,7 +90,6 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.nansum, np.nancumsum, np.nanstd, np.nanvar,
     np.nanprod, np.nancumprod,
     np.einsum_path, np.linspace,
-    np.trapz,  # deprecated in not NUMPY_LT_2_0
     np.sort, np.partition, np.meshgrid,
     np.common_type, np.result_type, np.can_cast, np.min_scalar_type,
     np.iscomplexobj, np.isrealobj,
@@ -105,8 +104,8 @@ SUBCLASS_SAFE_FUNCTIONS |= {  # Deprecated
 SUBCLASS_SAFE_FUNCTIONS |= {np.median}
 
 if NUMPY_LT_2_0:
-    # functions removed in numpy 2.0; alias for np.round in NUMPY_LT_1_25
-    SUBCLASS_SAFE_FUNCTIONS |= {np.msort, np.round_}  # noqa: NPY003
+    # functions (re)moved in numpy 2.0; alias for np.round in NUMPY_LT_1_25
+    SUBCLASS_SAFE_FUNCTIONS |= {np.msort, np.round_, np.trapz}  # noqa: NPY003
 else:
     # Array-API compatible versions (matrix axes always at end).
     SUBCLASS_SAFE_FUNCTIONS |= {
@@ -122,6 +121,9 @@ else:
         np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
         np.astype,
     }  # fmt: skip
+
+    # trapz was renamed to trapezoid
+    SUBCLASS_SAFE_FUNCTIONS |= {np.trapezoid}
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1172,22 +1172,32 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
 
 
 class TestIntDiffFunctions(metaclass=CoverageMeta):
-    @pytest.mark.filterwarnings("ignore:`trapz` is deprecated. Use `scipy.*")
-    def test_trapz(self):
+    def check_trapezoid(self, func):
         y = np.arange(9.0) * u.m / u.s
-        out = np.trapz(y)
-        expected = np.trapz(y.value) * y.unit
+        out = func(y)
+        expected = func(y.value) * y.unit
         assert np.all(out == expected)
 
         dx = 10.0 * u.s
-        out = np.trapz(y, dx=dx)
-        expected = np.trapz(y.value, dx=dx.value) * y.unit * dx.unit
+        out = func(y, dx=dx)
+        expected = func(y.value, dx=dx.value) * y.unit * dx.unit
         assert np.all(out == expected)
 
         x = np.arange(9.0) * u.s
-        out = np.trapz(y, x)
-        expected = np.trapz(y.value, x.value) * y.unit * x.unit
+        out = func(y, x)
+        expected = func(y.value, x.value) * y.unit * x.unit
         assert np.all(out == expected)
+
+    if NUMPY_LT_2_0:
+
+        @pytest.mark.filterwarnings("ignore:`trapz` is deprecated.")
+        def test_trapz(self):
+            self.check_trapezoid(np.trapz)
+
+    else:
+
+        def test_trapezoid(self):
+            self.check_trapezoid(np.trapezoid)
 
     def test_diff(self):
         # Simple diff works out of the box.

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -100,7 +100,6 @@ MASKED_SAFE_FUNCTIONS |= {
     np.atleast_1d, np.atleast_2d, np.atleast_3d, np.stack, np.hstack, np.vstack,
     # np.lib._function_base_impl
     np.average, np.diff, np.extract, np.meshgrid, np.gradient,
-    np.trapz,  # deprecated in not NUMPY_LT_2_0
     # np.lib.index_tricks
     np.diag_indices_from, np.triu_indices_from, np.tril_indices_from,
     np.fill_diagonal,
@@ -124,9 +123,11 @@ if NUMPY_LT_2_0:
     MASKED_SAFE_FUNCTIONS |= {np.ptp}
     # Removed in numpy 2.0.  Just an alias to vstack.
     MASKED_SAFE_FUNCTIONS |= {np.row_stack}
+    # renamed in numpy 2.0
+    MASKED_SAFE_FUNCTIONS |= {np.trapz}
 else:
     # new in numpy 2.0
-    MASKED_SAFE_FUNCTIONS |= {np.astype}
+    MASKED_SAFE_FUNCTIONS |= {np.astype, np.trapezoid}
 
 IGNORED_FUNCTIONS = {
     # I/O - useless for Masked, since no way to store the mask.

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1005,13 +1005,23 @@ class TestIntDiffFunctions(MaskedArraySetup):
         assert_array_equal(out.unmasked, expected)
         assert_array_equal(out.mask, expected_mask)
 
-    @pytest.mark.filterwarnings("ignore:`trapz` is deprecated. Use `scipy.*")
-    def test_trapz(self):
+    def check_trapezoid(self, func):
         ma = self.ma.copy()
         ma.mask[1] = False
-        out = np.trapz(ma)
-        assert_array_equal(out.unmasked, np.trapz(self.a))
+        out = func(ma)
+        assert_array_equal(out.unmasked, func(self.a))
         assert_array_equal(out.mask, np.array([True, False]))
+
+    if NUMPY_LT_2_0:
+
+        @pytest.mark.filterwarnings("ignore:`trapz` is deprecated.")
+        def test_trapz(self):
+            self.check_trapezoid(np.trapz)
+
+    else:
+
+        def test_trapezoid(self):
+            self.check_trapezoid(np.trapezoid)
 
     def test_gradient(self):
         out = np.gradient(self.ma)


### PR DESCRIPTION
Backport PR #15986 on branch v6.0.x 