### PR TITLE
BUG: declare private str ufuncs as unsupported (np._core.umath._expandtabs*)

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -388,6 +388,8 @@ if not NUMPY_LT_2_0:
         np._core.umath._lstrip_whitespace,
         np._core.umath._rstrip_whitespace,
         np._core.umath._replace,
+        np._core.umath._expandtabs,
+        np._core.umath._expandtabs_length,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
### Description
Quick follow up to #15699


xref https://github.com/numpy/numpy/pull/25891
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
