### PR TITLE
Reduce code duplication in `units.format.Generic` subclasses

### DIFF
--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -4,7 +4,6 @@
 Handles the "FITS" unit format.
 """
 
-import copy
 import keyword
 
 import numpy as np
@@ -131,17 +130,6 @@ class FITS(generic.Generic):
             parts.append(super().to_string(unit, fraction=fraction))
 
         return cls._scale_unit_separator.join(parts)
-
-    @classmethod
-    def _to_decomposed_alternative(cls, unit):
-        try:
-            s = cls.to_string(unit)
-        except core.UnitScaleError:
-            scale = unit.scale
-            unit = copy.copy(unit)
-            unit._scale = 1.0
-            return f"{cls.to_string(unit)} (with data multiplied by {scale})"
-        return s
 
     @classmethod
     def parse(cls, s, debug=False):

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -72,27 +72,6 @@ class FITS(generic.Generic):
         return names, deprecated_names, []
 
     @classmethod
-    def _validate_unit(cls, unit, detailed_exception=True):
-        if unit not in cls._units:
-            if detailed_exception:
-                raise ValueError(
-                    f"Unit '{unit}' not supported by the FITS standard. "
-                    + utils.did_you_mean_units(
-                        unit,
-                        cls._units,
-                        cls._deprecated_units,
-                        cls._to_decomposed_alternative,
-                    ),
-                )
-            else:
-                raise ValueError()
-
-        if unit in cls._deprecated_units:
-            utils.unit_deprecation_warning(
-                unit, cls._units[unit], "FITS", cls._to_decomposed_alternative
-            )
-
-    @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):
         cls._validate_unit(unit, detailed_exception=detailed_exception)
         return cls._units[unit]

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -14,16 +14,23 @@
 Handles a "generic" string format for units
 """
 
+from __future__ import annotations
+
 import re
 import unicodedata
 import warnings
+from copy import copy
 from fractions import Fraction
+from typing import TYPE_CHECKING
 
 from astropy.utils import classproperty, deprecated, parsing
 from astropy.utils.misc import did_you_mean
 
 from . import core
 from .base import Base
+
+if TYPE_CHECKING:
+    from astropy.units import UnitBase
 
 
 class Generic(Base):
@@ -591,6 +598,18 @@ class Generic(Base):
                     raise
                 else:
                     raise ValueError(f"Syntax error parsing unit '{s}'")
+
+    @classmethod
+    def _to_decomposed_alternative(cls, unit: UnitBase) -> str:
+        from astropy.units.core import UnitScaleError
+
+        try:
+            return cls.to_string(unit)
+        except UnitScaleError:
+            scale = unit.scale
+            unit = copy(unit)
+            unit._scale = 1.0
+            return f"{cls.to_string(unit)} (with data multiplied by {scale})"
 
 
 # 2023-02-18: The statement in the docstring is no longer true, the class is not used

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -28,6 +28,7 @@ from astropy.utils.misc import did_you_mean
 
 from . import core
 from .base import Base
+from .utils import did_you_mean_units, unit_deprecation_warning
 
 if TYPE_CHECKING:
     from astropy.units import UnitBase
@@ -598,6 +599,25 @@ class Generic(Base):
                     raise
                 else:
                     raise ValueError(f"Syntax error parsing unit '{s}'")
+
+    @classmethod
+    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
+        if unit not in cls._units:
+            if detailed_exception:
+                raise ValueError(
+                    f"Unit '{unit}' not supported by the {cls.__name__} standard. "
+                    + did_you_mean_units(
+                        unit,
+                        cls._units,
+                        cls._deprecated_units,
+                        cls._to_decomposed_alternative,
+                    ),
+                )
+            raise ValueError()
+        if unit in cls._deprecated_units:
+            unit_deprecation_warning(
+                unit, cls._units[unit], cls.__name__, cls._to_decomposed_alternative
+            )
 
     @classmethod
     def _to_decomposed_alternative(cls, unit: UnitBase) -> str:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -343,27 +343,6 @@ class OGIP(generic.Generic):
         return parsing.yacc(tabmodule="ogip_parsetab", package="astropy/units")
 
     @classmethod
-    def _validate_unit(cls, unit, detailed_exception=True):
-        if unit not in cls._units:
-            if detailed_exception:
-                raise ValueError(
-                    f"Unit '{unit}' not supported by the OGIP standard. "
-                    + utils.did_you_mean_units(
-                        unit,
-                        cls._units,
-                        cls._deprecated_units,
-                        cls._to_decomposed_alternative,
-                    ),
-                )
-            else:
-                raise ValueError()
-
-        if unit in cls._deprecated_units:
-            utils.unit_deprecation_warning(
-                unit, cls._units[unit], "OGIP", cls._to_decomposed_alternative
-            )
-
-    @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):
         cls._validate_unit(unit, detailed_exception=detailed_exception)
         return cls._units[unit]

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -126,6 +126,11 @@ class VOUnit(generic.Generic):
         return cls._units[unit]
 
     @classmethod
+    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
+        if unit not in cls._custom_units:
+            super()._validate_unit(unit, detailed_exception)
+
+    @classmethod
     def _get_unit_name(cls, unit):
         # The da- and d- prefixes are discouraged.  This has the
         # effect of adding a scale to value in the result.
@@ -142,18 +147,7 @@ class VOUnit(generic.Generic):
                 )
 
         name = super()._get_unit_name(unit)
-
-        if unit in cls._custom_units.values():
-            return name
-
-        if name not in cls._units:
-            raise ValueError(f"Unit {name!r} is not part of the VOUnit standard")
-
-        if name in cls._deprecated_units:
-            utils.unit_deprecation_warning(
-                name, unit, "VOUnit", cls._to_decomposed_alternative
-            )
-
+        cls._validate_unit(name)
         return name
 
     @classmethod

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -3,7 +3,6 @@
 Handles the "VOUnit" unit format.
 """
 
-import copy
 import keyword
 import re
 import warnings
@@ -228,16 +227,3 @@ class VOUnit(generic.Generic):
             )
 
         return super().to_string(unit, fraction=fraction)
-
-    @classmethod
-    def _to_decomposed_alternative(cls, unit):
-        from astropy.units import core
-
-        try:
-            s = cls.to_string(unit)
-        except core.UnitScaleError:
-            scale = unit.scale
-            unit = copy.copy(unit)
-            unit._scale = 1.0
-            return f"{cls.to_string(unit)} (with data multiplied by {scale})"
-        return s


### PR DESCRIPTION
### Description

The `Generic` subclasses contained identical implementations of `_to_decomposed_alternative()` and very similar implementations of `_validate_unit()`. Moving the implementations to the common parent class simplifies the code even if the parent class itself does not use these methods.

~Moving `_validate_unit()` required adding a new `class_name: str | None` argument to it. If the FITS formatter class would be named `FITS` instead of `Fits` then the argument would not be needed because `_validate_unit()` could then simply use `cls.__name__`, but changing the name of a class sounds like a big change and adding a new argument to a private method is a much less drastic solution.~ EDIT: the `Fits` class was renamed in a separate pull request.

The primary goal of this pull request is to simplify code by reducing duplication, but the new methods are also type annotated.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
