### PR TITLE
Fixed `io.acii` read IPAC tables for `long` column types on Windows

### DIFF
--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -14,6 +14,8 @@ from collections import OrderedDict, defaultdict
 from textwrap import wrap
 from warnings import warn
 
+import numpy as np
+
 from astropy.table.pprint import get_auto_format_func
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -214,6 +216,10 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
                 null = header_vals[3][i].strip()
                 fillval = "" if issubclass(col.type, core.StrType) else "0"
                 self.data.fill_values.append((null, fillval, col.name))
+            if "long".startswith(col.raw_type.lower()):
+                # ensure long columns are 64-bit int, to address (Windows-specific):
+                # https://github.com/astropy/astropy/issues/15989
+                col.dtype = np.int64
             start = col.end + 1
             cols.append(col)
 

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -217,7 +217,7 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
                 fillval = "" if issubclass(col.type, core.StrType) else "0"
                 self.data.fill_values.append((null, fillval, col.name))
             if "long".startswith(col.raw_type.lower()):
-                # ensure long columns are 64-bit int, to address (Windows-specific):
+                # ensure long columns are 64-bit int, to address:
                 # https://github.com/astropy/astropy/issues/15989
                 col.dtype = np.int64
             start = col.end + 1

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -53,6 +53,30 @@ def test_ipac_read_types():
         assert_equal(col.type, expected_type)
 
 
+def test_ipac_read_long_columns():
+    """Test for https://github.com/astropy/astropy/issues/15989"""
+    test_data = """\
+|              oid|expid|cadence|
+|             long|    l|    int|
+ 90000000000000001   123       1
+"""
+    dat = ascii.read(test_data, format="ipac")
+
+    # assert oid, as a long column, is at the minimal int64
+    oid = dat["oid"]
+    assert oid[0] == 90000000000000001
+    assert oid.dtype.kind == "i"
+    assert oid.dtype.itemsize >= 8
+
+    # expid is declared as a long column,
+    # the type needs to be at least int64, even though all
+    # the values are within int32 range
+    expid = dat["expid"]
+    assert expid[0] == 123
+    assert expid.dtype.kind == "i"
+    assert expid.dtype.itemsize >= 8
+
+
 def test_col_dtype_in_custom_class():
     """Test code in BaseOutputter._convert_vals to handle Column.dtype
     attribute. See discussion in #11895."""

--- a/docs/changes/io.ascii/15992.bugfix.rst
+++ b/docs/changes/io.ascii/15992.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed reading IPAC tables for ``long`` column type on Windows.

--- a/docs/changes/io.ascii/15992.bugfix.rst
+++ b/docs/changes/io.ascii/15992.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed reading IPAC tables for ``long`` column type on Windows.
+Fixed reading IPAC tables for ``long`` column type on some platforms, e.g., Windows.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address reading IPAC table files with `long` columns on Windows platforms. 
It forces `long` columns to use `np.int64` as the default data type (rather than 32-bit integers on Windows).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15989 for v6.0.x only. The fix for this issue in `main` (v6.1 and later) is more comprehensive at https://github.com/astropy/astropy/pull/16005 but it cannot be backported.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
