### PR TITLE
PERF: optimize a hot path in `Angle.__new__`

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -189,7 +189,9 @@ class Angle(SpecificTypeQuantity):
         return super().__new__(cls, angle, unit, dtype=dtype, copy=copy, **kwargs)
 
     @staticmethod
+    @functools.cache
     def _convert_unit_to_angle_unit(unit):
+        # using caching to return early when possible (unit comparison is expensive)
         return u.hourangle if unit == u.hour else unit
 
     def _set_unit(self, unit):


### PR DESCRIPTION
### Description

This pull request is to address the first bottleneck in #13479

For comparison, I fed the following script through IPython (`ipython t.py -I`), then measured instance creation + init using `%timeit`
```python
# t.py
import astropy.units as u
import numpy as np
from astropy.coordinates.angles import Longitude, Latitude, Angle
values = np.random.uniform(-89, 89, 100)
```

here's what I get on main
```python
In [1]: %timeit u.Quantity(values, u.deg)
1.06 µs ± 5.44 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit Angle(values, u.deg)
13.9 µs ± 51.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit Latitude(values, u.deg)
21.8 µs ± 95 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit Longitude(values, u.deg)
33.4 µs ± 220 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
And this branch:
```python
In [1]: %timeit u.Quantity(values, u.deg)
1.05 µs ± 1.61 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit Angle(values, u.deg)
2.96 µs ± 17.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit Latitude(values, u.deg)
11.8 µs ± 41.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: %timeit Longitude(values, u.deg)
21.3 µs ± 194 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

it also seem to reduce the time needed to run `pytest astropy/coordinates` by ~15% on my machine (of course this isn't a very scientific benchmark)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
