### PR TITLE
build: improve opt deps

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -37,8 +37,7 @@ Interface and Dependencies
   statement, which will raise an ``ImportError`` if the dependency is
   not available. In the astropy core package, such optional dependencies should
   be recorded in the ``pyproject.toml`` file in the ``[project.optional-dependencies]``
-  entry, under ``all`` (or ``test_all`` if the dependency is only
-  needed for testing).
+  entry (try to put it in the appropriate category of optional dependencies).
 
   At the module level, one can subclass a class from an optional dependency
   like so::

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -37,7 +37,7 @@ Interface and Dependencies
   statement, which will raise an ``ImportError`` if the dependency is
   not available. In the astropy core package, such optional dependencies should
   be recorded in the ``pyproject.toml`` file in the ``[project.optional-dependencies]``
-  entry (try to put it in the appropriate category of optional dependencies).
+  entry (put it in the appropriate category of optional dependencies).
 
   At the module level, one can subclass a class from an optional dependency
   like so::

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -39,8 +39,17 @@ option::
 
     python -m pip install --editable ".[test]"
 
-A detailed description of the plugins can be found in the :ref:`pytest-plugins`
-section.
+To test the full set of optional dependencies, use the ``test_all`` option::
+
+    python -m pip install --editable ".[test_all]"
+
+If you are looking to do development in Astropy beyond running the tests, e.g. building the documentation or doing static analysis, we provide the complete set of all
+dependencies with the ``dev_all`` option::
+
+    python -m pip install --editable ".[dev_all]"
+
+A detailed description of the |pytest-astropy| plugins can be found in the
+:ref:`pytest-plugins` section.
 
 .. _running-tests:
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -43,7 +43,8 @@ To test the full set of optional dependencies, use the ``test_all`` option::
 
     python -m pip install --editable ".[test_all]"
 
-If you are looking to do development in Astropy beyond running the tests, e.g. building the documentation or doing static analysis, we provide the complete set of all
+If you are looking to do development in Astropy beyond running the tests, e.g. building
+the documentation or doing static analysis, we provide the complete set of all
 dependencies with the ``dev_all`` option::
 
     python -m pip install --editable ".[dev_all]"

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -327,7 +327,7 @@ install the version of ``astropy`` you are working on into it. Do that with:
 
 .. code-block:: bash
 
-    python -m pip install --editable ".[test]"
+    python -m pip install --editable ".[test_all]"
 
 This will install ``astropy`` itself, along with a few packages which will be
 useful for testing the changes you will make down the road.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,35 +47,30 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = [
-    "pytest>=7.0",
-    "pytest-doctestplus>=0.12",
-    "pytest-astropy-header>=0.2.1",
-    "pytest-astropy>=0.10",
-    "pytest-xdist",
-    "threadpoolctl",
-]
-test_all = [
-    "astropy[test]",  # installs the [test] dependencies
-    "objgraph",
-    "ipykernel",
-    "ipython>=7.32",
-    "ipywidgets",
-    "coverage[toml]",
-    "skyfield>=1.20",
-    "sgp4>=2.3",
-    "array-api-strict",
-]
+# Recommended run-time dependencies to enable a lot of functionality within Astropy.
 recommended = [
     "scipy>=1.8",
     "matplotlib>=3.3,!=3.4.0,!=3.5.2",
 ]
-typing = [
-    "typing_extensions>=4.0.0"
+# Optional IPython-related behavior is in many places in Astropy. IPython is a complex
+# dependency that occasionally requires pinning one of it's upstream dependencies. If
+# you are using Astropy from an IPython-dependent IDE, like Jupyter, this should enforce
+# the minimum supported version of IPython.
+ipython = [
+    "ipython>=7.32",
 ]
+jupyter = [  # these are optional dependencies for `utils.console`
+    "astropy[ipython]",
+    "ipywidgets",
+    "ipykernel",
+]
+# This is ALL the run-time optional dependencies.
 all = [
-    "astropy[recommended]",  # installs the [recommended] dependencies
-    "astropy[typing]",
+    # Install grouped optional dependencies
+    "astropy[recommended]",
+    "astropy[ipython]",
+    "astropy[jupyter]",
+    # Install all remaining optional dependencies
     "certifi",
     "dask[array]",
     "h5py",
@@ -90,13 +85,32 @@ all = [
     "mpmath",
     "asdf-astropy>=0.3",
     "bottleneck",
-    "ipykernel",
-    "ipython>=7.32",
-    "ipywidgets",
-    "pytest>=7.0",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
+]
+# The base set of test-time dependencies.
+test = [
     "pre-commit",
+    "pytest>=7.0",
+    "pytest-doctestplus>=0.12",
+    "pytest-astropy-header>=0.2.1",
+    "pytest-astropy>=0.10",
+    "pytest-xdist",
+    "threadpoolctl",
+]
+test_all = [
+    # Install grouped optional dependencies
+    "astropy[all]",  # installs all optional run-time dependencies
+    "astropy[test]",
+    # Install all remaining dependencies
+    "objgraph",
+    "coverage[toml]",
+    "skyfield>=1.20",
+    "sgp4>=2.3",
+    "array-api-strict",
+]
+typing = [
+    "typing_extensions>=4.0.0"
 ]
 docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies
@@ -109,6 +123,17 @@ docs = [
     "tomli; python_version < '3.11'",
     "sphinxcontrib-globalsubs >= 0.1.1",
     "matplotlib!=3.9.0",  # https://github.com/matplotlib/matplotlib/issues/28234
+]
+# These group together all the dependencies needed for developing in Astropy.
+dev = [
+    "astropy[recommended]",  # installs the most common optional dependencies
+    "astropy[test]",
+    "astropy[docs]",
+    "astropy[typing]",
+]
+dev_all = [
+    "astropy[dev]",
+    "astropy[test_all]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ all = [
 ]
 # The base set of test-time dependencies.
 test = [
+    "coverage[toml]",
     "pre-commit",
     "pytest>=7.0",
     "pytest-doctestplus>=0.12",
@@ -104,13 +105,12 @@ test_all = [
     "astropy[test]",
     # Install all remaining dependencies
     "objgraph",
-    "coverage[toml]",
     "skyfield>=1.20",
     "sgp4>=2.3",
     "array-api-strict",
 ]
 typing = [
-    "typing_extensions>=4.0.0"
+    "typing_extensions>=4.0.0",
 ]
 docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies


### PR DESCRIPTION
Small improvements to the specification of optional dependencies. In particular, this improves `astropy[all]` to actually have everything and installs pre-commit for `astropy[test]` since our CI consists of 1. pre-commit checks, e.g. `yaml` verification, and 2. `pytest`-powered stuff.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
