### PR TITLE
Replace (most) `str.format()` calls with f-strings in `coordinates`

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -486,16 +486,10 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
     @property
     def _unitstr(self):
-        units_set = set(self._units.values())
-        if len(units_set) == 1:
-            unitstr = units_set.pop().to_string()
-        else:
-            unitstr = "({})".format(
-                ", ".join(
-                    self._units[component].to_string() for component in self.components
-                )
-            )
-        return unitstr
+        units = self._units.values()
+        if len(units_set := set(units)) == 1:
+            return str(units_set.pop())
+        return f"({', '.join(map(str, units))})"
 
     def __str__(self):
         return f"{np.array2string(self._values, separator=', ')} {self._unitstr:s}"
@@ -505,10 +499,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         arrstr = np.array2string(self._values, prefix=prefixstr, separator=", ")
 
         diffstr = ""
-        if getattr(self, "differentials", None):
-            diffstr = "\n (has differentials w.r.t.: {})".format(
-                ", ".join([repr(key) for key in self.differentials.keys()])
-            )
+        if diffs := getattr(self, "differentials", None):
+            diffstr = f"\n (has differentials w.r.t.: {', '.join(map(repr, diffs))})"
 
         unitstr = ("in " + self._unitstr) if self._unitstr else "[dimensionless]"
         return (


### PR DESCRIPTION
### Description

The recent f9d233ffcc8ed546d99aec393415125fd4902c91 made me check if there are still [`str.format()`](https://docs.python.org/3/library/stdtypes.html#str.format) calls in `coordinates` that could be replaced with [f-strings](https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals). I searched for them using `git grep '".format(' -- astropy/coordinates/`. In three functions I was indeed able to use f-strings, but I also made a few additional simplifications. Two uses of `str.format()` remain: https://github.com/astropy/astropy/blob/802dc273f6f397435f87d4d8df221713d19fd51a/astropy/coordinates/errors.py#L65 and https://github.com/astropy/astropy/blob/802dc273f6f397435f87d4d8df221713d19fd51a/astropy/coordinates/sky_coordinate_parsers.py#L250-L252
In those two cases the strings contain substrings that are constructed using [`str.join()`](https://docs.python.org/3/library/stdtypes.html#str.join) and that are meant to contain `'`-characters. Using f-strings there would require introducing local variables to avoid problems with nested quotations, so it wouldn't simplify the code.


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
