### PR TITLE
Use `math.prod()` where possible

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -8,6 +8,7 @@ to/from TABLEDATA_ and BINARY_ formats.
 import re
 import struct
 import sys
+from math import prod
 
 # THIRD-PARTY
 import numpy as np
@@ -598,11 +599,7 @@ class NumericArray(Array):
         self._base = base
         self._arraysize = arraysize
         self.format = f"{tuple(arraysize)}{base.format}"
-
-        self._items = 1
-        for dim in arraysize:
-            self._items *= dim
-
+        self._items = prod(arraysize)
         self._memsize = np.dtype(self.format).itemsize
         self._bigendian_format = ">" + self.format
 

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import abc
 import numbers
 from itertools import zip_longest
+from math import prod
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -225,10 +226,7 @@ class ShapedLikeNDArray(NDArrayShapeMethods, metaclass=abc.ABCMeta):
     @property
     def size(self) -> int:
         """The size of the object, as calculated from its shape."""
-        size = 1
-        for sh in self.shape:
-            size *= sh
-        return size
+        return prod(self.shape)
 
     @property
     def isscalar(self) -> bool:


### PR DESCRIPTION
### Description

[`math.prod()`](https://docs.python.org/3/library/math.html#math.prod) is available since Python 3.8. Using it in `utils` was discussed in the comment chain starting with https://github.com/astropy/astropy/pull/16282#discussion_r1558064872. Although grepping is not the best way of finding code that could be replaced with a `math.prod()` call, I was nonetheless able to find another relevant code block in `io.votable`.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
