### PR TITLE
BUG: fix `Angle.to_string()` for angles in degrees represented in hms and angles in hours represented in dms

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -351,10 +351,6 @@ class Angle(SpecificTypeQuantity):
                 fields=fields,
             )
         else:
-            if sep != "fromunit":
-                raise ValueError(
-                    f"'{unit}' can not be represented in sexagesimal notation"
-                )
             func = ("{:g}" if precision is None else f"{{0:0.{precision}f}}").format
             # Don't add unit by default for decimal.
             # TODO: could we use Quantity.to_string() here?

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -307,7 +307,12 @@ class Angle(SpecificTypeQuantity):
 
         """
         if unit is None:
-            unit = self.unit
+            if sep == "dms":
+                unit = u.degree
+            elif sep == "hms":
+                unit = u.hourangle
+            else:
+                unit = self.unit
         else:
             unit = self._convert_unit_to_angle_unit(u.Unit(unit))
 

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -306,8 +306,10 @@ class Angle(SpecificTypeQuantity):
             will be an array with a unicode dtype.
 
         """
-        if decimal and sep in ("dms", "hms"):
-            raise ValueError(f"decimal mode cannot be combined with {sep=!r}.")
+        if decimal and sep != "fromunit":
+            raise ValueError(
+                f"With decimal=True, separator cannot be used (got {sep=!r})"
+            )
 
         if unit is None:
             if sep == "dms":

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -306,6 +306,9 @@ class Angle(SpecificTypeQuantity):
             will be an array with a unicode dtype.
 
         """
+        if decimal and sep in ("dms", "hms"):
+            raise ValueError(f"decimal mode cannot be combined with {sep=!r}.")
+
         if unit is None:
             if sep == "dms":
                 unit = u.degree

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -229,14 +229,14 @@ class Angle(SpecificTypeQuantity):
     def to_string(
         self,
         unit=None,
-        decimal=False,
-        sep="fromunit",
-        precision=None,
-        alwayssign=False,
-        pad=False,
-        fields=3,
-        format=None,
-    ):
+        decimal: bool = False,
+        sep: str = "fromunit",
+        precision: int | None = None,
+        alwayssign: bool = False,
+        pad: bool = False,
+        fields: int = 3,
+        format: str | None = None,
+    ) -> str:
         """A string representation of the angle.
 
         Parameters

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -400,16 +400,6 @@ def test_angle_to_string_seps(unit, sep, expected_string):
     assert a.to_string(sep=sep) == expected_string
 
 
-@pytest.mark.parametrize("unit, sep", [("deg", "dms"), ("hourangle", "hms")])
-def test_decimal_with_string_sep(unit, sep):
-    a = Angle(15, unit)
-    with pytest.raises(
-        ValueError,
-        match=f"decimal mode cannot be combined with sep='{sep}'",
-    ):
-        a.to_string(sep=sep, decimal=True)
-
-
 def test_angle_format_roundtripping():
     """
     Ensures that the string representation of an angle can be used to create a

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -388,9 +388,9 @@ def test_to_string_vector():
     [
         ("deg", "fromunit", "15d00m00s"),
         ("deg", "dms", "15d00m00s"),
-        pytest.param("deg", "hms", "1h00m00s", marks=pytest.mark.xfail),
+        ("deg", "hms", "1h00m00s"),
         ("hourangle", "fromunit", "15h00m00s"),
-        pytest.param("hourangle", "dms", "225d00m00s", marks=pytest.mark.xfail),
+        ("hourangle", "dms", "225d00m00s"),
         ("hourangle", "hms", "15h00m00s"),
     ],
 )

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -400,6 +400,16 @@ def test_angle_to_string_seps(unit, sep, expected_string):
     assert a.to_string(sep=sep) == expected_string
 
 
+@pytest.mark.parametrize("unit, sep", [("deg", "dms"), ("hourangle", "hms")])
+def test_decimal_with_string_sep(unit, sep):
+    a = Angle(15, unit)
+    with pytest.raises(
+        ValueError,
+        match=f"decimal mode cannot be combined with sep='{sep}'",
+    ):
+        a.to_string(sep=sep, decimal=True)
+
+
 def test_angle_format_roundtripping():
     """
     Ensures that the string representation of an angle can be used to create a

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -383,6 +383,23 @@ def test_to_string_vector():
     assert Angle(1.0 / 7.0, unit="deg").to_string() == "0d08m34.28571429s"
 
 
+@pytest.mark.parametrize(
+    "unit, sep, expected_string",
+    [
+        ("deg", "fromunit", "15d00m00s"),
+        ("deg", "dms", "15d00m00s"),
+        pytest.param("deg", "hms", "1h00m00s", marks=pytest.mark.xfail),
+        ("hourangle", "fromunit", "15h00m00s"),
+        pytest.param("hourangle", "dms", "225d00m00s", marks=pytest.mark.xfail),
+        ("hourangle", "hms", "15h00m00s"),
+    ],
+)
+def test_angle_to_string_seps(unit, sep, expected_string):
+    # see https://github.com/astropy/astropy/issues/11280
+    a = Angle(15, unit)
+    assert a.to_string(sep=sep) == expected_string
+
+
 def test_angle_format_roundtripping():
     """
     Ensures that the string representation of an angle can be used to create a

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -2,6 +2,7 @@
 Tests the Angle string formatting capabilities.  SkyCoord formatting is in
 test_sky_coord
 """
+import numpy as np
 import pytest
 
 from astropy import units as u
@@ -55,8 +56,23 @@ def test_to_string_decimal():
     assert angle3.to_string(decimal=True, precision=1) == "4.0"
     assert angle3.to_string(decimal=True, precision=0) == "4"
 
-    with pytest.raises(ValueError, match="sexagesimal notation"):
-        angle3.to_string(decimal=True, sep="abc")
+
+@pytest.mark.parametrize("sep", [":", ":.", "dms", "hms"])
+@pytest.mark.parametrize(
+    "angle",
+    [
+        Angle(np.pi / 12, "rad"),
+        Angle(15, "deg"),
+        Angle(15, "hourangle"),
+    ],
+)
+def test_angle_to_string_decimal_with_sep_error(angle, sep):
+    # see https://github.com/astropy/astropy/pull/16085#discussion_r1501177163
+    with pytest.raises(
+        ValueError,
+        match=rf"With decimal=True, separator cannot be used \(got sep='{sep}'\)",
+    ):
+        angle.to_string(sep=sep, decimal=True)
 
 
 def test_to_string_formats():

--- a/docs/changes/coordinates/16085.bugfix.rst
+++ b/docs/changes/coordinates/16085.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``Angle.to_string()`` for angles in degrees represented in 'hms' and angles in hours represented in 'dms'.


### PR DESCRIPTION
### Description
One way to fix #11280
This is a minimal, backward compatible, test + fix, assuming that we want to embrace treating `sep='dms'` and `sep='hms'` as special cases, which we might not. It could be improved by letting the `unit` argument take the wheel when explicitly specified, as was suggested in the discussion, though the situation was very confusing at the time (and still is, to some extent), so I kept it simple for now, so we have a solid foundation to rekindle that discussion !


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
