### PR TITLE
Fix minus signs in WCSAxes in TeX mode

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -19,6 +19,7 @@ from astropy.visualization.wcsaxes.frame import (
     RectangularFrame,
     RectangularFrame1D,
 )
+from astropy.visualization.wcsaxes.ticklabels import TickLabels
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
 from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.wcs import WCS
@@ -497,6 +498,43 @@ def test_simplify_labels_usetex(ignore_matplotlibrc, tmp_path):
     ax.grid()
 
     fig.savefig(tmp_path / "plot.png")
+
+
+@pytest.mark.parametrize(
+    "usetex, unicode_minus, label_str",
+    [
+        (True, True, "$-{}$"),
+        (True, False, "$-{}$"),
+        (False, True, "\N{MINUS SIGN}{}"),
+        (False, False, "-{}"),
+    ],
+)
+def test_simplify_labels_minus_sign(
+    ignore_matplotlibrc, usetex, unicode_minus, label_str
+):
+    # Ensure minus signs aren't removed from the front of labels across a grid of configuration possibilities
+    if usetex and TEX_UNAVAILABLE:
+        pytest.skip("TeX is unavailable")
+
+    ticklabels = TickLabels(None)
+    expected_labels = []
+    for i in range(1, 6):
+        label = label_str.format(i)
+        ticklabels.add(
+            axis="axis",
+            world=0,
+            angle=0,
+            text=label,
+            axis_displacement=0,
+            data=(i, i),
+        )
+        expected_labels.append(label)
+
+    with mpl.rc_context(
+        rc={"text.usetex": usetex, "axes.unicode_minus": unicode_minus}
+    ):
+        ticklabels.simplify_labels()
+    assert ticklabels.text["axis"] == expected_labels
 
 
 @pytest.mark.parametrize("frame_class", [RectangularFrame, EllipticalFrame])

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -126,7 +126,11 @@ class TickLabels(Text):
         """
         self.sort()
         skippable_chars = "0123456789."
-        skippable_chars += "\N{MINUS SIGN}" if rcParams["axes.unicode_minus"] else "-"
+        if rcParams["axes.unicode_minus"] and not rcParams["text.usetex"]:
+            skippable_chars += "\N{MINUS SIGN}"
+        else:
+            skippable_chars += "-"
+
         for axis in self.world:
             t1 = self.text[axis][0]
             for i in range(1, len(self.world[axis])):

--- a/docs/changes/visualization/16406.bugfix.rst
+++ b/docs/changes/visualization/16406.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where ``WCSAxes`` could be missing negative signs on axis labels when using matplotlib's ``usetex`` mode.


### PR DESCRIPTION
### Description
This is a small fix to #15902. For a moment in that PR, repeated minus signs were trimmed from axis labels, and that still happens when using matplotlib's TeX mode (note the bottom y tick):

```python
from astropy.wcs import WCS
import matplotlib.pyplot as plt
import numpy as np
wcs = WCS(naxis=2)
wcs.wcs.ctype = 'RA', 'DEC'
wcs.wcs.crpix = 25, 25

plt.rcParams['text.usetex'] = True
ax = plt.subplot(1, 1, 1, projection=wcs)
plt.imshow(np.zeros((50, 50)))
```

![image](https://github.com/astropy/astropy/assets/23462789/b1f50faa-708b-4ac3-9e14-f5cb61f00fb0)

This is because minuses are still hyphens in TeX mode (they should be, because LaTeX will render them right, and it happens because `formatter_locator._fix_minus` only looks at the first character of each label, which is `$` in TeX mode). But `TickLabels.simplify_labels` still expects a unicode minus, so it trims the hyphen.

This PR has `TickLabels.simplify_labels` expect hyphens in TeX mode, no matter the `unicode_minus` setting.

I added a test, but it's awkward because TeX tests are currently not run, pending #13326. If I force-enable TeX tests, the new test passes with this fix and fails without this fix:
```python
=================================== FAILURES ===================================
__________________ test_simplify_labels_minus_sign[True-True] __________________

ignore_matplotlibrc = None, usetex = True, unicode_minus = True

    @pytest.mark.parametrize("usetex", [True, False])
    @pytest.mark.parametrize("unicode_minus", [True, False])
    def test_simplify_labels_minus_sign(ignore_matplotlibrc, usetex, unicode_minus):
        with mpl.rc_context(rc={"text.usetex": usetex, "axes.unicode_minus": unicode_minus}):
            ticklabels = TickLabels(None)
            expected_labels = []
            for i in [1, 2]:
                if usetex:
                    label = f"$-{i}$"
                elif unicode_minus:
                    label = f"\N{MINUS SIGN}{i}"
                else:
                    label = f"-{i}"
                ticklabels.add(axis='axis', world=0, angle=0, text=label, axis_displacement=0, data=(0, 0))
                expected_labels.append(label)
            ticklabels.simplify_labels()
>           assert ticklabels.text['axis'] == expected_labels
E           AssertionError: assert ['$-1$', '$2$'] == ['$-1$', '$-2$']
E             
E             At index 1 diff: '$2$' != '$-2$'
E             Use -v to get more diff

tests/test_misc.py:520: AssertionError
=========================== short test summary info ============================
FAILED tests/test_misc.py::test_simplify_labels_minus_sign[True-True] - AssertionError: assert ['$-1$', '$2$'] == ['$-1$', '$-2$']
=================== 1 failed, 33 passed, 1 skipped in 1.93s ====================
```