### PR TITLE
BUG: Fix Binary2 serialization for VOTable

### DIFF
--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
@@ -53,6 +53,7 @@
      <OPTION name="bogus" value="whatever"/>
     </VALUES>
    </FIELD>
+   <FIELD ID="intNoNull" datatype="int" name="intNoNull"/>
    <FIELD ID="long" datatype="long" name="long">
     <VALUES ref="int_nulls"/>
     <LINK href="http://www.long-integers.com/"/>
@@ -121,6 +122,7 @@
       <TD>128</TD>
       <TD>4096</TD>
       <TD>268435456</TD>
+      <TD>3</TD>
       <TD>922337203685477</TD>
       <TD>8.9990234375</TD>
       <TD>1</TD>
@@ -151,6 +153,7 @@
       <TD>255</TD>
       <TD>32767</TD>
       <TD>2147483647</TD>
+      <TD>3</TD>
       <TD>123456789</TD>
       <TD>0</TD>
       <TD>0</TD>
@@ -181,6 +184,7 @@
       <TD>0</TD>
       <TD>-4096</TD>
       <TD>-268435456</TD>
+      <TD>3</TD>
       <TD>-1152921504606846976</TD>
       <TD>+InF</TD>
       <TD>+InF</TD>
@@ -211,6 +215,7 @@
       <TD>255</TD>
       <TD>32767</TD>
       <TD>268435455</TD>
+      <TD>3</TD>
       <TD>1152921504606846975</TD>
       <TD/>
       <TD>+InF</TD>
@@ -241,6 +246,7 @@
       <TD>255</TD>
       <TD>32767</TD>
       <TD>123456789</TD>
+      <TD>3</TD>
       <TD>123456789</TD>
       <TD>-InF</TD>
       <TD/>
@@ -281,6 +287,7 @@
        <TD>128</TD>
        <TD>4096</TD>
        <TD>268435456</TD>
+       <TD>3</TD>
        <TD>922337203685477</TD>
        <TD>8.9990234375</TD>
        <TD>1</TD>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -52,6 +52,7 @@
      <OPTION name="bogus" value="whatever"/>
     </VALUES>
    </FIELD>
+   <FIELD ID="intNoNull" datatype="int" name="intNoNull"/>
    <FIELD ID="long" datatype="long" name="long">
     <VALUES ref="int_nulls"/>
     <LINK href="http://www.long-integers.com/"/>
@@ -120,6 +121,7 @@
       <TD>128</TD>
       <TD>4096</TD>
       <TD>268435456</TD>
+      <TD>3</TD>
       <TD>922337203685477</TD>
       <TD>8.9990234375</TD>
       <TD>1</TD>
@@ -150,6 +152,7 @@
       <TD>255</TD>
       <TD>32767</TD>
       <TD>2147483647</TD>
+      <TD>3</TD>
       <TD/>
       <TD>0</TD>
       <TD>0</TD>
@@ -180,6 +183,7 @@
       <TD>0</TD>
       <TD>-4096</TD>
       <TD>-268435456</TD>
+      <TD>3</TD>
       <TD>-1152921504606846976</TD>
       <TD>+InF</TD>
       <TD>+InF</TD>
@@ -210,6 +214,7 @@
       <TD>255</TD>
       <TD>32767</TD>
       <TD>268435455</TD>
+      <TD>3</TD>
       <TD>1152921504606846975</TD>
       <TD/>
       <TD>+InF</TD>
@@ -240,6 +245,7 @@
       <TD>255</TD>
       <TD>32767</TD>
       <TD/>
+      <TD>3</TD>
       <TD/>
       <TD>-InF</TD>
       <TD/>
@@ -282,6 +288,7 @@
        <TD>128</TD>
        <TD>4096</TD>
        <TD>268435456</TD>
+       <TD>3</TD>
        <TD>922337203685477</TD>
        <TD>8.9990234375</TD>
        <TD>1</TD>

--- a/astropy/io/votable/tests/data/regression.xml
+++ b/astropy/io/votable/tests/data/regression.xml
@@ -56,6 +56,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   </VALUES>
   <IGNORE_ME/>
 </FIELD>
+<FIELD ID="intNoNull" datatype="int" name="intNoNull"/>
 <FIELD ID="long" name="long" datatype="long">
   <LINK href="http://www.long-integers.com/"/>
   <VALUES ref="int_nulls"/>
