### PR TITLE
BUG: ensure find_equivalent_units returns proper equivalent units

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1718,7 +1718,9 @@ class UnitBase:
             max_depth=1,
             include_prefix_units=include_prefix_units,
         )
-        results = {x.bases[0] for x in results if len(x.bases) == 1}
+        results = {
+            x.bases[0] for x in results if len(x.bases) == 1 and x.powers[0] == 1
+        }
         return self.EquivalentUnitsList(results)
 
     def is_unity(self):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -14,6 +14,16 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.units.equivalencies import Equivalency
 
 
+def test_find_equivalent_units():
+    # Only finds units in the namespace
+    e1 = (u.m**3).find_equivalent_units()
+    assert len(e1) == 1
+    assert e1[0] == u.l
+    # Regression test for gh-16124
+    e2 = (u.m**-3).find_equivalent_units()
+    assert len(e2) == 0
+
+
 def test_dimensionless_angles():
     # test that the angles_dimensionless option allows one to change
     # by any order in radian in the unit (#1161)

--- a/docs/changes/units/16127.bugfix.rst
+++ b/docs/changes/units/16127.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that ``find_equivalent_units`` only returns actual units, not units
+that raised to some power match the requested one.  With this fix,
+``(u.m**-3).find_equivalent_units()`` properly finds nothing, rather than all
+units of length.


### PR DESCRIPTION
Fixes #16124

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
