### PR TITLE
ENH: replace `try/except ImportError` blocks with `if HAS_X`

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -9,6 +9,7 @@ from astropy import units as u
 from astropy.modeling.convolution import Convolution
 from astropy.modeling.core import SPECIAL_OPERATORS, CompoundModel
 from astropy.nddata import support_nddata
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.console import human_file_size
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -54,12 +55,10 @@ def _next_fast_lengths(shape):
     Calculated directly with `scipy.fft.next_fast_len`, if available; otherwise
     looked up from list and scaled by powers of 10, if necessary.
     """
-    try:
+    if HAS_SCIPY:
         import scipy.fft
 
         return np.array([scipy.fft.next_fast_len(j) for j in shape])
-    except ImportError:
-        pass
 
     newshape = np.empty(len(np.atleast_1d(shape)), dtype=int)
     for i, j in enumerate(shape):

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -15,6 +15,7 @@ import numpy as np
 from astropy import units as u
 from astropy.constants import c as speed_of_light
 from astropy.utils.compat import COPY_IF_NEEDED
+from astropy.utils.compat.optional_deps import HAS_JPLEPHEM
 from astropy.utils.data import download_file
 from astropy.utils.decorators import classproperty, deprecated
 from astropy.utils.state import ScienceState
@@ -164,13 +165,12 @@ def _get_kernel(value):
     if value is None or value.lower() == "builtin":
         return None
 
-    try:
-        from jplephem.spk import SPK
-    except ImportError:
-        raise ImportError(
+    if not HAS_JPLEPHEM:
+        raise ModuleNotFoundError(
             "Solar system JPL ephemeris calculations require the jplephem package "
             "(https://pypi.org/project/jplephem/)"
         )
+    from jplephem.spk import SPK
 
     if value.lower() == "jpl":
         # Get the default JPL ephemeris URL

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -12,6 +12,7 @@ import warnings
 from copy import deepcopy
 
 from astropy.table import Column
+from astropy.utils.compat.optional_deps import HAS_BS4
 from astropy.utils.xml import writer
 
 from . import core
@@ -75,12 +76,11 @@ class HTMLInputter(core.BaseInputter):
         Convert the given input into a list of SoupString rows
         for further processing.
         """
-        try:
-            from bs4 import BeautifulSoup
-        except ImportError:
+        if not HAS_BS4:
             raise core.OptionalTableImportError(
                 "BeautifulSoup must be installed to read HTML tables"
             )
+        from bs4 import BeautifulSoup
 
         if "parser" not in self.html:
             with warnings.catch_warnings():

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -20,6 +20,7 @@ import numpy as np
 from packaging.version import Version
 
 from astropy.utils import data
+from astropy.utils.compat.optional_deps import HAS_DASK
 from astropy.utils.exceptions import AstropyUserWarning
 
 path_like = (str, bytes, os.PathLike)
@@ -894,19 +895,10 @@ def _rstrip_inplace(array):
 
 
 def _is_dask_array(data):
-    """Check whether data is a dask array.
-
-    We avoid importing dask unless it is likely it is a dask array,
-    so that non-dask code is not slowed down.
-    """
-    if not hasattr(data, "compute"):
+    """Check whether data is a dask array."""
+    if not HAS_DASK or not hasattr(data, "compute"):
         return False
 
-    try:
-        from dask.array import Array
-    except ImportError:
-        # If we cannot import dask, surely this cannot be a
-        # dask array!
-        return False
-    else:
-        return isinstance(data, Array)
+    from dask.array import Array
+
+    return isinstance(data, Array)

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -10,6 +10,8 @@ import warnings
 
 import numpy as np
 
+from astropy.utils.compat.optional_deps import HAS_H5PY
+
 # NOTE: Do not import anything from astropy.table here.
 # https://github.com/astropy/astropy/issues/6604
 from astropy.utils.exceptions import AstropyUserWarning
@@ -52,12 +54,12 @@ def is_hdf5(origin, filepath, fileobj, *args, **kwargs):
     elif filepath is not None:
         return filepath.endswith((".hdf5", ".h5"))
 
-    try:
+    if HAS_H5PY:
         import h5py
-    except ImportError:
-        return False
-    else:
+
         return isinstance(args[0], (h5py.File, h5py.Group, h5py.Dataset))
+    else:
+        return False
 
 
 def read_table_hdf5(input, path=None, character_as_bytes=True):
