### PR TITLE
BLD: require numpy 2.0.0 (stable) at build time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ wcslint = "astropy.wcs.wcslint:main"
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0,<3.1.0",
-            "numpy>=2.0.0rc1", # see https://github.com/astropy/astropy/issues/16257
+            "numpy>=2.0.0",
             "extension-helpers==1.*"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Description
NumPy 2.0 just dropped on PyPI !

Fixes #16257

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
