### PR TITLE
RFC: use actual numpy dev version numbers in NUMPY_LT_* definitions

### DIFF
--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -24,8 +24,8 @@ __all__ = [
 NUMPY_LT_1_24 = not minversion(np, "1.24")
 NUMPY_LT_1_25 = not minversion(np, "1.25")
 NUMPY_LT_1_26 = not minversion(np, "1.26")
-NUMPY_LT_2_0 = not minversion(np, "2.0.dev")
-NUMPY_LT_2_1 = not minversion(np, "2.1.dev")
+NUMPY_LT_2_0 = not minversion(np, "2.0.0.dev")
+NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None


### PR DESCRIPTION
### Description
Only just noticed this now, but the string versions we're comparing to numpy's version at runtime do not match how numpy dev versions are actually numbered. In practice, this changes nothing (comparisons were already returning correct results), but it saves the next person to notice from wondering *if* it makes a difference for 5 minutes.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
