### PR TITLE
MAINT: The __init__ cols argument should be set to None in TableColumns

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1011,7 +1011,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     searchsorted.__doc__ = np.ndarray.searchsorted.__doc__
 
-    def convert_unit_to(self, new_unit, equivalencies=None):
+    def convert_unit_to(self, new_unit, equivalencies=[]):
         """
         Converts the values of the column in-place from the current
         unit to the given unit.
@@ -1034,7 +1034,6 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         astropy.units.UnitsError
             If units are inconsistent
         """
-        equivalencies = [] if equivalencies is None else equivalencies
         if self.unit is None:
             raise ValueError("No unit set on column")
         self.data[:] = self.unit.to(new_unit, self.data, equivalencies=equivalencies)
@@ -1101,7 +1100,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             self, self.unit, copy=False, dtype=self.dtype, order="A", subok=True
         )
 
-    def to(self, unit, equivalencies=None, **kwargs):
+    def to(self, unit, equivalencies=[], **kwargs):
         """
         Converts this table column to a `~astropy.units.Quantity` object with
         the requested units.
@@ -1121,7 +1120,6 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             A quantity object with the contents of this column in the units
             ``unit``.
         """
-        equivalencies = [] if equivalencies is None else equivalencies
         return self.quantity.to(unit, equivalencies)
 
     def _copy_attrs(self, obj):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1011,7 +1011,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     searchsorted.__doc__ = np.ndarray.searchsorted.__doc__
 
-    def convert_unit_to(self, new_unit, equivalencies=[]):
+    def convert_unit_to(self, new_unit, equivalencies=None):
         """
         Converts the values of the column in-place from the current
         unit to the given unit.
@@ -1034,6 +1034,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         astropy.units.UnitsError
             If units are inconsistent
         """
+        equivalencies = [] if equivalencies is None else equivalencies
         if self.unit is None:
             raise ValueError("No unit set on column")
         self.data[:] = self.unit.to(new_unit, self.data, equivalencies=equivalencies)
@@ -1100,7 +1101,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             self, self.unit, copy=False, dtype=self.dtype, order="A", subok=True
         )
 
-    def to(self, unit, equivalencies=[], **kwargs):
+    def to(self, unit, equivalencies=None, **kwargs):
         """
         Converts this table column to a `~astropy.units.Quantity` object with
         the requested units.
@@ -1120,6 +1121,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             A quantity object with the contents of this column in the units
             ``unit``.
         """
+        equivalencies = [] if equivalencies is None else equivalencies
         return self.quantity.to(unit, equivalencies)
 
     def _copy_attrs(self, obj):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -239,7 +239,9 @@ class TableColumns(OrderedDict):
         Column objects as data structure that can init dict (see above)
     """
 
-    def __init__(self, cols={}):
+    def __init__(self, cols=None):
+        if cols is None:
+            cols = {}
         if isinstance(cols, (list, tuple)):
             # `cols` should be a list of two-tuples, but it is allowed to have
             # columns (BaseColumn or mixins) in the list.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -240,7 +240,8 @@ class TableColumns(OrderedDict):
     """
 
     def __init__(self, cols=None):
-        cols = {} if cols is None else cols
+        if cols is None:
+            cols = {}
         if isinstance(cols, (list, tuple)):
             # `cols` should be a list of two-tuples, but it is allowed to have
             # columns (BaseColumn or mixins) in the list.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -240,8 +240,7 @@ class TableColumns(OrderedDict):
     """
 
     def __init__(self, cols=None):
-        if cols is None:
-            cols = {}
+        cols = {} if cols is None else cols
         if isinstance(cols, (list, tuple)):
             # `cols` should be a list of two-tuples, but it is allowed to have
             # columns (BaseColumn or mixins) in the list.


### PR DESCRIPTION
While trying to debug https://github.com/astropy/astropy/issues/16089 I ran into this bit of code.

`def __init__(self, cols={}):` can have unintended consequences, not sure if there is a specific reason for this?