### PR TITLE
 MAINT: Let ruff format run on docs and examples

### DIFF
--- a/docs/nddata/examples/cutout2d_tofits.py
+++ b/docs/nddata/examples/cutout2d_tofits.py
@@ -24,12 +24,12 @@ def download_image_save_cutout(url, position, size):
     hdu.header.update(cutout.wcs.to_header())
 
     # Write the cutout to a new FITS file
-    cutout_filename = 'example_cutout.fits'
+    cutout_filename = "example_cutout.fits"
     hdu.writeto(cutout_filename, overwrite=True)
 
 
-if __name__ == '__main__':
-    url = 'https://astropy.stsci.edu/data/photometry/spitzer_example_image.fits'
+if __name__ == "__main__":
+    url = "https://astropy.stsci.edu/data/photometry/spitzer_example_image.fits"
 
     position = (500, 300)
     size = (400, 400)

--- a/docs/wcs/examples/cube_wcs.py
+++ b/docs/wcs/examples/cube_wcs.py
@@ -3,7 +3,23 @@
 import astropy.wcs
 
 wcs_dict = {
-'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10, 'NAXIS1': 5,
-'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 4,
-'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 3}
+    "CTYPE1": "WAVE    ",
+    "CUNIT1": "Angstrom",
+    "CDELT1": 0.2,
+    "CRPIX1": 0,
+    "CRVAL1": 10,
+    "NAXIS1": 5,
+    "CTYPE2": "HPLT-TAN",
+    "CUNIT2": "deg",
+    "CDELT2": 0.5,
+    "CRPIX2": 2,
+    "CRVAL2": 0.5,
+    "NAXIS2": 4,
+    "CTYPE3": "HPLN-TAN",
+    "CUNIT3": "deg",
+    "CDELT3": 0.4,
+    "CRPIX3": 2,
+    "CRVAL3": 1,
+    "NAXIS3": 3,
+}
 input_wcs = astropy.wcs.WCS(wcs_dict)

--- a/docs/wcs/examples/from_file.py
+++ b/docs/wcs/examples/from_file.py
@@ -51,9 +51,8 @@ def load_wcs_from_file(filename):
     x = 0
     y = 0
     origin = 0
-    assert (w.wcs_pix2world(x, y, origin) ==
-            w.wcs_pix2world(x + 1, y + 1, origin + 1))
+    assert w.wcs_pix2world(x, y, origin) == w.wcs_pix2world(x + 1, y + 1, origin + 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     load_wcs_from_file(sys.argv[-1])

--- a/docs/wcs/examples/planetary_wcs.py
+++ b/docs/wcs/examples/planetary_wcs.py
@@ -7,10 +7,12 @@ from astropy.wcs.utils import celestial_frame_to_wcs
 
 class MARSCustomBodycentricRepresentation(BaseBodycentricRepresentation):
     _equatorial_radius = 3399190.0 * u.m
-    _flattening = 0.5886* u.percent
+    _flattening = 0.5886 * u.percent
+
 
 class MARSCustomBodyFrame(BaseCoordinateFrame):
     name = "Mars"
+
 
 frame = MARSCustomBodyFrame()
 frame.representation_type = MARSCustomBodycentricRepresentation

--- a/docs/wcs/examples/programmatic.py
+++ b/docs/wcs/examples/programmatic.py
@@ -46,8 +46,7 @@ assert np.max(np.abs(pixcrd - pixcrd2)) < 1e-6
 x = 0
 y = 0
 origin = 0
-assert (w.wcs_pix2world(x, y, origin) ==
-        w.wcs_pix2world(x + 1, y + 1, origin + 1))
+assert w.wcs_pix2world(x, y, origin) == w.wcs_pix2world(x + 1, y + 1, origin + 1)
 
 # Now, write out the WCS object as a FITS header
 header = w.to_header()

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -51,12 +51,15 @@ import astropy.units as u
 # We'll use the data for the star HD 39881 from the `Simbad
 # <https://simbad.unistra.fr/simbad/>`_ database:
 
-c1 = coord.SkyCoord(ra=89.014303*u.degree, dec=13.924912*u.degree,
-                    distance=(37.59*u.mas).to(u.pc, u.parallax()),
-                    pm_ra_cosdec=372.72*u.mas/u.yr,
-                    pm_dec=-483.69*u.mas/u.yr,
-                    radial_velocity=0.37*u.km/u.s,
-                    frame='icrs')
+c1 = coord.SkyCoord(
+    ra=89.014303 * u.degree,
+    dec=13.924912 * u.degree,
+    distance=(37.59 * u.mas).to(u.pc, u.parallax()),
+    pm_ra_cosdec=372.72 * u.mas / u.yr,
+    pm_dec=-483.69 * u.mas / u.yr,
+    radial_velocity=0.37 * u.km / u.s,
+    frame="icrs",
+)
 
 ##############################################################################
 # This is a high proper-motion star; suppose we'd like to transform its position
@@ -87,9 +90,8 @@ print(gc1.v_x, gc1.v_y, gc1.v_z)
 
 v_sun = [11.1, 244, 7.25] * (u.km / u.s)  # [vx, vy, vz]
 gc_frame = coord.Galactocentric(
-    galcen_distance=8*u.kpc,
-    galcen_v_sun=v_sun,
-    z_sun=0*u.pc)
+    galcen_distance=8 * u.kpc, galcen_v_sun=v_sun, z_sun=0 * u.pc
+)
 
 ##############################################################################
 # We can then transform to this frame instead, with our custom parameters:
