### PR TITLE
Simplify `_generate_unit_names()` in `Generic` unit formatter subclasses

### DIFF
--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -4,8 +4,6 @@
 Handles the "FITS" unit format.
 """
 
-import keyword
-
 import numpy as np
 
 from . import core, generic, utils
@@ -43,15 +41,8 @@ class FITS(generic.Generic):
 
         special_cases = {"dbyte": u.Unit("dbyte", 0.1 * u.byte)}
 
-        for base in bases:
-            for prefix in prefixes:
-                key = prefix + base
-                if keyword.iskeyword(key):
-                    continue
-                elif key in special_cases:
-                    names[key] = special_cases[key]
-                else:
-                    names[key] = getattr(u, key)
+        for key, _ in utils.get_non_keyword_units(bases, prefixes):
+            names[key] = special_cases[key] if key in special_cases else getattr(u, key)
         simple_units = [
             "deg", "arcmin", "arcsec", "mas", "min", "h", "d", "Ry",
             "solMass", "u", "solLum", "solRad", "AU", "lyr", "count",

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -36,7 +36,6 @@ class FITS(generic.Generic):
             "F", "Wb", "T", "H", "lm", "lx", "a", "yr", "eV",
             "pc", "Jy", "mag", "R", "bit", "byte", "G", "barn",
         ]  # fmt: skip
-        deprecated_bases = []
         prefixes = [
             "y", "z", "a", "f", "p", "n", "u", "m", "c", "d",
             "", "da", "h", "k", "M", "G", "T", "P", "E", "Z", "Y",
@@ -44,7 +43,7 @@ class FITS(generic.Generic):
 
         special_cases = {"dbyte": u.Unit("dbyte", 0.1 * u.byte)}
 
-        for base in bases + deprecated_bases:
+        for base in bases:
             for prefix in prefixes:
                 key = prefix + base
                 if keyword.iskeyword(key):
@@ -53,9 +52,6 @@ class FITS(generic.Generic):
                     names[key] = special_cases[key]
                 else:
                     names[key] = getattr(u, key)
-        for base in deprecated_bases:
-            for prefix in prefixes:
-                deprecated_names.add(prefix + base)
         simple_units = [
             "deg", "arcmin", "arcsec", "mas", "min", "h", "d", "Ry",
             "solMass", "u", "solLum", "solRad", "AU", "lyr", "count",

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -17,7 +17,6 @@ FITS files
 """
 
 import copy
-import keyword
 import math
 import warnings
 from fractions import Fraction
@@ -53,7 +52,6 @@ class OGIP(generic.Generic):
     def _generate_unit_names():
         from astropy import units as u
 
-        names = {}
         deprecated_names = set()
         bases = [
             "A", "C", "cd", "eV", "F", "g", "H", "Hz", "J",
@@ -65,12 +63,10 @@ class OGIP(generic.Generic):
             "", "da", "h", "k", "M", "G", "T", "P", "E", "Z", "Y",
         ]  # fmt: skip
 
-        for base in bases:
-            for prefix in prefixes:
-                key = prefix + base
-                if keyword.iskeyword(key):
-                    continue
-                names[key] = getattr(u, key)
+        names = {
+            unit: getattr(u, unit)
+            for unit, _ in utils.get_non_keyword_units(bases, prefixes)
+        }
         simple_units = [
             "angstrom", "arcmin", "arcsec", "AU", "barn", "bin",
             "byte", "chan", "count", "day", "deg", "erg", "G",

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -60,21 +60,17 @@ class OGIP(generic.Generic):
             "Jy", "K", "lm", "lx", "m", "mol", "N", "ohm", "Pa",
             "pc", "rad", "s", "S", "sr", "T", "V", "W", "Wb",
         ]  # fmt: skip
-        deprecated_bases = []
         prefixes = [
             "y", "z", "a", "f", "p", "n", "u", "m", "c", "d",
             "", "da", "h", "k", "M", "G", "T", "P", "E", "Z", "Y",
         ]  # fmt: skip
 
-        for base in bases + deprecated_bases:
+        for base in bases:
             for prefix in prefixes:
                 key = prefix + base
                 if keyword.iskeyword(key):
                     continue
                 names[key] = getattr(u, key)
-        for base in deprecated_bases:
-            for prefix in prefixes:
-                deprecated_names.add(prefix + base)
         simple_units = [
             "angstrom", "arcmin", "arcsec", "AU", "barn", "bin",
             "byte", "chan", "count", "day", "deg", "erg", "G",

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -7,13 +7,21 @@ Utilities shared by the different formats.
 from __future__ import annotations
 
 import warnings
+from keyword import iskeyword
 from typing import TYPE_CHECKING
 
 from astropy.units.utils import maybe_simple_fraction
 from astropy.utils.misc import did_you_mean
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Container, Mapping, Sequence
+    from collections.abc import (
+        Callable,
+        Container,
+        Generator,
+        Iterable,
+        Mapping,
+        Sequence,
+    )
     from numbers import Real
     from typing import TypeVar
 
@@ -245,3 +253,12 @@ def unit_deprecation_warning(
     if decomposed is not None:
         message += f" Suggested: {decomposed}."
     warnings.warn(message, UnitsWarning)
+
+
+def get_non_keyword_units(
+    bases: Iterable[str], prefixes: Sequence[str]
+) -> Generator[tuple[str, str], None, None]:
+    for base in bases:
+        for prefix in prefixes:
+            if not iskeyword(unit := prefix + base):
+                yield unit, base

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -3,7 +3,6 @@
 Handles the "VOUnit" unit format.
 """
 
-import keyword
 import re
 import warnings
 
@@ -54,14 +53,8 @@ class VOUnit(generic.Generic):
         }  # fmt: skip
 
         def do_defines(bases, prefixes, skips=[]):
-            for base in bases:
-                for prefix in prefixes:
-                    key = prefix + base
-                    if key in skips:
-                        continue
-                    if keyword.iskeyword(key):
-                        continue
-
+            for key, base in utils.get_non_keyword_units(bases, prefixes):
+                if key not in skips:
                     names[key] = getattr(u if hasattr(u, key) else uvo, key)
                     if base in deprecated_units:
                         deprecated_names.add(key)


### PR DESCRIPTION
### Description

The `FITS` and `OGIP` unit formatters contain mechanisms for dealing with deprecated unit bases, but there are no such bases, so the mechanisms can be removed.

The `FITS`, `OGIP` and `VOUnit` unit formatters contain some duplicated code that can be replaced with a new generator I've implemented in unit formatter utils.

The two changes might seem distinct, but they both deal with the `for base in bases + deprecated_bases:` blocks in the `FITS` and `OGIP` unit formatters, so it's best to handle them together.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
