### PR TITLE
BLD: build with numpy 2.0.0rc1 (or newer)

### DIFF
--- a/docs/changes/16252.other.rst
+++ b/docs/changes/16252.other.rst
@@ -1,0 +1,3 @@
+astropy is now compiled against NumPy 2.0, enabling runtime compatibility
+with this new major release. Compatibility with NumPy 1.23 and newer
+versions of NumPy 1.x is preserved through this change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ wcslint = "astropy.wcs.wcslint:main"
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0,<3.1.0",
-            "numpy>=1.25",
+            "numpy>=2.0.0rc1", # see https://github.com/astropy/astropy/issues/16257
             "extension-helpers==1.*"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Description
Now that numpy 2.0.0 pre-releases reached ABI statbility, we can start building wheels against it.
This is required (but possibly not sufficient) to close #16167

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
