### PR TITLE
Use cython to speed-up wrap angle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.dll
 __pycache__
 
+# cythonize -a output during development
+astropy/**/*.html
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, put that into the src/ subdirectory of a
 # package or else use `git add -f filename.c`.

--- a/astropy/coordinates/angles/_wrap.pyx
+++ b/astropy/coordinates/angles/_wrap.pyx
@@ -1,0 +1,55 @@
+#cython: language_level=3
+cimport cython
+cimport numpy as np
+from libc cimport math
+
+np.import_array()
+
+ctypedef fused dtype:
+    short
+    int
+    long
+    float
+    double
+
+
+@cython.ufunc
+@cython.cdivision(True)
+cdef dtype wrap_at(dtype angle, dtype wrap_angle, dtype period):
+    cdef dtype wrap_angle_floor
+    wrap_angle_floor = wrap_angle - period
+
+    if dtype is float or dtype is double:
+        if math.isnan(angle):
+            return angle
+
+    if (angle >= wrap_angle_floor) and (angle < wrap_angle):
+        return angle
+
+    cdef int wraps
+    wraps = int((angle - wrap_angle_floor) // period)
+
+    angle -= wraps * period
+
+    # Rounding errors can cause problems.
+    if angle >= wrap_angle:
+        angle -= period
+    elif angle < wrap_angle_floor:
+        angle += period
+
+    return angle
+
+
+@cython.ufunc
+@cython.cdivision(True)
+cdef dtype needs_wrapping(dtype angle, dtype wrap_angle, dtype period):
+    cdef dtype wrap_angle_floor
+    wrap_angle_floor = wrap_angle - period
+
+    if dtype is float or dtype is double:
+        if math.isnan(angle):
+            return False
+
+    if (angle >= wrap_angle_floor) and (angle < wrap_angle):
+        return False
+    return True

--- a/docs/changes/coordinates/16326.feature.rst
+++ b/docs/changes/coordinates/16326.feature.rst
@@ -1,0 +1,1 @@
+Add new cython module to optimize angle wrapping.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This is a follow-up to #13510, #13497 and #16222 to further improve up 13479.

I now use `cython.ufunc` to get a large speedup, factors of 2 to 3 for larger arrays, but faster in all cases I tested compared to current main (which already includes the improvements of #16222).

I'll open a similar one for the checks in `Latitude` which remain a bottleneck.

I'd also suggest to keep open ~#13497~ #13479 for the time being, it's still true that these functions are bottlenecks, even with the recent improvements.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
