### PR TITLE
API: forbid integral data types for Angle and subclasses

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -148,6 +148,11 @@ class Angle(SpecificTypeQuantity):
     _include_easy_conversion_members = True
 
     def __new__(cls, angle, unit=None, dtype=np.inexact, copy=True, **kwargs):
+        if dtype is not np.inexact and np.dtype(dtype).kind == "i":
+            raise TypeError(
+                f"{cls.__name__} doesn't support integral data types. Received {dtype!r}"
+            )
+
         if not isinstance(angle, u.Quantity):
             if unit is not None:
                 unit = cls._convert_unit_to_angle_unit(u.Unit(unit))

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -693,6 +693,17 @@ def test_wrap_at_inplace():
     assert np.all(a.degree == np.array([-20.0, 150.0, -10.0, 0.0]))
 
 
+@pytest.mark.parametrize("cls", [Angle, Longitude, Latitude])
+def test_dtype_int(cls):
+    # for why this is forbidden
+    # see https://github.com/astropy/astropy/issues/16217
+    with pytest.raises(
+        TypeError,
+        match=f"{cls.__name__} doesn't support integral data types. Received 'int'",
+    ):
+        cls(0, u.deg, dtype="int")
+
+
 def test_latitude():
     with pytest.raises(ValueError):
         Latitude(["91d", "89d"])
@@ -838,7 +849,7 @@ def test_longitude():
 
     # also make sure dtype is correctly conserved
     assert Longitude(0, u.deg, dtype=float).dtype == np.dtype(float)
-    assert Longitude(0, u.deg, dtype=int).dtype == np.dtype(int)
+    assert Longitude(0, u.deg, dtype="float32").dtype == np.dtype("float32")
 
     # Test errors when trying to interoperate with latitudes.
     with pytest.raises(

--- a/docs/changes/coordinates/16220.api.rst
+++ b/docs/changes/coordinates/16220.api.rst
@@ -1,0 +1,1 @@
+Forbid integral data types for ``Angle`` and subclasses.


### PR DESCRIPTION
### Description
Fixes #16217
Alternative to #16218
A _third_ approach would be to first deprecate this use case, and/or promoting integral dtypes to floating point, but this seems niche enough that a clean break could maybe make it directly into a minor release. At the time of writing I only know of one test case that fails with the change (already adapted), let's see if CI finds more.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
