### PR TITLE
BUG: fix a bug where astropy.utils.console.Spinner would leak newlines for messages longer than terminal width

### DIFF
--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -872,10 +872,15 @@ class Spinner:
         write = file.write
         flush = file.flush
         try_fallback = True
+        terminal_width = terminal_size(self._file)[1]
+        if len(self._msg) > terminal_width:
+            message = self._msg[: terminal_width - 8] + " ..."
+        else:
+            message = self._msg
 
         while True:
             write("\r")
-            color_print(self._msg, self._color, file=file, end="")
+            color_print(message, self._color, file=file, end="")
             write(" ")
             try:
                 if try_fallback:

--- a/docs/changes/utils/16040.bugfix.rst
+++ b/docs/changes/utils/16040.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug where ``astropy.utils.console.Spinner`` would leak newlines for
+messages longer than terminal width.


### PR DESCRIPTION
### Description

Fixes #11556
This use case, as this whole module, is difficult to test systematically, and `Spinner` in particular only has one dedicated unit test, so I'm assuming it's okay to not include a test for this one.

Instead, here's a MWE, marginally simpler than the one included in the issue:

```python
from astropy.utils.console import Spinner

with Spinner('this is a long string '*10) as s:
    for item in range(1000000):
        s.update()
```

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
