### PR TITLE
Simplify `_parse_coordinate_arg()` signature

### DIFF
--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -276,9 +276,7 @@ def _parse_coordinate_data(frame, args, kwargs):
         # will contain keys like 'ra', 'dec', 'distance' along with any
         # frame attributes like equinox or obstime which were explicitly
         # specified in the coordinate object (i.e. non-default).
-        _skycoord_kwargs, _components = _parse_coordinate_arg(
-            args[0], frame, units, kwargs
-        )
+        _skycoord_kwargs, _components = _parse_coordinate_arg(args[0], frame, units)
 
         # Copy other 'info' attr only if it has actually been defined.
         if "info" in getattr(args[0], "__dict__", ()):
@@ -347,7 +345,7 @@ def _get_representation_component_units(args, kwargs):
     return units
 
 
-def _parse_coordinate_arg(coords, frame, units, init_kwargs):
+def _parse_coordinate_arg(coords, frame, units):
     from .sky_coordinate import SkyCoord
 
     is_scalar = False  # Differentiate between scalar and list input
@@ -450,7 +448,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # this parsing path is used when there are coordinate-like objects
             # in the list - instead of creating lists of values, we create
             # SkyCoords from the list elements and then combine them.
-            scs = [SkyCoord(coord, **init_kwargs) for coord in coords]
+            scs = list(map(SkyCoord, coords))
 
             # Check that all frames are equivalent
             for sc in scs[1:]:

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -348,19 +348,6 @@ def _get_representation_component_units(args, kwargs):
 
 
 def _parse_coordinate_arg(coords, frame, units, init_kwargs):
-    """
-    Single unnamed arg supplied.  This must be:
-    - Coordinate frame with data
-    - Representation
-    - SkyCoord
-    - List or tuple of:
-      - String which splits into two values
-      - Iterable with two values
-      - SkyCoord, frame, or representation objects.
-
-    Returns a dict mapping coordinate attribute names to values (or lists of
-    values)
-    """
     from .sky_coordinate import SkyCoord
 
     is_scalar = False  # Differentiate between scalar and list input


### PR DESCRIPTION
### Description

The `init_kwargs` argument of `_parse_coordinate_arg()` served no purpose because the function is only called from one place where `init_kwargs` is guaranteed to be an empty `dict` (EDIT: as noted by @mhvk in https://github.com/astropy/astropy/pull/16226#discussion_r1534185405).

When I read the docstring of the function to see how it should be edited to reflect the signature change it immediately became apparent that what the docstring is describing is very different from what the function is actually doing (with or without `init_kwargs`), so the docstring should be removed too.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
