### PR TITLE
Ensure unsigned integer dtype is preserved also for empty table

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -368,20 +368,15 @@ class FITS_rec(np.recarray):
             arr = column.array
 
             if arr is None:
-                array_size = 0
-            else:
-                array_size = len(arr)
+                # The input column had an empty array, so just use the fill
+                # value
+                continue
 
-            n = min(array_size, nrows)
+            n = min(len(arr), nrows)
 
             # TODO: At least *some* of this logic is mostly redundant with the
             # _convert_foo methods in this class; see if we can eliminate some
             # of that duplication.
-
-            if not n:
-                # The input column had an empty array, so just use the fill
-                # value
-                continue
 
             field = _get_recarray_field(data, idx)
             name = column.name

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1102,3 +1102,17 @@ def test_null_propagation_in_table_read(tmp_path):
     # equal to NULL_VALUE
     t = Table.read(output_filename)
     assert t["a"].fill_value == NULL_VALUE
+
+
+def test_unsigned_int_dtype_propagation_for_zero_length_table():
+    # Regression test for gh-16501
+    tbl = Table(
+        [
+            Column(name="unsigned16", dtype="uint16"),
+            Column(name="unsigned32", dtype="uint32"),
+            Column(name="unsigned64", dtype="uint64"),
+        ]
+    )
+    hdu = BinTableHDU(tbl)
+    tbl2 = Table.read(hdu)
+    assert tbl.dtype == tbl2.dtype

--- a/docs/changes/io.fits/16505.bugfix.rst
+++ b/docs/changes/io.fits/16505.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that also zero-length tables preserve whether integer data are
+signed or unsigned.


### PR DESCRIPTION
This pull request ensures that an empty table with unsigned integer round-trips properly through fits, preserving the unsigned dtype.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16501

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
