### PR TITLE
RFC: refactor internal usage of copy=False to copy=COPY_IF_NEEDED

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -15,7 +15,7 @@ import numpy as np
 from astropy import units as u
 from astropy.units import SpecificTypeQuantity
 from astropy.utils import isiterable
-from astropy.utils.compat import NUMPY_LT_2_0
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 
 from . import formats
 
@@ -179,12 +179,12 @@ class Angle(SpecificTypeQuantity):
 
                 if angle_unit is not unit:
                     # Possible conversion to `unit` will be done below.
-                    angle = u.Quantity(angle, angle_unit, copy=False)
+                    angle = u.Quantity(angle, angle_unit, copy=COPY_IF_NEEDED)
 
             elif isiterable(angle) and not (
                 isinstance(angle, np.ndarray) and angle.dtype.kind not in "SUVO"
             ):
-                angle = [Angle(x, unit, copy=False) for x in angle]
+                angle = [Angle(x, unit, copy=COPY_IF_NEEDED) for x in angle]
 
         return super().__new__(cls, angle, unit, dtype=dtype, copy=copy, **kwargs)
 

--- a/astropy/coordinates/angles/utils.py
+++ b/astropy/coordinates/angles/utils.py
@@ -22,6 +22,7 @@ from astropy.coordinates.representation import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
+from astropy.utils.compat import COPY_IF_NEEDED
 
 _TWOPI = 2 * np.pi
 
@@ -228,5 +229,5 @@ def uniform_spherical_random_volume(size=1, max_radius=1):
 
     usph = uniform_spherical_random_surface(size=size)
 
-    r = np.cbrt(rng.uniform(size=size)) * u.Quantity(max_radius, copy=False)
+    r = np.cbrt(rng.uniform(size=size)) * u.Quantity(max_radius, copy=COPY_IF_NEEDED)
     return SphericalRepresentation(usph.lon, usph.lat, r)

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -6,6 +6,7 @@ import numpy as np
 # Project
 from astropy import units as u
 from astropy.utils import ShapedLikeNDArray
+from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = [
     "Attribute",
@@ -341,7 +342,7 @@ class QuantityAttribute(Attribute):
             )
 
         oldvalue = value
-        value = u.Quantity(oldvalue, self.unit, copy=False)
+        value = u.Quantity(oldvalue, self.unit, copy=COPY_IF_NEEDED)
         if self.shape is not None and value.shape != self.shape:
             if value.shape == () and oldvalue == 0:
                 # Allow a single 0 to fill whatever shape is needed.

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -14,6 +14,7 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .cirs import CIRS
@@ -53,15 +54,15 @@ def cirs_to_observed(cirs_coo, observed_frame):
 
     if is_unitspherical:
         rep = UnitSphericalRepresentation(
-            lat=u.Quantity(lat, u.radian, copy=False),
-            lon=u.Quantity(lon, u.radian, copy=False),
+            lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
             copy=False,
         )
     else:
         # since we've transformed to CIRS at the observatory location, just use CIRS distance
         rep = SphericalRepresentation(
-            lat=u.Quantity(lat, u.radian, copy=False),
-            lon=u.Quantity(lon, u.radian, copy=False),
+            lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
             distance=cirs_coo.distance,
             copy=False,
         )

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -14,6 +14,7 @@ from astropy.coordinates.transformations import (
     DynamicMatrixTransform,
     FunctionTransformWithFiniteDifference,
 )
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import format_doc
 
 from .baseradec import BaseRADecFrame, doc_components
@@ -153,7 +154,11 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     # the observing time/epoch) of the coordinates. See issue #1496 for a
     # discussion of this.
     eterms_a = CartesianRepresentation(
-        u.Quantity(fk4_e_terms(fk4coord.equinox), u.dimensionless_unscaled, copy=False),
+        u.Quantity(
+            fk4_e_terms(fk4coord.equinox),
+            u.dimensionless_unscaled,
+            copy=COPY_IF_NEEDED,
+        ),
         copy=False,
     )
     rep = rep - eterms_a + eterms_a.dot(rep) * rep
