### PR TITLE
Add support for custom coordinate frames in WCSAxes specifically in transform_coord_meta_from_wcs

### DIFF
--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -18,7 +18,7 @@ from .coordinates_map import CoordinatesMap
 from .core import *
 from .helpers import *
 from .patches import *
-from .wcsapi import custom_ucd_wcscoord_mapping
+from .wcsapi import custom_ucd_coord_meta_mapping
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -18,6 +18,7 @@ from .coordinates_map import CoordinatesMap
 from .core import *
 from .helpers import *
 from .patches import *
+from .wcsapi import custom_ucd_wcscoord_mapping
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -268,15 +268,17 @@ def test_coord_type_from_ctype(cube_wcs):
     assert coord_meta["wrap"] == [None, None]
 
     myframe_mapping = {
-        'custom:pos.myframe.lon':  {
+        "custom:pos.myframe.lon": {
             "coord_wrap": 180.0 * u.deg,
             "format_unit": u.arcsec,
-            "coord_type": "longitude"
+            "coord_type": "longitude",
         },
-        "custom:pos.myframe.lat": {"format_unit": u.arcsec, "coord_type": "latitude"}
+        "custom:pos.myframe.lat": {"format_unit": u.arcsec, "coord_type": "latitude"},
     }
 
-    astropy.visualization.wcsaxes.wcsapi.CUSTOM_UCD_COORD_META_MAPPING.update(myframe_mapping)
+    astropy.visualization.wcsaxes.wcsapi.CUSTOM_UCD_COORD_META_MAPPING.update(
+        myframe_mapping
+    )
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ["MFLN-TAN", "MFLT-TAN"]
@@ -294,7 +296,7 @@ def test_coord_type_from_ctype(cube_wcs):
 
     assert coord_meta["type"] == ["longitude", "latitude"]
     assert coord_meta["format_unit"] == [u.arcsec, u.arcsec]
-    assert coord_meta["wrap"] == [180*u.deg, None]
+    assert coord_meta["wrap"] == [180 * u.deg, None]
 
 
 def test_coord_type_1d_1d_wcs():

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from matplotlib.transforms import Affine2D, IdentityTransform
 
-import astropy.visualization.wcsaxes.wcsapi
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -276,32 +275,6 @@ def test_coord_type_from_ctype(cube_wcs):
         },
         "custom:pos.myframe.lat": {"format_unit": u.arcsec, "coord_type": "latitude"},
     }
-
-    astropy.visualization.wcsaxes.wcsapi.CUSTOM_UCD_COORD_META_MAPPING.update(
-        myframe_mapping
-    )
-
-    wcs = WCS(naxis=2)
-    wcs.wcs.ctype = ["MFLN-TAN", "MFLT-TAN"]
-    wcs.wcs.crpix = [256.0] * 2
-    wcs.wcs.cdelt = [-0.05] * 2
-    wcs.wcs.crval = [50.0] * 2
-    wcs.wcs.set()
-
-    custom_mapping = {
-        "MFLN": "custom:pos.myframe.lon",
-        "MFLT": "custom:pos.myframe.lat",
-    }
-    with custom_ctype_to_ucd_mapping(custom_mapping):
-        _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
-
-    assert coord_meta["type"] == ["longitude", "latitude"]
-    assert coord_meta["format_unit"] == [u.arcsec, u.arcsec]
-    assert coord_meta["wrap"] == [180 * u.deg, None]
-
-    del astropy.visualization.wcsaxes.wcsapi.CUSTOM_UCD_COORD_META_MAPPING[
-        "custom:pos.myframe.lon"
-    ]
 
 
 def test_custom_coord_type_from_ctype():

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -299,6 +299,10 @@ def test_coord_type_from_ctype(cube_wcs):
     assert coord_meta["format_unit"] == [u.arcsec, u.arcsec]
     assert coord_meta["wrap"] == [180 * u.deg, None]
 
+    del astropy.visualization.wcsaxes.wcsapi.CUSTOM_UCD_COORD_META_MAPPING[
+        "custom:pos.myframe.lon"
+    ]
+
 
 def test_custom_coord_type_from_ctype():
     wcs = WCS(naxis=1)

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -391,9 +391,10 @@ def test_custom_coord_type_1d_2d_wcs_overwrite():
 
     custom_meta = {
         "custom:pos.heliographic.stonyhurst.lon": {
-            "coord_wrap": 180 * u.deg,
             "format_unit": u.arcsec,
-            "coord_type": "longitude",
+            # This also tests that we don't overwrite the custom meta with the
+            # stock meta that will set to longitude when the UCD ends in lon
+            "coord_type": "latitude",
         }
     }
 
