### PR TITLE
TST: enable faster coverage in Python>=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test_all = [
     "ipykernel",
     "ipython>=7.32",
     "ipywidgets",
-    "coverage[toml]",
+    "coverage[toml]>=7.4.2",
     "skyfield>=1.20",
     "sgp4>=2.3",
     "array-api-strict",

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ setenv =
     NUMPY_WARN_IF_NO_MEM_POLICY = 1
     # For coverage, we need to pass extra options to the C compiler
     cov: CFLAGS = --coverage -fno-inline-functions -O0
+    cov: COVERAGE_CORE=sysmon
     image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data -W ignore::DeprecationWarning
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii


### PR DESCRIPTION
### Description
Since version 7.4.2, coverage now fallback gracefully when the option isn't available (i.e. on Python 3.11 and older). This feature is still documented as experimental (as of version 7.5.1), but the migration cost is so low that it seems worth a shot.
Currently it only affects one regular tox env, but the gain (~40%) is significant.

Fixes #15975

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
