### PR TITLE
RFC: refactor copy argument sanitizing into a unified compat function

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import NUMPY_LT_2_0
+from astropy.utils.compat import NUMPY_LT_2_0, sanitize_copy_arg
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -522,10 +522,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         copy=False,
         copy_indices=True,
     ):
-        if not NUMPY_LT_2_0 and copy is False:
-            # strict backward compatibility
-            # see https://github.com/astropy/astropy/pull/16142
-            copy = None
+        copy = sanitize_copy_arg(copy)
 
         if data is None:
             self_data = np.zeros((length,) + shape, dtype=dtype)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -28,7 +28,7 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray, lazyproperty
-from astropy.utils.compat import NUMPY_LT_2_0, PYTHON_LT_3_11
+from astropy.utils.compat import PYTHON_LT_3_11, sanitize_copy_arg
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
@@ -1972,10 +1972,7 @@ class Time(TimeBase):
         location=None,
         copy=False,
     ):
-        if not NUMPY_LT_2_0 and copy is False:
-            # strict backward compatibility
-            # see https://github.com/astropy/astropy/pull/16142
-            copy = None
+        copy = sanitize_copy_arg(copy)
 
         if location is not None:
             from astropy.coordinates import EarthLocation
@@ -3371,10 +3368,7 @@ def _make_array(val, copy=False):
     else:
         dtype = None
 
-    if not NUMPY_LT_2_0 and copy is False:
-        # strict backward compatibility
-        # see https://github.com/astropy/astropy/pull/16142
-        copy = None
+    copy = sanitize_copy_arg(copy)
 
     val = np.array(val, copy=copy, subok=True, dtype=dtype)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,6 +20,7 @@ import numpy as np
 
 # LOCAL
 from astropy import config as _config
+from astropy.utils.compat import sanitize_copy_arg
 from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.decorators import deprecated
@@ -445,10 +446,7 @@ class Quantity(np.ndarray):
         if float_default:
             dtype = None
 
-        if not NUMPY_LT_2_0 and copy is False:
-            # strict backward compatibility
-            # see https://github.com/astropy/astropy/pull/16142
-            copy = None
+        copy = sanitize_copy_arg(copy)
 
         # optimize speed for Quantity with no dtype given, copy=COPY_IF_NEEDED
         if isinstance(value, Quantity):

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -14,6 +14,7 @@ __all__ = [
     "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
     "COPY_IF_NEEDED",
+    "sanitize_copy_arg",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -26,3 +27,10 @@ NUMPY_LT_2_0 = not minversion(np, "2.0.dev")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
+
+
+def sanitize_copy_arg(copy, /):
+    if not NUMPY_LT_2_0 and copy is False:
+        return None
+
+    return copy

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -19,7 +19,7 @@ import builtins
 
 import numpy as np
 
-from astropy.utils.compat import NUMPY_LT_2_0
+from astropy.utils.compat import NUMPY_LT_2_0, sanitize_copy_arg
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.shapes import NDArrayShapeMethods
 
@@ -513,11 +513,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
     def from_unmasked(cls, data, mask=None, copy=False):
         # Note: have to override since __new__ would use ndarray.__new__
         # which expects the shape as its first argument, not an array.
-
-        if not NUMPY_LT_2_0 and copy is False:
-            # strict backward compatibility
-            # see https://github.com/astropy/astropy/pull/16142
-            copy = None
+        copy = sanitize_copy_arg(copy)
 
         data = np.array(data, subok=True, copy=copy)
         self = data.view(cls)


### PR DESCRIPTION
### Description
This is a follow up to #16142 so we have a single source of truth regarding how we treat user-provided `copy=False` arguments.

This is also a step forward followin my proposed long term plan (see #16167), but it's in itself not an API cchange and could be backported for convenience if desired.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