@@ -103,19 +105,19 @@ print(gc2.v_x, gc2.v_y, gc2.v_z)
 # velocity components. With an assumed distance, we can convert proper motion
 # components to Cartesian velocity components using `astropy.units`:
 
-galcen_distance = 8*u.kpc
-pm_gal_sgrA = [-6.379, -0.202] * u.mas/u.yr # from Reid & Brunthaler 2004
-vy, vz = -(galcen_distance * pm_gal_sgrA).to(u.km/u.s, u.dimensionless_angles())
+galcen_distance = 8 * u.kpc
+pm_gal_sgrA = [-6.379, -0.202] * u.mas / u.yr  # from Reid & Brunthaler 2004
+vy, vz = -(galcen_distance * pm_gal_sgrA).to(u.km / u.s, u.dimensionless_angles())
 
 ##############################################################################
 # We still have to assume a line-of-sight velocity for the Galactic center,
 # which we will again take to be 11 km/s:
-vx = 11.1 * u.km/u.s
+vx = 11.1 * u.km / u.s
 v_sun2 = u.Quantity([vx, vy, vz])  # List of Quantity -> a single Quantity
 
-gc_frame2 = coord.Galactocentric(galcen_distance=galcen_distance,
-                                 galcen_v_sun=v_sun2,
-                                 z_sun=0*u.pc)
+gc_frame2 = coord.Galactocentric(
+    galcen_distance=galcen_distance, galcen_v_sun=v_sun2, z_sun=0 * u.pc
+)
 gc3 = c1.transform_to(gc_frame2)
 print(gc3.v_x, gc3.v_y, gc3.v_z)
 
@@ -126,21 +128,23 @@ print(gc3.v_x, gc3.v_y, gc3.v_z)
 # Galactocentric radii with the same circular velocity, and transform them to
 # Heliocentric coordinates:
 
-ring_distances = np.arange(10, 25+1, 5) * u.kpc
-circ_velocity = 220 * u.km/u.s
+ring_distances = np.arange(10, 25 + 1, 5) * u.kpc
+circ_velocity = 220 * u.km / u.s
 
-phi_grid = np.linspace(90, 270, 512) * u.degree # grid of azimuths
+phi_grid = np.linspace(90, 270, 512) * u.degree  # grid of azimuths
 ring_rep = coord.CylindricalRepresentation(
-    rho=ring_distances[:,np.newaxis],
+    rho=ring_distances[:, np.newaxis],
     phi=phi_grid[np.newaxis],
-    z=np.zeros_like(ring_distances)[:,np.newaxis])
+    z=np.zeros_like(ring_distances)[:, np.newaxis],
+)
 
-angular_velocity = (-circ_velocity / ring_distances).to(u.mas/u.yr,
-                                                        u.dimensionless_angles())
+angular_velocity = (-circ_velocity / ring_distances).to(
+    u.mas / u.yr, u.dimensionless_angles()
+)
 ring_dif = coord.CylindricalDifferential(
-    d_rho=np.zeros(phi_grid.shape)[np.newaxis]*u.km/u.s,
-    d_phi=angular_velocity[:,np.newaxis],
-    d_z=np.zeros(phi_grid.shape)[np.newaxis]*u.km/u.s
+    d_rho=np.zeros(phi_grid.shape)[np.newaxis] * u.km / u.s,
+    d_phi=angular_velocity[:, np.newaxis],
+    d_z=np.zeros(phi_grid.shape)[np.newaxis] * u.km / u.s,
 )
 
 ring_rep = ring_rep.with_differentials(ring_dif)
@@ -151,20 +155,20 @@ gc_rings = coord.SkyCoord(ring_rep, frame=coord.Galactocentric)
 # the positions and velocities of the rings; note that in the velocity plot,
 # the velocities of the 4 rings are identical and thus overlaid under the same
 # curve:
-fig,axes = plt.subplots(1, 2, figsize=(12,6))
+fig, axes = plt.subplots(1, 2, figsize=(12, 6))
 
 # Positions
