### PR TITLE
ENH: adding parquet.votable

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -226,6 +226,7 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
     "PTH116",  # os-stat
     "PTH117",  # os-path-isabs
+    "S314",  # defusedxml
     "SLOT000",  # Subclasses of `str` should define `__slots__`
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -311,3 +311,12 @@ lint.unfixable = [
 "examples/coordinates/*" = []
 
 ".pyinstaller/*.py" = ["PTH"]
+
+
+[lint.flake8-import-conventions.aliases]
+# xml is hardly ever used thus the alias should not be mandated
+# There is no way to remove from the default list, only to override
+# the default thus we list the things here that we actually should use.
+"numpy" = "np"
+"matplotlib" = "mpl"
+"matplotlib.pyplot" = "plt"

--- a/astropy/io/misc/connect.py
+++ b/astropy/io/misc/connect.py
@@ -6,3 +6,4 @@ from . import hdf5, parquet
 
 hdf5.register_hdf5()
 parquet.register_parquet()
+parquet.register_parquet_votable()

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -509,7 +509,7 @@ def get_pyarrow():
     return pa, parquet
 
 
-def write_parquet_votable(table, output, *, metadata, overwrite=False,
+def write_parquet_votable(table, output, *, metadata=None, overwrite=False,
                           overwrite_metadata=False):
     """
     Writes a Parquet file with a VOT (XML) metadata table included.
@@ -532,7 +532,6 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False,
         If `True`, overwrite existing column metadata. Default is `False`.
     """
     # TODO cases to handle:
-    # - missing metadata kwarg, e.g. it could be inherited from the input table
     # - overwriting metadata, metadata could be partially missing, the provided
     #   one then could overwrite the existing one in the table
     # - make overwrite actually overwrite rather than delete the file upfront
@@ -557,9 +556,15 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False,
     # We only use the first row of the astropy table to get the general
     # information such as arraysize, ID, or datatype.
 
-    # TODO this step looses the metadata that the astropy Table input might have had, e.g. column units.
+    # TODO this step looses the metadata that the astropy Table input might have had,
+    # e.g. column units.
     votablefile = VOTableFile()
     votable_write = votablefile.from_table(table[0:1])
+
+    # TODO: API placeholder for inheriting metadata from exising table, thus
+    # no API change is needed for making this technically optional
+    if metadata is None:
+        raise NotImplementedError("metadata has to be always specified")
 
     # Then add the other metadata keys to the FIELDS parameters of the VOTable
     metadatakeys = list(metadata[next(iter(metadata.keys()))].keys())

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -549,7 +549,7 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False):
     for field in votable_write.resources[0].tables[0].fields:
         for mkey in metadatakeys:
             if mkey in field._attr_list:
-                exec(f'field.{mkey} = metadata[field.name]["{mkey}"]')
+                setattr(field, mkey, metadata[field.name][mkey])
             else:
                 if (mkey == "description") & (field.description is not None):
                     field.description = metadata[field.name]["description"]

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -546,10 +546,14 @@ def write_parquet_votable(
 
     from astropy.io.votable.tree import VOTableFile
 
-    if os.path.exists(output):
+    if not isinstance(output, (str, os.PathLike)):
+        raise TypeError(f"`output` should be a string or path-like, not {output}")
+    output = Path(output)
+
+    if Path.exists(output):
         if overwrite:
             # We must remove the file prior to writing below.
-            os.remove(output)
+            Path.unlink(output)
         else:
             raise OSError(NOT_OVERWRITING_MSG.format(output))
 

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -606,7 +606,6 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False):
 
     # write the parquet file with required Type 1 metadata
     pyarrow.parquet.write_table(pyarrow_table, output)
-    print(f"parquet file written to {output}")
 
 
 def read_parquet_votable(filename):
@@ -641,7 +640,7 @@ def read_parquet_votable(filename):
     empty_table_with_columns_and_metadata = Table.read(votable.parse(vot_blob))
 
     # Load the data from the parquet table using the Table.read() functionality
-    data_table_with_no_metadata = Table.read(filename)
+    data_table_with_no_metadata = Table.read(filename, format="parquet")
 
     # Stitch the two tables together to create final table
     complete_table = vstack(

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -509,8 +509,9 @@ def get_pyarrow():
     return pa, parquet
 
 
-def write_parquet_votable(table, output, *, metadata=None, overwrite=False,
-                          overwrite_metadata=False):
+def write_parquet_votable(
+    table, output, *, metadata=None, overwrite=False, overwrite_metadata=False
+):
     """
     Writes a Parquet file with a VOT (XML) metadata table included.
 
@@ -561,7 +562,7 @@ def write_parquet_votable(table, output, *, metadata=None, overwrite=False,
     votablefile = VOTableFile()
     votable_write = votablefile.from_table(table[0:1])
 
-    # TODO: API placeholder for inheriting metadata from exising table, thus
+    # TODO: API placeholder for inheriting metadata from existing table, thus
     # no API change is needed for making this technically optional
     if metadata is None:
         raise NotImplementedError("metadata has to be always specified")
@@ -574,8 +575,9 @@ def write_parquet_votable(table, output, *, metadata=None, overwrite=False,
                 if (getattr(field, mkey) is None) or overwrite_metadata:
                     setattr(field, mkey, metadata[field.name][mkey])
             else:
-                if ((mkey == "description")
-                    and ((field.description is None) or overwrite_metadata)):
+                if (mkey == "description") and (
+                    (field.description is None) or overwrite_metadata
+                ):
                     field.description = metadata[field.name]["description"]
                 else:
                     print(f"Warning: '{mkey}' is not a valid VOT metadata key")

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -319,7 +319,7 @@ def write_table_parquet(table, output, overwrite=False):
     Parameters
     ----------
     table : `~astropy.table.Table`
-        Data table that is to be written to file.
+        Data table that is to be written to output.
     output : str or path-like
         The filename to write the table to.
     overwrite : bool, optional
@@ -509,49 +509,19 @@ def get_pyarrow():
     return pa, parquet
 
 
-def write_parquet_vot(tab, metadata, filename):
+def write_parquet_votable(table, output, *, metadata):
     """
     Writes a Parquet file with a VOT (XML) metadata table included.
 
     Parameters
     ----------
-    ===========
-    tab : astropy table
-        An Astropy table containing the data
-
+    table : `~astropy.table.Table`
+        Data table that is to be written to output.
+    output : str or path-like
+        The filename to write the table to.
     metadata : dict
-        Nested dictionary (keys = column names; sub-keys = meta keys) for each of the columns
-        containing a dictionary with metadata.
-
-    filename : str
-        File name where to save the table.
-
-    Return:
-    =======
-    None. Saves the table.
-
-    Example:
-    ========
-
-    > # create data
-    > number_of_objects = 10
-    > ids = ["COSMOS_{:03g}".format(ii) for ii in range(number_of_objects)]
-    > redshift = np.random.uniform(low=0 , high=3 , size=number_of_objects)
-    > mass = np.random.uniform(low=1e8 , high=1e10 , size=number_of_objects)
-    > sfr = np.random.uniform(low=1 , high=100 , size=number_of_objects)
-    > astropytab = Table([ids , redshift , mass , sfr] , names=["id","z","mass","sfr"],
-    >                    descriptions=["The ID of the Galaxy", "The redshift of the Galaxy", "The stellar mass of the Galaxy","The star formation of the galaxy"]
-    >                   )
-
-    > # Column Metadata
-    > column_metadata = {"id":{"unit":"","ucd":"meta.id","utype":"none","description":"The ID of the galaxy."},
-    >            "z":{"unit":"","ucd":"src.redshift","utype":"none","description":"The redshift of the galaxy."},
-    >            "mass":{"unit":"solMass","ucd":"phys.mass","utype":"none","description":"The stellar mass of the galaxy."},
-    >            "sfr":{"unit":"solMass / yr","ucd":"phys.SFR","utype":"none","description":"The star formation rate of the galaxy."}
-    >            }
-
-    > # Write Parquet file with XML metadata
-    > write_parquet_vot(astropytab , column_metadata , "test_parquet.parquet")
+        Nested dictionary (keys = column names; sub-keys = meta keys) for each
+        of the columns containing a dictionary with metadata.
 
     """
     import io
@@ -561,32 +531,32 @@ def write_parquet_vot(tab, metadata, filename):
 
     from astropy.io.votable.tree import VOTableFile
 
-    ## Prepare the VOTable (XML)
-    ## We only use the first row of the astropy table to get the general
-    ## information such as arraysize, ID, or datatype.
+    # Prepare the VOTable (XML)
+    # We only use the first row of the astropy table to get the general
+    # information such as arraysize, ID, or datatype.
     votablefile = VOTableFile()
-    votable_write = votablefile.from_table(tab[0:1])
+    votable_write = votablefile.from_table(table[0:1])
 
-    ## Then add the other metadata keys to the FIELDS parameters of the VOTable
+    # Then add the other metadata keys to the FIELDS parameters of the VOTable
     metadatakeys = list(metadata[list(metadata.keys())[0]].keys())
     for field in votable_write.resources[0].tables[0].fields:
         for mkey in metadatakeys:
             if mkey in field._attr_list:
                 exec(f'field.{mkey} = metadata[field.name]["{mkey}"]')
             else:
-                if (mkey == "description") & (field.description != None):
+                if (mkey == "description") & (field.description is not None):
                     field.description = metadata[field.name]["description"]
                 else:
                     print(f"Warning: '{mkey}' is not a valid VOT metadata key")
 
-    ## Convert the VOTable object into a Byte string to create an
-    ## XML that we can add to the Parquet metadata
+    # Convert the VOTable object into a Byte string to create an
+    # XML that we can add to the Parquet metadata
     xml_bstr = io.BytesIO()
     votable_write.to_xml(xml_bstr)
     xml_bstr = xml_bstr.getvalue()
 
-    ## Now remove the data from this XML string and just
-    ## recover DESCRIPTION and FIELD elements
+    # Now remove the data from this XML string and just
+    # recover DESCRIPTION and FIELD elements
 
     # get the table
     nsurl = "{http://www.ivoa.net/xml/VOTable/v1.3}"
@@ -606,10 +576,10 @@ def write_parquet_vot(tab, metadata, filename):
         root, encoding="unicode", method="xml", xml_declaration=True
     )
 
-    ## Write the Parquet file
-    pyarrow_table = pyarrow.Table.from_pydict({c: tab[c] for c in tab.colnames})
+    # Write the Parquet file
+    pyarrow_table = pyarrow.Table.from_pydict({c: table[c] for c in table.colnames})
 
-    ## add the required Type 1 file-level metadata
+    # add the required Type 1 file-level metadata
     original_metadata = pyarrow_table.schema.metadata or dict()
     updated_metadata = {
         **original_metadata,
@@ -620,37 +590,25 @@ def write_parquet_vot(tab, metadata, filename):
     }
     pyarrow_table = pyarrow_table.replace_schema_metadata(updated_metadata)
 
-    ## write the parquet file with required Type 1 metadata
-    pyarrow.parquet.write_table(pyarrow_table, filename)
-    print(f"parquet file written to {filename}")
+    # write the parquet file with required Type 1 metadata
+    pyarrow.parquet.write_table(pyarrow_table, output)
+    print(f"parquet file written to {output}")
 
 
-def read_parquet_vot(filename):
+def read_parquet_votable(filename):
     """
     Reads a Parquet file with a VOT (XML) metadata table included.
 
     Parameters
     ----------
-    ===========
-    filename : str
-        File name.
+    filename : str or path-like or file-like object
+        If a string or path-like object, the filename to read the table from.
+        If a file-like object, the stream to read data.
 
-    Return:
-    =======
-    An astropy table.
-
-    Example:
-    ========
-
-    > # load table
-    > loaded_table = read_parquet_vot("test_parquet.parquet")
-
-    > # Access the metadata
-    > print(loaded_table["mass"].unit)
-    > print(loaded_table["mass"].description)
-    > print(loaded_table["mass"].meta)
-    > print(loaded_table["mass"].meta["ucd"])
-
+    Returns
+    -------
+    table : `~astropy.table.Table`
+        A table with included votable metadata, e.g. as column units.
     """
     import io
 
@@ -659,19 +617,19 @@ def read_parquet_vot(filename):
     from astropy.io import votable
     from astropy.table import Table, vstack
 
-    ## First load the column metadata that is stored
-    ## in the parquet content
+    # First load the column metadata that is stored
+    # in the parquet content
     parquet_custom_metadata = pyarrow.parquet.ParquetFile(filename).metadata.metadata
 
-    ## Create an empty Astropy table inheriting all the column metadata
-    ## information.
+    # Create an empty Astropy table inheriting all the column metadata
+    # information.
     vot_blob = io.BytesIO(parquet_custom_metadata[b"IVOA.VOTable-Parquet.content"])
     empty_table_with_columns_and_metadata = Table.read(votable.parse(vot_blob))
 
-    ## Load the data from the parquet table using the Table.read() functionality
+    # Load the data from the parquet table using the Table.read() functionality
     data_table_with_no_metadata = Table.read(filename)
 
-    ## Stitch the two tables together to create final table
+    # Stitch the two tables together to create final table
     complete_table = vstack(
         [empty_table_with_columns_and_metadata, data_table_with_no_metadata]
     )
@@ -686,5 +644,5 @@ def register_parquet_votable():
     from astropy.io import registry as io_registry
     from astropy.table import Table
 
-    io_registry.register_reader("parquet.votable", Table, read_parquet_vot)
-    io_registry.register_writer("parquet.votable", Table, write_parquet_vot)
+    io_registry.register_reader("parquet.votable", Table, read_parquet_votable)
+    io_registry.register_writer("parquet.votable", Table, write_parquet_votable)

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -524,6 +524,11 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False):
         of the columns containing a dictionary with metadata.
 
     """
+    # TODO cases to handle:
+    # - missing metadata kwarg, e.g. it could be inherited from the input table
+    # - overwriting metadata, metadata could be partially missing, the provided
+    #   one then could overwrite the existing one in the table
+
     import io
     import xml.etree.ElementTree
 
@@ -541,6 +546,8 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False):
     # Prepare the VOTable (XML)
     # We only use the first row of the astropy table to get the general
     # information such as arraysize, ID, or datatype.
+
+    # TODO this step looses the metadata that the astropy Table input might have had, e.g. column units.
     votablefile = VOTableFile()
     votable_write = votablefile.from_table(table[0:1])
 

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -603,9 +603,8 @@ def write_parquet_votable(
     # remove the DATA element and replace it with a reference to the parquet
     data_tmp = tab_tmp.find(f"{nsurl}DATA")
     tab_tmp.remove(data_tmp)
-    data_tmp = xml.etree.ElementTree.SubElement(tab_tmp, f"{nsurl}DATA")
     _ = xml.etree.ElementTree.SubElement(
-        data_tmp, f"{nsurl}PARQUET", type="Parquet-local-XML"
+        tab_tmp, f"{nsurl}PARQUET", type="Parquet-local-XML"
     )
 
     # convert back to a string, encode, and return

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -545,7 +545,7 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False):
     votable_write = votablefile.from_table(table[0:1])
 
     # Then add the other metadata keys to the FIELDS parameters of the VOTable
-    metadatakeys = list(metadata[list(metadata.keys())[0]].keys())
+    metadatakeys = list(metadata[next(iter(metadata.keys()))].keys())
     for field in votable_write.resources[0].tables[0].fields:
         for mkey in metadatakeys:
             if mkey in field._attr_list:
@@ -587,7 +587,7 @@ def write_parquet_votable(table, output, *, metadata, overwrite=False):
     pyarrow_table = pyarrow.Table.from_pydict({c: table[c] for c in table.colnames})
 
     # add the required Type 1 file-level metadata
-    original_metadata = pyarrow_table.schema.metadata or dict()
+    original_metadata = pyarrow_table.schema.metadata or {}
     updated_metadata = {
         **original_metadata,
         b"IVOA.VOTable-Parquet.version": b"1.0",

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -509,7 +509,7 @@ def get_pyarrow():
     return pa, parquet
 
 
-def write_parquet_votable(table, output, *, metadata):
+def write_parquet_votable(table, output, *, metadata, overwrite=False):
     """
     Writes a Parquet file with a VOT (XML) metadata table included.
 
@@ -530,6 +530,13 @@ def write_parquet_votable(table, output, *, metadata):
     import pyarrow.parquet
 
     from astropy.io.votable.tree import VOTableFile
+
+    if os.path.exists(output):
+        if overwrite:
+            # We must remove the file prior to writing below.
+            os.remove(output)
+        else:
+            raise OSError(NOT_OVERWRITING_MSG.format(output))
 
     # Prepare the VOTable (XML)
     # We only use the first row of the astropy table to get the general

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -678,3 +678,13 @@ def read_parquet_vot(filename):
 
     return complete_table
 
+
+def register_parquet_votable():
+    """
+    Register Parquet VOT with Unified I/O.
+    """
+    from astropy.io import registry as io_registry
+    from astropy.table import Table
+
+    io_registry.register_reader("parquet.votable", Table, read_parquet_vot)
+    io_registry.register_writer("parquet.votable", Table, write_parquet_vot)

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -617,10 +617,14 @@ def write_parquet_votable(
     updated_metadata = {
         **original_metadata,
         b"IVOA.VOTable-Parquet.version": b"1.0",
-        b"IVOA.VOTable-Parquet.type": b"Parquet-local-XML",
-        b"IVOA.VOTable-Parquet.encoding": b"utf-8",
         b"IVOA.VOTable-Parquet.content": xml_str,
     }
+
+    # Some other metadata we were thinking about but don't yet use:
+    #   We mandate the encoding to be UTF-8, thus this is superfluous
+    #     b"IVOA.VOTable-Parquet.encoding": b"utf-8",
+    #   The type can be implied by the presence of IVOA.VOTable-Parquet.content
+    #     b"IVOA.VOTable-Parquet.type": b"Parquet-local-XML",
 
     pyarrow_table = pyarrow_table.replace_schema_metadata(updated_metadata)
 

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -509,11 +509,12 @@ def get_pyarrow():
     return pa, parquet
 
 
-def write_parquet_vot(tab , metadata, filename):
-    '''
+def write_parquet_vot(tab, metadata, filename):
+    """
     Writes a Parquet file with a VOT (XML) metadata table included.
 
-    Parameters:
+    Parameters
+    ----------
     ===========
     tab : astropy table
         An Astropy table containing the data
@@ -552,13 +553,13 @@ def write_parquet_vot(tab , metadata, filename):
     > # Write Parquet file with XML metadata
     > write_parquet_vot(astropytab , column_metadata , "test_parquet.parquet")
 
-    '''
-
-    import xml.etree.ElementTree
-    from astropy.io.votable.tree import VOTableFile
+    """
     import io
+    import xml.etree.ElementTree
+
     import pyarrow.parquet
 
+    from astropy.io.votable.tree import VOTableFile
 
     ## Prepare the VOTable (XML)
     ## We only use the first row of the astropy table to get the general
@@ -571,13 +572,12 @@ def write_parquet_vot(tab , metadata, filename):
     for field in votable_write.resources[0].tables[0].fields:
         for mkey in metadatakeys:
             if mkey in field._attr_list:
-                pass
-                exec("field.{} = metadata[field.name][\"{}\"]".format(mkey,mkey))
+                exec(f'field.{mkey} = metadata[field.name]["{mkey}"]')
             else:
                 if (mkey == "description") & (field.description != None):
                     field.description = metadata[field.name]["description"]
                 else:
-                    print("Warning: '{}' is not a valid VOT metadata key".format(mkey))
+                    print(f"Warning: '{mkey}' is not a valid VOT metadata key")
 
     ## Convert the VOTable object into a Byte string to create an
     ## XML that we can add to the Parquet metadata
@@ -597,10 +597,14 @@ def write_parquet_vot(tab , metadata, filename):
     data_tmp = tab_tmp.find(f"{nsurl}DATA")
     tab_tmp.remove(data_tmp)
     data_tmp = xml.etree.ElementTree.SubElement(tab_tmp, f"{nsurl}DATA")
-    _ = xml.etree.ElementTree.SubElement(data_tmp, f"{nsurl}PARQUET", type="Parquet-local-XML")
+    _ = xml.etree.ElementTree.SubElement(
+        data_tmp, f"{nsurl}PARQUET", type="Parquet-local-XML"
+    )
 
     # convert back to a string, encode, and return
-    xml_str = xml.etree.ElementTree.tostring(root, encoding="unicode", method="xml", xml_declaration=True)
+    xml_str = xml.etree.ElementTree.tostring(
+        root, encoding="unicode", method="xml", xml_declaration=True
+    )
 
     ## Write the Parquet file
     pyarrow_table = pyarrow.Table.from_pydict({c: tab[c] for c in tab.colnames})
@@ -620,15 +624,13 @@ def write_parquet_vot(tab , metadata, filename):
     pyarrow.parquet.write_table(pyarrow_table, filename)
     print(f"parquet file written to {filename}")
 
-    return(True)
-
-
 
 def read_parquet_vot(filename):
-    '''
+    """
     Reads a Parquet file with a VOT (XML) metadata table included.
 
-    Parameters:
+    Parameters
+    ----------
     ===========
     filename : str
         File name.
@@ -649,13 +651,13 @@ def read_parquet_vot(filename):
     > print(loaded_table["mass"].meta)
     > print(loaded_table["mass"].meta["ucd"])
 
-    '''
-
+    """
     import io
+
     import pyarrow.parquet
+
     from astropy.io import votable
     from astropy.table import Table, vstack
-
 
     ## First load the column metadata that is stored
     ## in the parquet content
@@ -670,6 +672,9 @@ def read_parquet_vot(filename):
     data_table_with_no_metadata = Table.read(filename)
 
     ## Stitch the two tables together to create final table
-    complete_table = vstack([empty_table_with_columns_and_metadata, data_table_with_no_metadata])
+    complete_table = vstack(
+        [empty_table_with_columns_and_metadata, data_table_with_no_metadata]
+    )
 
-    return(complete_table)
+    return complete_table
+

--- a/astropy/io/misc/tests/data/gaia_source_dr3_select_1_result.vot
+++ b/astropy/io/misc/tests/data/gaia_source_dr3_select_1_result.vot
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/votable-1.4.xsd">
+<RESOURCE type="results">
+<INFO name="QUERY_STATUS" value="OK"/>
+
+<INFO name="QUERY" value="SELECT TOP 1 source_id, ra, dec, parallax from gaiadr3.gaia_source"><![CDATA[SELECT TOP 1 source_id, ra, dec, parallax from gaiadr3.gaia_source]]></INFO>
+<INFO name="CAPTION" value=""/>
+<INFO name="CITATION" value="" ucd="meta.bib"/>
+<INFO name="PAGE" value=""/>
+<INFO name="PAGE_SIZE" value=""/>
+<INFO name="JOBID" value="1716255000252O"><![CDATA[1716255000252O]]></INFO>
+<INFO name="JOBNAME" value=""/>
+
+<PARAM name="RELEASE" ID="GaiaRelease" datatype="char" arraysize="*" value="Gaia DR3"/>
+
+<COOSYS ID="GAIADR3" epoch="J2016.0" system="ICRS"/>
+
+<RESOURCE>
+  <COOSYS ID="t11250306-coosys-1" epoch="J2016.0" system="ICRS"/>
+</RESOURCE>
+<TABLE>
+<FIELD ID="SOURCE_ID" datatype="long" name="source_id" ucd="meta.id">
+<DESCRIPTION>Unique source identifier (unique within a particular Data Release)</DESCRIPTION>
+</FIELD>
+<FIELD datatype="double" name="ra" ref="t11250306-coosys-1" ucd="pos.eq.ra;meta.main" unit="deg" utype="stc:AstroCoords.Position3D.Value3.C1">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD datatype="double" name="dec" ref="t11250306-coosys-1" ucd="pos.eq.dec;meta.main" unit="deg" utype="stc:AstroCoords.Position3D.Value3.C2">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD datatype="double" name="parallax" ucd="pos.parallax.trig" unit="mas">
+<DESCRIPTION>Parallax</DESCRIPTION>
+</FIELD>
+<DATA>
+<TABLEDATA>
+<TR><TD>3136752501901167744</TD><TD>112.5836308350694</TD><TD>4.667508081125457</TD><TD>0.30639294800127265</TD></TR>
+</TABLEDATA>
+</DATA>
+
+</TABLE>
+</RESOURCE>
+<RESOURCE type="meta" utype="adhoc:service" name="ancillary">
+    <DESCRIPTION>Retrieve DataLink file containing ancillary data for source</DESCRIPTION>
+    <PARAM name="standardID" datatype="char" arraysize="*" value="ivo://ivoa.net/std/DataLink#links-1.0"/>
+    <PARAM name="accessURL" datatype="char" arraysize="*" value="https://gea.esac.esa.int/data-server/datalink/links"/>
+    <PARAM name="contentType" datatype="char" arraysize="*" value="application/x-votable+xml;content=datalink"/>
+    <GROUP name="inputParams">
+        <PARAM name="ID" datatype="long" value="" ref="SOURCE_ID"/>
+        <PARAM name="RELEASE" ID="GaiaRelease" datatype="char" arraysize="*" value="Gaia DR3"/>
+    </GROUP>
+</RESOURCE>
+</VOTABLE>

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -3,53 +3,55 @@ import pytest
 
 from astropy.io.misc.parquet import read_parquet_vot, write_parquet_vot
 from astropy.table import Table
+import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
 
 # Skip all tests in this file if we cannot import pyarrow
 pyarrow = pytest.importorskip("pyarrow")
 
 
+number_of_objects = 10
+ids = [f"COSMOS_{ii}" for ii in range(number_of_objects)]
+redshift = np.random.uniform(low=0, high=3, size=number_of_objects)
+mass = np.random.uniform(low=1e8, high=1e10, size=number_of_objects)
+sfr = np.random.uniform(low=1, high=100, size=number_of_objects)
+
+input_table = Table(
+    [ids, redshift, mass, sfr],
+    names=["id", "z", "mass", "sfr"],
+)
+
+column_metadata = {
+    "id": {
+        "unit": "",
+        "ucd": "meta.id",
+        "utype": "none",
+        "description": "The ID of the galaxy.",
+    },
+    "z": {
+        "unit": "",
+        "ucd": "src.redshift",
+        "utype": "none",
+        "description": "The redshift of the galaxy.",
+    },
+    "mass": {
+        "unit": "solMass",
+        "ucd": "phys.mass",
+        "utype": "none",
+        "description": "The stellar mass of the galaxy.",
+    },
+    "sfr": {
+        "unit": "solMass / yr",
+        "ucd": "phys.SFR",
+        "utype": "none",
+        "description": "The star formation rate of the galaxy.",
+    },
+}
+
+
 def test_parquet_votable(tmp_path):
     """Test writing and reading a votable into a parquet file"""
     filename = tmp_path / "test_votable.parq"
-
-    number_of_objects = 10
-    ids = [f"COSMOS_{ii}" for ii in range(number_of_objects)]
-    redshift = np.random.uniform(low=0, high=3, size=number_of_objects)
-    mass = np.random.uniform(low=1e8, high=1e10, size=number_of_objects)
-    sfr = np.random.uniform(low=1, high=100, size=number_of_objects)
-
-    input_table = Table(
-        [ids, redshift, mass, sfr],
-        names=["id", "z", "mass", "sfr"],
-    )
-
-    column_metadata = {
-        "id": {
-            "unit": "",
-            "ucd": "meta.id",
-            "utype": "none",
-            "description": "The ID of the galaxy.",
-        },
-        "z": {
-            "unit": "",
-            "ucd": "src.redshift",
-            "utype": "none",
-            "description": "The redshift of the galaxy.",
-        },
-        "mass": {
-            "unit": "solMass",
-            "ucd": "phys.mass",
-            "utype": "none",
-            "description": "The stellar mass of the galaxy.",
-        },
-        "sfr": {
-            "unit": "solMass / yr",
-            "ucd": "phys.SFR",
-            "utype": "none",
-            "description": "The star formation rate of the galaxy.",
-        },
-    }
 
     write_parquet_vot(input_table, column_metadata, filename)
 
@@ -57,3 +59,20 @@ def test_parquet_votable(tmp_path):
         loaded_table = read_parquet_vot(filename)
 
     assert np.all(input_table == loaded_table)
+
+
+def test_compare_parquet_votable(tmp_path):
+    """ Parquet votable preserves column units and metadata"""
+
+    filename = tmp_path / "test_votable.parq"
+    write_parquet_vot(input_table, column_metadata, filename)
+
+    with pytest.warns(AstropyUserWarning, match="No table::len"):
+        parquet = Table.read(filename)
+        parquet_votable = Table.read(filename, format='parquet.votable')
+
+    assert len(parquet['sfr'].meta) == 0
+    assert parquet['sfr'].unit is None
+
+    assert parquet_votable['sfr'].meta['ucd'] == 'phys.SFR'
+    assert parquet_votable['sfr'].unit == u.solMass / u.yr

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
 
+import astropy.units as u
 from astropy.io.misc.parquet import read_parquet_votable, write_parquet_votable
 from astropy.table import Table
-import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
@@ -63,20 +63,20 @@ def test_parquet_votable(tmp_path):
 
 
 def test_compare_parquet_votable(tmp_path):
-    """ Parquet votable preserves column units and metadata"""
+    """Parquet votable preserves column units and metadata"""
 
     filename = tmp_path / "test_votable.parq"
     write_parquet_votable(input_table, filename, metadata=column_metadata)
 
     with pytest.warns(AstropyUserWarning, match="No table::len"):
         parquet = Table.read(filename)
-        parquet_votable = Table.read(filename, format='parquet.votable')
+        parquet_votable = Table.read(filename, format="parquet.votable")
 
-    assert len(parquet['sfr'].meta) == 0
-    assert parquet['sfr'].unit is None
+    assert len(parquet["sfr"].meta) == 0
+    assert parquet["sfr"].unit is None
 
-    assert parquet_votable['sfr'].meta['ucd'] == 'phys.SFR'
-    assert parquet_votable['sfr'].unit == u.solMass / u.yr
+    assert parquet_votable["sfr"].meta["ucd"] == "phys.SFR"
+    assert parquet_votable["sfr"].unit == u.solMass / u.yr
 
 
 def test_read_write_existing(tmp_path):

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -93,7 +93,7 @@ def test_parquet_votable_input_column_unit(overwrite_metadata, tmp_path):
     assert loaded_table["sfr"].unit == u.solMass / u.yr
 
 
-@pytest.mark.xfail(reason="TODO fix: exitsing column metadata is ignored")
+@pytest.mark.xfail(reason="TODO fix: existing column metadata is ignored")
 def test_parquet_votable_input_column_metadata(tmp_path):
     """Test preservation of column metadata"""
     filename = tmp_path / "test_votable.parq"
@@ -109,7 +109,7 @@ def test_parquet_votable_input_column_metadata(tmp_path):
     assert loaded_table["mass"].meta["foo"] == "bar"
 
 
-@pytest.mark.xfail(reason="TODO fix: exitsing metadata is ignored")
+@pytest.mark.xfail(reason="TODO fix: existing metadata is ignored")
 def test_parquet_votable_input_metadata(tmp_path):
     """Test preservation of table metadata"""
     filename = tmp_path / "test_votable.parq"

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from astropy.io.misc.parquet import write_parquet_vot, read_parquet_vot
+from astropy.io.misc.parquet import read_parquet_vot, write_parquet_vot
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -19,15 +19,37 @@ def test_parquet_votable(tmp_path):
     mass = np.random.uniform(low=1e8, high=1e10, size=number_of_objects)
     sfr = np.random.uniform(low=1, high=100, size=number_of_objects)
 
-    input_table = Table([ids, redshift, mass, sfr],
-                        names=["id", "z", "mass", "sfr"],
-                        )
+    input_table = Table(
+        [ids, redshift, mass, sfr],
+        names=["id", "z", "mass", "sfr"],
+    )
 
-    column_metadata = {"id": {"unit": "", "ucd": "meta.id", "utype": "none", "description": "The ID of the galaxy."},
-                       "z": {"unit": "", "ucd": "src.redshift", "utype": "none", "description": "The redshift of the galaxy."},
-                       "mass": {"unit": "solMass", "ucd": "phys.mass", "utype": "none", "description": "The stellar mass of the galaxy."},
-                       "sfr": {"unit": "solMass / yr", "ucd": "phys.SFR", "utype": "none", "description": "The star formation rate of the galaxy."}
-                       }
+    column_metadata = {
+        "id": {
+            "unit": "",
+            "ucd": "meta.id",
+            "utype": "none",
+            "description": "The ID of the galaxy.",
+        },
+        "z": {
+            "unit": "",
+            "ucd": "src.redshift",
+            "utype": "none",
+            "description": "The redshift of the galaxy.",
+        },
+        "mass": {
+            "unit": "solMass",
+            "ucd": "phys.mass",
+            "utype": "none",
+            "description": "The stellar mass of the galaxy.",
+        },
+        "sfr": {
+            "unit": "solMass / yr",
+            "ucd": "phys.SFR",
+            "utype": "none",
+            "description": "The star formation rate of the galaxy.",
+        },
+    }
 
     write_parquet_vot(input_table, column_metadata, filename)
 

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from astropy.io.misc.parquet import write_parquet_vot, read_parquet_vot
+from astropy.table import Table
+from astropy.utils.exceptions import AstropyUserWarning
+
+# Skip all tests in this file if we cannot import pyarrow
+pyarrow = pytest.importorskip("pyarrow")
+
+
+def test_parquet_votable(tmp_path):
+    """Test writing and reading a votable into a parquet file"""
+    filename = tmp_path / "test_votable.parq"
+
+    number_of_objects = 10
+    ids = [f"COSMOS_{ii}" for ii in range(number_of_objects)]
+    redshift = np.random.uniform(low=0, high=3, size=number_of_objects)
+    mass = np.random.uniform(low=1e8, high=1e10, size=number_of_objects)
+    sfr = np.random.uniform(low=1, high=100, size=number_of_objects)
+
+    input_table = Table([ids, redshift, mass, sfr],
+                        names=["id", "z", "mass", "sfr"],
+                        )
+
+    column_metadata = {"id": {"unit": "", "ucd": "meta.id", "utype": "none", "description": "The ID of the galaxy."},
+                       "z": {"unit": "", "ucd": "src.redshift", "utype": "none", "description": "The redshift of the galaxy."},
+                       "mass": {"unit": "solMass", "ucd": "phys.mass", "utype": "none", "description": "The stellar mass of the galaxy."},
+                       "sfr": {"unit": "solMass / yr", "ucd": "phys.SFR", "utype": "none", "description": "The star formation rate of the galaxy."}
+                       }
+
+    write_parquet_vot(input_table, column_metadata, filename)
+
+    with pytest.warns(AstropyUserWarning, match="No table::len"):
+        loaded_table = read_parquet_vot(filename)
+
+    assert np.all(input_table == loaded_table)

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -5,6 +5,7 @@ from astropy.io.misc.parquet import read_parquet_votable, write_parquet_votable
 from astropy.table import Table
 import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
 # Skip all tests in this file if we cannot import pyarrow
 pyarrow = pytest.importorskip("pyarrow")
@@ -76,3 +77,14 @@ def test_compare_parquet_votable(tmp_path):
 
     assert parquet_votable['sfr'].meta['ucd'] == 'phys.SFR'
     assert parquet_votable['sfr'].unit == u.solMass / u.yr
+
+
+def test_read_write_existing(tmp_path):
+    """Test writing an existing file without overwriting."""
+    filename = tmp_path / "test_votable.parquet"
+    with open(filename, "w"):
+        # create empty file
+        pass
+
+    with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
+        write_parquet_votable(input_table, filename, metadata=column_metadata)

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -1,4 +1,5 @@
 import copy
+
 import numpy as np
 import pytest
 
@@ -73,8 +74,12 @@ def test_parquet_votable_input_column_unit(overwrite_metadata, tmp_path):
     modified_input = copy.deepcopy(input_table)
     modified_input["mass"].unit = u.kg
 
-    write_parquet_votable(modified_input, filename, metadata=column_metadata,
-                          overwrite_metadata=overwrite_metadata)
+    write_parquet_votable(
+        modified_input,
+        filename,
+        metadata=column_metadata,
+        overwrite_metadata=overwrite_metadata,
+    )
 
     with pytest.warns(AstropyUserWarning, match="No table::len"):
         loaded_table = read_parquet_votable(filename)
@@ -82,7 +87,9 @@ def test_parquet_votable_input_column_unit(overwrite_metadata, tmp_path):
     # Compare data content
     assert np.all(modified_input == loaded_table)
 
-    assert (modified_input["mass"].unit == loaded_table["mass"].unit) is not overwrite_metadata
+    assert (
+        modified_input["mass"].unit == loaded_table["mass"].unit
+    ) is not overwrite_metadata
     assert loaded_table["sfr"].unit == u.solMass / u.yr
 
 
@@ -155,7 +162,7 @@ def test_write_from_votable_existing_metadata(tmp_path):
 
 
 # Not sure this use case should be supported at all
-@pytest.mark.xfail(reason="TODO fix: metadata could be overwriten")
+@pytest.mark.xfail(reason="TODO fix: metadata could be overwritten")
 def test_write_from_votable_overriding_metadata(tmp_path):
     """Read a votable into a Table and write it out as 'parquet.votable' preserving metadata"""
     output_filename = tmp_path / "test_votable.parq"

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -64,6 +64,7 @@ def test_parquet_votable(tmp_path):
     assert np.all(input_table == loaded_table)
 
 
+@pytest.mark.xfail(reason="TODO fix: metadata overwrites existing column unit")
 def test_parquet_votable_input_column_unit(tmp_path):
     """Test round trip of a table that has column units"""
     filename = tmp_path / "test_votable.parq"
@@ -80,6 +81,7 @@ def test_parquet_votable_input_column_unit(tmp_path):
     assert input_table["mass"].unit == loaded_table["mass"].unit
 
 
+@pytest.mark.xfail(reason="TODO fix: exitsing column metadata is ignored")
 def test_parquet_votable_input_column_metadata(tmp_path):
     """Test preservation of column metadata"""
     filename = tmp_path / "test_votable.parq"
@@ -94,6 +96,7 @@ def test_parquet_votable_input_column_metadata(tmp_path):
     assert loaded_table["mass"].meta["foo"] == "bar"
 
 
+@pytest.mark.xfail(reason="TODO fix: exitsing metadata is ignored")
 def test_parquet_votable_input_metadata(tmp_path):
     """Test preservation of table metadata"""
     filename = tmp_path / "test_votable.parq"
@@ -125,6 +128,7 @@ def test_compare_parquet_votable(tmp_path):
     assert parquet_votable["sfr"].unit == u.solMass / u.yr
 
 
+@pytest.mark.xfail(reason="TODO fix: metadata should be optional when it all already exist")
 def test_write_from_votable_existing_metadata(tmp_path):
     """Read a votable into a Table and write it out as 'parquet.votable' preserving metadata"""
     output_filename = tmp_path / "test_votable.parq"
@@ -144,6 +148,7 @@ def test_write_from_votable_existing_metadata(tmp_path):
 
 
 # Not sure this use case should be supported at all
+@pytest.mark.xfail(reason="TODO fix: metadata could be overwriten")
 def test_write_from_votable_overriding_metadata(tmp_path):
     """Read a votable into a Table and write it out as 'parquet.votable' preserving metadata"""
     output_filename = tmp_path / "test_votable.parq"

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from astropy.io.misc.parquet import read_parquet_vot, write_parquet_vot
+from astropy.io.misc.parquet import read_parquet_votable, write_parquet_votable
 from astropy.table import Table
 import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
@@ -53,10 +53,10 @@ def test_parquet_votable(tmp_path):
     """Test writing and reading a votable into a parquet file"""
     filename = tmp_path / "test_votable.parq"
 
-    write_parquet_vot(input_table, column_metadata, filename)
+    write_parquet_votable(input_table, filename, metadata=column_metadata)
 
     with pytest.warns(AstropyUserWarning, match="No table::len"):
-        loaded_table = read_parquet_vot(filename)
+        loaded_table = read_parquet_votable(filename)
 
     assert np.all(input_table == loaded_table)
 
@@ -65,7 +65,7 @@ def test_compare_parquet_votable(tmp_path):
     """ Parquet votable preserves column units and metadata"""
 
     filename = tmp_path / "test_votable.parq"
-    write_parquet_vot(input_table, column_metadata, filename)
+    write_parquet_votable(input_table, filename, metadata=column_metadata)
 
     with pytest.warns(AstropyUserWarning, match="No table::len"):
         parquet = Table.read(filename)

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -135,7 +135,6 @@ def test_compare_parquet_votable(tmp_path):
     assert parquet_votable["sfr"].unit == u.solMass / u.yr
 
 
-@pytest.mark.xfail(reason="TODO fix: metadata should be optional when it all already exist")
 def test_write_from_votable_existing_metadata(tmp_path):
     """Read a votable into a Table and write it out as 'parquet.votable' preserving metadata"""
     output_filename = tmp_path / "test_votable.parq"
@@ -143,15 +142,16 @@ def test_write_from_votable_existing_metadata(tmp_path):
 
     input_t = Table.read(input_data)
 
-    # Write out the VOTable into a parquet, preserving the metadata
-    # without providing an extra dictionary
-    input_t.write(output_filename, format="parquet.votable")
+    with pytest.raises(NotImplementedError):
+        # Write out the VOTable into a parquet, preserving the metadata
+        # without providing an extra dictionary
+        input_t.write(output_filename, format="parquet.votable")
 
-    loaded_table = Table.read(output_filename, format="parquet.votable")
+        loaded_table = Table.read(output_filename, format="parquet.votable")
 
-    assert np.all(input_t == loaded_table)
-    for attr in ["meta", "unit", "dtype", "description"]:
-        assert getattr(input_t["ra"], attr) == getattr(loaded_table["ra"], attr)
+        assert np.all(input_t == loaded_table)
+        for attr in ["meta", "unit", "dtype", "description"]:
+            assert getattr(input_t["ra"], attr) == getattr(loaded_table["ra"], attr)
 
 
 # Not sure this use case should be supported at all

--- a/docs/changes/io.misc/16375.api.rst
+++ b/docs/changes/io.misc/16375.api.rst
@@ -1,0 +1,2 @@
+New format `"parquet.votable"` is added to read and write a parquet file
+with a votable metadata included.

--- a/docs/changes/io.misc/16375.api.rst
+++ b/docs/changes/io.misc/16375.api.rst
@@ -1,2 +1,2 @@
-New format `"parquet.votable"` is added to read and write a parquet file
+New format ``"parquet.votable"`` is added to read and write a parquet file
 with a votable metadata included.


### PR DESCRIPTION
This PR adds a new format ``parquet.votable`` to be able to read parquet files that include a votable metadata. 

I open this as a draft for the first round of comments, and while adding some narrative documentation.


cc @tomdonaldson @gpdf @afaisst 

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
