### PR TITLE
Ensure cenfunc and stdfunc scalars are np.float64

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -315,10 +315,18 @@ class SigmaClip:
         # NaNs
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
-            self._max_value = self._cenfunc_parsed(data, axis=axis)
+            cen = self._cenfunc_parsed(data, axis=axis)
+            if np.isscalar(cen) and not isinstance(cen, np.float64):
+                # change bottleneck float scalar to np.float64
+                cen = np.float64(cen)
+
             std = self._stdfunc_parsed(data, axis=axis)
-            self._min_value = self._max_value - (std * self.sigma_lower)
-            self._max_value += std * self.sigma_upper
+            if np.isscalar(std) and not isinstance(std, np.float64):
+                # change bottleneck float scalar to np.float64
+                std = np.float64(std)
+
+            self._min_value = cen - (std * self.sigma_lower)
+            self._max_value = cen + (std * self.sigma_upper)
 
     def _sigmaclip_fast(
         self, data, axis=None, masked=True, return_bounds=False, copy=True

--- a/docs/changes/stats/16431.bugfix.rst
+++ b/docs/changes/stats/16431.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that return types from ``sigma_clip`` ``cenfunc`` and ``stdfunc``
+are np.float64 for scalar values.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

`bottleneck` returns `float` scalars -- this PR converts them to `np.float64` scalars for consistency.
Addresses https://github.com/astropy/astropy/pull/15065#issuecomment-2103196197

Technically, this is a (minor) API change.  Does it need a change log entry?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
