### PR TITLE
Return NaN for out of bound conversions in FITS WCS

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -332,7 +332,26 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
         return matrix
 
+    def _out_of_bounds_to_nan(self, pixel_arrays):
+        if self.pixel_bounds is not None:
+            pixel_arrays = list(pixel_arrays)
+            for idim in range(self.pixel_n_dim):
+                if self.pixel_bounds[idim] is None:
+                    continue
+                out_of_bounds = (pixel_arrays[idim] < self.pixel_bounds[idim][0]) | (
+                    pixel_arrays[idim] > self.pixel_bounds[idim][1]
+                )
+                if np.any(out_of_bounds):
+                    pix = pixel_arrays[idim].astype(float, copy=True)
+                    if np.isscalar(pix):
+                        pix = np.nan
+                    else:
+                        pix[out_of_bounds] = np.nan
+                    pixel_arrays[idim] = pix
+        return pixel_arrays
+
     def pixel_to_world_values(self, *pixel_arrays):
+        pixel_arrays = self._out_of_bounds_to_nan(pixel_arrays)
         world = self.all_pix2world(*pixel_arrays, 0)
         return world[0] if self.world_n_dim == 1 else tuple(world)
 
@@ -349,6 +368,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             pixel = self._array_converter(
                 lambda *args: e.best_solution, "input", *world_arrays, 0
             )
+
+        pixel = self._out_of_bounds_to_nan(pixel)
 
         return pixel[0] if self.pixel_n_dim == 1 else tuple(pixel)
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -342,10 +342,11 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     pixel_arrays[idim] > self.pixel_bounds[idim][1]
                 )
                 if np.any(out_of_bounds):
-                    pix = pixel_arrays[idim].astype(float, copy=True)
+                    pix = pixel_arrays[idim]
                     if np.isscalar(pix):
                         pix = np.nan
                     else:
+                        pix = pix.astype(float, copy=True)
                         pix[out_of_bounds] = np.nan
                     pixel_arrays[idim] = pix
         return pixel_arrays

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -64,7 +64,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_n_dim` scalars or arrays in units given by
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_units`. Note that pixel coordinates are
         assumed to be 0 at the center of the first pixel in each dimension. If a
-        pixel is in a region where the WCS is not defined, NaN can be returned.
+        pixel is in a region where the WCS is not defined, NaN should be returned.
         The coordinates should be specified in the ``(x, y)`` order, where for
         an image, ``x`` is the horizontal coordinate and ``y`` is the vertical
         coordinate.
