### PR TITLE
TST: (weekly cron) install pyerfa from wheels

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -163,7 +163,7 @@ jobs:
             source tests/bin/activate
             # cython and pyerfa versions in ubuntu repos are too old currently
             pip install -U cython
-            pip install -U --no-build-isolation pyerfa
+            pip install -U pyerfa
             ASTROPY_USE_SYSTEM_ALL=1 pip3 install -v --no-build-isolation -e .[test]
             pip3 list
             python3 -m pytest


### PR DESCRIPTION
I noticed that weekly cron were failing at pytest's collection time with the following error
```python-traceback
ImportError: /home/runner/work/astropy/astropy/tests/lib/python3.11/site-packages/erfa/ufunc.abi3.so: undefined symbol: PyDa
```

<details><summary>Full Traceback</summary>

```python-traceback
  Traceback (most recent call last):
    File "<frozen runpy>", line 198, in _run_module_as_main
    File "<frozen runpy>", line 88, in _run_code
    File "/usr/lib/python3/dist-packages/pytest/__main__.py", line 5, in <module>
      raise SystemExit(pytest.console_main())
                       ^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/_pytest/config/__init__.py", line 189, in console_main
      code = main()
             ^^^^^^
    File "/usr/lib/python3/dist-packages/_pytest/config/__init__.py", line 166, in main
      ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/pluggy/_hooks.py", line 433, in __call__
      return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/pluggy/_manager.py", line 112, in _hookexec
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/pluggy/_callers.py", line 116, in _multicall
      raise exception.with_traceback(exception.__traceback__)
    File "/usr/lib/python3/dist-packages/pluggy/_callers.py", line 80, in _multicall
      res = hook_impl.function(*args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/_pytest/main.py", line 317, in pytest_cmdline_main
      return wrap_session(config, _main)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/_pytest/main.py", line 312, in wrap_session
      config._ensure_unconfigure()
    File "/usr/lib/python3/dist-packages/_pytest/config/__init__.py", line 1059, in _ensure_unconfigure
      self.hook.pytest_unconfigure(config=self)
    File "/usr/lib/python3/dist-packages/pluggy/_hooks.py", line 433, in __call__
      return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/pluggy/_manager.py", line 112, in _hookexec
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3/dist-packages/pluggy/_callers.py", line 116, in _multicall
      raise exception.with_traceback(exception.__traceback__)
    File "/usr/lib/python3/dist-packages/pluggy/_callers.py", line 80, in _multicall
      res = hook_impl.function(*args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/work/astropy/astropy/astropy/conftest.py", line 124, in pytest_unconfigure
      from astropy.utils.iers import conf as iers_conf
    File "/home/runner/work/astropy/astropy/astropy/utils/iers/__init__.py", line 1, in <module>
      from .iers import *
    File "/home/runner/work/astropy/astropy/astropy/utils/iers/iers.py", line 18, in <module>
      import erfa
    File "/home/runner/work/astropy/astropy/tests/lib/python3.11/site-packages/erfa/__init__.py", line 5, in <module>
      from .version import version as __version__  # noqa
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/work/astropy/astropy/tests/lib/python3.11/site-packages/erfa/version.py", line 25, in <module>
      from . import ufunc
  ImportError: /home/runner/work/astropy/astropy/tests/lib/python3.11/site-packages/erfa/ufunc.abi3.so: undefined symbol: PyDataType_ELSIZE
```

</details>

[example logs](https://github.com/astropy/astropy/actions/runs/8595346105/job/23549888945)

This indicates that, because of the `--no-build-isolation` flag, `pyerfa` is being built against numpy 1, but using pre-compiled wheels should now be more robust
xref: 
- https://github.com/liberfa/pyerfa/pull/140 
- https://github.com/liberfa/pyerfa/pull/144

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
