### PR TITLE
TST: unpin pluggy following release of pytest-mpl 1.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,6 @@ deps =
     image: latex
     image: scipy
     image: pytest-mpl
-    # TODO: remove the next line when https://github.com/matplotlib/pytest-mpl/issues/216 is resolved
-    image: pluggy<1.4
 
     # Some FITS tests use fitsio as a comparison
     fitsio: fitsio


### PR DESCRIPTION
### Description
Fixes #15944

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
