### PR TITLE
Stop using `flynt`

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -66,12 +66,6 @@ jobs:
             toxenv: linkcheck
             toxposargs: --color
 
-          # This is sensitive to Python version.
-          - name: Run flynt to check string formatting
-            os: ubuntu-latest
-            python: '3.11'
-            toxenv: flynt
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,20 +250,6 @@ archs = ["auto", "aarch64"]
     syntax = "numpy"
 
 
-[tool.flynt]
-exclude= [
-    "astropy/extern",
-    "astropy/coordinates/angles/angle_lextab.py",
-    "astropy/units/format/cds_lextab.py",
-    "astropy/units/format/general_lextab.py",
-    "astropy/units/format/ogip_lextab.py",
-    "astropy/coordinates/angles/angle_parsetab.py",
-    "astropy/units/format/cds_parsetab.py",
-    "astropy/units/format/general_parsetab.py",
-    "astropy/units/format/ogip_parsetab.py",
-]
-
-
 [tool.coverage]
 
     [tool.coverage.run]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ envlist =
     build_docs
     linkcheck
     codestyle
-    flynt
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
@@ -151,14 +150,6 @@ deps =
 commands =
     pre-commit install-hooks
     pre-commit run {posargs:--color always --all-files --show-diff-on-failure}
-
-[testenv:flynt]
-skip_install = true
-description = Run flynt to convert old string formatting to f-strings
-deps =
-    flynt
-commands =
-    flynt -f {toxinidir}
 
 [testenv:pyinstaller]
 # Check that astropy can be included in a PyInstaller bundle without any issues. This


### PR DESCRIPTION
### Description

[`flynt`](https://pypi.org/project/flynt/) is a tool that can replace [%-formatted strings](https://docs.python.org/3/library/stdtypes.html#old-string-formatting) and [`str.format()`](https://docs.python.org/3/library/stdtypes.html#str.format) calls with [f-strings](https://docs.python.org/3/reference/lexical_analysis.html#f-strings), but in practice it doesn't seem to be doing anything [`ruff`](https://docs.astral.sh/ruff/) couldn't do.

Closes #14934

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