-axes[0].plot(gc_rings.x.T, gc_rings.y.T, marker='None', linewidth=3)
-axes[0].text(-8., 0, r'$\odot$', fontsize=20)
+axes[0].plot(gc_rings.x.T, gc_rings.y.T, marker="None", linewidth=3)
+axes[0].text(-8.0, 0, r"$\odot$", fontsize=20)
 
 axes[0].set_xlim(-30, 30)
 axes[0].set_ylim(-30, 30)
 
-axes[0].set_xlabel('$x$ [kpc]')
-axes[0].set_ylabel('$y$ [kpc]')
+axes[0].set_xlabel("$x$ [kpc]")
+axes[0].set_ylabel("$y$ [kpc]")
 
 # Velocities
-axes[1].plot(gc_rings.v_x.T, gc_rings.v_y.T, marker='None', linewidth=3)
+axes[1].plot(gc_rings.v_x.T, gc_rings.v_y.T, marker="None", linewidth=3)
 
 axes[1].set_xlim(-250, 250)
 axes[1].set_ylim(-250, 250)
@@ -183,13 +187,18 @@ gal_rings = gc_rings.transform_to(coord.Galactic)
 
 fig, ax = plt.subplots(1, 1, figsize=(8, 6))
 for i in range(len(ring_distances)):
-    ax.plot(gal_rings[i].l.degree, gal_rings[i].pm_l_cosb.value,
-            label=str(ring_distances[i]), marker='None', linewidth=3)
+    ax.plot(
+        gal_rings[i].l.degree,
+        gal_rings[i].pm_l_cosb.value,
+        label=str(ring_distances[i]),
+        marker="None",
+        linewidth=3,
+    )
 
 ax.set_xlim(360, 0)
 
-ax.set_xlabel('$l$ [deg]')
-ax.set_ylabel(fr'$\mu_l \, \cos b$ [{(u.mas/u.yr).to_string("latex_inline")}]')
+ax.set_xlabel("$l$ [deg]")
+ax.set_ylabel(rf'$\mu_l \, \cos b$ [{(u.mas/u.yr).to_string("latex_inline")}]')
 
 ax.legend()
 

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -56,15 +56,15 @@ from astropy.time import Time
 #
 # Get the coordinates of M33:
 
-m33 = SkyCoord.from_name('M33')
+m33 = SkyCoord.from_name("M33")
 
 ##############################################################################
 # Use `astropy.coordinates.EarthLocation` to provide the location of Bear
 # Mountain and set the time to 11pm EDT on 2012 July 12:
 
-bear_mountain = EarthLocation(lat=41.3*u.deg, lon=-74*u.deg, height=390*u.m)
-utcoffset = -4*u.hour  # Eastern Daylight Time
-time = Time('2012-7-12 23:00:00') - utcoffset
+bear_mountain = EarthLocation(lat=41.3 * u.deg, lon=-74 * u.deg, height=390 * u.m)
+utcoffset = -4 * u.hour  # Eastern Daylight Time
+time = Time("2012-7-12 23:00:00") - utcoffset
 
 ##############################################################################
 # `astropy.coordinates.EarthLocation.get_site_names` and
@@ -74,7 +74,7 @@ time = Time('2012-7-12 23:00:00') - utcoffset
 # Use `astropy.coordinates` to find the Alt, Az coordinates of M33 at as
 # observed from Bear Mountain at 11pm on 2012 July 12.
 
-m33altaz = m33.transform_to(AltAz(obstime=time,location=bear_mountain))
+m33altaz = m33.transform_to(AltAz(obstime=time, location=bear_mountain))
 print(f"M33's Altitude = {m33altaz.alt:.2}")
 
 ##############################################################################
@@ -85,10 +85,9 @@ print(f"M33's Altitude = {m33altaz.alt:.2}")
 # Find the alt,az coordinates of M33 at 100 times evenly spaced between 10pm
 # and 7am EDT:
 
-midnight = Time('2012-7-13 00:00:00') - utcoffset
-delta_midnight = np.linspace(-2, 10, 100)*u.hour
-frame_July13night = AltAz(obstime=midnight+delta_midnight,
-                          location=bear_mountain)
+midnight = Time("2012-7-13 00:00:00") - utcoffset
+delta_midnight = np.linspace(-2, 10, 100) * u.hour
+frame_July13night = AltAz(obstime=midnight + delta_midnight, location=bear_mountain)
 m33altazs_July13night = m33.transform_to(frame_July13night)
 
 ##############################################################################
@@ -102,8 +101,8 @@ m33airmasss_July13night = m33altazs_July13night.secz
 plt.plot(delta_midnight, m33airmasss_July13night)
 plt.xlim(-2, 10)
 plt.ylim(1, 4)
-plt.xlabel('Hours from EDT Midnight')
-plt.ylabel('Airmass [Sec(z)]')
+plt.xlabel("Hours from EDT Midnight")
+plt.ylabel("Airmass [Sec(z)]")
 plt.show()
 
 ##############################################################################
