### PR TITLE
PERF: reduce validation overhead in `Latitude._validate_angles`

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -621,7 +621,7 @@ class Latitude(Angle):
             # Otherwise, e.g., np.array(np.pi/2, 'f4') > np.pi/2 will yield True.
             angles_view = angles_view[np.newaxis]
 
-        invalid_angles = np.any(angles_view < -limit) or np.any(angles_view > limit)
+        invalid_angles = np.any(np.abs(angles_view) > limit)
         if invalid_angles:
             raise ValueError(
                 "Latitude angle(s) must be within -90 deg <= angle <= 90 deg, "

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -621,8 +621,7 @@ class Latitude(Angle):
             # Otherwise, e.g., np.array(np.pi/2, 'f4') > np.pi/2 will yield True.
             angles_view = angles_view[np.newaxis]
 
-        invalid_angles = np.any(np.abs(angles_view) > limit)
-        if invalid_angles:
+        if np.any(np.abs(angles_view) > limit):
             raise ValueError(
                 "Latitude angle(s) must be within -90 deg <= angle <= 90 deg, "
                 f"got {angles.to(u.degree)}"


### PR DESCRIPTION
### Description
Builds on top of #16088, also helps mitigating #13479
Specifically, this cuts about another 25 to 40% overhead on `Latitude` instantiation.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
