### PR TITLE
Update broken references to `units` API

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1792,9 +1792,9 @@ class SkyCoord(ShapedLikeNDArray):
 
           >>> vcorr_rel = vcorr.to(u.Hz, u.doppler_optical(1*u.Hz)).to(vcorr.unit, u.doppler_relativistic(1*u.Hz))  # doctest: +REMOTE_DATA
 
-        See also `~astropy.units.equivalencies.doppler_optical`,
-        `~astropy.units.equivalencies.doppler_radio`, and
-        `~astropy.units.equivalencies.doppler_relativistic` for more information on
+        See also `~astropy.units.doppler_optical`,
+        `~astropy.units.doppler_radio`, and
+        `~astropy.units.doppler_relativistic` for more information on
         the velocity conventions.
 
         The default is for this method to use the builtin ephemeris for

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -265,7 +265,7 @@ class _UnitRegistry:
         ----------
         equivalencies : list of tuple
             List of equivalent pairs, e.g., as returned by
-            `~astropy.units.equivalencies.dimensionless_angles`.
+            `~astropy.units.dimensionless_angles`.
         """
         self._reset_equivalencies()
         return self.add_enabled_equivalencies(equivalencies)
@@ -284,7 +284,7 @@ class _UnitRegistry:
         ----------
         equivalencies : list of tuple
             List of equivalent pairs, e.g., as returned by
-            `~astropy.units.equivalencies.dimensionless_angles`.
+            `~astropy.units.dimensionless_angles`.
         """
         # pre-normalize list to help catch mistakes
         equivalencies = _normalize_equivalencies(equivalencies)
@@ -484,7 +484,7 @@ def set_enabled_equivalencies(equivalencies):
     ----------
     equivalencies : list of tuple
         list of equivalent pairs, e.g., as returned by
-        `~astropy.units.equivalencies.dimensionless_angles`.
+        `~astropy.units.dimensionless_angles`.
 
     Examples
     --------
@@ -519,7 +519,7 @@ def add_enabled_equivalencies(equivalencies):
     ----------
     equivalencies : list of tuple
         list of equivalent pairs, e.g., as returned by
