### PR TITLE
Remove some trivial methods from unit formatters

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -64,18 +64,6 @@ class CDS(Base):
 
     @classproperty(lazy=True)
     def _units(cls) -> dict[str, UnitBase]:
-        return cls._generate_unit_names()
-
-    @classproperty(lazy=True)
-    def _parser(cls) -> ThreadSafeParser:
-        return cls._make_parser()
-
-    @classproperty(lazy=True)
-    def _lexer(cls) -> Lexer:
-        return cls._make_lexer()
-
-    @staticmethod
-    def _generate_unit_names() -> dict[str, UnitBase]:
         from astropy import units as u
         from astropy.units import cds
 
@@ -87,8 +75,8 @@ class CDS(Base):
 
         return names
 
-    @classmethod
-    def _make_lexer(cls) -> Lexer:
+    @classproperty(lazy=True)
+    def _lexer(cls) -> Lexer:
         tokens = cls._tokens
 
         t_PRODUCT = r"\."
@@ -145,8 +133,8 @@ class CDS(Base):
             lextab="cds_lextab", package="astropy/units", reflags=int(re.UNICODE)
         )
 
-    @classmethod
-    def _make_parser(cls) -> ThreadSafeParser:
+    @classproperty(lazy=True)
+    def _parser(cls) -> ThreadSafeParser:
         """
         The grammar here is based on the description in the `Standards
         for Astronomical Catalogues 2.0

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -76,15 +76,7 @@ class Generic(Base):
         return cls._all_units[2]
 
     @classproperty(lazy=True)
-    def _parser(cls):
-        return cls._make_parser()
-
-    @classproperty(lazy=True)
     def _lexer(cls):
-        return cls._make_lexer()
-
-    @classmethod
-    def _make_lexer(cls):
         tokens = cls._tokens
 
         t_COMMA = r"\,"
@@ -141,8 +133,8 @@ class Generic(Base):
             lextab="generic_lextab", package="astropy/units", reflags=int(re.UNICODE)
         )
 
-    @classmethod
-    def _make_parser(cls):
+    @classproperty(lazy=True)
+    def _parser(cls):
         """
         The grammar here is based on the description in the `FITS
         standard

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -22,7 +22,7 @@ import math
 import warnings
 from fractions import Fraction
 
-from astropy.utils import parsing
+from astropy.utils import classproperty, parsing
 
 from . import core, generic, utils
 
@@ -103,8 +103,8 @@ class OGIP(generic.Generic):
 
         return names, deprecated_names, functions
 
-    @classmethod
-    def _make_lexer(cls):
+    @classproperty(lazy=True)
+    def _lexer(cls):
         tokens = cls._tokens
 
         t_DIVISION = r"/"
@@ -157,8 +157,8 @@ class OGIP(generic.Generic):
 
         return parsing.lex(lextab="ogip_lextab", package="astropy/units")
 
-    @classmethod
-    def _make_parser(cls):
+    @classproperty(lazy=True)
+    def _parser(cls):
         """
         The grammar here is based on the description in the
         `Specification of Physical Units within OGIP FITS files


### PR DESCRIPTION
### Description

There are several methods that simply return the output of another method. I am not aware of any external API requiring the implementation of the methods in question, so removing them simplifies the code without any downsides.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
