### PR TITLE
DOC: add a note that wrapping Angle with integral dtypes isn't supported

### DIFF
--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -176,8 +176,8 @@ angles and wrapping to be within a single 360 degree slice. The
 boolean indicating whether an angle or angles is within the specified bounds.
 
 .. Note::
-    While creating |Angle| objects from arrays with integral data types
-    (for instance with ``dtype=int``) is technically possible, it is very
+    While creating |Angle| instances from arrays with integral data types
+    is technically possible (for example with ``dtype=int``), it is very
     limited in functionality and in particular wrapping is not supported for
     such objects.
 

--- a/docs/coordinates/angles.rst
+++ b/docs/coordinates/angles.rst
@@ -175,6 +175,12 @@ angles and wrapping to be within a single 360 degree slice. The
 :meth:`~astropy.coordinates.Angle.is_within_bounds` method returns a
 boolean indicating whether an angle or angles is within the specified bounds.
 
+.. Note::
+    While creating |Angle| objects from arrays with integral data types
+    (for instance with ``dtype=int``) is technically possible, it is very
+    limited in functionality and in particular wrapping is not supported for
+    such objects.
+
 
 Longitude and Latitude Objects
 ==============================


### PR DESCRIPTION
### Description
Fixes #16217

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
