### PR TITLE
ENH: Move _get_converter to public API

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1044,7 +1044,7 @@ class UnitBase:
 
     def _apply_equivalencies(self, unit, other, equivalencies):
         """
-        Internal function (used from `_get_converter`) to apply
+        Internal function (used from `get_converter`) to apply
         equivalence pairs.
         """
 
@@ -1090,12 +1090,37 @@ class UnitBase:
 
         raise UnitConversionError(f"{unit_str} and {other_str} are not convertible")
 
-    def _get_converter(self, other, equivalencies=[]):
-        """Get a converter for values in ``self`` to ``other``.
+    def get_converter(self, other, equivalencies=[]):
+        """
+        Create a function that converts values from this unit to another.
 
-        If no conversion is necessary, returns ``unit_scale_converter``
-        (which is used as a check in quantity helpers).
+        Parameters
+        ----------
+        other : unit-like
+            The unit to convert to.
+        equivalencies : list of tuple
+            A list of equivalence pairs to try if the units are not
+            directly convertible.  See :ref:`astropy:unit_equivalencies`.
+            This list is in addition to possible global defaults set by, e.g.,
+            `set_enabled_equivalencies`.
+            Use `None` to turn off all equivalencies.
 
+        Returns
+        -------
+        func : callable
+            A callable that takes an array-like argument and returns
+            it converted from units of self to units of other.
+
+        Raises
+        ------
+        UnitsError
+            If the units cannot be converted to each other.
+
+        Notes
+        -----
+        This method is used internally in `Quantity` to convert to
+        different units. Note that the function returned takes
+        and returns values, not quantities.
         """
         # First see if it is just a scaling.
         try:
@@ -1104,6 +1129,8 @@ class UnitBase:
             pass
         else:
             if scale == 1.0:
+                # If no conversion is necessary, returns ``unit_scale_converter``
+                # (which is used as a check in quantity helpers).
                 return unit_scale_converter
             else:
                 return lambda val: scale * _condition_arg(val)
@@ -1121,7 +1148,7 @@ class UnitBase:
                 for funit, tunit, a, b in other.equivalencies:
                     if other is funit:
                         try:
-                            converter = self._get_converter(tunit, equivalencies)
+                            converter = self.get_converter(tunit, equivalencies)
                         except Exception:
                             pass
                         else:
@@ -1198,7 +1225,7 @@ class UnitBase:
         if other is self and value is UNITY:
             return UNITY
         else:
-            return self._get_converter(Unit(other), equivalencies)(value)
+            return self.get_converter(Unit(other), equivalencies)(value)
 
     def in_units(self, other, value=1.0, equivalencies=[]):
         """
@@ -2016,7 +2043,7 @@ class UnrecognizedUnit(IrreducibleUnit):
         self._normalize_equivalencies(equivalencies)
         return self == other
 
