### PR TITLE
BUG: fix compatibility with numpy@maintenance/v2.0.x

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -18,7 +18,7 @@ from astropy.units.core import (
     dimensionless_unscaled,
     unit_scale_converter,
 )
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
@@ -390,6 +390,9 @@ if not NUMPY_LT_2_0:
         np._core.umath._replace,
         np._core.umath._expandtabs,
         np._core.umath._expandtabs_length,
+    }
+if not NUMPY_LT_2_1:
+    UNSUPPORTED_UFUNCS |= {
         np._core.umath._ljust,
         np._core.umath._rjust,
         np._core.umath._center,

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -13,6 +13,7 @@ __all__ = [
     "NUMPY_LT_1_25",
     "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
+    "NUMPY_LT_2_1",
     "COPY_IF_NEEDED",
     "sanitize_copy_arg",
 ]
@@ -24,6 +25,7 @@ NUMPY_LT_1_24 = not minversion(np, "1.24")
 NUMPY_LT_1_25 = not minversion(np, "1.25")
 NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0.dev")
+NUMPY_LT_2_1 = not minversion(np, "2.1.dev")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None


### PR DESCRIPTION
### Description

Since NumPy 2.0.x was branched out, we haven't been testing it directly: devdeps now run against nightlies produced from the 2.1dev (main) branch.
As a result, NumPy 2.0.x is now in a CI blindspot, so I ran tests locally against the backport branch and found this incompatibility.

follow up to #16205

xref https://github.com/numpy/numpy/pull/26033 and its backport https://github.com/numpy/numpy/pull/26052

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