@@ -116,6 +117,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   <TD>128</TD>
   <TD>4096</TD>
   <TD>268435456</TD>
+  <TD>3</TD>
   <TD>922337203685477</TD>
   <TD>8.9990234375</TD>
   <TD encoding="base64">P4AAAA==</TD>
@@ -146,6 +148,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   <TD>256</TD> <!-- should overflow to 0 -->
   <TD>65536</TD> <!-- should overflow to 0-->
   <TD>2147483647</TD> <!-- overflowing here would raise a Numpy exception -->
+  <TD>3</TD>
   <TD></TD>
   <TD>1.0e-325</TD> <!-- underflow to 0 -->
   <TD>1.0e-46</TD> <!-- underflow to 0 -->
@@ -176,6 +179,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   <TD>-23</TD> <!-- negative, should wrap around to positive -->
   <TD>-4096</TD> <!-- negative, perfectly valid -->
   <TD>-268435456</TD> <!-- negative, perfectly valid -->
+  <TD>3</TD>
   <TD>-1152921504606846976</TD>  <!-- negative, perfectly valid -->
   <TD>1.0E309</TD>
   <TD>1.0E45</TD>
@@ -206,6 +210,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   <TD>0xff</TD> <!-- hex -->
   <TD>0xffff</TD> <!-- hex - negative value -->
   <TD>0xfffffff</TD>
+  <TD>3</TD>
   <TD>0xfffffffffffffff</TD>
   <TD>NaN</TD>
   <TD>+Inf</TD>
@@ -236,6 +241,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   <TD>0x100</TD> <!-- hex, overflow -->
   <TD>0x10000</TD> <!-- hex, overflow -->
   <TD/>
+  <TD>3</TD>
   <TD/>
   <TD>-Inf</TD>
   <TD/>
@@ -276,6 +282,7 @@ The VOTable format is an XML standard for the interchange of data represented as
   <TD>128</TD>
   <TD>4096</TD>
   <TD>268435456</TD>
+  <TD>3</TD>
   <TD>922337203685477</TD>
   <TD>8.9990234375</TD>
   <TD encoding="base64">P4AAAA==</TD>

--- a/astropy/io/votable/tests/data/validation.txt
+++ b/astropy/io/votable/tests/data/validation.txt
@@ -58,11 +58,11 @@ Validation report for regression.xml
   <IGNORE_ME/>
   ^
 
-97: W17: GROUP element contains more than one DESCRIPTION element
+98: W17: GROUP element contains more than one DESCRIPTION element
     This should warn of a second description.
 ^
 
-104: W01: Array uses commas rather than whitespace
+105: W01: Array uses commas rather than whitespace
   <PARAM datatype="float" name="INPUT3" value="0.000000,0.000000" a...
   ^
 
@@ -71,163 +71,163 @@ Validation report for regression.xml
 <FIELD ID="string_test" name="fixed string test" datatype="char" ar...
 ^
 
-112: W46: char value is too long for specified length of 10
+113: W46: char value is too long for specified length of 10
   <TD>Fixed string long test</TD> <!-- Should truncate -->
       ^
 
-114: W46: unicodeChar value is too long for specified length of 10
+115: W46: unicodeChar value is too long for specified length of 10
   <TD>Ceçi n'est pas un pipe</TD>
       ^
 
-115: W46: char value is too long for specified length of 4
+116: W46: char value is too long for specified length of 4
   <TD>ab cd</TD>
       ^
 
-134: E02: Incorrect number of elements in array. Expected multiple of
+136: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1
   <TD/>
   ^
 
-134: W49: Empty cell illegal for integer fields.
+136: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-142: W46: char value is too long for specified length of 10
+144: W46: char value is too long for specified length of 10
   <TD>0123456789A</TD>
       ^
 
-145: W46: char value is too long for specified length of 4
+147: W46: char value is too long for specified length of 4
   <TD>0123456789A</TD>
       ^
 
-146: W51: Value '256' is out of range for a 8-bit unsigned integer
+148: W51: Value '256' is out of range for a 8-bit unsigned integer
   field
   <TD>256</TD> <!-- should overflow to 0 -->
       ^
 
-147: W51: Value '65536' is out of range for a 16-bit integer field
+149: W51: Value '65536' is out of range for a 16-bit integer field
   <TD>65536</TD> <!-- should overflow to 0-->
       ^
 
