### PR TITLE
UX: warn about units being ignored when inserting Quantity values into non Quantity columns in a QTable

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1407,6 +1407,15 @@ class Column(BaseColumn):
             A copy of column with ``values`` and ``mask`` inserted.  Note that the
             insertion does not occur in-place: a new column is returned.
         """
+        if any(isinstance(v, Quantity) for v in values):
+            with warnings.catch_warnings():
+                warnings.simplefilter("always")
+                warnings.warn(
+                    "Units from Quantity values will be ignored.",
+                    category=UserWarning,
+                    stacklevel=2,
+                )
+
         if self.dtype.kind == "O":
             # Even if values is array-like (e.g. [1,2,3]), insert as a single
             # object.  Numpy.insert instead inserts each element in an array-like

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1407,7 +1407,9 @@ class Column(BaseColumn):
             A copy of column with ``values`` and ``mask`` inserted.  Note that the
             insertion does not occur in-place: a new column is returned.
         """
-        if any(isinstance(v, Quantity) for v in values):
+        if (np.isscalar(values) and isinstance(values, Quantity)) or (
+            not np.isscalar(values) and any(isinstance(v, Quantity) for v in values)
+        ):
             with warnings.catch_warnings():
                 warnings.simplefilter("always")
                 warnings.warn(

--- a/docs/changes/16004.other.rst
+++ b/docs/changes/16004.other.rst
@@ -1,0 +1,2 @@
+A warning is now emitted when ``Quantity`` values are inserted into non ``Quantity``
+columns in a ``QTable``.


### PR DESCRIPTION
### Description

Fixes #15964 (second try)
See discussion over at #15971

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
