### PR TITLE
API: raise an exception when adding a multi-dimensional column as an index

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1086,6 +1086,11 @@ class Table:
                     f'Cannot create an index on column "{col.info.name}", '
                     f'of type "{type(col)}"'
                 )
+            if col.ndim > 1:
+                raise ValueError(
+                    f"Multi-dimensional column {col.info.name!r} "
+                    "cannot be used as an index."
+                )
 
         is_primary = not self.indices
         index = Index(columns, engine=engine, unique=unique)

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -606,7 +606,6 @@ def test_index_slice_exception():
         SlicedIndex(None, None)
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "masked",
     [pytest.param(False, id="raw-array"), pytest.param(True, id="masked array")],

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -604,3 +604,22 @@ def test_hstack_qtable_table():
 def test_index_slice_exception():
     with pytest.raises(TypeError, match="index_slice must be tuple or slice"):
         SlicedIndex(None, None)
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "masked",
+    [pytest.param(False, id="raw-array"), pytest.param(True, id="masked array")],
+)
+def test_nd_columun_as_index(masked):
+    # see https://github.com/astropy/astropy/issues/13292
+    # and https://github.com/astropy/astropy/pull/16360
+    t = Table()
+    data = np.arange(0, 6)
+    if masked:
+        data = np.ma.masked_inside(data, 2, 4)
+    t.add_column(data.reshape(3, -1), name="arr")
+    with pytest.raises(
+        ValueError, match="Multi-dimensional column 'arr' cannot be used as an index."
+    ):
+        t.add_index("arr")

--- a/docs/changes/table/16360.api.rst
+++ b/docs/changes/table/16360.api.rst
@@ -1,0 +1,2 @@
+An exception is now raised when trying to add a multi-dimensional column as an
+index via ``Table.add_index``.


### PR DESCRIPTION
### Description
Fixes #13292 

running the test without the fix gives out a warning

```
================================ test session starts =================================
platform darwin -- Python 3.12.2, pytest-8.1.1, pluggy-1.5.0
Matplotlib: 3.8.4
Freetype: 2.6.1

Running tests with Astropy version 7.0.0.dev41+gdcf60561fc.
Running tests in astropy/table.

Date: 2024-04-30T17:02:19

Platform: macOS-14.4.1-arm64-arm-64bit

Executable: /Users/clm/.pyenv/versions/astropy.dev/bin/python

Full Python Version: 
3.12.2 (main, Feb 22 2024, 09:53:39) [Clang 15.0.0 (clang-1500.1.0.2.5)]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.26.4
Scipy: 1.12.0
Matplotlib: 3.8.4
h5py: 3.11.0
Pandas: not available
PyERFA: 2.0.1.4
Cython: not available
Scikit-image: not available
asdf-astropy: not available
pyarrow: not available

Using Astropy options: remote_data: none.

CI: undefined
ARCH_ON_CI: undefined
IS_CRON: undefined

rootdir: /Users/clm/dev/astropy-project/coordinated/astropy
configfile: pyproject.toml
plugins: astropy-0.11.0, mpi-0.6, cov-5.0.0, hypothesis-6.100.1, remotedata-0.4.1, mpl-0.17.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, arraydiff-0.6.1, xdist-3.5.0, mock-3.14.0
collected 1198 items / 1197 deselected / 1 selected                                  
run-last-failure: rerun previous 1 failure (skipped 58 files)

astropy/table/tests/test_index.py F                                            [100%]

====================================== FAILURES ======================================
________________________________ test_masked_nd_index ________________________________

    def test_masked_nd_index():
        # see https://github.com/astropy/astropy/issues/13292
        t = Table()
        data = np.arange(0, 6)
        data_ma = np.ma.masked_inside(data, 2, 4)
        t.add_column(data_ma.reshape(3, -1), name="arr")
>       t.add_index("arr")

astropy/table/tests/test_index.py:615: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
astropy/table/table.py:1093: in add_index
    index = Index(columns, engine=engine, unique=unique)
astropy/table/index.py:95: in __init__
    row_index = Column(col.argsort(kind="stable"))
/Users/clm/.pyenv/versions/astropy.dev/lib/python3.12/site-packages/numpy/ma/core.py:5576: in argsort
    axis = _deprecate_argsort_axis(self)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

arr = <MaskedColumn name='arr' dtype='int64' shape=(2,) length=3>
  0 .. 1
-- .. --
 -- .. 5

    def _deprecate_argsort_axis(arr):
        """
        Adjust the axis passed to argsort, warning if necessary
    
        Parameters
        ----------
        arr
            The array which argsort was called on
    
        np.ma.argsort has a long-term bug where the default of the axis argument
        is wrong (gh-8701), which now must be kept for backwards compatibility.
        Thankfully, this only makes a difference when arrays are 2- or more-
        dimensional, so we only need a warning then.
        """
        if arr.ndim <= 1:
            # no warning needed - but switch to -1 anyway, to avoid surprising
            # subclasses, which are more likely to implement scalar axes.
            return -1
        else:
            # 2017-04-11, Numpy 1.13.0, gh-8701: warn on axis default
>           warnings.warn(
                "In the future the default for argsort will be axis=-1, not the "
                "current None, to match its documentation and np.argsort. "
                "Explicitly pass -1 or None to silence this warning.",
                MaskedArrayFutureWarning, stacklevel=3)
E           numpy.ma.core.MaskedArrayFutureWarning: In the future the default for argsort will be axis=-1, not the current None, to match its documentation and np.argsort. Explicitly pass -1 or None to silence this warning.

/Users/clm/.pyenv/versions/astropy.dev/lib/python3.12/site-packages/numpy/ma/core.py:107: MaskedArrayFutureWarning
============================== short test summary info ===============================
FAILED astropy/table/tests/test_index.py::test_masked_nd_index - numpy.ma.core.MaskedArrayFutureWarning: In the future the default for argsort wil...
========================= 1 failed, 1197 deselected in 0.32s =========================
```

Note that decorating the test with `@pytest.mark.filterwarnings("ignore")` allows to reproduce 
the exception that was originally reported.

To my surprise, simply following the advice given by the warning resolved the bug, and did not appear to break anything else !

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
