### PR TITLE
Bugfix for issue 15782: Remove needless functions from an io.ascii test helper file

### DIFF
--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -22,16 +22,3 @@ def setup_function(function):
 
 def teardown_function(function):
     os.chdir(CWD)
-
-
-# Compatibility functions to convert from nose to pytest
-def assert_equal(a, b):
-    assert a == b
-
-
-def assert_almost_equal(a, b, **kwargs):
-    assert np.allclose(a, b, **kwargs)
-
-
-def assert_true(a):
-    assert a

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -31,8 +31,6 @@ from astropy.table import MaskedColumn, Table
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyWarning
 
-from .common import assert_almost_equal, assert_equal, assert_true
-
 StringIO = lambda x: BytesIO(x.encode("ascii"))
 
 
@@ -41,24 +39,22 @@ def assert_table_equal(t1, t2, check_meta=False, rtol=1.0e-15, atol=1.0e-300):
     Test equality of all columns in a table, with stricter tolerances for
     float columns than the np.allclose default.
     """
-    assert_equal(len(t1), len(t2))
-    assert_equal(t1.colnames, t2.colnames)
+    np.testing.assert_equal(len(t1), len(t2))
+    np.testing.assert_equal(t1.colnames, t2.colnames)
     if check_meta:
-        assert_equal(t1.meta, t2.meta)
+        np.testing.assert_equal(t1.meta, t2.meta)
     for name in t1.colnames:
         if len(t1) != 0:
-            assert_equal(t1[name].dtype.kind, t2[name].dtype.kind)
+            np.testing.assert_equal(t1[name].dtype.kind, t2[name].dtype.kind)
         if not isinstance(t1[name], MaskedColumn):
             for i, el in enumerate(t1[name]):
                 try:
                     if not isinstance(el, str) and np.isnan(el):
-                        assert_true(
-                            not isinstance(t2[name][i], str) and np.isnan(t2[name][i])
-                        )
+                        assert not isinstance(t2[name][i], str) and np.isnan(t2[name][i])
                     elif isinstance(el, str):
-                        assert_equal(el, t2[name][i])
+                        np.testing.assert_equal(el, t2[name][i])
                     else:
-                        assert_almost_equal(el, t2[name][i], rtol=rtol, atol=atol)
+                        np.testing.assert_allclose(el, t2[name][i], rtol=rtol, atol=atol)
                 except (TypeError, NotImplementedError):
                     pass  # ignore for now
 
@@ -324,10 +320,10 @@ A B C D E F G H
 4 2 -12 .4 +.e1 - + six
 """
     table = read_basic(text)
-    assert_equal(table["A"].dtype.kind, "f")
+    np.testing.assert_equal(table["A"].dtype.kind, "f")
     assert table["B"].dtype.kind in ("S", "U")
-    assert_equal(table["C"].dtype.kind, "i")
-    assert_equal(table["D"].dtype.kind, "f")
+    np.testing.assert_equal(table["C"].dtype.kind, "i")
+    np.testing.assert_equal(table["D"].dtype.kind, "f")
     assert table["E"].dtype.kind in ("S", "U")
     assert table["F"].dtype.kind in ("S", "U")
     assert table["G"].dtype.kind in ("S", "U")
@@ -677,7 +673,7 @@ nan, 5, -9999
     assert isinstance(table["A"], MaskedColumn)
     assert table["A"][0] is ma.masked
     # '0' rather than 0 because there is a string in the column
-    assert_equal(table["A"].data.data[0], "0")
+    np.testing.assert_equal(table["A"].data.data[0], "0")
     assert table["A"][1] is not ma.masked
 
     table = read_basic(text, delimiter=",", fill_values=("-999", "0"))
@@ -686,7 +682,7 @@ nan, 5, -9999
     assert table["C"][2] is not ma.masked  # -9999 is not an exact match
     assert table["B"][1] is ma.masked
     # Numeric because the rest of the column contains numeric data
-    assert_equal(table["B"].data.data[1], 0.0)
+    np.testing.assert_equal(table["B"].data.data[1], 0.0)
     assert table["B"][0] is not ma.masked
 
     table = read_basic(text, delimiter=",", fill_values=[])
@@ -702,11 +698,11 @@ nan, 5, -9999
     assert table["B"][3] is not ma.masked
     assert table["A"][0] is ma.masked
     assert table["A"][2] is ma.masked
-    assert_equal(table["A"].data.data[0], "0")
-    assert_equal(table["A"].data.data[2], "999")
+    np.testing.assert_equal(table["A"].data.data[0], "0")
+    np.testing.assert_equal(table["A"].data.data[2], "999")
     assert table["C"][0] is ma.masked
-    assert_almost_equal(table["C"].data.data[0], 999.0)
-    assert_almost_equal(table["C"][1], -3.4)  # column is still of type float
+    np.testing.assert_allclose(table["C"].data.data[0], 999.0)
+    np.testing.assert_allclose(table["C"][1], -3.4)  # column is still of type float
 
 
 def test_fill_include_exclude_names(read_csv):
