### PR TITLE
Cythonize checking out of bounds latitudes

### DIFF
--- a/astropy/coordinates/angles/_validate_lat.pyx
+++ b/astropy/coordinates/angles/_validate_lat.pyx
@@ -1,0 +1,32 @@
+#cython: language_level=3
+cimport cython
+cimport numpy as np
+from libc cimport math
+from libc cimport stdlib
+
+np.import_array()
+
+ctypedef fused dtype:
+    short
+    int
+    long
+    float
+    double
+
+
+cdef bint is_invalid_lat(dtype angle, dtype limit):
+    if dtype is float or dtype is double:
+        angle = math.fabs(angle)
+    else:
+        angle = stdlib.abs(angle)
+    return angle > limit
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef bint any_invalid_lat(const dtype[:] angles, dtype limit):
+    cdef ssize_t size
+    size = angles.size
+    for i in range(size):
+        if is_invalid_lat(angles[i], limit):
+            return True
+    return False


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Essentially the same as #16326  but for the out of limits checking in `Latitude`;

Profiling `Latitude(angle)` for different shapes / number of nans in the array before and after:

![perf_lat](https://github.com/astropy/astropy/assets/5488440/db0046ae-cdd6-4236-aec6-8f115cbebffc)



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
