### PR TITLE
ci: mypy config

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,92 @@
+; This configuration file is temporary and will be moved to `pyproject.toml` when it is:
+; a) finished, or b) mypy supports cascading configuration and we can have the base
+; configuration in `pyproject.toml` and additional configuration here for WIP modules.
+
+[mypy]
+python_version = 3.11
+files = astropy/astropy/**/*.py
+plugins = numpy.typing.mypy_plugin
+show_error_codes = true
+# TODO: temporary
+ignore_missing_imports = true
+follow_imports = skip
+namespace_packages = true
+
+[mypy-*/tests/*]
+ignore_errors = true
+
+; =============================================================================
+; Sub-module specific configuration
+; The goal is to remove these as the modules are cleaned up and made mypy compliant.
+
+[mypy-astropy/logger]
+ignore_errors = true
+
+[mypy-astropy/_erfa/*]
+ignore_errors = true
+
+[mypy-astropy/config/*]
+ignore_errors = true
+
+[mypy-astropy/conftest]
+ignore_errors = true
+
+[mypy-astropy/constants/*]
+ignore_errors = true
+
+[mypy-astropy/convolution/*]
+ignore_errors = true
+
+[mypy-astropy/coordinates/*]
+ignore_errors = true
+
+[mypy-astropy/cosmology/*]
+ignore_errors = true
+
+[mypy-astropy/extern/*]
+ignore_errors = true
+
+[mypy-astropy/io/*]
+ignore_errors = true
+
+[mypy-astropy/modeling/*]
+ignore_errors = true
+
+[mypy-astropy/nddata/*]
+ignore_errors = true
+
+[mypy-astropy/samp/*]
+ignore_errors = true
+
+[mypy-astropy/stats/*]
+ignore_errors = true
+
+[mypy-astropy/table/*]
+ignore_errors = true
+
+[mypy-astropy/tests/*]
+ignore_errors = true
+
+[mypy-astropy/time/*]
+ignore_errors = true
+
+[mypy-astropy/timeseries/*]
+ignore_errors = true
+
+[mypy-astropy/uncertainty/*]
+ignore_errors = true
+
+[mypy-astropy/units/*]
+ignore_errors = true
+
+[mypy-astropy/utils/*]
+ignore_errors = true
+
+[mypy-astropy/version]
+ignore_errors = true
+
+[mypy-astropy/visualization/*]
+ignore_errors = true
+
+[mypy-astropy/wcs/*]
+ignore_errors = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,14 @@ repos:
     hooks:
       - id: sp-repo-review
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.13.0"
+    hooks:
+      - id: mypy
+        files: astropy
+        args: ["--config-file", ".mypy.ini", "--install-types", "--non-interactive"]
+        additional_dependencies: ["numpy"]
+
   - repo: local
     hooks:
       - id: changelogs-rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,49 +271,6 @@ archs = ["auto", "aarch64"]
     syntax = "numpy"
 
 
-
-[tool.mypy]
-python_version = "3.11"
-files = ["astropy/**/*.py"]
-plugins = ["numpy.typing.mypy_plugin"]
-ignore_missing_imports = true
-follow_imports = "skip"
-show_error_codes = true
-
-    [[tool.mypy.overrides]]
-    module = [
-        "astropy/logger",
-        "astropy/_erfa/*",
-        "astropy/config/*",
-        "astropy/conftest",
-        "astropy/constants/*",
-        "astropy/convolution/*",
-        "astropy/coordinates/*",
-        "astropy/cosmology/*",
-        "astropy/extern/*",
-        "astropy/io/*",
-        "astropy/modeling/*",
-        "astropy/nddata/*",
-        "astropy/samp/*",
-        "astropy/stats/*",
-        "astropy/table/*",
-        "astropy/tests/*",
-        "astropy/time/*",
-        "astropy/timeseries/*",
-        "astropy/uncertainty/*",
-        "astropy/units/*",
-        "astropy/utils/*",
-        "astropy/version",
-        "astropy/visualization/*",
-        "astropy/wcs/*",
-    ]
-    ignore_errors = true
-
-    [[tool.mypy.overrides]]
-    module = "*/tests/*"
-    ignore_errors = true
-
-
 [tool.coverage]
 
     [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ files = ["astropy/**/*.py"]
 plugins = ["numpy.typing.mypy_plugin"]
 ignore_missing_imports = true
 follow_imports = "skip"
+show_error_codes = true
 
     [[tool.mypy.overrides]]
     module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,48 @@ archs = ["auto", "aarch64"]
     syntax = "numpy"
 
 
+
+[tool.mypy]
+python_version = "3.11"
+files = ["astropy/**/*.py"]
+plugins = ["numpy.typing.mypy_plugin"]
+ignore_missing_imports = true
+follow_imports = "skip"
+
+    [[tool.mypy.overrides]]
+    module = [
+        "astropy/logger",
+        "astropy/_erfa/*",
+        "astropy/config/*",
+        "astropy/conftest",
+        "astropy/constants/*",
+        "astropy/convolution/*",
+        "astropy/coordinates/*",
+        "astropy/cosmology/*",
+        "astropy/extern/*",
+        "astropy/io/*",
+        "astropy/modeling/*",
+        "astropy/nddata/*",
+        "astropy/samp/*",
+        "astropy/stats/*",
+        "astropy/table/*",
+        "astropy/tests/*",
+        "astropy/time/*",
+        "astropy/timeseries/*",
+        "astropy/uncertainty/*",
+        "astropy/units/*",
+        "astropy/utils/*",
+        "astropy/version",
+        "astropy/visualization/*",
+        "astropy/wcs/*",
+    ]
+    ignore_errors = true
+
+    [[tool.mypy.overrides]]
+    module = "*/tests/*"
+    ignore_errors = true
+
+
 [tool.coverage]
 
     [tool.coverage.run]


### PR DESCRIPTION
A redo of #12971 now that we have `typing`!

This PR provides a ``mypy`` configuration where all folders are ignored.
As a sub-package adds type hints the module may be removed from the top ``[[tool.mypy.overrides]]`` that ignores all errors and sub-package specific settings added in a new ``[[tool.mypy.overrides]]``, below.

e.g.

```
    [[tool.mypy.overrides]]
    module="*/astropy/cosmology/*"
    ignore_errors = false
    ...
```

**Non-goals**

1. type-hint anything in this PR.
2. force any sub-package to start adding type hints
3. ~decide *where* type hints will be stored: in the code, or as type stubs in a separate directory.~ This is resolved.

**Goals**

have a quality setup that:

1.  allows any sub-package to start adding type hints. 
2. ~works for either type hint location.~ This is resolved

With this PR, @namurphy's PRs for tox and CI can proceed.