@@ -112,7 +111,7 @@ plt.show()
 
 from astropy.coordinates import get_sun
 
-delta_midnight = np.linspace(-12, 12, 1000)*u.hour
+delta_midnight = np.linspace(-12, 12, 1000) * u.hour
 times_July12_to_13 = midnight + delta_midnight
 frame_July12_to_13 = AltAz(obstime=times_July12_to_13, location=bear_mountain)
 sunaltazs_July12_to_13 = get_sun(times_July12_to_13).transform_to(frame_July12_to_13)
@@ -137,20 +136,40 @@ m33altazs_July12_to_13 = m33.transform_to(frame_July12_to_13)
 # Make a beautiful figure illustrating nighttime and the altitudes of M33 and
 # the Sun over that time:
 
-plt.plot(delta_midnight, sunaltazs_July12_to_13.alt, color='r', label='Sun')
-plt.plot(delta_midnight, moonaltazs_July12_to_13.alt, color=[0.75]*3, ls='--', label='Moon')
-plt.scatter(delta_midnight, m33altazs_July12_to_13.alt,
-            c=m33altazs_July12_to_13.az.value, label='M33', lw=0, s=8,
-            cmap='viridis')
-plt.fill_between(delta_midnight, 0*u.deg, 90*u.deg,
-                 sunaltazs_July12_to_13.alt < -0*u.deg, color='0.5', zorder=0)
-plt.fill_between(delta_midnight, 0*u.deg, 90*u.deg,
-                 sunaltazs_July12_to_13.alt < -18*u.deg, color='k', zorder=0)
-plt.colorbar().set_label('Azimuth [deg]')
-plt.legend(loc='upper left')
-plt.xlim(-12*u.hour, 12*u.hour)
-plt.xticks((np.arange(13)*2-12)*u.hour)
-plt.ylim(0*u.deg, 90*u.deg)
-plt.xlabel('Hours from EDT Midnight')
-plt.ylabel('Altitude [deg]')
+plt.plot(delta_midnight, sunaltazs_July12_to_13.alt, color="r", label="Sun")
+plt.plot(
+    delta_midnight, moonaltazs_July12_to_13.alt, color=[0.75] * 3, ls="--", label="Moon"
+)
+plt.scatter(
+    delta_midnight,
+    m33altazs_July12_to_13.alt,
+    c=m33altazs_July12_to_13.az.value,
+    label="M33",
+    lw=0,
+    s=8,
+    cmap="viridis",
+)
+plt.fill_between(
+    delta_midnight,
+    0 * u.deg,
+    90 * u.deg,
+    sunaltazs_July12_to_13.alt < -0 * u.deg,
+    color="0.5",
+    zorder=0,
+)
+plt.fill_between(
+    delta_midnight,
+    0 * u.deg,
+    90 * u.deg,
+    sunaltazs_July12_to_13.alt < -18 * u.deg,
+    color="k",
+    zorder=0,
+)
+plt.colorbar().set_label("Azimuth [deg]")
+plt.legend(loc="upper left")
+plt.xlim(-12 * u.hour, 12 * u.hour)
+plt.xticks((np.arange(13) * 2 - 12) * u.hour)
+plt.ylim(0 * u.deg, 90 * u.deg)
+plt.xlabel("Hours from EDT Midnight")
+plt.ylabel("Altitude [deg]")
 plt.show()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -98,9 +98,10 @@ class Sagittarius(coord.BaseCoordinateFrame):
 
     frame_specific_representation_info = {
         coord.SphericalRepresentation: [
-            coord.RepresentationMapping('lon', 'Lambda'),
-            coord.RepresentationMapping('lat', 'Beta'),
-            coord.RepresentationMapping('distance', 'distance')]
+            coord.RepresentationMapping("lon", "Lambda"),
+            coord.RepresentationMapping("lat", "Beta"),
+            coord.RepresentationMapping("distance", "distance"),
+        ]
     }
 
 
@@ -124,13 +125,13 @@ class Sagittarius(coord.BaseCoordinateFrame):
 # transformation matrix using pre-determined Euler angles and the
 # ``rotation_matrix`` helper function:
 
