### PR TITLE
TST: skip testing `numpy.array_api` in numpy 2.0 (module was removed)

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -642,6 +642,7 @@ class TestStructuredArray:
         assert value.dtype.names == ("x", "y", "z")
 
 
+@pytest.mark.skipif(not NUMPY_LT_2_0, reason="removed from numpy 2.0")
 @pytest.mark.filterwarnings(
     "ignore: The numpy.array_api submodule is still experimental. See NEP 47."
 )


### PR DESCRIPTION
### Description
xref https://github.com/numpy/numpy/pull/25911

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
