### PR TITLE
TST: Speed-up test suite when using pytest-xdist

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -108,15 +108,15 @@ def pytest_configure(config):
     # and https://github.com/scikit-learn/scikit-learn/pull/25918
     try:
         from threadpoolctl import threadpool_limits
-
+    except ImportError:
+        pass
+    else:
         xdist_worker_count = os.environ.get("PYTEST_XDIST_WORKER_COUNT")
         if xdist_worker_count is not None:
             # use number of physical cores, assume hyperthreading
             max_threads = os.cpu_count() // 2
             threads_per_worker = max(max_threads // int(xdist_worker_count), 1)
             threadpool_limits(threads_per_worker)
-    except ImportError:
-        pass
 
 
 def pytest_unconfigure(config):

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -151,3 +151,38 @@ def pytest_terminal_summary(terminalreporter):
         yellow=True,
         bold=True,
     )
+
+
+def pytest_runtest_setup(item):
+
+    # Limit the number of threads used by each worker when pytest-xdist is in use.
+    # Lifted from https://github.com/scipy/scipy/pull/14441
+    try:
+        from threadpoolctl import threadpool_limits
+
+        HAS_THREADPOOLCTL = True
+    except ImportError:
+        HAS_THREADPOOLCTL = False
+
+    if HAS_THREADPOOLCTL:
+        # Set the number of openblas threads based on the number of workers
+        # xdist is using to prevent oversubscription. Simplified version of what
+        # sklearn and scipy do.
+        try:
+            xdist_worker_count = int(os.environ['PYTEST_XDIST_WORKER_COUNT'])
+        except KeyError:
+            # when pytest-xdist is not installed, for robustness
+            return
+
+        # Only set the number of threads if the user has not already set it
+        if (not os.getenv('OMP_NUM_THREADS') and not os.getenv('OPENBLAS_NUM_THREADS') and
+            not os.getenv('MKL_NUM_THREADS') and not os.getenv('VECLIB_MAXIMUM_THREADS') and
+            not os.getenv('NUMEXPR_NUM_THREADS')):
+            # use nr of physical cores, assume hyperthreading
+            max_threads = os.cpu_count() // 2
+            threads_per_worker = max(max_threads // xdist_worker_count, 1)
+            try:
+                threadpool_limits(limits=threads_per_worker)
+            except Exception:
+                # Catch any error for robustness.
+                return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ test = [
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10",
     "pytest-xdist",
+    "threadpoolctl",
 ]
 test_all = [
     "astropy[test]",  # installs the [test] dependencies


### PR DESCRIPTION
This PR fixes a testing slowdown/bottleneck we see when parallelizing the test suite over all (or many, or most) available cores using `pytest-xdist`.  Other large science test suites have seen the same issue and solved it.  See https://github.com/scipy/scipy/pull/14441 and https://github.com/scikit-learn/scikit-learn/pull/25918.  Our solution here is similar.

The solution is to make sure that one limits the number of threads that openBLAS (and the others) use when parallelizing a pytest run so that pytest workers are not competing for cores with openBLAS threads.  This involves a pytest hook that uses `threadpoolctl` to set the number of threads to either 1 or some other small value depending on how many of the available cores are being used by `pytest-xdist`.  In the case of `-n auto`, it will be the equivalent of setting the env var`OPENBLAS_NUM_THREADS=1`.

Currently on main branch with `pytest-xdist` turned off, running a small subset of the test suite:

```
$ tox -e test -- -k lombscargle_multiband
<snip>
===== 960 passed, 51 skipped, 27292 deselected in 31.01s =====
```

And currently on main branch with `pytest-xdist` turned on, using all available cores on my 11 core M3 Pro Macbook:

```
$ tox -e test -- -k lombscargle_multiband -n auto
<snip>
===== 960 passed, 7 skipped in 1807.45s (0:30:07) =====
```

More than 50 times slower.

With this PR:

```
$ tox -e test -- -k lombscargle_multiband -n auto
<snip>
===== 960 passed, 7 skipped in 29.40s =====
```

Much more reasonable when compared to the first case above.

Since `pytest-xdist` is already a `[test]` extra dependency, it makes sense to add `threadpoolctl` there as well, as this is the standard tool for controlling threads from the underlying linear algebra libraries used by `numpy` when doing parallelization with workers.

Fixes #16195