### PR TITLE
Implement `Table.setdefault()`

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3379,6 +3379,79 @@ class Table:
 
         self.columns = columns
 
+    def setdefault(self, name, default):
+        """Ensure a column named ``name`` exists.
+
+        If ``name`` is already present then ``default`` is ignored.
+        Otherwise ``default`` can be any data object which is acceptable as
+        a `~astropy.table.Table` column object or can be converted.  This
+        includes mixin columns and scalar or length=1 objects which get
+        broadcast to match the table length.
+
+        Parameters
+        ----------
+        name : str
+            Name of the column.
+        default : object
+            Data object for the new column.
+
+        Returns
+        -------
+        `~astropy.table.Column`, `~astropy.table.MaskedColumn` or mixin-column type
+            The column named ``name`` if it is present already, or the
+            validated ``default`` converted to a column otherwise.
+
+        Raises
+        ------
+        TypeError
+            If the table is empty and ``default`` is a scalar object.
+
+        Examples
+        --------
+        Start with a simple table::
+
+          >>> t0 = Table({"a": ["Ham", "Spam"]})
+          >>> t0
+          <Table length=2>
+           a
+          str4
+          ----
+           Ham
+          Spam
+
+        Trying to add a column that already exists does not modify it::
+
+          >>> t0.setdefault("a", ["Breakfast"])
+          <Column name='a' dtype='str4' length=2>
+           Ham
+          Spam
+          >>> t0
+          <Table length=2>
+           a
+          str4
+          ----
+           Ham
+          Spam
+
+        But if the column does not exist it will be created with the
+        default value::
+
+          >>> t0.setdefault("approved", False)
+          <Column name='approved' dtype='bool' length=2>
+          False
+          False
+          >>> t0
+          <Table length=2>
+           a   approved
+          str4   bool
+          ---- --------
+           Ham    False
+          Spam    False
+        """
+        if name not in self.columns:
+            self[name] = default
+        return self[name]
+
     def update(self, other, copy=True):
         """
         Perform a dictionary-style update and merge metadata.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2600,6 +2600,45 @@ class TestUpdate:
         assert np.all(t1["c"] == t1_copy["c"])
 
 
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        pytest.param("a", [1, 2], id="existing_column"),
+        pytest.param("d", [9, 6], id="new_column"),
+    ],
+)
+def test_table_setdefault(name, expected):
+    t = table.table_helpers.simple_table(2)
+    np.testing.assert_array_equal(t.setdefault(name, [9, 6]), expected)
+    np.testing.assert_array_equal(t[name], expected)
+    assert name in t.columns
+    assert type(t[name]) is Column
+
+
+def test_table_setdefault_wrong_shape():
+    t = table.table_helpers.simple_table(2)
+    with pytest.raises(ValueError, match="^Inconsistent data column lengths$"):
+        t.setdefault("f", [1, 2, 3])
+    assert "f" not in t.columns
+
+
+@pytest.mark.parametrize("value", ([9], [9, 6]), ids=lambda x: f"len_{len(x)}_default")
+def test_empty_table_setdefault(value):
+    t = Table()
+    np.testing.assert_array_equal(t.setdefault("a", value), value)
+    np.testing.assert_array_equal(t["a"], value)
+    assert t.colnames == ["a"]
+    assert type(t["a"]) is Column
+
+
+def test_empty_table_setdefault_scalar():
+    t = Table()
+    with pytest.raises(
+        TypeError, match="^Empty table cannot have column set to scalar value$"
+    ):
+        t.setdefault("a", 9)
+
+
 def test_table_meta_copy():
     """
     Test no copy vs light (key) copy vs deep copy of table meta for different

--- a/docs/changes/table/16188.feature.rst
+++ b/docs/changes/table/16188.feature.rst
@@ -1,0 +1,2 @@
+``Table`` now has a ``setdefault()`` method, analogous to
+``dict.setdefault()``.

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -204,6 +204,40 @@ you need them to be references you can use the
 :meth:`~astropy.table.Table.update` method with ``copy=False``, see :ref:`copy_versus_reference`
 for details.
 
+**Ensure the existence of a column**
+
+|Table| has a :meth:`~astropy.table.Table.setdefault` method, which is
+analogous to :meth:`dict.setdefault`.
+It adds a column with a given name to the table if such a column is not in the
+table already.
+The default value passed to the method will be validated and, if necessary,
+converted.
+Either way the (possibly just inserted) column in the table is returned::
+
+  >>> t0 = Table({"a": ["Ham", "Spam"]})
+  >>> t0
+  <Table length=2>
+   a
+  str4
+  ----
+   Ham
+  Spam
+  >>> t0.setdefault("a", ["Breakfast"])  # Existing column
+  <Column name='a' dtype='str4' length=2>
+   Ham
+  Spam
+  >>> t0.setdefault("approved", False)  # New column
+  <Column name='approved' dtype='bool' length=2>
+  False
+  False
+  >>> t0
+  <Table length=2>
+   a   approved
+  str4   bool
+  ---- --------
+   Ham    False
+  Spam    False
+
 **Rename columns**
 
 .. EXAMPLE START: Renaming Columns in Tables


### PR DESCRIPTION
### Description

The new method is analogous to [`dict.setdefault()`](https://docs.python.org/3/library/stdtypes.html#dict.setdefault). Implementing it provides a convenient way of ensuring that a `Table` has a column with some specific name when there is a sensible default value. This could be useful e.g. reading in heterogeneous tables. It also makes `Table` more similar to a Python `dict`.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
