### PR TITLE
TST: add triggers for extra-CI workflows to auto-run them on change

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -5,7 +5,8 @@ name: Benchmark
 on:
   pull_request:
     types: [labeled, synchronize]
-
+    paths:
+      - .github/workflows/ci_benchmark.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -11,6 +11,8 @@ on:
     types:
       - synchronize
       - labeled
+    paths:
+      - .github/workflows/ci_cron_daily.yml
   push:
     # We want this workflow to always run on release branches as well as
     # all tags since we want to be really sure we don't introduce

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -11,6 +11,8 @@ on:
     types:
       - synchronize
       - labeled
+    paths:
+      - .github/workflows/ci_cron_weekly.yml
   push:
     # We want this workflow to always run on release branches as well as
     # all tags since we want to be really sure we don't introduce


### PR DESCRIPTION
### Description
I propose that labels for extra CI jobs wouldn't be needed to run when the workflows themselves are changed.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
