### PR TITLE
Support axes argument of gufuncs for Masked inputs

### DIFF
--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -191,7 +191,7 @@ class MaskedUfuncTests(MaskedArraySetup):
         assert_array_equal(rxp3.unmasked, exp)
         assert_array_equal(rxp3.mask, True)
 
-    def test_erfa_rxr(self):
+    def test_erfa_rxr_axes(self):
         m1 = Masked(np.arange(27.0).reshape(3, 3, 3))
         m2 = Masked(np.arange(-27.0, 0.0).reshape(3, 3, 3))
         rxr1 = erfa_ufunc.rxr(m1, m2)
@@ -202,6 +202,10 @@ class MaskedUfuncTests(MaskedArraySetup):
         rxr2 = erfa_ufunc.rxr(m1, m2)
         assert_array_equal(rxr2.unmasked, exp)
         assert np.all(rxr2.mask == [[[True]], [[False]], [[False]]])
+        rxr3 = erfa_ufunc.rxr(m1, m2, axes=[(0, 2), (-2, -1), (0, 1)])
+        exp3 = erfa_ufunc.rxr(m1.unmasked, m2.unmasked, axes=[(0, 2), (-2, -1), (0, 1)])
+        assert_array_equal(rxr3.unmasked, exp3)
+        assert np.all(rxr3.mask == [False, True, False])
 
     @pytest.mark.parametrize("axis", (0, 1, None))
     def test_add_reduce(self, axis):

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -752,15 +752,18 @@ class MaskedOperatorTests(MaskedArraySetup):
         assert_array_equal(mxm1.mask, False)
         m1.mask[0, 1, 2] = True
         m2.mask[0, 2, 0] = True
-        mxm2 = np.matmul(m1, m2, axes=[(0, 2), (-2, -1), (0, 1)])
-        exp2 = np.matmul(m1.unmasked, m2.unmasked, axes=[(0, 2), (-2, -1), (0, 1)])
+        axes = [(0, 2), (-2, -1), (0, 1)]
+        mxm2 = np.matmul(m1, m2, axes=axes)
+        exp2 = np.matmul(m1.unmasked, m2.unmasked, axes=axes)
+        # Any unmasked result will have all elements contributing unity,
+        # while masked entries mean the total will be lower.
         mask2 = (
             np.matmul(
                 (~m1.mask).astype(int),
                 (~m2.mask).astype(int),
-                axes=[(0, 2), (-2, -1), (0, 1)],
+                axes=axes,
             )
-            != 3
+            != m1.shape[axes[0][1]]
         )
         assert_array_equal(mxm2.unmasked, exp2)
         assert_array_equal(mxm2.mask, mask2)

--- a/docs/changes/utils/16121.feature.rst
+++ b/docs/changes/utils/16121.feature.rst
@@ -1,0 +1,1 @@
+For gufuncs on ``Masked`` instances, add support for the ``axes`` argument.


### PR DESCRIPTION
This pull request builds on #16120 to add support for `axes` for gufuncs with `Masked` inputs or outputs. It also refactors `__array_ufunc__` a little, ensuring that if `Masked` output is passed in, its mask always get used for possible in-place mask calculations.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