@@ -203,7 +208,9 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
     # discussion of this.
     eterms_a = CartesianRepresentation(
         u.Quantity(
-            fk4_e_terms(fk4noecoord.equinox), u.dimensionless_unscaled, copy=False
+            fk4_e_terms(fk4noecoord.equinox),
+            u.dimensionless_unscaled,
+            copy=COPY_IF_NEEDED,
         ),
         copy=False,
     )

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -18,6 +18,7 @@ from astropy.coordinates.transformations import (
     AffineTransform,
     FunctionTransformWithFiniteDifference,
 )
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .cirs import CIRS
 from .gcrs import GCRS
@@ -41,8 +42,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(cirs_dec, u.radian, copy=False),
-            lon=u.Quantity(cirs_ra, u.radian, copy=False),
+            lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
             copy=False,
         )
     else:
@@ -51,15 +52,15 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # no parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=False
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
         )
         newcart = icrs_coo.cartesian - astrom_eb
         srepr = newcart.represent_as(SphericalRepresentation)
         cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(
-            lat=u.Quantity(cirs_dec, u.radian, copy=False),
-            lon=u.Quantity(cirs_ra, u.radian, copy=False),
+            lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
             copy=False,
         )
@@ -82,8 +83,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=False),
-            lon=u.Quantity(i_ra, u.radian, copy=False),
+            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
             copy=False,
         )
     else:
@@ -93,14 +94,14 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=False),
-            lon=u.Quantity(i_ra, u.radian, copy=False),
+            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
             copy=False,
         )
 
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=False
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
         )
         newrep = intermedrep + astrom_eb
 
@@ -124,8 +125,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(gcrs_dec, u.radian, copy=False),
-            lon=u.Quantity(gcrs_ra, u.radian, copy=False),
+            lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
             copy=False,
         )
     else:
@@ -134,7 +135,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=False
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
         )
         newcart = icrs_coo.cartesian - astrom_eb
 
@@ -142,8 +143,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(
-            lat=u.Quantity(gcrs_dec, u.radian, copy=False),
-            lon=u.Quantity(gcrs_ra, u.radian, copy=False),
+            lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
             copy=False,
         )
@@ -167,8 +168,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=False),
-            lon=u.Quantity(i_ra, u.radian, copy=False),
+            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
             copy=False,
         )
     else:
@@ -178,14 +179,14 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=False),
-            lon=u.Quantity(i_ra, u.radian, copy=False),
+            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
+            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
             copy=False,
         )
 
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=False
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
         )
         newrep = intermedrep + astrom_eb
 
@@ -208,8 +209,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     # convert to Quantity objects
-    i_ra = u.Quantity(i_ra, u.radian, copy=False)
-    i_dec = u.Quantity(i_dec, u.radian, copy=False)
+    i_ra = u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED)
+    i_dec = u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED)
     if (
         gcrs_coo.data.get_name() == "unitspherical"
         or gcrs_coo.data.to_cartesian().x.unit == u.one
@@ -234,7 +235,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # against the shape of the pv array.
         # broadcast em to eh and scale eh
         eh = astrom["eh"] * astrom["em"][..., np.newaxis]
-        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=False)
+        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED)
 
         newrep = intermedrep.to_cartesian() + eh
 

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -14,6 +14,7 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .hadec import HADec
@@ -37,7 +38,7 @@ def icrs_to_observed(icrs_coo, observed_frame):
         srepr = icrs_coo.spherical
     else:
         observer_icrs = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=False
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
         )
         srepr = (icrs_coo.cartesian - observer_icrs).represent_as(
             SphericalRepresentation
@@ -90,10 +91,13 @@ def observed_to_icrs(observed_coo, icrs_frame):
     # Topocentric CIRS
     cirs_ra, cirs_dec = erfa.atoiq(coord_type, lon, lat, astrom) << u.radian
     if is_unitspherical:
-        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1, copy=False)
+        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1, copy=COPY_IF_NEEDED)
     else:
         srepr = SphericalRepresentation(
-            lon=cirs_ra, lat=cirs_dec, distance=observed_coo.distance, copy=False
+            lon=cirs_ra,
+            lat=cirs_dec,
+            distance=observed_coo.distance,
+            copy=COPY_IF_NEEDED,
         )
 
     # BCRS (Astrometric) direction to source
