### PR TITLE
DOC: use long-form command line options in contributing guidelines for better readability

### DIFF
--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -16,8 +16,8 @@ use cases you may have (see the examples below).
 .. note::
    Using JPL ephemerides requires that the `jplephem
    <https://pypi.org/project/jplephem/>`_ package be installed. This is
-   most conveniently achieved via ``pip install jplephem``, although whatever
-   package management system you use might have it as well.
+   most conveniently achieved via ``python -m pip install jplephem``, although
+   whatever package management system you use might have it as well.
 
 Two functions are provided; :func:`~astropy.coordinates.get_body` and
 :func:`~astropy.coordinates.get_body_barycentric`.

--- a/docs/development/building.rst
+++ b/docs/development/building.rst
@@ -51,4 +51,4 @@ from source in the ``conda`` environment in an OS-agnostic way. For example:
 * If you have not already, fetch all of the tags from the main repository.
   If you do not have the latest tag, your developer version number will be
   wrong.
-* Run ``pip install -e .`` to build ``astropy``.
+* Run ``python -m pip install --editable .`` to build ``astropy``.

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -169,7 +169,7 @@ To find the statistics and contributors, use the `generate_releaserst.xsh`_
 script. This requires `xonsh <https://xon.sh/>`_ and `docopt
 <http://docopt.org/>`_ which you can install with::
 
-   pip install xonsh docopt requests
+   python -m pip install xonsh docopt requests
 
 You should then run the script in the root of the astropy repository as follows::
 
@@ -275,8 +275,8 @@ You may also want to locally run the tests (with remote data on to ensure all
 of the tests actually run), using tox to do a thorough test in an isolated
 environment::
 
-   $ pip install tox --upgrade
-   $ tox -e test-alldeps -- --remote-data=any --run-slow --run-hugemem
+   python -m pip install tox --upgrade
+   tox -e test-alldeps -- --remote-data=any --run-slow --run-hugemem
 
 Additional notes
 ----------------

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -32,12 +32,12 @@ Astropy, in the ``pyproject.toml`` file they are not included under the
 ``[project.optional-dependences]`` section called ``test``.  Developers who want
 to run the test suite will need to either install pytest-astropy directly::
 
-    pip install pytest-astropy
+    python -m pip install pytest-astropy
 
 or install the core package in 'editable' mode specifying the ``[test]``
 option::
 
-    pip install -e ".[test]"
+    python -m pip install --editable ".[test]"
 
 A detailed description of the plugins can be found in the :ref:`pytest-plugins`
 section.
@@ -75,7 +75,7 @@ used in many cases to reproduce issues seen on those services.
 
 To run the tests with tox, first make sure that tox is installed, e.g.::
 
-    pip install tox
+    python -m pip install tox
 
 then run the basic test suite with::
 
@@ -121,13 +121,13 @@ which is generally faster than using tox for iterative development. In
 this case, it is important for developers to be aware that they must manually
 rebuild any extensions by running::
 
-    pip install -e ".[test]"
+    python -m pip install --editable ".[test]"
 
 before running the test with pytest with::
 
     pytest
 
-Instead of calling ``pip install -e ".[test]"``, you can also build the
+Instead of calling ``python -m pip install --editable ".[test]"``, you can also build the
 extensions with::
 
     python setup.py build_ext --inplace

--- a/docs/development/workflow/additional_git_topics.rst
+++ b/docs/development/workflow/additional_git_topics.rst
@@ -155,7 +155,7 @@ force push the branch; a normal push would give an error. If the branch you
 rebased is called ``cool-feature`` and your GitHub fork is available as the
 remote called ``origin``, you use this command to force-push::
 
-   git push -f origin cool-feature
+   git push --force origin cool-feature
 
 Note that this will overwrite the branch on GitHub, i.e. this is one of the few
 ways you can actually lose commits with git. Also note that it is never allowed

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -169,7 +169,7 @@ for git, for more information see
 We encourage you to setup and use these hooks to ensure that your code always meets
 our coding style standards. The easiest way to do this is by installing ``pre-commit``::
 
-    pip install pre-commit
+    python -m pip install pre-commit
 
 Or if you prefer `conda`_::
 
@@ -327,7 +327,7 @@ install the version of ``astropy`` you are working on into it. Do that with:
 
 .. code-block:: bash
 
-    pip install -e ".[test]"
+    python -m pip install --editable ".[test]"
 
 This will install ``astropy`` itself, along with a few packages which will be
 useful for testing the changes you will make down the road.

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -236,7 +236,7 @@ version you are using, try the command ``which pip`` on the terminal.
 
 In the directory where your copy of astropy is type::
 
-    pip install -e ".[test]"
+    python -m pip install --editable ".[test]"
 
 This command installs astropy itself, along with a few packages which will be
 useful for testing the changes you will make down the road. Several pages of

