### PR TITLE
TST: unignore imp deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,8 +224,6 @@ filterwarnings = [
     "ignore:numpy\\.ufunc size changed:RuntimeWarning",
     "ignore:numpy\\.ndarray size changed:RuntimeWarning",
     "ignore:matplotlibrc text\\.usetex:UserWarning:matplotlib",
-    # Triggered by ProgressBar > ipykernel.iostream (revisit when we bump oldest deps versions)
-    "ignore:the imp module is deprecated:DeprecationWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
### Description
A small follow up to #15546

`ipykernel` was fixed in https://github.com/ipython/ipykernel/pull/894, released as early as version 6.11.0
Since we don't pin `ipykernel` directly as far as I can tell, it's not 100% clear when this filter can be dropped, but I'm taking a bet that it works in oldest deps too by now.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
