### PR TITLE
Start enforcing Ruff rule ANN201 in `modeling`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -265,7 +265,6 @@ lint.unfixable = [
 ]
 "astropy/logger.py" = ["C408", "RET505"]
 "astropy/modeling/*" = [
-    "ANN201",  # Public function without return type annotation
     "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -684,7 +684,9 @@ class ModelBoundingBox(_BoundingDomain):
         else:
             return self._intervals[self._get_index(key)]
 
-    def bounding_box(self, order: str | None = None):
+    def bounding_box(
+        self, order: str | None = None
+    ) -> tuple[float, float] | tuple[tuple[float, float], ...]:
         """
         Return the old tuple of tuples representation of the bounding_box
             order='C' corresponds to the old bounding_box ordering
@@ -817,7 +819,7 @@ class ModelBoundingBox(_BoundingDomain):
 
         return new
 
-    def fix_inputs(self, model, fixed_inputs: dict, _keep_ignored=False):
+    def fix_inputs(self, model, fixed_inputs: dict, _keep_ignored=False) -> Self:
         """
         Fix the bounding_box for a `fix_inputs` compound model.
 
@@ -848,7 +850,7 @@ class ModelBoundingBox(_BoundingDomain):
     def dimension(self):
         return len(self)
 
-    def domain(self, resolution, order: str | None = None):
+    def domain(self, resolution, order: str | None = None) -> list[np.ndarray]:
         inputs = self._model.inputs
         order = self._get_order(order)
         if order == "C":
@@ -1606,7 +1608,7 @@ class CompoundBoundingBox(_BoundingDomain):
             self.selector_args.add_ignore(self._model, argument),
         )
 
-    def fix_inputs(self, model, fixed_inputs: dict):
+    def fix_inputs(self, model, fixed_inputs: dict) -> Self:
         """
         Fix the bounding_box for a `fix_inputs` compound model.
 


### PR DESCRIPTION
### Description

[ANN201](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/) checks for public functions without a return type annotation. `modeling` was the last sub-package where this rule was not enforced. Note that Ruff is configured to check this rule only for functions that already have a type annotation in their signature.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
