### PR TITLE
BUG: declare private str ufuncs as unsupported (np.core.math._(r)partition(_index))

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -397,6 +397,10 @@ if not NUMPY_LT_2_1:
         np._core.umath._rjust,
         np._core.umath._center,
         np._core.umath._zfill,
+        np._core.umath._partition_index,
+        np._core.umath._rpartition,
+        np._core.umath._rpartition_index,
+        np._core.umath._partition,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
### Description
Fix an incompatibility with numpy 2.1.0dev seen in weekly cron (example logs uns/8546114835/job/23415865202?pr=16181)

similar to #16205
xref https://github.com/numpy/numpy/pull/26082

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
