### PR TITLE
Remove ancient compatibility code from `BaseCoordinateFrame.represent_as()`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1064,19 +1064,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         <SkyCoord (ICRS): (x, y, z) [dimensionless]
             (1., 0., 0.)>
         """
-        # For backwards compatibility (because in_frame_units used to be the
-        # 2nd argument), we check to see if `new_differential` is a boolean. If
-        # it is, we ignore the value of `new_differential` and warn about the
-        # position change
-        if isinstance(s, bool):
-            warnings.warn(
-                "The argument position for `in_frame_units` in `represent_as` has"
-                " changed. Use as a keyword argument if needed.",
-                AstropyWarning,
-            )
-            in_frame_units = s
-            s = "base"
-
         # In the future, we may want to support more differentials, in which
         # case one probably needs to define **kwargs above and use it here.
         # But for now, we only care about the velocity.

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -43,7 +43,7 @@ from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from astropy.units import allclose
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .test_representation import unitphysics  # this fixture is used below  # noqa: F401
 
@@ -936,11 +936,6 @@ def test_represent_as():
     rep2 = icrs.represent_as("cylindrical")
     assert isinstance(rep2, r.CylindricalRepresentation)
     assert isinstance(rep2.differentials["s"], r.CylindricalDifferential)
-
-    # single class with positional in_frame_units, verify that warning raised
-    with pytest.warns(AstropyWarning, match="argument position") as w:
-        icrs.represent_as(r.CylindricalRepresentation, False)
-    assert len(w) == 1
 
     # TODO: this should probably fail in the future once we figure out a better
     # workaround for dealing with UnitSphericalRepresentation's with


### PR DESCRIPTION
### Description

The signature of `BaseCoordinateFrame.represent_as()` was changed in a backwards-incompatible way in 3115588090c6912415b5fe267ab44af2602d96d3, but compatibility code was added to allow calls following the older signature to succeed with a warning. By now users have had plenty of time to update their code.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
