### PR TITLE
CLN: cleanup unneeded explicit file encoding declarations

### DIFF
--- a/astropy/coordinates/angles/angle_lextab.py
+++ b/astropy/coordinates/angles/angle_lextab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/coordinates/angles/angle_parsetab.py
+++ b/astropy/coordinates/angles/angle_parsetab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/units/format/cds_lextab.py
+++ b/astropy/units/format/cds_lextab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/units/format/cds_parsetab.py
+++ b/astropy/units/format/cds_parsetab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/units/format/generic_lextab.py
+++ b/astropy/units/format/generic_lextab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/units/format/generic_parsetab.py
+++ b/astropy/units/format/generic_parsetab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/units/format/ogip_lextab.py
+++ b/astropy/units/format/ogip_lextab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/units/format/ogip_parsetab.py
+++ b/astropy/units/format/ogip_parsetab.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,

--- a/astropy/utils/parsing.py
+++ b/astropy/utils/parsing.py
@@ -22,8 +22,7 @@ if TYPE_CHECKING:
 __all__ = ["lex", "ThreadSafeParser", "yacc"]
 
 
-_TAB_HEADER = """# -*- coding: utf-8 -*-
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+_TAB_HEADER = """# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # This file was automatically generated from ply. To re-generate this file,
 # remove it from this folder, then build astropy and run the tests in-place:


### PR DESCRIPTION
### Description
utf-8 is used by default in Python 3

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
