### PR TITLE
TST: use numpy 2.0 (stable) in py312-test-cov tox env

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -62,10 +62,8 @@ jobs:
       envs: |
         # NOTE: this coverage test is needed for tests and code that
         #       run only with minimal dependencies.
-        # 2024-05-30: added predeps to ensure new PRs do not break numpy 2.0
-        # docs.  Fine to remove once numpy 2.0 is released (if problematic).
         - name: Python 3.12 with minimal dependencies and full coverage
-          linux: py312-test-cov-predeps
+          linux: py312-test-cov
           coverage: codecov
 
         - name: Python 3.11 in Parallel with all optional dependencies


### PR DESCRIPTION
### Description
Revert a temporary workaround from #15065, fixes #16512

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