@@ -796,11 +792,11 @@ def test_read_tab(read_tab):
     """
     text = '1\t2\t3\n  a\t b \t\n c\t" d\n e"\t  '
     table = read_tab(text)
-    assert_equal(table["1"][0], "  a")  # preserve line whitespace
-    assert_equal(table["2"][0], " b ")  # preserve field whitespace
+    np.testing.assert_equal(table["1"][0], "  a")  # preserve line whitespace
+    np.testing.assert_equal(table["2"][0], " b ")  # preserve field whitespace
     assert table["3"][0] is ma.masked  # empty value should be masked
-    assert_equal(table["2"][1], " d\n e")  # preserve whitespace in quoted fields
-    assert_equal(table["3"][1], "  ")  # preserve end-of-line whitespace
+    np.testing.assert_equal(table["2"][1], " d\n e")  # preserve whitespace in quoted fields
+    np.testing.assert_equal(table["3"][1], "  ")  # preserve end-of-line whitespace
 
 
 def test_default_data_start(read_basic):
@@ -862,9 +858,9 @@ A\tB\tC
     table = read_rdb(text)
     expected = Table([[1], [" 9"], [4.3]], names=("A", "B", "C"))
     assert_table_equal(table, expected)
-    assert_equal(table["A"].dtype.kind, "i")
+    np.testing.assert_equal(table["A"].dtype.kind, "i")
     assert table["B"].dtype.kind in ("S", "U")
-    assert_equal(table["C"].dtype.kind, "f")
+    np.testing.assert_equal(table["C"].dtype.kind, "f")
 
     with pytest.raises(ValueError) as e:
         text = "A\tB\tC\nN\tS\tN\n4\tb\ta"  # C column contains non-numeric data
@@ -1056,7 +1052,7 @@ a b c
 4 5 6
 """
     table = read_basic(text, check_meta=True)
-    assert_equal(table.meta["comments"], ["header comment", "comment 2", "comment 3"])
+    np.testing.assert_equal(table.meta["comments"], ["header comment", "comment 2", "comment 3"])
 
 
 def test_empty_quotes(read_basic):
@@ -1189,7 +1185,7 @@ def test_data_out_of_range(fast_reader, guess):
                 w[i].message
             )
     read_values = np.array([col[0] for col in t.itercols()])
-    assert_almost_equal(read_values, values, rtol=rtol, atol=1.0e-324)
+    np.testing.assert_allclose(read_values, values, rtol=rtol, atol=1.0e-324)
 
     # Test some additional corner cases
     fields = [
@@ -1221,7 +1217,7 @@ def test_data_out_of_range(fast_reader, guess):
                 w[i].message
             )
     read_values = np.array([col[0] for col in t.itercols()])
-    assert_almost_equal(read_values, values, rtol=rtol, atol=1.0e-324)
+    np.testing.assert_allclose(read_values, values, rtol=rtol, atol=1.0e-324)
 
     # Test corner cases again with non-standard exponent_style (auto-detection)
     if fast_reader and fast_reader.get("use_fast_converter"):
@@ -1253,7 +1249,7 @@ def test_data_out_of_range(fast_reader, guess):
         else:
             assert len(w) == 3
     read_values = np.array([col[0] for col in t.itercols()])
-    assert_almost_equal(read_values, values, rtol=rtol, atol=1.0e-324)
+    np.testing.assert_allclose(read_values, values, rtol=rtol, atol=1.0e-324)
 
 
 @pytest.mark.parametrize("guess", [True, False])
@@ -1297,7 +1293,7 @@ def test_data_at_range_limit(fast_reader, guess):
             guess=guess,
             fast_reader=fast_reader,
         )
-        assert_almost_equal(t["col1"][0], 10.0 ** -(D + 1), rtol=rtol, atol=1.0e-324)
+        np.testing.assert_allclose(t["col1"][0], 10.0 ** -(D + 1), rtol=rtol, atol=1.0e-324)
     for D in 99, 202, 308:
         t = ascii.read(
             StringIO("1" + D * "0" + ".0"),
@@ -1305,7 +1301,7 @@ def test_data_at_range_limit(fast_reader, guess):
             guess=guess,
             fast_reader=fast_reader,
         )
-        assert_almost_equal(t["col1"][0], 10.0**D, rtol=rtol, atol=1.0e-324)
+        np.testing.assert_allclose(t["col1"][0], 10.0**D, rtol=rtol, atol=1.0e-324)
 
     # 0.0 is always exact (no Overflow warning)!
     for s in "0.0", "0.0e+0", 399 * "0" + "." + 365 * "0":
@@ -1332,7 +1328,7 @@ def test_data_at_range_limit(fast_reader, guess):
             "resulting in degraded precision" in str(w[0].message)
         )
 
-    assert_almost_equal(t["col1"][0], 1.0e-315, rtol=1.0e-10, atol=1.0e-324)
+    np.testing.assert_allclose(t["col1"][0], 1.0e-315, rtol=1.0e-10, atol=1.0e-324)
 
 
 @pytest.mark.parametrize("guess", [True, False])