@@ -101,13 +105,16 @@ def observed_to_icrs(observed_coo, icrs_frame):
 
     # Correct for parallax to get ICRS representation
     if is_unitspherical:
-        icrs_srepr = UnitSphericalRepresentation(bcrs_ra, bcrs_dec, copy=False)
+        icrs_srepr = UnitSphericalRepresentation(bcrs_ra, bcrs_dec, copy=COPY_IF_NEEDED)
     else:
         icrs_srepr = SphericalRepresentation(
-            lon=bcrs_ra, lat=bcrs_dec, distance=observed_coo.distance, copy=False
+            lon=bcrs_ra,
+            lat=bcrs_dec,
+            distance=observed_coo.distance,
+            copy=COPY_IF_NEEDED,
         )
         observer_icrs = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=False
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
         )
         newrepr = icrs_srepr.to_cartesian() + observer_icrs
         icrs_srepr = newrepr.represent_as(SphericalRepresentation)

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 
 from astropy import units as u
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyWarning
 
 from .angles import Angle
@@ -161,7 +162,7 @@ class Distance(u.SpecificTypeQuantity):
                     value <<= u.AU
 
         elif parallax is not None:
-            parallax = u.Quantity(parallax, copy=False, subok=True)
+            parallax = u.Quantity(parallax, copy=COPY_IF_NEEDED, subok=True)
             value = parallax.to(unit or u.pc, equivalencies=u.parallax())
 
             if np.any(parallax < 0):
@@ -253,12 +254,12 @@ class Distance(u.SpecificTypeQuantity):
     def distmod(self):
         """The distance modulus as a `~astropy.units.Quantity`."""
         val = 5.0 * np.log10(self.to_value(u.pc)) - 5.0
-        return u.Quantity(val, u.mag, copy=False)
+        return u.Quantity(val, u.mag, copy=COPY_IF_NEEDED)
 
     @classmethod
     def _distmod_to_pc(cls, dm):
         dm = u.Quantity(dm, u.mag)
-        return cls(10 ** ((dm.value + 5) / 5.0), u.pc, copy=False)
+        return cls(10 ** ((dm.value + 5) / 5.0), u.pc, copy=COPY_IF_NEEDED)
 
     @property
     def parallax(self):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -14,6 +14,7 @@ from astropy import constants as consts
 from astropy import units as u
 from astropy.units.quantity import QuantityInfoBase
 from astropy.utils import data
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .angles import Angle, Latitude, Longitude
@@ -270,9 +271,9 @@ class EarthLocation(u.Quantity):
         # in that it will no longer possible to initialize with a unit-full x,
         # and unit-less y, z. Arguably, though, that would just solve a bug.
         try:
-            x = u.Quantity(x, unit, copy=False)
-            y = u.Quantity(y, unit, copy=False)
-            z = u.Quantity(z, unit, copy=False)
+            x = u.Quantity(x, unit, copy=COPY_IF_NEEDED)
+            y = u.Quantity(y, unit, copy=COPY_IF_NEEDED)
+            z = u.Quantity(z, unit, copy=COPY_IF_NEEDED)
         except u.UnitsError:
             raise u.UnitsError("Geocentric coordinate units should all be consistent.")
 