-SGR_PHI = (180 + 3.75) * u.degree # Euler angles (from Law & Majewski 2010)
+SGR_PHI = (180 + 3.75) * u.degree  # Euler angles (from Law & Majewski 2010)
 SGR_THETA = (90 - 13.46) * u.degree
 SGR_PSI = (180 + 14.111534) * u.degree
 
 # Generate the rotation matrix using the x-convention (see Goldstein)
 SGR_MATRIX = (
-    np.diag([1.,1.,-1.])
+    np.diag([1.0, 1.0, -1.0])
     @ rotation_matrix(SGR_PSI, "z")
     @ rotation_matrix(SGR_THETA, "x")
     @ rotation_matrix(SGR_PHI, "z")
@@ -142,7 +143,10 @@ SGR_MATRIX = (
 # the inverse of a rotation matrix is just its transpose, the required
 # transformation functions are very simple:
 
-@frame_transform_graph.transform(coord.StaticMatrixTransform, coord.Galactic, Sagittarius)
+
+@frame_transform_graph.transform(
+    coord.StaticMatrixTransform, coord.Galactic, Sagittarius
+)
 def galactic_to_sgr():
     """Compute the Galactic spherical to heliocentric Sgr transformation matrix."""
     return SGR_MATRIX
@@ -157,7 +161,10 @@ def galactic_to_sgr():
 # We then register the inverse transformation by using the transpose of the
 # rotation matrix (which is faster to compute than the inverse):
 
-@frame_transform_graph.transform(coord.StaticMatrixTransform, Sagittarius, coord.Galactic)
+
+@frame_transform_graph.transform(
+    coord.StaticMatrixTransform, Sagittarius, coord.Galactic
+)
 def sgr_to_galactic():
     """Compute the heliocentric Sgr to spherical Galactic transformation matrix."""
     return matrix_transpose(SGR_MATRIX)
@@ -170,7 +177,7 @@ def sgr_to_galactic():
 # transform to `~astropy.coordinates.Galactic`). For example, to transform from
 # ICRS coordinates to ``Sagittarius``, we would do:
 
-icrs = coord.SkyCoord(280.161732*u.degree, 11.91934*u.degree, frame='icrs')
+icrs = coord.SkyCoord(280.161732 * u.degree, 11.91934 * u.degree, frame="icrs")
 sgr = icrs.transform_to(Sagittarius)
 print(sgr)
 
@@ -178,24 +185,31 @@ print(sgr)
 # Or, to transform from the ``Sagittarius`` frame to ICRS coordinates (in this
 # case, a line along the ``Sagittarius`` x-y plane):
 
-sgr = coord.SkyCoord(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
-                     Beta=np.zeros(128)*u.radian, frame='sagittarius')
+sgr = coord.SkyCoord(
+    Lambda=np.linspace(0, 2 * np.pi, 128) * u.radian,
+    Beta=np.zeros(128) * u.radian,
+    frame="sagittarius",
+)
 icrs = sgr.transform_to(coord.ICRS)
 print(icrs)
 
 ##############################################################################
 # As an example, we'll now plot the points in both coordinate systems:
 
-fig, axes = plt.subplots(2, 1, figsize=(8, 10),
-                         subplot_kw={'projection': 'aitoff'})
+fig, axes = plt.subplots(2, 1, figsize=(8, 10), subplot_kw={"projection": "aitoff"})
 
 axes[0].set_title("Sagittarius")
-axes[0].plot(sgr.Lambda.wrap_at(180*u.deg).radian, sgr.Beta.radian,
-             linestyle='none', marker='.')
+axes[0].plot(
+    sgr.Lambda.wrap_at(180 * u.deg).radian,
+    sgr.Beta.radian,
+    linestyle="none",
+    marker=".",
+)
 
 axes[1].set_title("ICRS")
-axes[1].plot(icrs.ra.wrap_at(180*u.deg).radian, icrs.dec.radian,
-             linestyle='none', marker='.')
+axes[1].plot(
+    icrs.ra.wrap_at(180 * u.deg).radian, icrs.dec.radian, linestyle="none", marker="."
+)
 
 plt.show()
 
@@ -205,35 +219,36 @@ plt.show()
 # transformation of velocity components is therefore natively supported as
 # well:
 
-sgr = coord.SkyCoord(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
-                     Beta=np.zeros(128)*u.radian,
-                     pm_Lambda_cosBeta=np.random.uniform(-5, 5, 128)*u.mas/u.yr,
-                     pm_Beta=np.zeros(128)*u.mas/u.yr,
-                     frame='sagittarius')
+sgr = coord.SkyCoord(
+    Lambda=np.linspace(0, 2 * np.pi, 128) * u.radian,
+    Beta=np.zeros(128) * u.radian,
+    pm_Lambda_cosBeta=np.random.uniform(-5, 5, 128) * u.mas / u.yr,
+    pm_Beta=np.zeros(128) * u.mas / u.yr,
+    frame="sagittarius",
+)
 icrs = sgr.transform_to(coord.ICRS)
 print(icrs)
 
 fig, axes = plt.subplots(3, 1, figsize=(8, 10), sharex=True)
 
 axes[0].set_title("Sagittarius")
-axes[0].plot(sgr.Lambda.degree,
-             sgr.pm_Lambda_cosBeta.value,
-             linestyle='none', marker='.')
+axes[0].plot(
+    sgr.Lambda.degree, sgr.pm_Lambda_cosBeta.value, linestyle="none", marker="."
+)
 axes[0].set_xlabel(r"$\Lambda$ [deg]")
 axes[0].set_ylabel(
-    fr"$\mu_\Lambda \, \cos B$ [{sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')}]")
+    rf"$\mu_\Lambda \, \cos B$ [{sgr.pm_Lambda_cosBeta.unit.to_string('latex_inline')}]"
+)
 
 axes[1].set_title("ICRS")
-axes[1].plot(icrs.ra.degree, icrs.pm_ra_cosdec.value,
-             linestyle='none', marker='.')
+axes[1].plot(icrs.ra.degree, icrs.pm_ra_cosdec.value, linestyle="none", marker=".")
 axes[1].set_ylabel(
-    fr"$\mu_\alpha \, \cos\delta$ [{icrs.pm_ra_cosdec.unit.to_string('latex_inline')}]")
+    rf"$\mu_\alpha \, \cos\delta$ [{icrs.pm_ra_cosdec.unit.to_string('latex_inline')}]"
+)
 
 axes[2].set_title("ICRS")
