### PR TITLE
DEP: drop support for numpy 1.x

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -17,15 +17,12 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
+import numpy as np
 import pytest
 
 from astropy import __version__
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
-if not NUMPY_LT_2_0:
-    import numpy as np
-
-    np.set_printoptions(legacy="1.25")
+np.set_printoptions(legacy="1.25")
 
 # This is needed to silence a warning from matplotlib caused by
 # PyInstaller's matplotlib runtime hook.  This can be removed once the
@@ -38,7 +35,7 @@ if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
 
 # Note: while the filterwarnings is required, this import has to come after the
 # filterwarnings above, because this attempts to import matplotlib:
-from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB  # noqa: E402
 
 if HAS_MATPLOTLIB:
     import matplotlib as mpl

--- a/astropy/coordinates/angles/utils.py
+++ b/astropy/coordinates/angles/utils.py
@@ -22,7 +22,6 @@ from astropy.coordinates.representation import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
-from astropy.utils.compat import COPY_IF_NEEDED
 
 _TWOPI = 2 * np.pi
 
@@ -229,5 +228,5 @@ def uniform_spherical_random_volume(size=1, max_radius=1):
 
     usph = uniform_spherical_random_surface(size=size)
 
-    r = np.cbrt(rng.uniform(size=size)) * u.Quantity(max_radius, copy=COPY_IF_NEEDED)
+    r = np.cbrt(rng.uniform(size=size)) * u.Quantity(max_radius, copy=None)
     return SphericalRepresentation(usph.lon, usph.lat, r)

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -6,7 +6,6 @@ import numpy as np
 # Project
 from astropy import units as u
 from astropy.utils import ShapedLikeNDArray
-from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = [
     "Attribute",
@@ -369,7 +368,7 @@ class QuantityAttribute(Attribute):
             )
 
         oldvalue = value
-        value = u.Quantity(oldvalue, self.unit, copy=COPY_IF_NEEDED)
+        value = u.Quantity(oldvalue, self.unit, copy=None)
         if self.shape is not None and value.shape != self.shape:
             if value.shape == () and oldvalue == 0:
                 # Allow a single 0 to fill whatever shape is needed.

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -14,7 +14,6 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .cirs import CIRS
@@ -54,15 +53,15 @@ def cirs_to_observed(cirs_coo, observed_frame):
 
     if is_unitspherical:
         rep = UnitSphericalRepresentation(
-            lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(lat, u.radian, copy=None),
+            lon=u.Quantity(lon, u.radian, copy=None),
             copy=False,
         )
     else:
         # since we've transformed to CIRS at the observatory location, just use CIRS distance
         rep = SphericalRepresentation(
-            lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(lat, u.radian, copy=None),
+            lon=u.Quantity(lon, u.radian, copy=None),
             distance=cirs_coo.distance,
             copy=False,
         )

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -14,7 +14,6 @@ from astropy.coordinates.transformations import (
     DynamicMatrixTransform,
     FunctionTransformWithFiniteDifference,
 )
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import format_doc
 
 from .baseradec import BaseRADecFrame, doc_components
@@ -165,7 +164,7 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
         u.Quantity(
             fk4_e_terms(fk4coord.equinox),
             u.dimensionless_unscaled,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         ),
         copy=False,
     )
@@ -218,7 +217,7 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
         u.Quantity(
             fk4_e_terms(fk4noecoord.equinox),
             u.dimensionless_unscaled,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         ),
         copy=False,
     )

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -18,7 +18,6 @@ from astropy.coordinates.transformations import (
     AffineTransform,
     FunctionTransformWithFiniteDifference,
 )
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .cirs import CIRS
 from .gcrs import GCRS
