### PR TITLE
Remove distracting quotation marks form `UnknownSiteException` messages

### DIFF
--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -56,17 +56,20 @@ class NonRotationTransformationError(ValueError):
 
 class UnknownSiteException(KeyError):
     def __init__(self, site, attribute, close_names=None):
-        message = (
-            f"Site '{site}' not in database. Use {attribute} to see available sites."
-            f" If '{site}' exists in the online astropy-data repository, use the"
-            " 'refresh_cache=True' option to download the latest version."
-        )
-        if close_names:
-            message += " Did you mean one of: '{}'?'".format("', '".join(close_names))
         self.site = site
         self.attribute = attribute
         self.close_names = close_names
-        return super().__init__(message)
+
+    def __str__(self) -> str:
+        msg = (
+            f"Site {self.site!r} not in database. Use {self.attribute} to see "
+            f"available sites. If {self.site!r} exists in the online astropy-data "
+            "repository, use the 'refresh_cache=True' option to download the latest "
+            "version."
+        )
+        if self.close_names:
+            msg += f" Did you mean one of: {', '.join(map(repr, self.close_names))}?"
+        return msg
 
 
 class NonRotationTransformationWarning(AstropyUserWarning):

--- a/astropy/coordinates/tests/test_exceptions.py
+++ b/astropy/coordinates/tests/test_exceptions.py
@@ -88,20 +88,20 @@ def test_NonRotationTransformationWarning_message(coord_from, coord_to):
             "CERN",
             "EarthLocation.get_site_names",
             (
-                "\"Site 'CERN' not in database. Use EarthLocation.get_site_names to "
+                "Site 'CERN' not in database. Use EarthLocation.get_site_names to "
                 "see available sites. If 'CERN' exists in the online astropy-data "
                 "repository, use the 'refresh_cache=True' option to download the "
-                'latest version."'
+                "latest version."
             ),
         ),
         (
             "Fermilab",
             "the 'names' attribute",
             (
-                "\"Site 'Fermilab' not in database. Use the 'names' attribute to "
+                "Site 'Fermilab' not in database. Use the 'names' attribute to "
                 "see available sites. If 'Fermilab' exists in the online astropy-data "
                 "repository, use the 'refresh_cache=True' option to download the "
-                'latest version."'
+                "latest version."
             ),
         ),
     ],
@@ -123,8 +123,8 @@ def test_UnknownSiteException_with_suggestions(close_names, suggestion_str):
     assert str(
         UnknownSiteException("grenwich", "EarthLocation.get_site_names", close_names)
     ) == (
-        "\"Site 'grenwich' not in database. Use EarthLocation.get_site_names to see "
+        "Site 'grenwich' not in database. Use EarthLocation.get_site_names to see "
         "available sites. If 'grenwich' exists in the online astropy-data repository, "
         "use the 'refresh_cache=True' option to download the latest version. Did you "
-        f"mean one of: {suggestion_str}?'\""
+        f"mean one of: {suggestion_str}?"
     )


### PR DESCRIPTION
### Description

It is not necessarily good practice to require `pytest.raises()` to match error messages exactly in all tests, but it is still good to test full error messages in dedicated tests. When implementing such tests for `UnknownSiteException` I noticed that the messages contain distracting quotation marks (see the diff for the test file between the two commits of this pull request). One of them was a typo, the others I got rid of by implementing `UnknownSiteException.__str__()` instead of constructing the message in `UnknownSiteException.__init__()` and passing it to `super().__init__()`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
