### PR TITLE
Reduce the number of `_get_unit_name()` methods

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -39,10 +39,6 @@ class Base:
         super().__init_subclass__(**kwargs)
 
     @classmethod
-    def _get_unit_name(cls, unit: NamedUnit) -> str:
-        return unit.get_format_name(cls.name)
-
-    @classmethod
     def format_exponential_notation(cls, val: float, format_spec: str = "g") -> str:
         """
         Formats a value in exponential notation.
@@ -73,7 +69,7 @@ class Base:
         This is overridden in Latex where the name of the unit can depend on the power
         (e.g., for degrees).
         """
-        name = cls._get_unit_name(unit)
+        name = unit.get_format_name(cls.name)
         if power != 1:
             name += cls._format_superscript(utils.format_power(power))
         return name

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -328,7 +328,9 @@ class CDS(Base):
     @classmethod
     def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
+        unit = utils.decompose_to_known_units(
+            unit, lambda x: x.get_format_name(cls.name)
+        )
 
         if not unit.bases:
             if unit.scale == 1:

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -77,12 +77,6 @@ class FITS(generic.Generic):
         return cls._units[unit]
 
     @classmethod
-    def _get_unit_name(cls, unit):
-        name = super()._get_unit_name(unit)
-        cls._validate_unit(name)
-        return name
-
-    @classmethod
     def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -31,7 +31,7 @@ from .base import Base
 from .utils import did_you_mean_units, unit_deprecation_warning
 
 if TYPE_CHECKING:
-    from astropy.units import UnitBase
+    from astropy.units import NamedUnit, UnitBase
 
 
 class Generic(Base):
@@ -599,6 +599,12 @@ class Generic(Base):
                     raise
                 else:
                     raise ValueError(f"Syntax error parsing unit '{s}'")
+
+    @classmethod
+    def _get_unit_name(cls, unit: NamedUnit) -> str:
+        name = unit.get_format_name(cls.name)
+        cls._validate_unit(name)
+        return name
 
     @classmethod
     def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -22,18 +22,6 @@ class Latex(console.Console):
     _times = r" \times "
 
     @classmethod
-    def _get_unit_name(cls, unit):
-        # Do not use super() to help latex_inline subclass.
-        name = unit.get_format_name("latex")
-        if name == unit.name:
-            # This doesn't escape arbitrary LaTeX strings, but it should
-            # be good enough for unit names which are required to be alpha
-            # + "_" anyway.
-            return name.replace("_", r"\_")
-        else:
-            return name
-
-    @classmethod
     def _format_mantissa(cls, m):
         return m.replace("nan", r"{\rm NaN}").replace("inf", r"\infty")
 
@@ -43,7 +31,12 @@ class Latex(console.Console):
 
     @classmethod
     def _format_unit_power(cls, unit, power=1):
-        name = cls._get_unit_name(unit)
+        name = unit.get_format_name("latex")
+        if name == unit.name:
+            # This doesn't escape arbitrary LaTeX strings, but it should
+            # be good enough for unit names which are required to be alpha
+            # + "_" anyway.
+            name = name.replace("_", r"\_")
         if power != 1:
             # If the LaTeX representation of the base unit already ends with
             # a superscript, we need to spell out the unit to avoid double

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -364,12 +364,6 @@ class OGIP(generic.Generic):
                     raise ValueError(f"Syntax error parsing unit '{s}'")
 
     @classmethod
-    def _get_unit_name(cls, unit):
-        name = super()._get_unit_name(unit)
-        cls._validate_unit(name)
-        return name
-
-    @classmethod
     def _format_superscript(cls, number):
         return f"**({number})" if "/" in number else f"**{number}"
 

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -44,7 +44,7 @@ class Unicode(console.Console):
 
     @classmethod
     def _format_unit_power(cls, unit: NamedUnit, power: Real = 1) -> str:
-        name = cls._get_unit_name(unit)
+        name = unit.get_format_name(cls.name)
         # Check for superscript units
         if power != 1:
             if name in ("°", "e⁻", "″", "′", "ʰ"):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -145,10 +145,7 @@ class VOUnit(generic.Generic):
                     f"In '{unit}': VOUnit can not represent units with the 'd' "
                     "(deci) prefix"
                 )
-
-        name = super()._get_unit_name(unit)
-        cls._validate_unit(name)
-        return name
+        return super()._get_unit_name(unit)
 
     @classmethod
     def _def_custom_unit(cls, unit):


### PR DESCRIPTION
### Description

Currently there are 5 unit formatter classes that define a `_get_unit_name()` method, but in the updated code there are only 2.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
