### PR TITLE
Add magnetic helicity as a physical type

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -69,6 +69,7 @@ _units_and_physical_types = [
     (si.C / si.m**3, "electrical charge density"),
     (si.F / si.m, "permittivity"),
     (si.Wb, "magnetic flux"),
+    (si.Wb**2, "magnetic helicity"),
     (si.T, "magnetic flux density"),
     (si.A / si.m, "magnetic field strength"),
     (si.m**2 * si.A, "magnetic moment"),

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -76,6 +76,7 @@ unit_physical_type_pairs = [
     (u.C / u.m**3, "electrical charge density"),
     (u.F / u.m, "permittivity"),
     (u.Wb, "magnetic flux"),
+    (u.Wb**2, "magnetic helicity"),
     (u.T, "magnetic flux density"),
     (u.A / u.m, "magnetic field strength"),
     (u.H / u.m, "electromagnetic field strength"),

--- a/docs/changes/units/16101.feature.rst
+++ b/docs/changes/units/16101.feature.rst
@@ -1,0 +1,1 @@
+Added magnetic helicity as a physical type.


### PR DESCRIPTION
[Magnetic helicity](https://en.wikipedia.org/wiki/Magnetic_helicity) is a conserved integral quantity in ideal magnetohydrodynamics that plays an important role in plasma physics.  This PR adds magnetic helicity as a physical type in `astropy.units.physical`.