@@ -1666,10 +1662,10 @@ def test_conversion_fast(fast_reader):
     4 2 -12 .4 +.e1 - + six
     """
     table = ascii.read(text, fast_reader=fast_reader)
-    assert_equal(table["A"].dtype.kind, "f")
+    np.testing.assert_equal(table["A"].dtype.kind, "f")
     assert table["B"].dtype.kind in ("S", "U")
-    assert_equal(table["C"].dtype.kind, "i")
-    assert_equal(table["D"].dtype.kind, "f")
+    np.testing.assert_equal(table["C"].dtype.kind, "i")
+    np.testing.assert_equal(table["D"].dtype.kind, "f")
     assert table["E"].dtype.kind in ("S", "U")
     assert table["F"].dtype.kind in ("S", "U")
     assert table["G"].dtype.kind in ("S", "U")
@@ -1711,7 +1707,7 @@ def test_newline_as_delimiter(delimiter, fast_reader):
 
     if not fast_reader:
         pytest.xfail("Quoted fields are not parsed correctly by BaseSplitter")
-    assert_equal(t1["b"].dtype.kind, "i")
+    np.testing.assert_equal(t1["b"].dtype.kind, "i")
 
 
 @pytest.mark.parametrize("delimiter", [" ", "|", "\n", "\r"])

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -19,8 +19,6 @@ from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyWarning
 
-from .common import assert_almost_equal
-
 test_dat = [
     "names e d s i",
     "HD81809 1E-7 22.25608 +2 67",
@@ -503,7 +501,7 @@ def test_write_extra_skycoord_cols():
     for a, b in zip(lines[-2:], exp_output[-2:]):
         assert a[:18] == b[:18]
         assert a[30:42] == b[30:42]
-        assert_almost_equal(
+        np.testing.assert_allclose(
             np.fromstring(a[2:], sep=" "), np.fromstring(b[2:], sep=" ")
         )
 

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -7,8 +7,6 @@ from astropy import units as u
 from astropy.io import ascii
 
 from .common import (
-    assert_almost_equal,
-    assert_equal,
     setup_function,  # noqa: F401
     teardown_function,  # noqa: F401
 )
@@ -34,21 +32,21 @@ def test_description():
     data = "data/cds/description/table.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 2)
-        assert_equal(table["Cluster"].description, "Cluster name")
-        assert_equal(table["Star"].description, "")
-        assert_equal(table["Wave"].description, "wave ? Wavelength in Angstroms")
-        assert_equal(table["El"].description, "a")
-        assert_equal(
+        np.testing.assert_equal(len(table), 2)
+        np.testing.assert_equal(table["Cluster"].description, "Cluster name")
+        np.testing.assert_equal(table["Star"].description, "")
+        np.testing.assert_equal(table["Wave"].description, "wave ? Wavelength in Angstroms")
+        np.testing.assert_equal(table["El"].description, "a")
+        np.testing.assert_equal(
             table["ion"].description, "- Ionization stage (1 for neutral element)"
         )
-        assert_equal(
+        np.testing.assert_equal(
             table["loggf"].description,
             "log10 of the gf value - logarithm base 10 of stat. weight times "
             "oscillator strength",
         )
-        assert_equal(table["EW"].description, "Equivalent width (in mA)")
-        assert_equal(
+        np.testing.assert_equal(table["EW"].description, "Equivalent width (in mA)")
+        np.testing.assert_equal(
             table["Q"].description, "DAOSPEC quality parameter Q (large values are bad)"
         )
 
@@ -58,15 +56,15 @@ def test_multi_header():
     data = "data/cds/multi/lhs2065.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 18)
-        assert_almost_equal(table["Lambda"][-1], 6479.32)
-        assert_equal(table["Fnu"][-1], "0.285937")
+        np.testing.assert_equal(len(table), 18)
+        np.testing.assert_allclose(table["Lambda"][-1], 6479.32)
+        np.testing.assert_equal(table["Fnu"][-1], "0.285937")
     data = "data/cds/multi/lp944-20.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 18)
-        assert_almost_equal(table["Lambda"][0], 6476.09)
-        assert_equal(table["Fnu"][-1], "0.489005")
+        np.testing.assert_equal(len(table), 18)
+        np.testing.assert_allclose(table["Lambda"][0], 6476.09)
+        np.testing.assert_equal(table["Fnu"][-1], "0.489005")
 
 
 def test_glob_header():
@@ -74,9 +72,9 @@ def test_glob_header():
     data = "data/cds/glob/lmxbrefs.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 291)
-        assert_equal(table["Name"][-1], "J1914+0953")
-        assert_equal(table["BibCode"][-2], "2005A&A...432..235R")
+        np.testing.assert_equal(len(table), 291)
+        np.testing.assert_equal(table["Name"][-1], "J1914+0953")
+        np.testing.assert_equal(table["BibCode"][-2], "2005A&A...432..235R")
 
 
 def test_header_from_readme():
@@ -204,7 +202,7 @@ def test_cds_function_units2(reader_cls):
     assert table["vturb"].unit == u.km / u.s
     assert table["[Fe/H]"].unit == u.dex(u.one)
     assert table["e_[Fe/H]"].unit == u.dex(u.one)
-    assert_almost_equal(
+    np.testing.assert_allclose(
         table["[Fe/H]"].to(u.one), 10.0 ** (np.array([-2.07, -1.50, -2.11, -1.64]))
     )
 
@@ -216,9 +214,9 @@ def test_cds_ignore_nullable():
     data = "data/cds/null/table.dat"
     r = ascii.Cds(readme)
     r.read(data)
-    assert_equal(r.header.cols[6].description, "Temperature class codified (10)")
-    assert_equal(r.header.cols[8].description, "Luminosity class codified (11)")
-    assert_equal(r.header.cols[5].description, "Pericenter position angle (18)")
+    np.testing.assert_equal(r.header.cols[6].description, "Temperature class codified (10)")
+    np.testing.assert_equal(r.header.cols[8].description, "Luminosity class codified (11)")
+    np.testing.assert_equal(r.header.cols[5].description, "Pericenter position angle (18)")
 
 
 def test_cds_no_whitespace():
@@ -228,15 +226,15 @@ def test_cds_no_whitespace():
     data = "data/cds/null/table.dat"
     r = ascii.Cds(readme)
     r.read(data)
-    assert_equal(r.header.cols[6].description, "Temperature class codified (10)")
-    assert_equal(r.header.cols[6].null, "")
-    assert_equal(r.header.cols[7].description, "Equivalent width (in mA)")
-    assert_equal(r.header.cols[7].null, "-9.9")
-    assert_equal(
+    np.testing.assert_equal(r.header.cols[6].description, "Temperature class codified (10)")
+    np.testing.assert_equal(r.header.cols[6].null, "")
+    np.testing.assert_equal(r.header.cols[7].description, "Equivalent width (in mA)")
+    np.testing.assert_equal(r.header.cols[7].null, "-9.9")
+    np.testing.assert_equal(
         r.header.cols[10].description,
         "DAOSPEC quality parameter Q (large values are bad)",
     )
-    assert_equal(r.header.cols[10].null, "-9.999")
+    np.testing.assert_equal(r.header.cols[10].null, "-9.999")
 
 
 def test_cds_order():
@@ -246,6 +244,6 @@ def test_cds_order():
     data = "data/cds/null/table.dat"
     r = ascii.Cds(readme)
     r.read(data)
-    assert_equal(r.header.cols[5].description, "Catalogue Identification Number")
-    assert_equal(r.header.cols[8].description, "Equivalent width (in mA)")
-    assert_equal(r.header.cols[9].description, "Luminosity class codified (11)")
+    np.testing.assert_equal(r.header.cols[5].description, "Catalogue Identification Number")
+    np.testing.assert_equal(r.header.cols[8].description, "Equivalent width (in mA)")
+    np.testing.assert_equal(r.header.cols[9].description, "Luminosity class codified (11)")

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -9,11 +9,8 @@ import pytest
 from astropy.io import ascii
 from astropy.io.ascii.core import InconsistentTableError
 
-from .common import assert_almost_equal, assert_equal
-
-
 def assert_equal_splitlines(arg1, arg2):
-    assert_equal(arg1.splitlines(), arg2.splitlines())
+    np.testing.assert_equal(arg1.splitlines(), arg2.splitlines())
 
 
 def test_read_normal():
@@ -26,10 +23,10 @@ def test_read_normal():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    np.testing.assert_equal(dat.colnames, ["Col1", "Col2"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], '"hello"')
+    np.testing.assert_equal(dat[1][1], "'s worlds")
 
 
 def test_read_normal_names():
@@ -42,8 +39,8 @@ def test_read_normal_names():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth, names=("name1", "name2"))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name2"])
-    assert_almost_equal(dat[1][0], 2.4)
+    np.testing.assert_equal(dat.colnames, ["name1", "name2"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
 
 
 def test_read_normal_names_include():
@@ -60,9 +57,9 @@ def test_read_normal_names_include():
         include_names=("name1", "name3"),
     )
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name3"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], 3)
+    np.testing.assert_equal(dat.colnames, ["name1", "name3"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], 3)
 
 
 def test_read_normal_exclude():
@@ -75,8 +72,8 @@ def test_read_normal_exclude():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth, exclude_names=("Col1",))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col2"])
-    assert_equal(dat[1][0], "'s worlds")
+    np.testing.assert_equal(dat.colnames, ["Col2"])
+    np.testing.assert_equal(dat[1][0], "'s worlds")
 
 
 def test_read_weird():
@@ -88,10 +85,10 @@ def test_read_weird():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hel')
-    assert_equal(dat[1][1], "df's wo")
+    np.testing.assert_equal(dat.colnames, ["Col1", "Col2"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], '"hel')
+    np.testing.assert_equal(dat[1][1], "df's wo")
 
 
 def test_read_double():
@@ -103,10 +100,10 @@ def test_read_double():
 |   Bob  | 555-4527 | 192.168.1.9X|
 """
     dat = ascii.read(table, format="fixed_width", guess=False)
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    np.testing.assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[0][1], "555-1234")
+    np.testing.assert_equal(dat[2][2], "192.168.1.9")
 
 
 def test_read_space_delimiter():