--- a/docs/development/workflow/git_edit_workflow_examples.rst
+++ b/docs/development/workflow/git_edit_workflow_examples.rst
@@ -59,7 +59,7 @@ Set up an isolated workspace
   The example below shows the necessary steps in the Miniconda/Anaconda Python
   distribution::
 
-    conda create -n apy-1761 python=3.9 # replace 3.9 with desired version
+    conda create --name apy-1761 python=3.9 # replace 3.9 with desired version
     conda activate apy-1761
 
   If you are using a different distribution, see :ref:`virtual_envs` for
@@ -67,16 +67,17 @@ Set up an isolated workspace
 
 + Install our branch in this environment with::
 
-    pip install -e ".[test]"
+    python -m pip install --editable ".[test]"
 
 Do you really have to set up a separate Python environment for each fix? No,
 but you definitely want to have a Python environment for your work on code
 contributions. Making new environments is fast, does not take much space, and
 provide a way to keep your work organized.
 
-If installation fails, try to upgrade ``pip`` using ``pip install pip -U``
-command. It is also a good practice to keep your ``conda`` up-to-date by
-running ``conda update conda -n base`` when prompted to do so; maybe ``git`` too.
+If installation fails, try to upgrade ``pip`` using
+``python -m pip install pip --upgrade`` command. It is also a good practice to
+keep your ``conda`` up-to-date by running ``conda update conda --name base``
+when prompted to do so; maybe ``git`` too.
 
 Test first, please
 ==================

--- a/docs/development/workflow/virtual_pythons.rst
+++ b/docs/development/workflow/virtual_pythons.rst
@@ -85,7 +85,7 @@ Set up for virtual environments
   + First, install `virtualenvwrapper`_, which will also install `virtualenv`_,
     with::
 
-        pip install --user virtualenvwrapper
+        python -m pip install --user virtualenvwrapper
 
   + From the `documentation for virtualenvwrapper`_, you also need to::
 
@@ -96,7 +96,7 @@ Set up for virtual environments
 * `pipenv`_: Install the ``pipenv`` command using your default pip (the
   pip in the default Python environment)::
 
-      pip install --user pipenv
+      python -m pip install --user pipenv
 
 .. _list_env:
 
@@ -150,7 +150,7 @@ environment.
     + Make an environment called ``ENV`` with all of the packages in your ``base``
       Miniconda environment::
 
-        conda create -n ENV
+        conda create --name ENV
 
     + More details, and examples that start with none of the packages from
       your default Python environment, are in the
@@ -202,7 +202,7 @@ environment.
       :ref:`get_devel` if you are unsure how to get the source code.  After
       running ``git clone <your-astropy-fork>`` run ``cd astropy/`` then::
 
-        pipenv install -e .
+        pipenv install --editable .
 
     + This both creates the virtual environment for the project
       automatically, and also installs all of Astropy's dependencies, and
@@ -293,7 +293,7 @@ directory in which the ``ENV`` is located; both also provide commands to
 make that a bit easier.  `pipenv`_ includes a command for deleting the
 virtual environment associated with the current directory:
 
-* `conda`_: ``conda remove --all -n ENV``
+* `conda`_: ``conda remove --all --name ENV``
 
 * `virtualenvwrapper`_: ``rmvirtualenv ENV``
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,22 +24,22 @@ Using pip
 
 To install ``astropy`` with `pip`_, run::
 
-    pip install astropy
+    python -m pip install astropy
 
 If you want to make sure none of your existing dependencies get upgraded, you
 can also do::
 
-    pip install astropy --no-deps
+    python -m pip install astropy --no-deps
 
 On the other hand, if you want to install ``astropy`` along with recommended
 or even all of the available optional :ref:`dependencies <astropy-main-req>`,
 you can do::
 
-    pip install astropy[recommended]
+    python -m pip install "astropy[recommended]"
 
 or::
 
-    pip install astropy[all]
+    python -m pip install "astropy[all]"
 
 In most cases, this will install a pre-compiled version (called a *wheel*) of
 astropy, but if you are using a very recent version of Python, if a new version
@@ -82,11 +82,11 @@ for the list of available versions with ``conda search astropy``.
 If you want to install ``astropy`` along with recommended or all of the
 available optional :ref:`dependencies <astropy-main-req>`, you can do::
 
-    conda install -c conda-forge -c defaults scipy matplotlib
+    conda install --channel conda-forge --channel defaults scipy matplotlib
 
 or::
 
-    conda install -c conda-forge -c defaults scipy matplotlib \
+    conda install --channel conda-forge --channel defaults scipy matplotlib \
       h5py beautifulsoup4 html5lib bleach pandas sortedcontainers \
       pytz setuptools mpmath bottleneck jplephem asdf-astropy pyarrow
 
