### PR TITLE
table.vstack shouldn't modify inputs

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -62,7 +62,7 @@ def _get_list_of_tables(tables):
     # Convert inputs (Table, Row, or anything column-like) to Tables.
     # Special case that Quantity converts to a QTable.
     # Do this in a separate list to not modify the original input list
-    tables = [t for t in tables]
+    tables = list(tables)
     for ii, val in enumerate(tables):
         if isinstance(val, Table):
             pass

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -61,6 +61,8 @@ def _get_list_of_tables(tables):
 
     # Convert inputs (Table, Row, or anything column-like) to Tables.
     # Special case that Quantity converts to a QTable.
+    # Do this in a separate list to not modify the original input list
+    tables = [t for t in tables]
     for ii, val in enumerate(tables):
         if isinstance(val, Table):
             pass

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1540,6 +1540,20 @@ class TestVStack:
             "               --   four",
         ]
 
+    def test_vstack_inputs_not_modified(self):
+        """Tests that inputs are not modified, see issue #16119"""
+        t1 = Table(data=dict(x=[1,2,3], y=['a', 'b', 'c']))
+
+        rows = [r for r in t1]
+        assert isinstance(rows[0], table.Row)
+        t2 = table.vstack(rows)
+        assert isinstance(rows[0], table.Row)  # still a Row
+
+        tables = [t1,t1]
+        assert isinstance(tables[0], table.Table)
+        t3 = table.vstack(tables)
+        assert isinstance(tables[0], table.Table)  # still a Table
+
 
 class TestDStack:
     def _setup(self, t_cls=Table):

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1545,14 +1545,13 @@ class TestVStack:
         t1 = Table(data=dict(x=[1, 2, 3], y=["a", "b", "c"]))
 
         rows = list(t1)  # Table -> list of Rows
-        assert isinstance(rows[0], table.Row)
+        rows0 = rows[0]
         t2 = table.vstack(rows)
-        assert isinstance(rows[0], table.Row)  # still a Row
+        assert rows[0] is rows0
 
         tables = [t1, t1]
-        assert isinstance(tables[0], table.Table)
         t3 = table.vstack(tables)
-        assert isinstance(tables[0], table.Table)  # still a Table
+        assert tables[0] is t1
 
 
 class TestDStack:

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1544,7 +1544,7 @@ class TestVStack:
         """Tests that inputs are not modified, see issue #16119"""
         t1 = Table(data=dict(x=[1, 2, 3], y=["a", "b", "c"]))
 
-        rows = [r for r in t1]
+        rows = list(t1)  # Table -> list of Rows
         assert isinstance(rows[0], table.Row)
         t2 = table.vstack(rows)
         assert isinstance(rows[0], table.Row)  # still a Row

--- a/docs/changes/table/16130.bugfix.rst
+++ b/docs/changes/table/16130.bugfix.rst
@@ -1,0 +1,2 @@
+``astropy.table.vstack`` will no longer modify the input list when it
+is a list of ``astropy.table.Row`` objects.

--- a/docs/changes/table/16130.bugfix.rst
+++ b/docs/changes/table/16130.bugfix.rst
@@ -1,2 +1,2 @@
-``astropy.table.vstack`` will no longer modify the input list when it
-is a list of ``astropy.table.Row`` objects.
+``astropy.table.vstack`` will no longer modify the input list even when it
+contains non-Table objects like ``astropy.table.Row``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
This PR updates `table.vstack` so that it won't modify the input list,
including a test demonstrating the original problem (it now passes).
`table.vstack` still supports inputs being lists of Tables or Rows, but it no longer modifies the original user-provided list in-place, thus avoiding an unexpected side-effect of `vstack`.  See #16119 for context.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16119

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
