### PR TITLE
Fix IERS_Auto logic now that IERS-A is bundled

### DIFF
--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -199,11 +199,14 @@ def test_future_altaz():
 
     # check that these message(s) appear among any other warnings
     if PYTEST_LT_8_0:
-        ctx1 = nullcontext()
+        ctx = nullcontext()
     else:
-        ctx1 = pytest.warns(erfa.core.ErfaWarning)
-    with ctx1, pytest.warns(
-        AstropyWarning,
-        match="Tried to get polar motions for times after IERS data is valid.*",
+        ctx = pytest.warns(erfa.core.ErfaWarning)
+    with (
+        ctx,
+        pytest.warns(
+            AstropyWarning,
+            match="Tried to get polar motions for times after IERS data is valid.*",
+        ),
     ):
         SkyCoord(1 * u.deg, 2 * u.deg).transform_to(AltAz(location=location, obstime=t))

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -205,5 +205,5 @@ def test_future_altaz():
     with ctx1, pytest.warns(
         AstropyWarning,
         match="Tried to get polar motions for times after IERS data is valid.*",
-    ) as found_warnings:
+    ):
         SkyCoord(1 * u.deg, 2 * u.deg).transform_to(AltAz(location=location, obstime=t))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -191,7 +191,7 @@ class Conf(_config.ConfigNamespace):
         ["error", "warn", "ignore"],
         "IERS behavior if the range of available IERS data does not "
         "cover the times when converting time scales, potentially leading "
