### PR TITLE
BUG: fix compatibility with numpy 2.1 in Masked.nonzero

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1070,7 +1070,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             not_masked = ~self.mask[unmasked_nonzero]
             return tuple(u[not_masked] for u in unmasked_nonzero)
         else:
-            return unmasked_nonzero if not self.mask else np.nonzero(0)
+            return unmasked_nonzero if not self.mask else np.nonzero([0])
 
     def compress(self, condition, axis=None, out=None):
         if out is not None:

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -26,6 +26,7 @@ from astropy.utils.compat import (
     NUMPY_LT_1_24,
     NUMPY_LT_1_25,
     NUMPY_LT_2_0,
+    NUMPY_LT_2_1,
 )
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
@@ -179,14 +180,24 @@ class TestArgFunctions(MaskedArraySetup):
     def test_nonzero(self):
         self.check(np.nonzero, fill_value=0.0)
 
+    @pytest.mark.skipif(
+        not NUMPY_LT_2_1, reason="support for 0d arrays was removed in numpy 2.1"
+    )
     @pytest.mark.filterwarnings("ignore:Calling nonzero on 0d arrays is deprecated")
-    def test_nonzero_0d(self):
+    def test_nonzero_0d_np_lt_2_1(self):
         res1 = Masked(1, mask=False).nonzero()
         assert len(res1) == 1
-        assert_array_equal(res1[0], np.ones(()).nonzero()[0])
+        assert_array_equal(res1[0], 0)
         res2 = Masked(1, mask=True).nonzero()
         assert len(res2) == 1
-        assert_array_equal(res2[0], np.zeros(()).nonzero()[0])
+        assert_array_equal(res2[0], 0)
+
+    @pytest.mark.skipif(
+        NUMPY_LT_2_1, reason="support for 0d arrays was removed in numpy 2.1"
+    )
+    def test_nonzero_0d_np_ge_2_1(self):
+        with pytest.raises(ValueError):
+            Masked(1, mask=False).nonzero()
 
     def test_argwhere(self):
         self.check(np.argwhere, fill_value=0.0)


### PR DESCRIPTION
### Description
Fixes a new incompatibility with numpy dev (2.1, not 2.0)
[example logs](https://github.com/astropy/astropy/actions/runs/8719074091/job/23917671825?pr=15959)
xref: https://github.com/numpy/numpy/pull/26268

This is not needed for compat with numpy 2.0 but I'd still recommend backporting to astropy 6.1 if possible (ping @astrofrog and @saimn)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
