### PR TITLE
BUG: fix a bug where `SkyCoord.spherical_offsets_by` would crash when a wrap was needed

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -346,7 +346,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # Broadcast the data if necessary and set it
         if data is not None and data.shape != self._shape:
-            data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
+            if data.size == np.prod(self._shape):
+                # broadcasting isn't strictly needed, avoid it
+                # see https://github.com/astropy/astropy/issues/16219
+                data.shape = self._shape
+            else:
+                data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
         self._data = data
         # Broadcast the attributes if necessary by getting them again
         # (we now know the shapes will be OK).

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -346,12 +346,14 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # Broadcast the data if necessary and set it
         if data is not None and data.shape != self._shape:
-            if data.size == np.prod(self._shape):
-                # broadcasting isn't strictly needed, avoid it
+            try:
+                # if broadcasting isn't strictly needed, avoid it
                 # see https://github.com/astropy/astropy/issues/16219
-                data.shape = self._shape
-            else:
+                data = data.reshape(self._shape)
+            except Exception:
                 data = data._apply(np.broadcast_to, shape=self._shape, subok=True)
+                if copy:
+                    data = data.copy()
         self._data = data
         # Broadcast the attributes if necessary by getting them again
         # (we now know the shapes will be OK).

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1690,3 +1690,14 @@ def test_spherical_offsets_by_broadcast():
     assert SkyCoord(
         ra=np.array([123, 134, 145]), dec=np.array([45, 56, 67]), unit=u.deg
     ).spherical_offsets_by(2 * u.deg, 2 * u.deg).shape == (3,)
+
+
+@pytest.mark.xfail
+def test_spherical_offsets_with_wrap():
+    # see https://github.com/astropy/astropy/issues/16219
+    sc = SkyCoord(ra=np.array([123]), dec=np.array([90]), unit=u.deg)
+    scop = sc.spherical_offsets_by(+2 * u.deg, 0 * u.deg)
+    assert scop.shape == sc.shape
+
+    scom = sc.spherical_offsets_by(-2 * u.deg, 0 * u.deg)
+    assert scom.shape == sc.shape

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1692,11 +1692,12 @@ def test_spherical_offsets_by_broadcast():
     ).spherical_offsets_by(2 * u.deg, 2 * u.deg).shape == (3,)
 
 
-def test_spherical_offsets_with_wrap():
+@pytest.mark.parametrize("shape", [(1,), (2,)])
+def test_spherical_offsets_with_wrap(shape):
     # see https://github.com/astropy/astropy/issues/16219
-    sc = SkyCoord(ra=np.array([123]), dec=np.array([90]), unit=u.deg)
+    sc = SkyCoord(ra=np.broadcast_to(123.0, shape), dec=90.0, unit=u.deg)
     scop = sc.spherical_offsets_by(+2 * u.deg, 0 * u.deg)
-    assert scop.shape == sc.shape
+    assert scop.shape == shape
 
     scom = sc.spherical_offsets_by(-2 * u.deg, 0 * u.deg)
-    assert scom.shape == sc.shape
+    assert scom.shape == shape

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1692,7 +1692,6 @@ def test_spherical_offsets_by_broadcast():
     ).spherical_offsets_by(2 * u.deg, 2 * u.deg).shape == (3,)
 
 
-@pytest.mark.xfail
 def test_spherical_offsets_with_wrap():
     # see https://github.com/astropy/astropy/issues/16219
     sc = SkyCoord(ra=np.array([123]), dec=np.array([90]), unit=u.deg)

--- a/docs/changes/coordinates/16241.bugfix.rst
+++ b/docs/changes/coordinates/16241.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug where ``SkyCoord.spherical_offsets_by`` would crash when a wrap
+was needed.


### PR DESCRIPTION
### Description
Fixes #16219

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
