### PR TITLE
BUG: fix writing a `HDUList` to file when numpy 2 is installed and at least some of the data is represented as dask arrays (compatibility between numpy 2 and dask API)

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -704,9 +704,8 @@ class _ImageBaseHDU(_ValidHDU):
             # NOTE: the inplace flag to byteswap needs to be False otherwise the array is
             # byteswapped in place every time it is computed and this affects
             # the input dask array.
-            output = output.map_blocks(M.byteswap, False).map_blocks(
-                M.newbyteorder, "S"
-            )
+            output = output.map_blocks(M.byteswap, False)
+            output = output.view(output.dtype.newbyteorder("S"))
 
         initial_position = fileobj.tell()
         n_bytes = output.nbytes

--- a/docs/changes/io.fits/16384.bugfix.rst
+++ b/docs/changes/io.fits/16384.bugfix.rst
@@ -1,0 +1,2 @@
+Fix writing a ``HDUList`` to file when numpy 2 is installed and at least some of
+the data is represented as dask arrays.


### PR DESCRIPTION
### Description
This should fix a new error we're seeing in daily cron ([example logs](https://github.com/astropy/astropy/actions/runs/8955224026/job/24595706920)).
I'm very much a newbie in dask so I'm not 100% sure the fix is correct but it's following the recommendation included in numpy's error message (embedded in dask's) and it gets tests passing locally.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
