### PR TITLE
TST: improve test coverage for io.misc.yaml.AstropyDumper

### DIFF
--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -8,6 +8,7 @@ from io import StringIO
 
 import numpy as np
 import pytest
+from yaml import SafeDumper
 
 import astropy.units as u
 from astropy.coordinates import (
@@ -24,7 +25,7 @@ from astropy.coordinates import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.tests.test_representation import representation_equal
-from astropy.io.misc.yaml import dump, load, load_all
+from astropy.io.misc.yaml import AstropyDumper, dump, load, load_all
 from astropy.table import QTable, SerializedColumn
 from astropy.time import Time
 
@@ -59,6 +60,16 @@ def without_legacy_printoptions():
 def test_numpy_types(c):
     cy = load(dump(c))
     assert c == cy
+
+
+@pytest.mark.parametrize("c", [float("inf"), float("-inf"), np.inf, -np.inf])
+def test_astropydumper_represent_float_override(c):
+    # AstropyDumper overrides SafeDumper.represent_float, which has multiple
+    # branches, not all of which are intended to deviate.
+    # Check that the subclass behave as its parent in these cases.
+    d1 = SafeDumper(stream=StringIO())
+    d2 = AstropyDumper(stream=StringIO())
+    assert d2.represent_float(c).value == d1.represent_float(c).value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Follow up to #16416
Fixes #16429

I tried testing these branches through the public interface (à la `test_numpy_types`) but `pyyaml` appears
to transform data along the way such that they were actually never reached, so I resorted to writing a test for implementation details.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