@@ -118,10 +115,10 @@ def test_read_space_delimiter():
   Bob  555-4527     192.168.1.9
 """
     dat = ascii.read(table, format="fixed_width", guess=False, delimiter=" ")
-    assert_equal(tuple(dat.dtype.names), ("Name", "--Phone-", "----TCP-----"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    np.testing.assert_equal(tuple(dat.dtype.names), ("Name", "--Phone-", "----TCP-----"))
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[0][1], "555-1234")
+    np.testing.assert_equal(dat[2][2], "192.168.1.9")
 
 
 def test_read_no_header_autocolumn():
@@ -134,10 +131,10 @@ def test_read_no_header_autocolumn():
     dat = ascii.read(
         table, format="fixed_width", guess=False, header_start=None, data_start=0
     )
-    assert_equal(tuple(dat.dtype.names), ("col1", "col2", "col3"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    np.testing.assert_equal(tuple(dat.dtype.names), ("col1", "col2", "col3"))
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[0][1], "555-1234")
+    np.testing.assert_equal(dat[2][2], "192.168.1.9")
 
 
 def test_read_no_header_names():
@@ -156,10 +153,10 @@ def test_read_no_header_names():
         data_start=0,
         names=("Name", "Phone", "TCP"),
     )
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    np.testing.assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[0][1], "555-1234")
+    np.testing.assert_equal(dat[2][2], "192.168.1.9")
 
 
 def test_read_no_header_autocolumn_NoHeader():
@@ -170,10 +167,10 @@ def test_read_no_header_autocolumn_NoHeader():
 |   Bob  | 555-4527 | 192.168.1.9|
 """
     dat = ascii.read(table, format="fixed_width_no_header")
