### PR TITLE
DOC: cleanup Python 2 idioms

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -47,7 +47,7 @@ Interface and Dependencies
       except ImportError:
           warn(AstropyWarning('opdep is not present, so <functionality>'
                               'will not work.'))
-          class Superclass(object): pass
+          class Superclass: pass
 
       class Customclass(Superclass):
           ...
@@ -286,11 +286,9 @@ accept, and conservative in what you send."
 
 The following example class shows a way to implement this::
 
-    # -*- coding: utf-8 -*-
-
     from astropy import conf
 
-    class FloatList(object):
+    class FloatList:
         def __init__(self, init):
             if isinstance(init, str):
                 init = init.split('‖')
@@ -414,7 +412,7 @@ multiple inheritance case::
 
     # This is dangerous and bug-prone!
 
-    class A(object):
+    class A:
         def method(self):
             print('Doing A')
 
@@ -470,7 +468,7 @@ class should be handed control in the next `super` call::
 
     # This is safer
 
-    class A(object):
+    class A:
         def method(self):
             print('Doing A')
 
@@ -548,7 +546,7 @@ might read::
         # the function would be defined here
         pass
 
-    class AClass(object):
+    class AClass:
         # the class is defined here
         pass
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -511,7 +511,7 @@ functions. In the following::
         """Add two numbers."""
         return x + y
 
-    class TestAdd42(object):
+    class TestAdd42:
         """Test for add_nums with y=42."""
 
         def setup_class(self):
@@ -544,7 +544,7 @@ before and after *each* test. For this, use the ``setup_method`` and
         """Add two numbers."""
         return x + y
 
-    class TestAdd42(object):
+    class TestAdd42:
         """Test for add_nums with y=42."""
 
         def setup_method(self, method):

--- a/docs/samp/example_table_image.rst
+++ b/docs/samp/example_table_image.rst
@@ -108,7 +108,7 @@ We now set up a receiver class which will handle any received messages. We need
 to take care to write handlers for both notifications and calls (the difference
 between the two being that calls expect a reply)::
 
-    >>> class Receiver(object):
+    >>> class Receiver:
     ...     def __init__(self, client):
     ...         self.client = client
     ...         self.received = False
@@ -183,7 +183,7 @@ reads the table once it has::
     client.connect()
 
     # Set up a receiver class
-    class Receiver(object):
+    class Receiver:
         def __init__(self, client):
             self.client = client
             self.received = False

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -302,7 +302,7 @@ the ``astropy`` mixin test suite and is fully compliant as a mixin column.
 
   from astropy.utils.data_info import ParentDtypeInfo
 
-  class ArrayWrapper(object):
+  class ArrayWrapper:
       """
       Minimal mixin using a simple wrapper around a numpy array
       """


### PR DESCRIPTION
### Description
Stumbled upon one occurence of `clas X(object):` while reviewing code-style docs, so I grepped for it everywhere.
`# -*- coding: utf-8 -*-` is also a noop in Python 3

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
