### PR TITLE
FIX: make unit conversion with MaskedColumn work

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1803,6 +1803,12 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
 
         return out
 
+    def convert_unit_to(self, new_unit, equivalencies=[]):
+        # This is a workaround to fix gh-9521
+        super().convert_unit_to(new_unit, equivalencies)
+        self._basedict["_unit"] = new_unit
+        self._optinfo["_unit"] = new_unit
+
     def _copy_attrs_slice(self, out):
         # Fixes issue #3023: when calling getitem with a MaskedArray subclass
         # the original object attributes are not copied.
@@ -1845,4 +1851,3 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
     more = BaseColumn.more
     pprint = BaseColumn.pprint
     pformat = BaseColumn.pformat
-    convert_unit_to = BaseColumn.convert_unit_to

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1121,3 +1121,10 @@ def test_searchsorted(Column, dtype):
         assert np.all(res == exp)
         res = np.searchsorted(c, v, side="right")
         assert np.all(res == exp)
+
+
+def test_masked_unit_conversion():
+    # regression test for gh-9521
+    c = table.MaskedColumn([3.5, 2.4, 1.7], name="test", unit=u.km)
+    c.convert_unit_to(u.m)
+    assert c.unit == (c * 2.0).unit

--- a/docs/changes/table/16118.bugfix.rst
+++ b/docs/changes/table/16118.bugfix.rst
@@ -1,0 +1,4 @@
+The unit conversion ``convert_unit_to`` with MaskedColumn was
+broken as it was storing the old unit in a dictionary attached
+to underlying np.ma.MaskedArray. This fixes it by overwriting
+the old unit after unit conversion.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

While running around the codebase trying to understand memory leaks in `MaskedColumn` I ran into some weird behavior and found this https://github.com/astropy/astropy/issues/9521.

This PR is a hacky workaround to fix https://github.com/astropy/astropy/issues/9521.
I'm not too sure if I like this @mhvk 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
