### PR TITLE
Address Ruff rule PLR0911 in `io`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -250,7 +250,6 @@ lint.unfixable = [
 "astropy/io/*" = [
     "G001",  # logging-string-format
     "G004",  # logging-f-string
-    "PLR0911",  # too-many-return-statements
     "PTH116",  # os-stat
     "PTH117",  # os-path-isabs
     "RET505",  # superfluous-else-return

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -1272,29 +1272,21 @@ def _format_value(value):
     if isinstance(value, str):
         if value == "":
             return "''"
-        else:
-            exp_val_str = value.replace("'", "''")
-            val_str = f"'{exp_val_str:8}'"
-            return f"{val_str:20}"
+        exp_val_str = value.replace("'", "''")
+        val_str = f"'{exp_val_str:8}'"
+        return f"{val_str:20}"
 
+    val_str = None
     # must be before int checking since bool is also int
-    elif isinstance(value, (bool, np.bool_)):
-        return f"{repr(value)[0]:>20}"  # T or F
-
+    if isinstance(value, (bool, np.bool_)):
+        val_str = repr(value)[0]  # T or F
     elif _is_int(value):
-        return f"{value:>20d}"
-
+        val_str = str(value)
     elif isinstance(value, (float, np.floating)):
-        return f"{_format_float(value):>20}"
-
+        val_str = _format_float(value)
     elif isinstance(value, (complex, np.complexfloating)):
         val_str = f"({_format_float(value.real)}, {_format_float(value.imag)})"
-        return f"{val_str:>20}"
-
-    elif isinstance(value, Undefined):
-        return ""
-    else:
-        return ""
+    return "" if val_str is None else f"{val_str:>20}"
 
 
 def _format_float(value):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1281,14 +1281,12 @@ class HDUList(list, _Verify):
 
         Returns True if a new HDU was loaded, or False otherwise.
         """
-        if self._read_all:
+        fileobj = self._file
+        if self._read_all or (fileobj is not None and fileobj.closed):
             return False
 
         saved_compression_enabled = compressed.COMPRESSION_ENABLED
-        fileobj, data, kwargs = self._file, self._data, self._open_kwargs
-
-        if fileobj is not None and fileobj.closed:
-            return False
+        data, kwargs = self._data, self._open_kwargs
 
         try:
             self._in_read_next_hdu = True


### PR DESCRIPTION
### Description

[PLR0911](https://docs.astral.sh/ruff/rules/too-many-return-statements/) guards against functions with very many return statements. The three functions in `astropy.io` violating that rule (which all happened to be in `io.fits`) have been updated. Two of them no longer violate the rule. The third has fewer return statements than before but still needs a [`noqa` instruction](https://docs.astral.sh/ruff/linter/#error-suppression). The updated code also has fewer violations of rules [C901](https://docs.astral.sh/ruff/rules/complex-structure/), [SIM108](https://docs.astral.sh/ruff/rules/if-else-block-instead-of-if-exp/), [SIM114](https://docs.astral.sh/ruff/rules/if-with-same-arms/), [PLR0912](https://docs.astral.sh/ruff/rules/too-many-branches/) and [RET505](https://docs.astral.sh/ruff/rules/superfluous-else-return/).

I was able to dedent a lot of code in `_convert_to_valid_data_type()`, so for reviewing the changes it might be helpful to tell Git to ignore lines where the only change was in their indentation level:
```
$ git diff --stat main 
 .ruff.toml                     |   1 -
 astropy/io/fits/card.py        |  26 +++++----------
 astropy/io/fits/column.py      | 115 ++++++++++++++++++++++++++++------------------------------------
 astropy/io/fits/hdu/hdulist.py |   8 ++---
 4 files changed, 62 insertions(+), 88 deletions(-)
$ git diff --stat --ignore-space-change main 
 .ruff.toml                     |  1 -
 astropy/io/fits/card.py        | 20 ++++++--------------
 astropy/io/fits/column.py      | 33 +++++++++------------------------
 astropy/io/fits/hdu/hdulist.py |  8 +++-----
 4 files changed, 18 insertions(+), 44 deletions(-)
```
[This option is also available in the GitHub UI](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#diff-view-options).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
