### PR TITLE
Address Ruff rule PLR0911 in `coordinates`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -109,7 +109,6 @@ lint.ignore = [
     "PLE0101",  # return-in-init
     "PLR0124",  # Name compared with itself
     "PLR0402",  # ConsiderUsingFromImport
-    "PLR0911",  # too-many-return-statements
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-args
     "PLR0915",  # too-many-statements
@@ -239,6 +238,7 @@ lint.unfixable = [
     "RET505",  # superfluous-else-return
 ]
 "astropy/convolution/*" = [
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
@@ -255,6 +255,7 @@ lint.unfixable = [
 "astropy/io/*" = [
     "G001",  # logging-string-format
     "G004",  # logging-f-string
+    "PLR0911",  # too-many-return-statements
     "PTH116",  # os-stat
     "PTH117",  # os-path-isabs
     "RET505",  # superfluous-else-return
@@ -266,6 +267,7 @@ lint.unfixable = [
 "astropy/logger.py" = ["C408", "RET505"]
 "astropy/modeling/*" = [
     "ANN201",  # Public function without return type annotation
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
@@ -280,6 +282,7 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/stats/*" = [
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
@@ -296,12 +299,14 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/timeseries/*" = [
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
 "astropy/units/*" = [
     "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
@@ -312,12 +317,14 @@ lint.unfixable = [
 ]
 "astropy/utils/*" = [
     "N811",  # constant-imported-as-non-constant
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "S321",  # Suspicious-ftp-lib-usage
 ]
 "astropy/visualization/*" = [
     "B015",
+    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1333,7 +1333,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         return attrnm in self._attr_names_with_defaults
 
     @staticmethod
-    def _frameattr_equiv(left_fattr, right_fattr):
+    def _frameattr_equiv(left_fattr, right_fattr):  # noqa: PLR0911
         """
         Determine if two frame attributes are equivalent.  Implemented as a
         staticmethod mainly as a convenient location, although conceivable it
@@ -1353,8 +1353,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             return False
 
         left_is_repr = isinstance(left_fattr, r.BaseRepresentationOrDifferential)
-        right_is_repr = isinstance(right_fattr, r.BaseRepresentationOrDifferential)
-        if left_is_repr and right_is_repr:
+        if left_is_repr ^ isinstance(right_fattr, r.BaseRepresentationOrDifferential):
+            return False
+        if left_is_repr:
             # both are representations.
             if getattr(left_fattr, "differentials", False) or getattr(
                 right_fattr, "differentials", False
@@ -1372,19 +1373,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 if type(left_fattr) is type(right_fattr)
                 else left_fattr.to_cartesian() == right_fattr.to_cartesian()
             )
-        elif left_is_repr or right_is_repr:
-            return False
 
         left_is_coord = isinstance(left_fattr, BaseCoordinateFrame)
-        right_is_coord = isinstance(right_fattr, BaseCoordinateFrame)
-        if left_is_coord and right_is_coord:
-            # both are coordinates
-            if left_fattr.is_equivalent_frame(right_fattr):
-                return np.all(left_fattr == right_fattr)
-            else:
-                return False
-        elif left_is_coord or right_is_coord:
+        if left_is_coord ^ isinstance(right_fattr, BaseCoordinateFrame):
             return False
+        if left_is_coord:
+            # both are coordinates
+            return left_fattr.is_equivalent_frame(right_fattr) and np.all(
+                left_fattr == right_fattr
+            )
 
         return np.all(left_fattr == right_fattr)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1339,10 +1339,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         staticmethod mainly as a convenient location, although conceivable it
         might be desirable for subclasses to override this behavior.
 
-        Primary purpose is to check for equality of representations.  This
-        aspect can actually be simplified/removed now that representations have
-        equality defined.
-
+        Primary purpose is to check for equality of representations.
         Secondary purpose is to check for equality of coordinate attributes,
         which first checks whether they themselves are in equivalent frames
         before checking for equality in the normal fashion.  This is because
@@ -1370,19 +1367,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                     AstropyWarning,
                 )
                 return False
-            if isinstance(right_fattr, left_fattr.__class__):
-                # if same representation type, compare components.
-                return np.all(
-                    [
-                        (getattr(left_fattr, comp) == getattr(right_fattr, comp))
-                        for comp in left_fattr.components
-                    ]
-                )
-            else:
-                # convert to cartesian and see if they match
-                return np.all(
-                    left_fattr.to_cartesian().xyz == right_fattr.to_cartesian().xyz
-                )
+            return np.all(
+                left_fattr == right_fattr
+                if type(left_fattr) is type(right_fattr)
+                else left_fattr.to_cartesian() == right_fattr.to_cartesian()
+            )
         elif left_is_repr or right_is_repr:
             return False
 


### PR DESCRIPTION
### Description

[PLR0911](https://docs.astral.sh/ruff/rules/too-many-return-statements/) guards against functions with very many `return` statements.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
