### PR TITLE
A couple of WCS DistortionLookupTable fixes

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -1024,7 +1024,7 @@ The dimensions of the tabular array
 """
 
 DistortionLookupTable = """
-DistortionLookupTable(*table*, *crpix*, *crval*, *cdelt*)
+DistortionLookupTable(table, crpix, crval, cdelt)
 
 Represents a single lookup table for a `distortion paper`_
 transformation.
@@ -1035,10 +1035,12 @@ table : 2-dimensional array
     The distortion lookup table.
 
 crpix : 2-tuple
-    The distortion array reference pixel
+    The distortion array reference pixel, in FITS Header format: 1-based
+    indexing, (x,y) order.
 
 crval : 2-tuple
-    The image array pixel coordinate
+    The image array pixel coordinate, in FITS Header format: 1-based indexing,
+    (x,y) order.
 
 cdelt : 2-tuple
     The grid step size

--- a/astropy/wcs/src/distortion.c
+++ b/astropy/wcs/src/distortion.c
@@ -79,11 +79,11 @@ image_coord_to_distortion_coord(
   assert(lookup != NULL);
   assert(axis < NAXES);
 
-  /* The "- 1./stepsize" is here because the input coordinates are 1-based,
+  /* The "- 1" is here because the input coordinates are 1-based,
      but this is a C-array underneath */
   result = (
       ((img - lookup->crval[axis]) / lookup->cdelt[axis]) +
-      lookup->crpix[axis]) - 1.0/lookup->cdelt[axis];
+      lookup->crpix[axis]) - 1.0;
 
   return CLAMP(result, 0.0, (double)(lookup->naxis[axis] - 1));
 }

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -53,6 +53,7 @@ from astropy.wcs.wcs import (
     WCS,
     WCSSUB_LATITUDE,
     WCSSUB_LONGITUDE,
+    DistortionLookupTable,
     FITSFixedWarning,
     Sip,
 )
@@ -209,6 +210,37 @@ def test_slice_with_sip():
         rtol=0.0,
         atol=1e-6 * pscale,
     )
+
+
+def test_slice_with_cpdis_tables():
+    # A basic WCS
+    mywcs = WCS(naxis=2)
+    mywcs.wcs.crval = [1, 1]
+    mywcs.wcs.cdelt = [0.1, 0.1]
+    mywcs.wcs.crpix = [1, 1]
+    mywcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+
+    # Arbitrary distortion maps for X and Y
+    distortion_array = np.arange(25 * 25, dtype=np.float32).reshape((25, 25))
+    mywcs.cpdis1 = DistortionLookupTable(distortion_array, (1, 1), (1, 1), (10, 10))
+    mywcs.cpdis2 = DistortionLookupTable(distortion_array, (1, 1), (1, 1), (10, 10))
+
+    # Test that equivalent pixels produce the same coordinates, whether or not
+    # they've been sliced out.
+    coord_from_slice = mywcs[40:, 50:].pixel_to_world(30, 60)
+    coord_from_full = mywcs.pixel_to_world(50 + 30, 40 + 60)
+
+    assert coord_from_full == coord_from_slice
+
+    # Test the same with a step size. (Note, per discussion in gh-10897,
+    # slicing a WCS means "binning", rather than "resampling", so there's a
+    # quarter-pixel offset to get the "equivalent" spot. The centers of the
+    # post-slice pixels are at the dividing line between the two "input" pixels
+    # that form this binned, post-slice pixel.)
+    coord_from_slice = mywcs[50::2, 50::2].pixel_to_world(24.75, 24.75)
+    coord_from_full = mywcs.pixel_to_world(100, 100)
+
+    assert coord_from_full == coord_from_slice
 
 
 def test_slice_getitem():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1857,3 +1857,84 @@ def test_swapaxes_same_val_roundtrip():
 
     # check round-tripping:
     assert np.allclose(w.wcs_world2pix([val_ref], 0)[0], imcoord, rtol=0, atol=1e-8)
