### PR TITLE
MNT: Remove defunct astropy-bot settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,14 +248,6 @@ markers = [
     "mpl_image_compare",
 ]
 
-[tool.astropy-bot]
-    [tool.astropy-bot.autolabel]
-        # Comment this out to re-enable but then labeler Action needs to be disabled.
-        enabled = false
-
-    [tool.astropy-bot.changelog_checker]
-        enabled = false
-
 [tool.cibuildwheel]
 # We disable testing for the following wheels:
 # - Linux AArch64 (no native hardware, tests take too long)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Heroku's greed killed the bot. We either use Actions or Giles now, so this setting is dead code and should be removed.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