-    assert_equal(tuple(dat.dtype.names), ("col1", "col2", "col3"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    np.testing.assert_equal(tuple(dat.dtype.names), ("col1", "col2", "col3"))
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[0][1], "555-1234")
+    np.testing.assert_equal(dat[2][2], "192.168.1.9")
 
 
 def test_read_no_header_names_NoHeader():
@@ -187,10 +184,10 @@ def test_read_no_header_names_NoHeader():
     dat = ascii.read(
         table, format="fixed_width_no_header", names=("Name", "Phone", "TCP")
     )
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    np.testing.assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[0][1], "555-1234")
+    np.testing.assert_equal(dat[2][2], "192.168.1.9")
 
 
 def test_read_col_starts():
@@ -209,11 +206,11 @@ def test_read_col_starts():
         col_starts=(0, 9, 18),
         col_ends=(5, 17, 28),
     )
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[0][1], "555- 1234")
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[1][2], "192.168.1.")
-    assert_equal(dat[2][2], "192.168.1")  # col_end=28 cuts this column off
+    np.testing.assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
+    np.testing.assert_equal(dat[0][1], "555- 1234")
+    np.testing.assert_equal(dat[1][0], "Mary")
+    np.testing.assert_equal(dat[1][2], "192.168.1.")
+    np.testing.assert_equal(dat[2][2], "192.168.1")  # col_end=28 cuts this column off
 
 
 def test_read_detect_col_starts_or_ends():
@@ -234,11 +231,11 @@ def test_read_detect_col_starts_or_ends():
             names=("Name", "Phone", "TCP"),
             **kwargs,
         )
-        assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-        assert_equal(dat[0][1], "555- 1234")
-        assert_equal(dat[1][0], "Mary")
-        assert_equal(dat[1][2], "192.168.1.123")
-        assert_equal(dat[3][2], "192.255.255.255")
+        np.testing.assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
+        np.testing.assert_equal(dat[0][1], "555- 1234")
+        np.testing.assert_equal(dat[1][0], "Mary")
+        np.testing.assert_equal(dat[1][2], "192.168.1.123")
+        np.testing.assert_equal(dat[3][2], "192.255.255.255")
 
 
 table = """\
@@ -400,10 +397,10 @@ def test_read_twoline_normal():
   2.4   's worlds
 """
     dat = ascii.read(table, format="fixed_width_two_line")
-    assert_equal(dat.dtype.names, ("Col1", "Col2"))
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    np.testing.assert_equal(dat.dtype.names, ("Col1", "Col2"))
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], '"hello"')
+    np.testing.assert_equal(dat[1][1], "'s worlds")
 
 
 def test_read_twoline_ReST():
@@ -423,10 +420,10 @@ def test_read_twoline_ReST():
         position_line=2,
         data_end=-1,
     )
-    assert_equal(dat.dtype.names, ("Col1", "Col2"))
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    np.testing.assert_equal(dat.dtype.names, ("Col1", "Col2"))
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], '"hello"')
+    np.testing.assert_equal(dat[1][1], "'s worlds")
 
 
 def test_read_twoline_human():
@@ -449,10 +446,10 @@ def test_read_twoline_human():
         data_start=3,
         data_end=-1,
     )
-    assert_equal(dat.dtype.names, ("Col1", "Col2"))
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    np.testing.assert_equal(dat.dtype.names, ("Col1", "Col2"))
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], '"hello"')
+    np.testing.assert_equal(dat[1][1], "'s worlds")
 
 
 def test_read_twoline_fail():

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -27,9 +27,6 @@ from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 # setup/teardown function to have the tests run in the correct directory
 from .common import (
-    assert_almost_equal,
-    assert_equal,
-    assert_true,
     setup_function,  # noqa: F401
     teardown_function,  # noqa: F401
 )
@@ -221,9 +218,9 @@ def test_read_all_files(fast_reader, path_format, home_is_data):
                 if "inputter_cls" not in test_opts:  # fast reader doesn't allow this
                     test_opts["fast_reader"] = fast_reader
             table = ascii.read(testfile["name"], **test_opts)
-            assert_equal(table.dtype.names, testfile["cols"])
+            np.testing.assert_equal(table.dtype.names, testfile["cols"])
             for colname in table.dtype.names:
