### PR TITLE
ENH: Add np.full to dispatchable functions

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -241,6 +241,10 @@ def like_helper(a, *args, **kwargs):
     unit = a.unit if subok else None
     return (a.view(np.ndarray),) + args, kwargs, unit, None
 
+@dispatched_function
+def full(shape, fill_value, dtype=None, order='C'):
+    return np.full(shape, fill_value, dtype, order), fill_value.unit, None
+
 
 @function_helper
 def sinc(x):

--- a/astropy/units/tests/test_quantity_helpers.py
+++ b/astropy/units/tests/test_quantity_helpers.py
@@ -31,3 +31,10 @@ def test_allclose_isclose():
     c = [90, 200] * u.cm
     assert not u.allclose(a, c)
     assert not np.all(u.isclose(a, c))
+
+
+def test_full():
+    a = u.Quantity(1, u.m)
+    b = np.full(3, a, like=a)
+    assert b.unit == a.unit
+    assert len(b) == 3


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This *almost* fixes https://github.com/astropy/astropy/issues/10836, with [NEP 35](https://numpy.org/neps/nep-0035-array-creation-dispatch-with-array-function.html) it is possible to dispatch functions like `np.full`.

With this change the following code should work:
```python
my_quantity = u.Quantity(1, u.m)
np.full(10, fill_value=my_quantity, like=my_quantity)
```
This does require passing in the `like` argument as numpy can't auto infer from `fill_value`, and I guess it gets close enough to the behavior requested in https://github.com/astropy/astropy/issues/10836#issue-719419096

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
