### PR TITLE
Deprecate `TableColumns.setdefault()` and `TableColumns.update()`

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -318,7 +318,7 @@ class TableColumns(OrderedDict):
         new_names = [mapper.get(name, name) for name in self]
         cols = list(self.values())
         self.clear()
-        self.update(list(zip(new_names, cols)))
+        super().update(zip(new_names, cols))
 
     def __delitem__(self, name):
         # Remove column names from pprint include/exclude attributes as needed.
@@ -363,6 +363,19 @@ class TableColumns(OrderedDict):
         """
         cols = [col for col in self.values() if not isinstance(col, cls)]
         return cols
+
+    # When the deprecation period of setdefault() and update() is over then they
+    # need to be rewritten to raise an error, not removed.
+
+    @deprecated(
+        since="6.1", alternative="t.setdefault()", name="t.columns.setdefault()"
+    )
+    def setdefault(self, key, default):
+        return super().setdefault(key, default)
+
+    @deprecated(since="6.1", alternative="t.update()", name="t.columns.update()")
+    def update(self, *args, **kwargs):
+        return super().update(*args, **kwargs)
 
 
 class TableAttribute(MetaAttribute):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -31,7 +31,7 @@ from astropy.time import Time, TimeDelta
 from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.compat.optional_deps import HAS_PANDAS
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
 
 from .conftest import MIXIN_COLS, MaskedTable
@@ -3490,3 +3490,27 @@ def test_table_hasattr_iloc():
 
     with pytest.raises(ValueError, match="for a table with indices"):
         t.loc[0]
+
+
+def test_table_columns_setdefault_deprecation():
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            r"^The t\.columns\.setdefault\(\) function is deprecated and may be "
+            "removed in a future version.\n"
+            r"        Use t\.setdefault\(\) instead\.$"
+        ),
+    ):
+        Table().columns.setdefault("a", [0])
+
+
+def test_table_columns_update_deprecation():
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            r"^The t\.columns\.update\(\) function is deprecated and may be "
+            "removed in a future version.\n"
+            r"        Use t\.update\(\) instead\.$"
+        ),
+    ):
+        Table().columns.update({"a": [0]})

--- a/docs/changes/table/16154.api.rst
+++ b/docs/changes/table/16154.api.rst
@@ -1,0 +1,5 @@
+``TableColumns.setdefault()``  and ``TableColumns.update()`` methods (which
+would typically be called as ``Table.columns.setdefault()`` and
+``Table.columns.update()``) have been deprecated because they can easily
+corrupt the ``Table`` instance the ``TableColumns`` instance is attached to.
+The ``Table.setdefault()`` and ``Table.update()`` methods are safe.


### PR DESCRIPTION
### Description

#### UPDATE

The `TableColumns.setdefault()` method is dangerous, as demonstrated below, and `TableColumns.update()` is dangerous for the same reasons. A `TableColumns` instance attached to a `Table` without any columns has no way of knowing what table it is attached to, so in that case it is not possible to call the column validation and conversion mechanisms of the parent table. The edge case of tables without columns is not negligible, so the methods can't be fixed (without modifying `TableColumns` a lot), so they should instead raise an error to ensure they do not corrupt the table. They are a part of public API, so they need to be deprecated first.

#### ORIGINAL DESCRIPTION

`TableColumns` inherits its `setdefault()` method from `OrderedDict`, but the latter knows nothing about `Table`, so using `TableColumns.setdefault()` can cause `Table` instances to become corrupt:
```python
>>> from astropy.table import Table
>>> t = Table()
>>> t.columns.setdefault("a", [1])
[1]
>>> t.colnames
['a']
>>> t.info
Traceback (most recent call last):
  ...
AttributeError: 'list' object has no attribute 'info'
```

The solution is to implement `TableColumns.setdefault()` that refers to the table it belongs to and lets that validate and convert its input. However, this does not work with an empty `TableColumns` because an empty `TableColumns` does not know anything about its parent table. In such cases it is better to raise a clear error than to risk corrupting the table.

It might be a good idea to implement `Table.setdefault()` which could easily work also with empty tables, but that would be a new feature and it should be implemented in a separate pull request that doesn't get backported. 

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
