### PR TITLE
Prefer `scipy.spatial` `KDTree` over `cKDTree`

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -455,23 +455,11 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt="kdtree", forceunit=None):
 
     Returns
     -------
-    kdt : `~scipy.spatial.cKDTree` or `~scipy.spatial.KDTree`
+    kdt : `~scipy.spatial.KDTree`
         The KD-Tree representing the 3D cartesian representation of the input
         coordinates.
     """
-    from warnings import warn
-
-    # without scipy this will immediately fail
-    from scipy import spatial
-
-    try:
-        KDTree = spatial.cKDTree
-    except Exception:
-        warn(
-            "C-based KD tree not found, falling back on (much slower) "
-            "python implementation"
-        )
-        KDTree = spatial.KDTree
+    from scipy.spatial import KDTree
 
     if attrname_or_kdt is True:  # backwards compatibility for pre v0.4
         attrname_or_kdt = "kdtree"
@@ -503,15 +491,9 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt="kdtree", forceunit=None):
         # There should be no NaNs in the kdtree data.
         if np.isnan(flatxyz.value).any():
             raise ValueError("Catalog coordinates cannot contain NaN entries.")
-        try:
-            # Set compact_nodes=False, balanced_tree=False to use
-            # "sliding midpoint" rule, which is much faster than standard for
-            # many common use cases
-            kdt = KDTree(flatxyz.value.T, compact_nodes=False, balanced_tree=False)
-        except TypeError:
-            # Python implementation does not take compact_nodes and balanced_tree
-            # as arguments.  However, it uses sliding midpoint rule by default
-            kdt = KDTree(flatxyz.value.T)
+        # Not obvious if compact_nodes=False, balanced_tree=False is still needed but
+        # we stay backwards-compatible with previous versions of `astropy` for now.
+        kdt = KDTree(flatxyz.value.T, compact_nodes=False, balanced_tree=False)
 
     if attrname_or_kdt:
         # cache the kdtree in `coord`

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -120,20 +120,6 @@ def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
-def test_python_kdtree(monkeypatch):
-    from astropy.coordinates import ICRS
-
-    cmatch = ICRS([4, 2.1] * u.degree, [0, 0] * u.degree, distance=[1, 2] * u.kpc)
-    ccatalog = ICRS(
-        [1, 2, 3, 4] * u.degree, [0, 0, 0, 0] * u.degree, distance=[1, 2, 3, 4] * u.kpc
-    )
-
-    monkeypatch.delattr("scipy.spatial.cKDTree")
-    with pytest.warns(UserWarning, match=r"C-based KD tree not found"):
-        matching.match_coordinates_sky(cmatch, ccatalog)
-
-
-@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_matching_method():
     from astropy.coordinates import ICRS, SkyCoord
     from astropy.coordinates.matching import match_coordinates_3d, match_coordinates_sky

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -234,7 +234,7 @@ def join_distance(distance, kdtree_args=None, query_args=None):
     "fuzzy" match can apply to 1-D or 2-D columns, where in the latter case
     the distance is a vector distance.
 
-    The distance cross-matching is done using `scipy.spatial.cKDTree`. If
+    The distance cross-matching is done using `scipy.spatial.KDTree`. If
     necessary you can tweak the default behavior by providing ``dict`` values
     for the ``kdtree_args`` or ``query_args``.
 
@@ -243,9 +243,9 @@ def join_distance(distance, kdtree_args=None, query_args=None):
     distance : float or `~astropy.units.Quantity` ['length']
         Maximum distance between points to be considered a join match
     kdtree_args : dict, None
-        Optional extra args for `~scipy.spatial.cKDTree`
+        Optional extra args for `~scipy.spatial.KDTree`
     query_args : dict, None
-        Optional extra args for `~scipy.spatial.cKDTree.query_ball_tree`
+        Optional extra args for `~scipy.spatial.KDTree.query_ball_tree`
 
     Returns
     -------
@@ -275,7 +275,7 @@ def join_distance(distance, kdtree_args=None, query_args=None):
 
     """
     try:
-        from scipy.spatial import cKDTree
+        from scipy.spatial import KDTree
     except ImportError as exc:
         raise ImportError("scipy is required to use join_distance()") from exc
 
@@ -306,8 +306,8 @@ def join_distance(distance, kdtree_args=None, query_args=None):
             col2.shape = col2.shape + (1,)
 
         # Cross-match col1 and col2 within dist using KDTree
-        kd1 = cKDTree(col1, **kdtree_args)
-        kd2 = cKDTree(col2, **kdtree_args)
+        kd1 = KDTree(col1, **kdtree_args)
+        kd2 = KDTree(col2, **kdtree_args)
         nears = kd1.query_ball_tree(kd2, r=dist, **query_args)
 
         # Output of above is nears which is a list of lists, where the outer

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -1186,8 +1186,8 @@ a generic distance between column values using the
 :func:`~astropy.table.join_distance` join function. This can apply to 1D or 2D
 (vector) columns. This will look very similar to the coordinates example, but
 here there is a bit more flexibility. The matching is done using
-:class:`scipy.spatial.cKDTree` and
-:meth:`scipy.spatial.cKDTree.query_ball_tree`, and the behavior of these can be
+:class:`scipy.spatial.KDTree` and
+:meth:`scipy.spatial.KDTree.query_ball_tree`, and the behavior of these can be
 controlled via the ``kdtree_args`` and ``query_args`` arguments, respectively.
 
 .. _unique-rows:


### PR DESCRIPTION
### Description

Before `scipy` v1.6.0 it used to be the case that `cKDTree` was more performant, but [since then `cKDTree` and `KDTree` are functionally identical](https://docs.scipy.org/doc/scipy/release/1.6.0-notes.html#scipy-spatial-improvements) and the [recommendation is to prefer `KDTree`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html).

As far as I can tell this change should be invisible to normal users, other than very minor changes in some documentation.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.