### PR TITLE
MAINT: Use array-api-strict instead of np.array_api

### DIFF
--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_equal
 
 from astropy import units as u
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
+from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT
 
 
 class TestQuantityArrayCopy:
@@ -642,13 +643,11 @@ class TestStructuredArray:
         assert value.dtype.names == ("x", "y", "z")
 
 
-@pytest.mark.filterwarnings(
-    "ignore: The numpy.array_api submodule is still experimental. See NEP 47."
-)
+@pytest.mark.skipif(not HAS_ARRAY_API_STRICT, reason="requires array_api_strict")
 def test_array_api_init():
-    import numpy.array_api as np_api
+    import array_api_strict as xp
 
-    array = np_api.asarray([1, 2, 3])
+    array = xp.asarray([1, 2, 3])
     quantity_array = u.Quantity(array, u.m)
     assert type(quantity_array) is u.Quantity
     assert_array_equal(quantity_array, [1, 2, 3] * u.m)

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -33,6 +33,7 @@ _optional_deps = [
     "lzma",
     "pyarrow",
     "pytest_mpl",
+    "array_api_strict",
 ]
 _deps = {k.upper(): k for k in _optional_deps}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test_all = [
     "coverage[toml]",
     "skyfield>=1.20",
     "sgp4>=2.3",
+    "array-api-strict",
 ]
 recommended = [
     "scipy>=1.8",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This fixes https://github.com/astropy/astropy/issues/16149 
I think we should just add this optional dependency (it's a light python package) instead of skipping the test all together. If we are moving towards an array api astropy future we would need to add this dependency soon enough :)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
