### PR TITLE
ENH: implement keep_order argument to table.join (proof of concept)

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import collections
 import enum
 import itertools
+import sys
 import warnings
 from collections import Counter, OrderedDict
 from collections.abc import Mapping, Sequence
@@ -22,17 +23,16 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import metadata
-from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.masked import Masked
 
 from . import _np_utils
 from .np_utils import TableMergeError
 from .table import Column, MaskedColumn, QTable, Row, Table
 
-if PYTHON_LT_3_11:
-    from typing_extensions import assert_never
-else:
+if sys.version_info > (3, 11):
     from typing import assert_never
+else:
+    from typing_extensions import assert_never
 
 __all__ = [
     "join",

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -376,7 +376,7 @@ def join(
     *,
     keys_left=None,
     keys_right=None,
-    keep_order=False,
+    keep_order: bool | None = None,
     uniq_col_name="{col_name}_{table_name}",
     table_names=["1", "2"],
     metadata_conflicts="warn",
@@ -403,7 +403,7 @@ def join(
     keys_right : str or list of str or list of column-like, optional
         Same as ``keys_left``, but for the right side of the join.
     keep_order: bool
-        By default (False), rows are sorted by the join keys.
+        By default, rows are sorted by the join keys.
         If True, preserve the orders of rows from the left table (or right table
         with join_type='right'). This argument is ignored with 'outer' and 'cartesian'
         joins.
@@ -434,17 +434,20 @@ def join(
         right = Table(right)
 
     sort_by = _JoinSortBy.KEYS
-    if keep_order is False:
-        pass
-    # TODO: use another enum for join_type internally so
-    # such a conditional tree can be checked for exhaustiveness by a type checker
-    elif join_type in ("inner", "left"):
-        sort_by = _JoinSortBy.LEFT
-    elif join_type == "right":
-        sort_by = _JoinSortBy.RIGHT
-    elif join_type in ("outer", "cartesian"):
+    if keep_order is True:
+        if join_type in ("inner", "left"):
+            sort_by = _JoinSortBy.LEFT
+        elif join_type == "right":
+            sort_by = _JoinSortBy.RIGHT
+        elif join_type == "outer":
+            warnings.warn(
+                f"keep_order=True argument is ignored with {join_type=}",
+                category=UserWarning,
+            )
+    elif keep_order is False and join_type == "cartesian":
         warnings.warn(
-            f"keep_order argument is ignored with {join_type=}", category=UserWarning
+            f"keep_order=False argument is ignored with {join_type=}",
+            category=UserWarning,
         )
 
     col_name_map = OrderedDict()

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -6,6 +6,7 @@
 - vstack()
 - dstack()
 """
+
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import annotations
 
@@ -376,7 +377,7 @@ def join(
     *,
     keys_left=None,
     keys_right=None,
-    keep_order: bool | None = None,
+    keep_order=None,
     uniq_col_name="{col_name}_{table_name}",
     table_names=["1", "2"],
     metadata_conflicts="warn",

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -18,15 +18,20 @@ from collections.abc import Mapping, Sequence
 from copy import deepcopy
 
 import numpy as np
-from typing_extensions import assert_never
 
 from astropy.units import Quantity
 from astropy.utils import metadata
+from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.masked import Masked
 
 from . import _np_utils
 from .np_utils import TableMergeError
 from .table import Column, MaskedColumn, QTable, Row, Table
+
+if PYTHON_LT_3_11:
+    from typing_extensions import assert_never
+else:
+    from typing import assert_never
 
 __all__ = [
     "join",

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -444,11 +444,12 @@ def join(
                 f"keep_order=True argument is ignored with {join_type=}",
                 category=UserWarning,
             )
-    elif keep_order is False and join_type == "cartesian":
-        warnings.warn(
-            f"keep_order=False argument is ignored with {join_type=}",
-            category=UserWarning,
-        )
+    elif keep_order is False:
+        if join_type == "cartesian":
+            warnings.warn(
+                f"keep_order=False argument is ignored with {join_type=}",
+                category=UserWarning,
+            )
 
     col_name_map = OrderedDict()
     out = _join(

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -713,7 +713,6 @@ class TestJoin:
         with pytest.raises(ValueError, match="cannot supply keys for a cartesian join"):
             t12 = table.join(t1, t2, join_type="cartesian", keys="a")
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         "t2_input, join_type, expected",
         [

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -829,7 +829,7 @@ class TestJoin:
         if join_type == "outer":
             ctx = pytest.warns(
                 UserWarning,
-                match=r"keep_order argument is ignored with join_type='outer'",
+                match=r"keep_order=True argument is ignored with join_type='outer'",
             )
         else:
             ctx = nullcontext()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "astropy-iers-data>=0.2024.2.26.0.28.55",
     "PyYAML>=3.13",
     "packaging>=19.0",
+    "typing_extensions>=4.0.0 ; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
@@ -67,9 +68,6 @@ test_all = [
 recommended = [
     "scipy>=1.8",
     "matplotlib>=3.3,!=3.4.0,!=3.5.2",
-]
-typing = [
-    "typing_extensions>=4.0.0"
 ]
 all = [
     "astropy[recommended]",  # installs the [recommended] dependencies


### PR DESCRIPTION
### Description
Fixes #11619
This is at the proof-of concept level implementation:
- compat with multi-keys joins is currently missing
- the current implementation is very drafty and probably very inefficient in terms of performance. I'm thinking the final impl would probably need to be cythonized.
- the interface itself is subject to discussion as I pointed to in https://github.com/astropy/astropy/issues/11619#issuecomment-1923820205 (but this part of the discussion can be postponed to later stages of the review)

I'm opening this early to get feedback on the tests; are they correctly describing the desired behavior ?
In particular, here are a couple questions for @taldcroft:
- what should happen in a cartesian join ? Currently I'm just ignoring the `keep_order` flag (and emitting a warning), but I haven't written a test for it yet.
- what should happen with multi-keys joins ? Despite this being supported, it doesn't seem to be illustrated in narrative docs and the only test I could find that exercises it is for outer join (which we essentially ignore here).
- Do we actually want to ignore `keep_order=True` for outer joins ? I think that from where I am it would be trivial to give it an actual meaning like "output rows follow the order they appear in the left table, then, remaining unmatched rows follow the order they appear in the right table"

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