-149: W49: Empty cell illegal for integer fields.
+152: W49: Empty cell illegal for integer fields.
   <TD></TD>
   ^
 
-152: W01: Array uses commas rather than whitespace
+155: W01: Array uses commas rather than whitespace
   <TD>42 32, 12 32</TD>
       ^
 
-168: E02: Incorrect number of elements in array. Expected multiple of
+171: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields.
+171: W49: Empty cell illegal for integer fields.
   <TD/>
   ^
 
-168: W49: Empty cell illegal for integer fields. (suppressing further
+171: W49: Empty cell illegal for integer fields. (suppressing further
   warnings of this type...)
   <TD/>
   ^
 
-174: W46: unicodeChar value is too long for specified length of 10
+177: W46: unicodeChar value is too long for specified length of 10
   <TD>0123456789A</TD>
       ^
 
-176: W51: Value '-23' is out of range for a 8-bit unsigned integer
+179: W51: Value '-23' is out of range for a 8-bit unsigned integer
   field
   <TD>-23</TD> <!-- negative, should wrap around to positive -->
       ^
 
-198: E02: Incorrect number of elements in array. Expected multiple of
+202: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
   ^
 
-207: W51: Value '65535' is out of range for a 16-bit integer field
+211: W51: Value '65535' is out of range for a 16-bit integer field
   <TD>0xffff</TD> <!-- hex - negative value -->
       ^
 
-212: W01: Array uses commas rather than whitespace
+217: W01: Array uses commas rather than whitespace
   <TD>NaN, 23</TD>
       ^
 
-214: E02: Incorrect number of elements in array. Expected multiple of
+219: E02: Incorrect number of elements in array. Expected multiple of
   6, got 0
   <TD/>
   ^
 
-222: E02: Incorrect number of elements in array. Expected multiple of
+227: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1
   <TD/>
   ^
 
-228: E02: Incorrect number of elements in array. Expected multiple of
+233: E02: Incorrect number of elements in array. Expected multiple of
   16, got 0
   <TD/>
   ^
 
-236: W51: Value '256' is out of range for a 8-bit unsigned integer
+241: W51: Value '256' is out of range for a 8-bit unsigned integer
   field
   <TD>0x100</TD> <!-- hex, overflow -->
       ^
 
-237: W51: Value '65536' is out of range for a 16-bit integer field
+242: W51: Value '65536' is out of range for a 16-bit integer field
   <TD>0x10000</TD> <!-- hex, overflow -->
       ^
 
-242: W01: Array uses commas rather than whitespace
+248: W01: Array uses commas rather than whitespace
   <TD>31, -1</TD>
       ^
 
-244: E02: Incorrect number of elements in array. Expected multiple of
+250: E02: Incorrect number of elements in array. Expected multiple of
   6, got 0
   <TD/>
   ^
 
-252: E02: Incorrect number of elements in array. Expected multiple of
+258: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1
   <TD/>
   ^
 
-254: E02: Incorrect number of elements in array. Expected multiple of
+260: E02: Incorrect number of elements in array. Expected multiple of
   4, got 1 (suppressing further warnings of this type...)
   <TD/>
   ^
 
-272: W46: char value is too long for specified length of 10
+278: W46: char value is too long for specified length of 10
   <TD>Fixed string long test</TD> <!-- Should truncate -->
       ^
 
-274: W46: unicodeChar value is too long for specified length of 10
+280: W46: unicodeChar value is too long for specified length of 10
   <TD>Ceçi n'est pas un pipe</TD>
       ^
 
-275: W46: char value is too long for specified length of 4
+281: W46: char value is too long for specified length of 4
   <TD>ab cd</TD>
       ^

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -78,6 +78,7 @@ def test_table(tmp_path):
         ("unsignedByte", {"datatype": "unsignedByte"}),
         ("short", {"datatype": "short"}),
         ("int", {"datatype": "int"}),
+        ("intNoNull", {"datatype": "int"}),
         ("long", {"datatype": "long"}),
         ("double", {"datatype": "double"}),
         ("float", {"datatype": "float"}),

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -783,7 +783,7 @@ class TestThroughBinary(TestParse):
         bio = io.BytesIO()
 
         # W31: NaN's can not be represented in integer field
-        with pytest.raises(W31):
+        with pytest.warns(W31):
             # https://github.com/astropy/astropy/issues/16090
             self.votable.to_xml(bio)
 

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -782,18 +782,19 @@ class TestThroughBinary2(TestParse):
             votable = parse(get_pkg_data_filename("data/regression.xml"))
         votable.version = "1.3"
         votable.get_first_table()._config["version_1_3_or_later"] = True
-        votable.get_first_table().format = "binary2"
+        
 
         self.xmlout = bio = io.BytesIO()
         # W39: Bit values can not be masked
-        with pytest.warns(W39):
-            votable.to_xml(bio)
+        # with pytest.warns(W39):
+        votable.to_xml(bio)
         bio.seek(0)
         self.votable = parse(bio)
-
+        self.votable.get_first_table().format = "binary2"
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
+        
 
     def test_get_coosys_by_id(self):
         # No COOSYS in VOTable 1.2 or later

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -19,7 +19,7 @@ from numpy.testing import assert_array_equal
 
 # LOCAL
 from astropy.io.votable import tree
-from astropy.io.votable.exceptions import W39, VOTableSpecError, VOWarning
+from astropy.io.votable.exceptions import W31, W39, VOTableSpecError, VOWarning
 from astropy.io.votable.table import parse, parse_single_table, validate
 from astropy.io.votable.xmlutil import validate_schema
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
@@ -60,7 +60,7 @@ def test_parse_single_table2():
         )
     assert isinstance(table2, tree.TableElement)
     assert len(table2.array) == 1
