### PR TITLE
TST: pyinstaller does not like matplotlib in quotes

### DIFF
--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -13,11 +13,8 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
-from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
-
-MPL_LT_3_8 = not minversion("matplotlib", "3.8")
 
 
 def assert_masked_equal(a, b):
@@ -1464,11 +1461,16 @@ class TestMaskedQuantityInteractionWithNumpyMA(
     pass
 
 
-@pytest.mark.skipif(
-    not HAS_PLT or MPL_LT_3_8,
-    reason="requires matplotlib.pyplot, and never worked before matplotlib 3.8",
-)
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
 def test_plt_scatter_masked():
+    import matplotlib as mpl
+    from astropy.utils import minversion
+
+    MPL_LT_3_8 = not minversion(mpl, "3.8")
+
+    if MPL_LT_3_8:
+        pytest.skip("never worked before matplotlib 3.8")
+
     # check that plotting Masked data doesn't raise an exception
     # see https://github.com/astropy/astropy/issues/12481
     import matplotlib.pyplot as plt

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1464,6 +1464,7 @@ class TestMaskedQuantityInteractionWithNumpyMA(
 @pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
 def test_plt_scatter_masked():
     import matplotlib as mpl
+
     from astropy.utils import minversion
 
     MPL_LT_3_8 = not minversion(mpl, "3.8")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is a follow-up of https://github.com/astropy/astropy/pull/15886 because it fails in pyinstaller.

Example log: https://github.com/astropy/astropy/actions/runs/7910507405/job/21593211569

p.s. I tried to do `pre-commit run` locally but does not work in Python 3.12 and I don't have time to deal with that. I will just fix it with bot of my style is not up to the golden standard.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
