### PR TITLE
Add type annotations to `utils/shape.py`

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -127,4 +127,10 @@ py:class reference target not found: (k, v)
 # Types used in annotations included here because of a Sphinx bug.
 # See https://github.com/sphinx-doc/sphinx/issues/9813
 # and https://github.com/sphinx-doc/sphinx/issues/11225
+# types
+py:class EllipsisType
 py:class ModuleType
+# numpy.typing
+py:class NDArray
+# locally defined type variable for ndarray dtype
+py:class DT


### PR DESCRIPTION
### Description

~The first commit only adds type annotations, the second commit also makes the `NDArrayShapeMethods` signatures explicit.~ There are a couple methods I did not annotate because they looked too complicated. I don't think that's a problem. The more code is annotated, the better type checkers can analyze it, so there's no need to get stuck on one or two methods early on.

`ShapedLikeNDArray` is a base class for many classes in `astropy`, so it would be good to get reviews from different sub-package maintainers who have expressed interest in type annotations.

UPDATE: Initially I edited the `NDArrayShapeMethods` method signatures in a separate commit because if those changes would have been controversial it would have been simple for me to undo them by dropping the commit. Based on initial reviews the explicit signatures are not a problem, so squashed the commits manually.

UPDATE 2: I have decided to update `NDArrayShapeMethods` method signatures in a separate commit (possibly separate pull request) after all because we should have tests that ensure the signatures match the corresponding `np.ndarray` method signatures.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
