### PR TITLE
WCSAxes: pre-compute the coord range to eliminate redundant transformations when drawing ticks/gridlines

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -675,8 +675,7 @@ class CoordinateHelper:
         # coordinate and once we have the tick positions, we can use the WCS
         # to determine the rotations.
 
-        # Find the range of coordinates in all directions
-        coord_range = self.parent_map.get_coord_range()
+        coord_range = self.parent_map._coord_range
 
         # First find the ticks we want to show
         tick_world_coordinates, self._fl_spacing = self.locator(
@@ -958,7 +957,7 @@ class CoordinateHelper:
         if self.coord_index is None:
             return
 
-        coord_range = self.parent_map.get_coord_range()
+        coord_range = self.parent_map._coord_range
 
         tick_world_coordinates, spacing = self.locator(*coord_range[self.coord_index])
         tick_world_coordinates_values = tick_world_coordinates.to_value(self.coord_unit)
@@ -1152,7 +1151,7 @@ class CoordinateHelper:
         world = self.transform.transform(pixel)
         field = world[:, self.coord_index].reshape(res, res).T
 
-        coord_range = self.parent_map.get_coord_range()
+        coord_range = self.parent_map._coord_range
 
         tick_world_coordinates, spacing = self.locator(*coord_range[self.coord_index])
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -505,8 +505,15 @@ class WCSAxes(Axes):
         for coords in self._all_coords:
             # Draw grids
             coords.frame.update()
+
+            # Pre-compute the coord range
+            coords._coord_range = coords.get_coord_range()
+
             for coord in coords:
                 coord._draw_grid(renderer)
+
+            # Delete the computation to protect from accidental use of a stale range
+            del coords._coord_range
 
         for coords in self._all_coords:
             # Draw tick labels

--- a/docs/changes/visualization/16366.perf.rst
+++ b/docs/changes/visualization/16366.perf.rst
@@ -1,0 +1,4 @@
+Removed redundant transformations when WCSAxes determines the coordinate ranges
+for ticks/gridlines, which speeds up typical plot generation by ~10%, and by
+much more if ``astropy.visualization.wcsaxes.conf.coordinate_range_samples`` is
+set to a large value


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

From #16362:

> When WCSAxes draws ticks/gridlines, it performs a pixel->world transform of (by default) a 50x50 grid of pixels, but it currently performs the identical calculation a total of four times: once when drawing ticks, again when drawing gridlines, and doubled because there are two components. These redundant calculations are particularly expensive when working with grid overlays (world->world) because then the coordinates framework is being used.

Inspired by @astrofrog, this PR pre-computes the coord range at just the right spot to exactly cover these four transformations, so now only one transformation is performed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16362

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
