### PR TITLE
Remove weekly cron for devdeps-noscipy [skip ci]

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -49,12 +49,6 @@ jobs:
             python: '3.10'
             toxenv: py310-test-devdeps
 
-          # https://github.com/astropy/astropy/issues/15701
-          - name: Python 3.11 with dev version of key dependencies without scipy
-            os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-devdeps-noscipy
-
           - name: Python 3.12 with dev version of infrastructure dependencies
             os: ubuntu-latest
             python: '3.12'

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ description =
     mpl334: with matplotlib 3.3.4
     mpldev: with the latest developer version of matplotlib
     double: twice in a row to check for global state changes
-    noscipy: without scipy-dev
+    noscipy: without scipy-dev and matplotlib-dev
 
 deps =
     numpy123: numpy==1.23.*


### PR DESCRIPTION
The `devdeps-noscipy` weekly cron was useful when scipy was not yet compatible with numpy 2.0, but this is no longer a problem, so it seems that this test run can be safely removed.

p.s. Adjusted the text in `tox.ini` to be clearer what actually is done with `noscipy`. Could also just remove the option if that's thought better.