### PR TITLE
PERF: quickly resolve inequalities for Quantities with different physical types

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1138,10 +1138,9 @@ class Quantity(np.ndarray):
     # DeprecationWarnings on any error, which is distracting, and does not
     # deal well with structured arrays (nor does the ufunc).
     def __eq__(self, other):
-        if (
-            hasattr(other, "unit")
-            and getattr(other.unit, "physical_type", True) != getattr(self.unit, "physical_type", False)
-        ):
+        if hasattr(other, "unit") and getattr(
+            other.unit, "physical_type", True
+        ) != getattr(self.unit, "physical_type", False):
             # hot path for flagrant inequality cases
             return False
         try:
@@ -1155,8 +1154,7 @@ class Quantity(np.ndarray):
     def __ne__(self, other):
         if (
             hasattr(other, "unit")
-            and hasattr(other.unit, "physical_type")
-            and (other.unit.physical_type) != self.unit.physical_type
+            and getattr(other.unit, "physical_type", True) != self.unit.physical_type
         ):
             # hot path for flagrant inequality cases
             return True

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1140,8 +1140,7 @@ class Quantity(np.ndarray):
     def __eq__(self, other):
         if (
             hasattr(other, "unit")
-            and hasattr(other.unit, "physical_type")
-            and (other.unit.physical_type) != self.unit.physical_type
+            and getattr(other.unit, "physical_type", True) != getattr(self.unit, "physical_type", False)
         ):
             # hot path for flagrant inequality cases
             return False

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1138,6 +1138,13 @@ class Quantity(np.ndarray):
     # DeprecationWarnings on any error, which is distracting, and does not
     # deal well with structured arrays (nor does the ufunc).
     def __eq__(self, other):
+        if (
+            hasattr(other, "unit")
+            and hasattr(other.unit, "physical_type")
+            and (other.unit.physical_type) != self.unit.physical_type
+        ):
+            # hot path for flagrant inequality cases
+            return False
         try:
             other_value = self._to_own_unit(other)
         except UnitsError:
@@ -1147,6 +1154,13 @@ class Quantity(np.ndarray):
         return self.value.__eq__(other_value)
 
     def __ne__(self, other):
+        if (
+            hasattr(other, "unit")
+            and hasattr(other.unit, "physical_type")
+            and (other.unit.physical_type) != self.unit.physical_type
+        ):
+            # hot path for flagrant inequality cases
+            return True
         try:
             other_value = self._to_own_unit(other)
         except UnitsError:


### PR DESCRIPTION
### Description
This patch is a candidate optimization (or rebalancing) for `Quantity` comparison (equality/inequality operations),
as was suggested in passing by @mhvk in https://github.com/astropy/astropy/pull/16088#pullrequestreview-1895919657

I used the following script, which heavily draws from the existing benchmark, to easily measure progress
```python
# adapted from astropy-benchmarks (time_quantity_equal)
from time import monotonic_ns
import astropy.units as u
import numpy as np

NLOOPS = 500_000
data = np.array([1.0, 2.0, 3.0])
data = data * u.g

# A different but dimensionally compatible unit
data2 = 0.001 * data * u.kg

data3 = data.copy()

def timeit(code:str, nloops:int=NLOOPS):
    tstart = monotonic_ns()
    for _ in range(nloops):
        exec(code)
    tstop = monotonic_ns()

    elapsed_ms = (tstop-tstart)/1e6
    print(f"'{code}' took {elapsed_ms / 1000 :.1f} s (or {elapsed_ms * 1000 / NLOOPS:.1f} us/iteration)")

timeit("data==data2")
timeit("data!=data2")
timeit("data==data3")
timeit("data!=data3")
```

On `main` I see
```
'data==data2' took 12.7 s (or 25.4 us/iteration)
'data!=data2' took 12.6 s (or 25.1 us/iteration)
'data==data3' took 3.5 s (or 7.0 us/iteration)
'data!=data3' took 3.5 s (or 7.0 us/iteration)
```

An with this patch
```
'data==data2' took 5.5 s (or 11.0 us/iteration)
'data!=data2' took 5.4 s (or 10.9 us/iteration)
'data==data3' took 5.1 s (or 10.2 us/iteration)
'data!=data3' took 5.1 s (or 10.2 us/iteration)
```

On `main`, performance seems biased towards comparison of equal objects (e.g. `data3` and `data`), while on my branch, the time it takes to compare objects is roughly independent of the result, and running the test script is overall faster, *but* the happy path is made longer by about 50%, so there's a rather clear tradeoff and a call to be made: it's not a pure optimization, but more of a re-balancing.

I don't know that the existing imbalance is intended, but maybe it is ?
I also don't know what's the hot path in end-user code (but I'd assume it really depends on applications).
Overall I'm not saying we *should* bring all comparison into the same ballpark performance; my original goal was to
make comparison always faster, or at least never slower, but seeing these interesting results, I figured I might as well
just open the conversation.

I should note that:
- running the test suite locally, I see that it breaks 3 tests, all for the same reason: redshifts' physical type doesn't compare equal to the dimensionless' physical type. After reading through #11202 and glossing over #11204, I'm honestly not sure whether this is a bug or a feature. @nstarman, what do you think ?
- there seem to be only one benchmark for quantity comparison, and it's the one I'm making faster here, so I don't expect existing benchmark to reveal the mixed results I've tried to highlight here, so I'll probably open a PR to add the one we're missing there.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
