### PR TITLE
MAINT: Deprecate TestRunner(Base) for downstream users

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -131,7 +131,7 @@ class astronomical_constants(base_constants_version):
     )
 
 
-# Create the test() function
+# # Create the test() function
 from .tests.runner import TestRunner
 
 test = TestRunner.make_test_runner_in(__path__[0])

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -13,6 +13,7 @@ from importlib.util import find_spec
 
 from astropy.config.paths import set_temp_cache, set_temp_config
 from astropy.utils import find_current_module
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 __all__ = ["TestRunner", "TestRunnerBase", "keyword"]
@@ -48,6 +49,11 @@ class keyword:
         return keyword
 
 
+@deprecated(
+    "6.1",
+    message="""Use pytest directly instead. You can read more about the motivation
+    for the deprecation at https://github.com/astropy/astropy/issues/16177""",
+)
 class TestRunnerBase:
     """
     The base class for the TestRunner.
@@ -287,6 +293,11 @@ class TestRunnerBase:
         return test
 
 
+@deprecated(
+    "6.1",
+    message="""Use pytest directly instead. You can read more about the motivation
+    for the deprecation at https://github.com/astropy/astropy/issues/16177""",
+)
 class TestRunner(TestRunnerBase):
     """
     A test runner for astropy tests.

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -6,6 +6,7 @@ import pytest
 from astropy.tests.runner import TestRunner as _TestRunner
 from astropy.tests.runner import TestRunnerBase as _TestRunnerBase
 from astropy.tests.runner import keyword
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_disable_kwarg():
@@ -14,15 +15,17 @@ def test_disable_kwarg():
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
 
-    r = no_remote_data(".")
-    with pytest.raises(TypeError):
-        r.run_tests(remote_data="bob")
+    with pytest.raises(AstropyDeprecationWarning):
+        r = no_remote_data(".")
+        with pytest.raises(TypeError):
+            r.run_tests(remote_data="bob")
 
 
 def test_wrong_kwarg():
-    r = _TestRunner(".")
-    with pytest.raises(TypeError):
-        r.run_tests(spam="eggs")
+    with pytest.raises(AstropyDeprecationWarning):
+        r = _TestRunner(".")
+        with pytest.raises(TypeError):
+            r.run_tests(spam="eggs")
 
 
 def test_invalid_kwarg():
@@ -31,9 +34,10 @@ def test_invalid_kwarg():
         def remote_data(self, remote_data, kwargs):
             return "bob"
 
-    r = bad_return(".")
-    with pytest.raises(TypeError):
-        r.run_tests(remote_data="bob")
+    with pytest.raises(AstropyDeprecationWarning):
+        r = bad_return(".")
+        with pytest.raises(TypeError):
+            r.run_tests(remote_data="bob")
 
 
 def test_new_kwarg():
@@ -42,11 +46,10 @@ def test_new_kwarg():
         def spam(self, spam, kwargs):
             return [spam]
 
-    r = Spam(".")
-
-    args = r._generate_args(spam="spam")
-
-    assert ["spam"] == args
+    with pytest.raises(AstropyDeprecationWarning):
+        r = Spam(".")
+        args = r._generate_args(spam="spam")
+        assert args == ["spam"]
 
 
 def test_priority():
@@ -59,11 +62,10 @@ def test_priority():
         def eggs(self, eggs, kwargs):
             return [eggs]
 
-    r = Spam(".")
-
-    args = r._generate_args(spam="spam", eggs="eggs")
-
-    assert ["eggs", "spam"] == args
+    with pytest.raises(AstropyDeprecationWarning):
+        r = Spam(".")
+        args = r._generate_args(spam="spam", eggs="eggs")
+        assert args == ["eggs", "spam"]
 
 
 def test_docs():
@@ -82,6 +84,7 @@ def test_docs():
             """
             return [eggs]
 
-    r = Spam(".")
-    assert "eggs" in r.run_tests.__doc__
-    assert "Spam Spam Spam" in r.run_tests.__doc__
+    with pytest.raises(AstropyDeprecationWarning):
+        r = Spam(".")
+        assert "eggs" in r.run_tests.__doc__
+        assert "Spam Spam Spam" in r.run_tests.__doc__


### PR DESCRIPTION
This PR addresses one of the point raised in https://github.com/astropy/astropy/issues/16177 and deprecates `TestRunner(Base)` for downstream packages which were built using the astropy-template.

I guess we can provide a better message for downstream libraries?

Assuming https://github.com/astropy/astropy/pull/16208 gets in, it shouldn't affect astropy itself :)

### Blocked by

* https://github.com/astropy/astropy/pull/16208