### PR TITLE
Fix bug in overlap_slices

### DIFF
--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -44,7 +44,6 @@ test_slices = [
 
 subsampling = 5
 
-test_pos_bad = [(-1, -4), (-2, 0), (6, 2), (6, 6)]
 test_nonfinite_positions = [
     (np.nan, np.nan),
     (np.inf, np.inf),
@@ -67,11 +66,23 @@ def test_slices_pos_different_dim():
         overlap_slices((4, 5), (1, 2), (0, 0, 3))
 
 
-@pytest.mark.parametrize("pos", test_pos_bad)
-def test_slices_no_overlap(pos):
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        ((5, 5), (2, 2), (-1, -4)),
+        ((5, 5), (2, 2), (-2, -0)),
+        ((5, 5), (2, 2), (6, 2)),
+        ((5, 5), (2, 2), (6, 6)),
+        ((7, 7), (0, 0), (-2, -2)),
+        ((7, 7), (3, 3), (-2, -2)),
+        ((7, 7), (3, 3), (-2, 2)),
+        ((7, 7), (3, 3), (2, -2)),
+    ],
+)
+def test_slices_no_overlap(inputs):
     """If there is no overlap between arrays, an error should be raised."""
     with pytest.raises(NoOverlapError):
-        overlap_slices((5, 5), (2, 2), pos)
+        overlap_slices(*inputs)
 
 
 def test_slices_partial_overlap():

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -115,7 +115,7 @@ def overlap_slices(large_array_shape, small_array_shape, position, mode="partial
     ]
 
     for e_max in indices_max:
-        if e_max < 0:
+        if e_max < 0 or (e_max == 0 and small_array_shape != (0, 0)):
             raise NoOverlapError("Arrays do not overlap.")
     for e_min, large_shape in zip(indices_min, large_array_shape):
         if e_min >= large_shape:

--- a/docs/changes/utils/16544.bugfix.rst
+++ b/docs/changes/utils/16544.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an edge-case bug in ``overlap_slices`` where the function could
+return an empty slice for non-overlapping slices.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes an edge-case bug in `overlap_slices` where instead of raising a `NoOverlapError`, it would return an "empty" tuple slice:

```python
>>> from astropy.nddata import overlap_slices
>>> overlap_slices((7, 7), (3, 3), (-2, -2))
((slice(0, 0, None), slice(0, 0, None)),
 (slice(3, 3, None), slice(3, 3, None)))
```

The input slices do NOT overlap.  However, the function returns an "empty" slice tuple (`(slice(0, 0, None), slice(0, 0, None)`) instead of raising a `NoOverlapError`.

For some reason, this function allows the input `small_array_shape` to be `(0, 0)`.  In that case, a slice tuple of (`(slice(0, 0, None), slice(0, 0, None)`) is also returned.  There is a test for that case, so I left that behavior unchanged. However, IMHO, `small_array_shape = (0, 0)` should also raise `NoOverlapError`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