-    assert len(table2.array.dtype.names) == 28
+    assert len(table2.array.dtype.names) == 29
 
 
 def test_parse_single_table3():
@@ -85,6 +85,7 @@ def _test_regression(tmp_path, _python_based=False, binary_mode=1):
         ("unsignedByte", "|u1"),
         ("short", "<i2"),
         ("int", "<i4"),
+        ("intNoNull", "<i4"),
         ("long", "<i8"),
         ("double", "<f8"),
         ("float", "<f4"),
@@ -276,7 +277,7 @@ def test_select_missing_columns_error_message(columns, expected_missing):
 
 
 def test_select_columns_by_index():
-    columns = [0, 5, 13]
+    columns = [0, 5, 14]
     table = parse(
         get_pkg_data_filename("data/regression.xml"), columns=columns
     ).get_first_table()
@@ -774,6 +775,18 @@ class TestThroughBinary(TestParse):
     def test_bit_array2_mask(self):
         assert not np.any(self.mask["bitarray2"])
 
+    def test_null_integer_binary(self):
+        # BINARY1 requires magic value to be specified
+
+        self.array.mask["intNoNull"][0] = True
+
+        bio = io.BytesIO()
+
+        # W31: NaN's can not be represented in integer field
+        with pytest.raises(W31):
+            # https://github.com/astropy/astropy/issues/16090
+            self.votable.to_xml(bio)
+
 
 class TestThroughBinary2(TestParse):
     def setup_class(self):
@@ -798,6 +811,18 @@ class TestThroughBinary2(TestParse):
     def test_get_coosys_by_id(self):
         # No COOSYS in VOTable 1.2 or later
         pass
+
+    def test_null_integer_binary2(self):
+        # Integers with no magic values should still be
+        # masked in BINARY2 format
+
+        self.array.mask["intNoNull"][0] = True
+
+        table = self.votable.get_first_table()
+        array = table.array
+
+        assert array.mask["intNoNull"][0]
+        assert array["intNoNull"].mask[0]
 
 
 @pytest.mark.parametrize("format_", ["binary", "binary2"])

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -782,18 +782,16 @@ class TestThroughBinary2(TestParse):
             votable = parse(get_pkg_data_filename("data/regression.xml"))
         votable.version = "1.3"
         votable.get_first_table()._config["version_1_3_or_later"] = True
-        
+        votable.get_first_table().format = "binary2"
 
         self.xmlout = bio = io.BytesIO()
-        # W39: Bit values can not be masked
         votable.to_xml(bio)
         bio.seek(0)
         self.votable = parse(bio)
-        self.votable.get_first_table().format = "binary2"
+
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
-        
 
     def test_get_coosys_by_id(self):
         # No COOSYS in VOTable 1.2 or later

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -786,7 +786,6 @@ class TestThroughBinary2(TestParse):
 
         self.xmlout = bio = io.BytesIO()
         # W39: Bit values can not be masked
-        # with pytest.warns(W39):
         votable.to_xml(bio)
         bio.seek(0)
         self.votable = parse(bio)

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -785,7 +785,9 @@ class TestThroughBinary2(TestParse):
         votable.get_first_table().format = "binary2"
 
         self.xmlout = bio = io.BytesIO()
