### PR TITLE
API: align default value for copy arguments with numpy at runtime (warn about copy=False)

### DIFF
--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -6,6 +6,7 @@ import pytest
 
 from astropy.constants import Constant
 from astropy.units import Quantity as Q
+from astropy.utils.compat import COPY_IF_NEEDED
 
 
 def test_c():
@@ -154,5 +155,5 @@ def test_view():
     assert c3.reference == c.reference
     assert c3.unit == c.unit
 
-    c4 = Q(c, subok=True, copy=False)
+    c4 = Q(c, subok=True, copy=COPY_IF_NEEDED)
     assert c4 is c

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -7,6 +7,7 @@ import pytest
 
 from astropy.constants import Constant
 from astropy.units import Quantity as Q
+from astropy.utils.compat import COPY_IF_NEEDED
 
 
 def test_c():
@@ -190,5 +191,5 @@ def test_view():
     assert c3.reference == c.reference
     assert c3.unit == c.unit
 
-    c4 = Q(c, subok=True, copy=False)
+    c4 = Q(c, subok=True, copy=COPY_IF_NEEDED)
     assert c4 is c

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -463,7 +463,7 @@ class Angle(SpecificTypeQuantity):
             `~astropy.coordinates.Angle` object with angles wrapped accordingly.
             Otherwise wrap in place and return `None`.
         """
-        wrap_angle = Angle(wrap_angle, copy=False)  # Convert to an Angle
+        wrap_angle = Angle(wrap_angle, copy=COPY_IF_NEEDED)  # Convert to an Angle
         if not inplace:
             self = self.copy()
         self._wrap_at(wrap_angle)
@@ -728,7 +728,7 @@ class Longitude(Angle):
 
     @wrap_angle.setter
     def wrap_angle(self, value):
-        self._wrap_angle = Angle(value, copy=False)
+        self._wrap_angle = Angle(value, copy=COPY_IF_NEEDED)
         self._wrap_at(self.wrap_angle)
 
     def __array_finalize__(self, obj):

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -264,7 +264,7 @@ class CartesianRepresentationAttribute(Attribute):
             value = value.to(self.unit)
 
             # now try and make a CartesianRepresentation.
-            cartrep = CartesianRepresentation(value, copy=False)
+            cartrep = CartesianRepresentation(value, copy=COPY_IF_NEEDED)
             return cartrep, converted
 
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.utils import ShapedLikeNDArray, check_broadcast
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import deprecated, format_doc, lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 
@@ -1159,7 +1160,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             for comp, new_attr_unit in zip(data.components, new_attrs["units"]):
                 if new_attr_unit:
                     datakwargs[comp] = datakwargs[comp].to(new_attr_unit)
-            data = data.__class__(copy=False, **datakwargs)
+            data = data.__class__(copy=COPY_IF_NEEDED, **datakwargs)
 
         if differential_cls:
             # the original differential
@@ -1202,7 +1203,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                         except Exception:
                             pass
 
-                diff = diff.__class__(copy=False, **diffkwargs)
+                diff = diff.__class__(copy=COPY_IF_NEEDED, **diffkwargs)
 
                 # Here we have to bypass using with_differentials() because
                 # it has a validation check. But because

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -56,7 +56,7 @@ def cirs_to_observed(cirs_coo, observed_frame):
         rep = UnitSphericalRepresentation(
             lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
     else:
         # since we've transformed to CIRS at the observatory location, just use CIRS distance
@@ -64,7 +64,7 @@ def cirs_to_observed(cirs_coo, observed_frame):
             lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
             distance=cirs_coo.distance,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
     return observed_frame.realize_frame(rep)
 

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -159,7 +159,7 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
             u.dimensionless_unscaled,
             copy=COPY_IF_NEEDED,
         ),
-        copy=False,
+        copy=COPY_IF_NEEDED,
     )
     rep = rep - eterms_a + eterms_a.dot(rep) * rep
 
@@ -212,7 +212,7 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
             u.dimensionless_unscaled,
             copy=COPY_IF_NEEDED,
         ),
-        copy=False,
+        copy=COPY_IF_NEEDED,
     )
 
     rep0 = rep.copy()

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -44,7 +44,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         newrep = UnitSphericalRepresentation(
             lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
     else:
         # When there is a distance,  we first offset for parallax to get the
@@ -62,7 +62,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
             lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
 
     return cirs_frame.realize_frame(newrep)
@@ -85,7 +85,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         newrep = UnitSphericalRepresentation(
             lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
     else:
         # When there is a distance, apply the parallax/offset to the SSB as the
@@ -97,7 +97,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
             lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
 
         astrom_eb = CartesianRepresentation(
@@ -127,7 +127,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         newrep = UnitSphericalRepresentation(
             lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
     else:
         # When there is a distance,  we first offset for parallax to get the
@@ -146,7 +146,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
             lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
 
     return gcrs_frame.realize_frame(newrep)
@@ -170,7 +170,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         newrep = UnitSphericalRepresentation(
             lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
     else:
         # When there is a distance, apply the parallax/offset to the SSB as the
@@ -182,7 +182,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
             lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
             lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
             distance=srepr.distance,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
 
         astrom_eb = CartesianRepresentation(
@@ -217,7 +217,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     ):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
-        newrep = UnitSphericalRepresentation(lat=i_dec, lon=i_ra, copy=False)
+        newrep = UnitSphericalRepresentation(lat=i_dec, lon=i_ra, copy=COPY_IF_NEEDED)
     else:
         # When there is a distance, apply the parallax/offset to the
         # Heliocentre as the last step to ensure round-tripping with the
@@ -226,7 +226,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # Note that the distance in intermedrep is *not* a real distance as it
         # does not include the offset back to the Heliocentre
         intermedrep = SphericalRepresentation(
-            lat=i_dec, lon=i_ra, distance=srepr.distance, copy=False
+            lat=i_dec, lon=i_ra, distance=srepr.distance, copy=COPY_IF_NEEDED
         )
 
         # astrom['eh'] and astrom['em'] contain Sun to observer unit vector,

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -56,11 +56,11 @@ def icrs_to_observed(icrs_coo, observed_frame):
 
     if is_unitspherical:
         obs_srepr = UnitSphericalRepresentation(
-            lon << u.radian, lat << u.radian, copy=False
+            lon << u.radian, lat << u.radian, copy=COPY_IF_NEEDED
         )
     else:
         obs_srepr = SphericalRepresentation(
-            lon << u.radian, lat << u.radian, srepr.distance, copy=False
+            lon << u.radian, lat << u.radian, srepr.distance, copy=COPY_IF_NEEDED
         )
     return observed_frame.realize_frame(obs_srepr)
 

--- a/astropy/coordinates/builtin_frames/itrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/itrs_observed_transforms.py
@@ -6,6 +6,7 @@ from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.matrix_utilities import matrix_transpose, rotation_matrix
 from astropy.coordinates.representation import CartesianRepresentation
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .hadec import HADec
@@ -71,7 +72,9 @@ def add_refraction(aa_crepr, observed_frame):
     # Need to renormalize to get agreement with CIRS->Observed on distance
     norm2, uv = erfa.pn(uv)
     uv = erfa.sxp(norm, uv)
-    return CartesianRepresentation(uv, xyz_axis=-1, unit=aa_crepr.x.unit, copy=False)
+    return CartesianRepresentation(
+        uv, xyz_axis=-1, unit=aa_crepr.x.unit, copy=COPY_IF_NEEDED
+    )
 
 
 def remove_refraction(aa_crepr, observed_frame):
@@ -95,7 +98,9 @@ def remove_refraction(aa_crepr, observed_frame):
     el -= delta_el
     uv = erfa.s2c(az, el)
     uv = erfa.sxp(norm, uv)
-    return CartesianRepresentation(uv, xyz_axis=-1, unit=aa_crepr.x.unit, copy=False)
+    return CartesianRepresentation(
+        uv, xyz_axis=-1, unit=aa_crepr.x.unit, copy=COPY_IF_NEEDED
+    )
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, ITRS, AltAz)

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -131,7 +131,7 @@ class Distance(u.SpecificTypeQuantity):
         if value is None:
             # If something else but `value` was provided then a new array will
             # be created anyways and there is no need to copy that.
-            copy = False
+            copy = COPY_IF_NEEDED
 
         if z is not None:
             if cosmology is None:

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -11,6 +11,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates.angles import Angle
 from astropy.utils import ShapedLikeNDArray, classproperty
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 
@@ -911,7 +912,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         # We shallow copy the differentials dictionary so we don't update the
         # current object's dictionary when adding new keys
         new_rep = self.__class__(
-            *args, differentials=self.differentials.copy(), copy=False
+            *args, differentials=self.differentials.copy(), copy=COPY_IF_NEEDED
         )
         new_rep._differentials.update(new_rep._validate_differentials(differentials))
 
@@ -930,7 +931,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
             return self
 
         args = [getattr(self, component) for component in self.components]
-        return self.__class__(*args, copy=False)
+        return self.__class__(*args, copy=COPY_IF_NEEDED)
 
     @classmethod
     def from_representation(cls, representation):
@@ -1397,7 +1398,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
         base_e, base_sf = cls._get_base_vectors(base)
         return cls(
             *(other.dot(e / base_sf[component]) for component, e in base_e.items()),
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
 
     def represent_as(self, other_class, base):
@@ -1490,7 +1491,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
             in radius.
         """
         scaled_attrs = [op(getattr(self, c), *args) for c in self.components]
