### PR TITLE
Fix #16246 change log entry

### DIFF
--- a/docs/changes/coordinates/16246.feature.rst
+++ b/docs/changes/coordinates/16246.feature.rst
@@ -3,8 +3,8 @@ methods now emit a warning if they have to perform a coordinate transformation
 that is not a pure rotation to inform the user that the angular separation can
 depend on the direction of the transformation.
 It is possible to modify this behaviour with the new optional keyword-only
-``frame_origin_mismatch`` argument.
-Specifying ``frame_origin_mismatch="ignore"`` allows any transformation to
+``origin_mismatch`` argument.
+Specifying ``origin_mismatch="ignore"`` allows any transformation to
 succeed without warning, which has been the behaviour so far.
-``frame_origin_mismatch="error"`` forbids all transformations that are not
+``origin_mismatch="error"`` forbids all transformations that are not
 pure rotations.


### PR DESCRIPTION
### Description

The change log entry uses a wrong name for the newly introduced argument it describes. The related Wnat's New entry, docstrings and narrative documentation all use the correct argument name.

xref #16246

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
