### PR TITLE
TST: follow numpy/pytest traceback conventions in assert_quantity_allclose test helper function

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -199,6 +199,7 @@ def assert_quantity_allclose(actual, desired, rtol=1.0e-7, atol=None, **kwargs):
 
     from astropy.units.quantity import _unquantify_allclose_arguments
 
+    __tracebackhide__ = True
     np.testing.assert_allclose(
         *_unquantify_allclose_arguments(actual, desired, rtol, atol), **kwargs
     )


### PR DESCRIPTION
### Description
Conventionally, `numpy.testing.assert_*` functions are hidden in pytest tracebacks.
I noticed that this helper function wasn't, despite being evidently inspired from `numpy.testing`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
