### PR TITLE
DOCS: Add docs about CI benchmarking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,8 @@ include the following:
   [astropy-benchmarks](https://github.com/astropy/astropy-benchmarks)
   repository. You can find out more about how to do this
   [in the README for that repository](https://github.com/astropy/astropy-benchmarks#contributing-benchmarks).
-  A maintainer will also be able to run a comparative benchmarks using
-  github actions on your changes to catch performance changes. The PR
+  A maintainer will also be able to run comparative benchmarks using
+  GitHub Actions on your changes to catch performance changes. The PR
   needs to have the `benchmark` label to run the workflow.
 
 - **Changelog entry**: whether you are fixing a bug or adding new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,9 @@ include the following:
   [astropy-benchmarks](https://github.com/astropy/astropy-benchmarks)
   repository. You can find out more about how to do this
   [in the README for that repository](https://github.com/astropy/astropy-benchmarks#contributing-benchmarks).
+  A maintainer will also be able to run a comparative benchmarks using
+  github actions on your changes to catch performance changes. The PR
+  needs to have the `benchmark` label to run the workflow.
 
 - **Changelog entry**: whether you are fixing a bug or adding new
   functionality, you should add a changelog fragment in the ``docs/changes/``

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1077,7 +1077,7 @@ In some cases, you may see failures on continuous integration services that
 you do not see locally, for example because the operating system is different,
 or because the failure happens with only 32-bit Python.
 
-Astropy also has the option to run a comparative benchmark using Github Actions
+Astropy also has the option to run a :ref:`comparative benchmark <benchmarks>` using Github Actions
 to test a new pull request against the current main branch. It uses the benchmarks
 from `Astropy Benchmarks <https://github.com/astropy/astropy-benchmarks/>`_. This
 action only runs if a maintainer adds the label ``benchmark`` to the pull request.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1077,6 +1077,14 @@ In some cases, you may see failures on continuous integration services that
 you do not see locally, for example because the operating system is different,
 or because the failure happens with only 32-bit Python.
 
+Astropy also has the option to run a comparative benchmark using Github Actions
+to test a new pull request against the current main branch. It uses the benchmarks
+from `Astropy Benchmarks <https://github.com/astropy/astropy-benchmarks/>`_. This
+action only runs if a maintainer adds the label `benchmark` to the pull request.
+It is important to note that these benchmarks can be flakey as they running on
+shared VMs but they should give a general idea of the performance impact of a
+pull request.
+
 .. _pytest-plugins:
 
 Pytest Plugins

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1080,10 +1080,10 @@ or because the failure happens with only 32-bit Python.
 Astropy also has the option to run a comparative benchmark using Github Actions
 to test a new pull request against the current main branch. It uses the benchmarks
 from `Astropy Benchmarks <https://github.com/astropy/astropy-benchmarks/>`_. This
-action only runs if a maintainer adds the label `benchmark` to the pull request.
-It is important to note that these benchmarks can be flakey as they running on
-shared VMs but they should give a general idea of the performance impact of a
-pull request.
+action only runs if a maintainer adds the label ``benchmark`` to the pull request.
+It is important to note that these benchmarks can be flakey as they run on
+virtual machines (and thus shared hardware) but they should give a general
+idea of the performance impact of a pull request.
 
 .. _pytest-plugins:
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -1077,11 +1077,10 @@ In some cases, you may see failures on continuous integration services that
 you do not see locally, for example because the operating system is different,
 or because the failure happens with only 32-bit Python.
 
-Astropy also has the option to run a :ref:`comparative benchmark <benchmarks>` using Github Actions
-to test a new pull request against the current main branch. It uses the benchmarks
-from `Astropy Benchmarks <https://github.com/astropy/astropy-benchmarks/>`_. This
-action only runs if a maintainer adds the label ``benchmark`` to the pull request.
-It is important to note that these benchmarks can be flakey as they run on
+Maintainers have the option to run :ref:`comparative benchmark <benchmarks>` using GitHub Actions
+to test a new pull request against the current ``main`` branch. It uses the benchmarks
+from `astropy-benchmarks <https://github.com/astropy/astropy-benchmarks/>`_.
+It is important to note that these benchmarks can be flaky as they run on
 virtual machines (and thus shared hardware) but they should give a general
 idea of the performance impact of a pull request.
 

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -179,12 +179,12 @@ Benchmarks
 If a pull request explicitly deals with a performance improvement, maintainers should
 use the ``benchmark`` label to run a comparative benchmark on the pull request. This
 will run a benchmark comparing the ``HEAD`` commit of the pull request branch with
-the main branch. The logs are uploaded as a action artifact and can be viewed
+the ``main`` branch. The logs are uploaded as a action artifact and can be viewed
 in the Actions tab. This workflow uses the benchmarks
-from `Astropy Benchmarks <https://github.com/astropy/astropy-benchmarks/>`_.
+from `astropy-benchmarks <https://github.com/astropy/astropy-benchmarks/>`_.
 
 Maintainers should also run the benchmark if they suspect the code change might have
-performance implications. The benchmark action takes significantly longer than regular CI to
+performance implications, but do note that benchmark action takes significantly longer than regular CI to
 complete.
 
 It is important to note that the benchmarking on Github Actions will be flaky and

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -179,14 +179,15 @@ Benchmarks
 If a pull request explicitly deals with a performance improvement, maintainers should
 use the ``benchmark`` label to run a comparative benchmark on the pull request. This
 will run a benchmark comparing the ``HEAD`` commit of the pull request branch with
-the main branch. The logs are uploaded as a action artefact and can be viewed
-in the Actions tab.
+the main branch. The logs are uploaded as a action artifact and can be viewed
+in the Actions tab. This workflow uses the benchmarks
+from `Astropy Benchmarks <https://github.com/astropy/astropy-benchmarks/>`_.
 
 Maintainers should also run the benchmark if they suspect the code change might have
-performance implications. The benchmark action takes approximately 25 minutes to
+performance implications. The benchmark action takes significantly longer than regular CI to
 complete.
 
-It is important to note that the benchmarking on Github Actions will be flakey and
+It is important to note that the benchmarking on Github Actions will be flaky and
 should only be used as a general guide.
 
 

--- a/docs/development/workflow/maintainer_workflow.rst
+++ b/docs/development/workflow/maintainer_workflow.rst
@@ -171,6 +171,25 @@ One can control the bot by making comments on the pull request:
   If you wish to run the pre-commit check first in CI without running Actions,
   use ``[skip actions]`` or ``[actions skip]`` in your commit message.
 
+.. _benchmarks:
+
+Benchmarks
+==========
+
+If a pull request explicitly deals with a performance improvement, maintainers should
+use the ``benchmark`` label to run a comparative benchmark on the pull request. This
+will run a benchmark comparing the ``HEAD`` commit of the pull request branch with
+the main branch. The logs are uploaded as a action artefact and can be viewed
+in the Actions tab.
+
+Maintainers should also run the benchmark if they suspect the code change might have
+performance implications. The benchmark action takes approximately 25 minutes to
+complete.
+
+It is important to note that the benchmarking on Github Actions will be flakey and
+should only be used as a general guide.
+
+
 .. _milestones-and-labels:
 
 ===========================


### PR DESCRIPTION
This fixes https://github.com/astropy/astropy/issues/16216

Maybe we should also add these docs to https://docs.astropy.org/en/latest/development/workflow/maintainer_workflow.html?