-        `~astropy.units.equivalencies.dimensionless_angles`.
+        `~astropy.units.dimensionless_angles`.
     """
     # get a context with a new registry, which is a copy of the current one
     context = _UnitContext(get_current_unit_registry())

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -34,7 +34,7 @@ The length unit *parsec* is defined such that a star one parsec away
 will exhibit a 1-arcsecond parallax. (Think of the name as a contraction
 between *parallax* and *arcsecond*.)
 
-The :func:`~astropy.units.equivalencies.parallax` function handles
+The :func:`~astropy.units.parallax` function handles
 conversions between parallax angles and length.
 
 .. EXAMPLE START: Converting Parallax to Distance
@@ -50,7 +50,7 @@ raises an exception::
   UnitConversionError: 'arcsec' (angle) and 'pc' (length) are not convertible
 
 To trigger the conversion between parallax angle and distance, provide
-:func:`~astropy.units.equivalencies.parallax` as the optional keyword
+:func:`~astropy.units.parallax` as the optional keyword
 argument (``equivalencies=``) to the
 :meth:`~astropy.units.core.UnitBase.to` method.
 
@@ -67,7 +67,7 @@ mistakes. However, this is not very handy when working with units related to
 rotational energy or the small angle approximation. (Indeed, this
 double-sidedness underlies why radians went from a `supplementary to derived unit
 <https://www.bipm.org/en/committees/cg/cgpm/20-1995/resolution-8>`__.) The function
-:func:`~astropy.units.equivalencies.dimensionless_angles` provides the required
+:func:`~astropy.units.dimensionless_angles` provides the required
 equivalency list that helps convert between angles and dimensionless units. It
 is somewhat different from all others in that it allows an arbitrary change in
 the number of powers to which radians is raised (i.e., including zero and
@@ -90,7 +90,7 @@ Normally the following would raise exceptions::
   UnitConversionError: 'cycle2 kg m2 / s2' and 'J' (energy) are not convertible
 
 But when passing the proper conversion function,
-:func:`~astropy.units.equivalencies.dimensionless_angles`, it works.
+:func:`~astropy.units.dimensionless_angles`, it works.
 
   >>> u.deg.to('', equivalencies=u.dimensionless_angles())  # doctest: +FLOAT_CMP
   0.017453292519943295
@@ -119,7 +119,7 @@ implement :math:`f=\omega/2\pi`). However, attempting this yields:
   <Quantity 6.283185307179586 Hz>
 
 Here, we might have expected ~0.159 Hz in the first example and 1 Hz in
-the second. However, :func:`~astropy.units.equivalencies.dimensionless_angles`
+the second. However, :func:`~astropy.units.dimensionless_angles`
 converts to radians per second and then drops radians as a unit. The
 implicit mistake made in these examples is that the unit Hz is taken to be
 equivalent to cycles per second, which it is not (it is just "per second").
@@ -136,14 +136,14 @@ between cycles per second and hertz:
 Spectral Units
 --------------
 
-:func:`~astropy.units.equivalencies.spectral` is a function that returns
+:func:`~astropy.units.spectral` is a function that returns
 an equivalency list to handle conversions between wavelength,
 frequency, energy, and wave number.
 
 .. EXAMPLE START: Using Spectral Units for Conversions
 
 As mentioned with parallax units, we pass a list of equivalencies (in this case,
-the result of :func:`~astropy.units.equivalencies.spectral`) as the second
+the result of :func:`~astropy.units.spectral`) as the second
 argument to the :meth:`~astropy.units.quantity.Quantity.to` method and
 wavelength, and then frequency and energy can be converted.
 
@@ -180,11 +180,9 @@ light:
     * Optical       :math:`V = c \frac{f_0 - f}{f  }  ;  f(V) = f_0 ( 1 + V/c )^{-1}`
     * Relativistic  :math:`V = c \frac{f_0^2 - f^2}{f_0^2 + f^2} ;  f(V) = f_0 \frac{\left(1 - (V/c)^2\right)^{1/2}}{(1+V/c)}`
 
-These three conventions are implemented in
-:mod:`astropy.units.equivalencies` as
-:func:`~astropy.units.equivalencies.doppler_optical`,
-:func:`~astropy.units.equivalencies.doppler_radio`, and
-:func:`~astropy.units.equivalencies.doppler_relativistic`.
+These three conventions are implemented as
+:func:`~astropy.units.doppler_optical`, :func:`~astropy.units.doppler_radio`,
+and :func:`~astropy.units.doppler_relativistic`.
 
 Example
 ^^^^^^^
@@ -208,7 +206,7 @@ their equivalent surface brightness units, and integrated flux units. Their use
 is more complex, since it is necessary to also supply the location in the
 spectrum for which the conversions will be done, and the units of those spectral
 locations. The function that handles these unit conversions is
-:func:`~astropy.units.equivalencies.spectral_density`. This function takes as
+:func:`~astropy.units.spectral_density`. This function takes as
 its arguments the |Quantity| for the spectral location.
 
 Example
@@ -216,8 +214,7 @@ Example
 
 .. EXAMPLE START: Converting Spectral Flux and Luminosity Density Units
 
-To perform unit conversions with
-:func:`~astropy.units.equivalencies.spectral_density`::
+To perform unit conversions with :func:`~astropy.units.spectral_density`::
 
     >>> (1.5 * u.Jy).to(u.photon / u.cm**2 / u.s / u.Hz,
     ...                 equivalencies=u.spectral_density(3500 * u.AA)) # doctest: +FLOAT_CMP
@@ -263,7 +260,7 @@ Examples
 .. EXAMPLE START: Converting Brightness Temperature and Surface Brightness
    Equivalency
 
-The :func:`~astropy.units.equivalencies.brightness_temperature` equivalency
+The :func:`~astropy.units.brightness_temperature` equivalency
 requires the beam area and frequency as arguments. Recalling that the area of a
 2D Gaussian is :math:`2 \pi \sigma^2` (see `wikipedia
 <https://en.wikipedia.org/wiki/Gaussian_function#Two-dimensional_Gaussian_function>`_),
@@ -299,7 +296,7 @@ Beam Equivalency
 Radio data, especially from interferometers, is often produced in units of
 ``Jy/beam``. Converting this number to a beam-independent value (e.g.,
 ``Jy/sr``), can be done with the
-:func:`~astropy.units.equivalencies.beam_angular_area` equivalency.
+:func:`~astropy.units.beam_angular_area` equivalency.
 
 Example
 ^^^^^^^
@@ -324,7 +321,7 @@ package deals with beam input/output and various operations more directly.
 Temperature Energy Equivalency
 ------------------------------
 
-The :func:`~astropy.units.equivalencies.temperature_energy` equivalency allows
+The :func:`~astropy.units.temperature_energy` equivalency allows
 conversion between temperature and its equivalent in energy (i.e., the
 temperature multiplied by the Boltzmann constant), usually expressed in
 electronvolts. This is used frequently for observations at high-energy, be it
@@ -348,7 +345,7 @@ To convert between temperature and its equivalent in energy::
 Thermodynamic Temperature Equivalency
 -------------------------------------
 
-This :func:`~astropy.units.equivalencies.thermodynamic_temperature`
+This :func:`~astropy.units.thermodynamic_temperature`
 equivalency allows conversion between ``Jy/beam`` and "thermodynamic
 temperature", :math:`T_{CMB}`, in Kelvins.
 
@@ -378,7 +375,7 @@ argument to the equivalency::
 Molar Mass AMU Equivalency
 --------------------------
 
-The :func:`~astropy.units.equivalencies.molar_mass_amu` equivalency allows
+The :func:`~astropy.units.molar_mass_amu` equivalency allows
 conversion between the atomic mass unit and the equivalent g/mol. For context,
 refer to the `NIST definition of SI Base Units
 <https://www.nist.gov/si-redefinition/definitions-si-base-units>`_.
@@ -422,13 +419,13 @@ cutout image::
 Or maybe you are designing an instrument for a telescope that someone told you
 has an inverse plate scale of 7.8 meters per radian (for your desired focus),
 and you want to know how big your pixels need to be to cover half an arcsecond.
-Using :func:`~astropy.units.equivalencies.plate_scale`::
+Using :func:`~astropy.units.plate_scale`::
 
     >>> tel_platescale = u.plate_scale(7.8*u.m/u.radian)
     >>> (0.5*u.arcsec).to(u.micron, tel_platescale)  # doctest: +FLOAT_CMP
     <Quantity 18.9077335632719 micron>
 
-The :func:`~astropy.units.equivalencies.pixel_scale` equivalency can also work
+The :func:`~astropy.units.pixel_scale` equivalency can also work
 in more general context, where the scale is specified as any quantity that is
 reducible to ``<composite unit>/u.pix`` or ``u.pix/<composite unit>`` (that is,
 the dimensionality of ``u.pix`` is 1 or -1). For instance, you may define the
@@ -497,7 +494,7 @@ Mass-Energy Equivalency
 .. EXAMPLE START: Using the Mass-Energy Equivalency
 
 In a special relativity context it can be convenient to use the
-:func:`~astropy.units.equivalencies.mass_energy` equivalency. For instance::
+:func:`~astropy.units.mass_energy` equivalency. For instance::
 
     >>> (1 * u.g).to(u.eV, u.mass_energy())  # doctest: +FLOAT_CMP
     <Quantity 5.60958865e+32 eV>
@@ -508,7 +505,7 @@ Doppler Redshift Equivalency
 ----------------------------
 
 Conversion between Doppler redshift and radial velocity can be done with the
-:func:`~astropy.units.equivalencies.doppler_redshift` equivalency.
+:func:`~astropy.units.doppler_redshift` equivalency.
 
 Example
 ^^^^^^^
@@ -581,7 +578,7 @@ A More Complex Example: Spectral Doppler Equivalencies
 
 We show how to define an equivalency using the radio convention for CO 1-0.
 This function is already defined in
-:func:`~astropy.units.equivalencies.doppler_radio`, but this example is
+:func:`~astropy.units.doppler_radio`, but this example is
 illustrative::
 
     >>> from astropy.constants import si
@@ -695,8 +692,8 @@ default off (done by giving an empty argument).
 
 :func:`~astropy.units.set_enabled_equivalencies` accepts any list of
 equivalencies, so you could add, for example,
-:func:`~astropy.units.equivalencies.spectral` and
-:func:`~astropy.units.equivalencies.spectral_density` (since these return
+:func:`~astropy.units.spectral` and
+:func:`~astropy.units.spectral_density` (since these return
 lists, they should indeed be combined by adding them together).
 
 .. EXAMPLE END

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -139,7 +139,7 @@ normally work:
     UnitConversionError: 'nm' (length) and 'Hz' (frequency) are not convertible
 
 But by passing an equivalency list, in this case
-:func:`~astropy.units.equivalencies.spectral`, it does:
+:func:`~astropy.units.spectral`, it does:
 
     >>> (1000 * u.nm).to(u.Hz, equivalencies=u.spectral())  # doctest: +FLOAT_CMP
     <Quantity  2.99792458e+14 Hz>

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -56,8 +56,8 @@ configuration files, etc.):
     <Quantity 15. m / s>
 
 The current unit and value can be accessed via the
-`~astropy.units.quantity.Quantity.unit` and
-`~astropy.units.quantity.Quantity.value` attributes:
+:attr:`~astropy.units.Quantity.unit` and
+:attr:`~astropy.units.Quantity.value` attributes:
 
     >>> q = 2.5 * u.m / u.s
     >>> q.unit
@@ -80,7 +80,7 @@ Converting to Different Units
 =============================
 
 |Quantity| objects can be converted to different units using the
-:meth:`~astropy.units.quantity.Quantity.to` method.
+:meth:`~astropy.units.Quantity.to` method.
 
 Examples
 --------
@@ -93,8 +93,8 @@ To convert |Quantity| objects to different units:
     >>> q.to(u.km / u.h)  # doctest: +FLOAT_CMP
     <Quantity 8.28 km / h>
 
-For convenience, the :attr:`~astropy.units.quantity.Quantity.si` and
-:attr:`~astropy.units.quantity.Quantity.cgs` attributes can be used to convert
+For convenience, the :attr:`~astropy.units.Quantity.si` and
+:attr:`~astropy.units.Quantity.cgs` attributes can be used to convert
 the |Quantity| to base `SI
 <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_ or `CGS
 <https://en.wikipedia.org/wiki/Centimetre-gram-second_system_of_units>`_ units:
@@ -220,7 +220,7 @@ To perform these operations on |Quantity| objects:
     <Quantity 20. cm / m>
 
 For multiplication, you can change how to represent the resulting object by
-using the :meth:`~astropy.units.quantity.Quantity.to` method:
+using the :meth:`~astropy.units.Quantity.to` method:
 
     >>> (1.1 * u.m * 140.3 * u.cm).to(u.m**2)  # doctest: +FLOAT_CMP
     <Quantity 1.5433 m2>
@@ -229,7 +229,7 @@ using the :meth:`~astropy.units.quantity.Quantity.to` method:
 
 For division, if the units are equivalent, you may want to make the resulting
 object dimensionless by reducing the units. To do this, use the
-:meth:`~astropy.units.quantity.Quantity.decompose()` method:
+:meth:`~astropy.units.Quantity.decompose` method:
 
     >>> (20. * u.cm / (1. * u.m)).decompose()  # doctest: +FLOAT_CMP
     <Quantity 0.2>


### PR DESCRIPTION
### Description

The documentation builds are failing on `main` because #16513 removed some link targets. This was not apparent in the pull request because Sphinx could still look up the targets from the latest built documentation: https://github.com/astropy/astropy/blob/e969c47734f718458f8b031aead6736f3b8b73ca/docs/conf.py#L112-L114

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