@@ -406,9 +407,9 @@ def test_custom_coord_type_1d_2d_wcs_overwrite():
     with custom_ucd_wcscoord_mapping(custom_meta, overwrite=True):
         _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 
-    assert coord_meta["type"] == ["longitude", "latitude"]
+    assert coord_meta["type"] == ["latitude", "latitude"]
     assert coord_meta["format_unit"] == [u.arcsec, u.deg]
-    assert coord_meta["wrap"] == [180.0 * u.deg, None]
+    assert coord_meta["wrap"] == [None, None]
 
 
 def test_coord_type_1d_1d_wcs():

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -19,7 +19,7 @@ from astropy.visualization.wcsaxes.frame import RectangularFrame, RectangularFra
 from astropy.visualization.wcsaxes.wcsapi import (
     WCSWorld2PixelTransform,
     apply_slices,
-    custom_ucd_wcscoord_mapping,
+    custom_ucd_coord_meta_mapping,
     transform_coord_meta_from_wcs,
 )
 from astropy.wcs import WCS
@@ -299,7 +299,7 @@ def test_custom_coord_type_from_ctype():
                 "coord_type": "longitude",
             }
         }
-        with custom_ucd_wcscoord_mapping(custom_meta):
+        with custom_ucd_coord_meta_mapping(custom_meta):
             ax = fig.add_subplot(111, projection=wcs)
             ax.coords
             assert ax.coords["eggs"].coord_type == "longitude"
@@ -332,14 +332,14 @@ def test_custom_coord_type_from_ctype_nested():
                 "coord_type": "longitude",
             }
         }
-        with custom_ucd_wcscoord_mapping(custom_meta_1):
+        with custom_ucd_coord_meta_mapping(custom_meta_1):
             custom_meta_2 = {
                 "pos.spam": {
                     "format_unit": u.deg,
                     "coord_type": "latitude",
                 }
             }
-            with custom_ucd_wcscoord_mapping(custom_meta_2):
+            with custom_ucd_coord_meta_mapping(custom_meta_2):
                 ax = fig.add_subplot(111, projection=wcs)
                 ax.coords
                 assert ax.coords["eggs"].coord_type == "longitude"
@@ -378,10 +378,10 @@ def test_custom_coord_type_1d_2d_wcs_overwrite():
     with pytest.raises(
         ValueError, match="pos.heliographic.stonyhurst.lon already exists"
     ):
-        with custom_ucd_wcscoord_mapping(custom_meta):
+        with custom_ucd_coord_meta_mapping(custom_meta):
             _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 
-    with custom_ucd_wcscoord_mapping(custom_meta, overwrite=True):
+    with custom_ucd_coord_meta_mapping(custom_meta, overwrite=True):
         _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 
     assert coord_meta["type"] == ["latitude", "latitude"]

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -166,10 +166,10 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
                 if ucd in axis_type:
                     dim_meta.update(meta)
                     break
-
-            for ucd, meta in UCD_COORD_META_MAPPING.items():
-                if ucd == axis_type_split[-1]:
-                    dim_meta.update(meta)
+            else:
+                for ucd, meta in UCD_COORD_META_MAPPING.items():
+                    if ucd == axis_type_split[-1]:
+                        dim_meta.update(meta)
 
         coord_meta["type"].append(dim_meta["coord_type"])
         coord_meta["wrap"].append(dim_meta["coord_wrap"])

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -17,7 +17,7 @@ __all__ = [
     "transform_coord_meta_from_wcs",
     "WCSWorld2PixelTransform",
     "WCSPixel2WorldTransform",
-    "custom_ucd_wcscoord_mapping",
+    "custom_ucd_coord_meta_mapping",
 ]
 
 IDENTITY = WCS(naxis=2)
