### PR TITLE
Avoid modifying input pixel coordinates in-place

### DIFF
--- a/astropy/wcs/tests/test_multithreading.py
+++ b/astropy/wcs/tests/test_multithreading.py
@@ -1,0 +1,45 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# This module is specifically for tests that check that the WCS functionality
+# works correctly when used in a multi-threading context.
+
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.wcs import WCS
+from multiprocessing.pool import ThreadPool
+
+
+def test_no_inplace_modify_pixel():
+
+    # Regression test for a bug when converting coordinates in a multi-threaded
+    # context - the astropy WCSLIB wrapper would modify the input pixel array
+    # inplace to account for the 0-based vs 1-based pixel coordinates, but this
+    # caused results to be wrong when using multi-threading because each thread
+    # would re-apply the offset.
+
+    wcs = WCS(naxis=2)
+
+    N = 100_000
+
+    # The input array needs to have shape (N, 2) and be of the correct type
+    # (float) to avoid any copies being made.
+    pixel = np.random.randint(-1000, 1000, N * 2).reshape((N, 2)).astype(float)
+
+    n_threads = 4
+    pool = ThreadPool(n_threads)
+
+    def round_trip_transform(pixel):
+        world = wcs.wcs_pix2world(pixel, 0)
+        pixel = wcs.wcs_world2pix(world, 0)
+        return pixel
+
+    # Note that this is a deliberately inefficient example where each thread
+    # modifies all coordinates - if the input pixels were split up sensibly the
+    # issue wouldn't happen, but we can't assume users will never accidentally
+    # convert the same coordinates in different threads.
+    results = pool.map(round_trip_transform, (pixel,) * n_threads)
+
+    for pixel2 in results:
+        assert_allclose(pixel, pixel2)
+
+    pool.close()


### PR DESCRIPTION
As highlighted in https://github.com/astropy/astropy/issues/16244, modifying input pixel arrays in the WCSLIB C wrapper is not thread-safe. There are two possible solutions:

* **Option 1** Avoid modifying the input pixel arrays in-place, and instead copy the ``wcsprm``, offset ``crpix``, and then use that for the conversion. This has the added benefit that we also avoid modifying the ``wcsprm`` in-place to change NaN values to WCSLIB's ``UNDEFINED`` and back, which also has the risk of causing issues in a multi-threaded context (for instance if one thread changes ``UNDEFINED`` back to ``NaN`` while another thread is relying on the values being ``UNDEFINED``).
* **Option 2** Always make sure a copy is made of the pixel coordinates in the ``WCS`` Python API before passing them to e.g. ``wcs.wcs.p2s``. Currently if one calls ``wcs_pixel2world`` with ``(x, y, 0)``, a copy is made anyway to stack ``x`` and ``y``. But in the case where it is called with ``(xy, 0)``, a copy is not made if the data is contiguous and of floating-point type. We could check for this case and force a copy.
* **Option 3** Force a copy when we parse the Numpy array into the C extension in this line:

```
  pixcrd = (PyArrayObject*)PyArray_ContiguousFromAny(pixcrd_obj, NPY_DOUBLE, 2, 2);
```

we could change this line to use ``PyArray_FromArray`` and pass a flag to force a copy, always.

Option 1 is this PR, although there are other places where this needs to be fixed, but I am waiting to see if we go with this option. It does mean copying the ``wcsprm`` but this should have a small memory footprint.

Option 2 is not really optimal because (a) users might call the ``astropy.wcs.Wcsprm`` methods directly in which case the unsafe behavior will continue, and (b) because it is nice to have a way to call the conversion routines which does 

Option 3 should be safe and would require the fewest changes in lines of code, though it would increase memory usage, and would in particular result in unnecessary copies in some cases.

Performance-wise, Option 1 doesn't seem to be worse than the current code in ``main`` - we do require a copy of ``wcsprm`` but on the other hand we are not offsetting pixel coordinates. I'll be sure to add some benchmarks to astropy-benchmarks now though.

Anyway at this point, let's discuss if we like Option 1, and if so I can extend it to other parts of ``wcslib_wrap.c``.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
