### PR TITLE
TST: migrate macOS CI to arm64, move x86 to cron

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -52,6 +52,13 @@ jobs:
             toxargs: -v
             toxposargs: --remote-data=any
 
+          - name: Python 3.12 on macOS (intel x86)
+            os: macos-12
+            python: '3.12'
+            toxenv: py312-test-alldeps
+            toxargs: -v
+            toxposargs: --remote-data=any
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -88,7 +88,7 @@ jobs:
         - name: Python 3.11 with all optional dependencies (MacOS X)
           macos: py311-test-alldeps
           posargs: --durations=50 --run-slow
-          runs-on: macos-12
+          runs-on: macos-latest
 
         - name: Python 3.10 Double test (Run tests twice)
           linux: py310-test-double

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test_all = [
 ]
 recommended = [
     "scipy>=1.8",
+    "scipy!=1.13.0 ; platform_machine=='arm64' and platform_system=='Darwin'",
     "matplotlib>=3.3,!=3.4.0,!=3.5.2",
 ]
 typing = [


### PR DESCRIPTION
### Description

In the wake of #16319 and #16320, it seems we can no longer assume that both macOS' taget archs (x86, arm64) behave similarly enough that we can just test one.

arm64 is the only arch targeted by macOS these days, but it still makes sense to test x86 which wan discountinued in Jan 2023 according to [Wikipedia](https://en.wikipedia.org/wiki/Mac_transition_to_Apple_silicon), so I'm adding an env rather than changing the one we have.

Also note that [jobs relying on the moving tag `macos-latest` are being migrated](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) to amr64, so I'm setting `macos-12` and `macos-14` explicitly (which is the documented way to request x86 and amr64 runners, respectively).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
