### PR TITLE
FIX: preserve round trip with parquet i/o

### DIFF
--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -173,7 +173,7 @@ def read_table_parquet(
         names = [n for n, col in full_table_columns.items() if name == col]
         names_to_read.extend(names)
 
-    if not names_to_read:
+    if full_table_columns and not names_to_read:
         raise ValueError("No include_names specified were found in the table.")
 
     # We need to pop any unread serialized columns out of the meta_dict.

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -207,6 +207,16 @@ def test_write_wrong_type():
         t1.write(1212, format="parquet")
 
 
+def test_empty_roundtrip(tmp_path):
+    """Test writing and reading an empty Table."""
+    test_file = tmp_path / "test.parquet"
+    t1 = Table()
+    t1.write(test_file)
+    t2 = Table.read(test_file)
+    assert len(t2) == 0
+    assert t1.colnames == t2.colnames
+
+
 @pytest.mark.parametrize("dtype", ALL_DTYPES)
 def test_preserve_single_dtypes(tmp_path, dtype):
     """Test that round-tripping a single column preserves datatypes."""

--- a/docs/changes/io.misc/16237.bugfix.rst
+++ b/docs/changes/io.misc/16237.bugfix.rst
@@ -1,0 +1,2 @@
+Reading an empty table stored in parquet format now creates an empty
+table instead of raising an unexpected error.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address #16236 and makes sure we maintain the parquet readwrite roundtrip.

@neutrinoceros what do you think about this fix?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16236

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
