### PR TITLE
Implement `BaseCoordinateFrame.frame` property

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1745,9 +1745,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             )
         ):
             if origin_mismatch == "warn":
-                warnings.warn(NonRotationTransformationWarning(self, other.frame))
+                warnings.warn(NonRotationTransformationWarning(self, other))
             elif origin_mismatch == "error":
-                raise NonRotationTransformationError(self, other.frame)
+                raise NonRotationTransformationError(self, other)
             else:
                 raise ValueError(
                     f"{origin_mismatch=} is invalid. Allowed values are 'ignore', "

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -40,8 +40,10 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from astropy.coordinates import Latitude, Longitude, SkyCoord
+    from astropy.coordinates import Latitude, Longitude
     from astropy.units import Unit
+
+    from .typing import SupportsFrame
 
 # the graph used for all transformations between frames
 frame_transform_graph = TransformGraph()
@@ -661,7 +663,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         setattr(cls, attr_name, property(getter, doc=doc))
 
     @property
-    def frame(self) -> Self:
+    def frame(self) -> Self:  # To implement the `SupportsFrame` protocol.
         """A reference to this frame."""
         return self
 
@@ -1730,9 +1732,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         return np.logical_not(self == value)
 
     def _prepare_unit_sphere_coords(
-        self,
-        other: BaseCoordinateFrame | SkyCoord,
-        origin_mismatch: Literal["ignore", "warn", "error"],
+        self, other: SupportsFrame, origin_mismatch: Literal["ignore", "warn", "error"]
     ) -> tuple[Longitude, Latitude, Longitude, Latitude]:
         if not (
             origin_mismatch == "ignore"
@@ -1759,7 +1759,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         )
         return self_sph.lon, self_sph.lat, other_sph.lon, other_sph.lat
 
-    def position_angle(self, other: BaseCoordinateFrame | SkyCoord) -> Angle:
+    def position_angle(self, other: SupportsFrame) -> Angle:
         """Compute the on-sky position angle to another coordinate.
 
         Parameters
@@ -1794,7 +1794,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
 
     def separation(
         self,
-        other: BaseCoordinateFrame | SkyCoord,
+        other: SupportsFrame,
         *,
         origin_mismatch: Literal["ignore", "warn", "error"] = "warn",
     ) -> Angle:

--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from astropy.utils.exceptions import AstropyUserWarning
 
 if TYPE_CHECKING:
-    from astropy.coordinates import BaseCoordinateFrame
+    from .typing import SupportsFrame
 
 
 # TODO: consider if this should be used to `units`?
@@ -39,11 +39,9 @@ class NonRotationTransformationError(ValueError):
     depending on its direction.
     """
 
-    def __init__(
-        self, frame_to: BaseCoordinateFrame, frame_from: BaseCoordinateFrame
-    ) -> None:
-        self.frame_to = frame_to
-        self.frame_from = frame_from
+    def __init__(self, frame_to: SupportsFrame, frame_from: SupportsFrame) -> None:
+        self.frame_to = frame_to.frame
+        self.frame_from = frame_from.frame
 
     def __str__(self) -> str:
         return (
@@ -76,11 +74,9 @@ class NonRotationTransformationWarning(AstropyUserWarning):
     depending on its direction.
     """
 
-    def __init__(
-        self, frame_to: BaseCoordinateFrame, frame_from: BaseCoordinateFrame
-    ) -> None:
-        self.frame_to = frame_to
-        self.frame_from = frame_from
+    def __init__(self, frame_to: SupportsFrame, frame_from: SupportsFrame) -> None:
+        self.frame_to = frame_to.frame
+        self.frame_from = frame_from.frame
 
     def __str__(self) -> str:
         return (

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from . import Angle
 from .representation import UnitSphericalRepresentation
-from .sky_coordinate import SkyCoord
 
 __all__ = [
     "match_coordinates_3d",
@@ -74,10 +73,7 @@ def match_coordinates_3d(
     kdt = _get_cartesian_kdtree(catalogcoord, storekdtree)
 
     # make sure coordinate systems match
-    if isinstance(matchcoord, SkyCoord):
-        matchcoord = matchcoord.transform_to(catalogcoord, merge_attributes=False)
-    else:
-        matchcoord = matchcoord.transform_to(catalogcoord)
+    matchcoord = matchcoord.frame.transform_to(catalogcoord)
 
     # make sure units match
     catunit = catalogcoord.cartesian.x.unit
@@ -157,10 +153,7 @@ def match_coordinates_sky(
         )
 
     # send to catalog frame
-    if isinstance(matchcoord, SkyCoord):
-        newmatch = matchcoord.transform_to(catalogcoord, merge_attributes=False)
-    else:
-        newmatch = matchcoord.transform_to(catalogcoord)
+    newmatch = matchcoord.frame.transform_to(catalogcoord)
 
     # strip out distance info
     match_urepr = newmatch.data.represent_as(UnitSphericalRepresentation)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -38,6 +38,8 @@ from .sky_coordinate_parsers import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from .typing import SupportsFrame
+
 __all__ = ["SkyCoord", "SkyCoordInfo"]
 
 
@@ -296,9 +298,9 @@ class SkyCoord(ShapedLikeNDArray):
     info = SkyCoordInfo()
 
     # Methods implemented by the underlying frame
-    position_angle: Callable[[BaseCoordinateFrame | SkyCoord], Angle]
-    separation: Callable[[BaseCoordinateFrame | SkyCoord], Angle]
-    separation_3d: Callable[[BaseCoordinateFrame | SkyCoord], Distance]
+    position_angle: Callable[[SupportsFrame], Angle]
+    separation: Callable[[SupportsFrame], Angle]
+    separation_3d: Callable[[SupportsFrame], Distance]
 
     def __init__(self, *args, copy=True, **kwargs):
         # these are frame attributes set on this SkyCoord but *not* a part of
@@ -371,7 +373,7 @@ class SkyCoord(ShapedLikeNDArray):
                 raise ValueError("Cannot create a SkyCoord without data")
 
     @property
-    def frame(self):
+    def frame(self) -> BaseCoordinateFrame:
         return self._sky_coord_frame
 
     @property

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -664,28 +664,26 @@ class SkyCoord(ShapedLikeNDArray):
         except Exception:
             pass
 
-        if isinstance(frame, SkyCoord):
-            frame = frame.frame  # Change to underlying coord frame instance
-
-        if isinstance(frame, BaseCoordinateFrame):
-            new_frame_cls = frame.__class__
-            # Get frame attributes, allowing defaults to be overridden by
-            # explicitly set attributes of the source if ``merge_attributes``.
-            for attr in frame_transform_graph.frame_attributes:
-                self_val = getattr(self, attr, None)
-                frame_val = getattr(frame, attr, None)
-                if frame_val is not None and not (
-                    merge_attributes and frame.is_frame_attr_default(attr)
-                ):
-                    frame_kwargs[attr] = frame_val
-                elif self_val is not None and not self.is_frame_attr_default(attr):
-                    frame_kwargs[attr] = self_val
-                elif frame_val is not None:
-                    frame_kwargs[attr] = frame_val
-        else:
+        frame = getattr(frame, "frame", None)
+        if not isinstance(frame, BaseCoordinateFrame):
             raise ValueError(
                 "Transform `frame` must be a frame name, class, or instance"
             )
+
+        new_frame_cls = frame.__class__
+        # Get frame attributes, allowing defaults to be overridden by
+        # explicitly set attributes of the source if ``merge_attributes``.
+        for attr in frame_transform_graph.frame_attributes:
+            self_val = getattr(self, attr, None)
+            frame_val = getattr(frame, attr, None)
+            if frame_val is not None and not (
+                merge_attributes and frame.is_frame_attr_default(attr)
+            ):
+                frame_kwargs[attr] = frame_val
+            elif self_val is not None and not self.is_frame_attr_default(attr):
+                frame_kwargs[attr] = self_val
+            elif frame_val is not None:
+                frame_kwargs[attr] = frame_val
 
         # Get the composite transform to the new frame
         trans = frame_transform_graph.get_transform(self.frame.__class__, new_frame_cls)

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -147,11 +147,8 @@ def _get_frame_without_data(args, kwargs):
         if isinstance(arg, (Sequence, np.ndarray)) and len(args) == 1 and len(arg) > 0:
             arg = arg[0]
 
-        if isinstance(arg, BaseCoordinateFrame):
-            coord_frame_obj = arg
-        elif isinstance(arg, SkyCoord):
-            coord_frame_obj = arg.frame
-        else:
+        coord_frame_obj = getattr(arg, "frame", None)
+        if not isinstance(coord_frame_obj, BaseCoordinateFrame):
             continue
 
         coord_frame_cls = type(coord_frame_obj)

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -267,13 +267,9 @@ class SpectralCoord(SpectralQuantity):
         if coord is None:
             return
 
-        if not issubclass(coord.__class__, BaseCoordinateFrame):
-            if isinstance(coord, SkyCoord):
-                coord = coord.frame
-            else:
-                raise TypeError(
-                    f"{label} must be a SkyCoord or coordinate frame instance"
-                )
+        coord = getattr(coord, "frame", None)
+        if not isinstance(coord, BaseCoordinateFrame):
+            raise TypeError(f"{label} must be a SkyCoord or coordinate frame instance")
 
         # If the distance is not well-defined, ensure that it works properly
         # for generating differentials

--- a/astropy/coordinates/tests/test_exceptions.py
+++ b/astropy/coordinates/tests/test_exceptions.py
@@ -11,10 +11,9 @@ import pytest
 from astropy import units as u
 from astropy.coordinates import (
     GCRS,
-    ICRS,
-    Galactic,
     NonRotationTransformationError,
     NonRotationTransformationWarning,
+    SkyCoord,
 )
 
 if TYPE_CHECKING:
@@ -22,14 +21,11 @@ if TYPE_CHECKING:
 
 
 class FrameDescription(NamedTuple):
-    frame: BaseCoordinateFrame
+    frame: BaseCoordinateFrame | SkyCoord
     description: str
     pytest_id: str
 
 
-galactic = FrameDescription(
-    Galactic(0 * u.deg, 0 * u.deg), "Galactic Frame", "Galactic"
-)
 gcrs_custom = FrameDescription(
     GCRS(
         0 * u.deg,
@@ -51,12 +47,19 @@ gcrs_default = FrameDescription(
     ),
     "default_GCRS",
 )
-icrs = FrameDescription(ICRS(0 * u.deg, 0 * u.deg), "ICRS Frame", "ICRS")
+skycoord_galactic = FrameDescription(
+    SkyCoord(0 * u.deg, 0 * u.deg, frame="galactic"),
+    "Galactic Frame",
+    "SkyCoord_Galactic",
+)
+skycoord_icrs = FrameDescription(
+    SkyCoord(0 * u.deg, 0 * u.deg), "ICRS Frame", "SkyCoord_ICRS"
+)
 
 
 @pytest.mark.parametrize(
     "coord_from,coord_to",
-    [pytest.param(icrs, gcrs_custom), pytest.param(gcrs_default, galactic)],
+    [(skycoord_icrs, gcrs_custom), (gcrs_default, skycoord_galactic)],
     ids=lambda x: x.pytest_id,
 )
 def test_NonRotationTransformationError_message(coord_from, coord_to):
@@ -69,7 +72,7 @@ def test_NonRotationTransformationError_message(coord_from, coord_to):
 
 @pytest.mark.parametrize(
     "coord_from,coord_to",
-    [pytest.param(icrs, gcrs_default), pytest.param(gcrs_custom, galactic)],
+    [(skycoord_icrs, gcrs_default), (gcrs_custom, skycoord_galactic)],
     ids=lambda x: x.pytest_id,
 )
 def test_NonRotationTransformationWarning_message(coord_from, coord_to):

--- a/astropy/coordinates/typing.py
+++ b/astropy/coordinates/typing.py
@@ -1,0 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Experimental typing support for :mod:`astropy.coordinates`, subject to change
+without notice.
+"""
+
+__all__ = ["SupportsFrame"]
+
+from typing import Protocol
+
+from astropy.coordinates import BaseCoordinateFrame
+
+
+class SupportsFrame(Protocol):
+    """Protocol for classes that contain coordinate data.
+
+    In :mod:`astropy.coordinates` the classes that implement this protocol
+    are |SkyCoord| and :class:`~astropy.coordinates.BaseCoordinateFrame`
+    (together with its subclasses).
+    """
+
+    @property
+    def frame(self) -> BaseCoordinateFrame:
+        """Coordinate data as a
+        :class:`~astropy.coordinates.BaseCoordinateFrame` instance.
+        """

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -9,7 +9,7 @@ from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
 
-from astropy.coordinates import BaseCoordinateFrame, SkyCoord
+from astropy.coordinates import BaseCoordinateFrame
 from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_PIL
 from astropy.wcs import WCS
@@ -295,12 +295,7 @@ class WCSAxes(Axes):
         Apply transformations to arguments to ``plot_coord`` and
         ``scatter_coord``.
         """
-        if isinstance(args[0], (SkyCoord, BaseCoordinateFrame)):
-            # Extract the frame from the first argument.
-            frame0 = args[0]
-            if isinstance(frame0, SkyCoord):
-                frame0 = frame0.frame
-
+        if isinstance(frame0 := getattr(args[0], "frame", None), BaseCoordinateFrame):
             native_frame = self._transform_pixel2world.frame_out
             # Transform to the native frame of the plot
             frame0 = frame0.transform_to(native_frame)

--- a/docs/changes/coordinates/16356.feature.rst
+++ b/docs/changes/coordinates/16356.feature.rst
@@ -1,0 +1,5 @@
+``BaseCoordinateFrame`` instances now have a ``frame`` property that returns
+the frame instance itself.
+This can be useful for any code that extracts the coordinate data from a
+``SkyCoord`` by accessing its ``frame`` attribute because such code can now
+treat ``SkyCoord`` and ``BaseCoordinateFrame`` instances in a uniform manner.

--- a/docs/coordinates/ref_api.rst
+++ b/docs/coordinates/ref_api.rst
@@ -2,3 +2,4 @@ Reference/API
 *************
 
 .. automodapi:: astropy.coordinates
+.. automodapi:: astropy.coordinates.typing


### PR DESCRIPTION
### Description

It is not uncommon to have code that extracts (or could extract) the coordinate data from a `SkyCoord` as a `BaseCoordinateFrame` by accessing the `frame` property of the `SkyCoord`. Such code can now handle both `SkyCoord` and `BaseCoordinateFrame` instances in a uniform manner. Making use of this opportunity in `astropy` addresses Ruff rule [PLR0915 (too-many-statements)](https://docs.astral.sh/ruff/rules/too-many-statements/) in `astropy.coordinates.sky_coordinate_parsers._get_frame_without_data()` and a [UP038 (non-pep604-isinstance)](https://docs.astral.sh/ruff/rules/non-pep604-isinstance/) violation in `astropy.vizualisation.wcsaxes.core._transform_plot_args()`.

~`BaseCoordinateFrame.frame` could also be useful for implementing a `SupportsFrame` [protocol](https://peps.python.org/pep-0544/), but I'm not planning to do that yet.~
EDIT: I've implemented the protocol, lets see which way the discussion goes.

Most of the changes in this pull request are in `coordinates`, but it would be good if the `visualization` maintainers could review the one change I made there.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
