### PR TITLE
UX: warn about units being ignored when inserting Quantity values in empty Columns via Table.insert_row or Table.add_row

### DIFF
--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -891,7 +891,6 @@ class TestAddRow(SetupData):
                 UserWarning, match="Units from inserted quantities will be ignored."
             ),
             id="Table-Column",
-            marks=pytest.mark.xfail,
         ),
         pytest.param(
             table.QTable,
@@ -912,7 +911,6 @@ class TestAddRow(SetupData):
                 ),
             ),
             id="QTable-Column",
-            marks=pytest.mark.xfail,
         ),
         pytest.param(
             table.QTable,

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -875,6 +875,98 @@ class TestAddRow(SetupData):
                 t.insert_row(index, row)
 
 
+@pytest.mark.parametrize(
+    "table_type, table_inputs, expected_column_type, expected_pformat, insert_ctx",
+    [
+        pytest.param(
+            table.Table,
+            dict(names=["a", "b", "c"]),
+            table.Column,
+            [
+                " a   b   c ",
+                "--- --- ---",
+                "1.0 2.0 3.0",
+            ],
+            pytest.warns(
+                UserWarning, match="Units from inserted quantities will be ignored."
+            ),
+            id="Table-Column",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            table.QTable,
+            dict(names=["a", "b", "c"]),
+            table.Column,
+            [
+                " a   b   c ",
+                "--- --- ---",
+                "1.0 2.0 3.0",
+            ],
+            pytest.warns(
+                UserWarning,
+                match=(
+                    "Units from inserted quantities will be ignored.\n"
+                    "If you were hoping to fill a QTable row by row, "
+                    "also initialize the units before starting, for instance\n"
+                    r"QTable\(names=\['a', 'b', 'c'\], units=\['m', 'kg', None\]\)"
+                ),
+            ),
+            id="QTable-Column",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            table.QTable,
+            dict(names=["a", "b", "c"], units=["m", "kg", None]),
+            u.Quantity,
+            [
+                " a   b   c ",
+                " m   kg    ",
+                "--- --- ---",
+                "1.0 2.0 3.0",
+            ],
+            nullcontext(),
+            id="QTable-Quantity",
+        ),
+        pytest.param(
+            table.QTable,
+            dict(names=["a", "b", "c"], units=["cm", "g", None]),
+            u.Quantity,
+            [
+                "  a     b     c ",
+                "  cm    g       ",
+                "----- ------ ---",
+                "100.0 2000.0 3.0",
+            ],
+            nullcontext(),
+            id="QTable-Quantity-other_units",
+        ),
+    ],
+)
+def test_inserting_quantity_row_in_empty_table(
+    table_type, table_inputs, expected_column_type, expected_pformat, insert_ctx
+):
+    # see https://github.com/astropy/astropy/issues/15964
+    table = table_type(**table_inputs)
+    pre_unit_a = copy.copy(table["a"].unit)
+    pre_unit_b = copy.copy(table["b"].unit)
+    pre_unit_c = copy.copy(table["c"].unit)
+    assert type(table["a"]) is expected_column_type
+    assert type(table["b"]) is expected_column_type
+    assert type(table["c"]) is Column
+
+    with insert_ctx:
+        table.add_row([1 * u.m, 2 * u.kg, 3])
+
+    assert table["a"].unit == pre_unit_a
+    assert table["b"].unit == pre_unit_b
+    assert table["c"].unit == pre_unit_c
+    assert type(table["a"]) is expected_column_type
+    assert type(table["b"]) is expected_column_type
+    assert type(table["c"]) is Column
+
+    assert table.pformat() == expected_pformat
+
+
 @pytest.mark.usefixtures("table_types")
 class TestTableColumn(SetupData):
     def test_column_view(self, table_types):

--- a/docs/changes/table/16038.api.rst
+++ b/docs/changes/table/16038.api.rst
@@ -1,0 +1,2 @@
+A warning is now emitted when ``Quantity`` values are inserted into empty ``Column`` objects
+via ``Table.insert_row`` or ``Table.add_row``.


### PR DESCRIPTION
### Description
Alternative to #16004, as suggested in https://github.com/astropy/astropy/pull/16004#issuecomment-1942915020

Fixes #15964

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
