### PR TITLE
MAINT: Use ruff-format instead of running black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
+      - id: ruff-format
 
   - repo: https://github.com/scientific-python/cookie
     rev: 2024.01.24
@@ -106,11 +107,6 @@ repos:
               docs/ |
               examples/
           )
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
-    hooks:
-      - id: black
 
   - repo: local
     hooks:

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -59,7 +59,7 @@ def _true_ecliptic_rotation_matrix(equinox):
 
 
 def _obliquity_only_rotation_matrix(
-    obl=erfa.obl80(EQUINOX_J2000.jd1, EQUINOX_J2000.jd2) * u.radian
+    obl=erfa.obl80(EQUINOX_J2000.jd1, EQUINOX_J2000.jd2) * u.radian,
 ):
     # This code only accounts for the obliquity,
     # which can be passed explicitly.

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -24,9 +24,7 @@ from astropy.coordinates.name_resolve import (
 from astropy.coordinates.sky_coordinate import SkyCoord
 
 _cached_ngc3642 = {}
-_cached_ngc3642[
-    "simbad"
-] = """# NGC 3642    #Q22523669
+_cached_ngc3642["simbad"] = """# NGC 3642    #Q22523669
 #=S=Simbad (via url):    1
 %@ 503952
 %I.0 NGC 3642
@@ -41,9 +39,7 @@ _cached_ngc3642[
 
 #====Done (2013-Feb-12,16:37:11z)===="""
 
-_cached_ngc3642[
-    "vizier"
-] = """# NGC 3642    #Q22523677
+_cached_ngc3642["vizier"] = """# NGC 3642    #Q22523677
 #=V=VizieR (local):    1
 %J 170.56 +59.08 = 11:22.2     +59:05
 %I.0 {NGC} 3642
@@ -52,9 +48,7 @@ _cached_ngc3642[
 
 #====Done (2013-Feb-12,16:37:42z)===="""
 
-_cached_ngc3642[
-    "all"
-] = """# ngc3642       #Q2779348
+_cached_ngc3642["all"] = """# ngc3642    #Q2779348
 #=Si=Simbad, all IDs (via url):    1    41ms
 %@ 503952
 %I.0 NGC 3642
@@ -72,9 +66,7 @@ _cached_ngc3642[
 """
 
 _cached_castor = {}
-_cached_castor[
-    "all"
-] = """# castor        #Q2779274
+_cached_castor["all"] = """# castor    #Q2779274
 #=Si=Simbad, all IDs (via url):    1     0ms (from cache)
 %@ 983633
 %I.0 * alf Gem
@@ -91,9 +83,7 @@ _cached_castor[
 
 #====Done (2024-Feb-15,11:25:36z)===="""
 
-_cached_castor[
-    "simbad"
-] = """# castor    #Q22524495
+_cached_castor["simbad"] = """# castor    #Q22524495
 #=S=Simbad (via url):    1
 %@ 983633
 %I.0 NAME CASTOR

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -398,9 +398,7 @@ class TestArithmetic:
         in_rep = self.cartesian.represent_as(representation)
         r_cross_r = in_rep.cross(in_rep)
         assert isinstance(r_cross_r, representation)
-        assert_quantity_allclose(
-            r_cross_r.norm(), 0.0 * u.kpc**2, atol=1.0 * u.mpc**2
-        )
+        assert_quantity_allclose(r_cross_r.norm(), 0.0 * u.kpc**2, atol=1.0 * u.mpc**2)
         r_cross_r_rev = in_rep.cross(in_rep[::-1])
         sep = angular_separation(self.lon, self.lat, self.lon[::-1], self.lat[::-1])
         expected = self.distance * self.distance[::-1] * np.sin(sep)

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -59,9 +59,7 @@ def test_unit_representation_subclass():
             "unitsphericalwrap180"
         ] = frame_specific_representation_info[
             "sphericalwrap180"
-        ] = frame_specific_representation_info[
-            "spherical"
-        ]
+        ] = frame_specific_representation_info["spherical"]
 
     @frame_transform_graph.transform(
         FunctionTransform, MyFrame, astropy.coordinates.ICRS

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -571,9 +571,7 @@ class LambdaCDM(FLRW):
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
-        return np.sqrt(
-            zp1**2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) + self._Ode0
-        )
+        return np.sqrt(zp1**2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) + self._Ode0)
 
     def inv_efunc(self, z):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -374,8 +374,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
 
         return sqrt(
-            zp1**3 * (Or * zp1 + self._Om0)
-            + self._Ode0 * zp1 ** (3.0 * (1 + self._w0))
+            zp1**3 * (Or * zp1 + self._Om0) + self._Ode0 * zp1 ** (3.0 * (1 + self._w0))
         )
 
     def inv_efunc(self, z):

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -130,9 +130,7 @@ class TestUintFunctions(FitsTestCase):
                 fits.Column(
                     name="a", format="I", array=np.arange(2**16, dtype=np.int16)
                 ),
-                fits.Column(
-                    name="b", format="I", bscale=1, bzero=2**15, array=dataref
-                ),
+                fits.Column(name="b", format="I", bscale=1, bzero=2**15, array=dataref),
             ]
         )
         tbhdu.writeto(self.temp("test_scaled_slicing.fits"))

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -108,8 +108,9 @@ class Covariance:
         if len(params) != 2:
             raise ValueError("Covariance must be indexed by two values.")
         if all(isinstance(item, str) for item in params):
