### PR TITLE
TST: follow numpy/pytest traceback conventions in simple assert_* test helper functions

### DIFF
--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -90,6 +90,7 @@ def assert_floatclose(x, y):
     """
     # The number used is set by the fact that the Windows FFT sometimes
     # returns an answer that is EXACTLY 10*np.spacing.
+    __tracebackhide__ = True
     assert_allclose(x, y, atol=10 * np.spacing(x.max()), rtol=0.0)
 
 

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -30,6 +30,7 @@ from astropy.tests.helper import assert_quantity_allclose, quantity_allclose
 
 
 def assert_representation_allclose(actual, desired, rtol=1.0e-7, atol=None, **kwargs):
+    __tracebackhide__ = True
     actual_xyz = actual.to_cartesian().get_xyz(xyz_axis=-1)
     desired_xyz = desired.to_cartesian().get_xyz(xyz_axis=-1)
     actual_xyz, desired_xyz = np.broadcast_arrays(actual_xyz, desired_xyz, subok=True)

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -35,3 +35,8 @@ def assert_almost_equal(a, b, **kwargs):
 
 def assert_true(a):
     assert a
+
+
+def assert_equal_splitlines(arg1, arg2):
+    __tracebackhide__ = True
+    assert arg1.splitlines() == arg2.splitlines()

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -40,6 +40,8 @@ def assert_table_equal(t1, t2, check_meta=False, rtol=1.0e-15, atol=1.0e-300):
     Test equality of all columns in a table, with stricter tolerances for
     float columns than the np.allclose default.
     """
+    __tracebackhide__ = True
+
     assert len(t1) == len(t2)
     assert t1.colnames == t2.colnames
     if check_meta:

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -9,11 +9,7 @@ import pytest
 from astropy.io import ascii
 from astropy.io.ascii.core import InconsistentTableError
 
-from .common import assert_almost_equal, assert_equal
-
-
-def assert_equal_splitlines(arg1, arg2):
-    assert_equal(arg1.splitlines(), arg2.splitlines())
+from .common import assert_almost_equal, assert_equal, assert_equal_splitlines
 
 
 def test_read_normal():

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -8,11 +8,7 @@ import astropy.units as u
 from astropy.io import ascii
 from astropy.table import QTable
 
-from .common import assert_almost_equal, assert_equal
-
-
-def assert_equal_splitlines(arg1, arg2):
-    assert_equal(arg1.splitlines(), arg2.splitlines())
+from .common import assert_almost_equal, assert_equal, assert_equal_splitlines
 
 
 def test_read_normal():

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -41,6 +41,7 @@ class TestImageFunctions(FitsTestCase):
 
     def test_constructor_ver_arg(self):
         def assert_ver_is(hdu, reference_ver):
+            __tracebackhide__ = True
             assert hdu.ver == reference_ver
             assert hdu.header["EXTVER"] == reference_ver
 

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -32,6 +32,7 @@ else:
 
 
 def assert_validate_schema(filename, version):
+    __tracebackhide__ = True
     if sys.platform.startswith("win"):
         return
 

--- a/astropy/nddata/_testing.py
+++ b/astropy/nddata/_testing.py
@@ -9,6 +9,7 @@ def assert_wcs_seem_equal(wcs1, wcs2):
     """Just checks a few attributes to make sure wcs instances seem to be
     equal.
     """
+    __tracebackhide__ = True
     if wcs1 is None and wcs2 is None:
         return
     assert wcs1 is not None

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -43,6 +43,7 @@ def main_col(request):
 
 
 def assert_col_equal(col, array):
+    __tracebackhide__ = True
     if isinstance(col, Time):
         assert np.all(col == Time(array, format="jyear"))
     else:

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -456,6 +456,7 @@ def assert_table_name_col_equal(t, name, col):
     """
     Assert all(t[name] == col), with special handling for known mixin cols.
     """
+    __tracebackhide__ = True
     if isinstance(col, coordinates.SkyCoord):
         assert np.all(t[name].ra == col.ra)
         assert np.all(t[name].dec == col.dec)

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -200,6 +200,7 @@ def assert_quantity_allclose(actual, desired, rtol=1.0e-7, atol=None, **kwargs):
 
     from astropy.units.quantity import _unquantify_allclose_arguments
 
+    __tracebackhide__ = True
     np.testing.assert_allclose(
         *_unquantify_allclose_arguments(actual, desired, rtol, atol), **kwargs
     )

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -23,6 +23,7 @@ needs_array_function = pytest.mark.xfail(
 
 def assert_time_all_equal(t1, t2):
     """Checks equality of shape and content."""
+    __tracebackhide__ = True
     assert t1.shape == t2.shape
     assert np.all(t1 == t2)
 

--- a/astropy/timeseries/periodograms/bls/tests/test_bls.py
+++ b/astropy/timeseries/periodograms/bls/tests/test_bls.py
@@ -23,6 +23,7 @@ def assert_allclose_blsresults(blsresult, other, **kwargs):
         The other results object to compare.
 
     """
+    __tracebackhide__ = True
     for k, v in blsresult.items():
         if k not in other:
             raise AssertionError(f"missing key '{k}'")

--- a/astropy/uncertainty/tests/test_containers.py
+++ b/astropy/uncertainty/tests/test_containers.py
@@ -29,10 +29,12 @@ from astropy.uncertainty import Distribution
 
 
 def assert_representation_equal(rep1, rep2):
+    __tracebackhide__ = True
     assert np.all(representation_equal(rep1, rep2))
 
 
 def assert_representation_allclose(rep1, rep2):
+    __tracebackhide__ = True
     result = True
     if type(rep1) is not type(rep2):
         return False

--- a/astropy/units/tests/test_quantity_info.py
+++ b/astropy/units/tests/test_quantity_info.py
@@ -19,6 +19,7 @@ def assert_info_equal(a, b, ignore=set()):
 
 
 def assert_no_info(a):
+    __tracebackhide__ = True
     assert "info" not in a.__dict__
 
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -20,6 +20,7 @@ from astropy.utils.masked import Masked, MaskedNDArray
 
 
 def assert_masked_equal(a, b):
+    __tracebackhide__ = True
     assert_array_equal(a.unmasked, b.unmasked)
     assert_array_equal(a.mask, b.mask)
 


### PR DESCRIPTION
### Description

Fixes #16071 and replaces #16069

Reviews:
- [ ] convolution - @keflavich 
- [x] coordinates
- [x] io.ascii
- [ ] io.fits - @saimn 
- ~io.misc~
- [x] io.votable
- [x] nddata - @mwcraig 
- [x] table
- [x] time
- [ ] timeseries - @astrofrog 
- [x] uncertainty - @mhvk 
- [x] units
- [x] utils.masked - @mhvk 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
