### PR TITLE
TST: use macOS arm64 in normal CI, move macOS x86_64 to weekly cron

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -60,6 +60,11 @@ jobs:
             python: '3.12'
             toxenv: py312-test-devinfra
 
+          - name: Python 3.12 on macOS (x86_64) with all optional dependencies
+            os: macos-13
+            python: '3.12'
+            toxenv: py312-test-alldeps
+
           - name: Documentation link check
             os: ubuntu-latest
             python: '3.x'

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -88,7 +88,7 @@ jobs:
         - name: Python 3.11 with all optional dependencies (MacOS X)
           macos: py311-test-alldeps
           posargs: --durations=50 --run-slow
-          runs-on: macos-12
+          runs-on: macos-latest
 
         - name: Python 3.10 Double test (Run tests twice)
           linux: py310-test-double


### PR DESCRIPTION
### Description
Following the release of [scipy 1.13.1](https://github.com/scipy/scipy/releases/tag/v1.13.1)
Follow up to #16330
Fixes #16320

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