-            i1, i2 = self.param_names.index(params[0]), self.param_names.index(
-                params[1]
+            i1, i2 = (
+                self.param_names.index(params[0]),
+                self.param_names.index(params[1]),
             )
         elif all(isinstance(item, int) for item in params):
             i1, i2 = params

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1632,9 +1632,7 @@ class Lorentz1D(Fittable1DModel):
     def fit_deriv(x, amplitude, x_0, fwhm):
         """One dimensional Lorentzian model derivative with respect to parameters."""
         d_amplitude = fwhm**2 / (fwhm**2 + (x - x_0) ** 2)
-        d_x_0 = (
-            amplitude * d_amplitude * (2 * x - 2 * x_0) / (fwhm**2 + (x - x_0) ** 2)
-        )
+        d_x_0 = amplitude * d_amplitude * (2 * x - 2 * x_0) / (fwhm**2 + (x - x_0) ** 2)
         d_fwhm = 2 * amplitude * d_amplitude / fwhm * (1 - d_amplitude)
         return [d_amplitude, d_x_0, d_fwhm]
 

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -318,10 +318,7 @@ class Drude1D(Fittable1DModel):
                 (1 / x_0)
                 + d_amplitude
                 * (x_0**2 / fwhm**2)
-                * (
-                    (-x / x_0 - 1 / x) * (x / x_0 - x_0 / x)
-                    - (2 * fwhm**2 / x_0**3)
-                )
+                * ((-x / x_0 - 1 / x) * (x / x_0 - x_0 / x) - (2 * fwhm**2 / x_0**3))
             )
         )
         d_fwhm = (2 * amplitude * d_amplitude / fwhm) * (1 - d_amplitude)

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -809,12 +809,12 @@ def test_models_fitting(model, fitter):
     m = model["class"](**model["parameters"])
     if len(model["evaluation"][0]) == 2:
         x = np.linspace(1, 3, 100) * model["evaluation"][0][0].unit
-        y = np.exp(-x.value**2) * model["evaluation"][0][1].unit
+        y = np.exp(-(x.value**2)) * model["evaluation"][0][1].unit
         args = [x, y]
     else:
         x = np.linspace(1, 3, 100) * model["evaluation"][0][0].unit
         y = np.linspace(1, 3, 100) * model["evaluation"][0][1].unit
-        z = np.exp(-x.value**2 - y.value**2) * model["evaluation"][0][2].unit
+        z = np.exp(-(x.value**2 + y.value**2)) * model["evaluation"][0][2].unit
         args = [x, y, z]
 
     # Test that the model fits even if it has units on parameters
@@ -1110,9 +1110,7 @@ def test_models_evaluate_magunits(model):
 
 def test_Schechter1D_errors():
     # Non magnitude units are bad
