### PR TITLE
MAINT: product/cumproduct/sometrue/alltrue is removed from numpy 2.0 dev

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -97,15 +97,18 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.apply_along_axis, np.take_along_axis, np.put_along_axis,
     np.linalg.cond, np.linalg.multi_dot,
 }  # fmt: skip
-SUBCLASS_SAFE_FUNCTIONS |= {  # Deprecated
-    np.product, np.cumproduct,  # noqa: NPY003
-}  # fmt: skip
 
 SUBCLASS_SAFE_FUNCTIONS |= {np.median}
 
 if NUMPY_LT_2_0:
     # functions (re)moved in numpy 2.0; alias for np.round in NUMPY_LT_1_25
-    SUBCLASS_SAFE_FUNCTIONS |= {np.msort, np.round_, np.trapz}  # noqa: NPY003, NPY201
+    SUBCLASS_SAFE_FUNCTIONS |= {
+        np.msort,
+        np.round_,  # noqa: NPY003, NPY201
+        np.trapz,
+        np.product,  # noqa: NPY003
+        np.cumproduct,  # noqa: NPY003
+    }
 else:
     # Array-API compatible versions (matrix axes always at end).
     SUBCLASS_SAFE_FUNCTIONS |= {
@@ -136,9 +139,11 @@ UNSUPPORTED_FUNCTIONS |= {
     np.busday_count, np.busday_offset, np.datetime_as_string,
     np.is_busday, np.all, np.any,
 }  # fmt: skip
-UNSUPPORTED_FUNCTIONS |= {  # Deprecated
-    np.sometrue, np.alltrue,  # noqa: NPY003
-}  # fmt: skip
+
+if NUMPY_LT_2_0:
+    UNSUPPORTED_FUNCTIONS |= {  # Deprecated
+        np.sometrue, np.alltrue,  # noqa: NPY003
+    }  # fmt: skip
 
 # Could be supported if we had a natural logarithm unit.
 UNSUPPORTED_FUNCTIONS |= {np.linalg.slogdet}

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -141,7 +141,7 @@ UNSUPPORTED_FUNCTIONS |= {
 }  # fmt: skip
 
 if NUMPY_LT_2_0:
-    UNSUPPORTED_FUNCTIONS |= {  # Deprecated
+    UNSUPPORTED_FUNCTIONS |= {  # removed in numpy 2.0
         np.sometrue, np.alltrue,  # noqa: NPY003
     }  # fmt: skip
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -675,12 +675,14 @@ class TestUfuncReductions(InvariantUnitTestSetup):
             np.all(self.q)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         with pytest.raises(TypeError):
             np.sometrue(self.q)  # noqa: NPY003
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         with pytest.raises(TypeError):
@@ -691,6 +693,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
             np.prod(self.q)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         with pytest.raises(u.UnitsError):
@@ -701,6 +704,9 @@ class TestUfuncReductions(InvariantUnitTestSetup):
             np.cumprod(self.q)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(
+        not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
+    )
     @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         with pytest.raises(u.UnitsError):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -674,14 +674,12 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(TypeError):
             np.all(self.q)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         with pytest.raises(TypeError):
             np.sometrue(self.q)  # noqa: NPY003
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
@@ -692,7 +690,6 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.prod(self.q)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
@@ -703,7 +700,6 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.cumprod(self.q)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(
         not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
     )
@@ -721,7 +717,6 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_round(self):
         self.check(np.round)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -619,11 +619,13 @@ class TestMethodLikes(MaskedArraySetup):
         self.check(np.all)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         self.check(np.sometrue, method="any")  # noqa: NPY003
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         self.check(np.alltrue, method="all")  # noqa: NPY003
@@ -632,6 +634,7 @@ class TestMethodLikes(MaskedArraySetup):
         self.check(np.prod)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         self.check(np.product, method="prod")  # noqa: NPY003
@@ -640,6 +643,9 @@ class TestMethodLikes(MaskedArraySetup):
         self.check(np.cumprod)
 
     # NUMPY_LT_1_25
+    @pytest.mark.skipif(
+        not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
+    )
     @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         self.check(np.cumproduct, method="cumprod")  # noqa: NPY003

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -618,13 +618,11 @@ class TestMethodLikes(MaskedArraySetup):
     def test_all(self):
         self.check(np.all)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         self.check(np.sometrue, method="any")  # noqa: NPY003
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
@@ -633,7 +631,6 @@ class TestMethodLikes(MaskedArraySetup):
     def test_prod(self):
         self.check(np.prod)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
@@ -642,7 +639,6 @@ class TestMethodLikes(MaskedArraySetup):
     def test_cumprod(self):
         self.check(np.cumprod)
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(
         not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
     )
@@ -653,7 +649,6 @@ class TestMethodLikes(MaskedArraySetup):
     def test_round(self):
         self.check(np.round, method="round")
 
-    # NUMPY_LT_1_25
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
     def test_round_(self):


### PR DESCRIPTION
The devdeps test started failing as product/cumproduct was recently removed from numpy's main branch.