-                assert_equal(len(table[colname]), testfile["nrows"])
+                np.testing.assert_equal(len(table[colname]), testfile["nrows"])
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -251,9 +248,9 @@ def test_read_all_files_via_table(fast_reader, path_format, home_is_data):
             if f"fast_{format}" in core.FAST_CLASSES:
                 test_opts["fast_reader"] = fast_reader
             table = Table.read(testfile["name"], format=format, **test_opts)
-            assert_equal(table.dtype.names, testfile["cols"])
+            np.testing.assert_equal(table.dtype.names, testfile["cols"])
             for colname in table.dtype.names:
-                assert_equal(len(table[colname]), testfile["nrows"])
+                np.testing.assert_equal(len(table[colname]), testfile["nrows"])
 
 
 def test_guess_all_files():
@@ -270,9 +267,9 @@ def test_guess_all_files():
                 k: v for k, v in testfile["opts"].items() if k not in filter_read_opts
             }
             table = ascii.read(testfile["name"], guess=True, **guess_opts)
-            assert_equal(table.dtype.names, testfile["cols"])
+            np.testing.assert_equal(table.dtype.names, testfile["cols"])
             for colname in table.dtype.names:
-                assert_equal(len(table[colname]), testfile["nrows"])
+                np.testing.assert_equal(len(table[colname]), testfile["nrows"])
 
 
 def test_validate_read_kwargs():
@@ -334,9 +331,9 @@ def test_daophot_header_keywords():
     keywords = table.meta["keywords"]  # Ordered dict of keyword structures
     for name, value, units, format_ in expected_keywords:
         keyword = keywords[name]
-        assert_equal(keyword["value"], value)
-        assert_equal(keyword["units"], units)
-        assert_equal(keyword["format"], format_)
+        np.testing.assert_equal(keyword["value"], value)
+        np.testing.assert_equal(keyword["units"], units)
+        np.testing.assert_equal(keyword["format"], format_)
 
 
 def test_daophot_multiple_aperture():
@@ -397,7 +394,7 @@ def test_set_names(fast_reader):
     data = ascii.read(
         "data/simple3.txt", names=names, delimiter="|", fast_reader=fast_reader
     )
-    assert_equal(data.dtype.names, names)
+    np.testing.assert_equal(data.dtype.names, names)
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -411,7 +408,7 @@ def test_set_include_names(fast_reader):
         delimiter="|",
         fast_reader=fast_reader,
     )
-    assert_equal(data.dtype.names, include_names)
+    np.testing.assert_equal(data.dtype.names, include_names)
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -423,19 +420,19 @@ def test_set_exclude_names(fast_reader):
         delimiter="|",
         fast_reader=fast_reader,
     )
-    assert_equal(data.dtype.names, ("obsid", "redshift", "X", "rad"))
+    np.testing.assert_equal(data.dtype.names, ("obsid", "redshift", "X", "rad"))
 
 
 def test_include_names_daophot():
     include_names = ("ID", "MAG", "PIER")
     data = ascii.read("data/daophot.dat", include_names=include_names)
-    assert_equal(data.dtype.names, include_names)
+    np.testing.assert_equal(data.dtype.names, include_names)
 
 
 def test_exclude_names_daophot():
     exclude_names = ("ID", "YCENTER", "MERR", "NITER", "CHI", "PERROR")
     data = ascii.read("data/daophot.dat", exclude_names=exclude_names)
-    assert_equal(data.dtype.names, ("XCENTER", "MAG", "MSKY", "SHARPNESS", "PIER"))
+    np.testing.assert_equal(data.dtype.names, ("XCENTER", "MAG", "MSKY", "SHARPNESS", "PIER"))
 
 
 def test_custom_process_lines():
@@ -447,8 +444,8 @@ def test_custom_process_lines():
     reader = ascii.get_reader(delimiter="|")
     reader.inputter.process_lines = process_lines
     data = reader.read("data/bars_at_ends.txt")
-    assert_equal(data.dtype.names, ("obsid", "redshift", "X", "Y", "object", "rad"))
-    assert_equal(len(data), 3)
+    np.testing.assert_equal(data.dtype.names, ("obsid", "redshift", "X", "Y", "object", "rad"))
+    np.testing.assert_equal(len(data), 3)
 
 
 def test_custom_process_line():
@@ -461,7 +458,7 @@ def test_custom_process_line():
     reader.data.splitter.process_line = process_line
     data = reader.read("data/nls1_stackinfo.dbout")
     cols = get_testfiles("data/nls1_stackinfo.dbout")["cols"]
-    assert_equal(data.dtype.names, cols[1:])
+    np.testing.assert_equal(data.dtype.names, cols[1:])
 
 
 def test_custom_splitters():
@@ -471,20 +468,20 @@ def test_custom_splitters():
     f = "data/test4.dat"
     data = reader.read(f)
     testfile = get_testfiles(f)
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
-    assert_almost_equal(data.field("zabs1.nh")[2], 0.0839710433091)
-    assert_almost_equal(data.field("p1.gamma")[2], 1.25997502704)
-    assert_almost_equal(data.field("p1.ampl")[2], 0.000696444029148)
-    assert_equal(data.field("statname")[2], "chi2modvar")
-    assert_almost_equal(data.field("statval")[2], 497.56468441)
+    np.testing.assert_equal(data.dtype.names, testfile["cols"])
+    np.testing.assert_equal(len(data), testfile["nrows"])
+    np.testing.assert_allclose(data.field("zabs1.nh")[2], 0.0839710433091)
+    np.testing.assert_allclose(data.field("p1.gamma")[2], 1.25997502704)
+    np.testing.assert_allclose(data.field("p1.ampl")[2], 0.000696444029148)
+    np.testing.assert_equal(data.field("statname")[2], "chi2modvar")
+    np.testing.assert_allclose(data.field("statval")[2], 497.56468441)
 
 
 def test_start_end():
     data = ascii.read("data/test5.dat", header_start=1, data_start=3, data_end=-5)