-    def _get_converter(self, other, equivalencies=None):
+    def get_converter(self, other, equivalencies=None):
         self._normalize_equivalencies(equivalencies)
         raise ValueError(
             f"The unit {self.name!r} is unrecognized.  It can not be converted "

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -230,7 +230,7 @@ def converters_and_unit(function, method, *args):
                     # Changing the unit does not work for, e.g., array-shaped
                     # power, but this is OK if we're (scaled) dimensionless.
                     try:
-                        converters[0] = units[0]._get_converter(dimensionless_unscaled)
+                        converters[0] = units[0].get_converter(dimensionless_unscaled)
                     except UnitConversionError:
                         raise exc
                     else:

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -36,10 +36,10 @@ def _d(unit):
 
 
 def get_converter(from_unit, to_unit):
-    """Like Unit._get_converter, except returns None if no scaling is needed,
+    """Like Unit.get_converter, except returns None if no scaling is needed,
     i.e., if the inferred scale is unity.
     """
-    converter = from_unit._get_converter(to_unit)
+    converter = from_unit.get_converter(to_unit)
     return None if converter is unit_scale_converter else converter
 
 

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -257,7 +257,7 @@ class StructuredUnit:
         This is useful since ``np.array(value)`` would treat tuples as lower
         levels of the array, rather than as elements of a structured array.
         The routine does presume that the type of the first tuple is
-        representative of the rest.  Used in ``_get_converter``.
+        representative of the rest.  Used in ``get_converter``.
 
         For the special value of ``UNITY``, all fields are assumed to be 1.0,
         and hence this will return an all-float dtype.
@@ -358,12 +358,12 @@ class StructuredUnit:
 
         return True
 
-    def _get_converter(self, other, equivalencies=[]):
+    def get_converter(self, other, equivalencies=[]):
         if not isinstance(other, type(self)):
             other = self.__class__(other, names=self)
 
         converters = [
-            self_part._get_converter(other_part, equivalencies=equivalencies)
+            self_part.get_converter(other_part, equivalencies=equivalencies)
             for (self_part, other_part) in zip(self.values(), other.values())
         ]
 
@@ -377,6 +377,8 @@ class StructuredUnit:
             return result if result.shape else result[()]
 
         return converter
+
+    get_converter.__doc__ = UnitBase.get_converter.__doc__
 
     def to(self, other, value=np._NoValue, equivalencies=[]):
         """Return values converted to the specified unit.
@@ -413,7 +415,7 @@ class StructuredUnit:
             # We do not have UNITY as a default, since then the docstring
             # would list 1.0 as default, yet one could not pass that in.
             value = UNITY
-        return self._get_converter(other, equivalencies=equivalencies)(value)
+        return self.get_converter(other, equivalencies=equivalencies)(value)
 
     def to_string(self, format="generic"):
         """Output the unit in the given format as a string.

--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -541,7 +541,7 @@ class TestGeodetic:
     def test_unit_errors(self):
         """Test unit errors when dimensionless parameters are used"""
 
-        msg = "'NoneType' object has no attribute '_get_converter'"
+        msg = "'NoneType' object has no attribute 'get_converter'"
         with pytest.raises(AttributeError, match=msg):
             erfa_ufunc.gc2gde(self.equatorial_radius_value, self.flattening, self.xyz)
         with pytest.raises(AttributeError, match=msg):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -58,7 +58,17 @@ def test_invalid_compare():
 
 
 def test_convert():
-    assert u.h._get_converter(u.s)(1) == 3600
+    assert u.h.get_converter(u.s)(1) == 3600
+
+
+def test_convert_roundtrip():
+    c1 = u.cm.get_converter(u.m)
+    c2 = u.m.get_converter(u.cm)
+    np.isclose(c1(c2(10.0)), c2(c1(10.0)), atol=0, rtol=1e-15)
+
+    c1 = u.arcsec.get_converter(u.pc, u.parallax())
+    c2 = u.pc.get_converter(u.arcsec, u.parallax())
+    np.isclose(c1(c2(10.0)), c2(c1(10.0)), atol=0, rtol=1e-15)
 
 
 def test_convert_fail():
@@ -69,7 +79,7 @@ def test_convert_fail():
 
 
 def test_composite():
-    assert (u.cm / u.s * u.h)._get_converter(u.m)(1) == 36
+    assert (u.cm / u.s * u.h).get_converter(u.m)(1) == 36
     assert u.cm * u.cm == u.cm**2
 
     assert u.cm * u.cm * u.cm == u.cm**3
@@ -185,7 +195,7 @@ def test_unknown_unit3():
     assert unit not in (None, u.m)
 
     with pytest.raises(ValueError):
-        unit._get_converter(unit3)
+        unit.get_converter(unit3)
 
     _ = unit.to_string("latex")
     _ = unit2.to_string("cgs")

--- a/docs/changes/units/16139.api.rst
+++ b/docs/changes/units/16139.api.rst
@@ -1,0 +1,5 @@
+Units now exposes ``get_converter`` which returns a function that
+will convert a scalar or array from one unit to another. This can be
+useful to speed up code that converts many quantities with the same
+unit to another one, especially if the quantity has not many elements,
+so that the overhead of creating a conversion function is relatively large.

--- a/docs/units/conversion.rst
+++ b/docs/units/conversion.rst
@@ -27,6 +27,30 @@ Arrays are permitted as arguments.
 
 .. EXAMPLE END
 
+Obtaining a Conversion Function
+-------------------------------
+
+.. EXAMPLE START: Obtaining a Conversion Function
+
+Finally, one may obtain a function that can be used to convert to the
+new unit. Normally this may seem like overkill when all one needs to
+do is multiply by a scale factor, but there are cases when the
+transformation between units may not be as simple as a single scale
+factor, for example when a custom equivalency table is in use.
+
+Conversion to different units involves obtaining a conversion function
+and then applying it to the value, or values to be converted.
+
+  >>> cms = u.cm / u.s
+  >>> cms_to_kmph = cms.get_converter(u.km / u.hour)
+  >>> cms_to_kmph(125.)
+  4.5
+  >>> cms_to_kmph([1000, 2000])
+  array([36., 72.])
+
+.. EXAMPLE END
+
+
 Incompatible Conversions
 ========================
 

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -15,8 +15,10 @@ define new equivalencies.
 
 Equivalencies are used by passing a list of equivalency pairs to the
 ``equivalencies`` keyword argument of `Quantity.to()
-<astropy.units.quantity.Quantity.to>` or `Unit.to()
-<astropy.units.core.UnitBase.to>` methods. The list can be supplied directly,
+<astropy.units.quantity.Quantity.to>` `Unit.to()
+<astropy.units.core.UnitBase.to>` or `Unit.get_converter()
+<astropy.units.core.UnitBase.get_converter>` methods.
+The list can be supplied directly,
 but ``astropy`` contains several functions that return appropriate lists so
 constructing them is often not necessary. Alternatively, if a larger piece of
 code needs the same equivalencies, you can set them for a :ref:`given context


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes https://github.com/astropy/astropy/issues/9080, fixes https://github.com/astropy/astropy/issues/8273, fixes https://github.com/astropy/astropy/issues/11206. It almost just reverts the 9 year old commit https://github.com/astropy/astropy/commit/55022e96c398003158accd765afcece8aa0ee187 😄 

With this in the public API something like this would be supported behaviour:
``` python
In [1]: import astropy.units as u

In [2]: c1 = u.cm.get_converter(u.m)

In [3]: c2 = u.m.get_converter(u.cm)

In [4]: c1(c2(10.0))
Out[4]: 10.0

In [5]: c2(c1(10.0))
Out[5]: 10.0
```

This does speed up the examples in the issues.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
