### PR TITLE
Support Masked setops functions and hashing of scalars.

### DIFF
--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2394,16 +2394,13 @@ def test_hash_masked_time(location, masked_array_type):
     t = Time([1, 1, 2, 3], format="cxcsec", location=location)
     t[3] = np.ma.masked
     with conf.set_temp("masked_array_type", masked_array_type):
-        if masked_array_type == "numpy":
-            h1 = hash(t[0])
-            h2 = hash(t[1])
-            h3 = hash(t[2])
-            assert h1 == h2
-            assert h1 != h3
-        else:
-            with pytest.raises(TypeError, match="value is masked"):
-                hash(t[0])
-
+        # Unmasked scalars should always be fine.
+        h1 = hash(t[0])
+        h2 = hash(t[1])
+        assert h2 == h1
+        h3 = hash(t[2])
+        assert h3 != h1
+        # But arrays and masked elements cannot be hashed
         with pytest.raises(
             TypeError, match=r"unhashable type: 'Time' \(must be scalar\)"
         ):
@@ -2420,16 +2417,13 @@ def test_hash_time_delta_masked(masked_array_type):
     t = TimeDelta([1, 1, 2, 3], format="sec")
     t[3] = np.ma.masked
     with conf.set_temp("masked_array_type", masked_array_type):
-        if masked_array_type == "numpy":
-            h1 = hash(t[0])
-            h2 = hash(t[1])
-            h3 = hash(t[2])
-            assert h1 == h2
-            assert h1 != h3
-        else:
-            with pytest.raises(TypeError, match=r"'TimeDelta' \(value is masked\)"):
-                hash(t[0])
-
+        # Unmasked scalars should always be fine.
+        h1 = hash(t[0])
+        h2 = hash(t[1])
+        h3 = hash(t[2])
+        assert h2 == h1
+        assert h3 != h1
+        # But arrays and masked elements cannot be hashed
         with pytest.raises(TypeError, match=r"'TimeDelta' \(must be scalar\)"):
             hash(t)
 

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1017,6 +1017,18 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         # For inplace, the mask will have been set already.
         return out
 
+    def __array_wrap__(self, obj, context=None, return_scalar=False):
+        if context is None:
+            # Functions like np.ediff1d call __array_wrap__ to turn the array
+            # into self's subclass.
+            return self.from_unmasked(*self._get_data_and_mask(obj))
+
+        raise NotImplementedError(
+            "__array_wrap__ should not be used with a context any more since all use "
+            "should go through array_function. Please raise an issue on "
+            "https://github.com/astropy/astropy"
+        )
+
     # Below are ndarray methods that need to be overridden as masked elements
     # need to be skipped and/or an initial value needs to be set.
     def _reduce_defaults(self, kwargs, initial_func=None):

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1303,6 +1303,14 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         else:
             return string
 
+    def __hash__(self):
+        # Try to be somewhat like a numpy array scalar if possible.
+        if self.ndim == 0 and not self.mask:
+            return hash(self.unmasked[()])
+
+        # Will raise regular ndarray error.
+        return hash((self.unmasked, self.mask))
+
 
 class MaskedRecarray(np.recarray, MaskedNDArray, data_cls=np.recarray):
     # Explicit definition since we need to override some methods.

--- a/astropy/utils/masked/tests/test_containers.py
+++ b/astropy/utils/masked/tests/test_containers.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import erfa
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/docs/changes/time/16224.bugfix.rst
+++ b/docs/changes/time/16224.bugfix.rst
@@ -1,0 +1,3 @@
+Scalar ``Time`` instances are now hashable if they are not masked, also if one
+uses ``Masked`` internally, matching the behaviour prior to astropy 6.0 (and
+the current behaviour when masking using ``np.ma.MaskedArray``).

--- a/docs/changes/utils/16224.api.rst
+++ b/docs/changes/utils/16224.api.rst
@@ -1,0 +1,3 @@
+Unmasked ``Masked`` scalar instances are now considered hashable, to match the
+implicit behaviour of regular arrays, where if an operation leads to a scalar,
+a hashable array scalar is returned.

--- a/docs/changes/utils/16224.feature.rst
+++ b/docs/changes/utils/16224.feature.rst
@@ -1,0 +1,2 @@
+``Masked`` instances now support the various numpy array set operations, such
+as ``np.unique`` and ``np.isin``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request supports functions like `np.unique` on `Masked` instances. It is needed to support `erfa` functions that raise errors or warnings (where unique status codes are looked for).

It also ensures an unmasked Masked scalar (like `Masked(-1)` can be hashed, and hence used as an index in a `dict` (also needed for the erfa routines). Note that I label the latter as an API change mostly so that I can do 2 changelog entries - I think it is minimal enough that there is no reason to wait for 7.0. I can relabel as a bugfix if desired (since this is required to fix #13041)

EDIT: my first attempts caused failures in `time` because unmasked scalar `Time` instances now became hashable. Since this was already the case previously, this effectively is a nice side benefit of this PR, fixing what was a bug I had not known how to address before.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13041 (last commit adds the regression test; with https://github.com/liberfa/pyerfa/pull/142 the erfa warning message count will be OK too).

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
