### PR TITLE
Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         args: ["--enforce-all", "--maxkb=300"]
@@ -60,14 +60,14 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.4"
+    rev: "v0.4.4"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/scientific-python/cookie
-    rev: 2024.01.24
+    rev: 2024.04.23
     hooks:
       - id: sp-repo-review
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1069,10 +1069,10 @@ class Header:
                 card = Card(*((k,) + v))
             else:
                 raise ValueError(
-                    "Header update value for key %r is invalid; the "
+                    f"Header update value for key {k!r} is invalid; the "
                     "value must be either a scalar, a 1-tuple "
                     "containing the scalar value, or a 2-tuple "
-                    "containing the value and a comment string." % k
+                    "containing the value and a comment string."
                 )
             self._update(card)
 

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -138,7 +138,7 @@ if NUMPY_LT_2_0:
     # Safe in < 2.0, because it deferred to the method. Overridden in >= 2.0.
     MASKED_SAFE_FUNCTIONS |= {np.ptp}
     # Removed in numpy 2.0.  Just an alias to vstack.
-    MASKED_SAFE_FUNCTIONS |= {np.row_stack}
+    MASKED_SAFE_FUNCTIONS |= {np.row_stack}  # noqa: NPY201
     # renamed in numpy 2.0
     MASKED_SAFE_FUNCTIONS |= {np.trapz}
 else:


### PR DESCRIPTION
Following #16396

Note that [autoupdate_commit_msg](https://pre-commit.ci/#configuration-autoupdate_commit_msg) doesn't appear to have a way to set the message body. Normally in git this can be done with a second `-m` or a `-a`.
