### PR TITLE
Make computing angular separations less surprising

### DIFF
--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -2,7 +2,21 @@
 
 """This module defines custom errors and exceptions used in astropy.coordinates."""
 
-__all__ = ["ConvertError", "UnknownSiteException"]
+from __future__ import annotations
+
+__all__ = [
+    "ConvertError",
+    "NonRotationTransformationError",
+    "NonRotationTransformationWarning",
+    "UnknownSiteException",
+]
+
+from typing import TYPE_CHECKING
+
+from astropy.utils.exceptions import AstropyUserWarning
+
+if TYPE_CHECKING:
+    from astropy.coordinates import BaseCoordinateFrame
 
 
 # TODO: consider if this should be used to `units`?
@@ -18,6 +32,28 @@ class ConvertError(Exception):
     """
 
 
+class NonRotationTransformationError(ValueError):
+    """
+    Raised for transformations that are not simple rotations. Such
+    transformations can change the angular separation between coordinates
+    depending on its direction.
+    """
+
+    def __init__(
+        self, frame_to: BaseCoordinateFrame, frame_from: BaseCoordinateFrame
+    ) -> None:
+        self.frame_to = frame_to
+        self.frame_from = frame_from
+
+    def __str__(self) -> str:
+        return (
+            "refusing to transform other coordinates from "
+            f"{self.frame_from.replicate_without_data()} to "
+            f"{self.frame_to.replicate_without_data()} because angular separation "
+            "can depend on the direction of the transformation"
+        )
+
+
 class UnknownSiteException(KeyError):
     def __init__(self, site, attribute, close_names=None):
         message = (
@@ -31,3 +67,25 @@ class UnknownSiteException(KeyError):
         self.attribute = attribute
         self.close_names = close_names
         return super().__init__(message)
+
+
+class NonRotationTransformationWarning(AstropyUserWarning):
+    """
+    Emitted for transformations that are not simple rotations. Such
+    transformations can change the angular separation between coordinates
+    depending on its direction.
+    """
+
+    def __init__(
+        self, frame_to: BaseCoordinateFrame, frame_from: BaseCoordinateFrame
+    ) -> None:
+        self.frame_to = frame_to
+        self.frame_from = frame_from
+
+    def __str__(self) -> str:
+        return (
+            "transforming other coordinates from "
+            f"{self.frame_from.replicate_without_data()} to "
+            f"{self.frame_to.replicate_without_data()}. Angular separation can depend "
+            "on the direction of the transformation."
+        )

--- a/astropy/coordinates/tests/test_exceptions.py
+++ b/astropy/coordinates/tests/test_exceptions.py
@@ -1,0 +1,80 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Tests for custom error and warning messages in `astropy.coordinates`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+
+from astropy import units as u
+from astropy.coordinates import (
+    GCRS,
+    ICRS,
+    Galactic,
+    NonRotationTransformationError,
+    NonRotationTransformationWarning,
+)
+
+if TYPE_CHECKING:
+    from astropy.coordinates import BaseCoordinateFrame
+
+
+class FrameDescription(NamedTuple):
+    frame: BaseCoordinateFrame
+    description: str
+    pytest_id: str
+
+
+galactic = FrameDescription(
+    Galactic(0 * u.deg, 0 * u.deg), "Galactic Frame", "Galactic"
+)
+gcrs_custom = FrameDescription(
+    GCRS(
+        0 * u.deg,
+        0 * u.deg,
+        obstime="J1950",
+        obsgeovel=[30, -7, 11] * u.km / u.s,
+    ),
+    (
+        "GCRS Frame (obstime=J1950.000, obsgeoloc=(0., 0., 0.) m, "
+        "obsgeovel=(30000., -7000., 11000.) m / s)"
+    ),
+    "custom_GCRS",
+)
+gcrs_default = FrameDescription(
+    GCRS(0 * u.deg, 0 * u.deg),
+    (
+        "GCRS Frame (obstime=J2000.000, obsgeoloc=(0., 0., 0.) m, "
+        "obsgeovel=(0., 0., 0.) m / s)"
+    ),
+    "default_GCRS",
+)
+icrs = FrameDescription(ICRS(0 * u.deg, 0 * u.deg), "ICRS Frame", "ICRS")
+
+
+@pytest.mark.parametrize(
+    "coord_from,coord_to",
+    [pytest.param(icrs, gcrs_custom), pytest.param(gcrs_default, galactic)],
+    ids=lambda x: x.pytest_id,
+)
+def test_NonRotationTransformationError_message(coord_from, coord_to):
+    assert str(NonRotationTransformationError(coord_to.frame, coord_from.frame)) == (
+        f"refusing to transform other coordinates from <{coord_from.description}> to "
+        f"<{coord_to.description}> because angular separation can depend on the "
+        "direction of the transformation"
+    )
+
+
+@pytest.mark.parametrize(
+    "coord_from,coord_to",
+    [pytest.param(icrs, gcrs_default), pytest.param(gcrs_custom, galactic)],
+    ids=lambda x: x.pytest_id,
+)
+def test_NonRotationTransformationWarning_message(coord_from, coord_to):
+    assert str(NonRotationTransformationWarning(coord_to.frame, coord_from.frame)) == (
+        f"transforming other coordinates from <{coord_from.description}> to "
+        f"<{coord_to.description}>. Angular separation can depend on the direction of "
+        "the transformation."
+    )

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -889,11 +889,14 @@ def test_directional_offset_by():
         ]:
             # Find the displacement from sc1 to sc2,
             posang = sc1.position_angle(sc2)
-            sep = sc1.separation(sc2)
+            sep = sc1.separation(sc2, origin_mismatch="ignore")
 
             # then do the offset from sc1 and verify that you are at sc2
             sc2a = sc1.directional_offset_by(position_angle=posang, separation=sep)
-            assert np.max(np.abs(sc2.separation(sc2a).arcsec)) < 1e-3
+            assert (
+                np.max(np.abs(sc2.separation(sc2a, origin_mismatch="ignore").arcsec))
+                < 1e-3
+            )
 
     # Specific test cases
     # Go over the North pole a little way, and

--- a/docs/changes/coordinates/16246.feature.rst
+++ b/docs/changes/coordinates/16246.feature.rst
@@ -1,0 +1,10 @@
+By default the ``SkyCoord`` and ``BaseCoordinateFrame`` ``separation()``
+methods now emit a warning if they have to perform a coordinate transformation
+that is not a pure rotation to inform the user that the angular separation can
+depend on the direction of the transformation.
+It is possible to modify this behaviour with the new optional keyword-only
+``frame_origin_mismatch`` argument.
+Specifying ``frame_origin_mismatch="ignore"`` allows any transformation to
+succeed without warning, which has been the behaviour so far.
+``frame_origin_mismatch="error"`` forbids all transformations that are not
+pure rotations.

--- a/docs/coordinates/common_errors.rst
+++ b/docs/coordinates/common_errors.rst
@@ -9,7 +9,7 @@ Object Separation
 -----------------
 
 When calculating the separation between objects, it is important to bear in mind that
-:meth:`~astropy.coordinates.BaseCoordinateFrame.separation` gives a different
+:meth:`~astropy.coordinates.BaseCoordinateFrame.separation` can give a different
 answer depending upon the order in which is used.
 For example::
 
@@ -20,10 +20,15 @@ For example::
     >>> t = Time("2010-05-22T00:00")
     >>> moon = SkyCoord(104.29*u.deg, 23.51*u.deg, 359367.3*u.km, frame=GCRS(obstime=t))
     >>> star = SkyCoord(101.4*u.deg, 23.02*u.deg, frame='icrs')
-    >>> star.separation(moon) # doctest: +FLOAT_CMP
+    >>> star.separation(moon) # doctest: +FLOAT_CMP, +SHOW_WARNINGS
     <Angle 139.84211884 deg>
-    >>> moon.separation(star) # doctest: +FLOAT_CMP
+    NonRotationTransformationWarning: transforming other coordinates from
+    <GCRS Frame (obstime=2010-05-22T00:00:00.000, obsgeoloc=(0., 0., 0.) m,
+    obsgeovel=(0., 0., 0.) m / s)> to <ICRS Frame>. Angular separation can
+    depend on the direction of the transformation.
+    >>> moon.separation(star) # doctest: +FLOAT_CMP, +SHOW_WARNINGS
     <Angle 2.70390995 deg>
+    NonRotationTransformationWarning: transforming other coordinates from...
 
 Why do these give such different answers?
 
@@ -33,6 +38,25 @@ So ``star.separation(moon)`` gives the angular separation in the ICRS frame.
 This is the separation as it would appear from the Solar System Barycenter.
 For a geocentric observer, ``moon.separation(star)`` gives the correct answer,
 since ``moon`` is in a geocentric frame.
+As can be seen from the above example, by default an appropriate warning is
+emitted if the coordinate transformation can cause the angular separation value
+to be order-dependent.
+It is possible to always suppress the warning::
+
+    >>> moon.separation(star, origin_mismatch="ignore") # doctest: +FLOAT_CMP
+    <Angle 2.70390995 deg>
+
+It is also possible to forbid coordinate transformations that are not pure
+rotations::
+
+    >>> moon.separation(star, origin_mismatch="error")
+    Traceback (most recent call last):
+        ...
+    astropy.coordinates.errors.NonRotationTransformationError: refusing to
+    transform other coordinates from <ICRS Frame> to <GCRS Frame
+    (obstime=2010-05-22T00:00:00.000, obsgeoloc=(0., 0., 0.) m,
+    obsgeovel=(0., 0., 0.) m / s)> because angular separation can depend on
+    the direction of the transformation
 
 AltAz calculations for Earth-based objects
 ------------------------------------------

--- a/docs/whatsnew/6.1.rst
+++ b/docs/whatsnew/6.1.rst
@@ -31,6 +31,69 @@ the `NumPy deprecation policy
 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_.
 
 
+Order-dependent angular separations now come with warnings
+==========================================================
+
+Angular separation between two points depends on the point of view.
+For example, during a lunar eclipse and for an observer on the Earth the Sun
+and the Moon will be in (more-or-less) opposite directions, but at the same
+time for an observer at the Earth-Sun L2 point (where Gaia and James Webb Space
+Telescope are) the Sun and the Moon will be (more-or-less) in the same
+direction.
+The :meth:`~astropy.coordinates.BaseCoordinateFrame.separation` method
+automatically converts a coordinate given to it to the frame of the coordinate
+it belongs to, so the separation can be different if the coordinates are
+swapped.
+Such transformations are now accompanied by an appropriate warning::
+
+    >>> from astropy import units as u
+    >>> from astropy.coordinates import SkyCoord
+    >>> icrs = SkyCoord(0 * u.deg, 0 * u.deg, 10 * u.pc)
+    >>> gcrs = SkyCoord(0 * u.deg, 0 * u.deg, 380_000 * u.km, frame="gcrs")
+    >>> icrs.separation(gcrs)  # doctest: +FLOAT_CMP +SHOW_WARNINGS
+    <Angle 100.67116925 deg>
+    NonRotationTransformationWarning: transforming other coordinates from
+    <GCRS Frame (obstime=J2000.000, obsgeoloc=(0., 0., 0.) m,
+    obsgeovel=(0., 0., 0.) m / s)> to <ICRS Frame>. Angular separation can
+    depend on the direction of the transformation.
+    >>> gcrs.separation(icrs)  # doctest: +FLOAT_CMP +SHOW_WARNINGS
+    <Angle 0.0010732 deg>
+    NonRotationTransformationWarning: transforming other coordinates from
+    <ICRS Frame> to <GCRS Frame (obstime=J2000.000, obsgeoloc=(0., 0., 0.) m,
+    obsgeovel=(0., 0., 0.) m / s)>. Angular separation can depend on the
+    direction of the transformation.
+
+The warning is not emitted if the coordinate transformation is a pure rotation
+because such transformations do not change the origin of the coordinate frames,
+so the angular separation does not depend on the order of the coordinates::
+
+    >>> galactic = SkyCoord(0 * u.deg, 0 * u.deg, 10 * u.pc, frame="galactic")
+    >>> icrs.separation(galactic)  # doctest: +FLOAT_CMP
+    <Angle 93.14572374 deg>
+    >>> galactic.separation(icrs)  # doctest: +FLOAT_CMP
+    <Angle 93.14572374 deg>
+
+It is possible to suppress the warning::
+
+    >>> icrs.separation(gcrs, origin_mismatch="ignore")  # doctest: +FLOAT_CMP +SHOW_WARNINGS
+    <Angle 100.67116925 deg>
+
+It is also possible to forbid non-rotation transformations::
+
+    >>> icrs.separation(gcrs, origin_mismatch="error")  # doctest: +FLOAT_CMP
+    Traceback (most recent call last):
+        ...
+    astropy.coordinates.errors.NonRotationTransformationError: refusing to
+    transform other coordinates from <GCRS Frame (obstime=J2000.000,
+    obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s)> to <ICRS Frame>
+    because angular separation can depend on the direction of the transformation
+
+Pure rotations will still succeed::
+
+    >>> galactic.separation(icrs, origin_mismatch="error")  # doctest: +FLOAT_CMP
+    <Angle 93.14572374 deg>
+
+
 .. _whatsnew-6.1-ascii-default-int-columns-as-int64:
 
 ``io.ascii`` uses 64-integers by default for integer columns


### PR DESCRIPTION
### Description

When computing the angular separation between coordinates in different frames they first need to be transformed into a common frame. However, the resulting angular separation value can depend on the direction of the transformation, unless it is a simple rotation. Users have found this to be surprising, so by default a warning should be emitted if a non-rotation transformation is needed. It should also be possible to always suppress the warning, or to forbid non-rotation transformations.

Computing the position angle can always be done silently because its value is expected to depend on the order of the coordinates anyways.

Closes #8505, closes #12189, closes #11388, closes #14812

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
