### PR TITLE
Deprecate `astropy.utils.misc.indent()`

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -11,11 +11,12 @@ from collections import OrderedDict
 from contextlib import suppress
 from functools import reduce
 from itertools import pairwise
+from textwrap import indent
 
 import numpy as np
 from numpy import char as chararray
 
-from astropy.utils import indent, isiterable, lazyproperty
+from astropy.utils import isiterable, lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .card import CARD_LENGTH, Card
@@ -669,7 +670,7 @@ class Column(NotifierMixin):
             msg = ["The following keyword arguments to Column were invalid:"]
 
             for val in invalid_kwargs.values():
-                msg.append(indent(val[1]))
+                msg.append(indent(val[1], 4 * " "))
 
             raise VerifyError("\n".join(msg))
 

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -2,8 +2,8 @@
 
 import operator
 import warnings
+from textwrap import indent
 
-from astropy.utils import indent
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -153,7 +153,7 @@ class _ErrList(list):
         for item in self:
             if not isinstance(item, _ErrList):
                 if filter is None or filter(item):
-                    yield item[0], indent(item[1], shift=shift)
+                    yield item[0], indent(item[1], 4 * shift * " ")
 
         # second time go through the next level items, each of the next level
         # must present, even it has nothing.
@@ -169,7 +169,7 @@ class _ErrList(list):
                     if self.unit:
                         # This line is sort of a header for the next level in
                         # the hierarchy
-                        yield None, indent(f"{self.unit} {element}:", shift=shift)
+                        yield None, indent(f"{self.unit} {element}:", 4 * shift * " ")
                     yield first_line
 
                 yield from next_lines

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -20,6 +20,7 @@ import inspect
 import operator
 from collections import defaultdict, deque
 from inspect import signature
+from textwrap import indent
 
 import numpy as np
 
@@ -31,7 +32,6 @@ from astropy.utils import (
     IncompatibleShapeError,
     check_broadcast,
     find_current_module,
-    indent,
     isiterable,
     metadata,
     sharedmethod,
@@ -2880,7 +2880,7 @@ class Model(metaclass=_ModelMeta):
             # Set units on the columns
             for name in self.param_names:
                 param_table[name].unit = getattr(self, name).unit
-            parts.append(indent(str(param_table), width=4))
+            parts.append(indent(str(param_table), 4 * " "))
 
         return "\n".join(parts)
 
@@ -3559,7 +3559,7 @@ class CompoundModel(Model):
         components = self._format_components()
         keywords = [
             ("Expression", expression),
-            ("Components", "\n" + indent(components)),
+            ("Components", "\n" + indent(components, 4 * " ")),
         ]
         return super()._format_str(keywords=keywords)
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -5,10 +5,11 @@ This module contains models representing polynomials and polynomial series.
 """
 # pylint: disable=invalid-name
 from math import comb
+from textwrap import indent
 
 import numpy as np
 
-from astropy.utils import check_broadcast, indent
+from astropy.utils import check_broadcast
 from astropy.utils.compat import COPY_IF_NEEDED
 
 from .core import FittableModel, Model
@@ -1862,7 +1863,7 @@ class SIP(Model):
     def __str__(self):
         parts = [f"Model: {self.__class__.__name__}"]
         for model in [self.shift_a, self.shift_b, self.sip1d_a, self.sip1d_b]:
-            parts.append(indent(str(model), width=4))
+            parts.append(indent(str(model), 4 * " "))
             parts.append("")
 
         return "\n".join(parts)
@@ -1945,7 +1946,7 @@ class InverseSIP(Model):
     def __str__(self):
         parts = [f"Model: {self.__class__.__name__}"]
         for model in [self.sip1d_ap, self.sip1d_bp]:
-            parts.append(indent(str(model), width=4))
+            parts.append(indent(str(model), 4 * " "))
             parts.append("")
 
         return "\n".join(parts)

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -54,6 +54,7 @@ def isiterable(obj):
         return False
 
 
+@deprecated(since="6.1", alternative="textwrap.indent()")
 def indent(s, shift=1, width=4):
     """Indent a block of text.  The indentation is applied to each line."""
     indented = "\n".join(" " * (width * shift) + l if l else "" for l in s.splitlines())

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -165,3 +165,8 @@ def test_dtype_bytes_or_chars():
     assert misc.dtype_bytes_or_chars(np.dtype(np.int32)) == 4
     assert misc.dtype_bytes_or_chars(np.array(b"12345").dtype) == 5
     assert misc.dtype_bytes_or_chars(np.array("12345").dtype) == 5
+
+
+def test_indent_deprecation():
+    with pytest.warns(AstropyDeprecationWarning, match=r"Use textwrap\.indent"):
+        misc.indent("Obsolete since Python 3.3")

--- a/docs/changes/utils/16223.api.rst
+++ b/docs/changes/utils/16223.api.rst
@@ -1,0 +1,2 @@
+``indent()`` is deprecated.
+Use ``textwrap.indent()`` from Python standard library instead.


### PR DESCRIPTION
### Description

Our `indent()` was made obsolete by [`textwrap.indent()`](https://docs.python.org/3/library/textwrap.html#textwrap.indent), introduced in Python version 3.3.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
