### PR TITLE
BUG: fix a crash when wrapping large integer Longitude

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -404,7 +404,7 @@ class Angle(SpecificTypeQuantity):
         # than Quantity objects for speed.
         a360 = u.degree.to(self.unit, 360.0)
         wrap_angle = wrap_angle.to_value(self.unit)
-        self_angle = self.view(np.ndarray)
+        self_angle = self.view(np.ndarray).astype(f"f{self.dtype.itemsize}", copy=False)
         if NUMPY_LT_2_0:
             # Ensure ndim>=1 so that comparison is done using the angle dtype.
             self_angle = self_angle[np.newaxis]

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -840,6 +840,9 @@ def test_longitude():
     assert Longitude(0, u.deg, dtype=float).dtype == np.dtype(float)
     assert Longitude(0, u.deg, dtype=int).dtype == np.dtype(int)
 
+    # regression test for https://github.com/astropy/astropy/issues/16217
+    assert Longitude(1234, u.deg, dtype=int).dtype == np.dtype(int)
+
     # Test errors when trying to interoperate with latitudes.
     with pytest.raises(
         TypeError, match="A Longitude angle cannot be created from a Latitude angle"

--- a/docs/changes/coordinates/16218.bugfix.rst
+++ b/docs/changes/coordinates/16218.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash when wrapping large integer ``Longitude`` .


### PR DESCRIPTION
### Description
Fixes #16217

Since this is a performance-critical function, I strongly recommend running benchmarks against this PR.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
