### PR TITLE
Update Ruff `pre-commit` hook to v0.3.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.0"
+    rev: "v0.3.4"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -526,9 +526,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         if len(args) > 0:
             raise TypeError(
-                "{}.__init__ had {} remaining unhandled arguments".format(
-                    self.__class__.__name__, len(args)
-                )
+                f"{type(self).__name__}.__init__ had {len(args)} remaining "
+                "unhandled arguments"
             )
 
         if representation_data is None and differential_data is not None:

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -762,9 +762,8 @@ class BaseHeader:
             and self.__class__.__name__ != "EcsvHeader"
         ):
             raise ValueError(
-                "Table format guessing requires at least two columns, got {}".format(
-                    list(self.colnames)
-                )
+                "Table format guessing requires at least two columns, "
+                f"got {list(self.colnames)}"
             )
 
         if names is not None and len(names) != len(self.colnames):

--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -105,9 +105,8 @@ def sortmore(*args, **kw):
         k = lambda x: (globalkey(*x),) + tuple(f(z) for (f, z) in zip(key, x))
     else:
         raise KeyError(
-            "kw arg 'key' should be None, callable, or a sequence of callables, not {}".format(
-                type(key)
-            )
+            "kw arg 'key' should be None, callable, or a sequence of callables, "
+            f"not {type(key)}"
         )
 
     res = sorted(zip(*args), key=k)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1689,7 +1689,9 @@ def test_newline_as_delimiter(delimiter, fast_reader):
         eol = "\r"
 
     inp0 = ["a  | b | c ", " 1 | '2' | 3.00000 "]
-    inp1 = "a {0:s} b {0:s}c{1:s} 1 {0:s}'2'{0:s} 3.0".format(delimiter, eol)
+    inp1 = (
+        f"a {delimiter:s} b {delimiter:s}c{eol:s} 1 {delimiter:s}'2'{delimiter:s} 3.0"
+    )
     inp2 = [f"a {delimiter} b{delimiter} c", f"1{delimiter} '2' {delimiter} 3.0"]
 
     t0 = ascii.read(inp0, delimiter="|", fast_reader=fast_reader)
@@ -1704,7 +1706,9 @@ def test_newline_as_delimiter(delimiter, fast_reader):
     assert_table_equal(t2, t0)
 
     inp0 = 'a {0:s} b {0:s} c{1:s} 1 {0:s}"2"{0:s} 3.0'.format("|", eol)
-    inp1 = 'a {0:s} b {0:s} c{1:s} 1 {0:s}"2"{0:s} 3.0'.format(delimiter, eol)
+    inp1 = (
+        f'a {delimiter:s} b {delimiter:s} c{eol:s} 1 {delimiter:s}"2"{delimiter:s} 3.0'
+    )
 
     t0 = ascii.read(inp0, delimiter="|", fast_reader=fast_reader)
     t1 = ascii.read(inp1, delimiter=delimiter, fast_reader=fast_reader)

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -208,9 +208,8 @@ def _get_format_class(format, reader_writer_cls, label):
             reader_writer_cls = core.FORMAT_CLASSES[format]
         else:
             raise ValueError(
-                "ASCII format {!r} not in allowed list {}".format(
-                    format, sorted(core.FORMAT_CLASSES)
-                )
+                f"ASCII format {format!r} not in allowed list "
+                f"{sorted(core.FORMAT_CLASSES)}"
             )
     return reader_writer_cls
 
