### PR TITLE
API: align default value for copy arguments with numpy at runtime (copy=False raises an error if copies cannot be avoided)

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import NUMPY_LT_2_0, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, sanitize_copy_arg
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -519,7 +519,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         unit=None,
         format=None,
         meta=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
         copy = sanitize_copy_arg(copy)
@@ -1246,7 +1246,7 @@ class Column(BaseColumn):
         unit=None,
         format=None,
         meta=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
         if isinstance(data, MaskedColumn) and np.any(data.mask):
@@ -1605,7 +1605,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         unit=None,
         format=None,
         meta=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
         if mask is None:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -10,7 +10,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -522,8 +522,6 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         copy=COPY_IF_NEEDED,
         copy_indices=True,
     ):
-        copy = sanitize_copy_arg(copy)
-
         if data is None:
             self_data = np.zeros((length,) + shape, dtype=dtype)
         elif isinstance(data, BaseColumn) and hasattr(data, "_name"):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -30,7 +30,7 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray, lazyproperty
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
@@ -1993,8 +1993,6 @@ class Time(TimeBase):
         location=None,
         copy=COPY_IF_NEEDED,
     ):
-        copy = sanitize_copy_arg(copy)
-
         if location is not None:
             from astropy.coordinates import EarthLocation
 
@@ -3388,8 +3386,6 @@ def _make_array(val, copy=COPY_IF_NEEDED):
         dtype = object
     else:
         dtype = None
-
-    copy = sanitize_copy_arg(copy)
 
     val = np.array(val, copy=copy, subok=True, dtype=dtype)
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1991,7 +1991,7 @@ class Time(TimeBase):
         in_subfmt=None,
         out_subfmt=None,
         location=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
     ):
         copy = sanitize_copy_arg(copy)
 
@@ -2960,7 +2960,7 @@ class TimeDelta(TimeBase):
         precision=None,
         in_subfmt=None,
         out_subfmt=None,
-        copy=False,
+        copy=COPY_IF_NEEDED,
     ):
         if isinstance(val, TimeDelta):
             if scale is not None:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,7 +20,6 @@ import numpy as np
 
 # LOCAL
 from astropy import config as _config
-from astropy.utils.compat import sanitize_copy_arg
 from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.decorators import deprecated
@@ -445,8 +444,6 @@ class Quantity(np.ndarray):
         float_default = dtype is np.inexact
         if float_default:
             dtype = None
-
-        copy = sanitize_copy_arg(copy)
 
         # optimize speed for Quantity with no dtype given, copy=COPY_IF_NEEDED
         if isinstance(value, Quantity):

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -15,7 +15,6 @@ __all__ = [
     "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
     "COPY_IF_NEEDED",
-    "sanitize_copy_arg",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -29,10 +28,3 @@ NUMPY_LT_2_1 = not minversion(np, "2.1.dev")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
-
-
-def sanitize_copy_arg(copy, /):
-    if not NUMPY_LT_2_0 and copy is False:
-        return None
-
-    return copy

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -112,12 +112,12 @@ class Masked(NDArrayShapeMethods):
     # Subclasses can override this in case the class does not work
     # with this signature, or to provide a faster implementation.
     @classmethod
-    def from_unmasked(cls, data, mask=None, copy=False):
+    def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
         """Create an instance from unmasked data and a mask."""
         return cls(data, mask=mask, copy=copy)
 
     @classmethod
-    def _get_masked_instance(cls, data, mask=None, copy=False):
+    def _get_masked_instance(cls, data, mask=None, copy=COPY_IF_NEEDED):
         data, data_mask = cls._get_data_and_mask(data)
         if mask is None:
             mask = False if data_mask is None else data_mask
@@ -511,7 +511,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
     # The two pieces typically overridden.
     @classmethod
-    def from_unmasked(cls, data, mask=None, copy=False):
+    def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
         # Note: have to override since __new__ would use ndarray.__new__
         # which expects the shape as its first argument, not an array.
         copy = sanitize_copy_arg(copy)

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -20,7 +20,7 @@ import builtins
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.shapes import NDArrayShapeMethods
 
@@ -514,8 +514,6 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
     def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
         # Note: have to override since __new__ would use ndarray.__new__
         # which expects the shape as its first argument, not an array.
-        copy = sanitize_copy_arg(copy)
-
         data = np.array(data, subok=True, copy=copy)
         self = data.view(cls)
         self._set_mask(mask, copy=copy)

--- a/docs/changes/16181.other.rst
+++ b/docs/changes/16181.other.rst
@@ -1,0 +1,3 @@
+Change the default value of ``copy`` arguments in public APIs from ``False`` to
+``None`` if Numpy 2.0 or newer is installed.
+For details, see the What's New page for Astropy 6.1 .

--- a/docs/changes/16181.other.rst
+++ b/docs/changes/16181.other.rst
@@ -1,3 +1,3 @@
 Change the default value of ``copy`` arguments in public APIs from ``False`` to
 ``None`` if Numpy 2.0 or newer is installed.
-For details, see the What's New page for Astropy 6.1 .
+For details, see the "Copy semantics" section on the What's New page for Astropy 6.1 .

--- a/docs/whatsnew/6.1.rst
+++ b/docs/whatsnew/6.1.rst
@@ -105,6 +105,34 @@ on Windows and potentially 32-bit architectures. Previously on those platforms, 
 columns with any long integers which overflowed the 32-bit integer would be returned
 as string columns. The new default behavior is consistent with ``numpy`` v2 and ``pandas``.
 
+.. _whatsnew-6.1-copy-semantics:
+
+Copy semantics
+==============
+
+Public APIs that expose a ``copy`` argument and that previously set ``False``
+as a default value now use ``None`` instead if ``numpy`` v2 or newer is installed.
+This is because in ``numpy`` v2, the meaning of the ``copy`` argument was changed,
+with ``copy=False`` now indicating that a copy should never be made, while
+``copy=None`` is used for the previous meaning of "avoid a copy if possible".
+
+This includes:
+- ``astropy.units.Quantity``
+- ``astropy.utils.Masked``
+- ``astropy.table.Column``
+- ``astropy.time.Time``
+- ``astropy.coordinates.SkyCoord``
+
+While this change ensures the default behaviour of astropy has not changed,
+code that explicitly passes ``copy=False`` to many of astropy's classes
+may need adjustments where the intention was to forbid unnecessary copies
+but allow the ones that couldn't be avoided.
+For portability across different versions of Numpy, we recommend that these
+instances of ``False`` be replaced with a ``COPY_IF_NEEDED`` constant defined
+as follow
+
+    COPY_IF_NEEDED = False if np.__version__.startswith("1.") else None
+
 
 Updates to `~astropy.cosmology`
 ===============================


### PR DESCRIPTION
### Description
This is based off #16166 and #16170 and adds a minor but crucial API change to align the default value of our `copy` arguments with whatever numpy API is installed. See #16167 for the broader context.

Alternative to #16174:
**Passing `copy=False` immediately breaks if copies cannot be avoided** (in alignment with numpy 2.0)

This is meant to be a small self-contained PR that we can ask downstream stakeholders to test from, but this will only make sense once #16166 and #16170 are merged. At that point, I'll call for feedback on the dev mailing list.

Close #16167

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