@@ -99,7 +99,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` scalars or arrays. Note that pixel
         coordinates are assumed to be 0 at the center of the first pixel in each
         dimension. If a world coordinate does not have a matching pixel
-        coordinate, NaN can be returned.  The coordinates should be returned in
+        coordinate, NaN should be returned.  The coordinates should be returned in
         the ``(x, y)`` order, where for an image, ``x`` is the horizontal
         coordinate and ``y`` is the vertical coordinate.
 
@@ -274,6 +274,9 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         within a certain range of pixel values, for example when defining a
         WCS that includes fitted distortions. This is an optional property,
         and it should return `None` if a shape is not known or relevant.
+
+        The bounds can be a mix of values along dimensions where bounds exist,
+        and None for other dimensions, e.g. ``[(xmin, xmax), None]``.
         """
         return None
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1438,7 +1438,12 @@ def test_out_of_bounds(direction):
 
     # Before setting bounds
 
-    # Scalars
+    # Python Scalars
+    xw, yw = func(1, 1)
+    assert_array_equal(xw, 1)
+    assert_array_equal(yw, 1)
+
+    # Numpy Scalars
     xw, yw = func(xp[0], yp[0])
     assert_array_equal(xw, 1)
     assert_array_equal(yw, 1)
@@ -1457,7 +1462,17 @@ def test_out_of_bounds(direction):
 
     wcs.pixel_bounds = [(-0.5, 3.5), None]
 
-    # Scalars
+    # Python Scalars
+
+    xw, yw = func(1, 1)
+    assert_array_equal(xw, 1)
+    assert_array_equal(yw, 1)
+
+    xw, yw = func(5, 5)
+    assert_array_equal(xw, np.nan)
+    assert_array_equal(yw, 5)
+
+    # Numpy Scalars
 
     xw, yw = func(xp[0], yp[0])
     assert_array_equal(xw, 1)
@@ -1481,7 +1496,17 @@ def test_out_of_bounds(direction):
 
     wcs.pixel_bounds = [(-0.5, 3.5), (2.5, 5.5)]
 
-    # Scalars
+    # Python Scalars
+
+    xw, yw = func(1, 1)
+    assert_array_equal(xw, 1)
+    assert_array_equal(yw, np.nan)
+
+    xw, yw = func(5, 5)
+    assert_array_equal(xw, np.nan)
+    assert_array_equal(yw, 5)
+
+    # Numpy Scalars
 
     xw, yw = func(xp[0], yp[0])
     assert_array_equal(xw, 1)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -51,7 +51,7 @@ CUNIT3  = deg
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", VerifyWarning)
     WCS_SPECTRAL_CUBE = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep="\n"))
-WCS_SPECTRAL_CUBE.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
+WCS_SPECTRAL_CUBE.pixel_bounds = [(-1, 50), (-2, 60), (-5, 70)]
 
 
 def test_invalid_slices():
@@ -90,9 +90,9 @@ This transformation has 3 pixel and 3 world dimensions
 Array shape (Numpy order): (30, 20, 10)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None              10  (-1, 11)
-        1  None              20  (-2, 18)
-        2  None              30  (5, 15)
+        0  None              10  (-1, 50)
+        1  None              20  (-2, 60)
+        2  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  Latitude   pos.galactic.lat  deg
@@ -158,7 +158,7 @@ def test_ellipsis():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29.0, 39.0, 44.0))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
 
-    assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-1, 50), (-2, 60), (-5, 70)])
 
     assert str(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
     assert EXPECTED_ELLIPSIS_REPR.strip() in repr(wcs)
@@ -189,8 +189,8 @@ This transformation has 2 pixel and 2 world dimensions
 Array shape (Numpy order): (30, 10)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None              10  (-1, 11)
-        1  None              30  (5, 15)
+        0  None              10  (-1, 50)
+        1  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  Latitude   pos.galactic.lat  deg
@@ -235,7 +235,7 @@ def test_spectral_slice():
     assert_allclose(wcs.world_to_pixel_values(10, 25), (29.0, 44.0))
     assert_equal(wcs.world_to_array_index_values(10, 25), (44, 29))
 
-    assert_equal(wcs.pixel_bounds, [(-1, 11), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-1, 50), (-5, 70)])
 
     assert str(wcs) == EXPECTED_SPECTRAL_SLICE_REPR.strip()
     assert EXPECTED_SPECTRAL_SLICE_REPR.strip() in repr(wcs)
@@ -249,9 +249,9 @@ This transformation has 3 pixel and 3 world dimensions
 Array shape (Numpy order): (30, 6, 10)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None              10  (-1, 11)
-        1  None               6  (-6, 14)
-        2  None              30  (5, 15)
+        0  None              10  (-1, 50)
+        1  None               6  (-6, 56)
+        2  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  Latitude   pos.galactic.lat  deg
@@ -317,7 +317,7 @@ def test_spectral_range():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29.0, 35.0, 44.0))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 35, 29))
 
-    assert_equal(wcs.pixel_bounds, [(-1, 11), (-6, 14), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-1, 50), (-6, 56), (-5, 70)])
 
     assert str(wcs) == EXPECTED_SPECTRAL_RANGE_REPR.strip()
     assert EXPECTED_SPECTRAL_RANGE_REPR.strip() in repr(wcs)
@@ -331,8 +331,8 @@ This transformation has 2 pixel and 3 world dimensions
 Array shape (Numpy order): (30, 20)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None              20  (-2, 18)
-        1  None              30  (5, 15)
+        0  None              20  (-2, 60)
+        1  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  Latitude   pos.galactic.lat  deg
@@ -397,7 +397,7 @@ def test_celestial_slice():
     assert_allclose(wcs.world_to_pixel_values(12.4, 20, 25), (39.0, 44.0))
     assert_equal(wcs.world_to_array_index_values(12.4, 20, 25), (44, 39))
 
-    assert_equal(wcs.pixel_bounds, [(-2, 18), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-2, 60), (-5, 70)])
 
     assert str(wcs) == EXPECTED_CELESTIAL_SLICE_REPR.strip()
     assert EXPECTED_CELESTIAL_SLICE_REPR.strip() in repr(wcs)
@@ -411,9 +411,9 @@ This transformation has 3 pixel and 3 world dimensions
 Array shape (Numpy order): (30, 20, 5)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None               5  (-6, 6)
-        1  None              20  (-2, 18)
-        2  None              30  (5, 15)
+        0  None               5  (-6, 45)
+        1  None              20  (-2, 60)
+        2  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  Latitude   pos.galactic.lat  deg
@@ -479,7 +479,7 @@ def test_celestial_range():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (24.0, 39.0, 44.0))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 24))
 
-    assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-6, 45), (-2, 60), (-5, 70)])
 
     assert str(wcs) == EXPECTED_CELESTIAL_RANGE_REPR.strip()
     assert EXPECTED_CELESTIAL_RANGE_REPR.strip() in repr(wcs)
@@ -492,7 +492,7 @@ with warnings.catch_warnings():
     WCS_SPECTRAL_CUBE_ROT = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep="\n"))
 WCS_SPECTRAL_CUBE_ROT.wcs.pc = [[0, 0, 1], [0, 1, 0], [1, 0, 0]]
 WCS_SPECTRAL_CUBE_ROT.wcs.crval[0] = 0
-WCS_SPECTRAL_CUBE_ROT.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
+WCS_SPECTRAL_CUBE_ROT.pixel_bounds = [(-1, 50), (-2, 60), (-5, 70)]
 
 EXPECTED_CELESTIAL_RANGE_ROT_REPR = """
 SlicedLowLevelWCS Transformation
@@ -502,9 +502,9 @@ This transformation has 3 pixel and 3 world dimensions
 Array shape (Numpy order): (30, 20, 5)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None               5  (-6, 6)
-        1  None              20  (-2, 18)
-        2  None              30  (5, 15)
+        0  None               5  (-6, 45)
+        1  None              20  (-2, 60)
+        2  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  Latitude   pos.galactic.lat  deg
@@ -570,7 +570,7 @@ def test_celestial_range_rot():
     assert_allclose(wcs.world_to_pixel_values(1, 15, 24), (14.0, 29.0, 34.0))
     assert_equal(wcs.world_to_array_index_values(1, 15, 24), (34, 29, 14))
 
-    assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-6, 45), (-2, 60), (-5, 70)])
 
     assert str(wcs) == EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip()
     assert EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip() in repr(wcs)
@@ -700,7 +700,7 @@ HEADER_SPECTRAL_CUBE_NONE_TYPES = {
 }
 
 WCS_SPECTRAL_CUBE_NONE_TYPES = WCS(header=HEADER_SPECTRAL_CUBE_NONE_TYPES)
-WCS_SPECTRAL_CUBE_NONE_TYPES.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
+WCS_SPECTRAL_CUBE_NONE_TYPES.pixel_bounds = [(-1, 50), (-2, 60), (-5, 70)]
 
 WCS_SPECTRAL_CUBE_NONE_TYPES_NP = WCS(header=HEADER_SPECTRAL_CUBE_NONE_TYPES)
 WCS_SPECTRAL_CUBE_NONE_TYPES_NP.pixel_bounds = [
@@ -716,9 +716,9 @@ This transformation has 3 pixel and 3 world dimensions
 Array shape (Numpy order): (30, 20, 10)
 
 Pixel Dim  Axis Name  Data size  Bounds
-        0  None              10  (-1, 11)
-        1  None              20  (-2, 18)
-        2  None              30  (5, 15)
+        0  None              10  (-1, 50)
+        1  None              20  (-2, 60)
+        2  None              30  (-5, 70)
 
 World Dim  Axis Name  Physical Type     Units
         0  None       pos.galactic.lat  deg
@@ -771,7 +771,7 @@ def test_ellipsis_none_types():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29.0, 39.0, 44.0))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
 
-    assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
+    assert_equal(wcs.pixel_bounds, [(-1, 50), (-2, 60), (-5, 70)])
 
     assert str(wcs) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
     assert EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip() in repr(wcs)
@@ -887,6 +887,8 @@ def validate_info_dict(result, expected):
 
 def test_dropped_dimensions():
     wcs = WCS_SPECTRAL_CUBE
+
+    print(wcs.pixel_bounds)
 
     sub = SlicedLowLevelWCS(wcs, np.s_[:, :, :])
 

--- a/docs/changes/wcs/16328.api.rst
+++ b/docs/changes/wcs/16328.api.rst
@@ -1,0 +1,3 @@
+``WCS.pixel_to_world_values``, ``WCS.world_to_pixel_values``,
+``WCS.pixel_to_world`` and ``WCS.world_to_pixel`` now correctly return NaN values for
+pixel positions that are outside of ``pixel_bounds``.


### PR DESCRIPTION
I updated the APE 14 base class to say 'should' instead of 'can' because I think it's important we have consistent behavior.