+
+
+def test_DistortionLookupTable():
+    img_world_wcs = wcs.WCS(naxis=2)
+    # A simple "pixel coordinates are world coordinates" WCS, to which we'll
+    # add distortion lookup tables
+    img_world_wcs.wcs.crpix = 1, 1
+    img_world_wcs.wcs.crval = 0, 0
+    img_world_wcs.wcs.cdelt = 1, 1
+
+    # Create maps with zero distortion except at one particular pixel
+    x_dist_array = np.zeros((25, 25))
+    x_dist_array[10, 20] = 0.5
+    map_x = wcs.DistortionLookupTable(
+        x_dist_array.astype(np.float32), (5, 10), (10, 20), (2, 2)
+    )
+
+    y_dist_array = np.zeros((25, 25))
+    y_dist_array[10, 5] = 0.7
+    map_y = wcs.DistortionLookupTable(
+        y_dist_array.astype(np.float32), (5, 10), (10, 20), (3, 3)
+    )
+
+    img_world_wcs.cpdis1 = map_x
+    img_world_wcs.cpdis2 = map_y
+
+    # The x distortion of 0.5 pixels should appear at a specific spot in the
+    # image, and we need to work out what that is so we can check it. The
+    # distortion is at array index (10, 20), which is a 1-based pixel
+    # coordinate of (21, 11) and therefore at an offset of (16, 1) from the
+    # lookup table's CRPIX of (5, 10). CDELT is 2 image pixels / distortion
+    # pixel, so the distortion applies to the image pixel which is at an offset
+    # of (32, 2) from the CRVAL of (10, 20), meaning we should see the
+    # distortion at the 1-based image pixel coordinate of (42, 22).
+    assert_allclose(map_x.get_offset(42, 22), 0.5)
+    # And we should see it applied at the 0-based coordinate (41, 21) with our
+    # simple img<->world wcs.
+    assert_allclose(img_world_wcs.pixel_to_world_values(41, 21), [41.5, 21])
+    # Similarly for the y distortion, the distortion is at array index (10, 5),
+    # which is a 1-based pixel coordinate of (6, 11) and therefore at an offset
+    # of (1, 1) from the lookup table's CRPIX of (5, 10). CDELT is 3 image
+    # pixels / distortion pixel, so the distortion applies to the image pixel
+    # which is at an offset of (3, 3) from the CRVAL of (10, 20), meaning we
+    # should see the distortion at the 1-based image pixel coordinate of (13,
+    # 23).
+    assert_allclose(map_y.get_offset(13, 23), 0.7)
+    # And we should see it applied at the 0-based coordinate (12, 22) with our
+    # simple img<->world wcs.
+    assert_allclose(img_world_wcs.pixel_to_world_values(12, 22), [12, 22.7])
+
+    # Now check that when we move the image location by the equivalent of 1/2
+    # distortion-array pixel, we see only half the distortion.
+    for dx, dy in [(0.5, 0), (-0.5, 0), (0, 0.5), (0, -0.5)]:
+        # Scale dx, dy by 2 for the CDELT in the x distortion table (since
+        # we're looking for the x distortion).
+        assert_allclose(
+            img_world_wcs.pixel_to_world_values(41 + dx * 2, 21 + dy * 2),
+            [41 + dx * 2 + 0.25, 21 + dy * 2],
+        )
+        # Scale dx, dy by 3 for the CDELT in the y distortion table (since
+        # we're looking for the y distortion).
+        assert_allclose(
+            img_world_wcs.pixel_to_world_values(12 + dx * 3, 22 + dy * 3),
+            [12 + dx * 3, 22 + dy * 3 + 0.35],
+        )
+
+    # Now check that when we move the image location by the equivalent of 1
+    # distortion-array pixel, we see no distortion.
+    for dx, dy in [(2, 0), (-2, 0), (0, 2), (0, -2)]:
+        # Scale dx, dy by 2 for the CDELT in the x distortion table (since
+        # we're looking for the x distortion).
+        assert_allclose(
+            img_world_wcs.pixel_to_world_values(41 + dx * 2, 21 + dy * 2),
+            [41 + dx * 2, 21 + dy * 2],
+        )
+        # Scale dx, dy by 3 for the CDELT in the y distortion table (since
+        # we're looking for the y distortion).
+        assert_allclose(
+            img_world_wcs.pixel_to_world_values(12 + dx * 3, 22 + dy * 3),
+            [12 + dx * 3, 22 + dy * 3],
+        )

--- a/docs/changes/wcs/16163.bugfix.rst
+++ b/docs/changes/wcs/16163.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in ``DistortionLookupTable`` (which implements ``cpdis`` and ``det2im`` projection corrections to a WCS) in which image pixels received an incorrect distortion value, from a location in the lookup table incorrectly offset by about 1 table pixel.

--- a/docs/changes/wcs/16163.feature.rst
+++ b/docs/changes/wcs/16163.feature.rst
@@ -1,0 +1,1 @@
+Added support for slicing WCS objects containing ``cpdis`` or ``det2im`` distortions, which previously were ignored.


### PR DESCRIPTION
This fixes #13456 and fixes #15047

The first commit adds a few tests for `DistortionLookupTable`, which looks like it had very little coverage before this. I've tried to make it easy to be sure that the tested-for behavior is correct. Both tests will fail without the following commits.

* #13456 was a long, stream-of-conciousness bug report (I wrote it, so I can say that). I don't think my "off-by-one" analysis then fully holds water. Looking at things again, I think `DistortionLookupTable`'s CRPIX and CRVAL are treated consistently through the code (as FITS-style one-based indices), but there is a problem with how the code calculates the distortion-table pixel corresponding to an image-pixel location. At the location of the code change, the image pixel coordinate and the `DistortionLookupTable`'s CRPIX and CRVAL are all 1-based indices, and so the conversion to a zero-based index that the comment there mentions should happen at the "end" of the calculation and should not be scaled by CDELT. With this change, one of the new tests passes.

* #15047 noted that `DistortionLookupTables` simply aren't handled when slicing a WCS. This PR implements that handling. I've also added handling for the "det2im" tables, which I'm not familiar with, but as far as I can tell they're just another name for "cpdis" distortion maps, so I've treated them the same way.