@@ -81,10 +83,9 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
         If `True` then Table columns are left as bytes.
         If `False` then Table columns are converted to unicode.
     """
-    try:
-        import h5py
-    except ImportError:
-        raise Exception("h5py is required to read and write HDF5 files")
+    if not HAS_H5PY:
+        raise ModuleNotFoundError("h5py is required to read and write HDF5 files")
+    import h5py
 
     # This function is iterative, and only gets to writing the file when
     # the input is an hdf5 Group. Moreover, the input variable is changed in
@@ -254,10 +255,9 @@ def write_table_hdf5(
     """
     from astropy.table import meta
 
-    try:
-        import h5py
-    except ImportError:
-        raise Exception("h5py is required to read and write HDF5 files")
+    if not HAS_H5PY:
+        raise ModuleNotFoundError("h5py is required to read and write HDF5 files")
+    import h5py
 
     if path is None:
         # table is just an arbitrary, hardcoded string here.

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -6,6 +6,7 @@ import os.path
 
 import astropy.io.registry as io_registry
 from astropy.table import Table
+from astropy.utils.compat.optional_deps import HAS_PANDAS
 from astropy.utils.misc import NOT_OVERWRITING_MSG
 
 __all__ = ["PANDAS_FMTS"]
@@ -52,10 +53,9 @@ def import_html_libs():
 
 def _pandas_read(fmt, filespec, **kwargs):
     """Provide io Table connector to read table using pandas."""
-    try:
-        import pandas as pd
-    except ImportError:
-        raise ImportError("pandas must be installed to use pandas table reader")
+    if not HAS_PANDAS:
+        raise ModuleNotFoundError("pandas must be installed to use pandas table reader")
+    import pandas as pd
 
     pandas_fmt = fmt[len(PANDAS_PREFIX) :]  # chop the 'pandas.' in front
     read_func = getattr(pd, "read_" + pandas_fmt)

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 
 from astropy.utils import minversion
+from astropy.utils.compat.optional_deps import HAS_PYARROW
 
 # NOTE: Do not import anything from astropy.table here.
 # https://github.com/astropy/astropy/issues/6604
@@ -501,11 +502,10 @@ def register_parquet():
 
 
 def get_pyarrow():
-    try:
-        import pyarrow as pa
-        from pyarrow import parquet
-    except ImportError:
-        raise Exception("pyarrow is required to read and write parquet files")
+    if not HAS_PYARROW:
+        raise ModuleNotFoundError("pyarrow is required to read and write parquet files")
+    import pyarrow as pa
+    from pyarrow import parquet
 
     if minversion(pa, "6.0.0"):
         writer_version = "2.4"

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -21,15 +21,9 @@ Examples
 import numpy as np
 
 from astropy import units as u
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 from .core import Model
-
-try:
-    from scipy.interpolate import interpn
-
-    has_scipy = True
-except ImportError:
-    has_scipy = False
 
 __all__ = ["tabular_model", "Tabular1D", "Tabular2D"]
 
@@ -237,8 +231,11 @@ class _Tabular(Model):
         shape = inputs[0].shape
         inputs = [inp.flatten() for inp in inputs[: self.n_inputs]]
         inputs = np.array(inputs).T
