### PR TITLE
Allow conversion of masked columns to masked quantities in QTable

### DIFF
--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -469,6 +469,7 @@ def test_table_aggregate(T1):
     t1m = QTable(T1, masked=True)
     t1m["c"].mask[4:6] = True
     t1m["d"].mask[4:6] = True
+    t1m["q"].mask[4:6] = True
     tg = t1m.group_by("a")
 
     if PYTEST_LT_8_0:
@@ -483,8 +484,8 @@ def test_table_aggregate(T1):
         " a   c    d    q  ",
         "               m  ",
         "--- ---- ---- ----",
-        "  0   --   --  4.0",
-        "  1  3.0 13.0 18.0",
+        "  0   --   --  ———",
+        "  1  3.0 13.0  ———",
         "  2 22.0  6.0  6.0",
     ]
 

--- a/docs/changes/table/16500.api.rst
+++ b/docs/changes/table/16500.api.rst
@@ -1,0 +1,7 @@
+Always use ``MaskedQuantity`` in ``QTable`` to represent masked ``Quantity``
+data or when the ``QTable`` is created with ``masked=True``.  Previously the
+default was to use a normal ``Quantity`` with a ``mask`` attribute of type
+``FalseArray`` as a stub to allow a minimal level of compatibility for certain
+operations. This update brings more consistent behavior and fixes functions
+like reading of table data from a list of dict that includes quantities with
+missing entries, and aggregation of ``MaskedQuantity`` in table groups.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -12,6 +12,7 @@ the 6.1 release.
 
 In particular, this release includes:
 
+* :ref:`whatsnew-7.0-table-masked-quantity`
 * :ref:`whatsnew_7_0_quantity_to_string_formatter`
 * :ref:`whatsnew_7_0_ecsv_meta_default_dict`
 * :ref:`whatsnew_7_0_contributor_doc_improvement`
@@ -23,6 +24,20 @@ By the numbers:
 * X issues have been closed since v6.1
 * X pull requests have been merged since v6.1
 * X distinct people have contributed code
+
+.. _whatsnew-7.0-table-masked-quantity:
+
+Full ``MaskedQuantity`` Support in ``QTable``
+=============================================
+
+Masked quantities were already used in many table functions, like reading from
+files, and are now fully supported throughout, i.e., ``MaskedQuantity`` are
+now always used in ``QTable`` to represent masked quantities (or when the
+``QTable`` is created with ``masked=True``). This removes the last vestiges of
+a work-around where a normal ``Quantity`` was used with a stub of a mask, and
+fixes functions like reading of table data from a list of dict that includes
+quantities with missing entries, and aggregation of ``MaskedQuantity`` in
+table groups.
 
 .. _whatsnew_7_0_quantity_to_string_formatter:
 


### PR DESCRIPTION
This pull request is to address that `MaskedColumn` and `MaskedQuantity` do not always convert from one to the other. It is built on #16498 ~, #16499, and #16503~ (EDIT: latter two merged; this PR rebased).

Opened as a draft since there probably should be more tests, but I'm running out of steam. I verified that the problems noted in #16495 are solved.

Fixes #16495

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
