### PR TITLE
Fix pandas to Table conversion failures with numpy-dev

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -4283,12 +4283,10 @@ class Table:
                 nan = np.nan
                 if all(isinstance(x, string_types) or x is nan for x in data):
                     # Force any missing (null) values to b''.  Numpy will
-                    # upcast to str/unicode as needed.
-                    data[mask] = b""
-
-                    # When the numpy object array is represented as a list then
-                    # numpy initializes to the correct string or unicode type.
-                    data = np.array(list(data))
+                    # upcast to str/unicode as needed. We go via a list to
+                    # avoid replacing objects in a view of the pandas array and
+                    # to ensure numpy initializes to string or bytes correctly.
+                    data = np.array([b"" if m else d for (d, m) in zip(data, mask)])
 
             # Numpy datetime64
             if data.dtype.kind == "M":

--- a/docs/changes/table/16439.bugfix.rst
+++ b/docs/changes/table/16439.bugfix.rst
@@ -1,0 +1,1 @@
+Fix problems converting Pandas Series to ``Table`` with numpy >=2.0.


### PR DESCRIPTION
This pull request is to address recent failures with numpy-dev in which a Pandas `Series` object can no longer be converted to a `Table`. ~Note that the first commit changes the CI cron, removing a job for `devdeps-noscipy` that was only useful when scipy was not yet compatible with numpy 2.0, with one in which `devdeps` is paired with `alldeps` to ensure astropy works with numpy 2.0 and all optional dependencies. It seemed to work in my trials, but perhaps more will come out.~ EDIT: removed this commit since it ends up duplicating `py312-test-alldeps-predeps` in daily cron.

cc @neutrinoceros

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
