### PR TITLE
Improve `io.ascii` error message when there is mismatch between converter type and column type

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1121,7 +1121,10 @@ class BaseOutputter:
 
                 converter_func, converter_type = col.converters[0]
                 if not issubclass(converter_type, col.type):
-                    raise TypeError("converter type does not match column type")
+                    raise TypeError(
+                        f"converter type {converter_type.__name__} does not match"
+                        f" column type {col.type.__name__} for column {col.name}"
+                    )
 
                 try:
                     col.data = converter_func(col.str_vals)

--- a/docs/changes/io.ascii/15991.bugfix.rst
+++ b/docs/changes/io.ascii/15991.bugfix.rst
@@ -1,0 +1,2 @@
+Clearer error message in reading ascii tables when there is
+a mismatch between converter type and column type.

--- a/docs/changes/io.ascii/15991.bugfix.rst
+++ b/docs/changes/io.ascii/15991.bugfix.rst
@@ -1,2 +1,0 @@
-Clearer error message in reading ascii tables when there is
-a mismatch between converter type and column type.

--- a/docs/changes/io.ascii/15991.feature.rst
+++ b/docs/changes/io.ascii/15991.feature.rst
@@ -1,0 +1,2 @@
+Clearer error message in reading ASCII tables when there is
+a mismatch between converter type and column type.


### PR DESCRIPTION
### Description
This pull request is to make the `TypeError` message clearer in reading ascii tables, when there is a mismatch between converter type and column type.

For the scenario in #15989, the error message is changed from
```
TypeError: converter type does not match column type
```
to:
```
TypeError: converter type StrType does not match column type IntType for column oid
```
stating the offending column and the specific type mismatch.

Test changes:
- so far none. I can only create the error condition in the scenario in #15989. I don't know enough of the `Table` internals to create a unit test for it.

### Functional testing

With astropy v `6.0.0` on Windows:
```
import numpy as np
from astropy.table import Table, QTable

# Test reading ZTF lc
tab = QTable.read(
    "https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves?ID=660106400019009&FORMAT=IPAC_TABLE",
    format="ascii.ipac",
    )
tab
```

The existing `TypeError` message is:
```python
WARNING: OverflowError converting to IntType in column oid, reverting to String. [astropy.io.ascii.core]
...
TypeError: converter type does not match column type
```

After this PR, the revised `TypeError` message is:
```python
WARNING: OverflowError converting to IntType in column oid, reverting to String. [astropy.io.ascii.core]
...
TypeError: converter type StrType does not match column type IntType for column oid
```


Note: the above scenario is not expected to occur in astropy releases after v `6.0.0`, as the underlying issue has been fixed to prevent the error from happening.


<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<hr>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