-axes[2].plot(icrs.ra.degree, icrs.pm_dec.value,
-             linestyle='none', marker='.')
+axes[2].plot(icrs.ra.degree, icrs.pm_dec.value, linestyle="none", marker=".")
 axes[2].set_xlabel("RA [deg]")
-axes[2].set_ylabel(
-    fr"$\mu_\delta$ [{icrs.pm_dec.unit.to_string('latex_inline')}]")
+axes[2].set_ylabel(rf"$\mu_\delta$ [{icrs.pm_dec.unit.to_string('latex_inline')}]")
 
 plt.show()

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -29,14 +29,18 @@ import astropy.units as u
 
 ################################################################################
 # Use the latest convention for the Galactocentric coordinates
-coord.galactocentric_frame_defaults.set('latest')
+coord.galactocentric_frame_defaults.set("latest")
 
 ################################################################################
 # For this example, let's work with the coordinates and barycentric radial
 # velocity of the star HD 155967, as obtained from
 # `Simbad <https://simbad.unistra.fr/simbad/>`_:
-icrs = coord.SkyCoord(ra=258.58356362*u.deg, dec=14.55255619*u.deg,
-                      radial_velocity=-16.1*u.km/u.s, frame='icrs')
+icrs = coord.SkyCoord(
+    ra=258.58356362 * u.deg,
+    dec=14.55255619 * u.deg,
+    radial_velocity=-16.1 * u.km / u.s,
+    frame="icrs",
+)
 
 ################################################################################
 # We next need to decide on the velocity of the Sun in the assumed GSR frame.

--- a/examples/io/create-mef.py
+++ b/examples/io/create-mef.py
@@ -31,7 +31,7 @@ new_hdul.append(fits.ImageHDU())
 ##############################################################################
 # Write out the new file to disk:
 
-new_hdul.writeto('test.fits')
+new_hdul.writeto("test.fits")
 
 ##############################################################################
 # Alternatively, the HDU instances can be created first (or read from an
@@ -44,9 +44,9 @@ new_hdul.writeto('test.fits')
 hdu1 = fits.PrimaryHDU()
 hdu2 = fits.ImageHDU()
 new_hdul = fits.HDUList([hdu1, hdu2])
-new_hdul.writeto('test.fits', overwrite=True)
+new_hdul.writeto("test.fits", overwrite=True)
 
 ##############################################################################
 # Finally, we'll remove the file we created:
 
-os.remove('test.fits')
+os.remove("test.fits")

--- a/examples/io/fits-tables.py
+++ b/examples/io/fits-tables.py
@@ -31,7 +31,7 @@ from astropy.utils.data import get_pkg_data_filename
 ##############################################################################
 # Download a FITS file
 
-event_filename = get_pkg_data_filename('tutorials/FITS-tables/chandra_events.fits')
+event_filename = get_pkg_data_filename("tutorials/FITS-tables/chandra_events.fits")
 
 ##############################################################################
 # Display information about the contents of the FITS file.
@@ -55,9 +55,9 @@ print(events.columns)
 # If a column contains unit information, it will have an associated
 # `astropy.units` object.
 
-print(events['energy'].unit)
+print(events["energy"].unit)
 
 ##############################################################################
 # Print the data stored in the Energy column.
 
-print(events['energy'])
+print(events["energy"])

--- a/examples/io/modify-fits-header.py
+++ b/examples/io/modify-fits-header.py
@@ -20,7 +20,7 @@ from astropy.utils.data import get_pkg_data_filename
 ##############################################################################
 # Download a FITS file:
 
-fits_file = get_pkg_data_filename('tutorials/FITS-Header/input_file.fits')
+fits_file = get_pkg_data_filename("tutorials/FITS-Header/input_file.fits")
 
 ##############################################################################
 # Look at contents of the FITS file
