### PR TITLE
DEPR: deprecate direct mutations of `TableElement.fields` by making it an owned list

### DIFF
--- a/astropy/io/votable/tests/test_converter.py
+++ b/astropy/io/votable/tests/test_converter.py
@@ -302,17 +302,15 @@ def test_vararray():
     table = tree.TableElement(votable)
     resource.tables.append(table)
 
-    tabarr = []
     heads = ["headA", "headB", "headC"]
     types = ["char", "double", "int"]
 
     vals = [["A", 1.0, 2], ["B", 2.0, 3], ["C", 3.0, 4]]
     for i in range(len(heads)):
-        tabarr.append(
+        table.add_field(
             tree.Field(votable, name=heads[i], datatype=types[i], arraysize="*")
         )
 
-    table.fields.extend(tabarr)
     table.create_arrays(len(vals))
     for i in range(len(vals)):
         values = tuple(vals[i])

--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -47,9 +47,7 @@ def test_make_Fields():
     table = tree.TableElement(votable)
     resource.tables.append(table)
 
-    table.fields.extend(
-        [tree.Field(votable, name="Test", datatype="float", unit="mag")]
-    )
+    table.add_field(tree.Field(votable, name="Test", datatype="float", unit="mag"))
 
 
 def test_unit_format():

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -881,7 +881,6 @@ def table_from_scratch():
     votable.to_xml(out)
 
 
-@pytest.mark.xfail
 def test_direct_fields_mutation():
     from astropy.io.votable.tree import Field, Resource, TableElement, VOTableFile
 

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -909,15 +909,15 @@ def test_build_from_scratch(tmp_path):
     resource.tables.append(table)
 
     # Define some fields
-    table.fields.extend(
-        [
-            tree.Field(
-                votable, ID="filename", name="filename", datatype="char", arraysize="1"
-            ),
-            tree.Field(
-                votable, ID="matrix", name="matrix", datatype="double", arraysize="2x2"
-            ),
-        ]
+    table.add_field(
+        tree.Field(
+            votable, ID="filename", name="filename", datatype="char", arraysize="1"
+        )
+    )
+    table.add_field(
+        tree.Field(
+            votable, ID="matrix", name="matrix", datatype="double", arraysize="2x2"
+        )
     )
 
     # Now, use those field definitions to create the numpy record arrays, with
@@ -1031,12 +1031,8 @@ def _run_test_from_scratch_example():
     resource.tables.append(table)
 
     # Define some fields
-    table.fields.extend(
-        [
-            Field(votable, name="filename", datatype="char", arraysize="*"),
-            Field(votable, name="matrix", datatype="double", arraysize="2x2"),
-        ]
-    )
+    table.add_field(Field(votable, name="filename", datatype="char", arraysize="*"))
+    table.add_field(Field(votable, name="matrix", datatype="double", arraysize="2x2"))
 
     # Now, use those field definitions to create the numpy record arrays, with
     # the given number of rows

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -881,6 +881,44 @@ def table_from_scratch():
     votable.to_xml(out)
 
 
+@pytest.mark.xfail
+def test_direct_fields_mutation():
+    from astropy.io.votable.tree import Field, Resource, TableElement, VOTableFile
+
+    votable = VOTableFile()
+    resource = Resource()
+    votable.resources.append(resource)
+    table = TableElement(votable)
+    resource.tables.append(table)
+    with pytest.deprecated_call(
+        match="Direct mutations of TableElement.fields via append"
+    ):
+        table.fields.append(
+            Field(
+                votable,
+                ID="filename",
+                datatype="char",
+                name="test_append",
+                arraysize="1",
+            )
+        )
+
+    with pytest.deprecated_call(
+        match="Direct mutations of TableElement.fields via extend"
+    ):
+        table.fields.extend(
+            [
+                Field(
+                    votable,
+                    ID="filename",
+                    datatype="char",
+                    name="test_extend",
+                    arraysize="1",
+                )
+            ]
+        )
+
+
 # https://github.com/astropy/astropy/issues/13341
 @np.errstate(over="ignore")
 def test_open_files():

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -845,42 +845,6 @@ def test_select_columns_binary(format_):
     assert table.colnames == ["string_test", "string_test_2", "unicode_test"]
 
 
-def table_from_scratch():
-    from astropy.io.votable.tree import Field, Resource, TableElement, VOTableFile
-
-    # Create a new VOTable file...
-    votable = VOTableFile()
-
-    # ...with one resource...
-    resource = Resource()
-    votable.resources.append(resource)
-
-    # ... with one table
-    table = TableElement(votable)
-    resource.tables.append(table)
-
-    # Define some fields
-    table.fields.extend(
-        [
-            Field(votable, ID="filename", datatype="char"),
-            Field(votable, ID="matrix", datatype="double", arraysize="2x2"),
-        ]
-    )
-
-    # Now, use those field definitions to create the numpy record arrays, with
-    # the given number of rows
-    table.create_arrays(2)
-
-    # Now table.array can be filled with data
-    table.array[0] = ("test1.xml", [[1, 0], [0, 1]])
-    table.array[1] = ("test2.xml", [[0.5, 0.3], [0.2, 0.1]])
-
-    # Now write the whole thing to a file.
-    # Note, we have to use the top-level votable file object
-    out = io.StringIO()
-    votable.to_xml(out)
-
-
 def test_direct_fields_mutation():
     from astropy.io.votable.tree import Field, Resource, TableElement, VOTableFile
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -19,7 +19,7 @@ from numpy import ma
 from astropy import __version__ as astropy_version
 from astropy.io import fits
 from astropy.utils import deprecated
-from astropy.utils.collections import HomogeneousList
+from astropy.utils.collections import HomogeneousList, _OwnedHomogeneousList
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.xml import iterparser
 from astropy.utils.xml.writer import XMLWriter
@@ -2536,8 +2536,26 @@ class TableElement(
         self.description = None
         self.format = "tabledata"
 
-        self._fields = HomogeneousList(Field)
-        self._all_fields = HomogeneousList(Field)
+        self._fields = _OwnedHomogeneousList(
+            Field,
+            owner_class=self.__class__,
+            public_attr_name="fields",
+            replacements={
+                "append": "add_field",
+                "extend": "add_field",
+                "__iadd__": "add_field",
+            },
+        )
+        self._all_fields = _OwnedHomogeneousList(
+            Field,
+            owner_class=self.__class__,
+            public_attr_name="all_fields",
+            replacements={
+                "append": "add_field",
+                "extend": "add_field",
+                "__iadd__": "add_field",
+            },
+        )
         self._params = HomogeneousList(Param)
         self._groups = HomogeneousList(Group)
         self._links = HomogeneousList(Link)
@@ -2665,7 +2683,7 @@ class TableElement(
         # To remedy this issue, we sync back the public property upon access.
         for field in self._fields:
             if field not in self._all_fields:
-                self._all_fields.append(field)
+                self._all_fields.append(field, _owned=True)
 
         return self._all_fields
 
@@ -2783,12 +2801,12 @@ class TableElement(
         return int(np.ceil(size * RESIZE_AMOUNT))
 
     def add_field(self, field: Field) -> None:
-        self.fields.append(field)
+        self.fields.append(field, _owned=True)
 
     def _register_field(self, iterator, tag, data, config, pos) -> None:
         field = Field(self._votable, config=config, pos=pos, **data)
         field.parse(iterator, config)
-        self._all_fields.append(field)
+        self._all_fields.append(field, _owned=True)
 
     def _add_param(self, iterator, tag, data, config, pos):
         param = Param(self._votable, config=config, pos=pos, **data)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2784,7 +2784,6 @@ class TableElement(
 
     def add_field(self, field: Field) -> None:
         self.fields.append(field)
-        self.all_fields.append(field)
 
     def _register_field(self, iterator, tag, data, config, pos) -> None:
         field = Field(self._votable, config=config, pos=pos, **data)

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -79,7 +79,7 @@ def _locked_mutator(instance_method):
         mtd_name = instance_method.__name__
         msg = (
             f"Direct mutations of {cls_name}.{self._attr_name} "
-            f"via {mtd_name} are deprecated since astropy 7.0 and "
+            f"via {mtd_name} are deprecated since astropy 7.1 and "
             "will raise an exception in the future. "
         )
 
@@ -108,7 +108,7 @@ class _OwnedMixin:
     This is meant as a helper class to prevent users from bypassing dedicated
     APIs by overriding mutating methods from the list API.
 
-    As of astropy 7.0, direct mutations are considered deprecated so a warning
+    As of astropy 7.1, direct mutations are considered deprecated so a warning
     is emitted. In a future major release of astropy, this class is meant to be
     removed, and its instances should be made completely private, possibly
     re-exposed as immutable properties (tuple).

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -11,9 +11,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import Any, SupportsIndex
-
-    from typing_extensions import Self
+    from typing import Any, Self, SupportsIndex
 
 
 class HomogeneousList(list):
@@ -35,7 +33,8 @@ class HomogeneousList(list):
         """
         self._types = types
         super().__init__()
-        self.extend(values)
+        for v in values:
+            self.append(v)
 
     def _assert(self, x):
         if not isinstance(x, self._types):

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -80,7 +80,7 @@ def _locked_mutator(instance_method):
         msg = (
             f"Direct mutations of {cls_name}.{self._attr_name} "
             f"via {mtd_name} are deprecated since astropy 7.0 and "
-            "will raise a TypeError in the future. "
+            "will raise an exception in the future. "
         )
 
         if (repl := self._replacements.get(mtd_name)) is not None:
@@ -102,20 +102,21 @@ def _locked_mutator(instance_method):
     return owned_method
 
 
-class _OwnedList(list):
+class _OwnedMixin:
     """
-    A list that can only be mutated by some owner object.
+    A collection that can only be mutated by some owner object.
     This is meant as a helper class to prevent users from bypassing dedicated
-    APIs.
+    APIs by overriding mutating methods from the list API.
 
     As of astropy 7.0, direct mutations are considered deprecated so a warning
-    is emitted. In a future major release of astropy, an actual exception will be
-    raised instead.
+    is emitted. In a future major release of astropy, this class is meant to be
+    removed, and its instances should be made completely private, possibly
+    re-exposed as immutable properties (tuple).
 
-    This class may be combined with other list subclasses via multiple inheritance,
-    in which case it is assumed to appear first on the inheritance chain, e.g.
+    Within multiple inheritance, this class is assumed to appear first on the
+    inheritance chain, and be combined with (a subclass of) list e.g.
 
-    >>> class _OwnedHomogeneousList(_OwnedList, HomogeneousList):
+    >>> class _OwnedHomogeneousList(_OwnedMixin, HomogeneousList):
     ...     pass
 
     otherwise, deprecation messages' might not point to the correct line.
@@ -185,5 +186,5 @@ class _OwnedList(list):
         return super().__delitem__(key)
 
 
-class _OwnedHomogeneousList(_OwnedList, HomogeneousList):
+class _OwnedHomogeneousList(_OwnedMixin, HomogeneousList):
     pass

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -111,6 +111,15 @@ class _OwnedList(list):
     As of astropy 7.0, direct mutations are considered deprecated so a warning
     is emitted. In a future major release of astropy, an actual exception will be
     raised instead.
+
+    This class may be combined with other list subclasses via multiple inheritance,
+    in which case it is assumed to appear first on the inheritance chain, e.g.
+
+    >>> class _OwnedHomogeneousList(_OwnedList, HomogeneousList):
+    ...     pass
+
+    otherwise, deprecation messages' might not point to the correct line.
+
     """
 
     def __init__(

--- a/astropy/utils/tests/test_collections.py
+++ b/astropy/utils/tests/test_collections.py
@@ -75,9 +75,13 @@ def test_homogeneous_list_works_with_generators():
     assert hl == [0, 1, 2]
 
 
+class OwnedList(collections._OwnedMixin, list):
+    pass
+
+
 class ListOwner:
     def __init__(self, data: list):
-        self._data = collections._OwnedList(
+        self._data = OwnedList(
             data,
             owner_class=self.__class__,
             public_attr_name="data",

--- a/docs/changes/io.votable/16314.api.rst
+++ b/docs/changes/io.votable/16314.api.rst
@@ -1,0 +1,4 @@
+Direct mutations of the ``fields`` attribute in a
+``astropy.io.votable.tree.TableElement`` object via, e.g., ``list.append`` or
+``list.extend`` are now deprecated. ``TableElement.add_field`` should be used
+instead.


### PR DESCRIPTION
### Description
Fixes #16314

The deprecation process is quite involved since we need to raise a warning for external usage of, say, `table.fields.append`, but still allow this operation to be performed silently internally.
My solution is to make `TableElement.fields` a "owned list" (my wording), that is, a list that has an owner object (namely the `TableElement` instance it belongs to), which is the only one allowed to directly mutate it (using a private keyword argument `_owned=True`). Mutations from other actors are still allowed as a temporary measure, but now raise a `DeprecationWarning`.

The commit history is meant to allow reviewing my process step by step. I'll also add some comments to the diff if I can help anticipate some questions from reviewers.
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


TODO
- [x] comment diff
- [x] handle magic methods too (`__iadd__`, `__imul__`, `__setitem__` and `__delitem__`)
- [x] Add docstrings to `_OwnedList` and `_OwnedHomegeneousList` (inheritance order matters !)
- [ ] open follow up issue to keep track of what to do when the deprecation ends (or we could just keep #16314 opened while the deprecation is on-going ?)

 

