### PR TITLE
DEPR: deprecate Time.ptp in favor of np.ptp with Numpy >= 2.0

### DIFF
--- a/docs/changes/time/16212.api.rst
+++ b/docs/changes/time/16212.api.rst
@@ -1,0 +1,2 @@
+Following the removal of ``np.ndarray.ptp`` in Numpy v2, ``Time.ptp`` is now
+deprecated in favor of ``np.ptp``.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -489,8 +489,8 @@ To apply arithmetic methods to |Time| instances::
 
   >>> t.max()
   <Time object: scale='utc' format='mjd' value=50002.5>
-  >>> t.ptp(axis=0)  # doctest: +FLOAT_CMP
-  <TimeDelta object: scale='tai' format='jd' value=[2. 2.]>
+  >>> t.min()
+  <Time object: scale='utc' format='mjd' value=50000.0>
 
 .. EXAMPLE END
 


### PR DESCRIPTION
### Description

Fixes #15379
Replaces closes #15497

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
