### PR TITLE
TST: temp pin macos x86 runners

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -88,6 +88,7 @@ jobs:
         - name: Python 3.11 with all optional dependencies (MacOS X)
           macos: py311-test-alldeps
           posargs: --durations=50 --run-slow
+          runs-on: macos-12
 
         - name: Python 3.10 Double test (Run tests twice)
           linux: py310-test-double


### PR DESCRIPTION
### Description



context: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

As can be seen in [example logs](https://github.com/astropy/astropy/actions/runs/8798691509/job/24146244116), our CI was automatically migrated from macos-12 to macos-14 images. This migration also involves a change in hardware arch from x86 to arm64, so regular CI is now hitting #161319 and #16320
This PR pins images to macos-12 (x86) as a temp measure while these issues are being figured out.
I'll do the migration explicitly in #16321 when we stabilize it.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
