### PR TITLE
Address Ruff rule PLR0911 in `convolution`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -236,7 +236,6 @@ lint.unfixable = [
     "RET505",  # superfluous-else-return
 ]
 "astropy/convolution/*" = [
-    "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -85,7 +85,9 @@ def add_kernel_arrays_2D(array_1, array_2):
     return array_2 + array_1
 
 
-def discretize_model(model, x_range, y_range=None, mode="center", factor=10):
+def discretize_model(  # noqa: PLR0911
+    model, x_range, y_range=None, mode="center", factor=10
+):
     """
     Evaluate an analytical model function on a pixel grid.
 


### PR DESCRIPTION
### Description

[PLR0911](https://docs.astral.sh/ruff/rules/too-many-return-statements/) guards against functions with very many `return` statements.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