-        return self.__class__(*scaled_attrs, copy=False)
+        return self.__class__(*scaled_attrs, copy=COPY_IF_NEEDED)
 
     def _combine_operation(self, op, other, reverse=False):
         """Combine two differentials, or a differential with a representation.

--- a/astropy/coordinates/representation/cartesian.py
+++ b/astropy/coordinates/representation/cartesian.py
@@ -5,6 +5,7 @@ import numpy as np
 from erfa import ufunc as erfa_ufunc
 
 import astropy.units as u
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 
@@ -94,7 +95,7 @@ class CartesianRepresentation(BaseRepresentation):
             x = u.Quantity(x, unit, copy=copy, subok=True)
             y = u.Quantity(y, unit, copy=copy, subok=True)
             z = u.Quantity(z, unit, copy=copy, subok=True)
-            copy = False
+            copy = COPY_IF_NEEDED
 
         super().__init__(x, y, z, copy=copy, differentials=differentials)
         if not (
@@ -107,9 +108,9 @@ class CartesianRepresentation(BaseRepresentation):
         l = np.broadcast_to(1.0 * u.one, self.shape, subok=True)
         o = np.broadcast_to(0.0 * u.one, self.shape, subok=True)
         return {
-            "x": CartesianRepresentation(l, o, o, copy=False),
-            "y": CartesianRepresentation(o, l, o, copy=False),
-            "z": CartesianRepresentation(o, o, l, copy=False),
+            "x": CartesianRepresentation(l, o, o, copy=COPY_IF_NEEDED),
+            "y": CartesianRepresentation(o, l, o, copy=COPY_IF_NEEDED),
+            "z": CartesianRepresentation(o, o, l, copy=COPY_IF_NEEDED),
         }
 
     def scale_factors(self):
@@ -190,7 +191,7 @@ class CartesianRepresentation(BaseRepresentation):
         # erfa rxp: Multiply a p-vector by an r-matrix.
         p = erfa_ufunc.rxp(matrix, self.get_xyz(xyz_axis=-1))
         # transformed representation
-        rep = self.__class__(p, xyz_axis=-1, copy=False)
+        rep = self.__class__(p, xyz_axis=-1, copy=COPY_IF_NEEDED)
         # Handle differentials attached to this representation
         new_diffs = {
             k: d.transform(matrix, self, rep) for k, d in self.differentials.items()
@@ -370,7 +371,7 @@ class CartesianDifferential(BaseDifferential):
             d_x = u.Quantity(d_x, unit, copy=copy, subok=True)
             d_y = u.Quantity(d_y, unit, copy=copy, subok=True)
             d_z = u.Quantity(d_z, unit, copy=copy, subok=True)
-            copy = False
+            copy = COPY_IF_NEEDED
 
         super().__init__(d_x, d_y, d_z, copy=copy)
         if not (
@@ -401,7 +402,7 @@ class CartesianDifferential(BaseDifferential):
         # erfa rxp: Multiply a p-vector by an r-matrix.
         p = erfa_ufunc.rxp(matrix, self.get_d_xyz(xyz_axis=-1))
 
-        return self.__class__(p, xyz_axis=-1, copy=False)
+        return self.__class__(p, xyz_axis=-1, copy=COPY_IF_NEEDED)
 
     def get_d_xyz(self, xyz_axis=0):
         """Return a vector array of the x, y, and z coordinates.

--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -154,7 +154,7 @@ class CylindricalDifferential(BaseDifferential):
 
     base_representation = CylindricalRepresentation
 
-    def __init__(self, d_rho, d_phi=None, d_z=None, copy=False):
+    def __init__(self, d_rho, d_phi=None, d_z=None, copy=COPY_IF_NEEDED):
         super().__init__(d_rho, d_phi, d_z, copy=copy)
         if not self._d_rho.unit.is_equivalent(self._d_z.unit):
             raise u.UnitsError("d_rho and d_z should have equivalent units.")

--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -99,7 +99,7 @@ class CylindricalRepresentation(BaseRepresentation):
         phi = np.arctan2(cart.y, cart.x)
         z = cart.z
 
-        return cls(rho=rho, phi=phi, z=z, copy=False)
+        return cls(rho=rho, phi=phi, z=z, copy=COPY_IF_NEEDED)
 
     def to_cartesian(self):
         """
@@ -110,7 +110,7 @@ class CylindricalRepresentation(BaseRepresentation):
         y = self.rho * np.sin(self.phi)
         z = self.z
 
-        return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=COPY_IF_NEEDED)
 
     def _scale_operation(self, op, *args):
         if any(
@@ -132,7 +132,9 @@ class CylindricalRepresentation(BaseRepresentation):
                     (rho_op, operator.pos, z_op), differential.components
                 )
             )
-            result.differentials[key] = differential.__class__(*new_comps, copy=False)
+            result.differentials[key] = differential.__class__(
+                *new_comps, copy=COPY_IF_NEEDED
+            )
         return result
 
 

--- a/astropy/coordinates/representation/geodetic.py
+++ b/astropy/coordinates/representation/geodetic.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.angles import Latitude, Longitude
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import format_doc
 
 from .base import BaseRepresentation
@@ -88,7 +89,7 @@ class BaseGeodeticRepresentation(BaseRepresentation):
             self.lat,
             self.height,
         )
-        return CartesianRepresentation(xyz, xyz_axis=-1, copy=False)
+        return CartesianRepresentation(xyz, xyz_axis=-1, copy=COPY_IF_NEEDED)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -100,7 +101,7 @@ class BaseGeodeticRepresentation(BaseRepresentation):
         lon, lat, height = erfa.gc2gde(
             cls._equatorial_radius, cls._flattening, cart.get_xyz(xyz_axis=-1)
         )
-        return cls(lon, lat, height, copy=False)
+        return cls(lon, lat, height, copy=COPY_IF_NEEDED)
 
 
 @format_doc(geodetic_base_doc)
@@ -151,7 +152,7 @@ class BaseBodycentricRepresentation(BaseRepresentation):
         x = r * coslon * coslat
         y = r * sinlon * coslat
         z = r * sinlat
-        return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=COPY_IF_NEEDED)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -168,7 +169,7 @@ class BaseBodycentricRepresentation(BaseRepresentation):
         r_spheroid = np.hypot(p_spheroid, z_spheroid)
         height = d - r_spheroid
         lon = np.arctan2(cart.y, cart.x)
-        return cls(lon, lat, height, copy=False)
+        return cls(lon, lat, height, copy=COPY_IF_NEEDED)
 
 
 @format_doc(geodetic_base_doc)

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -101,7 +101,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         """
         # erfa s2c: Convert [unit]spherical coordinates to Cartesian.
         p = erfa_ufunc.s2c(self.lon, self.lat)
-        return CartesianRepresentation(p, xyz_axis=-1, copy=False)
+        return CartesianRepresentation(p, xyz_axis=-1, copy=COPY_IF_NEEDED)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -111,7 +111,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         """
         p = cart.get_xyz(xyz_axis=-1)
         # erfa c2s: P-vector to [unit]spherical coordinates.
-        return cls(*erfa_ufunc.c2s(p), copy=False)
+        return cls(*erfa_ufunc.c2s(p), copy=COPY_IF_NEEDED)
 
     def represent_as(self, other_class, differential_class=None):
         # Take a short cut if the other class is a spherical representation
@@ -192,7 +192,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
         ):
             return super().__neg__()
 
-        result = self.__class__(self.lon + 180.0 * u.deg, -self.lat, copy=False)
+        result = self.__class__(
+            self.lon + 180.0 * u.deg, -self.lat, copy=COPY_IF_NEEDED
+        )
         for key, differential in self.differentials.items():
             new_comps = (
                 op(getattr(differential, comp))
@@ -200,7 +202,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
                     (operator.pos, operator.neg), differential.components
                 )
             )
-            result.differentials[key] = differential.__class__(*new_comps, copy=False)
+            result.differentials[key] = differential.__class__(
+                *new_comps, copy=COPY_IF_NEEDED
+            )
         return result
 
     def norm(self):
@@ -215,7 +219,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
         norm : `~astropy.units.Quantity` ['dimensionless']
             Dimensionless ones, with the same shape as the representation.
         """
-        return u.Quantity(np.ones(self.shape), u.dimensionless_unscaled, copy=False)
+        return u.Quantity(
+            np.ones(self.shape), u.dimensionless_unscaled, copy=COPY_IF_NEEDED
+        )
 
     def _combine_operation(self, op, other, reverse=False):
         self._raise_if_has_differentials(op.__name__)
@@ -341,7 +347,7 @@ class RadialRepresentation(BaseRepresentation):
         """
         Converts 3D rectangular cartesian coordinates to radial coordinate.
         """
-        return cls(distance=cart.norm(), copy=False)
+        return cls(distance=cart.norm(), copy=COPY_IF_NEEDED)
 
     def __mul__(self, other):
         if isinstance(other, BaseRepresentation):
@@ -455,7 +461,7 @@ class SphericalRepresentation(BaseRepresentation):
             and self._distance.unit.physical_type == "length"
         ):
             try:
-                self._distance = Distance(self._distance, copy=False)
+                self._distance = Distance(self._distance, copy=COPY_IF_NEEDED)
             except ValueError as e:
                 if e.args[0].startswith("distance must be >= 0"):
                     raise ValueError(
@@ -528,7 +534,7 @@ class SphericalRepresentation(BaseRepresentation):
                     theta=90 * u.deg - self.lat,
                     r=self.distance,
                     differentials=diffs,
-                    copy=False,
+                    copy=COPY_IF_NEEDED,
                 )
 
             elif issubclass(other_class, UnitSphericalRepresentation):
