### PR TITLE
BUG: declare private str ufuncs as unsupported (np._core.umath._(ljust, rjust, _center, _zfill))

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -390,6 +390,10 @@ if not NUMPY_LT_2_0:
         np._core.umath._replace,
         np._core.umath._expandtabs,
         np._core.umath._expandtabs_length,
+        np._core.umath._ljust,
+        np._core.umath._rjust,
+        np._core.umath._center,
+        np._core.umath._zfill,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
### Description

Follow up to #16144
xref https://github.com/numpy/numpy/pull/25908

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