@@ -316,11 +317,11 @@ class EarthLocation(u.Quantity):
         """
         ellipsoid = _check_ellipsoid(ellipsoid, default=cls._ellipsoid)
         # As wrapping fails on readonly input, we do so manually
-        lon = Angle(lon, u.degree, copy=False).wrap_at(180 * u.degree)
-        lat = Latitude(lat, u.degree, copy=False)
+        lon = Angle(lon, u.degree, copy=COPY_IF_NEEDED).wrap_at(180 * u.degree)
+        lat = Latitude(lat, u.degree, copy=COPY_IF_NEEDED)
         # don't convert to m by default, so we can use the height unit below.
         if not isinstance(height, u.Quantity):
-            height = u.Quantity(height, u.m, copy=False)
+            height = u.Quantity(height, u.m, copy=COPY_IF_NEEDED)
         # get geocentric coordinates.
         geodetic = ELLIPSOIDS[ellipsoid](lon, lat, height, copy=False)
         xyz = geodetic.to_cartesian().get_xyz(xyz_axis=-1) << height.unit

--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import astropy.units as u
 from astropy.coordinates.angles import Angle
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 from .cartesian import CartesianRepresentation
@@ -78,9 +79,9 @@ class CylindricalRepresentation(BaseRepresentation):
         sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
         l = np.broadcast_to(1.0, self.shape)
         return {
-            "rho": CartesianRepresentation(cosphi, sinphi, 0, copy=False),
-            "phi": CartesianRepresentation(-sinphi, cosphi, 0, copy=False),
-            "z": CartesianRepresentation(0, 0, l, unit=u.one, copy=False),
+            "rho": CartesianRepresentation(cosphi, sinphi, 0, copy=COPY_IF_NEEDED),
+            "phi": CartesianRepresentation(-sinphi, cosphi, 0, copy=COPY_IF_NEEDED),
+            "z": CartesianRepresentation(0, 0, l, unit=u.one, copy=COPY_IF_NEEDED),
         }
 
     def scale_factors(self):
@@ -122,7 +123,7 @@ class CylindricalRepresentation(BaseRepresentation):
         z_op = lambda x: op(x, *args)
 
         result = self.__class__(
-            rho_op(self.rho), phi_op(self.phi), z_op(self.z), copy=False
+            rho_op(self.rho), phi_op(self.phi), z_op(self.z), copy=COPY_IF_NEEDED
         )
         for key, differential in self.differentials.items():
             new_comps = (

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -10,6 +10,7 @@ from astropy.coordinates.angles import Angle, Latitude, Longitude
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.matrix_utilities import is_O3
 from astropy.utils import classproperty
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 from .cartesian import CartesianRepresentation
@@ -82,9 +83,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
         sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
         sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
         return {
-            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=False),
+            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=COPY_IF_NEEDED),
             "lat": CartesianRepresentation(
-                -sinlat * coslon, -sinlat * sinlon, coslat, copy=False
+                -sinlat * coslon, -sinlat * sinlon, coslat, copy=COPY_IF_NEEDED
             ),
         }
 
@@ -122,10 +123,18 @@ class UnitSphericalRepresentation(BaseRepresentation):
         if isinstance(other_class, type) and not differential_class:
             if issubclass(other_class, PhysicsSphericalRepresentation):
                 return other_class(
-                    phi=self.lon, theta=90 * u.deg - self.lat, r=1.0, copy=False
+                    phi=self.lon,
+                    theta=90 * u.deg - self.lat,
+                    r=1.0,
+                    copy=COPY_IF_NEEDED,
                 )
             elif issubclass(other_class, SphericalRepresentation):
-                return other_class(lon=self.lon, lat=self.lat, distance=1.0, copy=False)
+                return other_class(
+                    lon=self.lon,
+                    lat=self.lat,
+                    distance=1.0,
+                    copy=COPY_IF_NEEDED,
+                )
 
         return super().represent_as(other_class, differential_class)
 
@@ -491,12 +500,12 @@ class SphericalRepresentation(BaseRepresentation):
         sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
         sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
         return {
-            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=False),
+            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=COPY_IF_NEEDED),
             "lat": CartesianRepresentation(
-                -sinlat * coslon, -sinlat * sinlon, coslat, copy=False
+                -sinlat * coslon, -sinlat * sinlon, coslat, copy=COPY_IF_NEEDED
             ),
             "distance": CartesianRepresentation(
-                coslat * coslon, coslat * sinlon, sinlat, copy=False
+                coslat * coslon, coslat * sinlon, sinlat, copy=COPY_IF_NEEDED
             ),
         }
 
@@ -607,7 +616,10 @@ class SphericalRepresentation(BaseRepresentation):
         lon_op, lat_op, distance_op = _spherical_op_funcs(op, *args)
 
         result = self.__class__(
-            lon_op(self.lon), lat_op(self.lat), distance_op(self.distance), copy=False
+            lon_op(self.lon),
+            lat_op(self.lat),
+            distance_op(self.distance),
+            copy=COPY_IF_NEEDED,
         )
         for key, differential in self.differentials.items():
             new_comps = (
@@ -698,12 +710,12 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
         sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
         return {
-            "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=False),
+            "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=COPY_IF_NEEDED),
             "theta": CartesianRepresentation(
-                costheta * cosphi, costheta * sinphi, -sintheta, copy=False
+                costheta * cosphi, costheta * sinphi, -sintheta, copy=COPY_IF_NEEDED
             ),
             "r": CartesianRepresentation(
-                sintheta * cosphi, sintheta * sinphi, costheta, copy=False
+                sintheta * cosphi, sintheta * sinphi, costheta, copy=COPY_IF_NEEDED
             ),
         }
 
@@ -826,7 +838,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             phi_op(self.phi),
             phi_op(adjust_theta_sign(self.theta)),
             r_op(self.r),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         for key, differential in self.differentials.items():
             new_comps = (

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -14,6 +14,7 @@ from astropy.constants import c as speed_of_light
 from astropy.table import QTable
 from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -835,12 +836,12 @@ class SkyCoord(ShapedLikeNDArray):
             new_distance = Distance(parallax=starpm[4] << u.arcsec)
 
         icrs2 = ICRS(
-            ra=u.Quantity(starpm[0], u.radian, copy=False),
-            dec=u.Quantity(starpm[1], u.radian, copy=False),
-            pm_ra=u.Quantity(starpm[2], u.radian / u.yr, copy=False),
-            pm_dec=u.Quantity(starpm[3], u.radian / u.yr, copy=False),
+            ra=u.Quantity(starpm[0], u.radian, copy=COPY_IF_NEEDED),
+            dec=u.Quantity(starpm[1], u.radian, copy=COPY_IF_NEEDED),
+            pm_ra=u.Quantity(starpm[2], u.radian / u.yr, copy=COPY_IF_NEEDED),
+            pm_dec=u.Quantity(starpm[3], u.radian / u.yr, copy=COPY_IF_NEEDED),
             distance=new_distance,
-            radial_velocity=u.Quantity(starpm[5], u.km / u.s, copy=False),
+            radial_velocity=u.Quantity(starpm[5], u.km / u.s, copy=COPY_IF_NEEDED),
             differential_type=SphericalDifferential,
         )
 

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import IrreducibleUnit, Unit
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .baseframe import (
     BaseCoordinateFrame,
@@ -553,7 +554,9 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
         for frame_attr_name, repr_attr_class, value, unit in zip(
             frame_attr_names, repr_attr_classes, values, units
         ):
-            components[frame_attr_name] = repr_attr_class(value, unit=unit, copy=False)
+            components[frame_attr_name] = repr_attr_class(
+                value, unit=unit, copy=COPY_IF_NEEDED
+            )
     except Exception as err:
         raise ValueError(
             f'Cannot parse first argument data "{value}" for attribute'

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.constants import c as speed_of_light
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data import download_file
 from astropy.utils.decorators import classproperty, deprecated
 from astropy.utils.state import ScienceState
@@ -266,11 +267,14 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None, get_velocity=True):
                     body_pv_bary = erfa.pvppv(body_pv_helio, sun_pv_bary)
 
             body_pos_bary = CartesianRepresentation(
-                body_pv_bary["p"], unit=u.au, xyz_axis=-1, copy=False
+                body_pv_bary["p"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
             )
             if get_velocity:
                 body_vel_bary = CartesianRepresentation(
-                    body_pv_bary["v"], unit=u.au / u.day, xyz_axis=-1, copy=False
+                    body_pv_bary["v"],
+                    unit=u.au / u.day,
+                    xyz_axis=-1,
+                    copy=COPY_IF_NEEDED,
                 )
 
         else:

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -13,6 +13,7 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
 from astropy.coordinates.spectral_quantity import SpectralQuantity
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["SpectralCoord"]
@@ -392,7 +393,7 @@ class SpectralCoord(SpectralQuantity):
                 redshift=redshift,
                 doppler_convention=doppler_convention,
                 doppler_rest=doppler_rest,
-                copy=False,
+                copy=COPY_IF_NEEDED,
             )
 
     @property

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -32,6 +32,7 @@ from astropy.coordinates.representation import (
 )
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose_quantity
 from astropy.utils import isiterable
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 
 # create matrices for use in testing ``.transform()`` methods
@@ -1737,7 +1738,7 @@ class TestCartesianRepresentationWithDifferential:
 
         # make sure other kwargs are handled properly
         s1 = CartesianRepresentation(
-            x=1, y=2, z=3, differentials=diff, copy=False, unit=u.kpc
+            x=1, y=2, z=3, differentials=diff, copy=COPY_IF_NEEDED, unit=u.kpc
         )
         assert len(s1.differentials) == 1
         assert s1.differentials["s"] is diff

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import isiterable
+from astropy.utils.compat import COPY_IF_NEEDED
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -551,7 +552,9 @@ class _BoundingDomain(abc.ABC):
         List containing filled in output values and units
         """
         if valid_outputs_unit is not None:
