### PR TITLE
MAINT: Run PTH flake test in prep for supporting pathlib

### DIFF
--- a/.github/workflows/update_astropy_iers_data_pin.py
+++ b/.github/workflows/update_astropy_iers_data_pin.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import requests
 
@@ -9,8 +10,7 @@ metadata = requests.get(
 last_version = metadata["info"]["version"]
 project_file = "pyproject.toml"
 
-with open(project_file) as f:
-    lines = f.readlines()
+lines = Path(project_file).read_text().splitlines()
 
 changed_lines = 0
 
@@ -26,6 +26,4 @@ elif changed_lines > 1:
     print(f"More than one line found containing astropy-iers-data in {project_file}")
     sys.exit(1)
 
-
-with open(project_file, "w") as f:
-    f.writelines(lines)
+Path(project_file).write_text("\n".join(lines))

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -128,27 +128,6 @@ lint.ignore = [
     "PT022",   # pytest-useless-yield-fixture
     "PT023",   # pytest-incorrect-mark-parentheses-style
 
-    # flake8-use-pathlib (PTH)
-    "PTH100",  # os-path-abspath
-    "PTH101",  # os-chmod
-    "PTH102",  # os-mkdir
-    "PTH103",  # os-makedirs
-    "PTH104",  # os-rename
-    "PTH107",  # os-remove
-    "PTH108",  # os-unlink
-    "PTH109",  # os-getcwd
-    "PTH110",  # os-path-exists
-    "PTH111",  # os-path-expanduser
-    "PTH112",  # os-path-isdir
-    "PTH113",  # os-path-isfile
-    "PTH118",  # os-path-join
-    "PTH119",  # os-path-basename
-    "PTH120",  # os-path-dirname
-    "PTH122",  # os-path-splitext
-    "PTH123",  # builtin-open
-    "PTH202",  # `os.path.getsize` should be replaced by `Path.stat().st_size`
-    "PTH207",  # Replace `glob` with `Path.glob` or `Path.rglob`
-
     # flake8-return (RET)
     "RET501",  # unnecessary-return-none
     "RET502",  # implicit-return-value
@@ -223,6 +202,7 @@ lint.unfixable = [
 # is better to fix for subpackages individually. The general exclusion should be
 # copied to these subpackage sections and fixed there.
 "astropy/config/*" = [
+    "PTH",     # all flake8-use-pathlib
     "PTH114",  # os-path-islink
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
     "RET505",  # superfluous-else-return
@@ -248,6 +228,7 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/io/*" = [
+    "PTH",     # all flake8-use-pathlib
     "G001",  # logging-string-format
     "G004",  # logging-f-string
     "PLR0911",  # too-many-return-statements
@@ -275,6 +256,7 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/samp/*" = [
+    "PTH",     # all flake8-use-pathlib
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
 ]
@@ -284,12 +266,13 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/table/*" = [
+    "PTH",     # all flake8-use-pathlib
     "RET505",  # superfluous-else-return
     "RET506",  # superfluous-else-raise
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
 ]
-"astropy/tests/*" = ["C408", "RET505"]
+"astropy/tests/*" = ["C408", "RET505", "PTH"]
 "astropy/time/*" = [
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
@@ -315,6 +298,7 @@ lint.unfixable = [
     "RET506",  # superfluous-else-raise
 ]
 "astropy/utils/*" = [
+    "PTH",     # all flake8-use-pathlib
     "N811",  # constant-imported-as-non-constant
     "PLR0911",  # too-many-return-statements
     "RET505",  # superfluous-else-return
@@ -339,3 +323,6 @@ lint.unfixable = [
 ]
 "docs/*" = []
 "examples/coordinates/*" = []
+
+".pyinstaller/*.py" = ["PTH"]
+"examples/io/*" = ["PTH"]

--- a/astropy/_dev/scm_version.py
+++ b/astropy/_dev/scm_version.py
@@ -1,10 +1,10 @@
 # Try to use setuptools_scm to get the current version; this is only used
 # in development installations from the git repository.
-import os.path as pth
+from pathlib import Path
 
 try:
     from setuptools_scm import get_version
 
-    version = get_version(root=pth.join("..", ".."), relative_to=__file__)
+    version = get_version(root=Path("../.."), relative_to=__file__)
 except Exception:
     raise ImportError("setuptools_scm broken or not installed")

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -470,7 +470,9 @@ def test_empty_config_file():
 
 class TestAliasRead:
     def setup_class(self):
-        configuration._override_config_file = get_pkg_data_filename("data/alias.cfg")
+        configuration._override_config_file = str(
+            get_pkg_data_filename("data/alias.cfg")
+        )
 
     def test_alias_read(self):
         from astropy.utils.data import conf
@@ -512,7 +514,9 @@ def test_warning_move_to_top_level():
     # file works.  See #2514
     from astropy import conf
 
-    configuration._override_config_file = get_pkg_data_filename("data/deprecated.cfg")
+    configuration._override_config_file = str(
+        get_pkg_data_filename("data/deprecated.cfg")
+    )
 
     try:
         with pytest.warns(AstropyDeprecationWarning) as w:

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -9,6 +9,7 @@ import os
 import sys
 import tempfile
 import warnings
+from pathlib import Path
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -93,8 +94,8 @@ def pytest_configure(config):
     os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
     os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
 
-    os.mkdir(os.path.join(os.environ["XDG_CONFIG_HOME"], "astropy"))
-    os.mkdir(os.path.join(os.environ["XDG_CACHE_HOME"], "astropy"))
+    (Path(os.environ["XDG_CONFIG_HOME"]) / "astropy").mkdir()
+    (Path(os.environ["XDG_CACHE_HOME"]) / "astropy").mkdir()
 
     config.option.astropy_header = True
     PYTEST_HEADER_MODULES["PyERFA"] = "erfa"

--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import sys
+from pathlib import Path
 
 from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
-C_CONVOLVE_PKGDIR = os.path.relpath(os.path.dirname(__file__))
+C_CONVOLVE_PKGDIR = Path(__file__).parent.resolve().relative_to(Path.cwd())
 
 extra_compile_args = ["-UNDEBUG"]
 if not sys.platform.startswith("win"):
@@ -17,8 +17,8 @@ def get_extensions():
     # Add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
     # to report missed optimizations
     sources = [
-        os.path.join(C_CONVOLVE_PKGDIR, "_convolve.pyx"),
-        os.path.join(C_CONVOLVE_PKGDIR, "src", "convolve.c"),
+        str(C_CONVOLVE_PKGDIR / "_convolve.pyx"),
+        str(C_CONVOLVE_PKGDIR / "src" / "convolve.c"),
     ]
     _convolve_ext = Extension(
         name="astropy.convolution._convolve",

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -166,8 +166,7 @@ def get_icrs_coordinates(name, parse=False, cache=False):
             domains.append(domain)
 
             # Add the query to the end of the url, add to url list
-            fmt_url = os.path.join(url, "{db}?{name}")
-            fmt_url = fmt_url.format(name=urllib.parse.quote(name), db=db)
+            fmt_url = urllib.parse.urljoin(url, f"{db}?{urllib.parse.quote(name)}")
             urls.append(fmt_url)
 
     exceptions = []

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -4,9 +4,9 @@ This module contains convenience functions for retrieving solar system
 ephemerides from jplephem.
 """
 
-import os.path
 import re
 from inspect import cleandoc
+from pathlib import Path
 from urllib.parse import urlparse
 
 import erfa
@@ -181,7 +181,7 @@ def _get_kernel(value):
             f"/spk/planets/{value.lower():s}.bsp"
         )
 
-    elif os.path.isfile(value):
+    elif Path(value).is_file():
         return SPK.open(value)
 
     else:

--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -4,7 +4,7 @@ used by the accuracy tests.  Running this as a command-line script will
 generate them all.
 """
 
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -60,12 +60,12 @@ def ref_fk4_no_e_fk4(fnout="fk4_no_e_fk4.csv"):
     t.add_column(Column(name="dec_fk4ne", data=dec_fk4ne))
     t.add_column(Column(name="ra_fk4", data=ra_fk4))
     t.add_column(Column(name="dec_fk4", data=dec_fk4))
-    f = open(os.path.join("data", fnout), "wb")
-    f.write(
-        f"# This file was generated with the {os.path.basename(__file__)} script, and"
-        " the reference values were computed using AST\n"
-    )
-    t.write(f, format="ascii", delimiter=",")
+    with Path("data" / fnout).open("wb") as f:
+        f.write_text(
+            f"# This file was generated with the {Path(__file__).name} script, and"
+            " the reference values were computed using AST\n"
+        )
+        t.write(f, format="ascii", delimiter=",")
 
 
 def ref_fk4_no_e_fk5(fnout="fk4_no_e_fk5.csv"):
@@ -125,12 +125,12 @@ def ref_fk4_no_e_fk5(fnout="fk4_no_e_fk5.csv"):
     t.add_column(Column(name="dec_fk5", data=dec_fk5))
     t.add_column(Column(name="ra_fk4", data=ra_fk4))
     t.add_column(Column(name="dec_fk4", data=dec_fk4))
-    f = open(os.path.join("data", fnout), "wb")
-    f.write(
-        f"# This file was generated with the {os.path.basename(__file__)} script, and"
-        " the reference values were computed using AST\n"
-    )
-    t.write(f, format="ascii", delimiter=",")
+    with Path("data" / fnout).open("wb") as f:
+        f.write_text(
+            f"# This file was generated with the {Path(__file__).name} script, and"
+            " the reference values were computed using AST\n"
+        )
+        t.write(f, format="ascii", delimiter=",")
 
 
 def ref_galactic_fk4(fnout="galactic_fk4.csv"):
@@ -186,12 +186,12 @@ def ref_galactic_fk4(fnout="galactic_fk4.csv"):
     t.add_column(Column(name="dec_fk4", data=dec_fk4))
     t.add_column(Column(name="lon_gal", data=lon_gal))
     t.add_column(Column(name="lat_gal", data=lat_gal))
-    f = open(os.path.join("data", fnout), "wb")
-    f.write(
-        f"# This file was generated with the {os.path.basename(__file__)} script, and"
-        " the reference values were computed using AST\n"
-    )
-    t.write(f, format="ascii", delimiter=",")
+    with Path("data" / fnout).open("wb") as f:
+        f.write_text(
+            f"# This file was generated with the {Path(__file__).name} script, and"
+            " the reference values were computed using AST\n"
+        )
+        t.write(f, format="ascii", delimiter=",")
 
 
 def ref_icrs_fk5(fnout="icrs_fk5.csv"):
@@ -247,12 +247,12 @@ def ref_icrs_fk5(fnout="icrs_fk5.csv"):
     t.add_column(Column(name="dec_fk5", data=dec_fk5))
     t.add_column(Column(name="ra_icrs", data=ra_icrs))
     t.add_column(Column(name="dec_icrs", data=dec_icrs))
-    f = open(os.path.join("data", fnout), "wb")
-    f.write(
-        f"# This file was generated with the {os.path.basename(__file__)} script, and"
-        " the reference values were computed using AST\n"
-    )
-    t.write(f, format="ascii", delimiter=",")
+    with Path("data" / fnout).open("wb") as f:
+        f.write_text(
+            f"# This file was generated with the {Path(__file__).name} script, and"
+            " the reference values were computed using AST\n"
+        )
+        t.write(f, format="ascii", delimiter=",")
 
 
 if __name__ == "__main__":

--- a/astropy/coordinates/tests/accuracy/generate_spectralcoord_ref.py
+++ b/astropy/coordinates/tests/accuracy/generate_spectralcoord_ref.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
 
     for row in tab:
         # Produce input file for rv command
-        with open("rv.input", "w") as f:
+        with open("rv.input", "w") as f:  # noqa: PTH123
             f.write(
                 f"{row['obslon'].to_string('deg', sep=' ')}"
                 f" {row['obslat'].to_string('deg', sep=' ')}\n"
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         # Parse values from output file
         lis_lines = []
         started = False
-        for lis_line in open("rv.lis"):
+        for lis_line in open("rv.lis"):  # noqa: PTH123
             if started and lis_line.strip() != "":
                 lis_lines.append(lis_line.strip())
             elif "LOCAL GROUP" in lis_line:

--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -11,6 +11,7 @@ import heapq
 import subprocess
 from collections import defaultdict
 from contextlib import contextmanager
+from pathlib import Path
 
 from astropy.coordinates.transformations.affine import (
     AffineTransform,
@@ -460,7 +461,7 @@ class TransformGraph:
         addnodes : sequence of str
             Additional coordinate systems to add (this can include systems
             already in the transform graph, but they will only appear once).
-        savefn : None or str
+        savefn : None or str | Path
             The file name to save this graph to or `None` to not save
             to a file.
         savelayout : {"plain", "dot", "neato", "fdp", "sfdp", "circo", "twopi", "nop", "nop2", "osage", "patchwork"}
@@ -525,10 +526,11 @@ class TransformGraph:
         lines.append("}")
         dotgraph = "\n".join(lines)
 
+        if isinstance(savefn, str):
+            savefn = Path(savefn)
         if savefn is not None:
             if savelayout == "plain":
-                with open(savefn, "w") as f:
-                    f.write(dotgraph)
+                savefn.write_text(dotgraph)
             # Options from https://graphviz.org/docs/layouts/
             elif savelayout in (
                 "dot",
@@ -555,8 +557,7 @@ class TransformGraph:
                 if proc.returncode != 0:
                     raise OSError("problem running graphviz: \n" + stderr)
 
-                with open(savefn, "w") as f:
-                    f.write(stdout)
+                savefn.write_text(stdout)
             else:
                 raise NotImplementedError(f'savelayout="{savelayout}" is not supported')
 

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import inspect
-import os
 
 import pytest
 
@@ -82,15 +81,15 @@ class ReadWriteTestMixin(
         if (format, Cosmology) not in readwrite_registry._readers:
             pytest.xfail(f"no read method is registered for format {format!r}")
 
-        fname = str(tmp_path / f"{cosmo.name}.{format}")
+        fname = tmp_path / f"{cosmo.name}.{format}"
         cosmo.write(fname, format=format)
 
         # Also test kwarg "overwrite"
-        assert os.path.exists(fname)  # file exists
+        assert fname.is_file()
         with pytest.raises(IOError):
             cosmo.write(fname, format=format, overwrite=False)
 
-        assert os.path.exists(fname)  # overwrite file existing file
+        assert fname.exists()  # overwrite file existing file
         cosmo.write(fname, format=format, overwrite=True)
 
         # Read back

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -22,6 +22,7 @@ import warnings
 from collections import OrderedDict
 from contextlib import suppress
 from io import StringIO
+from pathlib import Path
 
 import numpy as np
 
@@ -329,8 +330,10 @@ class BaseInputter:
             List of lines
         """
         try:
-            if hasattr(table, "read") or (
-                "\n" not in table + "" and "\r" not in table + ""
+            if (
+                isinstance(table, Path)
+                or hasattr(table, "read")
+                or ("\n" not in table + "" and "\r" not in table + "")
             ):
                 with get_readable_fileobj(table, encoding=self.encoding) as fileobj:
                     table = fileobj.read()

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -47,7 +47,7 @@ def home_is_data(monkeypatch, request):
     In the tilde-path case, environment variables are temporarily
     modified so that '~' resolves to the data directory.
     """
-    path = get_pkg_data_path("data")
+    path = str(get_pkg_data_path("data"))
     # For Unix
     monkeypatch.setenv("HOME", path)
     # For Windows

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -33,7 +33,7 @@ def home_is_data(monkeypatch):
     In the tilde-path case, environment variables are temporarily
     modified so that '~' resolves to the data directory.
     """
-    path = get_pkg_data_path("data")
+    path = str(get_pkg_data_path("data"))
     # For Unix
     monkeypatch.setenv("HOME", path)
     # For Windows

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -10,10 +10,10 @@
 
 import inspect
 import logging
-import os
 import sys
 import warnings
 from contextlib import contextmanager
+from pathlib import Path
 
 from . import conf as _conf
 from . import config as _config
@@ -219,12 +219,13 @@ class AstropyLogger(Logger):
         # find the module object and thus the fully-package-specified module
         # name.  The module.__file__ is the original source file name.
         mod_name = None
-        mod_path, ext = os.path.splitext(mod_path)
-        for name, mod in list(sys.modules.items()):
+        mod_path = Path(mod_path).with_suffix("")
+        for mod in sys.modules.values():
             try:
                 # Believe it or not this can fail in some cases:
                 # https://github.com/astropy/astropy/issues/2671
-                path = os.path.splitext(getattr(mod, "__file__", ""))[0]
+                path = Path(getattr(mod, "__file__", "")).with_suffix("")
+
             except Exception:
                 continue
             if path == mod_path:
@@ -523,11 +524,11 @@ class AstropyLogger(Logger):
 
             try:
                 if log_file_path == "" or testing_mode:
-                    log_file_path = os.path.join(
-                        _config.get_config_dir("astropy"), "astropy.log"
+                    log_file_path = (
+                        Path(_config.get_config_dir("astropy")) / "astropy.log"
                     )
                 else:
-                    log_file_path = os.path.expanduser(log_file_path)
+                    log_file_path = Path(log_file_path).expanduser()
 
                 encoding = conf.log_file_encoding if conf.log_file_encoding else None
                 fh = logging.FileHandler(log_file_path, encoding=encoding)

--- a/astropy/modeling/tests/data/__init__.py
+++ b/astropy/modeling/tests/data/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
+from pathlib import Path
 
-dpath = os.path.split(os.path.abspath(__file__))[0]
+dpath = Path(__file__).parent

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -4,6 +4,8 @@ This module provides functions to help with testing against iraf tasks.
 """
 
 
+from pathlib import Path
+
 import numpy as np
 
 from astropy.logger import log
@@ -17,16 +19,14 @@ def get_records(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : str | PathLike
            name of an IRAF database file
 
     Returns
     -------
         A list of records
     """
-    f = open(fname)
-    dtb = f.read()
-    f.close()
+    dtb = Path(fname).read_text()
     recs = dtb.split("begin")[1:]
     records = [Record(r) for r in recs]
     return records
@@ -38,17 +38,14 @@ def get_database_string(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : str | PathLike
           name of an IRAF database file
 
     Returns
     -------
         the database file as a string
     """
-    f = open(fname)
-    dtb = f.read()
-    f.close()
-    return dtb
+    return Path(fname).read_text()
 
 
 class Record:

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import unittest.mock as mk
 from inspect import signature
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -617,12 +618,11 @@ def test_rename_path(tmp_path):
     # __main__.
 
     env = os.environ.copy()
-    paths = [os.path.dirname(astropy.__path__[0])] + sys.path
+    paths = [str(Path(astropy.__path__[0]).parent)] + sys.path
     env["PYTHONPATH"] = os.pathsep.join(paths)
 
     script = tmp_path / "rename.py"
-    with open(script, "w") as f:
-        f.write(MODEL_RENAME_CODE)
+    script.write_text(MODEL_RENAME_CODE)
 
     output = subprocess.check_output([sys.executable, script], env=env)
     assert output.splitlines() == MODEL_RENAME_EXPECTED.splitlines()

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -3,10 +3,10 @@
 Module to test fitting routines
 """
 # pylint: disable=invalid-name
-import os.path
 import unittest.mock as mk
 from importlib.metadata import EntryPoint
 from itertools import combinations
+from pathlib import Path
 from unittest import mock
 
 import numpy as np
@@ -234,10 +234,11 @@ class TestLinearLSQFitter:
     def test_chebyshev1D(self):
         """Tests fitting a 1D Chebyshev polynomial to some real world data."""
 
-        test_file = get_pkg_data_filename(os.path.join("data", "idcompspec.fits"))
-        with open(test_file) as f:
-            lines = f.read()
-            reclist = lines.split("begin")
+        reclist = (
+            Path(get_pkg_data_filename("data/idcompspec.fits"))
+            .read_text()
+            .split("begin")
+        )
 
         record = irafutil.IdentifyRecord(reclist[1])
         coeffs = record.coeff

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -7,6 +7,7 @@ Tests models.parameters
 import functools
 import itertools
 import unittest.mock as mk
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -244,11 +245,9 @@ class TestParameters:
 
         Create also a gaussian model.
         """
-        test_file = get_pkg_data_filename("data/idcompspec.fits")
-        f = open(test_file)
-        lines = f.read()
+        test_file = Path(get_pkg_data_filename("data/idcompspec.fits"))
+        lines = test_file.read_text()
         reclist = lines.split("begin")
-        f.close()
         record = irafutil.IdentifyRecord(reclist[1])
         self.icoeff = record.coeff
         order = int(record.fields["order"])

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -2,10 +2,10 @@
 
 """Tests for polynomial models."""
 # pylint: disable=invalid-name
-import os
 import unittest.mock as mk
 import warnings
 from itertools import product
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -351,8 +351,8 @@ def test_polynomial_init_with_constraints(model_class):
 
 def test_sip_hst():
     """Test SIP against astropy.wcs"""
-
-    test_file = get_pkg_data_filename(os.path.join("data", "hst_sip.hdr"))
+    test_file_path = Path("data") / "hst_sip.hdr"
+    test_file = get_pkg_data_filename(test_file_path)
     hdr = fits.Header.fromtextfile(test_file)
     crpix1 = hdr["CRPIX1"]
     crpix2 = hdr["CRPIX2"]
@@ -442,8 +442,8 @@ def test_sip_hst():
 
 def test_sip_irac():
     """Test forward and inverse SIP against astropy.wcs"""
-
-    test_file = get_pkg_data_filename(os.path.join("data", "irac_sip.hdr"))
+    test_file_path = Path("data") / "irac_sip.hdr"
+    test_file = get_pkg_data_filename(test_file_path)
     hdr = fits.Header.fromtextfile(test_file)
     crpix1 = hdr["CRPIX1"]
     crpix2 = hdr["CRPIX2"]

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -2,8 +2,8 @@
 
 """Test sky projections defined in WCS Paper II"""
 # pylint: disable=invalid-name, no-member
-import os
 import unittest.mock as mk
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -34,7 +34,7 @@ def test_Projection_properties():
 
 PIX_COORDINATES = [-10, 30]
 
-MAPS_DIR = os.path.join(os.pardir, os.pardir, "wcs", "tests", "data", "maps")
+MAPS_DIR = Path(__file__).parents[2] / "wcs" / "tests" / "data" / "maps"
 
 pars = [(x,) for x in projections.projcodes]
 # There is no groundtruth file for the XPH projection available here:
@@ -46,7 +46,7 @@ pars.remove(("XPH",))
 def test_Sky2Pix(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
+    wcs_map = MAPS_DIR / f"1904-66_{code}.hdr"
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
@@ -75,7 +75,7 @@ def test_Sky2Pix(code):
 def test_Pix2Sky(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
+    wcs_map = MAPS_DIR / f"1904-66_{code}.hdr"
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
@@ -103,7 +103,7 @@ def test_Pix2Sky(code):
 def test_Sky2Pix_unit(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
+    wcs_map = MAPS_DIR / f"1904-66_{code}.hdr"
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
@@ -130,7 +130,7 @@ def test_Sky2Pix_unit(code):
 def test_Pix2Sky_unit(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
+    wcs_map = MAPS_DIR / f"1904-66_{code}.hdr"
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
@@ -180,7 +180,7 @@ class TestZenithalPerspective:
 
     def setup_class(self):
         ID = "AZP"
-        wcs_map = os.path.join(MAPS_DIR, f"1904-66_{ID}.hdr")
+        wcs_map = MAPS_DIR / f"1904-66_{ID}.hdr"
         test_file = get_pkg_data_filename(wcs_map)
         header = fits.Header.fromfile(test_file, endcard=False, padding=False)
         self.wazp = wcs.WCS(header)
@@ -226,7 +226,7 @@ class TestCylindricalPerspective:
 
     def setup_class(self):
         ID = "CYP"
-        wcs_map = os.path.join(MAPS_DIR, f"1904-66_{ID}.hdr")
+        wcs_map = MAPS_DIR / f"1904-66_{ID}.hdr"
         test_file = get_pkg_data_filename(wcs_map)
         header = fits.Header.fromfile(test_file, endcard=False, padding=False)
         self.wazp = wcs.WCS(header)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import textwrap
 from contextlib import nullcontext
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -1103,7 +1103,7 @@ def test_sliced_ccdata_to_hdu():
 def test_read_write_tilde_paths(home_is_tmpdir):
     # Test for reading and writing to tilde-prefixed paths without errors
     ccd_data = create_ccd_data()
-    filename = os.path.join("~", "test.fits")
+    filename = Path("~") / "test.fits"
     ccd_data.write(filename)
 
     ccd_disk = CCDData.read(filename, unit=ccd_data.unit)
@@ -1111,7 +1111,7 @@ def test_read_write_tilde_paths(home_is_tmpdir):
 
     # Ensure the unexpanded path doesn't exist (e.g. no directory whose name is
     # a literal ~ was created)
-    assert not os.path.exists(filename)
+    assert not filename.exists()
 
 
 def test_ccddata_with_psf():

--- a/astropy/stats/setup_package.py
+++ b/astropy/stats/setup_package.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-import os
+from pathlib import Path
 
 from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
-ROOT = os.path.relpath(os.path.dirname(__file__))
+ROOT = Path(__file__).parent.resolve().relative_to(Path.cwd())
 SRCFILES = ["wirth_select.c", "compute_bounds.c", "fast_sigma_clip.c"]
-SRCFILES = [os.path.join(ROOT, "src", srcfile) for srcfile in SRCFILES]
+SRCFILES = [str(ROOT / "src" / srcfile) for srcfile in SRCFILES]
 
 
 def get_extensions():
@@ -21,7 +20,7 @@ def get_extensions():
     _stats_ext = Extension(
         name="astropy.stats._stats",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-        sources=[os.path.join(ROOT, "_stats.pyx")],
+        sources=[str(ROOT / "_stats.pyx")],
         include_dirs=[get_numpy_include()],
     )
 

--- a/astropy/time/setup_package.py
+++ b/astropy/time/setup_package.py
@@ -2,16 +2,14 @@
 
 # Copied from astropy/convolution/setup_package.py
 
-import os
+from pathlib import Path
 
 from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
-C_TIME_PKGDIR = os.path.relpath(os.path.dirname(__file__))
+C_TIME_PKGDIR = Path(__file__).parent.resolve().relative_to(Path.cwd())
 
-SRC_FILES = [
-    os.path.join(C_TIME_PKGDIR, filename) for filename in ["src/parse_times.c"]
-]
+SRC_FILES = [str(C_TIME_PKGDIR / "src" / "parse_times.c")]
 
 
 def get_extensions():

--- a/astropy/timeseries/periodograms/bls/setup_package.py
+++ b/astropy/timeseries/periodograms/bls/setup_package.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
+from pathlib import Path
 
 from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
-BLS_ROOT = os.path.relpath(os.path.dirname(__file__))
+BLS_ROOT = Path(__file__).parent.resolve().relative_to(Path.cwd())
 
 
 def get_extensions():
@@ -13,8 +13,8 @@ def get_extensions():
         "astropy.timeseries.periodograms.bls._impl",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[
-            os.path.join(BLS_ROOT, "bls.c"),
-            os.path.join(BLS_ROOT, "_impl.pyx"),
+            str(BLS_ROOT / "bls.c"),
+            str(BLS_ROOT / "_impl.pyx"),
         ],
         include_dirs=[get_numpy_include()],
     )

--- a/astropy/timeseries/periodograms/lombscargle/setup_package.py
+++ b/astropy/timeseries/periodograms/lombscargle/setup_package.py
@@ -1,18 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
+from pathlib import Path
 
 from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
-ROOT = os.path.relpath(os.path.dirname(__file__))
+ROOT = Path(__file__).parent.resolve().relative_to(Path.cwd())
 
 
 def get_extensions():
     ext = Extension(
         "astropy.timeseries.periodograms.lombscargle.implementations.cython_impl",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-        sources=[os.path.join(ROOT, "implementations", "cython_impl.pyx")],
+        sources=[str(ROOT / "implementations" / "cython_impl.pyx")],
         include_dirs=[get_numpy_include()],
     )
     return [ext]

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -12,6 +12,7 @@ celestial-to-terrestrial coordinate transformations
 import os
 import re
 from datetime import datetime, timezone
+from pathlib import Path
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -256,6 +257,9 @@ class IERS(QTable):
         For the IERS class itself, an IERS_B sub-class instance is opened.
 
         """
+        # FIXME: We shouldn't need to do this
+        if isinstance(file, Path):
+            file = str(file)
         if file is not None or cls.iers_table is None:
             if file is not None:
                 if urlparse(file).netloc:

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import warnings
+from pathlib import Path
 
 from astropy import log
 from astropy.io.fits import getdata
@@ -33,12 +33,12 @@ def fits2bitmap(
 
     Parameters
     ----------
-    filename : str
+    filename : str | PathLike
         The filename of the FITS file.
     ext : int
         FITS extension name or number of the image to convert. The
         default is 0.
-    out_fn : str
+    out_fn : str | PathLike
         The filename of the output bitmap image. The type of bitmap is
         determined by the filename extension (e.g. '.jpg', '.png'). The
         default is a PNG file with the same name as the FITS file.
@@ -100,14 +100,17 @@ def fits2bitmap(
     if image.ndim != 2:
         log.critical(f"data in FITS extension {ext} is not a 2D array")
 
-    if out_fn is None:
-        out_fn = os.path.splitext(filename)[0]
-        if out_fn.endswith(".fits"):
-            out_fn = os.path.splitext(out_fn)[0]
-        out_fn += ".png"
+    filename = Path(filename)
 
-    # explicitly define the output format
-    out_format = os.path.splitext(out_fn)[1][1:]
+    if out_fn is None:
+        out_fn = filename.with_suffix("")
+        # If the filename ends with .fits.*, remove the * extension.
+        if out_fn.suffix == ".fits":
+            out_fn = out_fn.with_suffix("")
+        out_fn = out_fn.with_suffix(out_fn.suffix + ".png")
+    else:
+        out_fn = Path(out_fn)
+    out_format = out_fn.suffix[1:]
 
     try:
         if minversion(mpl, "3.5"):

--- a/astropy/wcs/__init__.py
+++ b/astropy/wcs/__init__.py
@@ -33,6 +33,6 @@ def get_include():
     """
     Get the path to astropy.wcs's C header files.
     """
-    import os
+    from pathlib import Path
 
-    return os.path.join(os.path.dirname(__file__), "include")
+    return Path(__file__).parent / "include"

--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
 import pickle
 from contextlib import nullcontext
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -36,7 +36,7 @@ def test_dist():
         )
 
     with get_pkg_data_fileobj(
-        os.path.join("data", "dist.fits"), encoding="binary"
+        Path("data") / "dist.fits", encoding="binary"
     ) as test_file:
         hdulist = fits.open(test_file)
         # The use of ``AXISCORR`` for D2IM correction has been deprecated
@@ -57,7 +57,7 @@ def test_dist():
 
 def test_sip():
     with get_pkg_data_fileobj(
-        os.path.join("data", "sip.fits"), encoding="binary"
+        Path("data") / "sip.fits", encoding="binary"
     ) as test_file:
         hdulist = fits.open(test_file, ignore_missing_end=True)
         with pytest.warns(FITSFixedWarning):
@@ -76,7 +76,7 @@ def test_sip():
 
 def test_sip2():
     with get_pkg_data_fileobj(
-        os.path.join("data", "sip2.fits"), encoding="binary"
+        Path("data") / "sip2.fits", encoding="binary"
     ) as test_file:
         hdulist = fits.open(test_file, ignore_missing_end=True)
         with pytest.warns(FITSFixedWarning):
@@ -96,9 +96,7 @@ def test_sip2():
 # Ignore "PV2_2 = 0.209028857410973 invalid keyvalue" warning seen on Windows.
 @pytest.mark.filterwarnings(r"ignore:PV2_2")
 def test_wcs():
-    header = get_pkg_data_contents(
-        os.path.join("data", "outside_sky.hdr"), encoding="binary"
-    )
+    header = get_pkg_data_contents(Path("data") / "outside_sky.hdr", encoding="binary")
 
     wcs1 = wcs.WCS(header)
     s = pickle.dumps(wcs1)

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -13,8 +13,7 @@ from astropy.wcs.wcs import FITSFixedWarning
 # use the base name of the file, because everything we yield
 # will show up in the test name in the pandokia report
 hdr_map_file_list = [
-    os.path.basename(fname)
-    for fname in get_pkg_data_filenames("data/maps", pattern="*.hdr")
+    Path(fname).name for fname in get_pkg_data_filenames("data/maps", pattern="*.hdr")
 ]
 
 # Checking the number of files before reading them in.
@@ -38,7 +37,7 @@ def test_read_map_files():
 
 @pytest.mark.parametrize("filename", hdr_map_file_list)
 def test_map(filename):
-    header = get_pkg_data_contents(os.path.join("data/maps", filename))
+    header = get_pkg_data_contents(Path("data") / "maps" / filename)
     wcsobj = wcs.WCS(header)
 
     with NumpyRNGContext(123456789):
@@ -48,7 +47,7 @@ def test_map(filename):
 
 
 hdr_spec_file_list = [
-    os.path.basename(fname)
+    Path(fname).name
     for fname in get_pkg_data_filenames("data/spectra", pattern="*.hdr")
 ]
 
@@ -67,7 +66,7 @@ def test_read_spec_files():
 
 @pytest.mark.parametrize("filename", hdr_spec_file_list)
 def test_spectrum(filename):
-    header = get_pkg_data_contents(os.path.join("data", "spectra", filename))
+    header = get_pkg_data_contents(Path("data") / "spectra" / filename)
     # Warning only pops up for one of the inputs.
     with pytest.warns() as warning_lines:
         wcsobj = wcs.WCS(header)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import io
-import os
 from contextlib import nullcontext
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -75,10 +75,10 @@ class TestMaps:
         for filename in self._file_list:
             # use the base name of the file, so we get more useful messages
             # for failing tests.
-            filename = os.path.basename(filename)
+            filename = Path(filename).name
             # Now find the associated file in the installed wcs test directory.
             header = get_pkg_data_contents(
-                os.path.join("data", "maps", filename), encoding="binary"
+                Path("data") / "maps" / filename, encoding="binary"
             )
             # finally run the test.
             wcsobj = wcs.WCS(header)
@@ -109,10 +109,10 @@ class TestSpectra:
         for filename in self._file_list:
             # use the base name of the file, so we get more useful messages
             # for failing tests.
-            filename = os.path.basename(filename)
+            filename = Path(filename).name
             # Now find the associated file in the installed wcs test directory.
             header = get_pkg_data_contents(
-                os.path.join("data", "spectra", filename), encoding="binary"
+                Path("data/spectra") / filename, encoding="binary"
             )
             # finally run the test.
             if _WCSLIB_VER >= Version("7.4"):
@@ -468,8 +468,7 @@ def test_find_all_wcs_crash():
     """
     Causes a double free without a recent fix in wcslib_wrap.C
     """
-    with open(get_pkg_data_filename("data/too_many_pv.hdr")) as fd:
-        header = fd.read()
+    header = Path(get_pkg_data_filename("data/too_many_pv.hdr")).read_text()
     # We have to set fix=False here, because one of the fixing tasks is to
     # remove redundant SCAMP distortion parameters when SIP distortion
     # parameters are also present.
@@ -495,7 +494,7 @@ def test_validate():
         filename = "data/validate.5.0.txt"
     else:
         filename = "data/validate.txt"
-    with open(get_pkg_data_filename(filename)) as fd:
+    with open(get_pkg_data_filename(filename)) as fd:  # noqa: PTH123
         lines = fd.readlines()
     assert sorted({x.strip() for x in lines}) == results_txt
 
@@ -584,7 +583,7 @@ def test_all_world2pix(
     if fname is None:
         fname = get_pkg_data_filename("data/j94f05bgq_flt.fits")
         ext = ("SCI", 1)
-    if not os.path.isfile(fname):
+    if not Path(fname).is_file():
         raise OSError(f"Input file '{fname:s}' to 'test_all_world2pix' not found.")
     h = fits.open(fname)
     w = wcs.WCS(h[ext].header, h)
@@ -739,8 +738,7 @@ def test_footprint_to_file(tmp_path):
     testfile = tmp_path / "test.txt"
     w.footprint_to_file(testfile)
 
-    with open(testfile) as f:
-        lines = f.readlines()
+    lines = testfile.read_text().splitlines(keepends=True)
 
     assert len(lines) == 4
     assert lines[2] == "ICRS\n"
@@ -748,8 +746,7 @@ def test_footprint_to_file(tmp_path):
 
     w.footprint_to_file(testfile, coordsys="FK5", color="red")
 
-    with open(testfile) as f:
-        lines = f.readlines()
+    lines = testfile.read_text().splitlines(keepends=True)
 
     assert len(lines) == 4
     assert lines[2] == "FK5\n"
@@ -962,12 +959,8 @@ def test_no_iteration():
     _wcs.__version__[0] < "5", reason="TPV only works with wcslib 5.x or later"
 )
 def test_sip_tpv_agreement():
-    sip_header = get_pkg_data_contents(
-        os.path.join("data", "siponly.hdr"), encoding="binary"
-    )
-    tpv_header = get_pkg_data_contents(
-        os.path.join("data", "tpvonly.hdr"), encoding="binary"
-    )
+    sip_header = get_pkg_data_contents(Path("data") / "siponly.hdr", encoding="binary")
+    tpv_header = get_pkg_data_contents(Path("data") / "tpvonly.hdr", encoding="binary")
 
     if PYTEST_LT_8_0:
         ctx = nullcontext()
@@ -1004,10 +997,10 @@ def test_sip_tpv_agreement():
 
 def test_tpv_ctype_sip():
     sip_header = fits.Header.fromstring(
-        get_pkg_data_contents(os.path.join("data", "siponly.hdr"), encoding="binary")
+        get_pkg_data_contents(Path("data") / "siponly.hdr", encoding="binary")
     )
     tpv_header = fits.Header.fromstring(
-        get_pkg_data_contents(os.path.join("data", "tpvonly.hdr"), encoding="binary")
+        get_pkg_data_contents(Path("data") / "tpvonly.hdr", encoding="binary")
     )
     sip_header.update(tpv_header)
     sip_header["CTYPE1"] = "RA---TAN-SIP"
@@ -1035,10 +1028,10 @@ def test_tpv_ctype_sip():
 
 def test_tpv_ctype_tpv():
     sip_header = fits.Header.fromstring(
-        get_pkg_data_contents(os.path.join("data", "siponly.hdr"), encoding="binary")
+        get_pkg_data_contents(Path("data") / "siponly.hdr", encoding="binary")
     )
     tpv_header = fits.Header.fromstring(
-        get_pkg_data_contents(os.path.join("data", "tpvonly.hdr"), encoding="binary")
+        get_pkg_data_contents(Path("data") / "tpvonly.hdr", encoding="binary")
     )
     sip_header.update(tpv_header)
     sip_header["CTYPE1"] = "RA---TPV"
@@ -1066,10 +1059,10 @@ def test_tpv_ctype_tpv():
 
 def test_tpv_ctype_tan():
     sip_header = fits.Header.fromstring(
-        get_pkg_data_contents(os.path.join("data", "siponly.hdr"), encoding="binary")
+        get_pkg_data_contents(Path("data") / "siponly.hdr", encoding="binary")
     )
     tpv_header = fits.Header.fromstring(
-        get_pkg_data_contents(os.path.join("data", "tpvonly.hdr"), encoding="binary")
+        get_pkg_data_contents(Path("data") / "tpvonly.hdr", encoding="binary")
     )
     sip_header.update(tpv_header)
     sip_header["CTYPE1"] = "RA---TAN"
@@ -1138,9 +1131,7 @@ def test_car_sip_with_pv():
 def test_tpv_copy():
     # See #3904
 
-    tpv_header = get_pkg_data_contents(
-        os.path.join("data", "tpvonly.hdr"), encoding="binary"
-    )
+    tpv_header = get_pkg_data_contents(Path("data") / "tpvonly.hdr", encoding="binary")
 
     with pytest.warns(wcs.FITSFixedWarning):
         w_tpv = wcs.WCS(tpv_header)

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -1,5 +1,5 @@
 import abc
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -344,9 +344,9 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return WCSAxes, {"wcs": self}
 
 
-UCDS_FILE = os.path.join(os.path.dirname(__file__), "data", "ucds.txt")
-with open(UCDS_FILE) as f:
-    VALID_UCDS = {x.strip() for x in f.read().splitlines()[1:]}
+UCDS_FILE = Path(__file__).parent / "data" / "ucds.txt"
+
+VALID_UCDS = {x.strip() for x in UCDS_FILE.read_text().splitlines()[1:]}
 
 
 def validate_physical_types(physical_types):

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import hypothesis
 
@@ -65,8 +66,8 @@ hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", default))
 os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
 os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
 
-os.mkdir(os.path.join(os.environ["XDG_CONFIG_HOME"], "astropy"))
-os.mkdir(os.path.join(os.environ["XDG_CACHE_HOME"], "astropy"))
+(Path(os.environ["XDG_CONFIG_HOME"]) / "astropy").mkdir()
+(Path(os.environ["XDG_CACHE_HOME"]) / "astropy").mkdir()
 
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,10 +150,11 @@ for line in metadata.requires("astropy"):
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
-with open("common_links.txt") as cl:
-    rst_epilog += cl.read().format(
-        minimum_python=__minimum_python_version__, **min_versions
-    )
+# with Path("common_links.txt").open() as cl:
+#     rst_epilog += cl.read().format(
+#         minimum_python=__minimum_python_version__, **min_versions
+#     )
+rst_epilog += Path("common_links.txt").read_text().format(minimum_python=__minimum_python_version__, **min_versions)
 
 # Manually register doctest options since matplotlib 3.5 messed up allowing them
 # from pytest-doctestplus
@@ -313,7 +314,7 @@ edit_on_github_branch = "main"
 nitpicky = True
 # See docs/nitpick-exceptions file for the actual listing.
 nitpick_ignore = []
-for line in open("nitpick-exceptions"):
+for line in open("nitpick-exceptions"): #noqa: PTH123
     if line.strip() == "" or line.startswith("#"):
         continue
     dtype, target = line.split(None, 1)

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,6 +7,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -16,8 +17,8 @@ import pytest
 os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
 os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
 
-os.mkdir(os.path.join(os.environ["XDG_CONFIG_HOME"], "astropy"))
-os.mkdir(os.path.join(os.environ["XDG_CACHE_HOME"], "astropy"))
+(Path(os.environ["XDG_CONFIG_HOME"]) / "astropy").mkdir()
+(Path(os.environ["XDG_CACHE_HOME"]) / "astropy").mkdir()
 
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the
@@ -34,7 +35,7 @@ def _docdir(request):
         # Don't apply this fixture to io.rst.  It reads files and doesn't write.
         # Implementation from https://github.com/pytest-dev/pytest/discussions/10437
         if "io.rst" not in request.node.name:
-            old_cwd = os.getcwd()
+            old_cwd = Path.cwd()
             tmp_path = request.getfixturevalue("tmp_path")
             os.chdir(tmp_path)
             yield


### PR DESCRIPTION
This PR starts work on making a unified i/o interface for reading and writing to disk. In some places using strings for filenames work, in other pathlib objects works too. We should be able to pass around `Path` objects all around the code. For a first go I want to make the `PTH` ruff flake8 linter happy.

As a start this fixes ruff complaints in couple of sub packages. Didn't want to make the PR too big.

Also want to check if this works with windows CI all fine. (`pathlib` has had some issues with windows from what I remember).

One way to go about https://github.com/astropy/astropy/issues/14893