-    model = Schechter1D(
-        phi_star=1.0e-4 * (u.Mpc**-3), m_star=-20.0 * u.km, alpha=-1.9
-    )
+    model = Schechter1D(phi_star=1.0e-4 * (u.Mpc**-3), m_star=-20.0 * u.km, alpha=-1.9)
     MESSAGE = r"The units of magnitude and m_star must be a magnitude"
     with pytest.raises(u.UnitsError, match=MESSAGE):
         model(-23 * u.km)

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -453,9 +453,7 @@ def test_nddata_str():
     assert str(arr2d) == textwrap.dedent(
         """
         [[1 2]
-         [3 4]]"""[
-            1:
-        ]
+         [3 4]]"""[1:]
     )
 
     arr3d = NDData(np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]))
@@ -465,9 +463,7 @@ def test_nddata_str():
           [3 4]]
 
          [[5 6]
-          [7 8]]]"""[
-            1:
-        ]
+          [7 8]]]"""[1:]
     )
 
     # let's add units!

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1342,9 +1342,7 @@ def kuiper_false_positive_probability(D, N):
         # underflow warning if `under="warn"`.
         ms = np.arange(1, 18.82 / z)
         S1 = (2 * (4 * ms**2 * z**2 - 1) * np.exp(-2 * ms**2 * z**2)).sum()
-        S2 = (
-            ms**2 * (4 * ms**2 * z**2 - 3) * np.exp(-2 * ms**2 * z**2)
-        ).sum()
+        S2 = (ms**2 * (4 * ms**2 * z**2 - 3) * np.exp(-2 * ms**2 * z**2)).sum()
         return S1 - 8 * D / 3 * S2
 
 

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -454,7 +454,8 @@ def test_biweight_midcovariance_2d():
     d = [[5, 1, 10], [500, 5, 2]]
     cov = biweight_midcovariance(d)
     assert_allclose(
-        cov, [[14.54159077, -7.79026256], [-7.79026256, 6.92087252]]  # verified with R
+        cov,
+        [[14.54159077, -7.79026256], [-7.79026256, 6.92087252]],  # verified with R
     )
 
     cov = biweight_midcovariance(d, modify_sample_size=True)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -697,9 +697,8 @@ class TimeDecimalYear(TimeNumeric):
 
     def to_value(self, **kwargs):
         scale = self.scale.upper().encode("ascii")
-        iy_start, ims, ids, ihmsfs = erfa.d2dtf(
-            scale, 0, self.jd1, self.jd2  # precision=0
-        )
+        # precision=0
+        iy_start, ims, ids, ihmsfs = erfa.d2dtf(scale, 0, self.jd1, self.jd2)
         imon = np.ones_like(iy_start)
         iday = np.ones_like(iy_start)
         ihr = np.zeros_like(iy_start)
@@ -1183,9 +1182,8 @@ class TimeDatetime(TimeUnique):
         # Rather than define a value property directly, we have a function,
         # since we want to be able to pass in timezone information.
         scale = self.scale.upper().encode("ascii")
-        iys, ims, ids, ihmsfs = erfa.d2dtf(
-            scale, 6, self.jd1, self.jd2  # 6 for microsec
-        )
+        # 6 for microsec
+        iys, ims, ids, ihmsfs = erfa.d2dtf(scale, 6, self.jd1, self.jd2)
         ihrs = ihmsfs["h"]
         imins = ihmsfs["m"]
         isecs = ihmsfs["s"]

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -135,9 +135,7 @@ class TestDistributionStatistics:
         expected = np.var(self.data, axis=-1) * self.distr.unit**2
         pdf_var = self.distr.pdf_var()
         assert_quantity_allclose(pdf_var, expected)
-        assert_quantity_allclose(
-            pdf_var, [9, 4, 16, 25] * self.distr.unit**2, rtol=0.1
-        )
+        assert_quantity_allclose(pdf_var, [9, 4, 16, 25] * self.distr.unit**2, rtol=0.1)
 
         # make sure the right type comes out - should be a Quantity because it's
         # now a summary statistic
@@ -225,9 +223,7 @@ class TestDistributionStatistics:
         expected = np.median(self.data + another_data / 1000, axis=-1) * self.distr.unit
         assert_quantity_allclose(combined_distr.pdf_median(), expected)
 
-        expected = (
-            np.var(self.data + another_data / 1000, axis=-1) * self.distr.unit**2
-        )
+        expected = np.var(self.data + another_data / 1000, axis=-1) * self.distr.unit**2
         assert_quantity_allclose(combined_distr.pdf_var(), expected)
 
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -758,9 +758,7 @@ def thermodynamic_temperature(frequency, T_cmb=None):
         return x**2 * np.exp(x) / np.expm1(x) ** 2
 
     def convert_Jy_to_K(x_jybm):
-        factor = (f(nu) * 2 * _si.k_B * si.K * nu**2 / _si.c**2).to_value(
-            astrophys.Jy
-        )
+        factor = (f(nu) * 2 * _si.k_B * si.K * nu**2 / _si.c**2).to_value(astrophys.Jy)
         return x_jybm / factor
 
     def convert_K_to_Jy(x_K):

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -121,9 +121,7 @@ def make_function_with_signature(
         """{0}\
     def {name}({sig1}):
         return __{name}__func({sig2})