@@ -59,7 +59,7 @@ CUSTOM_UCD_COORD_META_MAPPING = {
 
 
 @contextmanager
-def custom_ucd_wcscoord_mapping(mapping, *, overwrite=False):
+def custom_ucd_coord_meta_mapping(mapping, *, overwrite=False):
     """
     A context manager that makes it possible to temporarily add new UCD+ to WCS coordinate
     plot metadata mappings.
@@ -75,7 +75,7 @@ def custom_ucd_wcscoord_mapping(mapping, *, overwrite=False):
     Examples
     --------
     >>> from matplotlib import pyplot as plt
-    >>> from astropy.visualization.wcsaxes.wcsapi import custom_ucd_wcscoord_mapping
+    >>> from astropy.visualization.wcsaxes.wcsapi import custom_ucd_coord_meta_mapping
     >>> from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping
     >>> wcs = WCS(naxis=1)
     >>> wcs.wcs.ctype = ["eggs"]
@@ -89,7 +89,7 @@ def custom_ucd_wcscoord_mapping(mapping, *, overwrite=False):
     ...             "coord_type": "longitude",
     ...         }
     ...     }
-    ...     with custom_ucd_wcscoord_mapping(custom_meta):
+    ...     with custom_ucd_coord_meta_mapping(custom_meta):
     ...        fig = plt.figure()
     ...        ax = fig.add_subplot(111, projection=wcs)
     ...        ax.coords

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -68,24 +68,33 @@ class custom_ucd_wcscoord_mapping:
 
     Examples
     --------
-    >>> from astropy.wcs import WCS
-    >>> wcs = WCS(naxis=1)
-    >>> wcs.wcs.ctype = ['custom:pos.ham.eggs']
-
-
-    >>> fig = plt.figure()
-    >>> ax = fig.add_subplot(111, projection=wcs)
-    >>> ax.coords
-
-    >>> custom_meta = {'custom:pos.ham.eggs': {
-    >>>                 'coord_wrap': 360.0 * u.deg,
-    >>>                 'format_unit': u.deg,
-    >>>                 'coord_type': 'longitude'}}
-    >>> fig = plt.figure()
-    >>> with custom_ucd_wcscoord_mapping(custom_meta):
-    >>>     ax = fig.add_subplot(111, projection=wcs)
-    >>>     ax.coords
-
+        >>> from matplotlib import pyplot as plt
+        >>> from astropy.visualization.wcsaxes.wcsapi import custom_ucd_wcscoord_mapping
+        >>> from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping
+        >>> wcs = WCS(naxis=1)
+        >>> wcs.wcs.ctype = ["eggs"]
+        >>> wcs.wcs.cunit = ["deg"]
+        >>> custom_mapping = {"eggs": "custom:pos.eggs"}
+        >>> with custom_ctype_to_ucd_mapping(custom_mapping):
+        ...     custom_meta = {
+        ...         "pos.eggs": {
+        ...             "coord_wrap": 360.0 * u.deg,
+        ...             "format_unit": u.arcsec,
+        ...             "coord_type": "longitude",
+        ...         }
+        ...     }
+        ...     with custom_ucd_wcscoord_mapping(custom_meta):
+        ...        fig = plt.figure()
+        ...        ax = fig.add_subplot(111, projection=wcs)
+        ...        ax.coords
+        <CoordinatesMap with 1 world coordinates:
+        <BLANKLINE>
+          index       aliases           type   unit  wrap format_unit visible
+                                                     deg
+          ----- -------------------- --------- ---- ----- ----------- -------
+              0 custom:pos.eggs eggs longitude  deg 360.0      arcsec     yes
+        <BLANKLINE>
+        >
     """
 
     def __init__(self, mapping):

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -170,6 +170,7 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
                 for ucd, meta in UCD_COORD_META_MAPPING.items():
                     if ucd == axis_type_split[-1]:
                         dim_meta.update(meta)
+                        break
 
         coord_meta["type"].append(dim_meta["coord_type"])
         coord_meta["wrap"].append(dim_meta["coord_wrap"])

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -105,6 +105,7 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
             for ucd, meta in CUSTOM_UCD_COORD_META_MAPPING.items():
                 if ucd in axis_type:
                     dim_meta.update(meta)
+                    break
 
             for ucd, meta in UCD_COORD_META_MAPPING.items():
                 if ucd == axis_type_split[-1]:

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -95,12 +95,12 @@ def custom_ucd_wcscoord_mapping(mapping, *, overwrite=False):
     ...        ax.coords
     <CoordinatesMap with 1 world coordinates:
     <BLANKLINE>
-        index       aliases           type   unit  wrap format_unit visible
-                                                    deg
-        ----- -------------------- --------- ---- ----- ----------- -------
-            0 custom:pos.eggs eggs longitude  deg 360.0      arcsec     yes
+      index       aliases           type   unit  wrap format_unit visible
+                                                 deg
+      ----- -------------------- --------- ---- ----- ----------- -------
+          0 custom:pos.eggs eggs longitude  deg 360.0      arcsec     yes
     <BLANKLINE>
-
+    >
     """
     for k, v in mapping.items():
         k = k.removeprefix("custom:")

--- a/docs/changes/visualization/16347.feature.rst
+++ b/docs/changes/visualization/16347.feature.rst
@@ -1,1 +1,1 @@
-Add support for custom coordinate frames for ``WCSAxes`` through a context manager ``custom_ucd_wcscoord_mapping`` using a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` in ``astropy.visualization.wcsaxes.wcsapi``.
+Add support for custom coordinate frames for ``WCSAxes`` through a context manager ``astropy.visualization.wcsaxes.custom_ucd_wcscoord_mapping`` using a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` in ``astropy.visualization.wcsaxes.wcsapi``.

--- a/docs/changes/visualization/16347.feature.rst
+++ b/docs/changes/visualization/16347.feature.rst
@@ -1,1 +1,1 @@
-Add support for custom coordinate frames to ``WCSAxes`` by adding a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` to ``astropy.visualization.wcsaxes.wcsapi``.
+Add support for custom coordinate frames for ``WCSAxes`` through a context manager ``custom_ucd_wcscoord_mappin`` using a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` to ``astropy.visualization.wcsaxes.wcsapi``

--- a/docs/changes/visualization/16347.feature.rst
+++ b/docs/changes/visualization/16347.feature.rst
@@ -1,1 +1,1 @@
-Add support for custom coordinate frames for ``WCSAxes`` through a context manager ``custom_ucd_wcscoord_mappin`` using a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` to ``astropy.visualization.wcsaxes.wcsapi``
+Add support for custom coordinate frames for ``WCSAxes`` through a context manager ``custom_ucd_wcscoord_mapping`` using a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` in ``astropy.visualization.wcsaxes.wcsapi``.

--- a/docs/changes/visualization/16347.feature.rst
+++ b/docs/changes/visualization/16347.feature.rst
@@ -1,1 +1,1 @@
-Add support for custom coordinate frames to `WCSAxes` by adding the UCD to property mappings to `CUSTOM_UCD_COORD_META_MAPPING`.
+Add support for custom coordinate frames to ``WCSAxes`` by adding a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` to ``astropy.visualization.wcsaxes.wcsapi``.

--- a/docs/changes/visualization/16347.feature.rst
+++ b/docs/changes/visualization/16347.feature.rst
@@ -1,0 +1,1 @@
+Add support for custom coordinate frames to `WCSAxes` by adding the UCD to property mappings to `CUSTOM_UCD_COORD_META_MAPPING`.

--- a/docs/changes/visualization/16347.feature.rst
+++ b/docs/changes/visualization/16347.feature.rst
@@ -1,1 +1,2 @@
-Add support for custom coordinate frames for ``WCSAxes`` through a context manager ``astropy.visualization.wcsaxes.custom_ucd_wcscoord_mapping`` using a custom property mapping ``CUSTOM_UCD_COORD_META_MAPPING`` in ``astropy.visualization.wcsaxes.wcsapi``.
+Add support for custom coordinate frames for ``WCSAxes`` through a context
+manager ``astropy.visualization.wcsaxes.custom_ucd_coord_meta_mapping``.


### PR DESCRIPTION
### Description

This pull request adds support for externally created customs coordinate frames to WCSAxes by altering how `transform_coord_meta_from_wcs` operates.
-  Creating a new variable `CUSTOM_UCD_COORD_META_MAPPING` which could be extended by external packages.
-  Move existing custom frame to this new variable

If this approach is ok then the custom sunpy frame could be moved into the sunpy repo.

~~I didn't add a new test as while there is new code the current tests cover it I think.~~

In an external package I could register new CTYPE to UCD and  UCD to coord meta data mappings.

```
MYFRAME_CTYPE_TO_UCD1 = {
    "SXLT": "custom:pos.myframe.lat",
    "SXLN": "custom:pos.myframe.lon",
    "SXRZ": "custom:pos.myframe.z"
}
astropy.wcs.wcsapi.fitswcs.CTYPE_TO_UCD1_CUSTOM.update(MYFRAME_CTYPE_TO_UCD1)


MYFAME_UCD_COORD_META_MAPPING = {
    "custom:pos.myframe.lon": {
        "coord_wrap": 180.0 * u.deg,
        "format_unit": u.arcsec,
        "coord_type": "longitude",
    },

astropy.visualization.wcsaxes.wcsapi.CUSTOM_UCD_COORD_META_MAPPING.update(MYFAME_UCD_COORD_META_MAPPING)
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16339 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
