### PR TITLE
add `foe` to `units.astrophys`

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -124,6 +124,13 @@ def_unit(
     doc="Rydberg: Energy of a photon whose wavenumber is the Rydberg constant",
     format={"latex": r"R_{\infty}", "unicode": "R∞"},
 )
+def_unit(
+    ["foe", "Bethe", "bethe"],
+    1e51 * si.g * si.cm**2 / si.s**2,
+    namespace=_ns,
+    prefixes=False,
+    doc="foe or Bethe: 1e51 erg, used to measure energy emitted by a supernova",
+)
 
 ###########################################################################
 # ILLUMINATION

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -649,7 +649,7 @@ def test_equivalent_units2():
     match = {
         u.AU, u.Angstrom, u.Hz, u.J, u.Ry, u.cm, u.eV, u.erg, u.lyr, u.lsec,
         u.m, u.micron, u.pc, u.solRad, u.Bq, u.Ci, u.k, u.earthRad,
-        u.jupiterRad,
+        u.jupiterRad, u.foe,
     }  # fmt: skip
     assert units == match
 
@@ -662,7 +662,7 @@ def test_equivalent_units2():
             imperial.cal, u.cm, u.eV, u.erg, imperial.ft, imperial.fur,
             imperial.inch, imperial.kcal, u.lyr, u.m, imperial.mi, u.lsec,
             imperial.mil, u.micron, u.pc, u.solRad, imperial.yd, u.Bq, u.Ci,
-            imperial.nmi, u.k, u.earthRad, u.jupiterRad,
+            imperial.nmi, u.k, u.earthRad, u.jupiterRad, u.foe,
         }  # fmt: skip
         assert units == match
 
@@ -670,7 +670,7 @@ def test_equivalent_units2():
     match = {
         u.AU, u.Angstrom, u.Hz, u.J, u.Ry, u.cm, u.eV, u.erg, u.lyr, u.lsec,
         u.m, u.micron, u.pc, u.solRad, u.Bq, u.Ci, u.k, u.earthRad,
-        u.jupiterRad,
+        u.jupiterRad, u.foe,
     }  # fmt: skip
     assert units == match
 

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -70,6 +70,7 @@ To recompose a unit with :meth:`~astropy.units.core.UnitBase.compose`::
   >>> x = u.Ry.decompose()
   >>> x.compose()
   [Unit("Ry"),
+   Unit("2.17987e-62 foe"),
    Unit("2.17987e-18 J"),
    Unit("2.17987e-11 erg"),
    Unit("13.6057 eV")]

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -641,6 +641,7 @@ all kinds of things that ``Hz`` can be converted to::
     eV           | 1.60218e-19 m2 kg / s2 | electronvolt                     ,
     earthRad     | 6.3781e+06 m           | R_earth, Rearth                  ,
     erg          | 1e-07 m2 kg / s2       |                                  ,
+    foe          | 1e+44 m2 kg / s2       | Bethe, bethe                     ,
     jupiterRad   | 7.1492e+07 m           | R_jup, Rjup, R_jupiter, Rjupiter ,
     k            | 100 / m                | Kayser, kayser                   ,
     lsec         | 2.99792e+08 m          | lightsecond                      ,


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds the unit foe (or Bethe, equivalent to 1e51 erg) to ``astropy.units.astrophys``. This unit is commonly used to express the energy emitted by a supernova explosion.
As recommended by @mhvk in #13459, I’m not including prefixes. I’m also not including the short name `B`, since `astropy.units.B` is already in use as the short name of a Byte.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13459.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
