### PR TITLE
Don't return Quantities from high_level_objects_to_values

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -1,4 +1,5 @@
 import abc
+import numbers
 from collections import OrderedDict, defaultdict
 
 import numpy as np
@@ -241,8 +242,16 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
         else:
             world.append(rec_getattr(objects[key], attr))
 
-    # Strip of quantity-ness to return low-level objects
-    world = [world.value if isinstance(world, u.Quantity) else world]
+    # Check the type of the return values - should be scalars or plain Numpy
+    # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
+    # we don't want to match Numpy subclasses.
+    for w in world:
+        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
+            raise TypeError(
+                f"WCS world_axis_object_components results in "
+                f"values which are not scalars or plain Numpy "
+                f"arrays (got {type(w)})"
+            )
 
     return world
 
@@ -266,6 +275,16 @@ def values_to_high_level_objects(*world_values, low_level_wcs):
     low_level_wcs: `.BaseLowLevelWCS`
         The WCS object to use to interpret the coordinates.
     """
+    # Check the type of the input values - should be scalars or plain Numpy
+    # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
+    # we don't want to match Numpy subclasses.
+    for w in world_values:
+        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
+            raise TypeError(
+                f"Expected world coordinates as scalars or plain Numpy "
+                f"arrays (got {type(w)})"
+            )
+
     # Cache the classes and components since this may be expensive
     components = low_level_wcs.world_axis_object_components
     classes = low_level_wcs.world_axis_object_classes

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -124,7 +124,8 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
 
     This function uses the information in ``wcs.world_axis_object_classes`` and
     ``wcs.world_axis_object_components`` to convert the high level objects
-    (such as `~.SkyCoord`) to low level "values" `~.Quantity` objects.
+    (such as `~.SkyCoord`) to low level "values" which should be scalars or
+    Numpy arrays.
 
     This is used in `.HighLevelWCSMixin.world_to_pixel`, but provided as a
     separate function for use in other places where needed.
@@ -239,6 +240,9 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
             world.append(attr(objects[key]))
         else:
             world.append(rec_getattr(objects[key], attr))
+
+    # Strip of quantity-ness to return low-level objects
+    world = [world.value if isinstance(world, u.Quantity) else world]
 
     return world
 

--- a/docs/changes/wcs/16287.api.rst
+++ b/docs/changes/wcs/16287.api.rst
@@ -1,0 +1,3 @@
+Errors may now occur if a ``BaseLowLevelWCS`` class defines
+``world_axis_object_components`` which returns values that are not scalars or
+plain Numpy arrays as per APE 14.


### PR DESCRIPTION
The ``high_level_objects_to_values`` function should not be returning quantities because otherwise this is resulting in quantities being passed through to ``world_to_pixel_values`` which should not happen (only bare scalars/arrays should be used).

I have also added a conversion of units to ``world_axis_units`` but I'm not sure if we should. This is a possible pragmatic solution to the fact that some WCSes might define ``world_axis_object_components`` in a way that is inconsistent with ``world_axis_units``, such as in https://github.com/spacetelescope/gwcs/issues/495 - however, if all the metadata was defined correctly this should not be needed. So another option is to be strict here and simply replace ``.to_value()`` by ``.value``.

I still need to add a test for this, will do once we agree on the approach.