### PR TITLE
BUG: fix compatibility with numpy 2 in diff reports (io.fits, utils)

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -17,14 +17,13 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
+import numpy as np
 import pytest
 
 from astropy import __version__
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 if not NUMPY_LT_2_0:
-    import numpy as np
-
     np.set_printoptions(legacy="1.25")
 
 # This is needed to silence a warning from matplotlib caused by
@@ -66,6 +65,17 @@ def fast_thread_switching():
     sys.setswitchinterval(1e-6)
     yield
     sys.setswitchinterval(old)
+
+
+@pytest.fixture
+def without_legacy_printoptions():
+    # this can be removed when/after removing the call to np.set_printoptions
+    # at the top level
+    # reverting https://github.com/astropy/astropy/pull/15096
+    legacy_val = np.get_printoptions()["legacy"]
+    np.set_printoptions(legacy=False)
+    yield
+    np.set_printoptions(legacy=legacy_val)
 
 
 def pytest_configure(config):

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1112,7 +1112,8 @@ class ImageDataDiff(_BaseDiff):
             return
 
         for index, values in self.diff_pixels:
-            index = [x + 1 for x in reversed(index)]
+            # Convert to int to avoid np.int64 in list repr.
+            index = [int(x + 1) for x in reversed(index)]
             self._writeln(f" Data differs at {index}:")
             report_diff_values(
                 values[0],

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -658,6 +658,7 @@ class TestDiff(FitsTestCase):
         assert "a: 2\n b: 3" in report
         assert "No differences found between common HDUs" in report
 
+    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_partially_identical_files2(self):
         """
         Test files that have some identical HDUs but one different HDU.

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -64,6 +64,7 @@ class TestFITSDiff_script(FitsTestCase):
         numdiff = fitsdiff.main([tmp_a, tmp_b])
         assert numdiff == 1
 
+    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_manydiff(self, capsys):
         a = np.arange(100).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)
@@ -94,6 +95,7 @@ class TestFITSDiff_script(FitsTestCase):
             "     100 different pixels found (100.00% different).",
         ]
 
+    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_outputfile(self):
         a = np.arange(100).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)
@@ -146,6 +148,7 @@ class TestFITSDiff_script(FitsTestCase):
         numdiff = fitsdiff.main(["-r", "1e-1", tmp_a, tmp_b])
         assert numdiff == 0
 
+    @pytest.mark.usefixtures("without_legacy_printoptions")
     def test_rtol_diff(self, capsys):
         a = np.arange(100, dtype=float).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -29,16 +29,6 @@ from astropy.table import QTable, SerializedColumn
 from astropy.time import Time
 
 
-@pytest.fixture
-def without_legacy_printoptions():
-    # this can be removed when/after reverting
-    # https://github.com/astropy/astropy/pull/15096
-    legacy_val = np.get_printoptions()["legacy"]
-    np.set_printoptions(legacy=False)
-    yield
-    np.set_printoptions(legacy=legacy_val)
-
-
 @pytest.mark.parametrize(
     "c",
     [

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -1,6 +1,5 @@
 import difflib
 import functools
-import numbers
 import sys
 from textwrap import indent
 
@@ -126,12 +125,8 @@ def report_diff_values(a, b, fileobj=sys.stdout, indent_width=0, rtol=0.0, atol=
         lnpad = " "
         sign_a = "a>"
         sign_b = "b>"
-        if isinstance(a, numbers.Number):
-            a = repr(a)
-            b = repr(b)
-        else:
-            a = str(a)
-            b = str(b)
+        a = str(a)
+        b = str(b)
     else:
         padding = max(len(typea.__name__), len(typeb.__name__)) + 3
         lnpad = (padding + 1) * " "
@@ -140,22 +135,8 @@ def report_diff_values(a, b, fileobj=sys.stdout, indent_width=0, rtol=0.0, atol=
 
         is_a_str = isinstance(a, str)
         is_b_str = isinstance(b, str)
-        a = (
-            repr(a)
-            if (
-                (is_a_str and not is_b_str)
-                or (not is_a_str and isinstance(a, numbers.Number))
-            )
-            else str(a)
-        )
-        b = (
-            repr(b)
-            if (
-                (is_b_str and not is_a_str)
-                or (not is_b_str and isinstance(b, numbers.Number))
-            )
-            else str(b)
-        )
+        a = repr(a) if is_a_str and not is_b_str else str(a)
+        b = repr(b) if is_b_str and not is_a_str else str(b)
 
     identical = True
 

--- a/docs/changes/io.fits/16426.bugfix.rst
+++ b/docs/changes/io.fits/16426.bugfix.rst
@@ -1,0 +1,1 @@
+Fix display of diff reports with numpy 2.


### PR DESCRIPTION
### Description
This pull request is to address part of #16423 (specifically, failing tests from io.fits)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
