### PR TITLE
TST: rewrite doctest in a floating-point-comparison friendly way

### DIFF
--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -249,9 +249,11 @@ the catalog:
 
 .. doctest-requires:: scipy
 
+    >>> d3d # doctest: +FLOAT_CMP
+    <Quantity [1335.55538257] kpc>
     >>> matches = catalog[idx]
-    >>> (matches.separation_3d(c) == d3d).all()
-    True
+    >>> matches.separation_3d(c) # doctest: +FLOAT_CMP
+    <Distance [1335.55538257] kpc>
     >>> dra, ddec = c.spherical_offsets_to(matches)
 
 This functionality can also be accessed from the


### PR DESCRIPTION
### Description
Fixes #16319, ~similar to #16329, but with stricter margins than the defaults.~

This test worked fine on every archs for at least 5 years, so maybe it's hinting at a real bug that should be inspected more closely, but I'm really not sure it's worth it.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