-        "to degraded accuracy.",
+        "to degraded accuracy.  Applies only to when using only IERS-B data.",
     )
     system_leap_second_file = _config.ConfigItem("", "System file with leap seconds.")
     iers_leap_second_auto_url = _config.ConfigItem(
@@ -761,7 +761,7 @@ class IERS_Auto(IERS_A):
 
     The returned table combines the IERS-A and IERS-B files, with the data
     in the IERS-B file considered to be official values and thus superseding
-    values from th IERS-A file at the same times.
+    values from the IERS-A file at the same times.
     """
 
     iers_table = None

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -167,7 +167,7 @@ class Conf(_config.ConfigNamespace):
         True,
         "Enable auto-downloading of the latest IERS-A data.  If set to False "
         "then the bundled IERS-A file will be used by default (even if a "
-        "newer version of the IERS-A file was already downloaded and cached). "
+        "newer version of the IERS-A file was previously downloaded and cached). "
         "This parameter also controls whether internet resources will be "
         "queried to update the leap second table if the installed version is "
         "out of date. Default is True.",
@@ -545,7 +545,7 @@ class IERS_A(IERS):
 
     Notes
     -----
-    If the package IERS A file (```iers.IERS_A_FILE``) is out of date, a new
+    If the package IERS A file (``iers.IERS_A_FILE``) is out of date, a new
     version can be downloaded from ``iers.IERS_A_URL`` or ``iers.IERS_A_URL_MIRROR``.
     See ``iers.__doc__`` for instructions on use in ``Time``, etc.
     """
@@ -684,7 +684,7 @@ class IERS_B(IERS):
 
     Notes
     -----
-    If the package IERS B file (```iers.IERS_B_FILE``) is out of date, a new
+    If the package IERS B file (``iers.IERS_B_FILE``) is out of date, a new
     version can be downloaded from ``iers.IERS_B_URL``.
 
     See `~astropy.utils.iers.IERS_B.read` for instructions on how to read
@@ -821,7 +821,9 @@ class IERS_Auto(IERS_A):
             # Issue a warning here, perhaps user is offline.  An exception
             # will be raised downstream if actually trying to interpolate
             # predictive values.
-            warn("unable to download valid IERS file, using local IERS-A", IERSWarning)
+            warn(
+                "unable to download valid IERS file, using bundled IERS-A", IERSWarning
+            )
             cls.iers_table = cls.read()
 
         return cls.iers_table

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -191,7 +191,7 @@ class Conf(_config.ConfigNamespace):
         ["error", "warn", "ignore"],
         "IERS behavior if the range of available IERS data does not "
         "cover the times when converting time scales, potentially leading "
-        "to degraded accuracy.  Applies only to when using only IERS-B data.",
+        "to degraded accuracy.  Applies only when using IERS-B data on its own.",
     )
     system_leap_second_file = _config.ConfigItem("", "System file with leap seconds.")
     iers_leap_second_auto_url = _config.ConfigItem(

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -25,25 +25,7 @@ from astropy.utils.iers import iers
 
 FILE_NOT_FOUND_ERROR = getattr(__builtins__, "FileNotFoundError", OSError)
 
-try:
-    iers.IERS_A.open("finals2000A.all")  # check if IERS_A is available
-except OSError:
-    HAS_IERS_A = False
-else:
-    HAS_IERS_A = True
-
 IERS_A_EXCERPT = get_pkg_data_filename(os.path.join("data", "iers_a_excerpt"))
-
-
-def setup_module():
-    # Need auto_download so that IERS_B won't be loaded and cause tests to
-    # fail. Files to be downloaded are handled appropriately in the tests.
-    iers.conf.auto_download = True
-
-
-def teardown_module():
-    # This setting is to be consistent with astropy/conftest.py
-    iers.conf.auto_download = False
 
 
 class TestBasic:
@@ -216,7 +198,6 @@ class TestIERS_AExcerpt:
         assert len(iers_tab[:2]) == 2
 
 
-@pytest.mark.skipif(not HAS_IERS_A, reason="requires IERS_A")
 class TestIERS_A:
     @classmethod
     def teardown_class(self):
@@ -260,6 +241,14 @@ class TestIERS_Auto:
         self.iers_a_url_1 = Path(self.iers_a_file_1).as_uri()
         self.iers_a_url_2 = Path(self.iers_a_file_2).as_uri()
         self.t = Time.now() + TimeDelta(10, format="jd") * np.arange(self.N)
+
+        # This group of tests requires auto downloading to be on
+        iers.conf.auto_download = True
+
+        # auto_download = False is tested in test_IERS_B_parameters_loading_into_IERS_Auto()
+
+    def teardown_class(self):
+        iers.conf.auto_download = False
 
     def teardown_method(self, method):
         """Run this after every test."""
@@ -310,12 +299,6 @@ class TestIERS_Auto:
                     iers_table = iers.IERS_Auto.open()
                     _ = iers_table.ut1_utc(self.t.jd1, self.t.jd2)
 
-    def test_no_auto_download(self):
-        with iers.conf.set_temp("auto_download", False):
-            t = iers.IERS_Auto.open()
-        assert type(t) is iers.IERS_B
-
-    @pytest.mark.remote_data
     def test_simple(self):
         with iers.conf.set_temp("iers_auto_url", self.iers_a_url_1):
             dat = iers.IERS_Auto.open()
@@ -383,8 +366,10 @@ class TestIERS_Auto:
             assert dat["MJD"][-1] == (57539.0 + 60) * u.d
 
 
-@pytest.mark.remote_data
 def test_IERS_B_parameters_loading_into_IERS_Auto():
+    # Double-check that auto downloading is off
+    assert not iers.conf.auto_download
+
     A = iers.IERS_Auto.open()
     B = iers.IERS_B.open()
 
@@ -448,35 +433,31 @@ def test_iers_b_dl():
         iers.IERS_B.close()
 
 
-@pytest.mark.remote_data
-def test_iers_out_of_range_handling(tmp_path):
-    # Make sure we don't have IERS-A data available anywhere
-    with set_temp_cache(tmp_path):
-        iers.IERS_A.close()
-        iers.IERS_Auto.close()
-        iers.IERS.close()
+def test_iers_b_out_of_range_handling():
+    # The following error/warning applies only to IERS_B, not to the default IERS_Auto
+    with iers.earth_orientation_table.set(iers.IERS_B.open()):
         now = Time.now()
-        with iers.conf.set_temp("auto_download", False):
-            # Should be fine with built-in IERS_B
-            (now - 300 * u.day).ut1
 
-            # Default is to raise an error
-            match = r"\(some\) times are outside of range covered by IERS table"
-            with pytest.raises(iers.IERSRangeError, match=match):
+        # Should be fine with bundled IERS-B
+        (now - 300 * u.day).ut1
+
+        # Default is to raise an error
+        match = r"\(some\) times are outside of range covered by IERS table"
+        with pytest.raises(iers.IERSRangeError, match=match):
+            (now + 100 * u.day).ut1
+
+        with iers.conf.set_temp("iers_degraded_accuracy", "warn"):
+            with pytest.warns(iers.IERSDegradedAccuracyWarning, match=match):
                 (now + 100 * u.day).ut1
 
-            with iers.conf.set_temp("iers_degraded_accuracy", "warn"):
-                with pytest.warns(iers.IERSDegradedAccuracyWarning, match=match):
-                    (now + 100 * u.day).ut1
-
-            with iers.conf.set_temp("iers_degraded_accuracy", "ignore"):
-                (now + 100 * u.day).ut1
+        with iers.conf.set_temp("iers_degraded_accuracy", "ignore"):
+            (now + 100 * u.day).ut1
 
 
 @pytest.mark.remote_data
 def test_iers_download_error_handling(tmp_path):
-    # Make sure we don't have IERS-A data available anywhere
-    with set_temp_cache(tmp_path):
+    # Make sure an IERS-A table isn't already loaded
+    with set_temp_cache(tmp_path), iers.conf.set_temp("auto_download", True):
         iers.IERS_A.close()
         iers.IERS_Auto.close()
         iers.IERS.close()
@@ -488,7 +469,7 @@ def test_iers_download_error_handling(tmp_path):
             with iers.conf.set_temp("iers_auto_url_mirror", "https://google.com"):
                 with pytest.warns(iers.IERSWarning) as record:
                     with iers.conf.set_temp("iers_degraded_accuracy", "ignore"):
-                        (now + 100 * u.day).ut1
+                        (now + 400 * u.day).ut1
 
                 assert len(record) == 3
                 assert str(record[0].message).startswith(
@@ -498,7 +479,7 @@ def test_iers_download_error_handling(tmp_path):
                     "malformed IERS table from https://google.com"
                 )
                 assert str(record[2].message).startswith(
-                    "unable to download valid IERS file, using local IERS-B"
+                    "unable to download valid IERS file, using local IERS-A"
                 )
 
 

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -243,12 +243,14 @@ class TestIERS_Auto:
         self.t = Time.now() + TimeDelta(10, format="jd") * np.arange(self.N)
 
         # This group of tests requires auto downloading to be on
+        self._auto_download = iers.conf.auto_download
         iers.conf.auto_download = True
 
         # auto_download = False is tested in test_IERS_B_parameters_loading_into_IERS_Auto()
 
     def teardown_class(self):
-        iers.conf.auto_download = False
+        # Restore the auto downloading setting
+        iers.conf.auto_download = self._auto_download
 
     def teardown_method(self, method):
         """Run this after every test."""
@@ -367,10 +369,9 @@ class TestIERS_Auto:
 
 
 def test_IERS_B_parameters_loading_into_IERS_Auto():
-    # Double-check that auto downloading is off
-    assert not iers.conf.auto_download
-
-    A = iers.IERS_Auto.open()
+    # Make sure that auto downloading is off
+    with iers.conf.set_temp("auto_download", False):
+        A = iers.IERS_Auto.open()
     B = iers.IERS_B.open()
 
     ok_A = A["MJD"] <= B["MJD"][-1]

--- a/docs/changes/utils/16187.api.rst
+++ b/docs/changes/utils/16187.api.rst
@@ -1,0 +1,1 @@
+The return type of ``IERS_Auto.open()`` is no longer ``IERS_B`` when automatic updating of the IERS-A file is disabled or the downloading of the new file fails.

--- a/docs/changes/utils/16187.api.rst
+++ b/docs/changes/utils/16187.api.rst
@@ -1,2 +1,5 @@
-``IERS_Auto.open()`` now always returns a table of type ``IERS_Auto`` that contains the combination of IERS-A and IERS-B data, even if automatic updating of the IERS-A file is disabled or if downloading the new file fails.
-Previously, under those conditions, it would return a table of a different type (``IERS_B``) with only IERS-B data.
+``IERS_Auto.open()`` now always returns a table of type ``IERS_Auto`` that
+contains the combination of IERS-A and IERS-B data, even if automatic
+updating of the IERS-A file is disabled or if downloading the new file fails.
+Previously, under those conditions, it would return a table of a different type
+(``IERS_B``) with only IERS-B data.

--- a/docs/changes/utils/16187.api.rst
+++ b/docs/changes/utils/16187.api.rst
@@ -1,1 +1,2 @@
-The return type of ``IERS_Auto.open()`` is no longer ``IERS_B`` when automatic updating of the IERS-A file is disabled or the downloading of the new file fails.
+``IERS_Auto.open()`` now always returns a table of type ``IERS_Auto`` that contains the combination of IERS-A and IERS-B data, even if automatic updating of the IERS-A file is disabled or if downloading the new file fails.
+Previously, under those conditions, it would return a table of a different type (``IERS_B``) with only IERS-B data.

--- a/docs/changes/utils/16187.bugfix.rst
+++ b/docs/changes/utils/16187.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the unintended behavior where the IERS-A file bundled in ``astropy-iers-data`` would be ignored if automatic updating of the IERS-A file were disabled or if downloading the new file failed.

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -263,8 +263,8 @@ systems. The parallel access to the home directory can also trigger concurrency
 problems in the Astropy data cache, though we have tried to minimize these. We
 therefore recommend the following guidelines:
 
- * Set ``astropy.utils.iers.conf.auto_download = False`` in your Astropy config
-   file (see :ref:`astropy_config`) or in your code so that Astropy will not
+ * Set ``astropy.utils.iers.conf.auto_download = False`` in your ``astropy`` config
+   file (see :ref:`astropy_config`) or in your code so that ``astropy`` will not
    automatically attempt to download a newer version of the IERS-A table than
    the one already bundled in the ``astropy-iers-data`` package.  To update the
    IERS-A table, do one of the following:

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -265,9 +265,9 @@ therefore recommend the following guidelines:
 
  * Set ``astropy.utils.iers.conf.auto_download = False`` in your ``astropy`` config
    file (see :ref:`astropy_config`) or in your code so that ``astropy`` will not
-   automatically attempt to download a newer version of the IERS-A table than
-   the one already bundled in the ``astropy-iers-data`` package.  To update the
-   IERS-A table, do one of the following:
+   attempt to download a newer version of the IERS-A table than the one already
+   bundled in the ``astropy-iers-data`` package.  To update the IERS-A table, do
+   one of the following:
 
    * Upgrade the ``astropy-iers-data`` package.
    * Write a simple script that sets ``astropy.utils.iers.conf.auto_download =

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -9,8 +9,7 @@ Introduction
 
 A number of Astropy's tools work with data sets that are either awkwardly
 large (e.g., `~astropy.coordinates.solar_system_ephemeris`) or
-regularly updated (e.g., `~astropy.utils.iers.IERS_B`) or both
-(e.g., `~astropy.utils.iers.IERS_A`). This kind of
+regularly updated (e.g., `~astropy.utils.iers.IERS_A`). This kind of
 data - authoritative data made available on the Web, and possibly updated
 from time to time - is reasonably common in astronomy. The Astropy Project therefore
 provides some tools for working with such data.
@@ -235,9 +234,8 @@ adding files to an existing cache directory.
 If your application needs IERS data specifically, you can download the
 appropriate IERS table, covering the appropriate time span, by any means you
 find convenient. You can then load this file into your application and use the
-resulting table rather than `~astropy.utils.iers.IERS_Auto`. In fact, the IERS
-B table is small enough that a version (not necessarily recent) is bundled with
-``astropy`` as ``astropy.utils.iers.IERS_B_FILE``. Using a specific non-automatic
+resulting table rather than `~astropy.utils.iers.IERS_Auto`.
+Using a specific non-automatic
 table also has the advantage of giving you control over exactly which version
 of the IERS data your application is using. See also :ref:`iers-working-offline`.
 
@@ -265,25 +263,19 @@ systems. The parallel access to the home directory can also trigger concurrency
 problems in the Astropy data cache, though we have tried to minimize these. We
 therefore recommend the following guidelines:
 
- * Do one of the following:
+ * Set ``astropy.utils.iers.conf.auto_download = False`` in your Astropy config
+   file (see :ref:`astropy_config`) or in your code so that Astropy will not
+   automatically attempt to download a newer version of the IERS-A table than
+   the one already bundled in the ``astropy-iers-data`` package.  To update the
+   IERS-A table, do one of the following:
 
+   * Upgrade the ``astropy-iers-data`` package.
    * Write a simple script that sets ``astropy.utils.iers.conf.auto_download =
      True`` and then accesses all cached resources your code will need,
      including source name lookups and IERS tables. Run it on the head node from
      time to time (frequently enough to beat the timeout
      ``astropy.utils.iers.conf.auto_max_age``, which defaults to 30 days) to
      ensure all data is up to date.
-   * Set ``astropy.utils.iers.conf.auto_download = False`` in your code and set
-     ``astropy.utils.iers.conf.iers_degraded_accuracy`` to either ``'warn'``
-     or ``'ignore'``. These prevent the normal exception that occurs if a
-     time conversion falls outside the bounds of available (local) IERS data.
-     **WARNING**: only use this option if your application does not need full
-     accuracy time conversions.
-
- * Make an Astropy config file (see :ref:`astropy_config`) that sets
-   ``astropy.utils.iers.conf.auto_download = False`` so that the worker jobs will
-   not suddenly notice an out-of-date table all at once and frantically attempt
-   to download it.
 
  * Optionally, in this file, set ``astropy.utils.data.conf.allow_internet = False`` to
    prevent any attempt to download any file from the worker nodes; if you do this,

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -94,9 +94,9 @@ that relate to automatic IERS downloading. Four of the most
 important to consider are the following:
 
   auto_download:
-    Enable auto-downloading of the latest IERS data.  If set to ``False`` then
-    the local IERS-A and IERS-B files will be used by default (even if the full
-    IERS file with predictions was already downloaded and cached).  This
+    Enable auto-downloading of the latest IERS-A data.  If set to ``False`` then
+    the bundled IERS-A file will be used by default (even if a newer
+    versions of the IERS-A file was already downloaded and cached).  This
     parameter also controls whether internet resources will be queried to update
     the leap second table if the installed version is out of date.
 

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -109,12 +109,10 @@ important to consider are the following:
 
   iers_degraded_accuracy:
     Some time conversions like UTC -> UT1 require IERS-A Earth rotation data
-    for full accuracy. In cases where full accuracy is not required and
-    downloading the IERS-A is not possible or desired (for instance running on
-    a cluster) then this option can be set to either ``'warn'`` or ``'ignore'``.
-    The default is ``'error'`` which will raise an exception if full accuracy
-    is not possible for a time conversion, ``'warn'`` will issue a warning, and
-    ``'ignore'`` will ignore the problem and use available IERS-B data.
+    for full accuracy.  This parameter controls the behavior when computations
+    use only the IERS-B data and full accuracy is not possible.  ``'error'``
+    (the default) will raise an exception, ``'warn'`` will issue a warning, and
+    ``'ignore'`` will ignore the problem (i.e., the inaccuracy is acceptable).
 
 Auto refresh behavior
 ---------------------


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

#14819 moved the IERS files to a separate package (`astropy-iers-data`), and now IERS-A is essentially bundled with `astropy`.  However, there persist some remnants of the old logic, where IERS-A is available only if the download were triggered.  This results in the peculiar behavior that if automatic downloading of IERS-A files is disabled (`iers.conf.auto_download = False`) or fails, the bundled IERS-A file is ignored even though it is present (see https://github.com/astropy/astropy/issues/13227#issuecomment-1986724516).

This PR fixes the logic so that the bundled IERS-A file is used if `iers.conf.auto_download = False`, with corresponding fixes in documentation and tests.

This PR does *not* attempt to fix the logic so that a previously downloaded IERS-A file is used if `iers.conf.auto_download` is subsequently set to `False`.  I didn't want to wrap my head around whether the downloaded file should have priority over the bundled file, given that `astropy-iers-data` could also be upgraded.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13227: With `astropy` 6.0, the response to the report would be to upgrade `astropy-iers-data` to obtain a recent IERS-A table.  This PR then fixes the residual bug where setting `iers.conf.auto_download = False` would ignore that bundled IERS-A table.

Fixes #16128: Because the bundled IERS-A is now no longer ignored by the default `IERS_Auto` when downloading is blocked, it's now typically impossible to trigger the "degraded accuracy" error/warning unless the user expressly forces the use of the IERS-B data alone (e.g., through the `earth_orientation_table` `ScienceState`).

Other related issues:

* #4436
* #9227

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