@@ -536,7 +542,7 @@ class SphericalRepresentation(BaseRepresentation):
                     other_class, differential_class
                 )
                 return other_class(
-                    lon=self.lon, lat=self.lat, differentials=diffs, copy=False
+                    lon=self.lon, lat=self.lat, differentials=diffs, copy=COPY_IF_NEEDED
                 )
 
         return super().represent_as(other_class, differential_class)
@@ -555,7 +561,7 @@ class SphericalRepresentation(BaseRepresentation):
         # erfa s2p: Convert spherical polar coordinates to p-vector.
         p = erfa_ufunc.s2p(self.lon, self.lat, d)
 
-        return CartesianRepresentation(p, xyz_axis=-1, copy=False)
+        return CartesianRepresentation(p, xyz_axis=-1, copy=COPY_IF_NEEDED)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -565,7 +571,7 @@ class SphericalRepresentation(BaseRepresentation):
         """
         p = cart.get_xyz(xyz_axis=-1)
         # erfa p2s: P-vector to spherical polar coordinates.
-        return cls(*erfa_ufunc.p2s(p), copy=False)
+        return cls(*erfa_ufunc.p2s(p), copy=COPY_IF_NEEDED)
 
     def transform(self, matrix):
         """Transform the spherical coordinates using a 3x3 matrix.
@@ -628,7 +634,9 @@ class SphericalRepresentation(BaseRepresentation):
                     (operator.pos, lat_op, distance_op), differential.components
                 )
             )
-            result.differentials[key] = differential.__class__(*new_comps, copy=False)
+            result.differentials[key] = differential.__class__(
+                *new_comps, copy=COPY_IF_NEEDED
+            )
         return result
 
 
@@ -738,7 +746,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
                     lat=90 * u.deg - self.theta,
                     distance=self.r,
                     differentials=diffs,
-                    copy=False,
+                    copy=COPY_IF_NEEDED,
                 )
             elif issubclass(other_class, UnitSphericalRepresentation):
                 diffs = self._re_represent_differentials(
@@ -748,7 +756,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
                     lon=self.phi,
                     lat=90 * u.deg - self.theta,
                     differentials=diffs,
-                    copy=False,
+                    copy=COPY_IF_NEEDED,
                 )
 
         return super().represent_as(other_class, differential_class)
@@ -768,7 +776,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         y = d * np.sin(self.theta) * np.sin(self.phi)
         z = d * np.cos(self.theta)
 
-        return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+        return CartesianRepresentation(x=x, y=y, z=z, copy=COPY_IF_NEEDED)
 
     @classmethod
     def from_cartesian(cls, cart):
@@ -782,7 +790,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         phi = np.arctan2(cart.y, cart.x)
         theta = np.arctan2(s, cart.z)
 
-        return cls(phi=phi, theta=theta, r=r, copy=False)
+        return cls(phi=phi, theta=theta, r=r, copy=COPY_IF_NEEDED)
 
     def transform(self, matrix):
         """Transform the spherical coordinates using a 3x3 matrix.
@@ -847,7 +855,9 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
                     (operator.pos, adjust_theta_sign, r_op), differential.components
                 )
             )
-            result.differentials[key] = differential.__class__(*new_comps, copy=False)
+            result.differentials[key] = differential.__class__(
+                *new_comps, copy=COPY_IF_NEEDED
+            )
         return result
 
 
@@ -1371,7 +1381,8 @@ class RadialDifferential(BaseDifferential):
     @classmethod
     def from_cartesian(cls, other, base):
         return cls(
-            other.dot(base.represent_as(UnitSphericalRepresentation)), copy=False
+            other.dot(base.represent_as(UnitSphericalRepresentation)),
+            copy=COPY_IF_NEEDED,
         )
 
     @classmethod
@@ -1391,7 +1402,7 @@ class RadialDifferential(BaseDifferential):
                 first, second = other.distance, self.d_distance
             else:
                 first, second = self.d_distance, other.distance
-            return other.__class__(op(first, second), copy=False)
+            return other.__class__(op(first, second), copy=COPY_IF_NEEDED)
         elif isinstance(
             other, (BaseSphericalDifferential, BaseSphericalCosLatDifferential)
         ):

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -20,6 +20,7 @@ from astropy import time
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.units import allclose
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 
@@ -56,7 +57,7 @@ def test_representations_api():
 
     # Default is to copy arrays, but optionally, it can be a reference
     UnitSphericalRepresentation(
-        lon=[8, 9] * u.hourangle, lat=[5, 6] * u.deg, copy=False
+        lon=[8, 9] * u.hourangle, lat=[5, 6] * u.deg, copy=COPY_IF_NEEDED
     )
 
     # strings are parsed by `Latitude` and `Longitude` constructors, so no need to

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -212,7 +212,9 @@ class TestSphericalRepresentation:
         lat = Latitude([5, 6] * u.deg)
         distance = Distance([1, 2] * u.kpc)
 
-        s1 = SphericalRepresentation(lon=lon, lat=lat, distance=distance, copy=False)
+        s1 = SphericalRepresentation(
+            lon=lon, lat=lat, distance=distance, copy=COPY_IF_NEEDED
+        )
 
         lon[:] = [1, 2] * u.rad
         lat[:] = [3, 4] * u.arcmin
@@ -226,7 +228,7 @@ class TestSphericalRepresentation:
         """Regression test against #2983"""
         lon = Longitude(np.float32([1.0, 2.0]), u.degree)
         lat = Latitude(np.float32([3.0, 4.0]), u.degree)
-        s1 = UnitSphericalRepresentation(lon=lon, lat=lat, copy=False)
+        s1 = UnitSphericalRepresentation(lon=lon, lat=lat, copy=COPY_IF_NEEDED)
         assert s1.lon.dtype == np.float32
         assert s1.lat.dtype == np.float32
         assert s1._values["lon"].dtype == np.float32
@@ -270,13 +272,16 @@ class TestSphericalRepresentation:
 
     def test_broadcasting_and_nocopy(self):
         s1 = SphericalRepresentation(
-            lon=[200] * u.deg, lat=[0] * u.deg, distance=[0] * u.kpc, copy=False
+            lon=[200] * u.deg,
+            lat=[0] * u.deg,
+            distance=[0] * u.kpc,
+            copy=COPY_IF_NEEDED,
         )
         # With no copying, we should be able to modify the wrap angle of the longitude component
         s1.lon.wrap_angle = 180 * u.deg
 
         s2 = SphericalRepresentation(
-            lon=[200] * u.deg, lat=0 * u.deg, distance=0 * u.kpc, copy=False
+            lon=[200] * u.deg, lat=0 * u.deg, distance=0 * u.kpc, copy=COPY_IF_NEEDED
         )
         # We should be able to modify the wrap angle of the longitude component even if other
         # components need to be broadcasted
@@ -557,7 +562,7 @@ class TestUnitSphericalRepresentation:
         lon = Longitude([8, 9] * u.hourangle)
         lat = Latitude([5, 6] * u.deg)
 
-        s1 = UnitSphericalRepresentation(lon=lon, lat=lat, copy=False)
+        s1 = UnitSphericalRepresentation(lon=lon, lat=lat, copy=COPY_IF_NEEDED)
 
         lon[:] = [1, 2] * u.rad
         lat[:] = [3, 4] * u.arcmin
@@ -745,7 +750,9 @@ class TestPhysicsSphericalRepresentation:
         theta = Angle([5, 6] * u.deg)
         r = Distance([1, 2] * u.kpc)
 
-        s1 = PhysicsSphericalRepresentation(phi=phi, theta=theta, r=r, copy=False)
+        s1 = PhysicsSphericalRepresentation(
+            phi=phi, theta=theta, r=r, copy=COPY_IF_NEEDED
+        )
 
         phi[:] = [1, 2] * u.rad
         theta[:] = [3, 4] * u.arcmin
@@ -1068,7 +1075,7 @@ class TestCartesianRepresentation:
         y = [5, 6, 7] * u.Mpc
         z = [2, 3, 4] * u.kpc
 
-        s1 = CartesianRepresentation(x=x, y=y, z=z, copy=False)
+        s1 = CartesianRepresentation(x=x, y=y, z=z, copy=COPY_IF_NEEDED)
 
         x[:] = [1, 2, 3] * u.kpc
         y[:] = [9, 9, 8] * u.kpc
@@ -1080,7 +1087,7 @@ class TestCartesianRepresentation:
 
     def test_xyz_is_view_if_possible(self):
         xyz = np.arange(1.0, 10.0).reshape(3, 3)
-        s1 = CartesianRepresentation(xyz, unit=u.kpc, copy=False)
+        s1 = CartesianRepresentation(xyz, unit=u.kpc, copy=COPY_IF_NEEDED)
         s1_xyz = s1.xyz
         assert s1_xyz.value[0, 0] == 1.0
         xyz[0, 0] = 0.0
@@ -1088,7 +1095,7 @@ class TestCartesianRepresentation:
         assert s1_xyz.value[0, 0] == 0.0
         # Not possible: we don't check that tuples are from the same array
         xyz = np.arange(1.0, 10.0).reshape(3, 3)
-        s2 = CartesianRepresentation(*xyz, unit=u.kpc, copy=False)
+        s2 = CartesianRepresentation(*xyz, unit=u.kpc, copy=COPY_IF_NEEDED)
         s2_xyz = s2.xyz
         assert s2_xyz.value[0, 0] == 1.0
         xyz[0, 0] = 0.0
