### PR TITLE
Avoid building docs with `matplotlib` 3.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ docs = [
     "Jinja2>=3.1.3",
     "tomli; python_version < '3.11'",
     "sphinxcontrib-globalsubs >= 0.1.1",
+    "matplotlib!=3.9.0",  # https://github.com/matplotlib/matplotlib/issues/28234
 ]
 
 [project.urls]


### PR DESCRIPTION
### Description

`matplotlib` 3.9.0 is causing documentation build failures for projects that inherit docstrings that use the `:mpltype:` custom role: matplotlib/matplotlib#28234. Their issue has been milestoned for 3.9.1, so ignoring only 3.9.0 should be a good enough solution.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
