### PR TITLE
Simplify coordinate transformation graph caching

### DIFF
--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -124,10 +124,7 @@ class TransformGraph:
         A `set` of all component names every defined within any frame class in
         this TransformGraph.
         """
-        if self._cached_component_names is None:
-            self._cached_component_names = frame_comps_from_set(self.frame_set)
-
-        return self._cached_component_names
+        return frame_comps_from_set(self.frame_set)
 
     def invalidate_cache(self):
         """
@@ -139,7 +136,6 @@ class TransformGraph:
         self._cached_names_dct = None
         self._cached_frame_set = None
         self._cached_frame_attributes = None
-        self._cached_component_names = None
         self._shortestpaths = {}
         self._composite_cache = {}
 


### PR DESCRIPTION
### Description

`TransformGraph.frame_component_names()` implements caching, but is not called by `astropy` and I am quite confident it is not being frequently called by users either, so it doesn't look like caching it is worth the effort.

Two other methods implement caching by carefully managing a private variable when they could instead use ~[`functools.cached_property()`](https://docs.python.org/3/library/functools.html#functools.cached_property) (available since Python 3.8).~ [`lazyproperty`](https://docs.astropy.org/en/stable/api/astropy.utils.decorators.lazyproperty.html#lazyproperty), which is preferable over `cached_property` because if the cached property has not been called then clearing the cached value does not require explicitly suppressing an `AttributeError`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
