### PR TITLE
Backport PR #16280 on branch v6.1.x (Remove an erroneous special case from search_around_3d())

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -263,15 +263,6 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree="kdtree_3d"):
             " a scalar coordinate."
         )
 
-    if len(coords1) == 0 or len(coords2) == 0:
-        # Empty array input: return empty match
-        return (
-            np.array([], dtype=int),
-            np.array([], dtype=int),
-            Angle([], u.deg),
-            u.Quantity([], coords1.distance.unit),
-        )
-
     kdt2 = _get_cartesian_kdtree(coords2, storekdtree)
     cunit = coords2.cartesian.x.unit
 

--- a/docs/changes/coordinates/16280.bugfix.rst
+++ b/docs/changes/coordinates/16280.bugfix.rst
@@ -1,0 +1,5 @@
+``search_around_3d()`` now always raises a ``UnitConversionError`` if the units
+of the distances in ``coord1`` and ``coord2`` and the unit of ``distlimit`` do
+not agree.
+Previously the error was not raised if at least one of the coordinates was
+empty.


### PR DESCRIPTION
### Description

Manual backport of #16280.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
