### PR TITLE
Reorganize the reference/API section of the units docs

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -2,7 +2,7 @@
 
 """
 This subpackage contains classes and functions for defining and converting
-between different physical units.
+between different physical units, as well as the units themselves.
 
 This code is adapted from the `pynbody
 <https://github.com/pynbody/pynbody>`_ units module written by Andrew

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-This package defines the astrophysics-specific units.  They are also
-available in the `astropy.units` namespace.
+This package defines the astrophysics-specific units. They are also
+available in (and should be used through) the `astropy.units` namespace.
 """
 
 import numpy as np

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This package defines the CGS units.  They are also available in the
-top-level `astropy.units` namespace.
-
+This package defines the CGS units.  They are also available in
+(and should be used through) the `astropy.units` namespace.
 """
 
 from fractions import Fraction

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -1,5 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""A set of standard astronomical equivalencies."""
+"""
+A set of standard astronomical equivalencies.
+
+The equivalency class and all equivalency functions defined here are also
+available in (and should be used through) the `astropy.units` namespace.
+
+"""
 
 from collections import UserList
 

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -2,6 +2,10 @@
 
 """
 A collection of different unit formats.
+
+General usage is by their name in the |Unit| constructor or
+in the :meth:`~astropy.units.UnitBase.to_string` method, i.e.,
+these classes rarely if ever need to be imported directly.
 """
 
 import sys

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -10,12 +10,11 @@ from astropy.units import (
     UnitsError,
     UnitTypeError,
     dimensionless_unscaled,
-    photometric,
 )