@@ -42,8 +41,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(cirs_dec, u.radian, copy=None),
+            lon=u.Quantity(cirs_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -52,15 +51,15 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # no parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newcart = icrs_coo.cartesian - astrom_eb
         srepr = newcart.represent_as(SphericalRepresentation)
         cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(
-            lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(cirs_dec, u.radian, copy=None),
+            lon=u.Quantity(cirs_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
@@ -83,8 +82,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -94,14 +93,14 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
 
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newrep = intermedrep + astrom_eb
 
@@ -125,8 +124,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(gcrs_dec, u.radian, copy=None),
+            lon=u.Quantity(gcrs_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -135,7 +134,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newcart = icrs_coo.cartesian - astrom_eb
 
@@ -143,8 +142,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(
-            lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(gcrs_dec, u.radian, copy=None),
+            lon=u.Quantity(gcrs_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
@@ -168,8 +167,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -179,14 +178,14 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
 
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newrep = intermedrep + astrom_eb
 
@@ -209,8 +208,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     # convert to Quantity objects
-    i_ra = u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED)
-    i_dec = u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED)
+    i_ra = u.Quantity(i_ra, u.radian, copy=None)
+    i_dec = u.Quantity(i_dec, u.radian, copy=None)
     if (
         gcrs_coo.data.get_name() == "unitspherical"
         or gcrs_coo.data.to_cartesian().x.unit == u.one
@@ -235,7 +234,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # against the shape of the pv array.
         # broadcast em to eh and scale eh
         eh = astrom["eh"] * astrom["em"][..., np.newaxis]
-        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED)
+        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=None)
 
         newrep = intermedrep.to_cartesian() + eh
 

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -15,7 +15,6 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .hadec import HADec
@@ -39,7 +38,7 @@ def icrs_to_observed(icrs_coo, observed_frame):
         srepr = icrs_coo.spherical
     else:
         observer_icrs = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         srepr = (icrs_coo.cartesian - observer_icrs).represent_as(
             SphericalRepresentation
@@ -92,13 +91,13 @@ def observed_to_icrs(observed_coo, icrs_frame):
     # Topocentric CIRS
     cirs_ra, cirs_dec = erfa.atoiq(coord_type, lon, lat, astrom) << u.radian
     if is_unitspherical:
-        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1, copy=COPY_IF_NEEDED)
+        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1, copy=None)
     else:
         srepr = SphericalRepresentation(
             lon=cirs_ra,
             lat=cirs_dec,
             distance=observed_coo.distance,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
 
     # BCRS (Astrometric) direction to source
@@ -106,16 +105,16 @@ def observed_to_icrs(observed_coo, icrs_frame):
 
     # Correct for parallax to get ICRS representation
     if is_unitspherical:
-        icrs_srepr = UnitSphericalRepresentation(bcrs_ra, bcrs_dec, copy=COPY_IF_NEEDED)
+        icrs_srepr = UnitSphericalRepresentation(bcrs_ra, bcrs_dec, copy=None)
     else:
         icrs_srepr = SphericalRepresentation(
             lon=bcrs_ra,
             lat=bcrs_dec,
             distance=observed_coo.distance,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
         observer_icrs = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newrepr = icrs_srepr.to_cartesian() + observer_icrs
         icrs_srepr = newrepr.represent_as(SphericalRepresentation)

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -10,7 +10,6 @@ import warnings
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyWarning
 
 from .angles import Angle
@@ -162,7 +161,7 @@ class Distance(u.SpecificTypeQuantity):
                     value <<= u.AU
 
         elif parallax is not None:
-            parallax = u.Quantity(parallax, copy=COPY_IF_NEEDED, subok=True)
+            parallax = u.Quantity(parallax, copy=None, subok=True)
             value = parallax.to(unit or u.pc, equivalencies=u.parallax())
 
             if np.any(parallax < 0):
@@ -254,12 +253,12 @@ class Distance(u.SpecificTypeQuantity):
     def distmod(self):
         """The distance modulus as a `~astropy.units.Quantity`."""
         val = 5.0 * np.log10(self.to_value(u.pc)) - 5.0
-        return u.Quantity(val, u.mag, copy=COPY_IF_NEEDED)
+        return u.Quantity(val, u.mag, copy=None)
 
     @classmethod
     def _distmod_to_pc(cls, dm):
         dm = u.Quantity(dm, u.mag)
-        return cls(10 ** ((dm.value + 5) / 5.0), u.pc, copy=COPY_IF_NEEDED)
+        return cls(10 ** ((dm.value + 5) / 5.0), u.pc, copy=None)
 
     @property
     def parallax(self):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -14,7 +14,6 @@ from astropy import constants as consts
 from astropy import units as u
 from astropy.units.quantity import QuantityInfoBase
 from astropy.utils import data
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .angles import Angle, Latitude, Longitude
@@ -271,9 +270,9 @@ class EarthLocation(u.Quantity):
         # in that it will no longer possible to initialize with a unit-full x,
         # and unit-less y, z. Arguably, though, that would just solve a bug.
         try:
-            x = u.Quantity(x, unit, copy=COPY_IF_NEEDED)
-            y = u.Quantity(y, unit, copy=COPY_IF_NEEDED)
-            z = u.Quantity(z, unit, copy=COPY_IF_NEEDED)
+            x = u.Quantity(x, unit, copy=None)
+            y = u.Quantity(y, unit, copy=None)
+            z = u.Quantity(z, unit, copy=None)
         except u.UnitsError:
             raise u.UnitsError("Geocentric coordinate units should all be consistent.")
 
@@ -317,11 +316,11 @@ class EarthLocation(u.Quantity):
         """
         ellipsoid = _check_ellipsoid(ellipsoid, default=cls._ellipsoid)
         # As wrapping fails on readonly input, we do so manually
-        lon = Angle(lon, u.degree, copy=COPY_IF_NEEDED).wrap_at(180 * u.degree)
-        lat = Latitude(lat, u.degree, copy=COPY_IF_NEEDED)
+        lon = Angle(lon, u.degree, copy=None).wrap_at(180 * u.degree)
+        lat = Latitude(lat, u.degree, copy=None)
         # don't convert to m by default, so we can use the height unit below.
         if not isinstance(height, u.Quantity):
-            height = u.Quantity(height, u.m, copy=COPY_IF_NEEDED)
+            height = u.Quantity(height, u.m, copy=None)
         # get geocentric coordinates.
         geodetic = ELLIPSOIDS[ellipsoid](lon, lat, height, copy=False)
         xyz = geodetic.to_cartesian().get_xyz(xyz_axis=-1) << height.unit

--- a/astropy/coordinates/polarization.py
+++ b/astropy/coordinates/polarization.py
@@ -6,7 +6,6 @@ from typing import NamedTuple
 import numpy as np
 
 from astropy.utils import unbroadcast
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.shapes import ShapedLikeNDArray
 
@@ -187,7 +186,7 @@ class StokesCoord(ShapedLikeNDArray):
     def dtype(self):
         return self._data.dtype
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         return self._data.astype(dtype, copy=copy)
 
     def _apply(self, method, *args, **kwargs):

--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import astropy.units as u
 from astropy.coordinates.angles import Angle
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 from .cartesian import CartesianRepresentation
@@ -79,9 +78,9 @@ class CylindricalRepresentation(BaseRepresentation):
         sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
         l = np.broadcast_to(1.0, self.shape)
         return {
-            "rho": CartesianRepresentation(cosphi, sinphi, 0, copy=COPY_IF_NEEDED),
-            "phi": CartesianRepresentation(-sinphi, cosphi, 0, copy=COPY_IF_NEEDED),
-            "z": CartesianRepresentation(0, 0, l, unit=u.one, copy=COPY_IF_NEEDED),
+            "rho": CartesianRepresentation(cosphi, sinphi, 0, copy=None),
+            "phi": CartesianRepresentation(-sinphi, cosphi, 0, copy=None),
+            "z": CartesianRepresentation(0, 0, l, unit=u.one, copy=None),
         }
 
     def scale_factors(self):
@@ -123,7 +122,7 @@ class CylindricalRepresentation(BaseRepresentation):
         z_op = lambda x: op(x, *args)
 
         result = self.__class__(
-            rho_op(self.rho), phi_op(self.phi), z_op(self.z), copy=COPY_IF_NEEDED
+            rho_op(self.rho), phi_op(self.phi), z_op(self.z), copy=None
         )
         for key, differential in self.differentials.items():
             new_comps = (

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -11,7 +11,6 @@ from astropy.coordinates.angles import Angle, Latitude, Longitude
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.matrix_utilities import is_O3
 from astropy.utils import classproperty
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 from .cartesian import CartesianRepresentation
@@ -84,9 +83,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
         sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
         sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
         return {
-            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=COPY_IF_NEEDED),
+            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=None),
             "lat": CartesianRepresentation(
-                -sinlat * coslon, -sinlat * sinlon, coslat, copy=COPY_IF_NEEDED
+                -sinlat * coslon, -sinlat * sinlon, coslat, copy=None
             ),
         }
 
@@ -127,14 +126,14 @@ class UnitSphericalRepresentation(BaseRepresentation):
                     phi=self.lon,
                     theta=90 * u.deg - self.lat,
                     r=1.0,
-                    copy=COPY_IF_NEEDED,
+                    copy=None,
                 )
             elif issubclass(other_class, SphericalRepresentation):
                 return other_class(
                     lon=self.lon,
                     lat=self.lat,
                     distance=1.0,
-                    copy=COPY_IF_NEEDED,
+                    copy=None,
                 )
 
         return super().represent_as(other_class, differential_class)
@@ -501,12 +500,12 @@ class SphericalRepresentation(BaseRepresentation):
         sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
         sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
         return {
-            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=COPY_IF_NEEDED),
+            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=None),
             "lat": CartesianRepresentation(
-                -sinlat * coslon, -sinlat * sinlon, coslat, copy=COPY_IF_NEEDED
+                -sinlat * coslon, -sinlat * sinlon, coslat, copy=None
             ),
             "distance": CartesianRepresentation(
-                coslat * coslon, coslat * sinlon, sinlat, copy=COPY_IF_NEEDED
+                coslat * coslon, coslat * sinlon, sinlat, copy=None
             ),
         }
 
@@ -620,7 +619,7 @@ class SphericalRepresentation(BaseRepresentation):
             lon_op(self.lon),
             lat_op(self.lat),
             distance_op(self.distance),
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
         for key, differential in self.differentials.items():
             new_comps = (
@@ -711,12 +710,12 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
         sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
         return {
-            "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=COPY_IF_NEEDED),
+            "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=None),
             "theta": CartesianRepresentation(
-                costheta * cosphi, costheta * sinphi, -sintheta, copy=COPY_IF_NEEDED
+                costheta * cosphi, costheta * sinphi, -sintheta, copy=None
             ),
             "r": CartesianRepresentation(
-                sintheta * cosphi, sintheta * sinphi, costheta, copy=COPY_IF_NEEDED
+                sintheta * cosphi, sintheta * sinphi, costheta, copy=None
             ),
         }
 
@@ -852,7 +851,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             phi_op(self.phi),
             phi_op(adjust_theta_sign(self.theta)),
             r_op(self.r),
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
         for key, differential in self.differentials.items():
             new_comps = (

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -14,7 +14,6 @@ from astropy.constants import c as speed_of_light
 from astropy.table import QTable
 from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -836,12 +835,12 @@ class SkyCoord(ShapedLikeNDArray):
             new_distance = Distance(parallax=starpm[4] << u.arcsec)
 
         icrs2 = ICRS(
-            ra=u.Quantity(starpm[0], u.radian, copy=COPY_IF_NEEDED),
-            dec=u.Quantity(starpm[1], u.radian, copy=COPY_IF_NEEDED),
-            pm_ra=u.Quantity(starpm[2], u.radian / u.yr, copy=COPY_IF_NEEDED),
-            pm_dec=u.Quantity(starpm[3], u.radian / u.yr, copy=COPY_IF_NEEDED),
+            ra=u.Quantity(starpm[0], u.radian, copy=None),
+            dec=u.Quantity(starpm[1], u.radian, copy=None),
+            pm_ra=u.Quantity(starpm[2], u.radian / u.yr, copy=None),
+            pm_dec=u.Quantity(starpm[3], u.radian / u.yr, copy=None),
             distance=new_distance,
-            radial_velocity=u.Quantity(starpm[5], u.km / u.s, copy=COPY_IF_NEEDED),
+            radial_velocity=u.Quantity(starpm[5], u.km / u.s, copy=None),
             differential_type=SphericalDifferential,
         )
 

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import IrreducibleUnit, Unit
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .baseframe import (
     BaseCoordinateFrame,
@@ -529,9 +528,7 @@ def _parse_coordinate_arg(coords, frame, units):
         for frame_attr_name, repr_attr_class, value, unit in zip(
             frame_attr_names, repr_attr_classes, values, units
         ):
-            components[frame_attr_name] = repr_attr_class(
-                value, unit=unit, copy=COPY_IF_NEEDED
-            )
+            components[frame_attr_name] = repr_attr_class(value, unit=unit, copy=None)
     except Exception as err:
         raise ValueError(
             f'Cannot parse first argument data "{value}" for attribute'

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.constants import c as speed_of_light
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data import download_file
 from astropy.utils.decorators import classproperty, deprecated
 from astropy.utils.state import ScienceState
@@ -267,14 +266,14 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None, get_velocity=True):
                     body_pv_bary = erfa.pvppv(body_pv_helio, sun_pv_bary)
 
             body_pos_bary = CartesianRepresentation(
-                body_pv_bary["p"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+                body_pv_bary["p"], unit=u.au, xyz_axis=-1, copy=None
             )
             if get_velocity:
                 body_vel_bary = CartesianRepresentation(
                     body_pv_bary["v"],
                     unit=u.au / u.day,
                     xyz_axis=-1,
-                    copy=COPY_IF_NEEDED,
+                    copy=None,
                 )
 
         else:

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -13,7 +13,6 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
 from astropy.coordinates.spectral_quantity import SpectralQuantity
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["SpectralCoord"]
@@ -393,7 +392,7 @@ class SpectralCoord(SpectralQuantity):
                 redshift=redshift,
                 doppler_convention=doppler_convention,
                 doppler_rest=doppler_rest,
-                copy=COPY_IF_NEEDED,
+                copy=None,
             )
 
     @property

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -19,7 +19,6 @@ from astropy.coordinates import (
     Latitude,
     Longitude,
 )
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 
 def test_create_angles():
@@ -203,11 +202,6 @@ def test_angle_methods():
     a_var = a.var()
     assert type(a_var) is u.Quantity
     assert a_var == 1.0 * u.degree**2
-    if NUMPY_LT_2_0:
-        # np.ndarray.ptp() method removed in numpy 2.0.
-        a_ptp = a.ptp()
-        assert type(a_ptp) is Angle
-        assert a_ptp == 2.0 * u.degree
     a_max = a.max()
     assert type(a_max) is Angle
     assert a_max == 2.0 * u.degree

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -17,7 +17,6 @@ from astropy.coordinates import (
 )
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
-from astropy.utils.compat import NUMPY_LT_1_24
 
 
 def test_angle_arrays():
@@ -45,17 +44,7 @@ def test_angle_arrays():
     assert a6.unit is u.degree
 
     with ExitStack() as stack:
-        if NUMPY_LT_1_24:
-            stack.enter_context(pytest.raises(TypeError))
-            stack.enter_context(
-                pytest.warns(
-                    np.VisibleDeprecationWarning,
-                    match="Creating an ndarray from ragged nested sequences",
-                )
-            )
-        else:
-            stack.enter_context(pytest.raises(ValueError))
-
+        stack.enter_context(pytest.raises(ValueError))
         Angle([a1, a2, a3], unit=u.degree)
 
     a8 = Angle(["04:02:02", "03:02:01", "06:02:01"], unit=u.degree)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -32,7 +32,6 @@ from astropy.coordinates.representation import (
 )
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose_quantity
 from astropy.utils import isiterable
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 
 # create matrices for use in testing ``.transform()`` methods
@@ -1790,7 +1789,7 @@ class TestCartesianRepresentationWithDifferential:
 
         # make sure other kwargs are handled properly
         s1 = CartesianRepresentation(
-            x=1, y=2, z=3, differentials=diff, copy=COPY_IF_NEEDED, unit=u.kpc
+            x=1, y=2, z=3, differentials=diff, copy=None, unit=u.kpc
         )
         assert len(s1.differentials) == 1
         assert s1.differentials["s"] is diff

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -15,7 +15,6 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import isiterable
-from astropy.utils.compat import COPY_IF_NEEDED
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -552,9 +551,7 @@ class _BoundingDomain(abc.ABC):
         List containing filled in output values and units
         """
         if valid_outputs_unit is not None:
-            return Quantity(
-                outputs, valid_outputs_unit, copy=COPY_IF_NEEDED, subok=True
-            )
+            return Quantity(outputs, valid_outputs_unit, copy=None, subok=True)
 
         return outputs
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -38,7 +38,6 @@ from astropy.utils import (
     sharedmethod,
 )
 from astropy.utils.codegen import make_function_with_signature
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .bounding_box import CompoundBoundingBox, ModelBoundingBox
 from .parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
@@ -444,9 +443,7 @@ class _ModelMeta(abc.ABCMeta):
                     # default is not a Quantity, attach the unit to the
                     # default.
                     if unit is not None:
-                        default = Quantity(
-                            default, unit, copy=COPY_IF_NEEDED, subok=True
-                        )
+                        default = Quantity(default, unit, copy=None, subok=True)
                     kwargs.append((param_name, default))
             else:
                 args = ("self",) + tuple(pdict.keys())

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from astropy.units import MagUnit, Quantity
 from astropy.utils import isiterable
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .utils import array_repr_oneline, get_inputs_and_params
 
@@ -732,7 +731,7 @@ class Parameter:
 
         return wrapper
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         # Make np.asarray(self) work a little more straightforwardly
         arr = np.asarray(self.value, dtype=dtype)
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -11,7 +11,6 @@ from textwrap import indent
 import numpy as np
 
 from astropy.utils import check_broadcast
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .core import FittableModel, Model
 from .functional_models import Shift
@@ -536,7 +535,7 @@ class Chebyshev1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -657,7 +656,7 @@ class Hermite1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -836,7 +835,7 @@ class Hermite2D(OrthoPolynomialBase):
         """
         Derivative of 1D Hermite series.
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:
@@ -939,7 +938,7 @@ class Legendre1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -1492,7 +1491,7 @@ class Chebyshev2D(OrthoPolynomialBase):
         """
         Derivative of 1D Chebyshev series.
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:
@@ -1646,7 +1645,7 @@ class Legendre2D(OrthoPolynomialBase):
 
     def _legendderiv1d(self, x, deg):
         """Derivative of 1D Legendre polynomial."""
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         d = np.empty((deg + 1,) + x.shape, dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from astropy import log
 from astropy.units import Unit, UnitConversionError, UnitsError  # noqa: F401
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .flag_collection import FlagCollection
 from .mixins.ndarithmetic import NDArithmeticMixin
@@ -229,7 +228,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         else:
             self._flags = value
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         """
         This allows code that requests a Numpy array to use an NDData
         object as a Numpy array.

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -8,17 +8,13 @@ from astropy.stats._fast_sigma_clip import _sigma_clip_fast
 from astropy.stats.funcs import mad_std
 from astropy.units import Quantity
 from astropy.utils import isiterable
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_BOTTLENECK
 from astropy.utils.exceptions import AstropyUserWarning
 
 if HAS_BOTTLENECK:
     import bottleneck
 
-if NUMPY_LT_2_0:
-    from numpy.core.multiarray import normalize_axis_index
-else:
-    from numpy.lib.array_utils import normalize_axis_index
+from numpy.lib.array_utils import normalize_axis_index
 
 __all__ = ["SigmaClip", "sigma_clip", "sigma_clipped_stats"]
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -10,7 +10,6 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import NUMPY_LT_2_0, sanitize_copy_arg
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -522,8 +521,6 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         copy=False,
         copy_indices=True,
     ):
-        copy = sanitize_copy_arg(copy)
-
         if data is None:
             self_data = np.zeros((length,) + shape, dtype=dtype)
         elif isinstance(data, BaseColumn) and hasattr(data, "_name"):
@@ -745,11 +742,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
            we also want to consistently return an array rather than a column
            (see #1446 and #1685)
         """
-        if NUMPY_LT_2_0:
-            out_arr = super().__array_wrap__(out_arr, context)
-            return_scalar = True
-        else:
-            out_arr = super().__array_wrap__(out_arr, context, return_scalar)
+        out_arr = super().__array_wrap__(out_arr, context, return_scalar)
 
         if self.shape != out_arr.shape or (
             isinstance(out_arr, BaseColumn)

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -6,8 +6,6 @@ from operator import index as operator_index
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED
-
 
 class Row:
     """A class to represent one row of a Table object.
@@ -90,7 +88,7 @@ class Row:
             )
         return self.as_void() != other
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         """Support converting Row to np.array via np.array(table).
 
         Coercion to a different dtype via np.array(table, dtype) is not

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -11,7 +11,6 @@ from numpy.testing import assert_array_equal
 from astropy import table, time
 from astropy import units as u
 from astropy.tests.helper import assert_follows_unicode_guidelines
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
 
 
@@ -384,14 +383,7 @@ class TestColumn:
             c.insert(0, "string")
 
         c = Column(["a", "b"])
-        with pytest.raises(
-            TypeError,
-            match=(
-                "string operation on non-string array"
-                if NUMPY_LT_2_0
-                else "ufunc 'str_len' did not contain a loop"
-            ),
-        ):
+        with pytest.raises(TypeError, match=("ufunc 'str_len' did not contain a loop")):
             c.insert(0, 1)
 
     def test_insert_multidim(self, Column):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -28,7 +28,6 @@ from astropy.table import (
 )
 from astropy.tests.helper import PYTEST_LT_8_0, assert_follows_unicode_guidelines
 from astropy.time import Time, TimeDelta
-from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.compat.optional_deps import HAS_PANDAS
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
@@ -1660,21 +1659,13 @@ def test_values_equal_part1():
         # Shape mismatch
         t3.values_equal(t1)
 
-    if NUMPY_LT_1_25:
-        with pytest.raises(ValueError, match="unable to compare column c"):
-            # Type mismatch in column c causes FutureWarning
-            t1.values_equal(2)
+    eq = t2.values_equal(2)
+    for col in eq.colnames:
+        assert np.all(eq[col] == [False, True])
 
-        with pytest.raises(ValueError, match="unable to compare column c"):
-            t1.values_equal([1, 2])
-    else:
-        eq = t2.values_equal(2)
-        for col in eq.colnames:
-            assert np.all(eq[col] == [False, True])
-
-        eq = t2.values_equal([1, 2])
-        for col in eq.colnames:
-            assert np.all(eq[col] == [True, True])
+    eq = t2.values_equal([1, 2])
+    for col in eq.colnames:
+        assert np.all(eq[col] == [True, True])
 
     eq = t2.values_equal(t2)
     for col in eq.colnames:

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -11,7 +11,6 @@ from astropy.coordinates import EarthLocation
 from astropy.table import Table
 from astropy.time import Time, conf
 from astropy.utils import iers
-from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_1_26
 from astropy.utils.compat.optional_deps import HAS_H5PY
 from astropy.utils.masked import Masked
 
@@ -335,19 +334,14 @@ def test_all_formats(format_, masked_cls, masked_array_type):
         t_format = getattr(t, format_)
         tm_format = getattr(tm, format_)
         assert isinstance(tm_format, out_cls)
-        if NUMPY_LT_1_26 and format_ == "ymdhms" and out_cls is np.ma.MaskedArray:
-            # Work around https://github.com/numpy/numpy/issues/24554
-            expected = out_cls(t_format, mask=mask)
-        else:
-            expected = t_format
+
+        expected = t_format
         assert np.all(tm_format == expected)
 
         # Check masked scalar.
         tm0_format = getattr(tm[0], format_)
         assert isinstance(tm0_format, out_cls)
-        if NUMPY_LT_1_25 and tm0_format.dtype.kind == "M":
-            # Comparison bug in older numpy, just skip it.
-            return
+
         comparison = tm0_format == tm_format[0]
         assert comparison.mask
         if out_cls is Masked:

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -3,7 +3,6 @@
 import copy
 import itertools
 import warnings
-from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -13,7 +12,6 @@ from astropy.time import Time
 from astropy.time.utils import day_frac
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 from astropy.utils import iers
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 needs_array_function = pytest.mark.xfail(
@@ -640,11 +638,7 @@ class TestArithmetic:
         assert np.ptp(self.t0, axis=0).shape == (5, 5)
         assert np.ptp(self.t0, 0, keepdims=True).shape == (1, 5, 5)
 
-        if NUMPY_LT_2_0:
-            ctx = nullcontext()
-        else:
-            ctx = pytest.warns(AstropyDeprecationWarning)
-        with ctx:
+        with pytest.warns(AstropyDeprecationWarning):
             assert self.t0.ptp() == self.t0.max() - self.t0.min()
 
     def test_sort(self, use_mask):

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -7,20 +7,12 @@ Distribution class and associated machinery.
 import builtins
 
 import numpy as np
+from numpy.lib._function_base_impl import _parse_gufunc_signature
+from numpy.lib._stride_tricks_impl import DummyArray
+from numpy.lib.array_utils import normalize_axis_index
 
 from astropy import stats
 from astropy import units as u
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
-
-if NUMPY_LT_2_0:
-    from numpy.core.multiarray import normalize_axis_index
-    from numpy.lib.function_base import _parse_gufunc_signature
-    from numpy.lib.stride_tricks import DummyArray
-else:
-    from numpy.lib._function_base_impl import _parse_gufunc_signature
-    from numpy.lib._stride_tricks_impl import DummyArray
-    from numpy.lib.array_utils import normalize_axis_index
-
 
 from .function_helpers import FUNCTION_HELPERS
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -11,7 +11,6 @@ import warnings
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
@@ -910,7 +909,7 @@ class UnitBase:
         try:
             from .quantity import Quantity
 
-            return Quantity(m, self, copy=COPY_IF_NEEDED, subok=True)
+            return Quantity(m, self, copy=None, subok=True)
         except Exception:
             if isinstance(m, np.ndarray):
                 raise

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -4,6 +4,7 @@
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
+from numpy._core import umath as np_umath
 
 from astropy.units import (
     Quantity,
@@ -14,12 +15,6 @@ from astropy.units import (
     UnitTypeError,
     dimensionless_unscaled,
 )
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
-
-if NUMPY_LT_2_0:
-    from numpy.core import umath as np_umath
-else:
-    from numpy._core import umath as np_umath
 
 __all__ = ["FunctionUnitBase", "FunctionQuantity"]
 
@@ -312,7 +307,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
     def __rlshift__(self, other):
         """Unit conversion operator ``<<``."""
         try:
-            return self._quantity_class(other, self, copy=COPY_IF_NEEDED, subok=True)
+            return self._quantity_class(other, self, copy=None, subok=True)
         except Exception:
             return NotImplemented
 

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -12,7 +12,6 @@ from astropy.units import (
     dimensionless_unscaled,
     photometric,
 )
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 from .core import FunctionQuantity, FunctionUnitBase
 from .units import dB, dex, mag
@@ -391,21 +390,13 @@ class LogQuantity(FunctionQuantity):
         unit = self.unit._copy(dimensionless_unscaled)
         return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof, unit=unit)
 
-    if NUMPY_LT_2_0:
-
-        def ptp(self, axis=None, out=None):
+    def __array_function__(self, function, types, args, kwargs):
+        # TODO: generalize this to all supported functions!
+        if function is np.ptp:
             unit = self.unit._copy(dimensionless_unscaled)
-            return self._wrap_function(np.ptp, axis, out=out, unit=unit)
-
-    else:
-
-        def __array_function__(self, function, types, args, kwargs):
-            # TODO: generalize this to all supported functions!
-            if function is np.ptp:
-                unit = self.unit._copy(dimensionless_unscaled)
-                return self._wrap_function(np.ptp, *args[1:], unit=unit, **kwargs)
-            else:
-                return super().__array_function__(function, types, args, kwargs)
+            return self._wrap_function(np.ptp, *args[1:], unit=unit, **kwargs)
+        else:
+            return super().__array_function__(function, types, args, kwargs)
 
     def diff(self, n=1, axis=-1):
         unit = self.unit._copy(dimensionless_unscaled)

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -4,8 +4,6 @@
 
 import numbers
 
-from astropy.utils.compat import COPY_IF_NEEDED
-
 from . import (
     astrophys,
     cgs,
@@ -543,7 +541,7 @@ def get_physical_type(obj):
         unit = obj
     else:
         try:
-            unit = quantity.Quantity(obj, copy=COPY_IF_NEEDED).unit
+            unit = quantity.Quantity(obj, copy=None).unit
         except TypeError as exc:
             raise TypeError(f"{obj} does not correspond to a physical type.") from exc
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,8 +20,6 @@ import numpy as np
 
 # LOCAL
 from astropy import config as _config
-from astropy.utils.compat import sanitize_copy_arg
-from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyWarning
@@ -241,7 +239,7 @@ class QuantityInfo(QuantityInfoBase):
             key: (data if key == "value" else getattr(cols[-1], key))
             for key in self._represent_as_dict_attrs
         }
-        map["copy"] = COPY_IF_NEEDED
+        map["copy"] = None
         out = self._construct_from_dict(map)
 
         # Set remaining info attributes
@@ -446,14 +444,12 @@ class Quantity(np.ndarray):
         if float_default:
             dtype = None
 
-        copy = sanitize_copy_arg(copy)
-
-        # optimize speed for Quantity with no dtype given, copy=COPY_IF_NEEDED
+        # optimize speed for Quantity with no dtype given, copy=None
         if isinstance(value, Quantity):
             if unit is not None and unit is not value.unit:
                 value = value.to(unit)
                 # the above already makes a copy (with float dtype)
-                copy = COPY_IF_NEEDED
+                copy = None
 
             if type(value) is not cls and not (subok and isinstance(value, cls)):
                 value = value.view(cls)
@@ -542,7 +538,7 @@ class Quantity(np.ndarray):
                 if unit is None:
                     unit = value_unit
                 elif unit is not value_unit:
-                    copy = COPY_IF_NEEDED  # copy will be made in conversion at end
+                    copy = None  # copy will be made in conversion at end
 
         value = np.array(
             value, dtype=dtype, copy=copy, order=order, subok=True, ndmin=ndmin
@@ -829,7 +825,7 @@ class Quantity(np.ndarray):
         if obj is None:
             obj = self.view(np.ndarray)
         else:
-            obj = np.array(obj, copy=COPY_IF_NEEDED, subok=True)
+            obj = np.array(obj, copy=None, subok=True)
 
         # Take the view, set the unit, and update possible other properties
         # such as ``info``, ``wrap_angle`` in `Longitude`, etc.
@@ -1692,7 +1688,7 @@ class Quantity(np.ndarray):
         if self.dtype.kind == "i" and check_precision:
             # If, e.g., we are casting float to int, we want to fail if
             # precision is lost, but let things pass if it works.
-            _value = np.array(_value, copy=COPY_IF_NEEDED, subok=True)
+            _value = np.array(_value, copy=None, subok=True)
             if not np.can_cast(_value.dtype, self.dtype):
                 self_dtype_array = np.array(_value, self.dtype, subok=True)
                 if not np.all((self_dtype_array == _value) | np.isnan(_value)):
@@ -1706,14 +1702,6 @@ class Quantity(np.ndarray):
         if _value.dtype.names is not None:
             _value = _value.astype(self.dtype, copy=False)
         return _value
-
-    if NUMPY_LT_2_0:
-
-        def itemset(self, *args):
-            if len(args) == 0:
-                raise ValueError("itemset must have at least one argument")
-
-            self.view(np.ndarray).itemset(*(args[:-1] + (self._to_own_unit(args[-1]),)))
 
     def tostring(self, order="C"):
         """Not implemented, use ``.value.tostring()`` instead."""
@@ -1791,17 +1779,10 @@ class Quantity(np.ndarray):
         )
 
     # ensure we do not return indices as quantities
-    if NUMPY_LT_2_0:
-
-        def argsort(self, axis=-1, kind=None, order=None):
-            return self.view(np.ndarray).argsort(axis=axis, kind=kind, order=order)
-
-    else:
-
-        def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
-            return self.view(np.ndarray).argsort(
-                axis=axis, kind=kind, order=order, stable=stable
-            )
+    def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
+        return self.view(np.ndarray).argsort(
+            axis=axis, kind=kind, order=order, stable=stable
+        )
 
     def searchsorted(self, v, *args, **kwargs):
         return np.searchsorted(
@@ -2223,9 +2204,9 @@ def allclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False) -> bool:
 
 
 def _unquantify_allclose_arguments(actual, desired, rtol, atol):
-    actual = Quantity(actual, subok=True, copy=COPY_IF_NEEDED)
+    actual = Quantity(actual, subok=True, copy=None)
 
-    desired = Quantity(desired, subok=True, copy=COPY_IF_NEEDED)
+    desired = Quantity(desired, subok=True, copy=None)
     try:
         desired = desired.to(actual.unit)
     except UnitsError:
@@ -2241,7 +2222,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         # units for a and b.
         atol = Quantity(0)
     else:
-        atol = Quantity(atol, subok=True, copy=COPY_IF_NEEDED)
+        atol = Quantity(atol, subok=True, copy=None)
         try:
             atol = atol.to(actual.unit)
         except UnitsError:
@@ -2250,7 +2231,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
                 f"({actual.unit}) are not convertible"
             )
 
-    rtol = Quantity(rtol, subok=True, copy=COPY_IF_NEEDED)
+    rtol = Quantity(rtol, subok=True, copy=None)
     try:
         rtol = rtol.to(dimensionless_unscaled)
     except Exception:

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -10,6 +10,7 @@ units for a given ufunc, given input units.
 from fractions import Fraction
 
 import numpy as np
+from numpy._core import umath as np_umath
 
 from astropy.units.core import (
     UnitConversionError,
@@ -18,12 +19,7 @@ from astropy.units.core import (
     dimensionless_unscaled,
     unit_scale_converter,
 )
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1
-
-if NUMPY_LT_2_0:
-    from numpy.core import umath as np_umath
-else:
-    from numpy._core import umath as np_umath
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_1
 
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
 
@@ -358,39 +354,36 @@ UNSUPPORTED_UFUNCS |= {
     np.isnat,
     np.gcd,
     np.lcm,
+    # string utilities - make no sense for Quantity.
+    np.bitwise_count,
+    np._core.umath.count,
+    np._core.umath.isalpha,
+    np._core.umath.isdigit,
+    np._core.umath.isspace,
+    np._core.umath.isnumeric,
+    np._core.umath.isdecimal,
+    np._core.umath.isalnum,
+    np._core.umath.istitle,
+    np._core.umath.islower,
+    np._core.umath.isupper,
+    np._core.umath.index,
+    np._core.umath.rindex,
+    np._core.umath.startswith,
+    np._core.umath.endswith,
+    np._core.umath.find,
+    np._core.umath.rfind,
+    np._core.umath.str_len,
+    np._core.umath._strip_chars,
+    np._core.umath._lstrip_chars,
+    np._core.umath._rstrip_chars,
+    np._core.umath._strip_whitespace,
+    np._core.umath._lstrip_whitespace,
+    np._core.umath._rstrip_whitespace,
+    np._core.umath._replace,
+    np._core.umath._expandtabs,
+    np._core.umath._expandtabs_length,
 }
 
-if not NUMPY_LT_2_0:
-    # string utilities - make no sense for Quantity.
-    UNSUPPORTED_UFUNCS |= {
-        np.bitwise_count,
-        np._core.umath.count,
-        np._core.umath.isalpha,
-        np._core.umath.isdigit,
-        np._core.umath.isspace,
-        np._core.umath.isnumeric,
-        np._core.umath.isdecimal,
-        np._core.umath.isalnum,
-        np._core.umath.istitle,
-        np._core.umath.islower,
-        np._core.umath.isupper,
-        np._core.umath.index,
-        np._core.umath.rindex,
-        np._core.umath.startswith,
-        np._core.umath.endswith,
-        np._core.umath.find,
-        np._core.umath.rfind,
-        np._core.umath.str_len,
-        np._core.umath._strip_chars,
-        np._core.umath._lstrip_chars,
-        np._core.umath._rstrip_chars,
-        np._core.umath._strip_whitespace,
-        np._core.umath._lstrip_whitespace,
-        np._core.umath._rstrip_whitespace,
-        np._core.umath._replace,
-        np._core.umath._expandtabs,
-        np._core.umath._expandtabs_length,
-    }
 if not NUMPY_LT_2_1:
     UNSUPPORTED_UFUNCS |= {
         np._core.umath._ljust,

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -8,8 +8,6 @@ import operator
 
 import numpy as np
 
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_24
-
 from .core import UNITY, Unit, UnitBase
 
 __all__ = ["StructuredUnit"]
@@ -239,10 +237,7 @@ class StructuredUnit:
             will return a new `~astropy.units.StructuredUnit` instance.
         """
         applied = tuple(func(part) for part in self.values())
-        if NUMPY_LT_1_24:
-            results = np.array(applied, self._units.dtype)[()]
-        else:
-            results = np.void(applied, self._units.dtype)
+        results = np.void(applied, self._units.dtype)
         if cls is not None:
             return results.view((cls, results.dtype))
 

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_allclose
 from astropy import constants as c
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 lu_units = [u.dex, u.mag, u.decibel]
 
@@ -1009,13 +1008,6 @@ class TestLogQuantityMethods:
                 assert res.unit == u.mag**2
             else:
                 assert res.unit == mag.unit
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="ptp method removed in numpy 2.0")
-    def test_always_ok_ptp(self):
-        for mag in self.mags:
-            res = mag.ptp()
-            assert np.all(res.value == mag._function_view.ptp().value)
-            assert res.unit == u.mag()
 
     def test_clip(self):
         for mag in self.mags:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_allclose, assert_array_almost_equal, assert_arr
 from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
 from astropy.utils import isiterable, minversion
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyWarning
 
 """ The Quantity class will represent a number + unit + uncertainty """
@@ -1660,7 +1659,7 @@ class QuantityMimic:
         self.value = value
         self.unit = unit
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         return np.array(self.value, dtype=dtype, copy=copy)
 
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -6,7 +6,6 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT
 
 
@@ -468,19 +467,6 @@ class TestArrayConversion:
         assert q1[1] == 1 * u.m / u.km
         with pytest.raises(TypeError):
             q1[1] = 1.5 * u.m / u.km
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="itemset method removed in numpy 2.0")
-    def test_itemset(self):
-        q1 = u.Quantity(np.array([1, 2, 3]), u.m / u.km, dtype=int)
-        assert q1.item(1) == 2 * q1.unit
-        q1.itemset(1, 1)
-        assert q1.item(1) == 1000 * u.m / u.km
-        q1.itemset(1, 100 * u.cm / u.km)
-        assert q1.item(1) == 1 * u.m / u.km
-        with pytest.raises(TypeError):
-            q1.itemset(1, 1.5 * u.m / u.km)
-        with pytest.raises(ValueError):
-            q1.itemset()
 
     def test_take_put(self):
         q1 = np.array([1, 2, 3]) * u.m / u.km

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -21,11 +21,6 @@ from astropy.units.quantity_helper.function_helpers import (
     TBD_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
-from astropy.utils.compat import (
-    NUMPY_LT_1_24,
-    NUMPY_LT_1_25,
-    NUMPY_LT_2_0,
-)
 
 if TYPE_CHECKING:
     from types import FunctionType, ModuleType
@@ -46,17 +41,7 @@ needs_array_function = pytest.mark.xfail(
 # To get the functions that could be covered, we look for those that
 # are in modules we care about and have been overridden.
 def get_wrapped_functions(*modules: ModuleType) -> set[FunctionType]:
-    if NUMPY_LT_1_25:
-
-        def allows_array_function_override(f):
-            return (
-                hasattr(f, "__wrapped__")
-                and f is not np.printoptions
-                and not f.__name__.startswith("_")
-            )
-
-    else:
-        from numpy.testing.overrides import allows_array_function_override
+    from numpy.testing.overrides import allows_array_function_override
 
     return {
         f
@@ -215,10 +200,8 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         assert type(a1) is np.ndarray
         assert type(a2) is np.ndarray
 
-    if not NUMPY_LT_2_0:
-
-        def test_matrix_transpose(self):
-            self.check(np.matrix_transpose)
+    def test_matrix_transpose(self):
+        self.check(np.matrix_transpose)
 
 
 class TestArgFunctions(NoUnitTestSetup):
@@ -319,13 +302,6 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         copy = np.copy(a=self.q)
         assert_array_equal(copy, self.q)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.asfarray is removed in NumPy 2.0")
-    @needs_array_function
-    def test_asfarray(self):
-        self.check(np.asfarray)  # noqa: NPY201
-        farray = np.asfarray(a=self.q)  # noqa: NPY201
-        assert_array_equal(farray, self.q)
-
     def test_empty_like(self):
         o = np.empty_like(self.q)
         assert o.shape == (3, 3)
@@ -355,11 +331,9 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.full_like(self.q, 0.5 * u.s)
 
-    if not NUMPY_LT_2_0:
-
-        def test_astype(self):
-            int32q = self.q.astype("int32")
-            assert_array_equal(np.astype(int32q, "int32"), int32q)
+    def test_astype(self):
+        int32q = self.q.astype("int32")
+        assert_array_equal(np.astype(int32q, "int32"), int32q)
 
 
 class TestAccessingParts(InvariantUnitTestSetup):
@@ -674,39 +648,13 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(TypeError):
             np.all(self.q)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
-    def test_sometrue(self):
-        with pytest.raises(TypeError):
-            np.sometrue(self.q)  # noqa: NPY003
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
-    def test_alltrue(self):
-        with pytest.raises(TypeError):
-            np.alltrue(self.q)  # noqa: NPY003
-
     def test_prod(self):
         with pytest.raises(u.UnitsError):
             np.prod(self.q)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
-    def test_product(self):
-        with pytest.raises(u.UnitsError):
-            np.product(self.q)  # noqa: NPY003
-
     def test_cumprod(self):
         with pytest.raises(u.UnitsError):
             np.cumprod(self.q)
-
-    @pytest.mark.skipif(
-        not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
-    )
-    @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
-    def test_cumproduct(self):
-        with pytest.raises(u.UnitsError):
-            np.cumproduct(self.q)  # noqa: NPY003
 
 
 class TestUfuncLike(InvariantUnitTestSetup):
@@ -716,11 +664,6 @@ class TestUfuncLike(InvariantUnitTestSetup):
 
     def test_round(self):
         self.check(np.round)
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
-    def test_round_(self):
-        self.check(np.round_)  # noqa: NPY003, NPY201
 
     def test_around(self):
         self.check(np.around)
@@ -1179,7 +1122,7 @@ class TestVariousProductFunctions:
 
 
 class TestIntDiffFunctions:
-    def check_trapezoid(self, func):
+    def test_trapezoid(self):
         y = np.arange(9.0) * u.m / u.s
         out = func(y)
         expected = func(y.value) * y.unit
@@ -1194,16 +1137,6 @@ class TestIntDiffFunctions:
         out = func(y, x)
         expected = func(y.value, x.value) * y.unit * x.unit
         assert np.all(out == expected)
-
-    if NUMPY_LT_2_0:
-
-        def test_trapz(self):
-            self.check_trapezoid(np.trapz)
-
-    else:
-
-        def test_trapezoid(self):
-            self.check_trapezoid(np.trapezoid)
 
     def test_diff(self):
         # Simple diff works out of the box.
@@ -1770,10 +1703,6 @@ class TestSortFunctions(InvariantUnitTestSetup):
     def test_sort_axis(self):
         self.check(np.sort, axis=0)
 
-    @pytest.mark.skipif(not NUMPY_LT_1_24, reason="np.msort is deprecated")
-    def test_msort(self):
-        self.check(np.msort)
-
     @needs_array_function
     def test_sort_complex(self):
         self.check(np.sort_complex)
@@ -1961,50 +1890,48 @@ class TestSetOpsFunctions:
     def test_unique_more_complex(self, kwargs):
         self.check1(np.unique, **kwargs)
 
-    if not NUMPY_LT_2_0:
+    @needs_array_function
+    def test_unique_all(self):
+        values, indices, inverse_indices, counts = np.unique(
+            self.q,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            equal_nan=False,
+        )
+        res = np.unique_all(self.q)
+        assert len(res) == 4
 
-        @needs_array_function
-        def test_unique_all(self):
-            values, indices, inverse_indices, counts = np.unique(
-                self.q,
-                return_index=True,
-                return_inverse=True,
-                return_counts=True,
-                equal_nan=False,
-            )
-            res = np.unique_all(self.q)
-            assert len(res) == 4
+        assert_array_equal(res.values, values)
+        assert_array_equal(res.indices, indices)
+        assert_array_equal(res.inverse_indices, inverse_indices)
+        assert_array_equal(res.counts, counts)
 
-            assert_array_equal(res.values, values)
-            assert_array_equal(res.indices, indices)
-            assert_array_equal(res.inverse_indices, inverse_indices)
-            assert_array_equal(res.counts, counts)
+    @needs_array_function
+    def test_unique_counts(self):
+        values, counts = np.unique(self.q, return_counts=True, equal_nan=False)
+        res = np.unique_counts(self.q)
+        assert len(res) == 2
 
-        @needs_array_function
-        def test_unique_counts(self):
-            values, counts = np.unique(self.q, return_counts=True, equal_nan=False)
-            res = np.unique_counts(self.q)
-            assert len(res) == 2
+        assert_array_equal(res.values, values)
+        assert_array_equal(res.counts, counts)
 
-            assert_array_equal(res.values, values)
-            assert_array_equal(res.counts, counts)
+    @needs_array_function
+    def test_unique_inverse(self):
+        values, inverse_indices = np.unique(
+            self.q, return_inverse=True, equal_nan=False
+        )
+        res = np.unique_inverse(self.q)
+        assert len(res) == 2
 
-        @needs_array_function
-        def test_unique_inverse(self):
-            values, inverse_indices = np.unique(
-                self.q, return_inverse=True, equal_nan=False
-            )
-            res = np.unique_inverse(self.q)
-            assert len(res) == 2
+        assert_array_equal(res.values, values)
+        assert_array_equal(res.inverse_indices, inverse_indices)
 
-            assert_array_equal(res.values, values)
-            assert_array_equal(res.inverse_indices, inverse_indices)
-
-        @needs_array_function
-        def test_unique_values(self):
-            values = np.unique(self.q, equal_nan=False)
-            res = np.unique_values(self.q)
-            assert_array_equal(res, values)
+    @needs_array_function
+    def test_unique_values(self):
+        values = np.unique(self.q, equal_nan=False)
+        res = np.unique_values(self.q)
+        assert_array_equal(res, values)
 
     @needs_array_function
     @pytest.mark.parametrize("kwargs", ({}, dict(return_indices=True)))
@@ -2217,9 +2144,9 @@ class TestLinAlg(InvariantUnitTestSetup):
             np.linalg.pinv(self.q.value, rcond.to_value(self.q.unit)) / self.q.unit
         )
         assert_array_equal(pinv2, expected2)
-        if not NUMPY_LT_2_0:
-            pinv3 = np.linalg.pinv(self.q, rtol=rcond)
-            assert_array_equal(pinv3, expected2)
+
+        pinv3 = np.linalg.pinv(self.q, rtol=rcond)
+        assert_array_equal(pinv3, expected2)
 
     @needs_array_function
     def test_tensorinv(self):
@@ -2361,79 +2288,76 @@ class TestLinAlg(InvariantUnitTestSetup):
         wx = np.linalg.eigvalsh(self.q.value) << self.q.unit
         assert_array_equal(w, wx)
 
-    if not NUMPY_LT_2_0:
-        # Numpy 2.0 added array-api compatible definitions of
-        # diagonal and trace to np.linalg. Since these have
-        # name conflicts with the main numpy namespace, they
-        # are tracked as linalg_diagonal and linalg_trace.
-        def test_diagonal(self):
-            self.check(np.linalg.diagonal)
+    # Numpy 2.0 added array-api compatible definitions of
+    # diagonal and trace to np.linalg. Since these have
+    # name conflicts with the main numpy namespace, they
+    # are tracked as linalg_diagonal and linalg_trace.
+    def test_diagonal(self):
+        self.check(np.linalg.diagonal)
 
-        def test_trace(self):
-            self.check(np.trace)
+    def test_trace(self):
+        self.check(np.trace)
 
-        @needs_array_function
-        def test_cross(self):
-            q1 = np.array([1, 2, 3]) << u.m
-            q2 = np.array([4, 5, 6]) << u.s
-            assert_array_equal(np.linalg.cross(q1, q2), np.cross(q1, q2))
-            assert_array_equal(np.linalg.cross(q1, q2.value), np.cross(q1, q2.value))
+    @needs_array_function
+    def test_cross(self):
+        q1 = np.array([1, 2, 3]) << u.m
+        q2 = np.array([4, 5, 6]) << u.s
+        assert_array_equal(np.linalg.cross(q1, q2), np.cross(q1, q2))
+        assert_array_equal(np.linalg.cross(q1, q2.value), np.cross(q1, q2.value))
 
-        @needs_array_function
-        def test_outer(self):
-            q = self.q.flatten()
-            assert_array_equal(np.linalg.outer(q, q), np.outer(q, q))
-            assert_array_equal(np.linalg.outer(q, q.value), np.outer(q, q.value))
+    @needs_array_function
+    def test_outer(self):
+        q = self.q.flatten()
+        assert_array_equal(np.linalg.outer(q, q), np.outer(q, q))
+        assert_array_equal(np.linalg.outer(q, q.value), np.outer(q, q.value))
 
-        @needs_array_function
-        def test_svdvals(self):
-            _, ref, _ = np.linalg.svd(self.q)
-            res = np.linalg.svdvals(self.q)
-            assert_allclose(res, ref, rtol=5e-16)
+    @needs_array_function
+    def test_svdvals(self):
+        _, ref, _ = np.linalg.svd(self.q)
+        res = np.linalg.svdvals(self.q)
+        assert_allclose(res, ref, rtol=5e-16)
 
-        @needs_array_function
-        def test_vecdot(self):
-            ref = (self.q * self.q).sum(-1)
-            res = np.linalg.vecdot(self.q, self.q)
-            assert_array_equal(res, ref)
+    @needs_array_function
+    def test_vecdot(self):
+        ref = (self.q * self.q).sum(-1)
+        res = np.linalg.vecdot(self.q, self.q)
+        assert_array_equal(res, ref)
 
-        @needs_array_function
-        def test_tensordot(self):
-            ref = np.tensordot(self.q, self.q)
-            res = np.linalg.tensordot(self.q, self.q)
-            assert_array_equal(res, ref)
+    @needs_array_function
+    def test_tensordot(self):
+        ref = np.tensordot(self.q, self.q)
+        res = np.linalg.tensordot(self.q, self.q)
+        assert_array_equal(res, ref)
 
-        @needs_array_function
-        def test_matmul(self):
-            ref = np.matmul(self.q, self.q)
-            res = np.linalg.matmul(self.q, self.q)
-            assert_array_equal(res, ref)
+    @needs_array_function
+    def test_matmul(self):
+        ref = np.matmul(self.q, self.q)
+        res = np.linalg.matmul(self.q, self.q)
+        assert_array_equal(res, ref)
 
-        def test_matrix_transpose(self):
-            t = np.linalg.matrix_transpose(self.q)
-            assert_array_equal(t, self.q.swapaxes(-2, -1))
+    def test_matrix_transpose(self):
+        t = np.linalg.matrix_transpose(self.q)
+        assert_array_equal(t, self.q.swapaxes(-2, -1))
 
-        @needs_array_function
-        def test_matrix_norm(self):
-            n = np.linalg.matrix_norm(self.q)
-            expected = np.linalg.norm(self.q.value) << self.q.unit
-            assert_array_equal(n, expected)
+    @needs_array_function
+    def test_matrix_norm(self):
+        n = np.linalg.matrix_norm(self.q)
+        expected = np.linalg.norm(self.q.value) << self.q.unit
+        assert_array_equal(n, expected)
 
-        @needs_array_function
-        def test_vector_norm(self):
-            n = np.linalg.vector_norm(self.q)
-            expected = np.linalg.norm(self.q.value.ravel()) << self.q.unit
-            assert_array_equal(n, expected)
-            # Special case: 1-D, ord=0.
-            n1 = np.linalg.vector_norm(self.q[0], ord=0)
-            expected1 = np.linalg.norm(self.q[0].value.ravel(), ord=0) << u.one
-            assert_array_equal(n1, expected1)
-            # Axis combo, just in case
-            n2 = np.linalg.vector_norm(self.q, axis=(-1, -2))
-            expected2 = (
-                np.linalg.vector_norm(self.q.value, axis=(-1, -2)) << self.q.unit
-            )
-            assert_array_equal(n2, expected2)
+    @needs_array_function
+    def test_vector_norm(self):
+        n = np.linalg.vector_norm(self.q)
+        expected = np.linalg.norm(self.q.value.ravel()) << self.q.unit
+        assert_array_equal(n, expected)
+        # Special case: 1-D, ord=0.
+        n1 = np.linalg.vector_norm(self.q[0], ord=0)
+        expected1 = np.linalg.norm(self.q[0].value.ravel(), ord=0) << u.one
+        assert_array_equal(n1, expected1)
+        # Axis combo, just in case
+        n2 = np.linalg.vector_norm(self.q, axis=(-1, -2))
+        expected2 = np.linalg.vector_norm(self.q.value, axis=(-1, -2)) << self.q.unit
+        assert_array_equal(n2, expected2)
 
 
 class TestRecFunctions:

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -17,16 +17,12 @@ from astropy import units as u
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_25, NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-if NUMPY_LT_2_0:
-    from numpy.core import umath as np_umath
-else:
-    from numpy._core import umath as np_umath
+from numpy._core import umath as np_umath
 
 
 class testcase(NamedTuple):
@@ -360,7 +356,6 @@ class TestQuantityMathFuncs:
         r2 = np.matmul(q1, q2)
         assert np.all(r2 == np.matmul(q1.value, q2.value) * q1.unit * q2.unit)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="vecdot only added in numpy 2.0")
     def test_vecdot(self):
         q1 = np.array([1j, 2j, 3j]) * u.m
         q2 = np.array([4j, 5j, 6j]) / u.s
@@ -1075,15 +1070,6 @@ class TestWhere:
         result = np.add(q, 1 * u.km, out=out, where=[True, True, True, False])
         assert result is out
         assert_array_equal(result, [1000.0, 1001.0, 1002.0, 0.0] << u.m)
-
-    @pytest.mark.xfail(
-        NUMPY_LT_1_25, reason="where array_ufunc support introduced in numpy 1.25"
-    )
-    def test_exception_with_where_quantity(self):
-        a = np.ones(2)
-        where = np.ones(2, bool) << u.m
-        with pytest.raises(TypeError, match="all returned NotImplemented"):
-            np.add(a, a, out=a, where=where)
 
 
 @pytest.mark.skipif(not hasattr(np_umath, "clip"), reason="no clip ufunc available")

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -9,30 +9,19 @@ import numpy as np
 from astropy.utils import minversion
 
 __all__ = [
-    "NUMPY_LT_1_24",
-    "NUMPY_LT_1_25",
-    "NUMPY_LT_1_26",
-    "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
-    "COPY_IF_NEEDED",
+    "None",
     "sanitize_copy_arg",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_24 = not minversion(np, "1.24")
-NUMPY_LT_1_25 = not minversion(np, "1.25")
-NUMPY_LT_1_26 = not minversion(np, "1.26")
-NUMPY_LT_2_0 = not minversion(np, "2.0.dev")
 NUMPY_LT_2_1 = not minversion(np, "2.1.dev")
 
 
-COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
-
-
 def sanitize_copy_arg(copy, /):
-    if not NUMPY_LT_2_0 and copy is False:
+    if copy is False:
         return None
 
     return copy

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -22,11 +22,6 @@ from astropy.units.tests.test_quantity_non_ufuncs import (
     get_covered_functions,
     get_wrapped_functions,
 )
-from astropy.utils.compat import (
-    NUMPY_LT_1_24,
-    NUMPY_LT_1_25,
-    NUMPY_LT_2_0,
-)
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
     APPLY_TO_BOTH_FUNCTIONS,
@@ -107,10 +102,8 @@ class TestShapeManipulation(BasicTestSetup):
     def test_transpose(self):
         self.check(np.transpose)
 
-    if not NUMPY_LT_2_0:
-
-        def test_matrix_transpose(self):
-            self.check(np.matrix_transpose)
+    def test_matrix_transpose(self):
+        self.check(np.matrix_transpose)
 
     def test_atleast_1d(self):
         self.check(np.atleast_1d)
@@ -288,17 +281,9 @@ class TestCopyAndCreation(InvariantMaskTestSetup):
         copy = np.copy(a=self.ma)
         assert_array_equal(copy, self.ma)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.asfarray is removed in NumPy 2.0")
-    def test_asfarray(self):
-        self.check(np.asfarray)  # noqa: NPY201
-        farray = np.asfarray(a=self.ma)  # noqa: NPY201
-        assert_array_equal(farray, self.ma)
-
-    if not NUMPY_LT_2_0:
-
-        def test_astype(self):
-            int32ma = self.ma.astype("int32")
-            assert_array_equal(np.astype(int32ma, "int32"), int32ma)
+    def test_astype(self):
+        int32ma = self.ma.astype("int32")
+        assert_array_equal(np.astype(int32ma, "int32"), int32ma)
 
 
 class TestArrayCreation(MaskedArraySetup):
@@ -619,41 +604,14 @@ class TestMethodLikes(MaskedArraySetup):
     def test_all(self):
         self.check(np.all)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
-    def test_sometrue(self):
-        self.check(np.sometrue, method="any")  # noqa: NPY003
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
-    def test_alltrue(self):
-        self.check(np.alltrue, method="all")  # noqa: NPY003
-
     def test_prod(self):
         self.check(np.prod)
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
-    def test_product(self):
-        self.check(np.product, method="prod")  # noqa: NPY003
 
     def test_cumprod(self):
         self.check(np.cumprod)
 
-    @pytest.mark.skipif(
-        not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
-    )
-    @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
-    def test_cumproduct(self):
-        self.check(np.cumproduct, method="cumprod")  # noqa: NPY003
-
     def test_round(self):
         self.check(np.round, method="round")
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
-    def test_round_(self):
-        self.check(np.round_, method="round")  # noqa: NPY003, NPY201
 
     def test_around(self):
         self.check(np.around, method="round")
@@ -916,11 +874,6 @@ class TestReductionLikeFunctions(MaskedArraySetup):
         assert o2 is out
         assert_array_equal(o2.unmasked, expected.unmasked)
         assert_array_equal(o2.mask, expected.mask)
-        if NUMPY_LT_2_0:
-            # Method is removed in numpy 2.0.
-            o3 = self.ma.ptp(**kwargs)
-            assert_array_equal(o3.unmasked, expected.unmasked)
-            assert_array_equal(o3.mask, expected.mask)
 
     def test_trace(self):
         o = np.trace(self.ma)
@@ -956,10 +909,6 @@ class TestPartitionLikeFunctions:
         assert_array_equal(o.filled(np.nan), expected)
         assert_array_equal(o.mask, np.isnan(expected))
         # Also check that we can give an output MaskedArray.
-        if NUMPY_LT_1_25 and kwargs.get("keepdims", False):
-            # numpy bug gh-22714 prevents using out with keepdims=True.
-            # This is fixed in numpy 1.25.
-            return
 
         out = np.zeros_like(o)
         o2 = function(self.ma, *args, out=out, **kwargs)
@@ -1013,15 +962,8 @@ class TestIntDiffFunctions(MaskedArraySetup):
         assert_array_equal(out.unmasked, func(self.a))
         assert_array_equal(out.mask, np.array([True, False]))
 
-    if NUMPY_LT_2_0:
-
-        def test_trapz(self):
-            self.check_trapezoid(np.trapz)
-
-    else:
-
-        def test_trapezoid(self):
-            self.check_trapezoid(np.trapezoid)
+    def test_trapezoid(self):
+        self.check_trapezoid(np.trapezoid)
 
     def test_gradient(self):
         out = np.gradient(self.ma)
@@ -1068,7 +1010,7 @@ class TestSpaceFunctions:
         # are determined just by their respective point?
         if function is np.geomspace:
             expected_mask[0] = self.mask_a
-        if NUMPY_LT_2_0 or function is not np.geomspace:
+        else:
             expected_mask[-1] = self.mask_b
 
         assert_array_equal(out.unmasked, expected)
@@ -1177,12 +1119,6 @@ class TestSortFunctions(MaskedArraySetup):
         o = np.sort_complex(ma)
         indx = np.lexsort((ma.unmasked.imag, ma.unmasked.real, ma.mask))
         expected = ma[indx]
-        assert_masked_equal(o, expected)
-
-    @pytest.mark.skipif(not NUMPY_LT_1_24, reason="np.msort is deprecated")
-    def test_msort(self):
-        o = np.msort(self.ma)
-        expected = np.sort(self.ma, axis=0)
         assert_masked_equal(o, expected)
 
     def test_partition(self):
@@ -1491,30 +1427,25 @@ class TestArraySetOps:
         assert_array_equal(indices2, [1, 0, 2])
         assert_array_equal(inverse_indices2, [1, 0, 2])
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def check_unique(self, test):
         for name in test._fields:
             assert_array_equal(getattr(test, name), getattr(self, name))
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_all(self):
         test = np.unique_all(self.data)
         assert len(test) == 4
         self.check_unique(test)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_counts(self):
         test = np.unique_counts(self.data)
         assert len(test) == 2
         self.check_unique(test)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_inverse(self):
         test = np.unique_inverse(self.data)
         assert len(test) == 2
         self.check_unique(test)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_values(self):
         test = np.unique_values(self.data)
         assert isinstance(test, Masked)
@@ -1596,9 +1527,6 @@ class TestArraySetOps:
         c = np.isin(a.astype(dtype), b.astype(dtype))
         assert_masked_equal(c, ec)
 
-    @pytest.mark.filterwarnings("ignore:in1d.*deprecated")  # not NUMPY_LT_2_0
-    def test_in1d(self):
-        # Once we require numpy>=2.0, these tests should be joined with np.isin.
         a = Masked([1, 2, 5, -2, -1], mask=[0, 0, 0, 1, 1])
         b = Masked([1, 2, 3, 4, 5, -2], mask=[0, 0, 0, 0, 0, 1])
         test = np.in1d(a, b)
@@ -1613,7 +1541,6 @@ class TestArraySetOps:
         assert_masked_equal(np.in1d(Masked([]), []), Masked([]))
         assert_masked_equal(np.in1d(Masked([]), [], invert=True), Masked([]))
 
-    @pytest.mark.skipif(NUMPY_LT_1_24, reason="kind introduced in numpy 1.24")
     def test_in1d_kind_table_error(self):
         with pytest.raises(ValueError, match="'table' method is not supported"):
             np.in1d(Masked([1, 2, 3]), [4, 5], kind="table")

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -18,7 +18,6 @@ from numpy.testing import assert_allclose, assert_array_equal
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.utils import minversion
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_25
 from astropy.utils.masked.core import Masked
 
 from .test_masked import (
@@ -116,7 +115,6 @@ class MaskedUfuncTests(MaskedArraySetup):
         with pytest.raises(TypeError):
             np.add(self.ma, self.mb, out=out)
 
-    @pytest.mark.xfail(NUMPY_LT_1_25, reason="masked where not supported in numpy<1.25")
     def test_ufunc_inplace_error_masked_where(self):
         # Input and output are not masked, but where is.
         # Note: prior to numpy 1.25, we cannot control this.

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -6,15 +6,8 @@ import numbers
 from itertools import zip_longest
 
 import numpy as np
-
-from astropy.utils.compat import NUMPY_LT_2_0
-
-if NUMPY_LT_2_0:
-    import numpy.core as np_core
-    from numpy.core.multiarray import normalize_axis_index
-else:
-    import numpy._core as np_core
-    from numpy.lib.array_utils import normalize_axis_index
+import numpy._core as np_core
+from numpy.lib.array_utils import normalize_axis_index
 
 __all__ = [
     "NDArrayShapeMethods",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=1.23",
+    "numpy>=2.0.0rc1",
     "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2024.2.26.0.28.55",
     "PyYAML>=3.13",
@@ -126,7 +126,7 @@ wcslint = "astropy.wcs.wcslint:main"
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0,<3.1.0",
-            "numpy>=1.25",
+            "numpy>=2.0.0rc1",
             "extension-helpers==1.*"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Description
NumPy 2.0.0rc1 is here, and new is better, so let's just onboard our users onto the hype train and just pull the bandaid immediately !
- better promote all the hard work that went into numpy 2.0
- improved performance for end users ...
- ... and cheaper CI for everyone dowstream of us !
- better science (?)!

in short: WCGW ?

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