-            return Quantity(outputs, valid_outputs_unit, copy=False, subok=True)
+            return Quantity(
+                outputs, valid_outputs_unit, copy=COPY_IF_NEEDED, subok=True
+            )
 
         return outputs
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -37,6 +37,7 @@ from astropy.utils import (
     sharedmethod,
 )
 from astropy.utils.codegen import make_function_with_signature
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .bounding_box import CompoundBoundingBox, ModelBoundingBox
 from .parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
@@ -442,7 +443,9 @@ class _ModelMeta(abc.ABCMeta):
                     # default is not a Quantity, attach the unit to the
                     # default.
                     if unit is not None:
-                        default = Quantity(default, unit, copy=False, subok=True)
+                        default = Quantity(
+                            default, unit, copy=COPY_IF_NEEDED, subok=True
+                        )
                     kwargs.append((param_name, default))
             else:
                 args = ("self",) + tuple(pdict.keys())

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -762,7 +762,7 @@ class Table:
             # self.__class__ and respects the `copy` arg.  The returned
             # Table object should NOT then be copied.
             data = data.__astropy_table__(self.__class__, copy, **kwargs)
-            copy = False
+            copy = COPY_IF_NEEDED
         elif kwargs:
             raise TypeError(
                 f"__init__() got unexpected keyword argument {next(iter(kwargs.keys()))!r}"
@@ -1380,7 +1380,7 @@ class Table:
             # scalar then it gets returned unchanged so the original object gets
             # passed to `Column` later.
             data = _convert_sequence_data_to_array(data, dtype)
-            copy = False  # Already made a copy above
+            copy = COPY_IF_NEEDED  # Already made a copy above
             col_cls = (
                 masked_col_cls
                 if isinstance(data, np.ma.MaskedArray)
@@ -4284,7 +4284,7 @@ class QTable(Table):
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
             try:
-                qcol = q_cls(col.data, col.unit, copy=False, subok=True)
+                qcol = q_cls(col.data, col.unit, copy=COPY_IF_NEEDED, subok=True)
             except Exception as exc:
                 warnings.warn(
                     f"column {col.info.name} has a unit but is kept as "

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -28,7 +28,7 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray, lazyproperty
-from astropy.utils.compat import PYTHON_LT_3_11, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, PYTHON_LT_3_11, sanitize_copy_arg
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
@@ -1736,7 +1736,7 @@ class TimeBase(ShapedLikeNDArray):
             val2=jd2,
             format="jd",
             scale=self.scale,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         result.format = self.format
         return result
@@ -2458,7 +2458,7 @@ class Time(TimeBase):
             longitude = longitude.lon
         else:
             # Sanity check on input; default unit is degree.
-            longitude = Longitude(longitude, u.degree, copy=False)
+            longitude = Longitude(longitude, u.degree, copy=COPY_IF_NEEDED)
 
         theta = self._call_erfa(function, scales)
 
@@ -3102,7 +3102,7 @@ class TimeDelta(TimeBase):
         # If other is something consistent with a dimensionless quantity
         # (could just be a float or an array), then we can just multiple in.
         try:
-            other = u.Quantity(other, u.dimensionless_unscaled, copy=False)
+            other = u.Quantity(other, u.dimensionless_unscaled, copy=COPY_IF_NEEDED)
         except Exception:
             # If not consistent with a dimensionless quantity, try downgrading
             # self to a quantity and see if things work.
@@ -3135,7 +3135,7 @@ class TimeDelta(TimeBase):
         # If other is something consistent with a dimensionless quantity
         # (could just be a float or an array), then we can just divide in.
         try:
-            other = u.Quantity(other, u.dimensionless_unscaled, copy=False)
+            other = u.Quantity(other, u.dimensionless_unscaled, copy=COPY_IF_NEEDED)
         except Exception:
             # If not consistent with a dimensionless quantity, try downgrading
             # self to a quantity and see if things work.
@@ -3353,7 +3353,7 @@ class ScaleValueError(Exception):
     pass
 
 
-def _make_array(val, copy=False):
+def _make_array(val, copy=COPY_IF_NEEDED):
     """
     Take ``val`` and convert/reshape to an array.  If ``copy`` is `True`
     then copy input values.

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -12,6 +12,7 @@ import warnings
 
 import numpy as np
 
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
@@ -910,7 +911,7 @@ class UnitBase:
         try:
             from .quantity import Quantity
 
-            return Quantity(m, self, copy=False, subok=True)
+            return Quantity(m, self, copy=COPY_IF_NEEDED, subok=True)
         except Exception:
             if isinstance(m, np.ndarray):
                 raise

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -14,7 +14,7 @@ from astropy.units import (
     UnitTypeError,
     dimensionless_unscaled,
 )
-from astropy.utils.compat import NUMPY_LT_2_0
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
@@ -312,7 +312,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
     def __rlshift__(self, other):
         """Unit conversion operator ``<<``."""
         try:
-            return self._quantity_class(other, self, copy=False, subok=True)
+            return self._quantity_class(other, self, copy=COPY_IF_NEEDED, subok=True)
         except Exception:
             return NotImplemented
 

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -4,6 +4,8 @@
 
 import numbers
 
+from astropy.utils.compat import COPY_IF_NEEDED
+
 from . import (
     astrophys,
     cgs,
@@ -541,7 +543,7 @@ def get_physical_type(obj):
         unit = obj
     else:
         try:
-            unit = quantity.Quantity(obj, copy=False).unit
+            unit = quantity.Quantity(obj, copy=COPY_IF_NEEDED).unit
         except TypeError as exc:
             raise TypeError(f"{obj} does not correspond to a physical type.") from exc
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -241,7 +241,7 @@ class QuantityInfo(QuantityInfoBase):
             key: (data if key == "value" else getattr(cols[-1], key))
             for key in self._represent_as_dict_attrs
         }
-        map["copy"] = False
+        map["copy"] = COPY_IF_NEEDED
         out = self._construct_from_dict(map)
 
         # Set remaining info attributes
@@ -2223,9 +2223,9 @@ def allclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False) -> bool:
 
 
 def _unquantify_allclose_arguments(actual, desired, rtol, atol):
-    actual = Quantity(actual, subok=True, copy=False)
+    actual = Quantity(actual, subok=True, copy=COPY_IF_NEEDED)
 
-    desired = Quantity(desired, subok=True, copy=False)
+    desired = Quantity(desired, subok=True, copy=COPY_IF_NEEDED)
     try:
         desired = desired.to(actual.unit)
     except UnitsError:
@@ -2241,7 +2241,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         # units for a and b.
         atol = Quantity(0)
     else:
-        atol = Quantity(atol, subok=True, copy=False)
+        atol = Quantity(atol, subok=True, copy=COPY_IF_NEEDED)
         try:
             atol = atol.to(actual.unit)
         except UnitsError:
@@ -2250,7 +2250,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
                 f"({actual.unit}) are not convertible"
             )
 
-    rtol = Quantity(rtol, subok=True, copy=False)
+    rtol = Quantity(rtol, subok=True, copy=COPY_IF_NEEDED)
     try:
         rtol = rtol.to(dimensionless_unscaled)
     except Exception:

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -47,7 +47,7 @@ from astropy.units.core import (
     dimensionless_unscaled,
 )
 from astropy.utils import isiterable
-from astropy.utils.compat import NUMPY_LT_1_24, NUMPY_LT_2_0
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_24, NUMPY_LT_2_0
 
 if NUMPY_LT_2_0:
     import numpy.core as np_core
@@ -343,7 +343,7 @@ def _as_quantity(a):
     from astropy.units import Quantity
 
     try:
-        return Quantity(a, copy=False, subok=True)
+        return Quantity(a, copy=COPY_IF_NEEDED, subok=True)
     except Exception:
         # If we cannot convert to Quantity, we should just bail.
         raise NotImplementedError
@@ -355,7 +355,7 @@ def _as_quantities(*args):
 
     try:
         # Note: this should keep the dtype the same
-        return tuple(Quantity(a, copy=False, subok=True, dtype=None) for a in args)
+        return tuple(Quantity(a, copy=COPY_IF_NEEDED, subok=True, dtype=None) for a in args)
     except Exception:
         # If we cannot convert to Quantity, we should just bail.
         raise NotImplementedError

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -30,6 +30,7 @@ COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
 
 
 def sanitize_copy_arg(copy, /):
+    return copy
     if not NUMPY_LT_2_0 and copy is False:
         return None
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -30,7 +30,6 @@ COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
 
 
 def sanitize_copy_arg(copy, /):
-    return copy
     if not NUMPY_LT_2_0 and copy is False:
         return None
 

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -19,7 +19,7 @@ import builtins
 
 import numpy as np
 
-from astropy.utils.compat import NUMPY_LT_2_0, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, sanitize_copy_arg
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.shapes import NDArrayShapeMethods
 
@@ -287,7 +287,7 @@ class Masked(NDArrayShapeMethods):
             data = getattr(self.unmasked, method)(*args, **kwargs)
             mask = getattr(self.mask, method)(*args, **kwargs)
 
-        result = self.from_unmasked(data, mask, copy=False)
+        result = self.from_unmasked(data, mask, copy=COPY_IF_NEEDED)
         if "info" in self.__dict__:
             result.info = self.info
 


### PR DESCRIPTION
### Description

~This pull request will be pushed in 5 layers because we need to run CI 5 times to validate it.
I'll edit this message once it's ready.~

> **Update**: actually, 6 times.

This applies the first step described in #16167: making backward compatibility shims introduced in #16142 redundant for internal usage. It is meant to be reviewed commit-by-commit. Particularly, the exit status of devdeps is crucial.
- commit 1 removes compatibility shims -> devdeps fails (this demonstrate their current necessity)
- commit 2 reverts commit 1 -> devdeps succeeds anew
- commit 3 applies internal refactor that should make compatibility shims redundant for internal usage, but *doesn't change any API* (default values `copy=False` are preserved) -> devdeps still succeeds 
- commit 4 removes compatibility shims again -> devdeps fails !
- commit 5 introduces minimal API changes (`copy=False` becomes `copy=COPY_IF_NEEDED` in signatures) -> devdeps succeeds once again !
- commit 6 reverts commit 4


> **Update again**: commit 4 was split out to #16174, but I think keeping the old explanation is maybe less confusing (?) so for now I don't want to edit it further.

By construction, 4 out of 6 commits should cancel out, so squash merging is expected.
Also note that commit 3 is, in itself, a pure refactor, and *could* be backported (but I don't know that it's wanted). Minor API changes from commit 5 are aimed for astropy 6.1, but could also be rerolled in its own PR if requested (its presence in this PR is supposed to help demonstrating that it's needed in the grand scheme of #16167, but maybe that's only making it more confusing ?).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
