### PR TITLE
Ensure we can initialize using multiple MaskedQuantity inputs.

### DIFF
--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from contextlib import ExitStack
 
 import numpy as np
 import pytest
@@ -17,7 +16,6 @@ from astropy.coordinates import (
 )
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
-from astropy.utils.compat import NUMPY_LT_1_24
 
 
 def test_angle_arrays():
@@ -44,18 +42,7 @@ def test_angle_arrays():
     npt.assert_almost_equal(a6.value, 945.0)
     assert a6.unit is u.degree
 
-    with ExitStack() as stack:
-        if NUMPY_LT_1_24:
-            stack.enter_context(pytest.raises(TypeError))
-            stack.enter_context(
-                pytest.warns(
-                    np.VisibleDeprecationWarning,
-                    match="Creating an ndarray from ragged nested sequences",
-                )
-            )
-        else:
-            stack.enter_context(pytest.raises(ValueError))
-
+    with pytest.raises(ValueError):
         Angle([a1, a2, a3], unit=u.degree)
 
     a8 = Angle(["04:02:02", "03:02:01", "06:02:01"], unit=u.degree)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -495,12 +495,11 @@ class Quantity(np.ndarray):
 
             elif isinstance(value, (list, tuple)) and len(value) > 0:
                 if all(isinstance(v, Quantity) for v in value):
-                    # If a list/tuple contains only quantities, convert all
-                    # to the same unit.
-                    if unit is None:
-                        unit = value[0].unit
-                    value = [q.to_value(unit) for q in value]
-                    value_unit = unit  # signal below that conversion has been done
+                    # If a list/tuple contains only quantities, stack them,
+                    # which also converts them to the same unit.
+                    value = np.stack(value)
+                    copy = False
+
                 elif (
                     dtype is None
                     and not hasattr(value, "dtype")

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -348,6 +348,19 @@ class TestMaskedQuantityInitialization(TestMaskedArrayInitialization, QuantitySe
         assert_array_equal(mq.value.unmasked, a)
         assert_array_equal(mq.mask, m)
 
+    def test_initialization_with_list_of_masked_quantity_scalars(self):
+        mq = self.MQ([Masked(1 * u.m, True), 2 * u.km, Masked(3 * u.Mm, False)])
+        assert mq.unit == u.m
+        assert_array_equal(mq.value.unmasked, [1.0, 2e3, 3e6])
+        assert_array_equal(mq.mask, [True, False, False])
+
+    def test_initialization_with_list_of_masked_quantity_arrays(self):
+        ma = Masked(self.a, self.mask_a)
+        mq = self.MQ([ma, ma << u.km])
+        assert isinstance(mq, self.MQ)
+        assert_array_equal(mq.unmasked, u.Quantity([self.a, self.a << u.km]))
+        assert_array_equal(mq.mask, np.array([self.mask_a, self.mask_a]))
+
 
 class TestMaskSetting(ArraySetup):
     def test_whole_mask_setting_simple(self):

--- a/docs/changes/utils/16503.bugfix.rst
+++ b/docs/changes/utils/16503.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure ``MaskedQuantity`` can be initialized with a list of masked
+quantities (as long as their shapes match), just like regular
+``Quantity`` and ``ndarray``.


### PR DESCRIPTION
Just like one can initialize `Quantity([q1, q2])`, this ensures one can so `MaskedQuantity([mq1, mq2])`. This needed a little refactoring of the `Quantity` initializer, which is the reason I'd prefer not to backport this - it means a changed error message in some cases (as seen from the (simplifying) change to the angle tests). But am happy to be convinced otherwise.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
