### PR TITLE
ENH: registering the votable.parquet reader format

### DIFF
--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -278,3 +278,6 @@ def write_table_votable_parquet(input, output, column_metadata, *, overwrite=Fal
 
 
 io_registry.register_writer("votable.parquet", Table, write_table_votable_parquet)
+# We register the "votable.parquet" reader format for consistency with
+# the writer, even though the format is recognized by the "votable" reader
+io_registry.register_reader("votable.parquet", Table, read_table_votable)

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -329,11 +329,19 @@ def test_read_write_votable_parquet(tmp_path, overwrite):
 
 
 @pytest.mark.skipif(not HAS_PYARROW, reason="requires pyarrow")
-def test_stored_parquet_votable():
+@pytest.mark.parametrize("format", [None, "votable.parquet"])
+def test_stored_parquet_votable(format):
     # Ensures that parquet is found as relative to the votable and not the test file
     with warnings.catch_warnings():
         warnings.simplefilter("always", ResourceWarning)
-        stored_votable = Table.read(get_pkg_data_filename("data/parquet_binary.xml"))
+        if format is None:
+            stored_votable = Table.read(
+                get_pkg_data_filename("data/parquet_binary.xml")
+            )
+        else:
+            stored_votable = Table.read(
+                get_pkg_data_filename("data/parquet_binary.xml"), format=format
+            )
 
     assert len(stored_votable) == 10
     assert stored_votable.colnames == ["id", "z", "mass", "sfr"]

--- a/docs/changes/io.votable/16488.bugfix.rst
+++ b/docs/changes/io.votable/16488.bugfix.rst
@@ -1,0 +1,3 @@
+Making the "votable.parquet" format available as a reader format to ensure
+consistency with the writer formats, even though the format it recognised
+automatically by "votable".


### PR DESCRIPTION
While registering this format is not fully necessary (the `'votable'` format works just fine and automatically detects the parquet binary), yet, I automatically tried to specify it when working with such votable/parquet files. So overall I think it's useful to have it registered as the counterpart of the writer.

Borderline if this needs a changelog, I would think not as it's just an oversight in the original PR.

This is to close https://github.com/astropy/astropy/issues/15471