### PR TITLE
BUG: fix compatibility with numpy 2.0 copy semantics

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -96,12 +96,10 @@ def _copy_input_if_needed(
                 # is no way to specify the return type or order etc. In addition
                 # ``np.nan`` is a ``float`` and there is no conversion to an
                 # ``int`` type. Therefore, a pre-fill copy is needed for non
-                # ``float`` masked arrays. ``subok=True`` is needed to retain
-                # ``np.ma.maskedarray.filled()``. ``copy=False`` allows the fill
-                # to act as the copy if type and order are already correct.
-                output = np.array(
-                    input, dtype=dtype, copy=False, order=order, subok=True
-                )
+                # ``float`` masked arrays. ``asanyarray`` is needed to retain
+                # ``np.ma.maskedarray.filled()``.
+                # A copy is made if and only if order isn't already correct.
+                output = np.asanyarray(input, dtype=dtype, order=order)
                 output = output.filled(fill_value)
             else:
                 # Since we're making a copy, we might as well use `subok=False` to save,
@@ -114,11 +112,7 @@ def _copy_input_if_needed(
                 # mask != 0 yields a bool mask for all ints/floats/bool
                 output[mask != 0] = fill_value
         else:
-            # The call below is synonymous with np.asanyarray(array, ftype=float, order='C')
-            # The advantage of `subok=True` is that it won't copy when array is an ndarray subclass.
-            # If it is and `subok=False` (default), then it will copy even if `copy=False`. This
-            # uses less memory when ndarray subclasses are passed in.
-            output = np.array(input, dtype=dtype, copy=False, order=order, subok=True)
+            output = np.asanyarray(input, dtype=dtype, order=order)
     except (TypeError, ValueError) as e:
         raise TypeError(
             "input should be a Numpy array or something convertible into a float array",

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -177,7 +177,7 @@ class Kernel:
         """
         return kernel_arithmetics(self, value, "mul")
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         """
         Array representation of the kernel.
         """

--- a/astropy/coordinates/polarization.py
+++ b/astropy/coordinates/polarization.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 import numpy as np
 
 from astropy.utils import unbroadcast
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.shapes import ShapedLikeNDArray
 
@@ -186,8 +187,8 @@ class StokesCoord(ShapedLikeNDArray):
     def dtype(self):
         return self._data.dtype
 
-    def __array__(self, dtype=None):
-        return self._data.astype(dtype, copy=False)
+    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+        return self._data.astype(dtype, copy=copy)
 
     def _apply(self, method, *args, **kwargs):
         cls = type(self)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -2220,7 +2220,8 @@ class TestInfo:
 )
 def test_differential_norm_noncartesian(cls):
     # The norm of a non-Cartesian differential without specifying `base` should error
-    rep = cls(0, 0, 0)
+    args = (0,) * len(cls.attr_classes)
+    rep = cls(*args)
     with pytest.raises(ValueError, match=r"`base` must be provided .* " + cls.__name__):
         rep.norm()
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from astropy.units import MagUnit, Quantity
 from astropy.utils import isiterable
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .utils import array_repr_oneline, get_inputs_and_params
 
@@ -732,12 +733,12 @@ class Parameter:
 
         return wrapper
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
         # Make np.asarray(self) work a little more straightforwardly
         arr = np.asarray(self.value, dtype=dtype)
 
         if self.unit is not None:
-            arr = Quantity(arr, self.unit, copy=False, subok=True)
+            arr = Quantity(arr, self.unit, copy=copy, subok=True)
 
         return arr
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -9,6 +9,7 @@ from math import comb
 import numpy as np
 
 from astropy.utils import check_broadcast, indent
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .core import FittableModel, Model
 from .functional_models import Shift
@@ -533,7 +534,7 @@ class Chebyshev1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=False, ndmin=1)
+        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -654,7 +655,7 @@ class Hermite1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=False, ndmin=1)
+        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -833,7 +834,7 @@ class Hermite2D(OrthoPolynomialBase):
         """
         Derivative of 1D Hermite series.
         """
-        x = np.array(x, dtype=float, copy=False, ndmin=1)
+        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:
@@ -936,7 +937,7 @@ class Legendre1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=False, ndmin=1)
+        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -1489,7 +1490,7 @@ class Chebyshev2D(OrthoPolynomialBase):
         """
         Derivative of 1D Chebyshev series.
         """
-        x = np.array(x, dtype=float, copy=False, ndmin=1)
+        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:
@@ -1643,7 +1644,7 @@ class Legendre2D(OrthoPolynomialBase):
 
     def _legendderiv1d(self, x, deg):
         """Derivative of 1D Legendre polynomial."""
-        x = np.array(x, dtype=float, copy=False, ndmin=1)
+        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
         d = np.empty((deg + 1,) + x.shape, dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -268,7 +268,7 @@ class NDData(NDDataBase):
         ):
             # Data doesn't look like a numpy array, try converting it to
             # one.
-            data = np.array(data, subok=True, copy=False)
+            data = np.asanyarray(data)
         # Another quick check to see if what we got looks like an array
         # rather than an object (since numpy will convert a
         # non-numerical/non-string inputs to an array of objects).

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -175,7 +175,7 @@ class NDUncertainty(metaclass=ABCMeta):
     @array.setter
     def array(self, value):
         if isinstance(value, (list, np.ndarray)):
-            value = np.array(value, subok=False, copy=False)
+            value = np.asarray(value)
         self._array = value
 
     @property

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -40,7 +40,7 @@ class FakeNumpyArray:
     def __getitem__(self, key):
         pass
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         pass
 
     @property

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -522,6 +522,11 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         copy=False,
         copy_indices=True,
     ):
+        if not NUMPY_LT_2_0 and copy is False:
+            # strict backward compatibility
+            # see https://github.com/astropy/astropy/pull/16142
+            copy = None
+
         if data is None:
             self_data = np.zeros((length,) + shape, dtype=dtype)
         elif isinstance(data, BaseColumn) and hasattr(data, "_name"):

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -6,6 +6,8 @@ from operator import index as operator_index
 
 import numpy as np
 
+from astropy.utils.compat import COPY_IF_NEEDED
+
 
 class Row:
     """A class to represent one row of a Table object.
@@ -88,7 +90,7 @@ class Row:
             )
         return self.as_void() != other
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
         """Support converting Row to np.array via np.array(table).
 
         Coercion to a different dtype via np.array(table, dtype) is not
@@ -99,7 +101,7 @@ class Row:
         if dtype is not None:
             raise ValueError("Datatype coercion is not allowed")
 
-        return np.asarray(self.as_void())
+        return np.array(self.as_void(), copy=copy)
 
     def __len__(self):
         return len(self._table.columns)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -19,7 +19,7 @@ from astropy.utils import (
     deprecated,
     isiterable,
 )
-from astropy.utils.compat import NUMPY_LT_1_25
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_25
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, DataInfo, MixinInfo
 from astropy.utils.decorators import format_doc
@@ -1129,7 +1129,7 @@ class Table:
         """
         return _IndexModeContext(self, mode)
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
         """Support converting Table to np.array via np.array(table).
 
         Coercion to a different dtype via np.array(table, dtype) is not
@@ -1139,7 +1139,7 @@ class Table:
             if np.dtype(dtype) != object:
                 raise ValueError("Datatype coercion is not allowed")
 
-            out = np.array(None, dtype=object)
+            out = np.array(None, dtype=object, copy=copy)
             out[()] = self
             return out
 
@@ -1459,7 +1459,7 @@ class Table:
         if isinstance(col, Column) and not isinstance(col, self.ColumnClass):
             col_cls = self._get_col_cls_for_table(col)
             if col_cls is not col.__class__:
-                col = col_cls(col, copy=False)
+                col = col_cls(col, copy=COPY_IF_NEEDED)
 
         return col
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -97,7 +97,7 @@ class TestColumn:
 
         np_data = np.array(d)
         assert np.all(np_data == d)
-        np_data = np.array(d, copy=False)
+        np_data = np.asarray(d)
         assert np.all(np_data == d)
         np_data = np.array(d, dtype="i4")
         assert np.all(np_data == d)

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -121,7 +121,7 @@ class TestRow:
         assert np_data is not d.as_void()
         assert d.colnames == list(np_data.dtype.names)
 
-        np_data = np.array(d, copy=False)
+        np_data = np.asarray(d)
         if table_types.Table is not MaskedTable:
             assert np.all(np_data == d.as_void())
         assert np_data is not d.as_void()

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1508,7 +1508,7 @@ class TestConvertNumpyArray:
         assert np_data is not d.as_array()
         assert d.colnames == list(np_data.dtype.names)
 
-        np_data = np.array(d, copy=False)
+        np_data = np.asarray(d)
         if table_types.Table is not MaskedTable:
             assert np.all(np_data == d.as_array())
         assert d.colnames == list(np_data.dtype.names)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -27,7 +27,7 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray, lazyproperty
-from astropy.utils.compat import PYTHON_LT_3_11
+from astropy.utils.compat import NUMPY_LT_2_0, PYTHON_LT_3_11
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
@@ -1971,6 +1971,11 @@ class Time(TimeBase):
         location=None,
         copy=False,
     ):
+        if not NUMPY_LT_2_0 and copy is False:
+            # strict backward compatibility
+            # see https://github.com/astropy/astropy/pull/16142
+            copy = None
+
         if location is not None:
             from astropy.coordinates import EarthLocation
 
@@ -3364,6 +3369,11 @@ def _make_array(val, copy=False):
         dtype = object
     else:
         dtype = None
+
+    if not NUMPY_LT_2_0 and copy is False:
+        # strict backward compatibility
+        # see https://github.com/astropy/astropy/pull/16142
+        copy = None
 
     val = np.array(val, copy=copy, subok=True, dtype=dtype)
 

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -628,7 +628,7 @@ class ArrayDistribution(Distribution, np.ndarray):
             # If value is not already a Distribution, first make it an array
             # to help interpret possible structured dtype, and then turn it
             # into a Distribution with n_samples=1 (which will broadcast).
-            value = np.array(value, dtype=self.dtype, copy=False, subok=True)
+            value = np.asanyarray(value, dtype=self.dtype)
             value = Distribution(value[..., np.newaxis])
 
         super().__setitem__(item, value)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -455,7 +455,7 @@ class Quantity(np.ndarray):
             if unit is not None and unit is not value.unit:
                 value = value.to(unit)
                 # the above already makes a copy (with float dtype)
-                copy = False
+                copy = COPY_IF_NEEDED
 
             if type(value) is not cls and not (subok and isinstance(value, cls)):
                 value = value.view(cls)
@@ -544,12 +544,7 @@ class Quantity(np.ndarray):
                 if unit is None:
                     unit = value_unit
                 elif unit is not value_unit:
-                    copy = False  # copy will be made in conversion at end
-
-        if not NUMPY_LT_2_0 and copy is False:
-            # strict backward compatibility
-            # see https://github.com/astropy/astropy/pull/16142
-            copy = None
+                    copy = COPY_IF_NEEDED  # copy will be made in conversion at end
 
         value = np.array(
             value, dtype=dtype, copy=copy, order=order, subok=True, ndmin=ndmin

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_allclose, assert_array_almost_equal, assert_arr
 from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
 from astropy.utils import isiterable, minversion
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyWarning
 
 """ The Quantity class will represent a number + unit + uncertainty """
@@ -1655,8 +1656,8 @@ class QuantityMimic:
         self.value = value
         self.unit = unit
 
-    def __array__(self):
-        return np.array(self.value)
+    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+        return np.array(self.value, dtype=dtype, copy=copy)
 
 
 class QuantityMimic2(QuantityMimic):

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -13,6 +13,7 @@ __all__ = [
     "NUMPY_LT_1_25",
     "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
+    "COPY_IF_NEEDED",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -22,3 +23,6 @@ NUMPY_LT_1_24 = not minversion(np, "1.24")
 NUMPY_LT_1_25 = not minversion(np, "1.25")
 NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0.dev")
+
+
+COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -513,6 +513,12 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
     def from_unmasked(cls, data, mask=None, copy=False):
         # Note: have to override since __new__ would use ndarray.__new__
         # which expects the shape as its first argument, not an array.
+
+        if not NUMPY_LT_2_0 and copy is False:
+            # strict backward compatibility
+            # see https://github.com/astropy/astropy/pull/16142
+            copy = None
+
         data = np.array(data, subok=True, copy=copy)
         self = data.view(cls)
         self._set_mask(mask, copy=copy)


### PR DESCRIPTION
### Description
This adresses an new incompatibility with numpy dev:
`np.array(..., copy=False)` now raises a `ValueError` if a copy cannot be avoided. The suggested replacement, [implemented in scikit-learn by the author of the breaking change](https://github.com/scikit-learn/scikit-learn/pull/28323), is to use `np.asarray(...)` instead, which will only create a copy if necessary, as desired.

xref https://github.com/numpy/numpy/pull/25168


Note that this doesn't fix devdeps by itself: there's also [an upstream issue in pyerfa](https://github.com/liberfa/pyerfa/issues/133),~ and another incompat with `Unit` that I'll need to bisect, and which I think can be addressed separately.~
update: turns out this other incompatibility was an artifact of my first attempt at this patch, not an actual issue.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