+from astropy.utils import lazyproperty
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 from .core import FunctionQuantity, FunctionUnitBase
-from .units import dB, dex, mag
 
 __all__ = [
     "LogUnit",
@@ -26,10 +25,6 @@ __all__ = [
     "Magnitude",
     "Decibel",
     "Dex",
-    "STmag",
-    "ABmag",
-    "M_bol",
-    "m_bol",
 ]
 
 
@@ -52,8 +47,10 @@ class LogUnit(FunctionUnitBase):
     """
 
     # the four essential overrides of FunctionUnitBase
-    @property
+    @lazyproperty
     def _default_function_unit(self):
+        from .units import dex
+
         return dex
 
     @property
@@ -64,12 +61,17 @@ class LogUnit(FunctionUnitBase):
         """Transformation from value in physical to value in logarithmic units.
         Used in equivalency.
         """
+        # Local import to avoid circular dependency.
+        from .units import dex
+
         return dex.to(self._function_unit, np.log10(x))
 
     def to_physical(self, x):
         """Transformation from value in logarithmic to value in physical units.
         Used in equivalency.
         """
+        from .units import dex
+
         return 10 ** self._function_unit.to(dex, x)
 
     # ^^^^ the four essential overrides of FunctionUnitBase
@@ -143,8 +145,10 @@ class MagUnit(LogUnit):
         unit such as ``2 mag``.
     """
 
-    @property
+    @lazyproperty
     def _default_function_unit(self):
+        from .units import mag
+
         return mag
 
     @property
@@ -166,8 +170,10 @@ class DexUnit(LogUnit):
         unit such as ``0.5 dex``.
     """
 
-    @property
+    @lazyproperty
     def _default_function_unit(self):
+        from .units import dex
+
         return dex
 
     @property
@@ -198,8 +204,10 @@ class DecibelUnit(LogUnit):
         unit such as ``2 dB``.
     """
 
-    @property
+    @lazyproperty
     def _default_function_unit(self):
+        from .units import dB
+
         return dB
 
     @property
@@ -430,25 +438,3 @@ class Decibel(LogQuantity):
 
 class Magnitude(LogQuantity):
     _unit_class = MagUnit
-
-
-dex._function_unit_class = DexUnit
-dB._function_unit_class = DecibelUnit
-mag._function_unit_class = MagUnit
-
-
-STmag = MagUnit(photometric.STflux)
-STmag.__doc__ = "ST magnitude: STmag=-21.1 corresponds to 1 erg/s/cm2/A"
-
-ABmag = MagUnit(photometric.ABflux)
-ABmag.__doc__ = "AB magnitude: ABmag=-48.6 corresponds to 1 erg/s/cm2/Hz"
-
-M_bol = MagUnit(photometric.Bol)
-M_bol.__doc__ = (
-    f"Absolute bolometric magnitude: M_bol=0 corresponds to L_bol0={photometric.Bol.si}"
-)
-
-m_bol = MagUnit(photometric.bol)
-m_bol.__doc__ = (
-    f"Apparent bolometric magnitude: m_bol=0 corresponds to f_bol0={photometric.bol.si}"
-)

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -5,12 +5,17 @@ If called, their arguments are used to initialize the corresponding function
 unit (e.g., ``u.mag(u.ct/u.s)``).  Note that the prefixed versions cannot be
 called, as it would be unclear what, e.g., ``u.mmag(u.ct/u.s)`` would mean.
 
+It also defines a few commonly used magnitude unit instances, like STmag,
+for which the physical units are defined in `astropy.units.photometric`.
+
 All units are also available in (and should be used through) the
 `astropy.units` namespace.
 """
 
-from astropy.units.core import UnitBase, _add_prefixes
+from astropy.units import photometric
+from astropy.units.core import CompositeUnit, UnitBase, _add_prefixes
 
+from .logarithmic import DecibelUnit, DexUnit, MagUnit
 from .mixin import IrreducibleFunctionUnit, RegularFunctionUnit
 
 __all__: list[str] = []  #  Units are added at the end
@@ -26,6 +31,7 @@ _ns = globals()
 dex = IrreducibleFunctionUnit(
     ["dex"], namespace=_ns, doc="Dex: Base 10 logarithmic unit"
 )
+dex._function_unit_class = DexUnit
 
 dB = RegularFunctionUnit(
     ["dB", "decibel"],
@@ -33,6 +39,7 @@ dB = RegularFunctionUnit(
     namespace=_ns,
     doc="Decibel: ten per base 10 logarithmic unit",
 )
+dB._function_unit_class = DecibelUnit
 
 mag = RegularFunctionUnit(
     ["mag"],
@@ -40,18 +47,67 @@ mag = RegularFunctionUnit(
     namespace=_ns,
     doc="Astronomical magnitude: -2.5 per base 10 logarithmic unit",
 )
-
 _add_prefixes(mag, namespace=_ns, prefixes=True)
+mag._function_unit_class = MagUnit
+
+STmag = mag(photometric.STflux)
+STmag.__doc__ = "ST magnitude: STmag=-21.1 corresponds to 1 erg/s/cm2/A"
+
+ABmag = mag(photometric.ABflux)
+ABmag.__doc__ = "AB magnitude: ABmag=-48.6 corresponds to 1 erg/s/cm2/Hz"
+
+M_bol = mag(photometric.Bol)
+M_bol.__doc__ = (
+    f"Absolute bolometric magnitude: M_bol=0 corresponds to {photometric.Bol}"
+)
+
+m_bol = mag(photometric.bol)
+m_bol.__doc__ = (
+    f"Apparent bolometric magnitude: m_bol=0 corresponds to {photometric.bol}"
+)
 
 
 ###########################################################################
 # DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += [n for n, v in _ns.items() if isinstance(v, (UnitBase, MagUnit))]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
     from astropy.units.utils import generate_unit_summary as _generate_unit_summary
 
-    __doc__ += _generate_unit_summary(globals())
+    def _description(unit):
+        pu = unit.physical_unit.represents
+        if unit.__doc__[:2] in {"AB", "ST"}:
+            pu = 1.0 * CompositeUnit(1.0, pu.bases, pu.powers)
+        return "".join(
+            unit.__doc__.partition("corresponds to ")[:-1]
+            + (f":math:`{pu.to_string(format='latex')[1:-1]}`",)
+        )
+
+    template = """
+   * - ``{}``
+     - {}
+     - {}
+"""
+
+    __doc__ += (
+        _generate_unit_summary(globals())
+        + """
+.. list-table:: Available Magnitude Units
+   :header-rows: 1
+   :widths: 10 50 10
+
+   * - Unit
+     - Description
+     - Represents
+"""
+        + "".join(
+            [
+                template.format(key, _description(val), val)
+                for key, val in globals().items()
+                if isinstance(val, MagUnit)
+            ]
+        )
+    )

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -4,6 +4,9 @@ This package defines units that can also be used as functions of other units.
 If called, their arguments are used to initialize the corresponding function
 unit (e.g., ``u.mag(u.ct/u.s)``).  Note that the prefixed versions cannot be
 called, as it would be unclear what, e.g., ``u.mmag(u.ct/u.s)`` would mean.
+
+All units are also available in (and should be used through) the
+`astropy.units` namespace.
 """
 
 from astropy.units.core import UnitBase, _add_prefixes

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-This package defines miscellaneous units. They are also
-available in the `astropy.units` namespace.
+This package defines miscellaneous units. They are also available in
+(and should be used through) the `astropy.units` namespace.
 """
 
 import numpy as np

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -3,8 +3,12 @@
 """
 This module defines magnitude zero points and related photometric quantities.
 
-The corresponding magnitudes are given in the description of each unit
-(the actual definitions are in `~astropy.units.function.logarithmic`).
+The corresponding magnitudes are given in the description of each unit.
+(the actual definitions are in ``astropy.units.function.logarithmic``).
+
+Both the units and magnitudes are available in (and should be used
+through) the `astropy.units` namespace.
+
 """
 
 import numpy as np

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -4,7 +4,7 @@
 This module defines magnitude zero points and related photometric quantities.
 
 The corresponding magnitudes are given in the description of each unit.
-(the actual definitions are in ``astropy.units.function.logarithmic``).
+(the actual definitions are in `astropy.units.function.units`).
 
 Both the units and magnitudes are available in (and should be used
 through) the `astropy.units` namespace.

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -1,6 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""Defines the physical types that correspond to different units."""
+"""Defines the physical types that correspond to different units.
+
+The classes and functions defined here are also available in
+(and should be used through) the `astropy.units` namespace.
+"""
 
 import numbers
 

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This package defines the SI units.  They are also available in the
-`astropy.units` namespace.
-
+This package defines the SI units.  They are also available in
+(and should be used through) the `astropy.units` namespace.
 """
 
 import numpy as np

--- a/docs/units/ref_api.rst
+++ b/docs/units/ref_api.rst
@@ -1,11 +1,7 @@
 Reference/API
 *************
 
-.. automodapi:: astropy.units.quantity
-
 .. automodapi:: astropy.units
-
-.. automodapi:: astropy.units.format
 
 .. automodapi:: astropy.units.si
 
@@ -25,12 +21,7 @@ Reference/API
 
 .. automodapi:: astropy.units.physical
 
-.. automodapi:: astropy.units.equivalencies
-
-.. automodapi:: astropy.units.function.core
-
-.. automodapi:: astropy.units.function.logarithmic
-   :include-all-objects:
+.. automodapi:: astropy.units.format
 
 .. automodapi:: astropy.units.deprecated
 


### PR DESCRIPTION
It was found that the combination of `sphinx` and `typing` gives problems if the class used for typing is also listed in two separate places in the documentation. Since in general we should only list the place users should import a given class from, this PR removes several modules from the units API/reference list: `quantity`, `equivalencies`, `function.core`, and `function.logarithmic`. In the process, I also slightly updated the docstrings of the modules that are still included, to make clear(er) that most are not to be used directly -- but are handy as they give, e.g., the unit summaries.

One annoyance with `logarithmic` was that it was the one place that definitions of the various magnitudes (like `STmag`) were given. To solve that, I moved those to `function.units` in the second commit (which required a bit of rework to avoid circular dependencies). I also added a custom table to the docstring mentioning those (`generate_unit_summary` presumes things that are not true for function units).

I think this is good regardless of whether it now allows the cosmology module typing PR to be put in again, but obviously I hope it fixes the problems that were encountered! Definitely do check the readthedocs results!

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
