### PR TITLE
BUG/API: Changed the default value of the copy argument in `CylindricalDifferential.__init__` from `False` to `True`

### DIFF
--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -154,7 +154,7 @@ class CylindricalDifferential(BaseDifferential):
 
     base_representation = CylindricalRepresentation
 
-    def __init__(self, d_rho, d_phi=None, d_z=None, copy=False):
+    def __init__(self, d_rho, d_phi=None, d_z=None, copy=True):
         super().__init__(d_rho, d_phi, d_z, copy=copy)
         if not self._d_rho.unit.is_equivalent(self._d_z.unit):
             raise u.UnitsError("d_rho and d_z should have equivalent units.")

--- a/docs/changes/coordinates/16198.api.rst
+++ b/docs/changes/coordinates/16198.api.rst
@@ -1,0 +1,4 @@
+Changed the default value of the ``copy`` argument in
+``astropy.coordinates.representation.CylindricalDifferential.__init__`` from
+``False`` to ``True``, which is the intended behaviour for all subclasses of
+``astropy.coordinates.representation.BaseDifferential``.


### PR DESCRIPTION
### Description

Following https://github.com/astropy/astropy/pull/16181#discussion_r1525304064

I'm really not sure if the changelog fragment should be under `api` or `bug`. In any case I think this should go to 6.1.0, but I'll let @mhvk be the judge !

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
