### PR TITLE
DEPR: deprecate `astropy.utils.check_broadcast`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 
 from astropy import units as u
-from astropy.utils import ShapedLikeNDArray, check_broadcast
+from astropy.utils import ShapedLikeNDArray
 from astropy.utils.decorators import deprecated, format_doc, lazyproperty
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyWarning, _add_note_to_exception
 
 from . import representation as r
 from .angles import Angle, position_angle
@@ -344,11 +344,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
         # Determine the overall shape of the frame.
         try:
-            self._shape = check_broadcast(*shapes)
-        except ValueError as err:
-            raise ValueError(
-                f"non-scalar data and/or attributes with inconsistent shapes: {shapes}"
-            ) from err
+            self._shape = np.broadcast_shapes(*shapes)
+        except ValueError as exc:
+            _add_note_to_exception(
+                exc,
+                f"non-scalar data and/or attributes with inconsistent shapes: {shapes}",
+            )
+            raise exc
 
         # Broadcast the data if necessary and set it
         if data is not None and data.shape != self._shape:

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -10,7 +10,6 @@ from textwrap import indent
 
 import numpy as np
 
-from astropy.utils import check_broadcast
 from astropy.utils.compat import COPY_IF_NEEDED
 
 from .core import FittableModel, Model
@@ -1189,7 +1188,7 @@ class Polynomial2D(PolynomialModel):
         # still as expected by the broadcasting rules, even though the x and y
         # inputs are not used in the evaluation
         if self.degree == 0:
-            output_shape = check_broadcast(np.shape(coeffs[0]), x.shape)
+            output_shape = np.broadcast_shapes(np.shape(coeffs[0]), x.shape)
             if output_shape:
                 new_result = np.empty(output_shape)
                 new_result[:] = result

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -436,11 +436,7 @@ class TestSingleInputSingleOutputSingleModel:
         assert np.shape(y2) == (2, 2)
         assert np.all(y2 == [[111, 122], [211, 222]])
 
-        MESSAGE = (
-            r"self input argument 'x' of shape .* cannot be broadcast with parameter"
-            r" 'p1' of shape .*"
-        )
-        with pytest.raises(ValueError, match=MESSAGE):
+        with pytest.raises(ValueError, match="broadcast"):
             # Doesn't broadcast
             t([100, 200, 300])
 
@@ -466,11 +462,7 @@ class TestSingleInputSingleOutputSingleModel:
             ]
         )
 
-        MESSAGE = (
-            r"self input argument .* of shape .* cannot be broadcast with parameter .*"
-            r" of shape .*"
-        )
-        with pytest.raises(ValueError, match=MESSAGE):
+        with pytest.raises(ValueError, match="broadcast"):
             # Doesn't broadcast
             t([[100, 200, 300], [400, 500, 600]])
 
@@ -654,11 +646,7 @@ class TestSingleInputSingleOutputTwoModel:
         assert np.shape(y1) == (2, 3)
         assert np.all(y1 == [[111, 122, 133], [244, 255, 266]])
 
-        MESSAGE = (
-            r"Model input argument .* of shape .* cannot be broadcast with parameter .*"
-            r" of shape .*"
-        )
-        with pytest.raises(ValueError, match=MESSAGE):
+        with pytest.raises(ValueError, match="broadcast"):
             # Doesn't broadcast with the shape of the parameters, (3,)
             y2 = t([100, 200], model_set_axis=False)
 
@@ -682,11 +670,7 @@ class TestSingleInputSingleOutputTwoModel:
             ]
         )
 
-        MESSAGE = (
-            r"Model input argument .* of shape .* cannot be broadcast with parameter .*"
-            r" of shape .*"
-        )
-        with pytest.raises(ValueError, match=MESSAGE):
+        with pytest.raises(ValueError, match="broadcast"):
             y2 = t([[100, 200, 300], [400, 500, 600]])
 
         y2 = t([[[100, 200], [300, 400]], [[500, 600], [700, 800]]])