@@ -1270,7 +1277,7 @@ class TestCylindricalRepresentation:
         phi = [5, 6, 7] * u.deg
         z = [2, 3, 4] * u.kpc
 
-        s1 = CylindricalRepresentation(rho=rho, phi=phi, z=z, copy=False)
+        s1 = CylindricalRepresentation(rho=rho, phi=phi, z=z, copy=COPY_IF_NEEDED)
 
         rho[:] = [9, 2, 3] * u.kpc
         phi[:] = [1, 2, 3] * u.arcmin
@@ -1638,7 +1645,7 @@ def test_minimal_subclass():
             x = d * np.cos(self.lat) * np.cos(self.lon)
             y = d * np.cos(self.lat) * np.sin(self.lon)
             z = d * np.sin(self.lat)
-            return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+            return CartesianRepresentation(x=x, y=y, z=z, copy=COPY_IF_NEEDED)
 
         @classmethod
         def from_cartesian(cls, cart):
@@ -1646,7 +1653,7 @@ def test_minimal_subclass():
             r = np.hypot(s, cart.z)
             lon = np.arctan2(cart.y, cart.x)
             lat = np.arctan2(cart.z, s)
-            return cls(lon=lon, lat=lat, logd=u.Dex(r), copy=False)
+            return cls(lon=lon, lat=lat, logd=u.Dex(r), copy=COPY_IF_NEEDED)
 
     ld1 = LogDRepresentation(90.0 * u.deg, 0.0 * u.deg, 1.0 * u.dex(u.kpc))
     ld2 = LogDRepresentation(lon=90.0 * u.deg, lat=0.0 * u.deg, logd=1.0 * u.dex(u.kpc))
@@ -2096,9 +2103,11 @@ def unitphysics():
             sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
             sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
             return {
-                "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=False),
+                "phi": CartesianRepresentation(
+                    -sinphi, cosphi, 0.0, copy=COPY_IF_NEEDED
+                ),
                 "theta": CartesianRepresentation(
-                    costheta * cosphi, costheta * sinphi, -sintheta, copy=False
+                    costheta * cosphi, costheta * sinphi, -sintheta, copy=COPY_IF_NEEDED
                 ),
             }
 
@@ -2112,7 +2121,7 @@ def unitphysics():
             y = np.sin(self.theta) * np.sin(self.phi)
             z = np.cos(self.theta)
 
-            return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+            return CartesianRepresentation(x=x, y=y, z=z, copy=COPY_IF_NEEDED)
 
         @classmethod
         def from_cartesian(cls, cart):
@@ -2125,10 +2134,12 @@ def unitphysics():
             phi = np.arctan2(cart.y, cart.x)
             theta = np.arctan2(s, cart.z)
 
-            return cls(phi=phi, theta=theta, copy=False)
+            return cls(phi=phi, theta=theta, copy=COPY_IF_NEEDED)
 
         def norm(self):
