### PR TITLE
Manual `pre-commit` update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         args: ["--write-changes"]
@@ -60,7 +60,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.4.4"
+    rev: "v0.4.7"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -38,7 +38,7 @@ def cirs_to_observed(cirs_coo, observed_frame):
         or cirs_coo.cartesian.x.unit == u.one
     )
 
-    # We used to do "astrometric" corrections here, but these are no longer necesssary
+    # We used to do "astrometric" corrections here, but these are no longer necessary
     # CIRS has proper topocentric behaviour
     usrepr = cirs_coo.represent_as(UnitSphericalRepresentation)
     cirs_ra = usrepr.lon.to_value(u.radian)

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -369,7 +369,7 @@ class SpectralCoord(SpectralQuantity):
         doppler_convention = doppler_convention or self.doppler_convention
         doppler_rest = doppler_rest or self.doppler_rest
 
-        # If value is being taken from self and copy is Tru
+        # If value is being taken from self and copy is True
         if copy:
             value = value.copy()
 

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -386,7 +386,7 @@ class LambdaCDM(FLRW):
         -----
         The :func:`scipy.special.hyp2f1` code already implements the
         hypergeometric transformation suggested by Baes et al. [1]_ for use in
-        actual numerical evaulations.
+        actual numerical evaluations.
 
         References
         ----------

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -903,7 +903,7 @@ class Column(NotifierMixin):
 
         if not isinstance(coord_type, str) or len(coord_type) > 8:
             raise AssertionError(
-                "Coordinate/axis type must be a string of atmost 8 characters."
+                "Coordinate/axis type must be a string of at most 8 characters."
             )
 
     @ColumnAttribute("TCUNI")
@@ -1225,9 +1225,8 @@ class Column(NotifierMixin):
             elif len(coord_type) > 8:
                 msg = (
                     "Coordinate/axis type option (TCTYPn) must be a string "
-                    f"of atmost 8 characters (got {coord_type!r}). The invalid keyword "
-                    "will be ignored for the purpose of formatting this "
-                    "column."
+                    f"of at most 8 characters (got {coord_type!r}). The invalid "
+                    "keyword will be ignored for the purpose of formatting this column."
                 )
 
             if msg is None:

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -56,7 +56,7 @@ def test_quantity_call():
 
 def test_no_quantity_call():
     """
-    Test that if not constructed with Quantites they can be called without quantities.
+    Test that if not constructed with Quantities they can be called without quantities.
     """
     g = Gaussian1D(mean=3, stddev=3, amplitude=3)
     assert isinstance(g, Gaussian1D)

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -106,8 +106,8 @@ if NUMPY_LT_2_0:
         np.msort,
         np.round_,  # noqa: NPY003, NPY201
         np.trapz,
-        np.product,  # noqa: NPY003
-        np.cumproduct,  # noqa: NPY003
+        np.product,  # noqa: NPY003, NPY201
+        np.cumproduct,  # noqa: NPY003, NPY201
     }
 else:
     # Array-API compatible versions (matrix axes always at end).
@@ -142,7 +142,7 @@ UNSUPPORTED_FUNCTIONS |= {
 
 if NUMPY_LT_2_0:
     UNSUPPORTED_FUNCTIONS |= {  # removed in numpy 2.0
-        np.sometrue, np.alltrue,  # noqa: NPY003
+        np.sometrue, np.alltrue,  # noqa: NPY003, NPY201
     }  # fmt: skip
 
 # Could be supported if we had a natural logarithm unit.

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1456,7 +1456,7 @@ def test_decompose_regression():
 
 def test_arrays():
     """
-    Test using quantites with array values
+    Test using quantities with array values
     """
 
     qsec = u.Quantity(np.arange(10), u.second)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -678,13 +678,13 @@ class TestUfuncReductions(InvariantUnitTestSetup):
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
         with pytest.raises(TypeError):
-            np.sometrue(self.q)  # noqa: NPY003
+            np.sometrue(self.q)  # noqa: NPY003, NPY201
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
         with pytest.raises(TypeError):
-            np.alltrue(self.q)  # noqa: NPY003
+            np.alltrue(self.q)  # noqa: NPY003, NPY201
 
     def test_prod(self):
         with pytest.raises(u.UnitsError):
@@ -694,7 +694,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
         with pytest.raises(u.UnitsError):
-            np.product(self.q)  # noqa: NPY003
+            np.product(self.q)  # noqa: NPY003, NPY201
 
     def test_cumprod(self):
         with pytest.raises(u.UnitsError):
@@ -706,7 +706,7 @@ class TestUfuncReductions(InvariantUnitTestSetup):
     @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
         with pytest.raises(u.UnitsError):
-            np.cumproduct(self.q)  # noqa: NPY003
+            np.cumproduct(self.q)  # noqa: NPY003, NPY201
 
 
 class TestUfuncLike(InvariantUnitTestSetup):
@@ -1405,7 +1405,7 @@ class TestHistogramFunctions:
         if expected_units[0] is not None:
             expected_h = expected_h * expected_units[0]
         assert_array_equal(out_h, expected_h)
-        # Check bin edges.  Here, histogramdd returns an interable of the
+        # Check bin edges.  Here, histogramdd returns an iterable of the
         # bin edges as the second return argument, while histogram and
         # histogram2d return the bin edges directly.
         if function is np.histogramdd:

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -643,12 +643,12 @@ class TestMethodLikes(MaskedArraySetup):
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
     def test_sometrue(self):
-        self.check(np.sometrue, method="any")  # noqa: NPY003
+        self.check(np.sometrue, method="any")  # noqa: NPY003, NPY201
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
     def test_alltrue(self):
-        self.check(np.alltrue, method="all")  # noqa: NPY003
+        self.check(np.alltrue, method="all")  # noqa: NPY003, NPY201
 
     def test_prod(self):
         self.check(np.prod)
@@ -656,7 +656,7 @@ class TestMethodLikes(MaskedArraySetup):
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
     @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
     def test_product(self):
-        self.check(np.product, method="prod")  # noqa: NPY003
+        self.check(np.product, method="prod")  # noqa: NPY003, NPY201
 
     def test_cumprod(self):
         self.check(np.cumprod)
@@ -666,7 +666,7 @@ class TestMethodLikes(MaskedArraySetup):
     )
     @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
     def test_cumproduct(self):
-        self.check(np.cumproduct, method="cumprod")  # noqa: NPY003
+        self.check(np.cumproduct, method="cumprod")  # noqa: NPY003, NPY201
 
     def test_round(self):
         self.check(np.round, method="round")

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -397,7 +397,7 @@ and/or updated as a consequence of common operations. For example, when:
 3. Writing a file. All the necessary keywords are deleted, updated or added to the header.
 4. Calling an HDU's verify method (e.g., :func:`PrimaryHDU.verify`). Some keywords can be fixed automatically.
 
-In these cases any hand-written values users might assign to those keywords will be overwrittten.
+In these cases any hand-written values users might assign to those keywords will be overwritten.
 
 Working with Image Data
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -601,6 +601,7 @@ ignore-words-list = """
     cna,
     compiletime,
     coo,
+    Copin,
     datas,
     ded,
     dfine,


### PR DESCRIPTION
### Description

The automatic monthly `pre-commit` update in #16533 was not merged for two reasons.

- Ruff tried to remove usage of deprecated `numpy` functions, but the usage was in tests that were checking that those function calls still work, so we want to keep them.
- `codespell` had some trouble figuring out how to fix a couple of typos it detected, and one of the newly detected typos turned out to be a name instead.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
