### PR TITLE
Update combining_and_defining.rst

### DIFF
--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -99,7 +99,7 @@ can be enabled by calling :func:`~astropy.units.add_enabled_units`::
   ]
 
 If new units are defined with prefixes enabled, the prefixed units must be
-explicitly enabled as well, e.g. by using the `namespace` argument::
+explicitly enabled as well, e.g., by using the ``namespace`` argument::
 
   >>> new_units = dict()
   >>> foo = u.def_unit(['Fo', 'foo'], prefixes=True, namespace=new_units)

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -107,7 +107,7 @@ explicitly enabled as well, e.g. by using the `namespace` argument::
 
 Now, the prefixed units can be parsed etc::
 
-  >>> print( u.Unit("megafoo").find_equivalent_units() )
+  >>> print(u.Unit("megafoo").find_equivalent_units())
   Primary name | Unit definition | Aliases
   [
     Fo           | irreducible     | foo     ,

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -98,7 +98,7 @@ can be enabled by calling :func:`~astropy.units.add_enabled_units`::
     kmph         | 0.277778 m / s  |         ,
   ]
 
-If new units are defined with prefixes enabled, the prefixed units must be 
+If new units are defined with prefixes enabled, the prefixed units must be
 explicitly enabled as well, e.g. by using the `namespace` argument::
   
   >>> new_units = dict()

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -112,7 +112,7 @@ Now, the prefixed units can be parsed etc::
   [
     Fo           | irreducible     | foo     ,
   ]
-  >>> print( u.Unit("megafoo").to(u.Unit("kFo")) )
+  >>> print(u.Unit("megafoo").to(u.Unit("kFo")))
   1000.0
 
 .. EXAMPLE END

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -98,4 +98,21 @@ can be enabled by calling :func:`~astropy.units.add_enabled_units`::
     kmph         | 0.277778 m / s  |         ,
   ]
 
+If new units are defined with prefixes enabled, the prefixed units must be 
+explicitly enabled as well, e.g. by using the `namespace` argument::
+  
+  >>> new_units = dict()
+  >>> foo = u.def_unit(['Fo', 'foo'], prefixes = True, namespace = new_units)
+  >>> u.add_enabled_units(new_units.values() )
+
+Now, the prefixed units can be parsed etc::
+
+  >>> print( u.Unit("megafoo").find_equivalent_units() )
+  Primary name | Unit definition | Aliases
+  [
+    Fo           | irreducible     | foo     ,
+  ]
+  >>> print( u.Unit("megafoo").to(u.Unit("kFo")) )
+  1000.0
+
 .. EXAMPLE END

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -102,8 +102,8 @@ If new units are defined with prefixes enabled, the prefixed units must be
 explicitly enabled as well, e.g. by using the `namespace` argument::
   
   >>> new_units = dict()
-  >>> foo = u.def_unit(['Fo', 'foo'], prefixes = True, namespace = new_units)
-  >>> u.add_enabled_units(new_units.values() )
+  >>> foo = u.def_unit(['Fo', 'foo'], prefixes=True, namespace=new_units)
+  >>> u.add_enabled_units(new_units.values())
 
 Now, the prefixed units can be parsed etc::
 

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -100,10 +100,10 @@ can be enabled by calling :func:`~astropy.units.add_enabled_units`::
 
 If new units are defined with prefixes enabled, the prefixed units must be
 explicitly enabled as well, e.g. by using the `namespace` argument::
-  
+
   >>> new_units = dict()
   >>> foo = u.def_unit(['Fo', 'foo'], prefixes=True, namespace=new_units)
-  >>> u.add_enabled_units(new_units.values())
+  >>> u.add_enabled_units(new_units)
 
 Now, the prefixed units can be parsed etc::
 

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -104,6 +104,7 @@ explicitly enabled as well, e.g. by using the `namespace` argument::
   >>> new_units = dict()
   >>> foo = u.def_unit(['Fo', 'foo'], prefixes=True, namespace=new_units)
   >>> u.add_enabled_units(new_units)
+  <astropy.units.core._UnitContext object at ...>
 
 Now, the prefixed units can be parsed etc::
 


### PR DESCRIPTION
Clarify procedure for enabling new units with prefixes

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request clarifies the documentation regarding the procedure for defining/enabling new units with prefixes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
