### PR TITLE
TST: mark slow tests in astropy/time/tests

### DIFF
--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -696,7 +696,7 @@ def test_timedelta_conversion(scale1, scale2, jds_a, jds_b):
 
 # UTC disagrees when there are leap seconds
 _utc_bad = [
-    (pytest.param(s, marks=pytest.mark.xfail) if s == "utc" else s)
+    (pytest.param(s, marks=[pytest.mark.xfail, pytest.mark.slow]) if s == "utc" else s)
     for s in STANDARD_TIME_SCALES
 ]
 


### PR DESCRIPTION
I noticed that running `pytest astropy/time` took an inordinate amount of time (about 45s on my machine), as compared with most modules where all tests complete under 10s. Profiling with `pytest-timer` revealed that only 2 tests were actually responsible for about 80% of the execution time. Marking them as `slow` allows for quicker iterations.


### Functional testing

#### prerequisite
```shell
$ python -m pip install pytest-timer
```
In main:
```shell
$ pytest astropy/time --timer-top-n 5
=============================== test session starts ================================
...
=================================== pytest-timer ===================================
[fail] 41.17% astropy/time/tests/test_precision.py::test_datetime_to_timedelta[utc]: 17.1825s
[fail] 41.09% astropy/time/tests/test_precision.py::test_datetime_timedelta_roundtrip[utc]: 17.1473s
[success] 1.53% astropy/time/tests/test_precision.py::test_day_frac_always_less_than_half: 0.6388s
[success] 1.09% astropy/time/tests/test_precision.py::test_sidereal_lat_independent[mean]: 0.4569s
[success] 1.01% astropy/time/tests/test_precision.py::test_sidereal_lon_independent[mean]: 0.4229s
=================== 923 passed, 34 skipped, 9 xfailed in 42.99s ====================
```
In this branch
```shell
$ pytest astropy/time --timer-top-n 5
=============================== test session starts ================================
...
=================================== pytest-timer ===================================
[success] 9.14% astropy/time/tests/test_precision.py::test_day_frac_always_less_than_half: 0.5938s
[success] 5.91% astropy/time/tests/test_precision.py::test_sidereal_lat_independent[mean]: 0.3841s
[success] 5.21% astropy/time/tests/test_precision.py::test_abs_jd2_always_less_than_half_on_construction: 0.3383s
[success] 5.03% astropy/time/tests/test_precision.py::test_sidereal_lat_independent[apparent]: 0.3268s
[success] 5.01% astropy/time/tests/test_precision.py::test_sidereal_lon_independent[mean]: 0.3257s
==================== 923 passed, 40 skipped, 3 xfailed in 7.42s ====================
```
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
