### PR TITLE
Fix endian-dependence of test introduced in gh-16380

### DIFF
--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1503,10 +1503,10 @@ class TestMaskedRecarray(MaskedArraySetup):
         assert_array_equal(mra.a.mask, self.msa["b"].mask)
 
     def test_recarray_repr(self):
-        assert repr(self.mra) == (
+        # Omit dtype part with endian-dependence.
+        assert repr(self.mra).startswith(
             "MaskedRecarray([[(———, ———), ( 3.,  4.)],\n"
             "                [(11., ———), (———, 14.)]],\n"
-            "               dtype=[('a', '<f8'), ('b', '<f8')])"
         )
 
     def test_recarray_represent_as_dict(self):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a test error on big-endian systems introduced in #16380 - e.g., see 
https://github.com/astropy/astropy/actions/runs/8960434431/job/24606929816

Hence, the extra CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
