### PR TITLE
Revert "TST: temporarily pin pytest<8.1"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pytest>=7.0, <8.1",  # https://github.com/astropy/astropy/issues/16146
+    "pytest>=7.0",
     "pytest-doctestplus>=0.12",
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10",
@@ -87,7 +87,7 @@ all = [
     "asdf-astropy>=0.3",
     "bottleneck",
     "ipython>=4.2",
-    "pytest>=7.0, <8.1",  # https://github.com/astropy/astropy/issues/16146
+    "pytest>=7.0",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
     "pre-commit",
@@ -96,7 +96,7 @@ docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies
     "sphinx",
     "sphinx-astropy[confv2]>=1.9.1",
-    "pytest>=7.0, <8.1",  # https://github.com/astropy/astropy/issues/16146
+    "pytest>=7.0",
     "sphinx-changelog>=1.2.0",
     "sphinx_design",
     "Jinja2>=3.1.3",


### PR DESCRIPTION
Reverts astropy/astropy#16147

I think it was merged a little too quickly, before I had a chance to check emails... 😆 

Since then, I have released pytest-doctestplus and pytest-filter-subpackage that would have been compatible. But at the same time pytest also yanked its 8.1, so this pin is no longer needed.

Expectation: CI should be green now except for devdeps.