### PR TITLE
Deprecate `utils.xml.unescaper.unescape_all()`

### DIFF
--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -5,6 +5,7 @@ import io
 import pytest
 
 from astropy.utils.compat.optional_deps import HAS_BLEACH
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.xml import check, unescaper, writer
 
 
@@ -54,7 +55,8 @@ def test_unescape_all():
     url_out = (
         "http://casu.ast.cam.ac.uk/ag/iphas-dsa/SubmitCone?DSACAT=IDR&DSATAB=Emitters&"
     )
-    assert unescaper.unescape_all(url_in) == url_out
+    with pytest.warns(AstropyDeprecationWarning):
+        assert unescaper.unescape_all(url_in) == url_out
 
     # bytes
     url_in = (
@@ -64,7 +66,8 @@ def test_unescape_all():
     url_out = (
         b"http://casu.ast.cam.ac.uk/ag/iphas-dsa/SubmitCone?DSACAT=IDR&DSATAB=Emitters&"
     )
-    assert unescaper.unescape_all(url_in) == url_out
+    with pytest.warns(AstropyDeprecationWarning):
+        assert unescaper.unescape_all(url_in) == url_out
 
 
 def test_escape_xml():

--- a/astropy/utils/xml/unescaper.py
+++ b/astropy/utils/xml/unescaper.py
@@ -4,6 +4,8 @@
 # STDLIB
 from xml.sax import saxutils
 
+from astropy.utils import deprecated
+
 __all__ = ["unescape_all"]
 
 # This is DIY
@@ -22,6 +24,8 @@ _str_entities = {"&amp;&amp;": "&", "&&": "&", "%2F": "/"}
 _str_keys = ["&amp;&amp;", "&&", "&amp;", "&lt;", "&gt;", "%2F"]
 
 
+# Remove the entire file when the deprecation period ends!
+@deprecated(since="6.1")
 def unescape_all(url):
     """Recursively unescape a given URL.
 

--- a/docs/changes/utils/16115.api.rst
+++ b/docs/changes/utils/16115.api.rst
@@ -1,0 +1,1 @@
+``astropy.utils.xml.unescaper.unescape_all()`` is deprecated.


### PR DESCRIPTION
### Description

The function has been unused since 4ef6c24b186694658be2300f16ea1a5b1c038eb2. [It is a part of the public API](https://docs.astropy.org/en/stable/api/astropy.utils.xml.unescaper.unescape_all.html#astropy.utils.xml.unescaper.unescape_all), so we cannot remove it immediately.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
