### PR TITLE
TST: Sort test parametrization in cosmology

### DIFF
--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -697,7 +697,7 @@ class FLRWTest(
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize("z, exc", invalid_zs)
-    @pytest.mark.parametrize("method", _FLRW_redshift_methods)
+    @pytest.mark.parametrize("method", sorted(_FLRW_redshift_methods))
     def test_redshift_method_bad_input(self, cosmo, method, z, exc):
         """Test all the redshift methods for bad input."""
         with pytest.raises(exc):
@@ -925,7 +925,7 @@ class TestFLRW(FLRWTest):
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize("z, exc", invalid_zs)
-    @pytest.mark.parametrize("method", _FLRW_redshift_methods)
+    @pytest.mark.parametrize("method", sorted(_FLRW_redshift_methods))
     def test_redshift_method_bad_input(self, cosmo, method, z, exc):
         """Test all the redshift methods for bad input."""
         with pytest.raises(exc):
@@ -1057,7 +1057,9 @@ class FlatFLRWMixinTest(FlatCosmologyMixinTest, ParameterFlatOde0TestMixin):
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize("z, exc", invalid_zs)
-    @pytest.mark.parametrize("method", FLRWTest._FLRW_redshift_methods - {"Otot"})
+    @pytest.mark.parametrize(
+        "method", sorted(FLRWTest._FLRW_redshift_methods - {"Otot"})
+    )
     def test_redshift_method_bad_input(self, cosmo, method, z, exc):
         """Test all the redshift methods for bad input."""
         super().test_redshift_method_bad_input(cosmo, method, z, exc)

--- a/astropy/cosmology/flrw/tests/test_lambdacdm.py
+++ b/astropy/cosmology/flrw/tests/test_lambdacdm.py
@@ -57,7 +57,7 @@ class TestLambdaCDM(FLRWTest):
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize("z, exc", invalid_zs)
-    @pytest.mark.parametrize("method", _FLRW_redshift_methods)
+    @pytest.mark.parametrize("method", sorted(_FLRW_redshift_methods))
     def test_redshift_method_bad_input(self, cosmo, method, z, exc):
         """Test all the redshift methods for bad input."""
         super().test_redshift_method_bad_input(cosmo, method, z, exc)
@@ -128,7 +128,9 @@ class TestFlatLambdaCDM(FlatFLRWMixinTest, TestLambdaCDM):
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="scipy is not installed")
     @pytest.mark.parametrize("z, exc", invalid_zs)
-    @pytest.mark.parametrize("method", TestLambdaCDM._FLRW_redshift_methods - {"Otot"})
+    @pytest.mark.parametrize(
+        "method", sorted(TestLambdaCDM._FLRW_redshift_methods - {"Otot"})
+    )
     def test_redshift_method_bad_input(self, cosmo, method, z, exc):
         """Test all the redshift methods for bad input."""
         super().test_redshift_method_bad_input(cosmo, method, z, exc)

--- a/astropy/cosmology/funcs/tests/test_comparison.py
+++ b/astropy/cosmology/funcs/tests/test_comparison.py
@@ -47,7 +47,9 @@ class ComparisonFunctionTestBase(ToFromTestMixinBase):
 
     @pytest.fixture(
         scope="class",
-        params={k for k, _ in convert_registry._readers.keys()} - {"astropy.cosmology"},
+        params=sorted(
+            {k for k, _ in convert_registry._readers.keys()} - {"astropy.cosmology"}
+        ),
     )
     def format(self, request):
         return request.param

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -30,13 +30,13 @@ cosmo_instances = cosmology.realizations.available
 
 # Collect the registered read/write formats.
 #   (format, supports_metadata, has_all_required_dependencies)
-readwrite_formats = {
+readwrite_formats = [
     ("ascii.ecsv", True, True),
     ("ascii.html", False, HAS_BS4),
     ("ascii.latex", False, True),
     ("json", True, True),
     ("latex", False, True),
-}
+]
 
 
 # Collect all the registered to/from formats. Unfortunately this is NOT


### PR DESCRIPTION
### Description

This PR fixes an issue where test parametrizations in the cosmology subpackage were passed as sets, which are inherently unsorted.  They need to be sorted if one is to use `pytest-xdist`.  This converts them to sorted lists, as is done elsewhere in Astropy.

Fixes #16190
