### PR TITLE
Ensure Masked quantity works with np.block

### DIFF
--- a/docs/changes/utils/16499.bugfix.rst
+++ b/docs/changes/utils/16499.bugfix.rst
@@ -1,0 +1,1 @@
+``MaskedQuantity`` now works properly with ``np.block``.


### PR DESCRIPTION
This pull request is to address the fact that `np.block` did not work correctly on `MaskedQuantity` ~, as well as that one could not initialize one with a list, like `MaskedQuantity([mq1, mq2])`~. In the process, I had to adjust how `Quantity` deals with `np.block` ~and how multiple quantities are combined~.

Note: I separated out the part about the initialization, since that led to errors on older numpy and presents a bit of an API change, which is probably best not backported, while the commit here fixes a real bug.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
