### PR TITLE
BUG: fix bugs with how masked structured arrays were represented with numpy 2

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -17,14 +17,13 @@ except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
+import numpy as np
 import pytest
 
 from astropy import __version__
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 if not NUMPY_LT_2_0:
-    import numpy as np
-
     np.set_printoptions(legacy="1.25")
 
 # This is needed to silence a warning from matplotlib caused by
@@ -66,6 +65,17 @@ def fast_thread_switching():
     sys.setswitchinterval(1e-6)
     yield
     sys.setswitchinterval(old)
+
+
+@pytest.fixture
+def without_legacy_printoptions():
+    # this can be removed when/after removing the call to np.set_printoptions
+    # at the top level
+    # reverting https://github.com/astropy/astropy/pull/15096
+    legacy_val = np.get_printoptions()["legacy"]
+    np.set_printoptions(legacy=False)
+    yield
+    np.set_printoptions(legacy=legacy_val)
 
 
 def pytest_configure(config):

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -29,16 +29,6 @@ from astropy.table import QTable, SerializedColumn
 from astropy.time import Time
 
 
-@pytest.fixture
-def without_legacy_printoptions():
-    # this can be removed when/after reverting
-    # https://github.com/astropy/astropy/pull/15096
-    legacy_val = np.get_printoptions()["legacy"]
-    np.set_printoptions(legacy=False)
-    yield
-    np.set_printoptions(legacy=legacy_val)
-
-
 @pytest.mark.parametrize(
     "c",
     [

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
+from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
 
@@ -1391,16 +1392,21 @@ def test_masked_str_explicit_string():
     assert repr(msa) == repr_
 
 
+@pytest.mark.usefixtures("without_legacy_printoptions")
 def test_masked_str_explicit_structured():
     sa = np.array([(1.0, 2.0), (3.0, 4.0)], dtype="f8,f8")
     msa = Masked(sa, [(False, True), (False, False)])
     assert str(msa) == "[(1., ——) (3., 4.)]"
-    assert str(msa[0]) == "(1., ——)"
-    assert str(msa[1]) == "(3., 4.)" == str(sa[1])
+    assert str(msa[0]) == ("(1., ——)" if NUMPY_LT_2_0 else "(1.0, ———)")
+    assert str(msa[1]) == str(sa[1]) == ("(3., 4.)" if NUMPY_LT_2_0 else "(3.0, 4.0)")
     with np.printoptions(precision=3, floatmode="fixed"):
         assert str(msa) == "[(1.000,   ———) (3.000, 4.000)]"
-        assert str(msa[0]) == "(1.000,   ———)"
-        assert str(msa[1]) == "(3.000, 4.000)" == str(sa[1])
+        assert str(msa[0]) == ("(1.000,   ———)" if NUMPY_LT_2_0 else "(1.0, ———)")
+        assert (
+            str(msa[1])
+            == str(sa[1])
+            == ("(3.000, 4.000)" if NUMPY_LT_2_0 else "(3.0, 4.0)")
+        )
 
 
 def test_masked_repr_explicit_structured():

--- a/docs/changes/utils/16443.bugfix.rst
+++ b/docs/changes/utils/16443.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bugs with how masked structured arrays were represented with numpy 2.


### PR DESCRIPTION
### Description
This pull request is to address part of #16423 (specifically, `io.utils.masked`).
The first commit is common with #16426, #16427, #16433 and #16442 (allowing them to be merged in arbitrary order).
The fix itself is cherry-picked from #15065


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
