### PR TITLE
Add ``keep_order`` argument to ``table.join`` for original table order

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -10,6 +10,7 @@
 
 import collections
 import itertools
+import warnings
 from collections import Counter, OrderedDict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
@@ -360,6 +361,7 @@ def join(
     *,
     keys_left=None,
     keys_right=None,
+    keep_order=False,
     uniq_col_name="{col_name}_{table_name}",
     table_names=["1", "2"],
     metadata_conflicts="warn",
@@ -385,6 +387,11 @@ def join(
         column-like values with the same lengths as the left table.
     keys_right : str or list of str or list of column-like, optional
         Same as ``keys_left``, but for the right side of the join.
+    keep_order: bool, optional
+        By default, rows are sorted by the join keys. If True, preserve the order of
+        rows from the left table for "inner" or "left" joins, or from the right table
+        for "right" joins. For other join types this argument is ignored except that a
+        warning is issued if ``keep_order=True``.
     uniq_col_name : str or None
         String generate a unique output column name in case of a conflict.
         The default is '{col_name}_{table_name}'.
@@ -411,6 +418,22 @@ def join(
     if not isinstance(right, Table):
         right = Table(right)
 
+    # Define a magic key that won't conflict with any user column name. This is to
+    # support the keep_order argument. In this case a temporary column is added to the
+    # left or right table to keep track of the original row order. After joining, the
+    # order is restored and the temporary column is removed.
+    sort_table_index_key = "__astropy_table_keep_order_sort_index__"
+    sort_table = None
+    if keep_order:
+        if join_type not in ["left", "right", "inner"]:
+            warnings.warn(
+                "keep_order=True is only supported for left, right, and inner joins",
+                UserWarning,
+            )
+        else:
+            sort_table = right if join_type == "right" else left
+            sort_table[sort_table_index_key] = np.arange(len(sort_table))
+
     col_name_map = OrderedDict()
     out = _join(
         left,
@@ -425,6 +448,13 @@ def join(
         keys_left=keys_left,
         keys_right=keys_right,
     )
+
+    if sort_table is not None:
+        # Sort the table back to the original order and remove the temporary columns.
+        # If sort_table is not None that implies keep_order=True.
+        out.sort(sort_table_index_key)
+        del out[sort_table_index_key]
+        del sort_table[sort_table_index_key]
 
     # Merge the column and table meta data. Table subclasses might override
     # these methods for custom merge behavior.

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -429,6 +429,7 @@ def join(
             warnings.warn(
                 "keep_order=True is only supported for left, right, and inner joins",
                 UserWarning,
+                stacklevel=2,
             )
         else:
             sort_table = right if join_type == "right" else left

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -2273,6 +2273,18 @@ def test_join_keep_sort_order(join_type):
     assert np.all(t12t[sort_key_true] == sorted([t12t[sort_key_true]]))
 
 
+def test_join_keep_sort_order_exception():
+    """Test that exception in join(..., keep_order=True) leaves table unchanged"""
+    t1 = Table([[1, 2]], names=["id"])
+    t2 = Table([[2, 3]], names=["id"])
+    with pytest.raises(
+        TableMergeError, match=r"Left table does not have key column 'not-a-key'"
+    ):
+        table.join(t1, t2, keys="not-a-key", join_type="inner", keep_order=True)
+    assert t1.colnames == ["id"]
+    assert t2.colnames == ["id"]
+
+
 def test_vstack_bytes(operation_table_type):
     """
     Test for issue #5617 when vstack'ing bytes columns in Py3.

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -2217,6 +2217,62 @@ def test_unique(operation_table_type):
     ]
 
 
+@pytest.mark.parametrize("join_type", ["inner", "outer", "left", "right", "cartesian"])
+def test_join_keep_sort_order(join_type):
+    """Test the keep_order argument for table.join.
+
+    See https://github.com/astropy/astropy/issues/11619.
+
+    This defines a left and right table which have an ``id`` column that is not sorted
+    and not unique. Each table has common and unique ``id`` key values along with an
+    ``order`` column to keep track of the original order.
+    """
+    keep_supported = join_type in ["left", "right", "inner"]
+    t1 = Table()
+    t1["id"] = [2, 8, 2, 0, 0, 1]  # Join key
+    t1["order"] = np.arange(len(t1))  # Original table order
+
+    t2 = Table()
+    t2["id"] = [2, 0, 1, 9, 0, 1]  # Join key
+    t2["order"] = np.arange(len(t2))  # Original table order
+
+    # No keys arg is allowed for cartesian join.
+    keys_kwarg = {} if join_type == "cartesian" else {"keys": "id"}
+
+    # Now do table joints with keep_order=False and keep_order=True.
+    t12f = table.join(t1, t2, join_type=join_type, keep_order=False, **keys_kwarg)
+    # For keep_order=True there should be a warning if keep_order is not supported for
+    # the join type.
+    ctx = (
+        nullcontext()
+        if keep_supported
+        else pytest.warns(
+            UserWarning,
+            match=r"keep_order=True is only supported for left, right, and inner joins",
+        )
+    )
+    with ctx:
+        t12t = table.join(t1, t2, join_type=join_type, keep_order=True, **keys_kwarg)
+
+    assert len(t12f) == len(t12t)
+    assert t12f.colnames == t12t.colnames
+
+    # Define expected sorting of join table for keep_order=False. Cartesian joins are
+    # always sorted by the native order of the left table, otherwise the table is sorted
+    # by the sort key ``id``.
+    sort_key_false = "order_1" if join_type == "cartesian" else "id"
+
+    # For keep_order=True the "order" column is sorted if keep is supported otherwise
+    # the table is sorted as for keep_order=False.
+    if keep_supported:
+        sort_key_true = "order_2" if join_type == "right" else "order_1"
+    else:
+        sort_key_true = sort_key_false
+
+    assert np.all(t12f[sort_key_false] == sorted(t12f[sort_key_false]))
+    assert np.all(t12t[sort_key_true] == sorted([t12t[sort_key_true]]))
+
+
 def test_vstack_bytes(operation_table_type):
     """
     Test for issue #5617 when vstack'ing bytes columns in Py3.

--- a/docs/changes/table/16361.feature.rst
+++ b/docs/changes/table/16361.feature.rst
@@ -1,0 +1,4 @@
+Add a ``keep_order`` argument to the ``astropy.table.join`` function which specifies to
+maintain the original order of the key table in the joined output. This applies for
+inner, left, and right joins. The default is ``False`` in which case the output is
+ordered by the join keys, consistent with prior behavior.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to allow maintaining the original table order when doing a `left`, `right` or `inner` table join. This is done by adding a new keyword argument `keep_order` to the `join` function.

For `outer` or `cartesian` joins there is no meaningful unique ordering so the `keep_order` argument value is ignored but a warning is issued for `keep_order=True`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11619

Close https://github.com/astropy/astropy/pull/15994

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
