### PR TITLE
RFC: inline usage of sys.version_info to enable automated clean up of compatibility code

### DIFF
--- a/astropy/cosmology/tests/test_core.py
+++ b/astropy/cosmology/tests/test_core.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import abc
 import inspect
 import pickle
+import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -26,7 +27,6 @@ from astropy.cosmology.tests.test_connect import (
     ToFromFormatTestMixin,
 )
 from astropy.table import Column, QTable, Table
-from astropy.utils.compat import PYTHON_LT_3_11
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -219,11 +219,13 @@ class CosmologyTest(
         assert cosmo.name == self.cls_kwargs["name"]  # test has expected value
 
         # immutable
-        match = (
-            "can't set"
-            if PYTHON_LT_3_11
-            else f"property 'name' of {cosmo.__class__.__name__!r} object has no setter"
-        )
+        if sys.version_info < (3, 11):
+            match = "can't set"
+        else:
+            match = (
+                f"property 'name' of {cosmo.__class__.__name__!r} object has no setter"
+            )
+
         with pytest.raises(AttributeError, match=match):
             cosmo.name = None
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -2,6 +2,7 @@
 
 import math
 import os
+import sys
 import time
 
 import numpy as np
@@ -925,9 +926,14 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp("test0.fits")) as hdul:
             assert (orig_data == hdul[1].data).all()
 
-    # The test below raised a `ResourceWarning: unclosed transport` exception
-    # due to a bug in PYTHON_LT_3_11 (cf. cpython#90476)
-    @pytest.mark.filterwarnings("ignore:unclosed transport <asyncio.sslproto")
+    if sys.version_info < (3, 11):
+        # The test below raised a `ResourceWarning: unclosed transport` exception
+        # due to a bug in Python < 3.11 (cf. cpython#90476)
+        mark = pytest.mark.filterwarnings("ignore:unclosed transport <asyncio.sslproto")
+    else:
+        mark = lambda f: f
+
+    @mark
     def test_open_scaled_in_update_mode(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/119

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -5,11 +5,11 @@ from the installed astropy.  It makes use of the |pytest| testing framework.
 """
 import os
 import pickle
+import sys
 
 import pytest
 
 from astropy.units import allclose as quantity_allclose  # noqa: F401
-from astropy.utils.compat import PYTHON_LT_3_11
 from astropy.utils.introspection import minversion
 
 # For backward-compatibility with affiliated packages
@@ -141,7 +141,7 @@ def generic_recursive_equality_test(a, b, class_history):
     Check if the attributes of a and b are equal. Then,
     check if the attributes of the attributes are equal.
     """
-    if PYTHON_LT_3_11:
+    if sys.version_info < (3, 11):
         dict_a = a.__getstate__() if hasattr(a, "__getstate__") else a.__dict__
     else:
         # NOTE: The call may need to be adapted if other objects implementing a __getstate__

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -11,6 +11,7 @@ import copy
 import enum
 import operator
 import os
+import sys
 import threading
 from collections import defaultdict
 from datetime import date, datetime, timezone
@@ -28,7 +29,7 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray, lazyproperty
-from astropy.utils.compat import COPY_IF_NEEDED, PYTHON_LT_3_11, sanitize_copy_arg
+from astropy.utils.compat import COPY_IF_NEEDED, sanitize_copy_arg
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
@@ -496,7 +497,10 @@ class TimeBase(ShapedLikeNDArray):
 
     def __getstate__(self):
         # For pickling, we remove the cache from what's pickled
-        state = (self.__dict__ if PYTHON_LT_3_11 else super().__getstate__()).copy()
+        if sys.version_info < (3, 11):
+            state = self.__dict__.copy()
+        else:
+            state = super().__getstate__().copy()
         state.pop("_id_cache", None)
         state.pop("cache", None)
         return state

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import functools
+import sys
 
 import numpy as np
 import pytest
@@ -10,7 +11,7 @@ from astropy.coordinates import EarthLocation
 from astropy.table import Table
 from astropy.time import Time, conf
 from astropy.utils import iers
-from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_1_26, PYTHON_LT_3_11
+from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_1_26
 from astropy.utils.compat.optional_deps import HAS_H5PY
 from astropy.utils.masked import Masked
 
@@ -21,11 +22,10 @@ is_masked = np.ma.is_masked
 
 # The first form is expanded to r"can't set attribute '{0}'" in Python 3.10, and replaced
 # with the more informative second form as of 3.11 (python/cpython#31311).
-no_setter_err = (
-    r"can't set attribute"
-    if PYTHON_LT_3_11
-    else r"property '{0}' of '{1}' object has no setter"
-)
+if sys.version_info < (3, 11):
+    no_setter_err = r"can't set attribute"
+else:
+    no_setter_err = r"property '{0}' of '{1}' object has no setter"
 
 
 def test_simple():

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -7,14 +7,10 @@ be accessed from there.
 """
 
 import functools
-import sys
 
 from astropy.utils.decorators import deprecated
 
-__all__ = ["override__dir__", "PYTHON_LT_3_10", "PYTHON_LT_3_11"]
-
-PYTHON_LT_3_11 = sys.version_info < (3, 11)
-PYTHON_LT_3_10 = sys.version_info < (3, 10)
+__all__ = ["override__dir__"]
 
 
 @deprecated(


### PR DESCRIPTION
### Description
Following the discussion in https://github.com/astropy/astropy/pull/16183#discussion_r1520149483
*This one is on the house (I'm not going to bill it), I'm just mostly scratching my own itch*

The goal is to make future PRs similar to #15063 a tad easier to write and maintain by enabling automatic cleanups for compatibility branches using the `UP036` rule from pyupgrade (and re-implemented in ruff).

I also note that there's actually an existing precedent for using `sys.version_info` instead of `PYTHON_LT_*` internally, so this actually uniformizes the code base.

I believe @eerovaher @mhvk and @nstarman would be interested in this.

<!-- Optional opt-out -->
- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