-    assert_equal(len(data), 13)
-    assert_equal(data.field("statname")[0], "chi2xspecvar")
-    assert_equal(data.field("statname")[-1], "chi2gehrels")
+    np.testing.assert_equal(len(data), 13)
+    np.testing.assert_equal(data.field("statname")[0], "chi2xspecvar")
+    np.testing.assert_equal(data.field("statname")[-1], "chi2gehrels")
 
 
 def test_set_converters():
@@ -493,8 +490,8 @@ def test_set_converters():
         "p1.gamma": [ascii.convert_numpy("str")],
     }
     data = ascii.read("data/test4.dat", converters=converters)
-    assert_equal(str(data["zabs1.nh"].dtype), "float32")
-    assert_equal(data["p1.gamma"][0], "1.26764500000")
+    np.testing.assert_equal(str(data["zabs1.nh"].dtype), "float32")
+    np.testing.assert_equal(data["p1.gamma"][0], "1.26764500000")
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -504,8 +501,8 @@ def test_from_string(fast_reader):
         table = fd.read()
     testfile = get_testfiles(f)[0]
     data = ascii.read(table, fast_reader=fast_reader, **testfile["opts"])
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
+    np.testing.assert_equal(data.dtype.names, testfile["cols"])
+    np.testing.assert_equal(len(data), testfile["nrows"])
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -514,8 +511,8 @@ def test_from_filelike(fast_reader):
     testfile = get_testfiles(f)[0]
     with open(f, "rb") as fd:
         data = ascii.read(fd, fast_reader=fast_reader, **testfile["opts"])
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
+    np.testing.assert_equal(data.dtype.names, testfile["cols"])
+    np.testing.assert_equal(len(data), testfile["nrows"])
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -525,15 +522,15 @@ def test_from_lines(fast_reader):
         table = fd.readlines()
     testfile = get_testfiles(f)[0]
     data = ascii.read(table, fast_reader=fast_reader, **testfile["opts"])
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
+    np.testing.assert_equal(data.dtype.names, testfile["cols"])
+    np.testing.assert_equal(len(data), testfile["nrows"])
 
 
 def test_comment_lines():
     table = ascii.get_reader(reader_cls=ascii.Rdb)
     data = table.read("data/apostrophe.rdb")
-    assert_equal(table.comment_lines, ["# first comment", "  # second comment"])
-    assert_equal(data.meta["comments"], ["first comment", "second comment"])
+    np.testing.assert_equal(table.comment_lines, ["# first comment", "  # second comment"])
+    np.testing.assert_equal(data.meta["comments"], ["first comment", "second comment"])
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -543,10 +540,10 @@ def test_fill_values(fast_reader):
     data = ascii.read(
         f, fill_values=("a", "1"), fast_reader=fast_reader, **testfile["opts"]
     )
-    assert_true((data["a"].mask == [False, True]).all())
-    assert_true((data["a"] == [1, 1]).all())
-    assert_true((data["b"].mask == [False, True]).all())
-    assert_true((data["b"] == [2, 1]).all())
+    assert (data["a"].mask == [False, True]).all()
+    assert (data["a"] == [1, 1]).all()
+    assert (data["b"].mask == [False, True]).all()
+    assert (data["b"] == [2, 1]).all()
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -590,12 +587,12 @@ def test_fill_values_exclude_names(fast_reader):
 def check_fill_values(data):
     """compare array column by column with expectation"""
     assert not hasattr(data["a"], "mask")
-    assert_true((data["a"] == ["1", "a"]).all())
-    assert_true((data["b"].mask == [False, True]).all())
+    assert (data["a"] == ["1", "a"]).all()
+    assert (data["b"].mask == [False, True]).all()
     # Check that masked value is "do not care" in comparison
-    assert_true((data["b"] == [2, -999]).all())
+    assert (data["b"] == [2, -999]).all()
     data["b"].mask = False  # explicitly unmask for comparison
-    assert_true((data["b"] == [2, 1]).all())
+    assert (data["b"] == [2, 1]).all()
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -609,14 +606,14 @@ def test_fill_values_list(fast_reader):
         **testfile["opts"],
     )
     data["a"].mask = False  # explicitly unmask for comparison
-    assert_true((data["a"] == [42, 42]).all())
+    assert (data["a"] == [42, 42]).all()
 
 
 def test_masking_Cds_Mrt():
     f = "data/cds.dat"  # Tested for CDS and MRT
     for testfile in get_testfiles(f):
         data = ascii.read(f, **testfile["opts"])
-        assert_true(data["AK"].mask[0])
+        assert data["AK"].mask[0]
         assert not hasattr(data["Fit"], "mask")
 
 

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -8,11 +8,8 @@ import astropy.units as u
 from astropy.io import ascii
 from astropy.table import QTable
 
