### PR TITLE
CLN: cleanup unused try block in astropy/convolution/convolve.py

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -454,11 +454,7 @@ def convolve(
         return new_result
     if array_dtype.kind == "f":
         # Try to preserve the input type if it's a floating point type
-        # Avoid making another copy if possible
-        try:
-            return result.astype(array_dtype, copy=False)
-        except TypeError:
-            return result.astype(array_dtype)
+        return result.astype(array_dtype, copy=False)
     else:
         return result
 


### PR DESCRIPTION
### Description
As a side effect of my digging through `copy=False` cases (context: #16170), I found this 11 years old try block which I think is now completely redundant with how `numpy.ndarray.astype` works. And to make it clear (it wasn't for me), numpy 2.0 doesn't change the meaning of `copy=False` for `astype`. See https://github.com/numpy/numpy/issues/25925

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
