### PR TITLE
TST: Mark slow tests in astropy/samp

### DIFF
--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -19,6 +19,7 @@ def test_SAMPHubProxy():
     SAMPHubProxy()
 
 
+@pytest.mark.slow
 def test_SAMPClient():
     """Test that SAMPClient can be instantiated"""
     proxy = SAMPHubProxy()

--- a/astropy/samp/tests/test_hub.py
+++ b/astropy/samp/tests/test_hub.py
@@ -17,6 +17,7 @@ def test_SAMPHubServer():
     SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)
 
 
+@pytest.mark.slow
 def test_SAMPHubServer_run():
     """Test that SAMPHub can be run"""
     hub = SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)


### PR DESCRIPTION
### Description
A quick follow up to #16064
I found the 10 longest (non-slow, not parametrized) tests with `pytest astropy/ --timer-top-n 20` (with `pytest-timer`), which is also about the same set of tests that take
longer than a second on my machine (supposedly a pretty fast M2).
On my install, `pytest astropy` takes about 2'15 on main, and 1'55 with this branch, hence I claim that skipping those 10 tests (out of 24k) might save about 10% CI time. 


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