-from .common import assert_almost_equal, assert_equal
-
-
 def assert_equal_splitlines(arg1, arg2):
-    assert_equal(arg1.splitlines(), arg2.splitlines())
+    np.testing.assert_equal(arg1.splitlines(), arg2.splitlines())
 
 
 def test_read_normal():
@@ -28,10 +25,10 @@ def test_read_normal():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    np.testing.assert_equal(dat.colnames, ["Col1", "Col2"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], '"hello"')
+    np.testing.assert_equal(dat[1][1], "'s worlds")
 
 
 def test_read_normal_names():
@@ -47,8 +44,8 @@ def test_read_normal_names():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST, names=("name1", "name2"))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name2"])
-    assert_almost_equal(dat[1][0], 2.4)
+    np.testing.assert_equal(dat.colnames, ["name1", "name2"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
 
 
 def test_read_normal_names_include():
@@ -68,9 +65,9 @@ def test_read_normal_names_include():
         include_names=("name1", "name3"),
     )
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name3"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], 3)
+    np.testing.assert_equal(dat.colnames, ["name1", "name3"])
+    np.testing.assert_allclose(dat[1][0], 2.4)
+    np.testing.assert_equal(dat[0][1], 3)
 
 
 def test_read_normal_exclude():
@@ -85,8 +82,8 @@ def test_read_normal_exclude():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST, exclude_names=("Col1",))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col2"])
-    assert_equal(dat[1][0], "'s worlds")
+    np.testing.assert_equal(dat.colnames, ["Col2"])
+    np.testing.assert_equal(dat[1][0], "'s worlds")
 
 
 def test_read_unbounded_right_column():
@@ -102,8 +99,8 @@ def test_read_unbounded_right_column():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat[0][2], "Hello")
-    assert_equal(dat[1][2], "Worlds")
+    np.testing.assert_equal(dat[0][2], "Hello")
+    np.testing.assert_equal(dat[1][2], "Worlds")
 
 
 def test_read_unbounded_right_column_header():
@@ -119,7 +116,7 @@ def test_read_unbounded_right_column_header():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames[-1], "Col3Long")
+    np.testing.assert_equal(dat.colnames[-1], "Col3Long")
 
 
 def test_read_right_indented_table():
@@ -135,9 +132,9 @@ def test_read_right_indented_table():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
-    assert_equal(dat[0][2], "foo")
-    assert_equal(dat[1][0], 1)
+    np.testing.assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
+    np.testing.assert_equal(dat[0][2], "foo")
+    np.testing.assert_equal(dat[1][0], 1)
 
 
 def test_trailing_spaces_in_row_definition():
@@ -158,9 +155,9 @@ def test_trailing_spaces_in_row_definition():
 
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
-    assert_equal(dat[0][2], "foo")
-    assert_equal(dat[1][0], 1)
+    np.testing.assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
+    np.testing.assert_equal(dat[0][2], "foo")
+    np.testing.assert_equal(dat[1][0], 1)
 
 
 table = """\

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -8,9 +8,6 @@ import pytest
 
 from astropy.io import ascii
 
-from .common import assert_equal
-
-
 def test_types_from_dat():
     converters = {"a": [ascii.convert_numpy(float)], "e": [ascii.convert_numpy(str)]}
 
@@ -30,7 +27,7 @@ def test_rdb_write_types():
     out = StringIO()
     ascii.write(dat, out, format="rdb")
     outs = out.getvalue().splitlines()
-    assert_equal(outs[1], "N\tN\tS\tN")
+    np.testing.assert_equal(outs[1], "N\tN\tS\tN")
 
 
 def test_ipac_read_types():
@@ -51,7 +48,7 @@ def test_ipac_read_types():
         ascii.StrType,
     ]
     for col, expected_type in zip(reader.cols, types):
-        assert_equal(col.type, expected_type)
+        np.testing.assert_equal(col.type, expected_type)
 
 
 def test_ipac_read_long_columns():

--- a/docs/changes/io.ascii/15782.bugfix.rst
+++ b/docs/changes/io.ascii/15782.bugfix.rst
@@ -1,0 +1,1 @@
+Removed unnecessary functions from `astropy/io/ascii/common.py` and replaced them with calls to ``np.testing``

--- a/docs/changes/io.ascii/15782.bugfix.rst
+++ b/docs/changes/io.ascii/15782.bugfix.rst
@@ -1,1 +1,1 @@
-Removed unnecessary functions from `astropy/io/ascii/common.py` and replaced them with calls to ``np.testing``
+Removed unnecessary functions from ``astropy/io/ascii/common.py`` and replaced them with calls to ``np.testing``


### PR DESCRIPTION
EDIT: close https://github.com/astropy/astropy/pull/15839

resolving issue, fix #15782

replaced all calls of:
    assert_equal() -> np.testing.assert_equal()
    assert_almost_equal() -> np.testing.assert_allclose()
    assert_true(a) -> assert a
in the following files:
    astropy/io/ascii/tests/test_c_reader.py
    astropy/io/ascii/tests/test_cds.py
    astropy/io/ascii/tests/test_rst.py
    astropy/io/ascii/tests/test_types.py
    astropy/io/ascii/tests/test_read.py
    astropy/io/ascii/tests/test_fixedwidth.py
    astropy/io/ascii/tests/test_cds_header_from_readme.py

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
