### PR TITLE
CLN: cleanup unused bits now that Python 3.9 was dropped

### DIFF
--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -926,7 +926,7 @@ class TestImageFunctions(FitsTestCase):
             assert (orig_data == hdul[1].data).all()
 
     # The test below raised a `ResourceWarning: unclosed transport` exception
-    # due to a bug in Python <=3.10 (cf. cpython#90476)
+    # due to a bug in PYTHON_LT_3_11 (cf. cpython#90476)
     @pytest.mark.filterwarnings("ignore:unclosed transport <asyncio.sslproto")
     def test_open_scaled_in_update_mode(self):
         """

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -2188,13 +2188,4 @@ def populate_entry_points(entry_points):
                     )
 
 
-def _populate_ep():
-    # TODO: Exclusively use select when Python minversion is 3.10
-    ep = entry_points()
-    if hasattr(ep, "select"):
-        populate_entry_points(ep.select(group="astropy.modeling"))
-    else:
-        populate_entry_points(ep.get("astropy.modeling", []))
-
-
-_populate_ep()
+populate_entry_points(entry_points().select(group="astropy.modeling"))

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -3,8 +3,6 @@
 This module defines structured units and quantities.
 """
 
-from __future__ import annotations  # For python < 3.10
-
 # Standard library
 import operator
 


### PR DESCRIPTION
A quick follow up to #15603

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