@@ -48,20 +48,20 @@ print(repr(fits.getheader(fits_file, 1)))
 # `~astropy.io.fits.setval()` function. For example, set the OBJECT keyword
 # to 'M31':
 
-fits.setval(fits_file, 'OBJECT', value='M31')
+fits.setval(fits_file, "OBJECT", value="M31")
 
 ##############################################################################
 # With no extra arguments, this will modify the header for extension 0, but
 # this can be changed using the ``ext`` keyword argument. For example, we can
 # specify extension 1 instead:
 
-fits.setval(fits_file, 'OBJECT', value='M31', ext=1)
+fits.setval(fits_file, "OBJECT", value="M31", ext=1)
 
 ##############################################################################
 # This can also be used to create a new keyword-value pair ("card" in FITS
 # lingo):
 
-fits.setval(fits_file, 'ANEWKEY', value='some value')
+fits.setval(fits_file, "ANEWKEY", value="some value")
 
 ##############################################################################
 # Again, this is useful for one-off modifications, but can be inefficient
@@ -69,9 +69,9 @@ fits.setval(fits_file, 'ANEWKEY', value='some value')
 # because `~astropy.io.fits.setval()` loads the whole file each time it
 # is called. To make several modifications, it's better to load the file once:
 
-with fits.open(fits_file, 'update') as f:
+with fits.open(fits_file, "update") as f:
     for hdu in f:
-        hdu.header['OBJECT'] = 'CAT'
+        hdu.header["OBJECT"] = "CAT"
 
 print("After modifications:")
 print()

--- a/examples/io/plot_fits-image.py
+++ b/examples/io/plot_fits-image.py
@@ -31,7 +31,7 @@ plt.style.use(astropy_mpl_style)
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
 
-image_file = get_pkg_data_filename('tutorials/FITS-images/HorseHead.fits')
+image_file = get_pkg_data_filename("tutorials/FITS-images/HorseHead.fits")
 
 ##############################################################################
 # Use `astropy.io.fits.info()` to display the structure of the file:
@@ -55,5 +55,5 @@ print(image_data.shape)
 # Display the image data:
 
 plt.figure()
-plt.imshow(image_data, cmap='gray')
+plt.imshow(image_data, cmap="gray")
 plt.colorbar()

--- a/examples/io/skip_create-large-fits.py
+++ b/examples/io/skip_create-large-fits.py
@@ -29,7 +29,7 @@ hdu = fits.PrimaryHDU(data=data)
 # Then use the `astropy.io.fits.writeto()` method to write out the new
 # file to disk
 
-hdu.writeto('large.fits')
+hdu.writeto("large.fits")
 
 ##############################################################################
 # However, a 40000 x 40000 array of doubles is nearly twelve gigabytes! Most
@@ -67,9 +67,9 @@ while len(header) < (36 * 4 - 1):
 # files are written. Instead, we can write just the header to a file using the
 # `astropy.io.fits.Header.tofile` method:
 
-header['NAXIS1'] = 40000
-header['NAXIS2'] = 40000
-header.tofile('large.fits')
+header["NAXIS1"] = 40000
+header["NAXIS2"] = 40000
+header.tofile("large.fits")
 
 ##############################################################################
 # Finally, grow out the end of the file to match the length of the
@@ -77,7 +77,7 @@ header.tofile('large.fits')
 # most systems by seeking past the end of the file and writing a single byte,
 # like so:
 
-with open('large.fits', 'rb+') as fobj:
+with open("large.fits", "rb+") as fobj:
     # Seek past the length of the header, plus the length of the
     # Data we want to write.
     # 8 is the number of bytes per value, i.e. abs(header['BITPIX'])/8
@@ -85,15 +85,17 @@ with open('large.fits', 'rb+') as fobj:
     # The -1 is to account for the final byte that we are about to
     # write:
     fobj.seek(len(header.tostring()) + (40000 * 40000 * 8) - 1)
-    fobj.write(b'\0')
+    fobj.write(b"\0")
 
 ##############################################################################
 # More generally, this can be written:
 