@@ -94,7 +94,7 @@ To also be able to run tests (see below) and support :ref:`builddocs` use the
 following. We use ``pip`` for these packages to ensure getting the latest
 releases which are compatible with the latest ``pytest`` and ``sphinx`` releases::
 
-    pip install pytest-astropy sphinx-astropy
+    python -m pip install pytest-astropy sphinx-astropy
 
 .. warning::
 
@@ -323,13 +323,13 @@ Building and Installing
 
 To build and install ``astropy`` (from the root of the source tree)::
 
-    pip install .
+    python -m pip install .
 
 If you install in this way and you make changes to the code, you will need to
 re-run the install command for changes to be reflected. Alternatively, you can
 use::
 
-    pip install -e .
+    python -m pip install --editable .
 
 which installs ``astropy`` in develop/editable mode -- this then means that
 changes in the code are immediately reflected in the installed version.
@@ -341,14 +341,14 @@ If you get an error mentioning that you do not have the correct permissions to
 install ``astropy`` into the default ``site-packages`` directory, you can try
 installing with::
 
-    pip install . --user
+    python -m pip install --user .
 
 which will install into a default directory in your home directory.
 
 If you get an error directing use of option ``-std=c99`` or ``-std=gnu99``, you can try
 installing with::
 
-    CFLAGS='-std=c99' pip install -e .
+    CFLAGS='-std=c99' python -m pip install --editable .
 
 This is necessary for use with CentOS7.
 
@@ -367,11 +367,11 @@ the package.
 For example, to build ``astropy`` using the system's expat parser
 library, use::
 
-    ASTROPY_USE_SYSTEM_EXPAT=1 pip install -e .
+    ASTROPY_USE_SYSTEM_EXPAT=1 python -m pip install --editable .
 
 To build using all of the system libraries, use::
 
-    ASTROPY_USE_SYSTEM_ALL=1 pip install -e .
+    ASTROPY_USE_SYSTEM_ALL=1 python -m pip install --editable .
 
 The C libraries currently bundled with ``astropy`` include:
 
@@ -395,7 +395,7 @@ to find out what is currently being offered.
 
 Installing these "nightlies" of ``astropy`` can be achieved by using ``pip``::
 
-  $ pip install -U -i https://pypi.anaconda.org/astropy/simple astropy --pre
+  python -m pip install --upgrade --index-url https://pypi.anaconda.org/astropy/simple astropy --pre
 
 The extra index URL tells ``pip`` to check the ``pip`` index on
 pypi.anaconda.org, where the nightlies are stored, and the ``--pre`` command
@@ -427,17 +427,17 @@ documentation, you will need to make sure that a number of dependencies are
 installed. If you use conda, the easiest way to install the dependencies is
 with::
 
-    conda install -c conda-forge sphinx-astropy
+    conda install --channel conda-forge sphinx-astropy
 
 Without conda, you install the dependencies by specifying ``[docs]`` when
 installing ``astropy`` with pip::
 
-    pip install -e '.[docs]'
+    python -m pip install --editable ".[docs]"
 
 You can alternatively install the `sphinx-astropy
 <https://github.com/astropy/sphinx-astropy>`_ package with pip::
 
-    pip install sphinx-astropy
+    python -m pip install sphinx-astropy
 
 In addition to providing configuration common to packages in the Astropy
 ecosystem, this package also serves as a way to automatically get the main
@@ -501,7 +501,7 @@ this uses the installed version of astropy, so if you want to make sure
 the current repository version is used, you will need to install it with
 e.g.::
 
-    pip install -e .[docs]
+    python -m pip install --editable ".[docs]"
 
 before changing to the ``docs`` directory.
 


### PR DESCRIPTION
### Description
While reading dev docs I realized that in many places, we give examples of commands using short form flags, but given that these docs are aimed to complete beginners, I think using long form flags (when available) helps clarifying what they are meant for.

Scanning for those, I also found that in a lot of places we showed `pip install ...` commands with the following problems:
- depending on installation details, running `pip install` directly (as opposed to `python -m pip install`) can result in a different `pip` running than the one attached to the running environment. The resulting errors (ModuleNotFoundError: No module named 'astropy'`) can be *extremely* confusing to beginners, so I propose we keep everyone safe from this situation by showing the more robust command only (experts know how to simplify it back if they want to).
- in some places we recommend installing astropy with extra dependencies like `pip install astropy[recommended]`, which doesn't work in some shells like zsh (very popular on Linux, and the default shell on MacOS, so, not something exotic). Again, the errors generated by this command running in an improper environment are very confusing to begginers. Using quotes makes it more portable. 


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
