### PR TITLE
TST: pin numpy<2 on image tests with oldest supported mpl

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ deps =
     numpy125: numpy==1.25.*
 
     mpl360: matplotlib==3.6.0
+    # mpl 3.6.0 isn't compatible with numpy 2.0 but didn't include a pin
+    mpl360: numpy<2.0
 
     image: latex
     image: scipy


### PR DESCRIPTION
### Description
This pull request is to address a surprise issue with numpy 2.0 (just released): matplotlib 3.6.0 didn't pin for it so we need to do it on our side

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
