### PR TITLE
Rename `Fits` class in `units.format` to `FITS`

### DIFF
--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -4,17 +4,20 @@
 A collection of different unit formats.
 """
 
+import sys
+import warnings
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
 # This is pretty atrocious, but it will prevent a circular import for those
 # formatters that need access to the units.core module An entry for it should
 # exist in sys.modules since astropy.units.core imports this module
-import sys
-
 core = sys.modules["astropy.units.core"]
 
 from .base import Base
 from .cds import CDS
 from .console import Console
-from .fits import Fits
+from .fits import FITS
 from .generic import Generic, Unscaled
 from .latex import Latex, LatexInline
 from .ogip import OGIP
@@ -26,7 +29,7 @@ __all__ = [
     "Generic",
     "CDS",
     "Console",
-    "Fits",
+    "FITS",
     "Latex",
     "LatexInline",
     "OGIP",
@@ -35,6 +38,19 @@ __all__ = [
     "VOUnit",
     "get_format",
 ]
+
+
+def __getattr__(name):
+    if name == "Fits":
+        warnings.warn(
+            AstropyDeprecationWarning(
+                'The class "Fits" has been renamed to "FITS" in version 7.0. The old '
+                "name is deprecated and may be removed in a future version.\n"
+                "        Use FITS instead."
+            )
+        )
+        return FITS
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _known_formats():

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -12,7 +12,7 @@ import numpy as np
 from . import core, generic, utils
 
 
-class Fits(generic.Generic):
+class FITS(generic.Generic):
     """
     The FITS standard unit format.
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -16,6 +16,7 @@ from astropy.constants import si
 from astropy.units import PrefixUnit, Unit, UnitBase, UnitsWarning, dex
 from astropy.units import format as u_format
 from astropy.units.utils import is_effectively_unity
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 @pytest.mark.parametrize(
@@ -306,13 +307,13 @@ class TestRoundtripVOUnit(RoundtripBase):
 
 class TestRoundtripFITS(RoundtripBase):
     format_ = "fits"
-    deprecated_units = u_format.Fits._deprecated_units
+    deprecated_units = u_format.FITS._deprecated_units
 
     @pytest.mark.parametrize(
         "unit",
         [
             unit
-            for unit in u_format.Fits._units.values()
+            for unit in u_format.FITS._units.values()
             if (isinstance(unit, UnitBase) and not isinstance(unit, PrefixUnit))
         ],
     )
@@ -388,7 +389,7 @@ class TestRoundtripOGIP(RoundtripBase):
 
 
 def test_fits_units_available():
-    u_format.Fits._units
+    u_format.FITS._units
 
 
 def test_vo_units_available():
@@ -566,7 +567,7 @@ def test_fits_to_string_function_error():
     """
 
     with pytest.raises(TypeError, match="unit argument must be"):
-        u_format.Fits.to_string(None)
+        u_format.FITS.to_string(None)
 
 
 def test_fraction_repr():
@@ -650,7 +651,7 @@ def test_fits_function(string):
     # Function units cannot be written, so ensure they're not parsed either.
     with pytest.raises(ValueError):
         print(string)
-        u_format.Fits().parse(string)
+        u_format.FITS().parse(string)
 
 
 @pytest.mark.parametrize("string", ["mag(ct/s)", "dB(mW)", "dex(cm s**-2)"])
@@ -1003,3 +1004,16 @@ def test_format_latex_one(format_spec, expected_mantissa):
     m, ex = split_mantissa_exponent(1, format_spec)
     assert ex == ""
     assert m == expected_mantissa
+
+
+def test_Fits_name_deprecation():
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            r'^The class "Fits" has been renamed to "FITS" in version 7\.0\. '
+            r"The old name is deprecated and may be removed in a future version\.\n"
+            r"        Use FITS instead\.$"
+        ),
+    ):
+        from astropy.units.format import Fits
+    assert Fits is u.format.FITS

--- a/docs/changes/units/16455.api.rst
+++ b/docs/changes/units/16455.api.rst
@@ -1,0 +1,4 @@
+The ``format.Fits`` formatter class has been renamed to ``format.FITS`` and the
+old name is deprecated.
+Specifying the FITS format for converting ``Quantity`` and ``UnitBase``
+instances to and from strings is not affected by this change.


### PR DESCRIPTION
### Description

Many unit formatter classes are named exactly (i.e. including capitalization) like the standard that they implement (e.g. `OGIP` or `VOUnit`), but the class implementing FITS unit formatting is called `Fits` instead of `FITS`. This is proving to be very inconvenient in #16445, which is reducing code duplication in the `units.format.Generic` subclasses by replacing some of their individual methods with common implementations in `Generic`. In particular, if the `_validate_unit()` class method raises an error or a warning then the message should refer to the relevant unit standard, but using `cls.__name__` is not suitable because `Fits` has the wrong capitalization and `cls.__name__.upper()` would ruin the capitalization of `VOUnit`. This pull request will therefore simplify #16445, but it is better to have separate pull requests for API changes and user-invisible refactoring.

The renaming should have a very low impact for users because the unit formatter classes are not meant to be imported or used directly anyways.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
