### PR TITLE
MAINT: Benchmark action should fail if a regression is caught

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -95,8 +95,10 @@ jobs:
       - name: "Check ccache performance"
         shell: bash -l {0}
         run: ccache -s
+        if: always()
 
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: asv-benchmark-results
           path: benchmarks.log

--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -87,6 +87,11 @@ jobs:
               | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
               | tee benchmarks.log
 
+          # Error out the action
+          if grep "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
+              exit 1
+          fi
+
       - name: "Check ccache performance"
         shell: bash -l {0}
         run: ccache -s

--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -88,7 +88,7 @@ jobs:
               | tee benchmarks.log
 
           # Error out the action
-          if grep "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log > /dev/null ; then
+          if grep -q "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log ; then
               exit 1
           fi
 


### PR DESCRIPTION
The benchmark should fail if there is a regression in the benchmark run on the CI as caught in https://github.com/astropy/astropy/pull/16135#issuecomment-2001210945