-    """.format(
-            "\n" * lineno, name=name, sig1=def_signature, sig2=call_signature
-        )
+    """.format("\n" * lineno, name=name, sig1=def_signature, sig2=call_signature)
     )
 
     code = compile(template, filename, "single")

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -131,10 +131,12 @@ class Conf(_config.ConfigNamespace):
         True, "If False, prevents any attempt to download from Internet."
     )
     compute_hash_block_size = _config.ConfigItem(
-        2**16, "Block size for computing file hashes."  # 64K
+        2**16,  # 64K
+        "Block size for computing file hashes.",
     )
     download_block_size = _config.ConfigItem(
-        2**16, "Number of bytes of remote data to download per step."  # 64K
+        2**16,  # 64K
+        "Number of bytes of remote data to download per step.",
     )
     delete_temporary_downloads_at_exit = _config.ConfigItem(
         True,

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1146,10 +1146,11 @@ def test_read_unicode(filename):
     contents = get_pkg_data_contents(os.path.join("data", filename), encoding="binary")
     assert isinstance(contents, bytes)
     x = contents.splitlines()[1]
-    assert x == (
+    expected = (
         b"\xff\xd7\x94\xd7\x90\xd7\xa1\xd7\x98\xd7\xa8\xd7\x95\xd7\xa0\xd7\x95"
         b"\xd7\x9e\xd7\x99 \xd7\xa4\xd7\x99\xd7\x99\xd7\xaa\xd7\x95\xd7\x9f"[1:]
     )
+    assert x == expected
 
 
 def test_compressed_stream():

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -153,7 +153,7 @@ CTYPE_TO_UCD1 = {
     "LOCAL": "time",
     # Distance coordinates
     "DIST": "pos.distance",
-    "DSUN": "custom:pos.distance.sunToObserver"
+    "DSUN": "custom:pos.distance.sunToObserver",
     # UT() and TT() are handled separately in world_axis_physical_types
 }
 

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -136,29 +136,28 @@ Coding Style/Conventions
   using only 4 spaces for indentation, and never tabs.
 
   * ``astropy`` itself enforces this style guide using the
-    `black <https://black.readthedocs.io/en/stable/>`_ code formatter, see
-    `The Black Code Style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`_
-    for details.
+    `ruff <https://docs.astral.sh/ruff/formatter/>`_ code formatter, which closely follows the
+    `The Black Code Style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`_.
 
-  * We recognize that sometimes ``black`` will autoformat things in undesirable
-    ways, e.g., matrices.  In the cases that ``black`` produces undesirable code
+  * We recognize that sometimes ``ruff`` will autoformat things in undesirable
+    ways, e.g., matrices.  In the cases that ``ruff`` produces undesirable code
     formatting:
 
       * one can wrap code the code in ``# fmt: off`` and ``# fmt: on`` to disable
-        ``black`` formatting over multiple lines.
+        ``ruff`` formatting over multiple lines.
 
       * or one can add a single ``# fmt: skip`` comment to the end of a line to
-        disable ``black`` formatting for that line.
+        disable ``ruff`` formatting for that line.
 
     This should be done sparingly, and only
-    when ``black`` produces undesirable formatting.
+    when ``ruff`` produces undesirable formatting.
 
       .. note::
         When a list or array should be formatted as one item per line then this is best
         achieved by using the
         `magic trailing comma <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma>`_.
         This is frequently sufficient for keeping matrices formatted as one row
-        per line while still allowing ``black`` to check the code::
+        per line while still allowing ``ruff`` to check the code::
 
             arr = [
                 [0, 1],

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -136,28 +136,28 @@ Coding Style/Conventions
   using only 4 spaces for indentation, and never tabs.
 
   * ``astropy`` itself enforces this style guide using the
-    `ruff <https://docs.astral.sh/ruff/formatter/>`_ code formatter, which closely follows the
+    `ruff format <https://docs.astral.sh/ruff/formatter/>`_ code formatter, which closely follows the
     `The Black Code Style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`_.
 
-  * We recognize that sometimes ``ruff`` will autoformat things in undesirable
-    ways, e.g., matrices.  In the cases that ``ruff`` produces undesirable code
+  * We recognize that sometimes ruff_ will autoformat things in undesirable
+    ways, e.g., matrices.  In the cases that ruff_ produces undesirable code
     formatting:
 
       * one can wrap code the code in ``# fmt: off`` and ``# fmt: on`` to disable
-        ``ruff`` formatting over multiple lines.
+        ruff_ formatting over multiple lines.
 
       * or one can add a single ``# fmt: skip`` comment to the end of a line to
-        disable ``ruff`` formatting for that line.
+        disable ruff_ formatting for that line.
 
     This should be done sparingly, and only
-    when ``ruff`` produces undesirable formatting.
+    when ruff_ produces undesirable formatting.
 
       .. note::
         When a list or array should be formatted as one item per line then this is best
         achieved by using the
         `magic trailing comma <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma>`_.
         This is frequently sufficient for keeping matrices formatted as one row
-        per line while still allowing ``ruff`` to check the code::
+        per line while still allowing ruff_ to check the code::
 
             arr = [
                 [0, 1],
@@ -572,4 +572,4 @@ Further tips and hints relating to the coding guidelines are included below.
 .. _matplotlib: https://matplotlib.org/
 .. _Cython: https://cython.org/
 .. _PyPI: https://pypi.org/project
-.. _ruff: https://beta.ruff.rs/docs
+.. _ruff: https://docs.astral.sh/ruff/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,23 +236,6 @@ archs = ["x86_64", "arm64"]
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 
-[tool.black]
-force-exclude = """
-^/(
-  (
-    # Directories to always exclude (.gitignore is always excluded)
-      examples
-    | docs/wcs/examples
-    | docs/nddata/examples
-    | cextern
-    | astropy/extern
-  )/
-  # Individual files to always exclude
-  | astropy/coordinates/.*tab.py
-  | astropy/units/format/.*tab.py
-)
-"""
-
 
 [tool.docformatter]
     # The ``summaries`` are not (yet) 75 characters because the summary lines can't be
@@ -362,6 +345,10 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # flake8-fixme (FIX)
     "FIX002",  # Line contains TODO | notes for improvements are OK iff the code works
 
+    # ISC001 shouldn't be used with ruff format
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "ISC001",
+
     # pep8-naming (N)
     "N803",  # invalid-argument-name. Physics variables are often poor code variables
     "N806",  # non-lowercase-variable-in-function. Physics variables are often poor code variables
@@ -378,6 +365,9 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # Ruff-specific rules (RUF)
     "RUF005",  # unpack-instead-of-concatenating-to-collection-literal -- it's not clearly faster.
 ]
+
+[tool.ruff.format]
+exclude = ["docs/*", "examples/*"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.


### PR DESCRIPTION
This resolves https://github.com/astropy/astropy/issues/15757 as https://github.com/astropy/astropy-APEs/pull/90 has been accepted.

https://github.com/astropy/astropy/commit/c69079e866c0cf394759bd7d1ffcda1a0e48cb0c has the changes caused by this.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
