### PR TITLE
Add type annotations to `Console` and `Unicode` unit formatters

### DIFF
--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -4,7 +4,17 @@
 Handles the "Console" unit format.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from . import base, utils
+
+if TYPE_CHECKING:
+    from numbers import Real
+    from typing import ClassVar, Literal
+
+    from astropy.units import UnitBase
 
 
 class Console(base.Base):
@@ -25,20 +35,20 @@ class Console(base.Base):
       2.1798721*10^-18 m^2 kg / s^2
     """
 
-    _times = "*"
-    _line = "-"
-    _space = " "
+    _times: ClassVar[str] = "*"
+    _line: ClassVar[str] = "-"
+    _space: ClassVar[str] = " "
 
     @classmethod
-    def _format_mantissa(cls, m):
+    def _format_mantissa(cls, m: str) -> str:
         return m
 
     @classmethod
-    def _format_superscript(cls, number):
+    def _format_superscript(cls, number: str) -> str:
         return f"^{number}"
 
     @classmethod
-    def format_exponential_notation(cls, val, format_spec=".8g"):
+    def format_exponential_notation(cls, val: Real, format_spec: str = ".8g") -> str:
         m, ex = utils.split_mantissa_exponent(val, format_spec)
 
         parts = []
@@ -51,7 +61,13 @@ class Console(base.Base):
         return cls._times.join(parts)
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, fraction="multiline"):
+    def _format_fraction(
+        cls,
+        scale: str,
+        numerator: str,
+        denominator: str,
+        fraction: Literal[True, "inline", "multiline"] = "multiline",
+    ) -> str:
         if fraction != "multiline":
             return super()._format_fraction(
                 scale, numerator, denominator, fraction=fraction
@@ -69,7 +85,9 @@ class Console(base.Base):
         )
 
     @classmethod
-    def to_string(cls, unit, fraction=False):
+    def to_string(
+        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
+    ) -> str:
         # Change default of fraction to False, i.e., we typeset
         # without a fraction by default.
         return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -4,7 +4,17 @@
 Handles the "Unicode" unit format.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from . import console, utils
+
+if TYPE_CHECKING:
+    from numbers import Real
+    from typing import ClassVar
+
+    from astropy.units import NamedUnit
 
 
 class Unicode(console.Console):
@@ -25,15 +35,15 @@ class Unicode(console.Console):
       100000 kg / (m s²)
     """
 
-    _times = "×"
-    _line = "─"
+    _times: ClassVar[str] = "×"
+    _line: ClassVar[str] = "─"
 
     @classmethod
-    def _format_mantissa(cls, m):
+    def _format_mantissa(cls, m: str) -> str:
         return m.replace("-", "−")
 
     @classmethod
-    def _format_unit_power(cls, unit, power=1):
+    def _format_unit_power(cls, unit: NamedUnit, power: Real = 1) -> str:
         name = cls._get_unit_name(unit)
         # Check for superscript units
         if power != 1:
@@ -43,7 +53,7 @@ class Unicode(console.Console):
         return name
 
     @classmethod
-    def _format_superscript(cls, number):
+    def _format_superscript(cls, number: str) -> str:
         mapping = str.maketrans(
             {
                 "0": "⁰",

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -130,6 +130,7 @@ py:class reference target not found: (k, v)
 # types
 py:class EllipsisType
 py:class ModuleType
+py:class Real
 # numpy.typing
 py:class NDArray
 # locally defined type variable for ndarray dtype


### PR DESCRIPTION
### Description

This continues the work of adding type annotations to `units/format/` by annotating the `Console` formatter and the `Unicode` formatter, which is a subclass of `Console`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
