### PR TITLE
Deprecate `utils.introspection.resolve_name()`

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -21,6 +21,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
+from importlib import import_module
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir, mkdtemp
 from warnings import warn
 
@@ -37,7 +38,7 @@ import astropy.config.paths
 from astropy import config as _config
 from astropy.utils.compat.optional_deps import HAS_FSSPEC
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from astropy.utils.introspection import find_current_module, resolve_name
+from astropy.utils.introspection import find_current_module
 
 # Order here determines order in the autosummary
 __all__ = [
@@ -1046,7 +1047,7 @@ def get_pkg_data_path(*path, package=None):
 
         # package errors if it isn't a str
         # so there is no need for checks in the containing if/else
-        module = resolve_name(package)
+        module = import_module(package)
 
     # module path within package
     module_path = os.path.dirname(module.__file__)
@@ -1054,8 +1055,7 @@ def get_pkg_data_path(*path, package=None):
 
     # Check that file is inside tree.
     rootpkgname = package.partition(".")[0]
-    rootpkg = resolve_name(rootpkgname)
-    root_dir = os.path.dirname(rootpkg.__file__)
+    root_dir = os.path.dirname(import_module(rootpkgname).__file__)
     if not _is_inside(full_path, root_dir):
         raise RuntimeError(
             f"attempted to get a local data file outside of the {rootpkgname} tree."

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -3,11 +3,10 @@
 
 from __future__ import annotations
 
-import importlib
 import inspect
 import os
 import sys
-from importlib import metadata
+from importlib import import_module, metadata
 from importlib.metadata import packages_distributions
 from typing import TYPE_CHECKING
 
@@ -24,6 +23,9 @@ __all__ = ["resolve_name", "minversion", "find_current_module", "isinstancemetho
 __doctest_skip__ = ["find_current_module"]
 
 
+@deprecated(
+    since="7.0", alternative="importlib (e.g. importlib.import_module for modules)"
+)
 def resolve_name(name: str, *additional_parts: str) -> object:
     """Resolve a name like ``module.object`` to an object and return it.
 
@@ -42,13 +44,6 @@ def resolve_name(name: str, *additional_parts: str) -> object:
     additional_parts : iterable, optional
         If more than one positional arguments are given, those arguments are
         automatically dotted together with ``name``.
-
-    Examples
-    --------
-    >>> resolve_name('astropy.utils.introspection.resolve_name')
-    <function resolve_name at 0x...>
-    >>> resolve_name('astropy', 'utils', 'introspection', 'resolve_name')
-    <function resolve_name at 0x...>
 
     Raises
     ------
@@ -126,7 +121,7 @@ def minversion(module: ModuleType | str, version: str, inclusive: bool = True) -
         module_name = module
         module_version = None
         try:
-            module = resolve_name(module_name)
+            module = import_module(module_name)
         except ImportError:
             return False
     else:
@@ -248,7 +243,7 @@ def find_current_module(
                 if inspect.ismodule(fd):
                     diffmods.append(fd)
                 elif isinstance(fd, str):
-                    diffmods.append(importlib.import_module(fd))
+                    diffmods.append(import_module(fd))
                 elif fd is True:
                     diffmods.append(currmod)
                 else:
@@ -340,7 +335,7 @@ def find_mod_objs(modname, onlylocals=False):
         the other arguments)
 
     """
-    mod = resolve_name(modname)
+    mod = import_module(modname)
 
     if hasattr(mod, "__all__"):
         pkgitems = [(k, mod.__dict__[k]) for k in mod.__all__]

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -15,6 +15,7 @@ from astropy.utils.introspection import (
     find_mod_objs,
     isinstancemethod,
     minversion,
+    resolve_name,
 )
 
 
@@ -139,3 +140,15 @@ def test_deprecated_isinstancemethod():
         assert isinstancemethod(MyClass, MyClass.a_staticmethod) is False
     with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
         assert isinstancemethod(MyClass, MyClass.an_instancemethod) is True
+
+
+def test_resolve_name_deprecation():
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^The resolve_name function is deprecated and may be removed in a future "
+            r"version\.\n        Use importlib \(e\.g\. importlib\.import_module for "
+            r"modules\) instead\.$"
+        ),
+    ):
+        assert resolve_name("astropy.utils.introspection") is introspection

--- a/docs/changes/utils/16479.api.rst
+++ b/docs/changes/utils/16479.api.rst
@@ -1,0 +1,2 @@
+The ``introspection.resolve_name()`` function is deprecated.
+It is better to use the standard library ``importlib`` instead.


### PR DESCRIPTION
### Description

Although the standard library `importlib` does not have a drop-in replacement for `resolve_name()` in all possible use cases, in practice we only use it to import modules, so we can use [`importlib.import_module()`](https://docs.python.org/3.10/library/importlib.html#importlib.import_module) instead (available since Python 3.1).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
