### PR TITLE
Backport PR #16144 on branch v6.0.x (BUG: declare private str ufuncs as unsupported (`np._core.umath._expandtabs*`))

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -388,6 +388,8 @@ if not NUMPY_LT_2_0:
         np._core.umath._lstrip_whitespace,
         np._core.umath._rstrip_whitespace,
         np._core.umath._replace,
+        np._core.umath._expandtabs,
+        np._core.umath._expandtabs_length,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
Backport PR #16144 on branch v6.0.x