### PR TITLE
Remove unneeded Python fallback code for XML parsing 

### DIFF
--- a/astropy/utils/xml/iterparser.py
+++ b/astropy/utils/xml/iterparser.py
@@ -11,6 +11,8 @@ import sys
 # ASTROPY
 from astropy.utils import data
 
+from ._iterparser import IterParser as _fast_iterparse
+
 __all__ = ["get_xml_iterator", "get_xml_encoding", "xml_readlines"]
 
 
@@ -69,7 +71,7 @@ def _convert_to_fd_or_read_function(fd):
                 yield new_fd.read
 
 
-def _fast_iterparse(fd, buffersize=2**10):
+def _slow_iterparse(fd, buffersize=2**10):
     from xml.parsers import expat
 
     if not callable(fd):
@@ -112,17 +114,6 @@ def _fast_iterparse(fd, buffersize=2**10):
 
     Parse("", True)
     yield from queue
-
-
-# Try to import the C version of the iterparser, otherwise fall back
-# to the Python implementation above.
-_slow_iterparse = _fast_iterparse
-try:
-    from . import _iterparser
-
-    _fast_iterparse = _iterparser.IterParser
-except ImportError:
-    pass
 
 
 @contextlib.contextmanager

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1,7 +1,7 @@
 /******************************************************************************
  * C extension code for astropy.utils.xml.iterparse
  *
- * Everything in this file has an alternate Python implementation and
+ * Everything in this file could be implemented in Python and
  * is included for performance reasons only.
  *
  * It has two main parts:

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -8,33 +8,8 @@ nicely-indented XML.
 import contextlib
 import textwrap
 
-try:
-    from . import _iterparser
-except ImportError:
-
-    def xml_escape_cdata(s):
-        """
-        Escapes &, < and > in an XML CDATA string.
-        """
-        s = s.replace("&", "&amp;")
-        s = s.replace("<", "&lt;")
-        s = s.replace(">", "&gt;")
-        return s
-
-    def xml_escape(s):
-        """
-        Escapes &, ', ", < and > in an XML attribute value.
-        """
-        s = s.replace("&", "&amp;")
-        s = s.replace("'", "&apos;")
-        s = s.replace('"', "&quot;")
-        s = s.replace("<", "&lt;")
-        s = s.replace(">", "&gt;")
-        return s
-
-else:
-    xml_escape_cdata = _iterparser.escape_xml_cdata
-    xml_escape = _iterparser.escape_xml
+from ._iterparser import escape_xml as xml_escape
+from ._iterparser import escape_xml_cdata as xml_escape_cdata
 
 
 class XMLWriter:


### PR DESCRIPTION
### Description

`astropy` contains a C extension for parsing XML files along with Python fallbacks in case the C extension is not available, but it always is. If it wasn't then the tests would fail at e.g. https://github.com/astropy/astropy/blob/b02ab673ccb9bdd5cbe84649afd2c5c47dd1bf3e/astropy/utils/tests/test_xml.py#L75

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