-shape = tuple(header[f'NAXIS{ii}'] for ii in range(1, header['NAXIS']+1))
-with open('large.fits', 'rb+') as fobj:
-    fobj.seek(len(header.tostring()) + (np.prod(shape) * np.abs(header['BITPIX']//8)) - 1)
-    fobj.write(b'\0')
+shape = tuple(header[f"NAXIS{ii}"] for ii in range(1, header["NAXIS"] + 1))
+with open("large.fits", "rb+") as fobj:
+    fobj.seek(
+        len(header.tostring()) + (np.prod(shape) * np.abs(header["BITPIX"] // 8)) - 1
+    )
+    fobj.write(b"\0")
 
 ##############################################################################
 # On modern operating systems this will cause the file (past the header) to be
@@ -109,4 +111,4 @@ with open('large.fits', 'rb+') as fobj:
 ##############################################################################
 # Finally, we'll remove the file we created:
 
-os.remove('large.fits')
+os.remove("large.fits")

--- a/examples/io/split-jpeg-to-fits.py
+++ b/examples/io/split-jpeg-to-fits.py
@@ -32,7 +32,7 @@ plt.style.use(astropy_mpl_style)
 ##############################################################################
 # Load and display the original 3-color jpeg image:
 
-image = Image.open('Hs-2009-14-a-web.jpg')
+image = Image.open("Hs-2009-14-a-web.jpg")
 xsize, ysize = image.size
 print(f"Image size: {ysize} x {xsize}")
 print(f"Image bands: {image.getbands()}")
@@ -43,7 +43,7 @@ ax = plt.imshow(image)
 # are flattened, so they are 1-dimensional:
 
 r, g, b = image.split()
-r_data = np.array(r.getdata()) # data is now an array of length ysize*xsize
+r_data = np.array(r.getdata())  # data is now an array of length ysize*xsize
 g_data = np.array(g.getdata())
 b_data = np.array(b.getdata())
 print(r_data.shape)
@@ -51,7 +51,7 @@ print(r_data.shape)
 ##############################################################################
 # Reshape the image arrays to be 2-dimensional:
 
-r_data = r_data.reshape(ysize, xsize) # data is now a matrix (ysize, xsize)
+r_data = r_data.reshape(ysize, xsize)  # data is now a matrix (ysize, xsize)
 g_data = g_data.reshape(ysize, xsize)
 b_data = b_data.reshape(ysize, xsize)
 print(r_data.shape)
@@ -61,19 +61,19 @@ print(r_data.shape)
 # Add and visualize header info
 
 red = fits.PrimaryHDU(data=r_data)
-red.header['LATOBS'] = "32:11:56" # add spurious header info
-red.header['LONGOBS'] = "110:56"
-red.writeto('red.fits')
+red.header["LATOBS"] = "32:11:56"  # add spurious header info
+red.header["LONGOBS"] = "110:56"
+red.writeto("red.fits")
 
 green = fits.PrimaryHDU(data=g_data)
-green.header['LATOBS'] = "32:11:56"
-green.header['LONGOBS'] = "110:56"
-green.writeto('green.fits')
+green.header["LATOBS"] = "32:11:56"
+green.header["LONGOBS"] = "110:56"
+green.writeto("green.fits")
 
 blue = fits.PrimaryHDU(data=b_data)
-blue.header['LATOBS'] = "32:11:56"
-blue.header['LONGOBS'] = "110:56"
-blue.writeto('blue.fits')
+blue.header["LATOBS"] = "32:11:56"
+blue.header["LONGOBS"] = "110:56"
+blue.writeto("blue.fits")
 
 from pprint import pprint
 
@@ -84,6 +84,6 @@ pprint(red.header)
 
 import os
 
-os.remove('red.fits')
-os.remove('green.fits')
-os.remove('blue.fits')
+os.remove("red.fits")
+os.remove("green.fits")
+os.remove("blue.fits")

--- a/examples/template/example-template.py
+++ b/examples/template/example-template.py
@@ -56,17 +56,17 @@ z = np.cos(xx) + np.cos(yy)
 plt.figure()
 plt.imshow(z)
 plt.colorbar()
-plt.xlabel('$x$')
-plt.ylabel('$y$')
+plt.xlabel("$x$")
+plt.ylabel("$y$")
 
 ###########################################################################
 # Again it is possible to continue the discussion with a new Python string. This
 # time to introduce the next code block generates 2 separate figures.
 
 plt.figure()
-plt.imshow(z, cmap=plt.cm.get_cmap('hot'))
+plt.imshow(z, cmap=plt.cm.get_cmap("hot"))
 plt.figure()
-plt.imshow(z, cmap=plt.cm.get_cmap('Spectral'), interpolation='none')
+plt.imshow(z, cmap=plt.cm.get_cmap("Spectral"), interpolation="none")
 
 ##########################################################################
 # There's some subtle differences between rendered html rendered comment
@@ -90,7 +90,7 @@ Triple-quoted string which tries to break parser but doesn't.
 ############################################################################
 # Output of the script is captured:
 
-print('Some output from Python')
+print("Some output from Python")
 
 ############################################################################
 # Finally, I'll call ``show`` at the end just so someone running the Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,9 +362,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "RUF005",  # unpack-instead-of-concatenating-to-collection-literal -- it's not clearly faster.
 ]
 
-[tool.ruff.format]
-exclude = ["docs/*", "examples/*"]
-
 [tool.ruff.lint.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
 ".github/workflows/*.py" = ["INP001"]


### PR DESCRIPTION
As mentioned in https://github.com/astropy/astropy/pull/16029#pullrequestreview-1878304512 this turns on code formatting for `docs/` and `examples/`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
