### PR TITLE
Deprecate `factor` parameter of `spectral_density()` equivalency

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -8,6 +8,7 @@ import numpy as np
 
 # LOCAL
 from astropy.constants import si as _si
+from astropy.utils import deprecated_renamed_argument
 from astropy.utils.misc import isiterable
 
 from . import astrophys, cgs, dimensionless_unscaled, misc, si
@@ -152,6 +153,9 @@ def spectral():
     )
 
 
+@deprecated_renamed_argument(
+    "factor", None, since="7.0", alternative='"wav" as a "Quantity"'
+)
 def spectral_density(wav, factor=None):
     """
     Returns a list of equivalence pairs that handle spectral density
@@ -162,13 +166,15 @@ def spectral_density(wav, factor=None):
     wav : `~astropy.units.Quantity`
         `~astropy.units.Quantity` associated with values being converted
         (e.g., wavelength or frequency).
+    factor : array_like
+        If ``wav`` is a |Unit| instead of a |Quantity| then ``factor``
+        is the value ``wav`` will be multiplied with to convert it to
+        a |Quantity|.
 
-    Notes
-    -----
-    The ``factor`` argument is left for backward-compatibility with the syntax
-    ``spectral_density(unit, factor)`` but users are encouraged to use
-    ``spectral_density(factor * unit)`` instead.
+        .. deprecated:: 7.0
 
+            ``factor`` is deprecated. Pass in ``wav`` as a |Quantity|,
+            not as a |Unit|.
     """
     from .core import UnitBase
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -12,6 +12,7 @@ from astropy import constants
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units.equivalencies import Equivalency
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_find_equivalent_units():
@@ -998,3 +999,17 @@ def test_pprint():
         "<tr><td>Ci</td><td>3.7e+10 / s</td><td>curie</td></tr>"
         "<tr><td>Hz</td><td>1 / s</td><td>Hertz, hertz</td></tr></table>"
     )
+
+
+def test_spectral_density_factor_deprecation():
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            r'^"factor" was deprecated in version 7\.0 and will be removed in a future '
+            r'version\. \n        Use "wav" as a "Quantity" instead\.$'
+        ),
+    ):
+        a = (u.erg / u.angstrom / u.cm**2 / u.s).to(
+            u.erg / u.Hz / u.cm**2 / u.s, 1, u.spectral_density(u.AA, factor=3500)
+        )
+    assert_quantity_allclose(a, 4.086160166177361e-12)

--- a/docs/changes/units/16343.api.rst
+++ b/docs/changes/units/16343.api.rst
@@ -1,0 +1,4 @@
+The ``factor`` parameter of the ``spectral_density`` equivalency, the use of
+which has been discouraged in the documentation since version 0.3, is now
+deprecated.
+Use the ``wav`` parameter as a ``Quantity``, not as a bare unit.


### PR DESCRIPTION
### Description

Since 935350e6d5e364800ec2a13fd5818023d74d8b3f there has been a note in the docstring saying that the parameter should not be used, but it has not been properly deprecated until now.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
