### PR TITLE
Fix serialization of structured masked arrays

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -1076,3 +1076,17 @@ def test_guess_ecsv_with_one_column():
     t = ascii.read(txt)
     assert t["col"].dtype.kind == "U"  # would be int with basic format
     assert t["col"].description == "hello"
+
+
+def test_write_structured_masked_column():
+    mc = MaskedColumn(
+        [(1, 2), (3, 4)],
+        mask=[(True, False), (False, False)],
+        dtype="i,i",
+    )
+    t = Table([mc], names=["mc"])
+    out = StringIO()
+    t.write(out, format="ascii.ecsv")
+    t2 = Table.read(out.getvalue(), format="ascii.ecsv")
+    assert (t2["mc"] == mc).all()
+    assert (t2["mc"].mask == mc.mask).all()

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -396,7 +396,7 @@ class ColumnInfo(BaseColumnInfo):
         else:
             units = [None] * len(names)
         for name, part_unit in zip(names, units):
-            part = Column(self._parent[name])
+            part = self._parent.__class__(self._parent[name])
             part.unit = part_unit
             part.description = None
             part.meta = {}

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -38,6 +38,7 @@ __construct_mixin_classes = (
     "astropy.table.column.Column",
     "astropy.table.column.MaskedColumn",
     "astropy.utils.masked.core.MaskedNDArray",
+    "astropy.utils.masked.core.MaskedRecarray",
     # Angles
     "astropy.coordinates.angles.core.Latitude",
     "astropy.coordinates.angles.core.Longitude",
@@ -193,7 +194,10 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols, exclude_classes=
         if not has_info_class(data, MixinInfo):
             col_cls = (
                 MaskedColumn
-                if (hasattr(data, "mask") and np.any(data.mask))
+                if (
+                    hasattr(data, "mask")
+                    and np.any(data.mask != np.zeros((), data.mask.dtype))
+                )
                 else Column
             )
             data = col_cls(data, name=new_name, **new_info)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1682,7 +1682,10 @@ class Table:
         This may be relatively slow for large tables as it requires checking the mask
         values of each column.
         """
-        return any(hasattr(col, "mask") and np.any(col.mask) for col in self.itercols())
+        return any(
+            hasattr(col, "mask") and np.any(col.mask != np.zeros((), col.mask.dtype))
+            for col in self.itercols()
+        )
 
     def _is_mixin_for_table(self, col):
         """

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1310,8 +1310,17 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         return hash((self.unmasked, self.mask))
 
 
+class MaskedRecarrayInfo(MaskedNDArrayInfo):
+    # Ensure that we output a plain MaskedArray, not a masked_recarray.
+    def _represent_as_dict(self):
+        masked_ndarray = self._parent.view(np.ndarray)
+        return masked_ndarray.info._represent_as_dict()
+
+
 class MaskedRecarray(np.recarray, MaskedNDArray, data_cls=np.recarray):
     # Explicit definition since we need to override some methods.
+
+    info = MaskedRecarrayInfo()
 
     def __array_finalize__(self, obj):
         # recarray.__array_finalize__ does not do super, so we do it

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1335,3 +1335,11 @@ class MaskedRecarray(np.recarray, MaskedNDArray, data_cls=np.recarray):
                 return
 
         raise NotImplementedError("can only set existing field from structured dtype.")
+
+    def __repr__(self):
+        cls_name = type(self).__name__
+        out = super().__repr__().splitlines()
+        prefix, _, rest = out[0].partition("(")
+        out0 = cls_name + "(" + rest
+        extra_space = (len(cls_name) - len(prefix)) * " "
+        return "\n".join([out0] + [extra_space + o for o in out[1:]])

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1509,6 +1509,15 @@ class TestMaskedRecarray(MaskedArraySetup):
             "               dtype=[('a', '<f8'), ('b', '<f8')])"
         )
 
+    def test_recarray_represent_as_dict(self):
+        rasd = self.mra.info._represent_as_dict()
+        assert type(rasd["data"]) is np.ma.MaskedArray
+        assert type(rasd["data"].base) is np.ndarray
+        mra2 = type(self.mra).info._construct_from_dict(rasd)
+        assert type(mra2) is type(self.mra)
+        assert_array_equal(mra2.unmasked, self.ra)
+        assert_array_equal(mra2.mask, self.mra.mask)
+
 
 class TestMaskedArrayInteractionWithNumpyMA(MaskedArraySetup):
     def test_masked_array_from_masked(self):

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1502,6 +1502,13 @@ class TestMaskedRecarray(MaskedArraySetup):
         assert_array_equal(mra.a.unmasked, self.msa["b"].unmasked)
         assert_array_equal(mra.a.mask, self.msa["b"].mask)
 
+    def test_recarray_repr(self):
+        assert repr(self.mra) == (
+            "MaskedRecarray([[(———, ———), ( 3.,  4.)],\n"
+            "                [(11., ———), (———, 14.)]],\n"
+            "               dtype=[('a', '<f8'), ('b', '<f8')])"
+        )
+
 
 class TestMaskedArrayInteractionWithNumpyMA(MaskedArraySetup):
     def test_masked_array_from_masked(self):

--- a/docs/changes/table/16380.bugfix.rst
+++ b/docs/changes/table/16380.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure structured ``MaskedColumn`` are serialized correctly, including
+the mask.

--- a/docs/changes/time/16380.bugfix.rst
+++ b/docs/changes/time/16380.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure Time in ymdhms format can also be serialized to files as part of a
+table if it is masked.

--- a/docs/changes/utils/16380.bugfix.rst
+++ b/docs/changes/utils/16380.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure Masked versions of ``np.recarray`` will show the correct class
+name of ``MaskedRecarray`` in their ``repr``, and that they will be
+serialized correctly if part of a table.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes multiple related failures for writing masked structured data to ECSV (either as `MaskedColumn` or `Masked`), which in turn meant some `Time` formats could not be serialized if the time was masked.

As a small side commit, it also ensures the `repr` of a `MaskedRecarray` shows the correct class name.

p.s. Not quite sure about the milestone. Put 6.1.1, but obviously nice if it can still get included in 6.1.0

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16370

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