@@ -1015,8 +1014,10 @@ def write(
 
     if diff_format_with_names:
         warnings.warn(
-            "The key(s) {} specified in the formats argument do not match a column"
-            " name.".format(diff_format_with_names),
+            (
+                f"The key(s) {diff_format_with_names} specified in the formats "
+                "argument do not match a column name."
+            ),
             AstropyWarning,
         )
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -129,8 +129,8 @@ class Card(_Verify):
     _rvkc_identifier = r"[a-zA-Z_]\w*"
     _rvkc_field = _rvkc_identifier + r"(\.\d+)?"
     _rvkc_field_specifier_s = rf"{_rvkc_field}(\.{_rvkc_field})*"
-    _rvkc_field_specifier_val = r"(?P<keyword>{}): +(?P<val>{})".format(
-        _rvkc_field_specifier_s, _numr_FSC
+    _rvkc_field_specifier_val = (
+        rf"(?P<keyword>{_rvkc_field_specifier_s}): +(?P<val>{_numr_FSC})"
     )
     _rvkc_keyword_val = rf"\'(?P<rawval>{_rvkc_field_specifier_val})\'"
     _rvkc_keyword_val_comm = rf" *{_rvkc_keyword_val} *(/ *(?P<comm>[ -~]*))?$"
@@ -141,9 +141,7 @@ class Card(_Verify):
     # string that is being used to index into a card list that contains
     # record value keyword cards (ex. 'DP1.AXIS.1')
     _rvkc_keyword_name_RE = re.compile(
-        r"(?P<keyword>{})\.(?P<field_specifier>{})$".format(
-            _rvkc_identifier, _rvkc_field_specifier_s
-        )
+        rf"(?P<keyword>{_rvkc_identifier})\.(?P<field_specifier>{_rvkc_field_specifier_s})$"
     )
 
     # regular expression to extract the field specifier and value and comment

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1092,9 +1092,9 @@ class Column(NotifierMixin):
                     # is in the range allowed by the column's format
                     msg = (
                         "Column null option (TNULLn) is invalid for binary "
-                        "table columns of type {!r} (got {!r}).  The invalid "
-                        "value will be ignored for the purpose of formatting "
-                        "the data in this column.".format(format, null)
+                        f"table columns of type {format!r} (got {null!r}).  "
+                        "The invalid value will be ignored for the purpose of "
+                        "formatting the data in this column."
                     )
 
             if msg is None:
@@ -1203,12 +1203,10 @@ class Column(NotifierMixin):
                     msg = None
                 elif reduce(operator.mul, dims_tuple) > format.repeat:
                     msg = (
-                        "The repeat count of the column format {!r} for column {!r} "
-                        "is fewer than the number of elements per the TDIM "
-                        "argument {!r}.  The invalid TDIMn value will be ignored "
-                        "for the purpose of formatting this column.".format(
-                            name, format, dim
-                        )
+                        f"The repeat count of the column format {name!r} for column "
+                        f"{format!r} is fewer than the number of elements per the TDIM "
+                        f"argument {dim!r}.  The invalid TDIMn value will be ignored "
+                        "for the purpose of formatting this column."
                     )
 
             if msg is None:
@@ -1221,8 +1219,8 @@ class Column(NotifierMixin):
             if not isinstance(coord_type, str):
                 msg = (
                     "Coordinate/axis type option (TCTYPn) must be a string "
-                    "(got {!r}). The invalid keyword will be ignored for the "
-                    "purpose of formatting this column.".format(coord_type)
+                    f"(got {coord_type!r}). The invalid keyword will be ignored "
+                    "for the purpose of formatting this column."
                 )
             elif len(coord_type) > 8:
                 msg = (
@@ -1242,8 +1240,8 @@ class Column(NotifierMixin):
             if not isinstance(coord_unit, str):
                 msg = (
                     "Coordinate/axis unit option (TCUNIn) must be a string "
-                    "(got {!r}). The invalid keyword will be ignored for the "
-                    "purpose of formatting this column.".format(coord_unit)
+                    f"(got {coord_unit!r}). The invalid keyword will be ignored "
+                    "for the purpose of formatting this column."
                 )
 
             if msg is None:
@@ -1260,11 +1258,9 @@ class Column(NotifierMixin):
                 msg = None
                 if not isinstance(v, numbers.Real):
                     msg = (
-                        "Column {} option ({}n) must be a real floating type (got"
-                        " {!r}). The invalid value will be ignored for the purpose of"
-                        " formatting the data in this column.".format(
-                            k, ATTRIBUTE_TO_KEYWORD[k], v
-                        )
+                        f"Column {k} option ({ATTRIBUTE_TO_KEYWORD[k]}n) must be a "
+                        f"real floating type (got {v!r}). The invalid value will be "
+                        "ignored for the purpose of formatting the data in this column."
                     )
 
                 if msg is None:
@@ -1277,8 +1273,8 @@ class Column(NotifierMixin):
             if not isinstance(time_ref_pos, str):
                 msg = (
                     "Time coordinate reference position option (TRPOSn) must be "
-                    "a string (got {!r}). The invalid keyword will be ignored for "
-                    "the purpose of formatting this column.".format(time_ref_pos)
+                    f"a string (got {time_ref_pos!r}). The invalid keyword will be "
+                    "ignored for the purpose of formatting this column."
                 )
 
             if msg is None:

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1126,9 +1126,8 @@ class ImageDataDiff(_BaseDiff):
         if self.diff_total > self.numdiffs:
             self._writeln(" ...")
         self._writeln(
-            " {} different pixels found ({:.2%} different).".format(
-                self.diff_total, self.diff_ratio
-            )
+            f" {self.diff_total} different pixels found "
+            f"({self.diff_ratio:.2%} different)."
         )
 
 
@@ -1214,9 +1213,8 @@ class RawDataDiff(ImageDataDiff):
 
         self._writeln(" ...")
         self._writeln(
-            " {} different bytes found ({:.2%} different).".format(
-                self.diff_total, self.diff_ratio
-            )
+            f" {self.diff_total} different bytes found "
+            f"({self.diff_ratio:.2%} different)."
         )
 
 
@@ -1544,9 +1542,8 @@ class TableDataDiff(_BaseDiff):
             self._writeln(" ...")
 
         self._writeln(
-            " {} different table data element(s) found ({:.2%} different).".format(
-                self.diff_total, self.diff_ratio
-            )
+            f" {self.diff_total} different table data element(s) found "
+            f"({self.diff_ratio:.2%} different)."
         )
 
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -936,10 +936,9 @@ class FITS_rec(np.recarray):
                     actual_nitems = field.shape[1]
                 if nitems > actual_nitems and not isinstance(recformat, _FormatP):
                     warnings.warn(
-                        "TDIM{} value {:d} does not fit with the size of "
-                        "the array items ({:d}).  TDIM{:d} will be ignored.".format(
-                            indx + 1, self._coldefs[indx].dims, actual_nitems, indx + 1
-                        )
+                        f"TDIM{indx + 1} value {self._coldefs[indx].dims:d} does not "
+                        f"fit with the size of the array items ({actual_nitems:d}).  "
+                        f"TDIM{indx + 1:d} will be ignored."
                     )
                     dim = None
 
@@ -1218,14 +1217,11 @@ class FITS_rec(np.recarray):
                 _ascii_encode(input_field, out=output_field)
             except _UnicodeArrayEncodeError as exc:
                 raise ValueError(
-                    "Could not save column '{}': Contains characters that "
-                    "cannot be encoded as ASCII as required by FITS, starting "
-                    "at the index {!r} of the column, and the index {} of "
-                    "the string at that location.".format(
-                        self._coldefs[col_idx].name,
-                        exc.index[0] if len(exc.index) == 1 else exc.index,
-                        exc.start,
-                    )
+                    f"Could not save column '{self._coldefs[col_idx].name}': "
+                    "Contains characters that cannot be encoded as ASCII as required "
+                    "by FITS, starting at the index "
+                    f"{exc.index[0] if len(exc.index) == 1 else exc.index!r} of the "
+                    f"column, and the index {exc.start} of the string at that location."
                 )
         else:
             # Otherwise go ahead and do a direct copy into--if both are type
@@ -1293,9 +1289,8 @@ class FITS_rec(np.recarray):
             value = fmt.format(value)
             if len(value) > starts[col_idx + 1] - starts[col_idx]:
                 raise ValueError(
-                    "Value {!r} does not fit into the output's itemsize of {}.".format(
-                        value, spans[col_idx]
-                    )
+                    f"Value {value!r} does not fit into the output's itemsize of "
+                    f"{spans[col_idx]}."
                 )
 
             if trailing_decimal and value[0] == " ":

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -228,10 +228,12 @@ def _verify_column_info(column_info, global_info):
 
         elif scale == "GPS":
             warnings.warn(
-                'Table column "{}" has a FITS recognized time scale value "GPS". '
-                'In Astropy, "GPS" is a time from epoch format which runs '
-                "synchronously with TAI; GPS runs ahead of TAI approximately "
-                "by 19 s. Hence, this format will be used.".format(column_info),
+                (
+                    f'Table column "{column_info}" has a FITS recognized time scale '
+                    'value "GPS". In Astropy, "GPS" is a time from epoch format which '
+                    "runs synchronously with TAI; GPS runs ahead of TAI approximately "
+                    "by 19 s. Hence, this format will be used."
+                ),
                 AstropyUserWarning,
             )
             column_info["scale"] = "tai"
@@ -239,11 +241,13 @@ def _verify_column_info(column_info, global_info):
 
         elif scale == "LOCAL":
             warnings.warn(
-                'Table column "{}" has a FITS recognized time scale value "LOCAL". '
-                'However, the standard states that "LOCAL" should be tied to one '
-                "of the existing scales because it is intrinsically unreliable "
-                "and/or ill-defined. Astropy will thus use the global time scale "
-                "(TIMESYS) as the default.".format(column_info),
+                (
+                    f'Table column "{column_info}" has a FITS recognized time scale '
+                    'value "LOCAL". However, the standard states that "LOCAL" should '
+                    "be tied to one of the existing scales because it is intrinsically "
+                    "unreliable and/or ill-defined. Astropy will thus use the global "
+                    "time scale (TIMESYS) as the default."
+                ),
                 AstropyUserWarning,
             )
             column_info["scale"] = global_info["scale"]
@@ -611,9 +615,11 @@ def time_to_fits(table):
             coord_meta[col.info.name]["time_ref_pos"] = None
             if location is not None:
                 warnings.warn(
-                    'Time Column "{}" has no specified location, but global Time '
-                    "Position is present, which will be the default for this column "
-                    "in FITS specification.".format(col.info.name),
+                    (
+                        f'Time Column "{col.info.name}" has no specified location, '
+                        "but global Time Position is present, which will be the "
+                        "default for this column in FITS specification."
+                    ),
                     AstropyUserWarning,
                 )
         else:
@@ -621,8 +627,10 @@ def time_to_fits(table):
             # Compatibility of Time Scales and Reference Positions
             if col.scale in BARYCENTRIC_SCALES:
                 warnings.warn(
-                    'Earth Location "TOPOCENTER" for Time Column "{}" is incompatible '
-                    'with scale "{}".'.format(col.info.name, col.scale.upper()),
+                    (
+                        f'Earth Location "TOPOCENTER" for Time Column "{col.info.name}" '
+                        f'is incompatible with scale "{col.scale.upper()}".'
+                    ),
                     AstropyUserWarning,
                 )
 

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -589,9 +589,8 @@ class CompImageHDU(BinTableHDU):
             not isinstance(data, np.ndarray) or data.dtype.fields is not None
         ):
             raise TypeError(
-                "CompImageHDU data has incorrect type:{}; dtype.fields = {}".format(
-                    type(data), data.dtype.fields
-                )
+                f"CompImageHDU data has incorrect type:{type(data)}; "
+                f"dtype.fields = {data.dtype.fields}"
             )
 
     @lazyproperty

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -816,9 +816,8 @@ class HDUList(list, _Verify):
 
         if not isinstance(_key, str):
             raise KeyError(
-                "{} indices must be integers, extension names as strings, "
-                "or (extname, version) tuples; got {}"
-                "".format(self.__class__.__name__, _key)
+                f"{type(self).__name__} indices must be integers, extension "
+                f"names as strings, or (extname, version) tuples; got {_key}"
             )
 
         _key = (_key.strip()).upper()

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -751,9 +751,8 @@ class Header:
             actual_block_size = _block_size(sep)
             if padding and len(blocks) % actual_block_size != 0:
                 raise OSError(
-                    "Header size ({}) is not a multiple of block size ({}).".format(
-                        len(blocks) - actual_block_size + BLOCK_SIZE, BLOCK_SIZE
-                    )
+                    f"Header size ({len(blocks) - actual_block_size + BLOCK_SIZE}) "
+                    f"is not a multiple of block size ({BLOCK_SIZE})."
                 )
 
             fileobj.flush()

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -84,9 +84,8 @@ class StoreListAction(argparse.Action):
                 setattr(namespace, self.dest, values)
             except OSError as exc:
                 log.warning(
-                    "reading {} for {} failed: {}; ignoring this argument".format(
-                        value, self.dest, exc
-                    )
+                    f"reading {value} for {self.dest} failed: {exc}; "
+                    "ignoring this argument"
                 )
                 del exc
         else:

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -801,9 +801,8 @@ def _free_space_check(hdulist, dirname=None):
             hdulist_size = sum(hdu.size for hdu in hdulist)
             if free_space < hdulist_size:
                 error_message = (
-                    "Not enough space on disk: requested {}, available {}. ".format(
-                        hdulist_size, free_space
-                    )
+                    f"Not enough space on disk: requested {hdulist_size}, "
+                    f"available {free_space}. "
                 )
 
         for hdu in hdulist:

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -191,9 +191,8 @@ def _lookup_by_attr_factory(attr, unique, iterator, element_name, doc):
         for element in lookup_by_attr(self, ref, before=before):
             return element
         raise KeyError(
-            "No {} with {} '{}' found before the referencing {}".format(
-                element_name, attr, ref, element_name
-            )
+            f"No {element_name} with {attr} '{ref}' found before the referencing "
+            f"{element_name}"
         )
 
     if unique:
@@ -231,9 +230,8 @@ def _lookup_by_id_or_name_factory(iterator, element_name, doc):
             if ref in (element.ID, element.name):
                 return element
         raise KeyError(
-            "No {} with ID or name '{}' found before the referencing {}".format(
-                element_name, ref, element_name
-            )
+            f"No {element_name} with ID or name '{ref}' found before the referencing "
+            f"{element_name}"
         )
 
     lookup_by_id_or_name.__doc__ = doc
@@ -2857,8 +2855,9 @@ class TableElement(
                                                 e,
                                                 config,
                                                 pos,
-                                                "(in row {:d}, col '{}')".format(
-                                                    len(array_chunk), fields[i].ID
+                                                (
+                                                    f"(in row {len(array_chunk):d}, "
+                                                    f"col '{fields[i].ID}')"
                                                 ),
                                             )
                                     else:
@@ -2871,8 +2870,9 @@ class TableElement(
                                                 e,
                                                 config,
                                                 pos,
-                                                "(in row {:d}, col '{}')".format(
-                                                    len(array_chunk), fields[i].ID
+                                                (
+                                                    f"(in row {len(array_chunk):d}, "
+                                                    f"col '{fields[i].ID}')"
                                                 ),
                                             )
                                 except Exception as e:
@@ -3266,8 +3266,8 @@ class TableElement(
                             except Exception as e:
                                 vo_reraise(
                                     e,
-                                    additional="(in row {:d}, col '{}')".format(
-                                        row, self.fields[i].ID
+                                    additional=(
+                                        f"(in row {row:d}, col '{self.fields[i].ID}')"
                                     ),
                                 )
                             if len(val):

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -711,11 +711,11 @@ def fits_ccddata_reader(
                     fits_unit_string = u.Unit(fits_unit_string)
                 except ValueError:
                     raise ValueError(
-                        "The Header value for the key BUNIT ({}) cannot be "
-                        "interpreted as valid unit. To successfully read the "
+                        f"The Header value for the key BUNIT ({fits_unit_string}) "
+                        "cannot be interpreted as valid unit. To successfully read the "
                         "file as CCDData you can pass in a valid `unit` "
                         "argument explicitly or change the header of the FITS "
-                        "file before reading it.".format(fits_unit_string)
+                        "file before reading it."
                     )
             else:
                 log.info(

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -39,9 +39,8 @@ class FlagCollection(dict):
                 super().__setitem__(item, value)
             else:
                 raise ValueError(
-                    "flags array shape {} does not match data shape {}".format(
-                        value.shape, self.shape
-                    )
+                    f"flags array shape {value.shape} does not match data shape "
+                    f"{self.shape}"
                 )
         else:
             raise TypeError("flags should be given as a Numpy array")

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -199,9 +199,8 @@ class NDUncertainty(metaclass=ABCMeta):
                     self._data_unit_to_uncertainty_unit(parent_unit).to(value)
                 except UnitConversionError:
                     raise UnitConversionError(
-                        "Unit {} is incompatible with unit {} of parent nddata".format(
-                            value, parent_unit
-                        )
+                        f"Unit {value} is incompatible with unit {parent_unit} of "
+                        "parent nddata"
                     )
 
             self._unit = Unit(value)
@@ -381,9 +380,8 @@ class NDUncertainty(metaclass=ABCMeta):
         if not self.supports_correlated:
             if isinstance(correlation, np.ndarray) or correlation != 0:
                 raise ValueError(
-                    "{} does not support uncertainty propagation"
+                    f"{type(self).__name__} does not support uncertainty propagation"
                     " with correlation."
-                    "".format(self.__class__.__name__)
                 )
 
         if other_nddata is not None:

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -826,11 +826,7 @@ class SAMPHubServer:
     def _declare_metadata(self, private_key, metadata):
         self._update_last_activity_time(private_key)
         if private_key in self._private_keys:
-            log.debug(
-                "declare_metadata: private-key = {} metadata = {}".format(
-                    private_key, str(metadata)
-                )
-            )
+            log.debug(f"declare_metadata: private-key = {private_key} {metadata = !s}")
             self._metadata[private_key] = metadata
             self._notify_metadata(private_key)
         else:
@@ -860,9 +856,7 @@ class SAMPHubServer:
 
         if private_key in self._private_keys:
             log.debug(
-                "declare_subscriptions: private-key = {} mtypes = {}".format(
-                    private_key, str(mtypes)
-                )
+                f"declare_subscriptions: private-key = {private_key} {mtypes = !s}"
             )
 
             # remove subscription to previous mtypes
@@ -888,9 +882,8 @@ class SAMPHubServer:
                                 del mtypes[mtype2]
 
             log.debug(
-                "declare_subscriptions: subscriptions accepted from {} => {}".format(
-                    private_key, str(mtypes)
-                )
+                "declare_subscriptions: subscriptions accepted from "
+                f"{private_key} => {str(mtypes)}"
             )
 
             for mtype in mtypes:
@@ -915,9 +908,8 @@ class SAMPHubServer:
             if client_private_key is not None:
                 if client_private_key in self._id2mtypes:
                     log.debug(
-                        "get_subscriptions: client-id = {} mtypes = {}".format(
-                            client_id, str(self._id2mtypes[client_private_key])
-                        )
+                        f"get_subscriptions: client-id = {client_id} "
+                        f"mtypes = {self._id2mtypes[client_private_key]!s}"
                     )
                     return self._id2mtypes[client_private_key]
                 else:
@@ -939,9 +931,7 @@ class SAMPHubServer:
                 if pkey != private_key:
                     reg_clients.append(self._private_keys[pkey][0])
             log.debug(
-                "get_registered_clients: private_key = {} clients = {}".format(
-                    private_key, reg_clients
-                )
+                f"get_registered_clients: {private_key = !s} clients = {reg_clients}"
             )
             return reg_clients
         else:
@@ -1278,8 +1268,9 @@ class SAMPHubServer:
 
         except Exception as exc:
             warnings.warn(
-                "{} reply from client {} to client {} failed [{}]".format(
-                    recipient_msg_tag, responder_public_id, recipient_public_id, exc
+                (
+                    f"{recipient_msg_tag} reply from client {responder_public_id} "
+                    f"to client {recipient_public_id} failed [{exc}]"
                 ),
                 SAMPWarning,
             )
@@ -1332,9 +1323,8 @@ class SAMPHubServer:
 
             except xmlrpc.Fault as exc:
                 log.debug(
-                    "{} XML-RPC endpoint error (attempt {}): {}".format(
-                        recipient_public_id, attempt + 1, exc.faultString
-                    )
+                    f"{recipient_public_id} XML-RPC endpoint error "
+                    f"(attempt {attempt + 1}): {exc.faultString}"
                 )
                 time.sleep(0.01)
             else:
@@ -1355,11 +1345,9 @@ class SAMPHubServer:
     def _get_new_hub_msg_id(self, sender_public_id, sender_msg_id):
         with self._thread_lock:
             self._hub_msg_id_counter += 1
-        return "msg#{};;{};;{};;{}".format(
-            self._hub_msg_id_counter,
-            self._hub_public_id,
-            sender_public_id,
-            sender_msg_id,
+        return (
+            f"msg#{self._hub_msg_id_counter};;{self._hub_public_id};;"
+            f"{sender_public_id};;{sender_msg_id}"
         )
 
     def _update_last_activity_time(self, private_key=None):

--- a/astropy/samp/standard_profile.py
+++ b/astropy/samp/standard_profile.py
@@ -154,8 +154,9 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
             socketserver.BaseServer.handle_error(self, request, client_address)
         else:
             warnings.warn(
-                "Exception happened during processing of request from {}: {}".format(
-                    client_address, sys.exc_info()[1]
+                (
+                    "Exception happened during processing of request from "
+                    f"{client_address}: {sys.exc_info()[1]}"
                 ),
                 SAMPWarning,
             )

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -61,18 +61,16 @@ def _table_group_by(table, keys):
         table_keys = keys
         if len(table_keys) != len(table):
             raise ValueError(
-                "Input keys array length {} does not match table length {}".format(
-                    len(table_keys), len(table)
-                )
+                f"Input keys array length {len(table_keys)} does not match "
+                f"table length {len(table)}"
             )
         table_index = None
         grouped_by_table_cols = False
 
     else:
         raise TypeError(
-            "Keys input must be string, list, tuple, Table or numpy array, but got {}".format(
-                type(keys)
-            )
+            f"Keys input must be string, list, tuple, Table or numpy array, "
+            f"but got {type(keys)}"
         )
 
     # TODO: don't use represent_mixins_as_columns here, but instead ensure that
@@ -158,9 +156,8 @@ def column_group_by(column, keys):
 
     if len(keys_sort) != len(column):
         raise ValueError(
-            "Input keys array length {} does not match column length {}".format(
-                len(keys), len(column)
-            )
+            f"Input keys array length {len(keys)} does not match "
+            f"column length {len(column)}"
         )
 
     try:
@@ -295,9 +292,8 @@ class ColumnGroups(BaseGroups):
             out = par_col.__class__(vals)
         except Exception as err:
             raise TypeError(
-                "Cannot aggregate column '{}' with type '{}': {}".format(
-                    par_col.info.name, par_col.info.dtype, err
-                )
+                f"Cannot aggregate column '{par_col.info.name}' "
+                f"with type '{par_col.info.dtype}': {err}"
             ) from err
 
         out_info = out.info

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -204,9 +204,8 @@ class Index:
             col_len = len(self.columns[0])
             return range(*row_specifier.indices(col_len))
         raise ValueError(
-            "Expected int, array of ints, or slice but got {} in remove_rows".format(
-                row_specifier
-            )
+            f"Expected int, array of ints, or slice but got {row_specifier} "
+            "in remove_rows"
         )
 
     def remove_rows(self, row_specifier):

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -100,9 +100,8 @@ def get_descrs(arrays, col_name_map):
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
             raise TableMergeError(
-                "The '{}' columns have incompatible types: {}".format(
-                    names[0], tme._incompat_types
-                )
+                f"The '{names[0]}' columns have incompatible types: "
+                f"{tme._incompat_types}"
             ) from tme
 
         # Make sure all input shapes are the same

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -983,9 +983,8 @@ def get_descrs(arrays, col_name_map):
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
             raise TableMergeError(
-                "The '{}' columns have incompatible types: {}".format(
-                    names[0], tme._incompat_types
-                )
+                f"The '{names[0]}' columns have incompatible types: "
+                f"{tme._incompat_types}"
             ) from tme
 
         # Make sure all input shapes are the same
@@ -1481,9 +1480,8 @@ def _vstack(arrays, join_type="outer", col_name_map=None, metadata_conflicts="wa
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
             raise TableMergeError(
-                "The '{}' columns have incompatible types: {}".format(
-                    out_name, err._incompat_types
-                )
+                f"The '{out_name}' columns have incompatible types: "
+                f"{err._incompat_types}"
             ) from err
 
         idx0 = 0

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -536,8 +536,8 @@ class TableFormatter:
                     yield format_col_str(idx)
                 except ValueError:
                     raise ValueError(
-                        'Unable to parse format string "{}" for entry "{}" '
-                        'in column "{}"'.format(col_format, col[idx], col.info.name)
+                        f'Unable to parse format string "{col_format}" for '
+                        f'entry "{col[idx]}" in column "{col.info.name}"'
                     )
 
         outs["show_length"] = show_length

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1085,9 +1085,8 @@ class Table:
         for col in columns:
             if not getattr(col.info, "_supports_indexing", False):
                 raise ValueError(
-                    'Cannot create an index on column "{}", of type "{}"'.format(
-                        col.info.name, type(col)
-                    )
+                    f'Cannot create an index on column "{col.info.name}", '
+                    f'of type "{type(col)}"'
                 )
 
         is_primary = not self.indices
@@ -2640,8 +2639,9 @@ class Table:
                     changed_attrs.append(attr)
 
             if changed_attrs:
-                msg = "replaced column '{}' and column attributes {} changed.".format(
-                    name, changed_attrs
+                msg = (
+                    f"replaced column '{name}' and column attributes "
+                    f"{changed_attrs} changed."
                 )
                 warnings.warn(msg, TableReplaceWarning, stacklevel=3)
 
@@ -3362,8 +3362,8 @@ class Table:
                         newcol[index] = np.ma.masked
                     else:
                         raise TypeError(
-                            "mask was supplied for column '{}' but it does not "
-                            "support masked values".format(col.info.name)
+                            f"mask was supplied for column '{col.info.name}' "
+                            "but it does not support masked values"
                         )
 
                 columns[name] = newcol

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -730,8 +730,9 @@ class TimeBase(ShapedLikeNDArray):
         return out
 
     def __repr__(self):
-        return "<{} object: scale='{}' format='{}' value={}>".format(
-            self.__class__.__name__, self.scale, self.format, self.to_string()
+        return (
+            f"<{type(self).__name__} object: scale='{self.scale}' "
+            f"format='{self.format}' value={self.to_string()}>"
         )
 
     def __str__(self):
@@ -3052,9 +3053,8 @@ class TimeDelta(TimeBase):
             and other.scale not in self.SCALES
         ):
             raise TypeError(
-                "Cannot add TimeDelta instances with scales '{}' and '{}'".format(
-                    self.scale, other.scale
-                )
+                "Cannot add TimeDelta instances with scales "
+                f"'{self.scale}' and '{other.scale}'"
             )
 
         # adjust the scale of other if the scale of self is set (or no scales)
@@ -3450,9 +3450,8 @@ class OperandTypeError(TypeError):
     def __init__(self, left, right, op=None):
         op_string = "" if op is None else f" for {op}"
         super().__init__(
-            "Unsupported operand type(s){}: '{}' and '{}'".format(
-                op_string, left.__class__.__name__, right.__class__.__name__
-            )
+            f"Unsupported operand type(s){op_string}: '{type(left).__name__}' "
+            f"and '{type(right).__name__}'"
         )
 
 

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -280,9 +280,8 @@ class CDS(Base):
         if unit not in cls._units:
             if detailed_exception:
                 raise ValueError(
-                    "Unit '{}' not supported by the CDS SAC standard. {}".format(
-                        unit, did_you_mean(unit, cls._units)
-                    )
+                    f"Unit '{unit}' not supported by the CDS SAC standard. "
+                    f"{did_you_mean(unit, cls._units)}"
                 )
             else:
                 raise ValueError()

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -2122,8 +2122,9 @@ class SpecificTypeQuantity(Quantity):
     def _set_unit(self, unit):
         if unit is None or not unit.is_equivalent(self._equivalent_unit):
             raise UnitTypeError(
-                "{} instances require units equivalent to '{}'".format(
-                    type(self).__name__, self._equivalent_unit
+                (
+                    f"{type(self).__name__} instances require units equivalent to "
+                    f"'{self._equivalent_unit}'"
                 )
                 + (
                     ", but no unit was given."

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -354,8 +354,8 @@ def human_time(seconds):
         unit1, limit1 = units[i]
         unit2, limit2 = units[i + 1]
         if seconds >= limit1:
-            return "{:2d}{}{:2d}{}".format(
-                seconds // limit1, unit1, (seconds % limit1) // limit2, unit2
+            return (
+                f"{seconds // limit1:2d}{unit1}{(seconds % limit1) // limit2:2d}{unit2}"
             )
     return "  ~inf"
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1275,8 +1275,9 @@ class LeapSeconds(QTable):
             with erfa.
         """
         current = cls(erfa.leap_seconds.get())
+        expires = erfa.leap_seconds.expires
         current._expires = Time(
-            "{0.year:04d}-{0.month:02d}-{0.day:02d}".format(erfa.leap_seconds.expires),
+            f"{expires.year:04d}-{expires.month:02d}-{expires.day:02d}",
             scale="tai",
         )
         if not built_in:

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -36,11 +36,12 @@ def deserialize_class(tpl, construct=True):
 def wcs_info_str(wcs):
     # Overall header
 
-    s = f"{wcs.__class__.__name__} Transformation\n\n"
-    s += "This transformation has {} pixel and {} world dimensions\n\n".format(
-        wcs.pixel_n_dim, wcs.world_n_dim
+    s = (
+        f"{type(wcs).__name__} Transformation\n\n"
+        f"This transformation has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} "
+        "world dimensions\n\n"
+        f"Array shape (Numpy order): {wcs.array_shape}\n\n"
     )
-    s += f"Array shape (Numpy order): {wcs.array_shape}\n\n"
 
     # Pixel dimensions table
 


### PR DESCRIPTION
### Description

The [Ruff rule UP032](https://docs.astral.sh/ruff/rules/f-string/) can automatically convert `str.format()` calls to f-strings. Before v0.3.2 Ruff avoided making changes if the naive conversion produced lines that exceeded the line length limit (88 characters for us), but [now it is more aggressive](https://github.com/astral-sh/ruff/releases/tag/v0.3.2). Updating the `pre-commit` hook manually prevents Ruff from producing overlong lines like it tried to do in #16253.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
