### PR TITLE
TST: add a test job for numpy 2.0.0 pre-releases

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -109,3 +109,7 @@ jobs:
         - name: (Allowed Failure) Python 3.12 with remote data and dev version of key dependencies
           linux: py312-test-devdeps
           posargs: --remote-data=any --verbose
+
+        - name: (Allowed Failure) Python 3.12 with numpy 2.0.0 release candidates
+          linux: py312-test-numpy200rc
+          posargs: --remote-data=any --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
     linkcheck
     codestyle
     flynt
+    py312-test-numpy200rc # TODO: remove this after numpy 2.0.0 final is out
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
@@ -21,6 +22,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
+    numpy200rc: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     mpldev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     fitsio: ASTROPY_ALWAYS_TESTS_FITSIO = "true"
@@ -48,6 +50,7 @@ description =
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
+    numpy200rc: with numpy 2.0.0rc*
     image: with image tests
     mpl334: with matplotlib 3.3.4
     mpldev: with the latest developer version of matplotlib
@@ -58,6 +61,7 @@ deps =
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
+    numpy200rc: numpy==2.0.0b1 # TODO: bump to 2.0.0rc1
 
     mpl334: matplotlib==3.3.4
 
@@ -112,6 +116,7 @@ extras =
 install_command =
     !devdeps: python -I -m pip install
     devdeps: python -I -m pip install -v --pre
+    numpy200rc: -v --pre
 
 commands =
     pip freeze


### PR DESCRIPTION
### Description

Numpy 2.0.0rc1 is now imminent (according to https://github.com/numpy/numpy/issues/24300#issuecomment-2027392563)
As I noted in https://github.com/astropy/astropy/pull/16229, we're not currently testing against numpy 2.0.0 pre-releases, and testing against the dev branch has proven to be an insufficient proxy, so I propose we introduce a new (temporary) test job specifically focused on covering this case.
I've tested this branch on my fork and pinning numpy to version `2.0.0b1`, but this may become outdated very soon, so I'll keep this as a draft until one of the following happens:
- numpy 2.0.0rc1 is out and I can update this PR
- the week-end is over

Maintainers should feel free to push to this branch if there's a need for getting this in earlier.
I don't *think* I'll be actively working on this over the weekend, but I'll still happily respond to pings, so please *do* ping me if you need to update this so I know to be careful if I want to push again myself.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