-            return u.Quantity(np.ones(self.shape), u.dimensionless_unscaled, copy=False)
+            return u.Quantity(
+                np.ones(self.shape), u.dimensionless_unscaled, copy=COPY_IF_NEEDED
+            )
 
     PhysicsSphericalRepresentation._unit_representation = (
         UnitPhysicsSphericalRepresentation

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -12,6 +12,7 @@ from astropy.coordinates import (
     SphericalRepresentation,
 )
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .test_representation import representation_equal
 
@@ -35,7 +36,7 @@ class ShapeSetup:
     """
 
     def setup_class(cls):
-        # We set up some representations with, on purpose, copy=False,
+        # We set up some representations with, on purpose, copy=COPY_IF_NEEDED,
         # so we can check that broadcasting is handled correctly.
         lon = Longitude(np.arange(0, 24, 4), u.hourangle)
         lat = Latitude(np.arange(-90, 91, 30), u.deg)
@@ -45,20 +46,24 @@ class ShapeSetup:
             lon[:, np.newaxis] * np.ones(lat.shape),
             lat * np.ones(lon.shape)[:, np.newaxis],
             np.ones(lon.shape + lat.shape) * u.kpc,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
 
         cls.diff = SphericalDifferential(
             d_lon=np.ones(cls.s0.shape) * u.mas / u.yr,
             d_lat=np.ones(cls.s0.shape) * u.mas / u.yr,
             d_distance=np.ones(cls.s0.shape) * u.km / u.s,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         cls.s0 = cls.s0.with_differentials(cls.diff)
 
         # With unequal arrays -> these will be broadcasted.
         cls.s1 = SphericalRepresentation(
-            lon[:, np.newaxis], lat, 1.0 * u.kpc, differentials=cls.diff, copy=False
+            lon[:, np.newaxis],
+            lat,
+            1.0 * u.kpc,
+            differentials=cls.diff,
+            copy=COPY_IF_NEEDED,
         )
 
         # For completeness on some tests, also a cartesian one
@@ -286,7 +291,7 @@ class TestSetShape(ShapeSetup):
         # Finally, a more complicated one that checks that things get reset
         # properly if it is not the first component that fails.
         s2 = SphericalRepresentation(
-            self.s1.lon.copy(), self.s1.lat, self.s1.distance, copy=False
+            self.s1.lon.copy(), self.s1.lat, self.s1.distance, copy=COPY_IF_NEEDED
         )
         assert 0 not in s2.lon.strides
         assert 0 in s2.lat.strides

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -11,6 +11,7 @@ from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.coordinates.builtin_frames import GCRS, ICRS, AltAz
 from astropy.time import Time
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
+from astropy.utils.compat import COPY_IF_NEEDED
 
 
 @pytest.fixture(params=[True, False] if ARRAY_FUNCTION_ENABLED else [True])
@@ -32,7 +33,7 @@ class TestManipulation:
     """
 
     def setup_class(cls):
-        # For these tests, we set up frames and coordinates using copy=False,
+        # For these tests, we set up frames and coordinates using copy=COPY_IF_NEEDED,
         # so we can check that broadcasting is handled correctly.
         lon = Longitude(np.arange(0, 24, 4), u.hourangle)
         lat = Latitude(np.arange(-90, 91, 30), u.deg)
@@ -40,7 +41,7 @@ class TestManipulation:
         cls.s0 = ICRS(
             lon[:, np.newaxis] * np.ones(lat.shape),
             lat * np.ones(lon.shape)[:, np.newaxis],
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         # Make an AltAz frame since that has many types of attributes.
         # Match one axis with times.
@@ -60,7 +61,7 @@ class TestManipulation:
             location=cls.location,
             pressure=cls.pressure,
             temperature=cls.temperature,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         # For some tests, also try a GCRS, since that has representation
         # attributes.  We match the second dimension (via the location)
@@ -71,17 +72,19 @@ class TestManipulation:
             obstime=cls.obstime,
             obsgeoloc=cls.obsgeoloc,
             obsgeovel=cls.obsgeovel,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         # For completeness, also some tests on an empty frame.
         cls.s3 = GCRS(
             obstime=cls.obstime,
             obsgeoloc=cls.obsgeoloc,
             obsgeovel=cls.obsgeovel,
-            copy=False,
+            copy=COPY_IF_NEEDED,
         )
         # And make a SkyCoord
-        cls.sc = SkyCoord(ra=lon[:, np.newaxis], dec=lat, frame=cls.s3, copy=False)
+        cls.sc = SkyCoord(
+            ra=lon[:, np.newaxis], dec=lat, frame=cls.s3, copy=COPY_IF_NEEDED
+        )
 
     def test_getitem0101(self):
         # We on purpose take a slice with only one element, as for the

--- a/astropy/coordinates/transformations/affine.py
+++ b/astropy/coordinates/transformations/affine.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 import numpy as np
 
 from astropy.coordinates.transformations.base import CoordinateTransform
+from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = [
     "BaseAffineTransform",
@@ -163,7 +164,9 @@ class BaseAffineTransform(CoordinateTransform):
                 kwargs = {comp: getattr(newdiff, comp) for comp in newdiff.components}
                 kwargs["d_distance"] = fromcoord.data.differentials["s"].d_distance
                 diffs = {
-                    "s": type(fromcoord.data.differentials["s"])(copy=False, **kwargs)
+                    "s": type(fromcoord.data.differentials["s"])(
+                        copy=COPY_IF_NEEDED, **kwargs
+                    )
                 }
 
             elif has_velocity and unit_vel_diff:

--- a/astropy/cosmology/_io/html.py
+++ b/astropy/cosmology/_io/html.py
@@ -85,13 +85,13 @@ enable this, set ``latex_names=True``.
 
     >>> temp_dir.cleanup()
 """
-
 import astropy.cosmology.units as cu
 import astropy.units as u
 from astropy.cosmology.connect import readwrite_registry
 from astropy.cosmology.core import Cosmology
 from astropy.cosmology.parameter import Parameter
 from astropy.table import QTable
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .table import from_table, to_table
 
@@ -317,7 +317,7 @@ def write_html_table(
         if not isinstance(param, Parameter) or param.unit in (None, u.one):
             continue
         # Replace column with unitless version
-        table.replace_column(name, (col << param.unit).value, copy=False)
+        table.replace_column(name, (col << param.unit).value, copy=COPY_IF_NEEDED)
 
     if latex_names:
         new_names = [_FORMAT_TABLE.get(k, k) for k in cosmology.parameters]

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -22,6 +22,7 @@ from io import StringIO
 import numpy as np
 
 from astropy.table import Table
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data import get_readable_fileobj
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyWarning
@@ -812,7 +813,9 @@ def _read_in_chunks(table, **kwargs):
 
     # Make final table from numpy arrays, converting dict to list
     out_cols = [out_cols[name] for name in tbl0.colnames]
-    out = tbl0.__class__(out_cols, names=tbl0.colnames, meta=tbl0.meta, copy=False)
+    out = tbl0.__class__(
+        out_cols, names=tbl0.colnames, meta=tbl0.meta, copy=COPY_IF_NEEDED
+    )
 
     return out
 
@@ -1000,10 +1003,10 @@ def write(
     if isinstance(table, Table):
         # While we are only going to read data from columns, we may need to
         # to adjust info attributes such as format, so we make a shallow copy.
-        table = table.__class__(table, names=names, copy=False)
+        table = table.__class__(table, names=names, copy=COPY_IF_NEEDED)
     else:
         # Otherwise, create a table from the input.
-        table = Table(table, names=names, copy=False)
+        table = Table(table, names=names, copy=COPY_IF_NEEDED)
 
     table0 = table[:0].copy()
     core._apply_include_exclude_names(

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -13,6 +13,7 @@ from astropy import units as u
 from astropy.io import registry as io_registry
 from astropy.table import Column, MaskedColumn, Table, meta, serialize
 from astropy.time import Time
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import serialize_context_as
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.misc import NOT_OVERWRITING_MSG
@@ -290,11 +291,11 @@ def read_table_fits(
                 data=data[col.name],
                 name=col.name,
                 mask=mask,
-                copy=False,
+                copy=COPY_IF_NEEDED,
                 fill_value=fill_value,
             )
         else:
-            column = Column(data=data[col.name], name=col.name, copy=False)
+            column = Column(data=data[col.name], name=col.name, copy=COPY_IF_NEEDED)
 
         # Copy over units
         if col.unit is not None:
@@ -309,7 +310,7 @@ def read_table_fits(
         columns.append(column)
 
     # Create Table object
-    t = Table(columns, copy=False)
+    t = Table(columns, copy=COPY_IF_NEEDED)
 
     # TODO: deal properly with unsigned integers
 
@@ -386,7 +387,7 @@ def _encode_mixins(tbl):
     # comments in the input table.
     if encode_tbl is tbl:
         meta_copy = deepcopy(tbl.meta)
-        encode_tbl = Table(tbl.columns, meta=meta_copy, copy=False)
+        encode_tbl = Table(tbl.columns, meta=meta_copy, copy=COPY_IF_NEEDED)
 
     # Get the YAML serialization of information describing the table columns.
     # This is re-using ECSV code that combined existing table.meta with with

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -13,6 +13,7 @@ from astropy.table.column import col_copy
 from astropy.time import Time, TimeDelta
 from astropy.time.core import BARYCENTRIC_SCALES
 from astropy.time.formats import FITS_DEPRECATED_SCALES
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 from . import Card, Header
@@ -564,7 +565,7 @@ def time_to_fits(table):
         else:
             new_col = col_copy(col, copy_indices=False) if col.info.indices else col
         new_cols.append(new_col)
-    newtable = table.__class__(new_cols, copy=False)
+    newtable = table.__class__(new_cols, copy=COPY_IF_NEEDED)
     newtable.meta = table.meta
 
     # Global time coordinate frame keywords

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import Quantity, UnitsError
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -1967,7 +1968,7 @@ class Const1D(Fittable1DModel):
             x = amplitude * np.ones_like(x, subok=False)
 
         if isinstance(amplitude, Quantity):
-            return Quantity(x, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(x, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True)
         return x
 
     @staticmethod
@@ -2022,7 +2023,7 @@ class Const2D(Fittable2DModel):
             x = amplitude * np.ones_like(x, subok=False)
 
         if isinstance(amplitude, Quantity):
-            return Quantity(x, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(x, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True)
         return x
 
     @property
@@ -2129,7 +2130,9 @@ class Ellipse2D(Fittable2DModel):
         result = np.select([in_ellipse], [amplitude])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(
+                result, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True
+            )
         return result
 
     @property
@@ -2216,7 +2219,9 @@ class Disk2D(Fittable2DModel):
         result = np.select([rr <= R_0**2], [amplitude])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(
+                result, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True
+            )
         return result
 
     @property
@@ -2342,7 +2347,9 @@ class Ring2D(Fittable2DModel):
         result = np.select([r_range], [amplitude])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(
+                result, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True
+            )
         return result
 
     @property
@@ -2530,7 +2537,9 @@ class Box2D(Fittable2DModel):
         result = np.select([np.logical_and(x_range, y_range)], [amplitude], 0)
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(
+                result, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True
+            )
         return result
 
     @property
@@ -2631,7 +2640,9 @@ class Trapezoid1D(Fittable1DModel):
         result = np.select([range_a, range_b, range_c], [val_a, val_b, val_c])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(
+                result, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True
+            )
         return result
 
     @property
@@ -2701,7 +2712,9 @@ class TrapezoidDisk2D(Fittable2DModel):
         result = np.select([range_1, range_2], [val_1, val_2])
 
         if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False, subok=True)
+            return Quantity(
+                result, unit=amplitude.unit, copy=COPY_IF_NEEDED, subok=True
+            )
         return result
 
     @property
@@ -2985,7 +2998,7 @@ class AiryDisk2D(Fittable2DModel):
 
         if isinstance(amplitude, Quantity):
             # make z quantity too, otherwise in-place multiplication fails.
-            z = Quantity(z, u.dimensionless_unscaled, copy=False, subok=True)
+            z = Quantity(z, u.dimensionless_unscaled, copy=COPY_IF_NEEDED, subok=True)
 
         z *= amplitude
         return z

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -6,6 +6,7 @@ Power law model variants.
 import numpy as np
 
 from astropy.units import Magnitude, Quantity, UnitsError, dimensionless_unscaled, mag
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .core import Fittable1DModel
 from .parameters import InputParameterError, Parameter
@@ -317,7 +318,7 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
             f[i] = amplitude * xx[i] ** (-alpha_1) * r ** ((alpha_1 - alpha_2) * delta)
 
         if return_unit:
-            return Quantity(f, unit=return_unit, copy=False, subok=True)
+            return Quantity(f, unit=return_unit, copy=COPY_IF_NEEDED, subok=True)
         return f
 
     @staticmethod

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -9,6 +9,7 @@ import numpy as np
 # from astropy.utils.compat import ignored
 from astropy import log
 from astropy.units import Quantity, Unit, UnitConversionError
+from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = [
     "MissingDataAssociationException",
@@ -213,7 +214,9 @@ class NDUncertainty(metaclass=ABCMeta):
         """
         This uncertainty as an `~astropy.units.Quantity` object.
         """
-        return Quantity(self.array, self.unit, copy=False, dtype=self.array.dtype)
+        return Quantity(
+            self.array, self.unit, copy=COPY_IF_NEEDED, dtype=self.array.dtype
+        )
 
     @property
     def parent_nddata(self):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import NUMPY_LT_2_0, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, sanitize_copy_arg
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -519,7 +519,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         unit=None,
         format=None,
         meta=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
         copy = sanitize_copy_arg(copy)
@@ -1246,7 +1246,7 @@ class Column(BaseColumn):
         unit=None,
         format=None,
         meta=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
         if isinstance(data, MaskedColumn) and np.any(data.mask):
@@ -1605,7 +1605,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         unit=None,
         format=None,
         meta=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
         if mask is None:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1099,7 +1099,12 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         # if the column's values are non-numeric (like strings), while .view
         # will happily return a quantity with gibberish for numerical values
         return Quantity(
-            self, self.unit, copy=False, dtype=self.dtype, order="A", subok=True
+            self,
+            self.unit,
+            copy=COPY_IF_NEEDED,
+            dtype=self.dtype,
+            order="A",
+            subok=True,
         )
 
     def to(self, unit, equivalencies=[], **kwargs):

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.io import registry
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from .info import serialize_method_as
 
@@ -68,7 +69,7 @@ class TableRead(registry.UnifiedReadWrite):
         # Table <=> QTable.
         if cls is not out.__class__:
             try:
-                out = cls(out, copy=False)
+                out = cls(out, copy=COPY_IF_NEEDED)
             except Exception:
                 raise TypeError(
                     f"could not convert reader output to {cls.__name__} class."

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -6,6 +6,7 @@ from itertools import pairwise
 
 import numpy as np
 
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .index import get_index_by_names
@@ -51,7 +52,7 @@ def _table_group_by(table, keys):
                 )
 
         # Make a column slice of the table without copying
-        table_keys = table.__class__([table[key] for key in keys], copy=False)
+        table_keys = table.__class__([table[key] for key in keys], copy=COPY_IF_NEEDED)
 
         # If available get a pre-existing index for these columns
         table_index = get_index_by_names(table, keys)

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import metadata
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.masked import Masked
 
 from . import _np_utils
@@ -499,13 +500,13 @@ def setdiff(table1, table2, keys=None):
             )
 
     # Make a light internal copy of both tables
-    t1 = table1.copy(copy_data=False)
+    t1 = table1.copy(copy_data=COPY_IF_NEEDED)
     t1.meta = {}
     t1.keep_columns(keys)
     t1["__index1__"] = np.arange(len(table1))  # Keep track of rows indices
 
     # Make a light internal copy to avoid touching table2
-    t2 = table2.copy(copy_data=False)
+    t2 = table2.copy(copy_data=COPY_IF_NEEDED)
     t2.meta = {}
     t2.keep_columns(keys)
     # Dummy column to recover rows after join
@@ -1170,8 +1171,8 @@ def _join(
 
         # Make light copies of left and right, then add temporary index columns
         # with all the same value so later an outer join turns into a cartesian join.
-        left = left.copy(copy_data=False)
-        right = right.copy(copy_data=False)
+        left = left.copy(copy_data=COPY_IF_NEEDED)
+        right = right.copy(copy_data=COPY_IF_NEEDED)
         left[cartesian_index_name] = np.uint8(0)
         right[cartesian_index_name] = np.uint8(0)
         keys = (cartesian_index_name,)
@@ -1294,10 +1295,10 @@ def _join(
             # If col is a Column but not MaskedColumn then upgrade at this point
             # because masking is required.
             if isinstance(col, Column) and not isinstance(col, MaskedColumn):
-                col = out.MaskedColumn(col, copy=False)
+                col = out.MaskedColumn(col, copy=COPY_IF_NEEDED)
 
             if isinstance(col, Quantity) and not isinstance(col, Masked):
-                col = Masked(col, copy=False)
+                col = Masked(col, copy=COPY_IF_NEEDED)
 
             # array_mask is 1-d corresponding to length of output column.  We need
             # make it have the correct shape for broadcasting, i.e. (length, 1, 1, ..).
@@ -1376,8 +1377,8 @@ def _join_keys_left_right(left, right, keys, keys_left, keys_right, join_funcs):
     # key columns in common.
     keys = [f"{ii}" for ii in range(len(cols_left))]
 
-    left = left.__class__(cols_left, names=keys, copy=False)
-    right = right.__class__(cols_right, names=keys, copy=False)
+    left = left.__class__(cols_left, names=keys, copy=COPY_IF_NEEDED)
+    right = right.__class__(cols_right, names=keys, copy=COPY_IF_NEEDED)
 
     return left, right, keys
 
@@ -1495,10 +1496,10 @@ def _vstack(arrays, join_type="outer", col_name_map=None, metadata_conflicts="wa
                 # If col is a Column but not MaskedColumn then upgrade at this point
                 # because masking is required.
                 if isinstance(col, Column) and not isinstance(col, MaskedColumn):
-                    col = out.MaskedColumn(col, copy=False)
+                    col = out.MaskedColumn(col, copy=COPY_IF_NEEDED)
 
                 if isinstance(col, Quantity) and not isinstance(col, Masked):
-                    col = Masked(col, copy=False)
+                    col = Masked(col, copy=COPY_IF_NEEDED)
 
                 try:
                     col[idx0:idx1] = col.info.mask_val
@@ -1604,10 +1605,10 @@ def _hstack(
                 # If col is a Column but not MaskedColumn then upgrade at this point
                 # because masking is required.
                 if isinstance(col, Column) and not isinstance(col, MaskedColumn):
-                    col = out.MaskedColumn(col, copy=False)
+                    col = out.MaskedColumn(col, copy=COPY_IF_NEEDED)
 
                 if isinstance(col, Quantity) and not isinstance(col, Masked):
-                    col = Masked(col, copy=False)
+                    col = Masked(col, copy=COPY_IF_NEEDED)
 
                 try:
                     col[arr_len:] = col.info.mask_val

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -55,7 +55,7 @@ class Row:
         except (KeyError, TypeError):
             if self._table._is_list_or_tuple_of_str(item):
                 cols = [self._table[name] for name in item]
-                out = self._table.__class__(cols, copy=False)[self._index]
+                out = self._table.__class__(cols, copy=COPY_IF_NEEDED)[self._index]
             elif isinstance(item, slice):
                 # https://github.com/astropy/astropy/issues/14007
                 out = tuple(self.values())[item]

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -6,6 +6,7 @@ from importlib import import_module
 import numpy as np
 
 from astropy.units.quantity import QuantityInfo
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 
 from .column import Column, MaskedColumn
@@ -300,7 +301,7 @@ def represent_mixins_as_columns(tbl, exclude_classes=()):
     if mixin_cols:
         meta = deepcopy(tbl.meta)
         meta["__serialized_columns__"] = mixin_cols
-        out = Table(new_cols, meta=meta, copy=False)
+        out = Table(new_cols, meta=meta, copy=COPY_IF_NEEDED)
     else:
         out = tbl
 
@@ -449,4 +450,6 @@ def _construct_mixins_from_columns(tbl):
     has_quantities = any(isinstance(col.info, QuantityInfo) for col in out.itercols())
     out_cls = QTable if has_quantities else Table
 
-    return out_cls(list(out.values()), names=out.colnames, copy=False, meta=meta)
+    return out_cls(
+        list(out.values()), names=out.colnames, copy=COPY_IF_NEEDED, meta=meta
+    )

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -956,7 +956,7 @@ class Table:
                     for col in self.itercols()
                 ],
                 names=self.colnames,
-                copy=False,
+                copy=COPY_IF_NEEDED,
             )
 
             # Set hidden attribute to force inplace setitem so that code like
@@ -1000,12 +1000,12 @@ class Table:
         """
         if self.masked or self.has_masked_columns or self.has_masked_values:
             # Get new columns with masked values filled, then create Table with those
-            # new cols (copy=False) but deepcopy the meta.
+            # new cols (copy=COPY_IF_NEEDED) but deepcopy the meta.
             data = [
                 col.filled(fill_value) if hasattr(col, "filled") else col
                 for col in self.itercols()
             ]
-            return self.__class__(data, meta=deepcopy(self.meta), copy=False)
+            return self.__class__(data, meta=deepcopy(self.meta), copy=COPY_IF_NEEDED)
         else:
             # Return copy of the original object.
             return self.copy()
@@ -1223,7 +1223,7 @@ class Table:
                 # setting masked values. As of astropy 4.0 the test condition below is
                 # always True since _init_from_dict cannot result in mixin columns.
                 if isinstance(col, Column) and not isinstance(col, MaskedColumn):
-                    self[name] = self.MaskedColumn(col, copy=False)
+                    self[name] = self.MaskedColumn(col, copy=COPY_IF_NEEDED)
 
                 # Finally do the masking in a mixin-safe way.
                 self[name][indexes] = np.ma.masked
@@ -1753,7 +1753,9 @@ class Table:
     def _make_index_row_display_table(self, index_row_name):
         if index_row_name not in self.columns:
             idx_col = self.ColumnClass(name=index_row_name, data=np.arange(len(self)))
-            return self.__class__([idx_col] + list(self.columns.values()), copy=False)
+            return self.__class__(
+                [idx_col] + list(self.columns.values()), copy=COPY_IF_NEEDED
+            )
         else:
             return self
 
@@ -3333,7 +3335,7 @@ class Table:
                         if issubclass(self.ColumnClass, self.MaskedColumn)
                         else self.MaskedColumn
                     )
-                    col = col_cls(col, copy=False)
+                    col = col_cls(col, copy=COPY_IF_NEEDED)
 
                 newcol = col.insert(index, val, axis=0)
 
@@ -3708,7 +3710,7 @@ class Table:
         return self.copy(True)
 
     def __copy__(self):
-        return self.copy(False)
+        return self.copy(COPY_IF_NEEDED)
 
     def __eq__(self, other):
         return self._rows_equal(other)

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -8,6 +8,7 @@ import pytest
 
 import astropy.units as u
 from astropy.table import Column, MaskedColumn, QTable, Table, TableColumns
+from astropy.utils.compat import COPY_IF_NEEDED
 
 
 class DictLike(Mapping):
@@ -112,7 +113,7 @@ class BaseInitFromListLike(BaseInitFrom):
     def test_names_copy_false(self, table_type):
         self._setup(table_type)
         with pytest.raises(ValueError):
-            table_type(self.data, names=["a"], dtype=[int], copy=False)
+            table_type(self.data, names=["a"], dtype=[int], copy=COPY_IF_NEEDED)
 
 
 @pytest.mark.usefixtures("table_type")
@@ -131,10 +132,10 @@ class TestInitFromNdarrayHomo(BaseInitFromListLike):
         assert t.colnames == ["col0", "col1", "col2"]
 
     def test_ndarray_ref(self, table_type):
-        """Init with ndarray and copy=False and show that this is a reference
+        """Init with ndarray and copy=COPY_IF_NEEDED and show that this is a reference
         to input ndarray"""
         self._setup(table_type)
-        t = table_type(self.data, copy=False)
+        t = table_type(self.data, copy=COPY_IF_NEEDED)
         t["col1"][1] = 0
         assert t.as_array()["col1"][1] == 0
         assert t["col1"][1] == 0
@@ -260,7 +261,7 @@ class TestInitFromColsList(BaseInitFromListLike):
     def test_ref(self, table_type):
         """Test that initializing from a list of columns can be done by reference"""
         self._setup(table_type)
-        t = table_type(self.data, copy=False)
+        t = table_type(self.data, copy=COPY_IF_NEEDED)
         t["x"][0] = 100
         assert self.data[0][0] == 100
 
@@ -273,10 +274,10 @@ class TestInitFromNdarrayStruct(BaseInitFromDictLike):
         )
 
     def test_ndarray_ref(self, table_type):
-        """Init with ndarray and copy=False and show that table uses reference
+        """Init with ndarray and copy=COPY_IF_NEEDED and show that table uses reference
         to input ndarray"""
         self._setup(table_type)
-        t = table_type(self.data, copy=False)
+        t = table_type(self.data, copy=COPY_IF_NEEDED)
 
         t["x"][1] = 0  # Column-wise assignment
         t[0]["y"] = 0  # Row-wise assignment
@@ -296,7 +297,7 @@ class TestInitFromNdarrayStruct(BaseInitFromDictLike):
 
     def test_partial_names_ref(self, table_type):
         self._setup(table_type)
-        t = table_type(self.data, names=["e", None, "d"], copy=False)
+        t = table_type(self.data, names=["e", None, "d"], copy=COPY_IF_NEEDED)
         assert t.colnames == ["e", "y", "d"]
         assert t["e"].dtype.type == np.int64
         assert t["y"].dtype.type == np.int32
@@ -393,7 +394,7 @@ class TestInitFromTable(BaseInitFromDictLike):
 
     def test_table_ref(self, table_type):
         self._setup(table_type)
-        t = table_type(self.data, copy=False)
+        t = table_type(self.data, copy=COPY_IF_NEEDED)
         t["x"][1] = 0
         assert t["x"][1] == 0
         assert self.data["x"][1] == 0
@@ -411,7 +412,7 @@ class TestInitFromTable(BaseInitFromDictLike):
 
     def test_partial_names_ref(self, table_type):
         self._setup(table_type)
-        t = table_type(self.data, names=["e", None, "d"], copy=False)
+        t = table_type(self.data, names=["e", None, "d"], copy=COPY_IF_NEEDED)
         assert t.colnames == ["e", "y", "d"]
         assert t["e"].dtype.type == np.int64
         assert t["y"].dtype.type == np.int64
@@ -512,10 +513,10 @@ def test_init_table_with_names_and_structured_dtype(has_data):
 def test_init_and_ref_from_multidim_ndarray(table_type):
     """
     Test that initializing from an ndarray structured array with
-    a multi-dim column works for both copy=False and True and that
+    a multi-dim column works for both copy=COPY_IF_NEEDED and True and that
     the referencing is as expected.
     """
-    for copy in (False, True):
+    for copy in (COPY_IF_NEEDED, True):
         nd = np.array(
             [(1, [10, 20]), (3, [30, 40])], dtype=[("a", "i8"), ("b", "i8", (2,))]
         )
@@ -534,11 +535,11 @@ def test_init_and_ref_from_multidim_ndarray(table_type):
 
 
 @pytest.mark.usefixtures("table_type")
-@pytest.mark.parametrize("copy", [False, True])
+@pytest.mark.parametrize("copy", [COPY_IF_NEEDED, True])
 def test_init_and_ref_from_dict(table_type, copy):
     """
-    Test that initializing from a dict works for both copy=False and True and that
-    the referencing is as expected.
+    Test that initializing from a dict works for both copy=COPY_IF_NEEDED
+    and True and that the referencing is as expected.
     """
     x1 = np.arange(10.0)
     x2 = np.zeros(10)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -27,6 +27,7 @@ from astropy.table import (
 from astropy.table.column import BaseColumn
 from astropy.table.serialize import represent_mixins_as_columns
 from astropy.table.table_helpers import ArrayWrapper
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.metadata import MergeConflictWarning
@@ -1018,7 +1019,7 @@ def test_skycoord_with_velocity():
     assert skycoord_equal(t2["col0"], sc)
 
 
-@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.parametrize("copy", [True, COPY_IF_NEEDED])
 @pytest.mark.parametrize("table_cls", [Table, QTable])
 def test_ensure_input_info_is_unchanged(table_cls, copy):
     """If a mixin input to a table has no info, it should stay that way.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -28,7 +28,7 @@ from astropy.table import (
 )
 from astropy.tests.helper import PYTEST_LT_8_0, assert_follows_unicode_guidelines
 from astropy.time import Time, TimeDelta
-from astropy.utils.compat import NUMPY_LT_1_25
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_25
 from astropy.utils.compat.optional_deps import HAS_PANDAS
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
@@ -337,7 +337,7 @@ class TestReverse:
         assert np.all(t["col0"] == np.array([3, 2, 1]))
         assert np.all(t["col1"] == np.array(["cc", "b", "a"]))
 
-        t2 = table_types.Table(t, copy=False)
+        t2 = table_types.Table(t, copy=COPY_IF_NEEDED)
         assert np.all(t2["col0"] == np.array([3, 2, 1]))
         assert np.all(t2["col1"] == np.array(["cc", "b", "a"]))
 
@@ -2383,7 +2383,7 @@ class TestReplaceColumn(SetupData):
     def test_replace_column_no_copy(self):
         t = Table([[1, 2], [3, 4]], names=["a", "b"])
         a = np.array([1.5, 2.5])
-        t.replace_column("a", a, copy=False)
+        t.replace_column("a", a, copy=COPY_IF_NEEDED)
         assert t["a"][0] == a[0]
         t["a"][0] = 10
         assert t["a"][0] == a[0]
@@ -2423,10 +2423,10 @@ class Test__Astropy_Table__:
             return cls(cols, names=names, copy=copy, meta=kwargs or self.meta)
 
     def test_simple_1(self):
-        """Make a SimpleTable and convert to Table, QTable with copy=False, True"""
+        """Make a SimpleTable and convert to Table, QTable with copy=COPY_IF_NEEDED, True"""
         for table_cls in (table.Table, table.QTable):
             col_c_class = u.Quantity if table_cls is table.QTable else table.Column
-            for cpy in (False, True):
+            for cpy in (COPY_IF_NEEDED, True):
                 st = self.SimpleTable()
                 # Test putting in a non-native kwarg `extra_meta` to Table initializer
                 t = table_cls(st, copy=cpy, extra_meta="extra!")
@@ -2548,7 +2548,7 @@ class TestUpdate:
         self._setup()
         t1 = Table([self.a, self.b])
         t2 = Table([self.b, self.c])
-        t1.update(t2, copy=False)
+        t1.update(t2, copy=COPY_IF_NEEDED)
         t2["b"] -= 1
         assert t1.colnames == ["a", "b", "c"]
         assert np.all(t1["a"] == self.a)
@@ -2556,7 +2556,7 @@ class TestUpdate:
         assert np.all(t1["c"] == self.c)
 
         d = {"b": np.array(self.b), "d": np.array(self.d)}
-        t2.update(d, copy=False)
+        t2.update(d, copy=COPY_IF_NEEDED)
         d["b"] *= 2
         assert t2.colnames == ["b", "c", "d"]
         assert np.all(t2["b"] == 2 * self.b)
@@ -2618,8 +2618,8 @@ def test_table_meta_copy():
     assert t2.meta == t.meta
     assert t2.meta[1] is t.meta[1]  # Value IS the list same object
 
-    # Table init with copy=False implies key copy
-    t2 = table.Table(t, copy=False)
+    # Table init with copy=COPY_IF_NEEDED implies key copy
+    t2 = table.Table(t, copy=COPY_IF_NEEDED)
     assert t2.meta is not t.meta  # NOT the same OrderedDict object but equal
     assert t2.meta == t.meta
     assert t2.meta[1] is t.meta[1]  # Value IS the same list object
@@ -2638,15 +2638,15 @@ def test_table_meta_copy_with_meta_arg():
     """
     meta = {1: [1, 2]}
     meta2 = {2: [3, 4]}
-    t = table.Table([[1]], meta=meta, copy=False)
+    t = table.Table([[1]], meta=meta, copy=COPY_IF_NEEDED)
     assert t.meta is meta
 
     t = table.Table([[1]], meta=meta)  # default copy=True
     assert t.meta is not meta
     assert t.meta == meta
 
-    # Test initializing from existing table with meta with copy=False
-    t2 = table.Table(t, meta=meta2, copy=False)
+    # Test initializing from existing table with meta with copy=COPY_IF_NEEDED
+    t2 = table.Table(t, meta=meta2, copy=COPY_IF_NEEDED)
     assert t2.meta is meta2
     assert t2.meta != t.meta  # Change behavior in #8404
 
@@ -2666,8 +2666,8 @@ def test_table_meta_copy_with_meta_arg():
     t2 = table.Table(t, copy=True, meta=None)
     assert t2.meta == t.meta
 
-    # Test initializing empty table with meta with copy=False
-    t = table.Table(meta=meta, copy=False)
+    # Test initializing empty table with meta with copy=COPY_IF_NEEDED
+    t = table.Table(meta=meta, copy=COPY_IF_NEEDED)
     assert t.meta is meta
     assert t.meta[1] is meta[1]
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -567,11 +567,11 @@ class TimeBase(ShapedLikeNDArray):
         # with shape broadcastable to jd2.
         if mask is not False:
             # Ensure that if the class is already masked, we do not lose it.
-            self._time.jd1 = Masked(self._time.jd1, copy=False)
+            self._time.jd1 = Masked(self._time.jd1, copy=COPY_IF_NEEDED)
             self._time.jd1.mask |= mask
             # Ensure we share the mask (it may have been broadcast).
             self._time.jd2 = Masked(
-                self._time.jd2, mask=self._time.jd1.mask, copy=False
+                self._time.jd2, mask=self._time.jd1.mask, copy=COPY_IF_NEEDED
             )
 
     def _get_time_fmt(
@@ -1221,9 +1221,9 @@ class TimeBase(ShapedLikeNDArray):
 
         if value is np.ma.masked or value is np.nan:
             if not isinstance(self._time.jd2, Masked):
-                self._time.jd1 = Masked(self._time.jd1, copy=False)
+                self._time.jd1 = Masked(self._time.jd1, copy=COPY_IF_NEEDED)
                 self._time.jd2 = Masked(
-                    self._time.jd2, mask=self._time.jd1.mask, copy=False
+                    self._time.jd2, mask=self._time.jd1.mask, copy=COPY_IF_NEEDED
                 )
             self._time.jd2.mask[item] = True
             return

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1970,7 +1970,7 @@ class Time(TimeBase):
         in_subfmt=None,
         out_subfmt=None,
         location=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
     ):
         copy = sanitize_copy_arg(copy)
 
@@ -2939,7 +2939,7 @@ class TimeDelta(TimeBase):
         precision=None,
         in_subfmt=None,
         out_subfmt=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
     ):
         if isinstance(val, TimeDelta):
             if scale is not None:

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -12,6 +12,7 @@ import erfa
 import numpy as np
 
 import astropy.units as u
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import classproperty, lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.masked import Masked
@@ -330,9 +331,9 @@ class TimeFormat:
             # careful with the conversion, so that, e.g., large numbers of
             # seconds get converted without losing precision because
             # 1/86400 is not exactly representable as a float.
-            val1 = u.Quantity(val1, copy=False)
+            val1 = u.Quantity(val1, copy=COPY_IF_NEEDED)
             if val2 is not None:
-                val2 = u.Quantity(val2, copy=False)
+                val2 = u.Quantity(val2, copy=COPY_IF_NEEDED)
 
             try:
                 val1, val2 = quantity_day_frac(val1, val2)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -30,6 +30,7 @@ from astropy.time import (
     conf,
 )
 from astropy.utils import iers, isiterable
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_PYTZ
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -143,7 +144,7 @@ class TestBasic:
         """
         t = Time(value, format="jd", scale="utc")
 
-        t2 = Time(t, copy=False)
+        t2 = Time(t, copy=COPY_IF_NEEDED)
         assert np.all(t.jd - t2.jd == 0)
         assert np.all((t - t2).jd == 0)
         assert t._time.jd1 is t2._time.jd1

--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -8,6 +8,7 @@ from astropy import units as u
 from astropy.time import Time, TimeDelta
 from astropy.timeseries.binned import BinnedTimeSeries
 from astropy.timeseries.sampled import TimeSeries
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["aggregate_downsample"]
@@ -256,7 +257,9 @@ def aggregate_downsample(
         if isinstance(values, u.Quantity):
             data = u.Quantity(np.repeat(np.nan, n_bins), unit=values.unit)
             data[unique_indices] = u.Quantity(
-                reduceat(values.value, groups, aggregate_func), values.unit, copy=False
+                reduceat(values.value, groups, aggregate_func),
+                values.unit,
+                copy=COPY_IF_NEEDED,
             )
         else:
             data = np.ma.zeros(n_bins, dtype=values.dtype)

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -755,7 +755,7 @@ class FunctionQuantity(Quantity):
         except UnitTypeError:
             return NotImplemented
 
-        return self.__class__(self, other, copy=False, subok=True)
+        return self.__class__(self, other, copy=COPY_IF_NEEDED, subok=True)
 
     # Ensure Quantity methods are used only if they make sense.
     def _wrap_function(self, function, *args, **kwargs):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1162,7 +1162,7 @@ class Quantity(np.ndarray):
         except UnitTypeError:
             return NotImplemented
 
-        return self.__class__(self, other, copy=False, subok=True)
+        return self.__class__(self, other, copy=COPY_IF_NEEDED, subok=True)
 
     def __ilshift__(self, other):
         try:

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -10,7 +10,7 @@ import operator
 
 import numpy as np
 
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_24
+from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_1_24
 
 from .core import UNITY, Unit, UnitBase
 
@@ -486,7 +486,7 @@ class StructuredUnit:
         try:
             from .quantity import Quantity
 
-            return Quantity(m, self, copy=False, subok=True)
+            return Quantity(m, self, copy=COPY_IF_NEEDED, subok=True)
         except Exception:
             return NotImplemented
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -162,29 +162,29 @@ class TestQuantityCreation:
             assert q4.dtype == np.float128
 
     def test_copy(self):
-        # By default, a new quantity is constructed, but not if copy=False
+        # By default, a new quantity is constructed, but not if copy=COPY_IF_NEEDED
 
         a = np.arange(10.0)
 
         q0 = u.Quantity(a, unit=u.m / u.s)
         assert q0.base is not a
 
-        q1 = u.Quantity(a, unit=u.m / u.s, copy=False)
+        q1 = u.Quantity(a, unit=u.m / u.s, copy=COPY_IF_NEEDED)
         assert q1.base is a
 
         q2 = u.Quantity(q0)
         assert q2 is not q0
         assert q2.base is not q0.base
 
-        q2 = u.Quantity(q0, copy=False)
+        q2 = u.Quantity(q0, copy=COPY_IF_NEEDED)
         assert q2 is q0
         assert q2.base is q0.base
 
-        q3 = u.Quantity(q0, q0.unit, copy=False)
+        q3 = u.Quantity(q0, q0.unit, copy=COPY_IF_NEEDED)
         assert q3 is q0
         assert q3.base is q0.base
 
-        q4 = u.Quantity(q0, u.cm / u.s, copy=False)
+        q4 = u.Quantity(q0, u.cm / u.s, copy=COPY_IF_NEEDED)
         assert q4 is not q0
         assert q4.base is not q0.base
 
@@ -259,7 +259,7 @@ class TestQuantityCreation:
         assert q2.unit is u.mm
         assert np.all(q2.value == 1000.0 * a)
 
-        q3 = u.Quantity(mylookalike, copy=False)
+        q3 = u.Quantity(mylookalike, copy=COPY_IF_NEEDED)
         assert np.all(q3.value == mylookalike)
         q3[2] = 0
         assert q3[2] == 0.0
@@ -267,7 +267,7 @@ class TestQuantityCreation:
 
         mylookalike = a.copy().view(MyQuantityLookalike)
         mylookalike.unit = u.m
-        q4 = u.Quantity(mylookalike, u.mm, copy=False)
+        q4 = u.Quantity(mylookalike, u.mm, copy=COPY_IF_NEEDED)
         q4[2] = 0
         assert q4[2] == 0.0
         assert mylookalike[2] == 2.0

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -6,6 +6,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT
 
@@ -17,7 +18,7 @@ class TestQuantityArrayCopy:
 
     def test_copy_on_creation(self):
         v = np.arange(1000.0)
-        q_nocopy = u.Quantity(v, "km/s", copy=False)
+        q_nocopy = u.Quantity(v, "km/s", copy=COPY_IF_NEEDED)
         q_copy = u.Quantity(v, "km/s", copy=True)
         v[0] = -1.0
         assert q_nocopy[0].value == v[0]

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -4,6 +4,8 @@ This is a collection of monkey patches and workarounds for bugs in
 earlier versions of Numpy.
 """
 
+import warnings
+
 import numpy as np
 
 from astropy.utils import minversion
@@ -31,6 +33,15 @@ COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
 
 def sanitize_copy_arg(copy, /):
     if not NUMPY_LT_2_0 and copy is False:
+        warnings.warn(
+            "With copy=False, copies are still made where they cannot be avoided. "
+            "In the future, an error will be raised in that scenario. "
+            "This is done following a change in numpy 2.0.\n"
+            "To silence this warning, pass copy=None, "
+            "or downgrade numpy<2.0 (not recommended).",
+            category=FutureWarning,
+            stacklevel=3,
+        )
         return None
 
     return copy

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -111,12 +111,12 @@ class Masked(NDArrayShapeMethods):
     # Subclasses can override this in case the class does not work
     # with this signature, or to provide a faster implementation.
     @classmethod
-    def from_unmasked(cls, data, mask=None, copy=False):
+    def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
         """Create an instance from unmasked data and a mask."""
         return cls(data, mask=mask, copy=copy)
 
     @classmethod
-    def _get_masked_instance(cls, data, mask=None, copy=False):
+    def _get_masked_instance(cls, data, mask=None, copy=COPY_IF_NEEDED):
         data, data_mask = cls._get_data_and_mask(data)
         if mask is None:
             mask = False if data_mask is None else data_mask
@@ -510,7 +510,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
     # The two pieces typically overridden.
     @classmethod
-    def from_unmasked(cls, data, mask=None, copy=False):
+    def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
         # Note: have to override since __new__ would use ndarray.__new__
         # which expects the shape as its first argument, not an array.
         copy = sanitize_copy_arg(copy)

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -447,7 +447,7 @@ class MaskedIterator:
             out = out[...]
             mask = mask[...]
 
-        return self._masked.from_unmasked(out, mask, copy=False)
+        return self._masked.from_unmasked(out, mask, copy=COPY_IF_NEEDED)
 
     def __setitem__(self, index, value):
         data, mask = self._masked._get_data_and_mask(value, allow_ma_masked=True)
@@ -461,7 +461,7 @@ class MaskedIterator:
         """
         out = next(self._dataiter)[...]
         mask = next(self._maskiter)[...]
-        return self._masked.from_unmasked(out, mask, copy=False)
+        return self._masked.from_unmasked(out, mask, copy=COPY_IF_NEEDED)
 
     next = __next__
 


### PR DESCRIPTION
### Description
This is based off #16166 and #16170 and adds a minor but crucial API change to align the default value of our `copy` arguments with whatever numpy API is installed. See #16167 for the broader context.

**Passing `copy=False` is still supported but raises a warning.**
Alternative: #16181

This is meant to be a small self-contained PR that we can ask downstream stakeholders to test from, but this will only make sense once #16166 and #16170 are merged. At that point, I'll call for feedback on the dev mailing list.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
