### PR TITLE
BUG: fix yaml table serialization compatibility with numpy 2

### DIFF
--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -9,7 +9,7 @@ from io import StringIO
 import numpy as np
 import pytest
 
-from astropy import units as u
+import astropy.units as u
 from astropy.coordinates import (
     Angle,
     CartesianDifferential,
@@ -29,6 +29,16 @@ from astropy.table import QTable, SerializedColumn
 from astropy.time import Time
 
 
+@pytest.fixture
+def without_legacy_printoptions():
+    # this can be removed when/after reverting
+    # https://github.com/astropy/astropy/pull/15096
+    legacy_val = np.get_printoptions()["legacy"]
+    np.set_printoptions(legacy=False)
+    yield
+    np.set_printoptions(legacy=legacy_val)
+
+
 @pytest.mark.parametrize(
     "c",
     [
@@ -45,6 +55,7 @@ from astropy.time import Time
         np.complex128(1.0 - 2**-52 + 1j * (1.0 - 2**-52)),
     ],
 )
+@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_numpy_types(c):
     cy = load(dump(c))
     assert c == cy

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -194,13 +194,13 @@ def _skycoord_constructor(loader, node):
 # Straight from yaml's Representer
 def _complex_representer(self, data):
     if data.imag == 0.0:
-        data = f"{data.real!r}"
+        data = f"{data.real!s}"
     elif data.real == 0.0:
-        data = f"{data.imag!r}j"
+        data = f"{data.imag!s}j"
     elif data.imag > 0:
-        data = f"{data.real!r}+{data.imag!r}j"
+        data = f"{data.real!s}+{data.imag!s}j"
     else:
-        data = f"{data.real!r}{data.imag!r}j"
+        data = f"{data.real!s}{data.imag!s}j"
     return self.represent_scalar("tag:yaml.org,2002:python/complex", data)
 
 

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -245,7 +245,9 @@ class AstropyDumper(yaml.SafeDumper):
 
     def represent_float(self, data):
         # Override to change repr(data) to str(data) since otherwise all the
-        # numpy scalars fail in not NUMPY_LT_1_20.
+        # numpy scalars fail in not NUMPY_LT_2_0.
+        # otherwise, this function is identical to yaml.SafeDumper.represent_float
+        # (as of pyyaml 6.0.1)
         if data != data or (data == 0.0 and data == 1.0):
             value = ".nan"
         elif data == self.inf_value:

--- a/docs/changes/io.misc/16416.bugfix.rst
+++ b/docs/changes/io.misc/16416.bugfix.rst
@@ -1,0 +1,1 @@
+Fix YAML table serialization compatibility with numpy 2.


### PR DESCRIPTION
### Description
Combines the regression test from #16414 and cherry-picks https://github.com/astropy/astropy/pull/15065/commits/9cdd95d51911d099bddedf0747f8eb40d78f219a and 3be8af07e23d9daab97533a991495cb9d315bfbc from #15065

This doesn't break any test that I could run locally against numpy 1.26, so it should be backportable, but I'm still keeping it as a draft until I see CI go green, just in case.

Fix https://github.com/astropy/astropy/issues/15792

Also resolves ~90% failures (340/380) from tests that currently rely on legacy print options as setup in
https://github.com/astropy/astropy/blob/b2e38be321ac6fb0c844704cbd4be1d1bf511b9b/astropy/conftest.py#L28


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
