### PR TITLE
Fix bug for integer compressed images with blanks

### DIFF
--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -467,10 +467,7 @@ def decompress_image_data_section(
             if zblank is not None:
                 if not tile_data.flags.writeable:
                     tile_data = tile_data.copy()
-                if zbitpix > 0:
-                    blank = zblank_header
-                else:
-                    blank = np.nan
+                blank = zblank_header if zbitpix > 0 else np.nan
                 tile_data[blank_mask] = blank
 
         image_data[tile_slices] = tile_data

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -359,7 +359,9 @@ def decompress_image_data_section(
     else:
         zzero_column = None
 
-    zblank_header = compressed_header.get("ZBLANK", None)
+    zblank_header = compressed_header.get(
+        "ZBLANK", compressed_header.get("BLANK", None)
+    )
 
     gzip_compressed_data_column = None
     gzip_compressed_data_dtype = None
@@ -465,7 +467,11 @@ def decompress_image_data_section(
             if zblank is not None:
                 if not tile_data.flags.writeable:
                     tile_data = tile_data.copy()
-                tile_data[blank_mask] = np.nan
+                if zbitpix > 0:
+                    blank = zblank_header
+                else:
+                    blank = np.nan
+                tile_data[blank_mask] = blank
 
         image_data[tile_slices] = tile_data
 

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -467,8 +467,7 @@ def decompress_image_data_section(
             if zblank is not None:
                 if not tile_data.flags.writeable:
                     tile_data = tile_data.copy()
-                blank = zblank_header if zbitpix > 0 else np.nan
-                tile_data[blank_mask] = blank
+                tile_data[blank_mask] = zblank_header if zbitpix > 0 else np.nan
 
         image_data[tile_slices] = tile_data
 

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -467,6 +467,14 @@ def _bintable_header_to_image_header(bintable_header):
         del image_header["PCOUNT"]
         del image_header["GCOUNT"]
 
+    # Fill in BLANK keyword if necessary
+    if (
+        image_header["BITPIX"] > 0
+        and "BLANK" not in image_header
+        and "ZBLANK" in bintable_header
+    ):
+        image_header["BLANK"] = bintable_header["ZBLANK"]
+
     # Look to see if there are any blank cards in the table
     # header.  If there are, there should be the same number
     # of blank cards in the image header.  Add blank cards to

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy.io import fits
 from astropy.io.fits.hdu.compressed._codecs import PLIO1
 from astropy.io.fits.hdu.compressed._compression import CfitsioException
+from astropy.utils.exceptions import AstropyUserWarning
 
 from .conftest import fitsio_param_to_astropy_param
 
@@ -63,6 +64,91 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
     with fits.open(tmp_path / "test_zblank.fits") as hdul:
         assert "ZBLANK" in hdul[1].header
         assert_equal(np.round(hdul[1].data), reference)
+
+
+def test_integer_blank_support(canonical_data_base_path, tmp_path):
+    # This uses a test 64x64 section of the m13 image to which three NaN values are added.
+    # It is converted to an integer image with blank values and compressed.
+    # Then 2 variations of the BLANK/ZBLANK specification are created by
+    # editing the header and compressed data table.
+    # When these are read in, the result is a float image that should be the same
+    # as the original (including NaNs for blanks).
+
+    with fits.open(canonical_data_base_path / "m13.fits") as hdul:
+        # pick a 64x64 pixel subset
+        data = hdul[0].data[116:180, 116:180]
+        header = hdul[0].header.copy()
+        del header["CHECKSUM"]
+        del header["DATASUM"]
+
+    # float version of image with NaNs as blanks
+    reference = data.astype(np.float32)
+    reference[[1, 2, 3], [1, 2, 3]] = np.nan
+
+    # set blanks in the int16 image and BLANK keyword in header
+    blank = -32768
+    data[np.isnan(reference)] = blank
+    header["BLANK"] = blank
+
+    # create the compressed file
+    cfile1 = tmp_path / "compressed_with_blank.fits"
+    hdu = fits.CompImageHDU(
+        data=data, header=header, compression_type="RICE_1", tile_shape=(16, 16)
+    )
+    hdu.writeto(cfile1, overwrite=True, checksum=False)
+
+    # replace BLANK keyword in header with ZBLANK keyword
+    cfile2 = tmp_path / "compressed_with_zblank.fits"
+    with fits.open(cfile1, disable_image_compression=True) as hdul:
+        assert "ZBLANK" not in hdul[1].header
+        hdul[1].header["ZBLANK"] = hdul[1].header["BLANK"]
+        del hdul[1].header["BLANK"]
+        hdul.writeto(cfile2, overwrite=True, checksum=False)
+
+    # replace ZBLANK in header with with ZBLANK in table column
+    # This creates a file structure that is unlikely to be encountered in the wild
+    # but that is apparently allowed by the FITS standard.
+    cfile3 = tmp_path / "compressed_with_zblank_column.fits"
+    with fits.open(cfile2, disable_image_compression=True) as hdul:
+        phdu = hdul[0]
+        thdu = hdul[1]
+        orig_table = hdul[1].data
+        orig_cols = orig_table.columns
+        zblank = thdu.header["ZBLANK"]
+        new_cols = fits.ColDefs(
+            [
+                fits.Column(
+                    name="COMPRESSED_DATA",
+                    format="1PB()",
+                    array=thdu.data.field("COMPRESSED_DATA"),
+                ),
+                fits.Column(
+                    name="ZBLANK",
+                    format="I",
+                    array=np.zeros(len(orig_table), dtype=np.int32) + zblank,
+                ),
+            ]
+        )
+        new_thdu = fits.BinTableHDU.from_columns(new_cols, header=thdu.header)
+        del new_thdu.header["ZBLANK"]
+        new_hdul = fits.HDUList([phdu, new_thdu])
+        new_hdul.writeto(cfile3, overwrite=True, checksum=False)
+
+    # now test the 3 files to confirm they all uncompress correctly
+    for filename in (cfile1, cfile2):
+        with fits.open(canonical_data_base_path / filename) as hdul:
+            assert_equal(hdul[1].data, reference)
+            # ensure that the uncompressed header is created with BLANK keyword
+            assert hdul[1].header.get("BLANK") == -32768
+
+    # this one generates an expected warning
+    with pytest.warns(
+        AstropyUserWarning,
+        match="Setting default value -32768 for missing BLANK keyword in compressed extension",
+    ):
+        with fits.open(cfile3) as hdul:
+            assert_equal(hdul[1].data, reference)
+            assert hdul[1].header.get("BLANK") == -32768
 
 
 @pytest.mark.parametrize(

--- a/docs/changes/io.fits/16550.bugfix.rst
+++ b/docs/changes/io.fits/16550.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a spurious exception when reading integer compressed images with blanks.


### PR DESCRIPTION
### Description

This pull request is to address a bug that raises an exception when some compressed images are read.

In `_tiled_compression.py:decompress_image_data_section()`, blanked pixels are assigned the value `np.nan`.  That is incorrect for integer datatypes and raises an exception because `np.nan` cannot be converted to an integer.

The fix is to use the `BLANK` keyword from the header.  If no `BLANK` or `ZBLANK` keyword is found for integer datatypes, the most negative integer (as determined by `ZBITPIX`) is used as a fill value. That should not happen if pixel-blanking is specified (otherwise why is `ZBLANK` there at all?). An `AstropyUserWarning` is issued in that case. 

This also fixes a bug in `decompress_image_data_section()` for the case where `BLANK` is specified in the header but `ZBLANK` is not.  The FITS standard recommends that `BLANK` should be used instead of `ZBLANK` for integer images.  For images with `BLANK` but not `ZBLANK`, the current code would not work correctly. The new version handles integer compressed images that specify either `BLANK` or `ZBLANK` (or both).

In the `compressed.py` module, integer images with blanks are converted to floats with `NaN` values. Previously that conversion happened only if `BZERO/BSCALE` keywords were also specified.  The new code does the conversion even if `BZERO` and `BSCALE` are not defined. The new behavior is consistent with the handling of these keywords in uncompressed image HDUs.

Test code is included.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->


<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15236

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
