### PR TITLE
TST: remove workarounds now that contourpy has unpinned nightlies

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -109,8 +109,3 @@ jobs:
         - name: (Allowed Failure) Python 3.12 with remote data and dev version of key dependencies
           linux: py312-test-devdeps
           posargs: --remote-data=any --verbose
-
-        # https://github.com/matplotlib/matplotlib/issues/26847
-        - name: (Allowed Failure) Python 3.12 with dev version of matplotlib
-          linux: py312-test-mpldev
-          posargs: --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -85,8 +85,10 @@ deps =
     # or nightly wheel of key dependencies.
     devdeps-!noscipy: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
-    devdeps: matplotlib>=0.0.dev0
+    devdeps-!noscipy: matplotlib>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
+
+    mpldev: matplotlib>=0.0.dev0
 
     # Latest developer version of infrastructure packages.
     devinfra: git+https://github.com/pytest-dev/pytest.git
@@ -102,7 +104,6 @@ deps =
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed
 extras =
     test: test
-    devdeps: test
     recdeps: recommended
     recdeps: test_all
     alldeps: all
@@ -113,8 +114,6 @@ install_command =
     devdeps: python -I -m pip install -v --pre
 
 commands =
-    mpldev: python -m pip install -U --pre matplotlib
-
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-mpldev,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl334}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{310,311,312,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl334}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py310-test-image-mpl334-cov
     py310-test-image-mpldev-cov
@@ -85,11 +85,8 @@ deps =
     # or nightly wheel of key dependencies.
     devdeps-!noscipy: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
-
-    # We separate out mpldev from devdeps because it pulls in contourpy
-    # that pins numpy<2 (https://github.com/matplotlib/matplotlib/issues/26847)
-    mpldev: matplotlib>=0.0.dev0
 
     # Latest developer version of infrastructure packages.
     devinfra: git+https://github.com/pytest-dev/pytest.git
@@ -105,6 +102,7 @@ deps =
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed
 extras =
     test: test
+    devdeps: test
     recdeps: recommended
     recdeps: test_all
     alldeps: all
@@ -115,6 +113,8 @@ install_command =
     devdeps: python -I -m pip install -v --pre
 
 commands =
+    mpldev: python -m pip install -U --pre matplotlib
+
     pip freeze
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}


### PR DESCRIPTION
### Description
This reverts ~#15290~ (and parts of #15363) following https://github.com/contourpy/contourpy/issues/362

EDIT: xref https://github.com/matplotlib/matplotlib/issues/26847#issuecomment-1968516509

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
