### PR TITLE
Forward port PR 16230 to main (Finalizing changelog for v6.0.1)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,6 @@
 Version 6.1.0 (2024-05-03)
 ==========================
 
-
 New Features
 ------------
 
@@ -457,6 +456,142 @@ Other Changes and Additions
 - astropy is now compiled against NumPy 2.0, enabling runtime compatibility
   with this new major release. Compatibility with NumPy 1.23 and newer
   versions of NumPy 1.x is preserved through this change. [#16252]
+
+Version 6.0.1 (2024-03-25)
+==========================
+
+Bug Fixes
+---------
+
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- Previously passing a ``SkyCoord`` instance to the ``BaseCoordinateFrame``
+  ``separation()`` or ``separation_3d()`` methods could produce wrong results,
+  depending on what additional frame attributes were defined on the ``SkyCoord``,
+  but now ``SkyCoord`` input can be used safely. [#15659]
+
+- ``Distance`` now accepts as ``parallax`` any angle-like value.
+  This includes types like ``Column`` which have a unit but are not ``Quantity`` subclasses. [#15712]
+
+- The new default for the class method ``SkyCoord.from_name()``
+  is to look for coordinates first in SIMBAD, then in NED, and then in VizieR,
+  instead of having no specific order. [#16046]
+
+astropy.io.ascii
+^^^^^^^^^^^^^^^^
+
+- Reading of CDS header files with multi-line descriptions where the continued line started with a number was broken. This is now fixed. [#15617]
+
+- Ensure that the names of mixin columns are properly propagated as
+  labels for the MRT format. [#15848]
+
+- Fixed reading IPAC tables for ``long`` column type on some platforms, e.g., Windows. [#15992]
+
+astropy.io.fits
+^^^^^^^^^^^^^^^
+
+- Fix TDISP parsing for floating numbers. [#16007]
+
+- Fix a crash when calling FITS ``writeto`` methods with stdout as the output stream. [#16008]
+
+- Fix TDISP parsing for floating numbers in formats ES / EN. [#16015]
+
+astropy.stats
+^^^^^^^^^^^^^
+
+- Fix a spurious warning when calling ``sigma_clipped_stats`` on a ``MaskedColumn``. [#15844]
+
+astropy.table
+^^^^^^^^^^^^^
+
+- Fix a Table bug when setting items (via slice or index list) in a ``bytes`` type
+  ``MaskedColumn`` would cause the column mask to be set to all ``False``. A common way to
+  trigger this bug was reading a FITS file with masked string data and then sorting the
+  table. [#15669]
+
+- Fix slicing logic for Row.
+  Previously, slicing a ``astropy.table.row.Row`` object would incorrectly return a column,
+  now it correctly returns a list of values from that row. [#15733]
+
+- Fix a ``ValueError`` raised by ``table.join`` when fed with large tables.
+  This would typically happen in situations when the result joined table would be
+  too large to fit in memory. In those situations, the error message is now much more
+  clearly about the necessary memory size. [#15734]
+
+- Fix an unintended exception being raised when attempting to compare two unequal ``Table`` instances. [#15845]
+
+- Ensure that if a ``Column`` is initialized with a ``Quantity`` it will use by
+  default a possible name defined on the quantity's ``.info``. [#15848]
+
+- The unit conversion ``convert_unit_to`` with MaskedColumn was
+  broken as it was storing the old unit in a dictionary attached
+  to underlying np.ma.MaskedArray. This fixes it by overwriting
+  the old unit after unit conversion. [#16118]
+
+- ``astropy.table.vstack`` will no longer modify the input list even when it
+  contains non-Table objects like ``astropy.table.Row``. [#16130]
+
+astropy.units
+^^^^^^^^^^^^^
+
+- Fix an issue with unicode string representations of units shown as
+  superscripts (like degree) when raised to some power. Like for
+  LaTeX representations, now the superscript unicode character is
+  replaced by the literal short name before adding the power. [#15755]
+
+- Fix a missing ``Sun`` unit in the list of VOUnits simple_units. [#15832]
+
+- Fix write/read roundtrips with empty ``Table`` dumped to ECSV. [#15885]
+
+- Fix a bug where LaTeX formatter would return empty strings for unity (1) input. [#15923]
+
+- Ensure powers of units are consistently as simple as possible. So, an
+  integer if possible, otherwise a float, or a fraction if the float is
+  really close to that. This also ensures the hash of a unit is unique
+  for any given unit (previously, the same power could be represented as
+  float, int or fraction, which made the hash different). [#16058]
+
+- Ensure that ``find_equivalent_units`` only returns actual units, not units
+  that raised to some power match the requested one.  With this fix,
+  ``(u.m**-3).find_equivalent_units()`` properly finds nothing, rather than all
+  units of length. [#16127]
+
+astropy.utils
+^^^^^^^^^^^^^
+
+- Fix a bug where ``astropy.utils.console.Spinner`` would leak newlines for
+  messages longer than terminal width. [#16040]
+
+- Update ``report_diff_values`` so the diff no longer depends on the
+  console terminal size. [#16065]
+
+- Fix support in ``Masked`` for generalized ufuncs with more than a
+  single core dimension (such as ``erfa.rxp``). [#16120]
+
+astropy.visualization
+^^^^^^^^^^^^^^^^^^^^^
+
+- Fix an edge case where ``quantity_support`` would produce duplicate tick labels for small data ranges. [#15841]
+
+astropy.wcs
+^^^^^^^^^^^
+
+- Updated bundled WCSLIB version to 8.2.2. This update fixes character buffer
+  overflows in the comment string for the longitude and latitude axes triggered
+  by some projections in ``wcshdo()``, and also the formatting for generic
+  coordinate systems. For a full list of changes - see
+  http://www.atnf.csiro.au/people/mcalabre/WCS/CHANGES or
+  ``astropy/cextern/wcslib/CHANGES`` [#15795]
+
+- Fixed a bug in ``fit_wcs_from_points`` that does not set the default value of the ``cdelt`` of the returned WCS object. [#16027]
+
+Other Changes and Additions
+---------------------------
+
+- Given the potential breaking changes with the upcoming Numpy 2.0 release,
+  this release pins Numpy<2.0 and support for Numpy 2.0 will be added in the
+  v6.1.0 release.
 
 Version 6.0.0 (2023-11-25)
 ==========================


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to belated forward-port https://github.com/astropy/astropy/pull/16230 back to main for v6.0.1 release.

Are we supposed to now backport this forward port to v6.1.x ? 🤪 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
