### PR TITLE
Bugfix for issue 14333 (convolve_models giving strange results)

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1002,7 +1002,14 @@ def interpolate_replace_nans(array, kernel, convolve=convolve, **kwargs):
 
 
 def convolve_models(
-    model, kernel, bounding_box, resolution, mode="convolve_fft", cache=True, **kwargs
+    model,
+    kernel,
+    mode="convolve_fft",
+    *,
+    bounding_box=None,
+    resolution=None,
+    cache=True,
+    **kwargs,
 ):
     """
     Convolve two models using `~astropy.convolution.convolve_fft`.
@@ -1013,17 +1020,23 @@ def convolve_models(
         Functional model
     kernel : `~astropy.modeling.core.Model`
         Convolution kernel
-    bounding_box : tuple
-        The bounding box which encompasses enough of the support of both
-        the ``model`` and ``kernel`` so that an accurate convolution can be
-        computed.
-    resolution : float
-        The resolution that one wishes to approximate the convolution
-        integral at.
     mode : str
         Keyword representing which function to use for convolution.
             * 'convolve_fft' : use `~astropy.convolution.convolve_fft` function.
             * 'convolve' : use `~astropy.convolution.convolve`.
+    bounding_box : optional, tuple
+        The bounding box which encompasses enough of the support of both
+        the ``model`` and ``kernel`` so that an accurate convolution can be
+        computed. It is recommended to always specify this parameter.
+        If not specified, a default of (-1, 1) will be used and a warning will
+        be issued because the returned compound model is not likely to behave as
+        desired.
+    resolution : optional, float
+        The resolution that one wishes to approximate the convolution
+        integral at. It is recommended to always specify this parameter.
+        If not specified, a default value of 1 will be used and a warning will
+        be issued because the returned compound model is not likely to behave as
+        desired.
     cache : optional, bool
         Default value True. Allow for the storage of the convolution
         computation for later reuse. Changes to the input model or kernel will not
@@ -1042,7 +1055,7 @@ def convolve_models(
     -----
     Special care must be taken when defining the model, kernel, and choosing the bounding_box
     and resolution inputs.
-    Under the hood, this function returns a `~astropy.modeling.convolution.Convolution`
+    Under the hood, this function returns a ``astropy.modeling.convolution.Convolution``
     object that functions as follows:
 
     1. Generates the domain array defined by the bounding_box and resolution parameters
@@ -1064,6 +1077,19 @@ def convolve_models(
         operator = SPECIAL_OPERATORS.add("convolve", partial(convolve, **kwargs))
     else:
         raise ValueError(f"Mode {mode} is not supported.")
+
+    if bounding_box is None:
+        warnings.warn(
+            "It is recommended to always specify the bounding_box parameter to avoid unexpected "
+            "errors when calling the CombinedModel that is returned from this function."
+        )
+        bounding_box = (-1, 1)
+    if resolution is None:
+        warnings.warn(
+            "It is recommended to always specify the resolution parameter to avoid unexpected "
+            "errors when calling the CombinedModel that is returned from this function."
+        )
+        resolution = 1
 
     return Convolution(operator, model, kernel, bounding_box, resolution, cache)
 
@@ -1103,7 +1129,7 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
     -----
     Special care must be taken when defining the model, kernel, and choosing the bounding_box
     and resolution inputs.
-    Under the hood, this function returns a `~astropy.modeling.convolution.Convolution`
+    Under the hood, this function returns a ``astropy.modeling.convolution.Convolution``
     object that functions as follows:
 
     1. Generates the domain array defined by the bounding_box and resolution parameters

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1031,7 +1031,7 @@ def convolve_models(
         If not specified, a default of (-1, 1) will be used and a warning will
         be issued because the returned compound model is not likely to behave as
         desired.
-    resolution : optional, float
+    resolution : optional, float or tuple
         The resolution that one wishes to approximate the convolution
         integral at. It is recommended to always specify this parameter.
         If not specified, a default value of 1 will be used and a warning will

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1024,19 +1024,13 @@ def convolve_models(
         Keyword representing which function to use for convolution.
             * 'convolve_fft' : use `~astropy.convolution.convolve_fft` function.
             * 'convolve' : use `~astropy.convolution.convolve`.
-    bounding_box : required, tuple
+    bounding_box : tuple
         The bounding box which encompasses enough of the support of both
         the ``model`` and ``kernel`` so that an accurate convolution can be
-        computed. It is recommended to always specify this parameter.
-        If not specified, a default of (-1, 1) will be used and a warning will
-        be issued because the returned compound model is not likely to behave as
-        desired.
-    resolution : required, float or tuple
+        computed. If not specified, a ValueError is raised.
+    resolution : float or tuple of float
         The resolution that one wishes to approximate the convolution
-        integral at. It is recommended to always specify this parameter.
-        If not specified, a default value of 1 will be used and a warning will
-        be issued because the returned compound model is not likely to behave as
-        desired.
+        integral at. If not specified, a ValueError is raised.
     cache : optional, bool
         Default value True. Allow for the storage of the convolution
         computation for later reuse. Changes to the input model or kernel will not
@@ -1050,6 +1044,11 @@ def convolve_models(
     -------
     default : `~astropy.modeling.core.CompoundModel`
         Convolved model
+
+    Raises
+    ------
+    ValueError
+        If either ``bounding_box`` or ``resolution`` keywords are not specified.
 
     Notes
     -----

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1024,14 +1024,14 @@ def convolve_models(
         Keyword representing which function to use for convolution.
             * 'convolve_fft' : use `~astropy.convolution.convolve_fft` function.
             * 'convolve' : use `~astropy.convolution.convolve`.
-    bounding_box : optional, tuple
+    bounding_box : required, tuple
         The bounding box which encompasses enough of the support of both
         the ``model`` and ``kernel`` so that an accurate convolution can be
         computed. It is recommended to always specify this parameter.
         If not specified, a default of (-1, 1) will be used and a warning will
         be issued because the returned compound model is not likely to behave as
         desired.
-    resolution : optional, float or tuple
+    resolution : required, float or tuple
         The resolution that one wishes to approximate the convolution
         integral at. It is recommended to always specify this parameter.
         If not specified, a default value of 1 will be used and a warning will
@@ -1054,9 +1054,8 @@ def convolve_models(
     Notes
     -----
     Special care must be taken when defining the model, kernel, and choosing the bounding_box
-    and resolution inputs.
-    Under the hood, this function returns a ``astropy.modeling.convolution.Convolution``
-    object that functions as follows:
+    and resolution inputs. Under the hood, this function returns a
+    ``astropy.modeling.convolution.Convolution`` object that functions as follows:
 
     1. Generates the domain array defined by the bounding_box and resolution parameters
     2. Runs that domain array through the input models (``model`` and ``kernel``)
@@ -1078,18 +1077,18 @@ def convolve_models(
     else:
         raise ValueError(f"Mode {mode} is not supported.")
 
-    if bounding_box is None:
-        warnings.warn(
-            "It is recommended to always specify the bounding_box parameter to avoid unexpected "
-            "errors when calling the CombinedModel that is returned from this function."
+    if bounding_box is None or resolution is None:
+        none_kws = " and ".join(
+            [
+                k
+                for k, v in {
+                    "bounding_box": bounding_box,
+                    "resolution": resolution,
+                }.items()
+                if v is None
+            ]
         )
-        bounding_box = (-1, 1)
-    if resolution is None:
-        warnings.warn(
-            "It is recommended to always specify the resolution parameter to avoid unexpected "
-            "errors when calling the CombinedModel that is returned from this function."
-        )
-        resolution = 1
+        raise ValueError(f"Required keyword(s) {none_kws} not provided or set to None")
 
     return Convolution(operator, model, kernel, bounding_box, resolution, cache)
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1064,6 +1064,19 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
     -------
     default : `~astropy.modeling.core.CompoundModel`
         Convolved model
+
+    Notes
+    -----
+    Special care must be taken when defining the models and choosing the bounding_box
+    and resolution inputs.
+    Under the hood, this function returns an `~astropy.modeling.convolution.Convolution`
+    object that functions as follows:
+      1. Generates the domain array defined by the bounding_box and resolution parameters
+      2. Runs that domain array through the input models (``model`` and ``kernel``)
+      3. Convolves the model outputs from step 2. The convolution result is (optionally)
+         cached.
+      4. When the combined model is called, the result of the convolution from step 3
+         is interpolated to the input domain and returned.
     """
     operator = SPECIAL_OPERATORS.add("convolve_fft", partial(convolve_fft, **kwargs))
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1026,7 +1026,9 @@ def convolve_models(
             * 'convolve' : use `~astropy.convolution.convolve`.
     cache : optional, bool
         Default value True. Allow for the storage of the convolution
-        computation for later reuse.
+        computation for later reuse. Changes to the input model or kernel will not
+        be reflected in the convolved model output if `cache` is True. For this reason,
+        if the convolved model will be used for fitting,``cache`` must be set to False.
     **kwargs : dict
         Keyword arguments to me passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.
@@ -1040,12 +1042,13 @@ def convolve_models(
     -----
     Special care must be taken when defining the model, kernel, and choosing the bounding_box
     and resolution inputs.
-    Under the hood, this function returns an `~astropy.modeling.convolution.Convolution`
+    Under the hood, this function returns a `~astropy.modeling.convolution.Convolution`
     object that functions as follows:
       1. Generates the domain array defined by the bounding_box and resolution parameters
       2. Runs that domain array through the input models (``model`` and ``kernel``)
-      3. Convolves the model outputs from step 2. The convolution result is (optionally)
-         cached.
+      3. Convolves the model outputs from step 2 using the convolution function defined
+         by the ``mode`` keyword. The convolution result is (optionally) cached in order
+         to reduce extra computation.
       4. When the combined model is called, the result of the convolution from step 3
          is interpolated to the input domain and returned.
 
@@ -1083,7 +1086,9 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
         integral at.
     cache : optional, bool
         Default value True. Allow for the storage of the convolution
-        computation for later reuse.
+        computation for later reuse. Changes to the input model or kernel will not
+        be reflected in the convolved model output if `cache` is True. For this reason,
+        if the convolved model will be used for fitting,``cache`` must be set to False.
     **kwargs : dict
         Keyword arguments to be passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.
@@ -1097,12 +1102,13 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
     -----
     Special care must be taken when defining the model, kernel, and choosing the bounding_box
     and resolution inputs.
-    Under the hood, this function returns an `~astropy.modeling.convolution.Convolution`
+    Under the hood, this function returns a `~astropy.modeling.convolution.Convolution`
     object that functions as follows:
       1. Generates the domain array defined by the bounding_box and resolution parameters
       2. Runs that domain array through the input models (``model`` and ``kernel``)
-      3. Convolves the model outputs from step 2. The convolution result is (optionally)
-         cached.
+      3. Convolves the model outputs from step 2 using the convolution function defined
+         by the ``mode`` keyword. The convolution result is (optionally) cached in order
+         to reduce extra computation.
       4. When the combined model is called, the result of the convolution from step 3
          is interpolated to the input domain and returned.
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -1027,8 +1027,8 @@ def convolve_models(
     cache : optional, bool
         Default value True. Allow for the storage of the convolution
         computation for later reuse. Changes to the input model or kernel will not
-        be reflected in the convolved model output if `cache` is True. For this reason,
-        if the convolved model will be used for fitting,``cache`` must be set to False.
+        be reflected in the convolved model output if set to True. For this reason,
+        if the convolved model will be used for fitting, ``cache`` must be set to False.
     **kwargs : dict
         Keyword arguments to me passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.
@@ -1044,13 +1044,14 @@ def convolve_models(
     and resolution inputs.
     Under the hood, this function returns a `~astropy.modeling.convolution.Convolution`
     object that functions as follows:
-      1. Generates the domain array defined by the bounding_box and resolution parameters
-      2. Runs that domain array through the input models (``model`` and ``kernel``)
-      3. Convolves the model outputs from step 2 using the convolution function defined
-         by the ``mode`` keyword. The convolution result is (optionally) cached in order
-         to reduce extra computation.
-      4. When the combined model is called, the result of the convolution from step 3
-         is interpolated to the input domain and returned.
+
+    1. Generates the domain array defined by the bounding_box and resolution parameters
+    2. Runs that domain array through the input models (``model`` and ``kernel``)
+    3. Convolves the model outputs from step 2 using the convolution function defined
+       by the ``mode`` keyword. The convolution result is (optionally) cached in order
+       to reduce extra computation.
+    4. When the combined model is called, the result of the convolution from step 3
+       is interpolated to the input domain and returned.
 
     For further details about special requirements for the model output from ``kernel``,
     see the documentation for `convolve` or `convolve_fft` depending on the selected ``mode``.
@@ -1087,8 +1088,8 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
     cache : optional, bool
         Default value True. Allow for the storage of the convolution
         computation for later reuse. Changes to the input model or kernel will not
-        be reflected in the convolved model output if `cache` is True. For this reason,
-        if the convolved model will be used for fitting,``cache`` must be set to False.
+        be reflected in the convolved model output if set to True. For this reason,
+        if the convolved model will be used for fitting, ``cache`` must be set to False.
     **kwargs : dict
         Keyword arguments to be passed either to `~astropy.convolution.convolve`
         or `~astropy.convolution.convolve_fft` depending on ``mode``.
@@ -1104,13 +1105,14 @@ def convolve_models_fft(model, kernel, bounding_box, resolution, cache=True, **k
     and resolution inputs.
     Under the hood, this function returns a `~astropy.modeling.convolution.Convolution`
     object that functions as follows:
-      1. Generates the domain array defined by the bounding_box and resolution parameters
-      2. Runs that domain array through the input models (``model`` and ``kernel``)
-      3. Convolves the model outputs from step 2 using the convolution function defined
-         by the ``mode`` keyword. The convolution result is (optionally) cached in order
-         to reduce extra computation.
-      4. When the combined model is called, the result of the convolution from step 3
-         is interpolated to the input domain and returned.
+
+    1. Generates the domain array defined by the bounding_box and resolution parameters
+    2. Runs that domain array through the input models (``model`` and ``kernel``)
+    3. Convolves the model outputs from step 2 using the convolution function defined
+       by the ``mode`` keyword. The convolution result is (optionally) cached in order
+       to reduce extra computation.
+    4. When the combined model is called, the result of the convolution from step 3
+       is interpolated to the input domain and returned.
 
     For further details about special requirements for the model output from ``kernel``,
     see the documentation for `convolve_fft`.

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -136,13 +136,13 @@ class TestConvolve1DModels:
 
     @pytest.mark.parametrize("bounding_box, resolution", [(None, 1), ((-1, 1), None)])
     @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
-    def test_convolve_models_warnings(self, bounding_box, resolution):
+    def test_convolve_models_exceptions(self, bounding_box, resolution):
         """
-        test that convolve models issues warnings when bounding_box or resolution are not specified
+        test that convolve models raises an exception when bounding_box or resolution are not specified
         """
         model = models.Gaussian1D()
         kernel = models.Box1D()
-        with pytest.warns(UserWarning):
+        with pytest.raises(ValueError):
             combined_model = convolve_models(
                 model, kernel, bounding_box=bounding_box, resolution=resolution
             )

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -53,6 +53,7 @@ class TestConvolve1DModels:
         assert_allclose(ans, model_conv(x), atol=1e-5)
 
     @pytest.mark.parametrize("mode", ["convolve_fft", "convolve"])
+    @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
     def test_sum_of_gaussians(self, mode):
         """
         Test that convolving N(a, b) with N(c, d) gives N(a + c, b + d),
@@ -73,6 +74,7 @@ class TestConvolve1DModels:
         assert_allclose(ans(x), model_conv(x), atol=1e-3)
 
     @pytest.mark.parametrize("mode", ["convolve_fft", "convolve"])
+    @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
     def test_convolve_box_models(self, mode):
         kernel = models.Box1D()
         model = models.Box1D()

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -18,7 +18,9 @@ class TestConvolve1DModels:
     def test_is_consistency_with_astropy_convolution(self, mode):
         kernel = models.Gaussian1D(1, 0, 1)
         model = models.Gaussian1D(1, 0, 1)
-        model_conv = convolve_models(model, kernel, (-5, 5), 1, mode=mode.__name__)
+        model_conv = convolve_models(
+            model, kernel, mode=mode.__name__, bounding_box=(-5, 5), resolution=1
+        )
         x = np.arange(-5, 6)
         ans = mode(model(x), kernel(x))
 
@@ -31,7 +33,9 @@ class TestConvolve1DModels:
 
         kernel = models.Gaussian1D(1, 0, 1)
         model = models.Gaussian1D(1, 0, 1)
-        model_conv = convolve_models(model, kernel, (-5, 5), 1, mode=mode)
+        model_conv = convolve_models(
+            model, kernel, mode=mode, bounding_box=(-5, 5), resolution=1
+        )
         x = np.arange(-5, 6)
         ans = fftconvolve(kernel(x), model(x), mode="same")
 
@@ -45,7 +49,12 @@ class TestConvolve1DModels:
         kernel = models.Gaussian1D(1, 0, 1)
         model = models.Gaussian1D(1, 0, 1)
         model_conv = convolve_models(
-            model, kernel, (-5, 5), 1, mode=mode, normalize_kernel=False
+            model,
+            kernel,
+            mode=mode,
+            bounding_box=(-5, 5),
+            resolution=1,
+            normalize_kernel=False,
         )
         x = np.arange(-5, 6)
         ans = fftconvolve(kernel(x), model(x), mode="same")
@@ -66,7 +75,12 @@ class TestConvolve1DModels:
         kernel = models.Gaussian1D(1 / math.sqrt(2 * np.pi), 1, 1)
         model = models.Gaussian1D(1 / math.sqrt(2 * np.pi), 3, 1)
         model_conv = convolve_models(
-            model, kernel, (-7, 7), 1, mode=mode, normalize_kernel=False
+            model,
+            kernel,
+            mode=mode,
+            bounding_box=(-7, 7),
+            resolution=1,
+            normalize_kernel=False,
         )
         ans = models.Gaussian1D(1 / (2 * math.sqrt(np.pi)), 4, np.sqrt(2))
         x = np.arange(-5, 6)
@@ -79,7 +93,12 @@ class TestConvolve1DModels:
         kernel = models.Box1D()
         model = models.Box1D()
         model_conv = convolve_models(
-            model, kernel, (-1, 1), 0.001, mode=mode, normalize_kernel=True
+            model,
+            kernel,
+            mode=mode,
+            bounding_box=(-1, 1),
+            resolution=0.001,
+            normalize_kernel=True,
         )
         x = np.linspace(-1, 1, 99)
         ans = (x + 1) * (x < 0) + (-x + 1) * (x >= 0)
@@ -103,9 +122,9 @@ class TestConvolve1DModels:
         init_model = convolve_models(
             b1,
             g1,
-            (-6 - 10 / 99, 6),
-            10 / 99,
             mode=mode,
+            bounding_box=(-6 - 10 / 99, 6),
+            resolution=10 / 99,
             normalize_kernel=False,
             cache=False,
         )
@@ -114,3 +133,16 @@ class TestConvolve1DModels:
 
         me = np.mean(fitted_model(x) - fake_data)
         assert_almost_equal(me, 0.0, decimal=2)
+
+    @pytest.mark.parametrize("bounding_box, resolution", [(None, 1), ((-1, 1), None)])
+    @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
+    def test_convolve_models_warnings(self, bounding_box, resolution):
+        """
+        test that convolve models issues warnings when bounding_box or resolution are not specified
+        """
+        model = models.Gaussian1D()
+        kernel = models.Box1D()
+        with pytest.warns(UserWarning):
+            combined_model = convolve_models(
+                model, kernel, bounding_box=bounding_box, resolution=resolution
+            )

--- a/astropy/modeling/convolution.py
+++ b/astropy/modeling/convolution.py
@@ -30,7 +30,7 @@ class Convolution(CompoundModel):
 
     Notes
     -----
-    This is wrapper is necessary to handle the limitations of the
+    This wrapper is necessary to handle the limitations of the
     pseudospectral convolution binary operator implemented in
     astropy.convolution under `~astropy.convolution.convolve_fft`. In this
     `~astropy.convolution.convolve_fft` it is assumed that the inputs ``array``

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -927,7 +927,6 @@ def test_print_special_operator_CompoundModel(capsys):
     """
     Test that issue #11310 has been fixed
     """
-
     model = convolve_models(
         models.Sersic2D(),
         models.Gaussian2D(),

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -928,11 +928,13 @@ def test_print_special_operator_CompoundModel(capsys):
     Test that issue #11310 has been fixed
     """
 
-    model = convolve_models(models.Sersic2D(), models.Gaussian2D())
+    model = convolve_models(
+        models.Sersic2D(), models.Gaussian2D(), ((-1, 1), (-2, 2)), (1, 1)
+    )
     with astropy.conf.set_temp("max_width", 80):
         # fmt: off
         assert str(model) == (
-            "Model: CompoundModel\n"
+            "Model: Convolution\n"
             "Inputs: ('x', 'y')\n"
             "Outputs: ('z',)\n"
             "Model set size: 1\n"

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -929,7 +929,10 @@ def test_print_special_operator_CompoundModel(capsys):
     """
 
     model = convolve_models(
-        models.Sersic2D(), models.Gaussian2D(), ((-1, 1), (-2, 2)), (1, 1)
+        models.Sersic2D(),
+        models.Gaussian2D(),
+        bounding_box=((-1, 1), (-2, 2)),
+        resolution=(1, 1),
     )
     with astropy.conf.set_temp("max_width", 80):
         # fmt: off

--- a/docs/changes/convolution/16020.api.rst
+++ b/docs/changes/convolution/16020.api.rst
@@ -1,2 +1,3 @@
-Added keyword parameters ``bounding_box``, ``resolution``, and ``cache``  to
+Added required keyword parameters ``bounding_box`` and ``resolution``,
+and optional keyword ``cache``  to
 ``astropy.convolution.convolve.convolve_models`` function.

--- a/docs/changes/convolution/16020.api.rst
+++ b/docs/changes/convolution/16020.api.rst
@@ -1,2 +1,2 @@
-Added required parameters ``bounding_box`` and ``resolution``  to
+Added keyword parameters ``bounding_box``, ``resolution``, and ``cache``  to
 ``astropy.convolution.convolve.convolve_models`` function.

--- a/docs/changes/convolution/16020.api.rst
+++ b/docs/changes/convolution/16020.api.rst
@@ -1,0 +1,2 @@
+Added required parameters ``bounding_box`` and ``resolution``  to
+``astropy.convolution.convolve.convolve_models`` function.

--- a/docs/changes/convolution/16020.bugfix.rst
+++ b/docs/changes/convolution/16020.bugfix.rst
@@ -1,0 +1,3 @@
+``astropy.convolution.convolve.convolve_models`` now returns an instance of
+``astropy.modeling.convolution.Convolution`` making the compound model return
+values independent of the input domain.

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -83,33 +83,6 @@ are some complexities involved in correctly matching up the inputs and outputs
 of all models used to build a compound model.  You can learn more details in
 the :doc:`compound-models` documentation.
 
-Astropy models also support convolution through the function
-`~astropy.convolution.convolve_models`, which returns a compound model.
-
-For instance, the convolution of two Gaussian functions is also a Gaussian
-function in which the resulting mean (variance) is the sum of the means
-(variances) of each Gaussian.
-
-.. plot::
-    :include-source:
-
-    import numpy as np
-    import matplotlib.pyplot as plt
-    from astropy.modeling import models
-    from astropy.convolution import convolve_models
-
-    g1 = models.Gaussian1D(1, -1, 1)
-    g2 = models.Gaussian1D(1, 1, 1)
-    g3 = convolve_models(g1, g2, (-4, 4), 0.1)
-
-    x = np.linspace(-3, 3, 50)
-    plt.plot(x, g1(x), 'k-')
-    plt.plot(x, g2(x), 'k-')
-    plt.plot(x, g3(x), 'k-')
-
-
-.. _compound-models:
-
 A comprehensive description
 ===========================
 
@@ -192,7 +165,8 @@ Creating compound models
 The only way to create compound models is
 to combine existing single models and/or compound models using expressions in
 Python with the binary operators ``+``, ``-``, ``*``, ``/``, ``**``, ``|``,
-and ``&``, each of which is discussed in the following sections.
+and ``&`` or by using the `~astropy.convolution.convolve_models` function,
+each of which is discussed in the following sections.
 
 The result of combining two models is a model instance::
 
@@ -534,6 +508,37 @@ transformation matrix::
     >>> # May be small numerical differences due to different implementations
     >>> allclose(scale_and_rotate(1, 2), affine(1, 2))
     True
+
+Model Convolution
+-----------------
+
+No operator has been assigned to this method of combining models. Astropy
+models support convolution through the function
+`~astropy.convolution.convolve_models`, which returns a compound model.
+
+For instance, the convolution of two Gaussian functions is also a Gaussian
+function in which the resulting mean (variance) is the sum of the means
+(variances) of each Gaussian.
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from astropy.modeling import models
+    from astropy.convolution import convolve_models
+
+    g1 = models.Gaussian1D(1, -1, 1)
+    g2 = models.Gaussian1D(1, 1, 1)
+    g3 = convolve_models(g1, g2, bounding_box=(-5, 5), resolution=0.1)
+
+    x = np.linspace(-4, 4, 50)
+    plt.plot(x, g1(x), color='tab:blue', label='g1')
+    plt.plot(x, g2(x), color='tab:orange', label='g2')
+    plt.plot(x, g3(x), color='tab:green', label='g3')
+    plt.legend(loc='upper right')
+
+.. _compound-models:
 
 Other Topics
 ============

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -100,7 +100,7 @@ function in which the resulting mean (variance) is the sum of the means
 
     g1 = models.Gaussian1D(1, -1, 1)
     g2 = models.Gaussian1D(1, 1, 1)
-    g3 = convolve_models(g1, g2)
+    g3 = convolve_models(g1, g2, (-4, 4), 0.1)
 
     x = np.linspace(-3, 3, 50)
     plt.plot(x, g1(x), 'k-')


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address bug reported in issue #14333. The root of this bug
is that the implementation of the astropy.convolution.convolve.convolve_models() function
simply convolves the output of the two input models. I found that the correct behavior
was implemented in the astropy.convolution.convolve.convolve_models_fft() function
and a description of how that function fixes the issue was buried in the docstring
for astropy.modeling.convolution.Convolution class.

A couple of notes:
1. The astropy.modeling.convolution.Convolution class is sensitive to the input
    models as well as the bounding box, resolution, and normalize_kernel argument.
    I tried to write clear documentation to that affect, but am open to improvements.
2. I tried to reference the astropy.modeling.convolution.Convolution class in the documentation
    but it is not found in the API documentation. I could not figure out the fix for this.
3. A more complex example could be added to the docs.modeling.compound-models.rst file
    with an example of using a Convolution combined model with a fitter to try to illustrate how
    to choose appropriate inputs.
4. Now the astropy.convolution.convolve.convolve_models_fft() function is duplicated by the
    functionality of astropy.convolution.convolve.convolve_models_fft(). Should convolve_models_fft()
    raise a Deprecation warning of some sort and plan to be removed in a future release?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14333 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
