### PR TITLE
BUG: make report_diff_values returns consistent (ignoring terminal size)

### DIFF
--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -47,6 +47,18 @@ def diff_values(a, b, rtol=0.0, atol=0.0):
         return a != b
 
 
+def _ignore_astropy_terminal_size(func):
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
+        from astropy import conf
+
+        with conf.set_temp("max_width", -1), conf.set_temp("max_lines", -1):
+            return func(*args, **kwargs)
+
+    return inner
+
+
+@_ignore_astropy_terminal_size
 def report_diff_values(a, b, fileobj=sys.stdout, indent_width=0, rtol=0.0, atol=0.0):
     """
     Write a diff report between two values to the specified file-like object.

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -145,6 +145,17 @@ NEW     2018-05-08   nan    9.0""",
     assert report_diff_values(a, a, fileobj=f)
 
 
+def test_large_table_diff():
+    # see https://github.com/astropy/astropy/issues/14010
+    colnames = [f"column{i}" for i in range(100)]
+    t1 = Table(names=colnames)
+
+    colnames.insert(50, "test")
+    t2 = Table(names=colnames)
+
+    assert not report_diff_values(t1, t2, fileobj=io.StringIO())
+
+
 @pytest.mark.parametrize("kwargs", [{}, {"atol": 0, "rtol": 0}])
 def test_where_not_allclose(kwargs):
     a = np.array([1, np.nan, np.inf, 4.5])

--- a/docs/changes/utils/16065.bugfix.rst
+++ b/docs/changes/utils/16065.bugfix.rst
@@ -1,0 +1,2 @@
+Update ``report_diff_values`` so the diff no longer depends on the
+console terminal size.


### PR DESCRIPTION
### Description

Fixes #14010 in a backportable fashion as suggested by @taldcroft. This puts the context manager in a decorator to minimize the diff.
Broader changes are to be discussed in #15828 and should probably be defered to the next major version.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
