### PR TITLE
BUG: fix extraneous space in LaTeX repr for Quantity objects with superscript units

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1511,7 +1511,11 @@ class Quantity(np.ndarray):
 
         delimiter_left, delimiter_right = formats[format][subfmt]
 
-        return rf"{delimiter_left}{latex_value} \; {latex_unit}{delimiter_right}"
+        # Add a space in front except for super-script units like degrees.
+        if not latex_unit.removeprefix("\\mathrm{").startswith("{}^"):
+            latex_unit = rf" \; {latex_unit}"
+
+        return rf"{delimiter_left}{latex_value}{latex_unit}{delimiter_right}"
 
     def __str__(self):
         return self.to_string()

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1086,6 +1086,22 @@ class TestQuantityDisplay:
         qinfnan = [np.inf, -np.inf, np.nan] * u.m
         assert qinfnan._repr_latex_() == r"$[\infty,~-\infty,~{\rm NaN}] \; \mathrm{m}$"
 
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(
+        "q, expected",
+        [
+            pytest.param(10 * u.deg_C, r"$10\mathrm{{}^{\circ}C}$", id="deg_C"),
+            pytest.param(20 * u.deg, r"$20\mathrm{{}^{\circ}}$", id="deg"),
+            pytest.param(30 * u.arcmin, r"$30\mathrm{{}^{\prime}}$", id="arcmin"),
+            pytest.param(40 * u.arcsec, r"$40\mathrm{{}^{\prime\prime}}$", id="arcsec"),
+            pytest.param(50 * u.hourangle, r"$50\mathrm{{}^{h}}$", id="hourangle"),
+        ],
+    )
+    def test_repr_latex_superscript_units(self, q, expected):
+        # see https://github.com/astropy/astropy/issues/14385
+        assert q._repr_latex_() == expected
+        assert q.to_string(format="latex") == expected
+
 
 def test_decompose():
     q1 = 5 * u.N

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1086,7 +1086,6 @@ class TestQuantityDisplay:
         qinfnan = [np.inf, -np.inf, np.nan] * u.m
         assert qinfnan._repr_latex_() == r"$[\infty,~-\infty,~{\rm NaN}] \; \mathrm{m}$"
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(
         "q, expected",
         [

--- a/docs/changes/units/16043.bugfix.rst
+++ b/docs/changes/units/16043.bugfix.rst
@@ -1,0 +1,2 @@
+Fix extraneous space in LaTeX repr for ``Quantity`` objects with superscript
+units (e.g. angles or temperatures in degree Celsius).


### PR DESCRIPTION
### Description
Fixes #14385
Special casing seems simple enough here. Maybe the check should be more fine tuned so that composite units that have ``deg`` as their first element also follow this special path ? I just assumed this wasn't desired.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