-        votable.to_xml(bio)
+        # W39: Bit values can not be masked
+        with pytest.warns(W39):
+            votable.to_xml(bio)
         bio.seek(0)
         self.votable = parse(bio)
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3354,7 +3354,9 @@ class TableElement(
                             if mode == 1:
                                 chunk = converter(array_row[i], array_mask[i])
                             else:
-                                chunk = converter(array_row[i], None) # mask is already handled
+                                chunk = converter(
+                                    array_row[i], None
+                                )  # mask is already handled
                             assert type(chunk) == bytes
                         except Exception as e:
                             vo_reraise(

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3344,7 +3344,6 @@ class TableElement(
                 for row in range(len(array)):
                     array_row = array.data[row]
                     array_mask = array.mask[row]
-
                     if mode == 2:
                         flattened = np.array([np.all(x) for x in array_mask])
                         data.write(converters.bool_to_bitarray(flattened))
@@ -3354,9 +3353,8 @@ class TableElement(
                             if mode == 1:
                                 chunk = converter(array_row[i], array_mask[i])
                             else:
-                                chunk = converter(
-                                    array_row[i], None
-                                )  # mask is already handled
+                                # Mask is already handled by BINARY2 behaviour
+                                chunk = converter(array_row[i], None)
                             assert type(chunk) == bytes
                         except Exception as e:
                             vo_reraise(

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3350,7 +3350,13 @@ class TableElement(
 
                     for i, converter in fields_basic:
                         try:
-                            if mode == 1:
+                            # BINARY2 cannot handle individual array element masks
+                            converter_type = converter.__self__.__class__
+                            # Delegate converter to handle the mask
+                            delegate_condition = issubclass(
+                                converter_type, converters.Array
+                            )
+                            if mode == 1 or delegate_condition:
                                 chunk = converter(array_row[i], array_mask[i])
                             else:
                                 # Mask is already handled by BINARY2 behaviour

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3351,7 +3351,10 @@ class TableElement(
 
                     for i, converter in fields_basic:
                         try:
-                            chunk = converter(array_row[i], array_mask[i])
+                            if mode == 1:
+                                chunk = converter(array_row[i], array_mask[i])
+                            else:
+                                chunk = converter(array_row[i], None) # mask is already handled
                             assert type(chunk) == bytes
                         except Exception as e:
                             vo_reraise(

--- a/docs/changes/io.votable/16091.bugfix.rst
+++ b/docs/changes/io.votable/16091.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure proper handling of null values during BINARY2 serialization. Previously, masks were handled in two different ways for BINARY2 serialization, resulting in incorrect handling of null values and errors.

--- a/docs/io/votable/16091.bugfix.rst
+++ b/docs/io/votable/16091.bugfix.rst
@@ -1,1 +1,1 @@
-Fix `TableElement._write_binary` method to ensure proper handling of null values during BINARY2 serialization.
+Ensure proper handling of null values during BINARY2 serialization. Previously, masks were handled in two different ways for BINARY2 serialization, resulting in incorrect handling of null values and errors.

--- a/docs/io/votable/16091.bugfix.rst
+++ b/docs/io/votable/16091.bugfix.rst
@@ -1,1 +1,0 @@
-Ensure proper handling of null values during BINARY2 serialization. Previously, masks were handled in two different ways for BINARY2 serialization, resulting in incorrect handling of null values and errors.

--- a/docs/io/votable/16091.bugfix.rst
+++ b/docs/io/votable/16091.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `TableElement._write_binary` method to ensure proper handling of null values during BINARY2 serialization.


### PR DESCRIPTION
### Description
(Fix #16090) - Looks like something possibly overlooked in the VOTable 1.3 support implementation

Error in question that was fixed: `astropy.io.votable.exceptions.W31: ?:?:?: W31: NaN given in an integral field without a specified null value`

In the `_write_binary` method, it seems we are ignoring the fact that the mask for binary2 serialization was already handled before unnecessarily passing the `array_mask` into the `converter.binoutput` method (making the handling useless). This causes an error that would make more sense to be shown in the case of a Binary serialization and not a Binary2 because the bit array indicating the mask is already written to the data stream.

I added a simple fix which just avoids passing a mask into converter.binoutput` methods when we are doing binary2 serialization.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
