### PR TITLE
TST: cleanup unused warning filter

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1196,7 +1196,6 @@ class TestIntDiffFunctions:
 
     if NUMPY_LT_2_0:
 
-        @pytest.mark.filterwarnings("ignore:`trapz` is deprecated.")
         def test_trapz(self):
             self.check_trapezoid(np.trapz)
 

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1012,7 +1012,6 @@ class TestIntDiffFunctions(MaskedArraySetup):
 
     if NUMPY_LT_2_0:
 
-        @pytest.mark.filterwarnings("ignore:`trapz` is deprecated.")
         def test_trapz(self):
             self.check_trapezoid(np.trapz)
 


### PR DESCRIPTION
A quick follow up to #15986, which was merged before I even realised that the warning filter wasn't needed any more because the deprecation didn't land in a release yet.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
