### PR TITLE
DEPR: emit a `FutureWarning` when mutating `Time.location` post-initialization

### DIFF
--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -42,11 +42,14 @@ class TestFitsTime(FitsTestCase):
         columns in a ``Table``.
         """
         t = table_types()
-        t["a"] = Time(self.time, format="isot", scale="utc")
-        t["b"] = Time(self.time, format="isot", scale="tt")
-
         # Check that vectorized location is stored using Green Bank convention
-        t["a"].location = EarthLocation([1.0, 2.0], [2.0, 3.0], [3.0, 4.0], unit="Mm")
+        t["a"] = Time(
+            self.time,
+            format="isot",
+            scale="utc",
+            location=EarthLocation([1.0, 2.0], [2.0, 3.0], [3.0, 4.0], unit="Mm"),
+        )
+        t["b"] = Time(self.time, format="isot", scale="tt")
 
         with pytest.warns(
             AstropyUserWarning,
@@ -83,15 +86,19 @@ class TestFitsTime(FitsTestCase):
         assert tm["b"].location == t["b"].location
 
         # Check that multiple Time columns with different locations raise an exception
-        t["a"].location = EarthLocation(1, 2, 3)
-        t["b"].location = EarthLocation(2, 3, 4)
+        t["a"] = Time(
+            self.time, format="isot", scale="utc", location=EarthLocation(1, 2, 3)
+        )
+        t["b"] = Time(
+            self.time, format="isot", scale="tt", location=EarthLocation(2, 3, 4)
+        )
 
         with pytest.raises(ValueError) as err:
             table, hdr = time_to_fits(t)
             assert "Multiple Time Columns with different geocentric" in str(err.value)
 
         # Check that Time column with no location specified will assume global location
-        t["b"].location = None
+        t["b"] = Time(self.time, format="isot", scale="tt", location=None)
 
         with pytest.warns(
             AstropyUserWarning,
@@ -104,7 +111,9 @@ class TestFitsTime(FitsTestCase):
         assert len(w) == 1
 
         # Check that multiple Time columns with same location can be written
-        t["b"].location = EarthLocation(1, 2, 3)
+        t["b"] = Time(
+            self.time, format="isot", scale="tt", location=EarthLocation(1, 2, 3)
+        )
 
         table, hdr = time_to_fits(t)
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2883,3 +2883,17 @@ def test_timedelta_empty_quantity():
 
     with pytest.raises(ValueError, match="only quantities with time units"):
         TimeDelta([] * u.m)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "kwargs", [{}, dict(location=None), dict(location=EarthLocation(0, 0, 0))]
+)
+def test_immutable_location(kwargs):
+    # see https://github.com/astropy/astropy/issues/16061
+    loc = EarthLocation(0, 0, 0)
+    t = Time("2024-02-19", **kwargs)
+
+    with pytest.warns(FutureWarning):
+        # in the future, this should be an AttributeError
+        t.location = loc

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2885,7 +2885,6 @@ def test_timedelta_empty_quantity():
         TimeDelta([] * u.m)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "kwargs", [{}, dict(location=None), dict(location=EarthLocation(0, 0, 0))]
 )

--- a/docs/changes/time/16063.api.rst
+++ b/docs/changes/time/16063.api.rst
@@ -1,0 +1,1 @@
+A ``FutureWarning`` is now emitted when mutating ``Time.location`` post-initialization.


### PR DESCRIPTION
### Description
Fixes #16061

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