-        if not has_scipy:  # pragma: no cover
-            raise ImportError("Tabular model requires scipy.")
+        if not HAS_SCIPY:  # pragma: no cover
+            raise ModuleNotFoundError("Tabular model requires scipy.")
+
+        from scipy.interpolate import interpn
+
         result = interpn(
             self.points,
             self.lookup_table,

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -13,7 +13,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
-import astropy.modeling.tabular as tabular_models
 from astropy import units as u
 from astropy.modeling import fitting, models
 from astropy.modeling.bounding_box import ModelBoundingBox
@@ -1010,6 +1009,8 @@ def test_tabular_str():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_tabular_evaluate():
+    import scipy.interpolate as scipy_interpolate
+
     points = np.arange(5)
     lt = np.arange(5)[::-1]
     t = models.Tabular1D(points, lt)
@@ -1018,8 +1019,9 @@ def test_tabular_evaluate():
 
     t.n_outputs = 2
     value = [np.array([3, 2, 1]), np.array([1, 2, 3])]
+
     with mk.patch.object(
-        tabular_models, "interpn", autospec=True, return_value=value
+        scipy_interpolate, "interpn", autospec=True, return_value=value
     ) as mkInterpn:
         outputs = t.evaluate([1, 2, 3])
         for index, output in enumerate(outputs):

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy import log
 from astropy.units import Quantity, Unit
+from astropy.utils.compat.optional_deps import HAS_DASK
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.metadata import MetaData
 from astropy.wcs.wcsapi import (
@@ -16,11 +17,6 @@ from astropy.wcs.wcsapi import (
     HighLevelWCSWrapper,
     SlicedLowLevelWCS,  # noqa: F401
 )
-
-try:
-    import dask.array as da
-except ImportError:
-    da = None
 
 from .nddata_base import NDDataBase
 from .nduncertainty import NDUncertainty, UnknownUncertainty
@@ -314,7 +310,12 @@ class NDData(NDDataBase):
         prefix = self.__class__.__name__ + "("
         # to support reprs for other non-ndarray `data` attributes,
         # add more cases here:
-        is_dask = da is not None and isinstance(self.data, da.Array)
+        if HAS_DASK:
+            import dask.array as da
+
+            is_dask = isinstance(self.data, da.Array)
+        else:
+            is_dask = False
 
         if (
             isinstance(self.data, (int, float, np.ndarray))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -13,6 +13,8 @@ import math
 
 import numpy as np
 
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
 from . import _stats
 
 __all__ = [
@@ -1295,12 +1297,11 @@ def kuiper_false_positive_probability(D, N):
            and significance points", Biometrika, v.52, p.309, 1965.
 
     """
-    try:
-        from scipy.special import comb, factorial
-    except ImportError:
-        # Retained for backwards compatibility with older versions of scipy
-        # (factorial appears to have moved here in 0.14)
-        from scipy.misc import comb, factorial
+    if not HAS_SCIPY:
+        raise ModuleNotFoundError(
+            "scipy is required for kuiper_false_positive_probability"
+        )
+    from scipy.special import comb, factorial
 
     if D < 0.0 or D > 2.0:
         raise ValueError("Must have 0<=D<=2 by definition of the Kuiper test")

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils import metadata
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.masked import Masked
 
 from . import _np_utils
@@ -275,10 +276,9 @@ def join_distance(distance, kdtree_args=None, query_args=None):
            4    --   0.5
 
     """
-    try:
-        from scipy.spatial import KDTree
-    except ImportError as exc:
-        raise ImportError("scipy is required to use join_distance()") from exc
+    if not HAS_SCIPY:
+        raise ModuleNotFoundError("scipy is required to use join_distance()")
+    from scipy.spatial import KDTree
 
     if kdtree_args is None:
         kdtree_args = {}

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -11,6 +11,7 @@ import erfa
 import numpy as np
 
 import astropy.units as u
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 from astropy.utils.decorators import classproperty, lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.masked import Masked
@@ -970,12 +971,9 @@ class TimePlotDate(TimeFromEpoch):
     @lazyproperty
     def epoch(self):
         """Reference epoch time from which the time interval is measured."""
-        try:
+        if HAS_MATPLOTLIB:
             from matplotlib.dates import get_epoch
-        except ImportError:
-            # If matplotlib is not installed then the epoch is '0001-01-01'
-            _epoch = self._epoch
-        else:
+
             # Get the matplotlib date epoch as an ISOT string in UTC
             epoch_utc = get_epoch()
             from erfa import ErfaWarning
@@ -985,6 +983,9 @@ class TimePlotDate(TimeFromEpoch):
                 warnings.filterwarnings("ignore", category=ErfaWarning)
                 _epoch = Time(epoch_utc, scale="utc", format="isot")
             _epoch.format = "jd"
+        else:
+            # If matplotlib is not installed then the epoch is '0001-01-01'
+            _epoch = self._epoch
 
         return _epoch
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -9,6 +9,8 @@ __all__ = ["lombscargle", "available_methods"]
 
 import numpy as np
 
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
 from .chi2_impl import lombscargle_chi2
 from .cython_impl import lombscargle_cython
 from .fast_impl import lombscargle_fast
@@ -30,11 +32,7 @@ def available_methods():
     methods = ["auto", "slow", "chi2", "cython", "fast", "fastchi2"]
 
     # Scipy required for scipy algorithm (obviously)
-    try:
-        import scipy  # noqa: F401
-    except ImportError:
-        pass
-    else:
+    if HAS_SCIPY:
         methods.append("scipy")
     return methods
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
 
 def lombscargle_scipy(t, y, frequency, normalization="standard", center_data=True):
     """Lomb-Scargle Periodogram.
@@ -34,10 +36,10 @@ def lombscargle_scipy(t, y, frequency, normalization="standard", center_data=Tru
     .. [2] W. Press et al, Numerical Recipes in C (2002)
     .. [3] Scargle, J.D. 1982, ApJ 263:835-853
     """
-    try:
-        from scipy import signal
-    except ImportError:
-        raise ImportError("scipy must be installed to use lombscargle_scipy")
+    if not HAS_SCIPY:
+        raise ModuleNotFoundError("scipy must be installed to use lombscargle_scipy")
+
+    from scipy import signal
 
     t, y = np.broadcast_arrays(t, y)
 

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -9,12 +9,15 @@ from importlib.util import find_spec
 # TODO: This list is a duplicate of the dependencies in pyproject.toml "all", but
 # some of the package names are different from the pip-install name (e.g.,
 # beautifulsoup4 -> bs4).
+# Some optional parts of the standard library also find a place here,
+# but don't appear in pyproject.toml
 _optional_deps = [
     "asdf_astropy",
     "bleach",
     "bottleneck",
     "bs4",
-    "bz2",
+    "bz2",  # stdlib
+    "certifi",
     "dask",
     "fsspec",
     "h5py",
@@ -33,7 +36,7 @@ _optional_deps = [
     "scipy",
     "skyfield",
     "sortedcontainers",
-    "lzma",
+    "lzma",  # stdlib
     "pyarrow",
     "pytest_mpl",
     "array_api_strict",

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -4,9 +4,10 @@ Contains a class that makes it simple to stream out well-formed and
 nicely-indented XML.
 """
 
-# STDLIB
 import contextlib
 import textwrap
+
+from astropy.utils.compat.optional_deps import HAS_BLEACH
 
 from ._iterparser import escape_xml as xml_escape
 from ._iterparser import escape_xml_cdata as xml_escape_cdata
@@ -159,14 +160,13 @@ class XMLWriter:
 
         if method == "bleach_clean":
             # NOTE: bleach is imported locally to avoid importing it when
-            # it is not nocessary
-            try:
-                import bleach
-            except ImportError:
+            # it is not necessary
+            if not HAS_BLEACH:
                 raise ValueError(
                     "bleach package is required when HTML escaping is disabled.\n"
                     'Use "pip install bleach".'
                 )
+            import bleach
 
             if clean_kwargs is None:
                 clean_kwargs = {}

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -8,6 +8,7 @@ import inspect
 import numpy as np
 from numpy import ma
 
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 from astropy.utils.decorators import deprecated_renamed_argument
 
 from .interval import (
@@ -27,10 +28,9 @@ from .stretch import (
     SqrtStretch,
 )
 
-try:
-    from matplotlib import pyplot as plt
+if HAS_MATPLOTLIB:
     from matplotlib.colors import Normalize
-except ImportError:
+else:
 
     class Normalize:
         def __init__(self, *args, **kwargs):
@@ -394,6 +394,14 @@ def imshow_norm(data, ax=None, **kwargs):
                                stretch=SqrtStretch())
         fig.colorbar(im)
     """
+    if ax is None:
+        if not HAS_MATPLOTLIB:
+            raise ModuleNotFoundError("matplotlib is required for imshow norm")
+
+        import matplotlib.pyplot as plt
+
+        ax = plt.gca()
+
     if "X" in kwargs:
         raise ValueError("Cannot give both ``X`` and ``data``")
 
@@ -412,10 +420,6 @@ def imshow_norm(data, ax=None, **kwargs):
             norm_kwargs[pname] = imshow_kwargs.pop(pname)
 
     imshow_kwargs["norm"] = ImageNormalize(**norm_kwargs)
-
-    if ax is None:
-        imshow_result = plt.imshow(data, **imshow_kwargs)
-    else:
-        imshow_result = ax.imshow(data, **imshow_kwargs)
+    imshow_result = ax.imshow(data, **imshow_kwargs)
 
     return imshow_result, imshow_kwargs["norm"]


### PR DESCRIPTION
### Description

Motivation: #16351 showed that we have hidden optional dependencies in a couple places, showing as modules that we *attempt* to import in a more-or-less recoverable fashion with plain try/except blocks such as
```python
try:
    import x
except ImportError:
    ...
else:
    ...
```
but that may not all be declared as optional dependencies in package metadata.

In this PR, I'm going for the bulk of these blocks (focusing on packages that are already declared as optional deps) and replacing them with our usual idiom
```python
if HAS_X:
    ...
else:
    ...
```
It some places, it leads to a user-visible improvement with how exceptions are chained, but the main idea is to make problematic occurrences of `except ImportError` like the one causing #16351 easier to spot.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

### Approvals by sub-package

- [x] `convolution` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028644440
- [x] `coordinates` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028862899
- [x] `io.ascii` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028072991
- [ ] `io.fits`
- [x] `io.misc`
- [ ] `modeling`
- [ ] `nddata`
- [x] `stats` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028644440
- [x] `table` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028072991
- [x] `time` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028072991
- [ ] `timeseries`
- [ ] `utils`
- [x] `visualization` https://github.com/astropy/astropy/pull/16353#pullrequestreview-2028644440