@@ -845,11 +829,7 @@ class TestSingleInputDoubleOutputSingleModel:
         assert np.all(y2 == [[111, 122], [211, 222]])
         assert np.all(z2 == [[1111, 2122], [1211, 2222]])
 
-        MESSAGE = (
-            r"self input argument .* of shape .* cannot be broadcast with parameter .*"
-            r" of shape .*"
-        )
-        with pytest.raises(ValueError, match=MESSAGE):
+        with pytest.raises(ValueError, match="broadcast"):
             # Doesn't broadcast
             y3, z3 = t([100, 200, 300])
 
@@ -885,11 +865,7 @@ class TestSingleInputDoubleOutputSingleModel:
             ]
         )
 
-        MESSAGE = (
-            r"self input argument .* of shape .* cannot be broadcast with parameter .*"
-            r" of shape .*"
-        )
-        with pytest.raises(ValueError, match=MESSAGE):
+        with pytest.raises(ValueError, match="broadcast"):
             # Doesn't broadcast
             y3, z3 = t([[100, 200, 300], [400, 500, 600]])
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -125,9 +125,7 @@ def test_inconsistent_input_shapes():
     g = Gaussian2D()
     x = np.arange(-1.0, 1, 0.2)
     y = np.arange(-1.0, 1, 0.1)
-    with pytest.raises(
-        ValueError, match="All inputs must have identical shapes or must be scalars"
-    ):
+    with pytest.raises(ValueError, match="broadcast"):
         g(x, y)
 
 

--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -75,6 +75,17 @@ class _NoValue:
 NoValue = _NoValue()
 
 
+def _add_note_to_exception(exc: Exception, note: str) -> None:
+    import sys
+
+    if sys.version_info >= (3, 11):
+        exc.add_note(note)
+    else:
+        # mimic Python 3.11 behavior:
+        # preserve error message and traceback
+        exc.args += ("\n", note)
+
+
 def __getattr__(name: str):
     if name in ("ErfaError", "ErfaWarning"):
         import warnings

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from astropy.utils.compat import NUMPY_LT_2_0
+from astropy.utils.decorators import deprecated
 
 if NUMPY_LT_2_0:
     import numpy.core as np_core
@@ -356,6 +357,7 @@ class IncompatibleShapeError(ValueError):
         super().__init__(shape_a, shape_a_idx, shape_b, shape_b_idx)
 
 
+@deprecated("7.0", alternative="np.broadcast_shapes")
 def check_broadcast(*shapes: tuple[int, ...]) -> tuple[int, ...]:
     """
     Determines whether two or more Numpy arrays can be broadcast with each

--- a/astropy/utils/tests/test_shapes.py
+++ b/astropy/utils/tests/test_shapes.py
@@ -6,9 +6,16 @@ from hypothesis import given
 from hypothesis.extra.numpy import basic_indices
 from numpy.testing import assert_equal
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.shapes import check_broadcast, simplify_basic_index, unbroadcast
 
 
+def test_check_broadcast_deprecation():
+    with pytest.warns(AstropyDeprecationWarning):
+        check_broadcast((1,), (2,))
+
+
+@pytest.mark.filterwarnings("ignore")
 def test_check_broadcast():
     assert check_broadcast((10, 1), (3,)) == (10, 3)
     assert check_broadcast((10, 1), (3,), (4, 1, 1, 3)) == (4, 1, 10, 3)

--- a/docs/changes/utils/16346.api.rst
+++ b/docs/changes/utils/16346.api.rst
@@ -1,0 +1,2 @@
+``astropy.utils.check_broadcast`` is now deprecated in favor of
+``numpy.broadcast_shapes``


### PR DESCRIPTION
### Description
Fixes #15211 and replaces #15499 (I marked @felipekhouri as a co-author here)

I note that this implies `IncompatibleShapeError` is now unused (outside `check_broadcast`. Since users might be importing it to construct `try/except` blocks around `check_broadcast`, it should probably be deprecated too. Let me know if this should be done in the same PR or as a follow up.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
