### PR TITLE
Backport PR #16261 on branch 6.0.x (BUG: fix a regression in astropy 6.0.1 where using a dimensionless Quantity as an exponent could raise an exception)

### DIFF
--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -16,6 +16,7 @@ from astropy.units.quantity import _UNIT_NOT_INITIALISED
 from astropy.utils import isiterable, minversion
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.masked import Masked
 
 """ The Quantity class will represent a number + unit + uncertainty """
 
@@ -463,6 +464,16 @@ class TestQuantityOperations:
         new_quantity = self.q1**3
         assert_array_almost_equal(new_quantity.value, 1489.355288, decimal=7)
         assert new_quantity.unit == u.Unit("m^3")
+
+    @pytest.mark.parametrize(
+        "exponent_type",
+        [int, float, np.uint64, np.int32, np.float32, u.Quantity, Masked],
+    )
+    def test_quantity_as_power(self, exponent_type):
+        # raise unit to a dimensionless Quantity power
+        # regression test for https://github.com/astropy/astropy/issues/16260
+        q = u.m ** exponent_type(2)
+        assert q == u.m**2
 
     def test_matrix_multiplication(self):
         a = np.eye(3)

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -214,7 +214,7 @@ def maybe_simple_fraction(p, max_denominator=100):
     """
     if p == 0 or p.__class__ is int or p.__class__ is Fraction:
         return p
-    n, d = p.as_integer_ratio()
+    n, d = float(p).as_integer_ratio()
     a = n // d
     # Normally, start with 0,1 and 1,0; here we have applied first iteration.
     n0, d0 = 1, 0

--- a/docs/changes/units/16261.bugfix.rst
+++ b/docs/changes/units/16261.bugfix.rst
@@ -1,0 +1,2 @@
+Using a dimensionless ``Quantity`` as an exponent works anew.
+In astropy 6.0.1 an exception was erroneously raised.


### PR DESCRIPTION
Backport PR #16261 on branch 6.0.x

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
