### PR TITLE
TST: use bottleneck release candidate for numpy 2.0 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ keywords = [
 ]
 dependencies = [
     "numpy>=1.23",
+    "numpy < 2.0 ; platform_system=='Windows'",
     "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2024.5.27.0.30.8",
     "PyYAML>=3.13",

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,9 @@ deps =
     devinfra: git+https://github.com/matplotlib/pytest-mpl.git
     devinfra: git+https://github.com/astropy/pytest-astropy.git
 
+    # https://github.com/astropy/astropy/issues/16574
+    alldeps: bottleneck>=1.4.0rc5
+
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed
 extras =
     test: test


### PR DESCRIPTION
### Description
`alldeps` jobs are currently failing due to `bottleneck` not yet having a compatible stable release.
This is a temporary workaround. #16574 is the reminder issue to revert it when possible.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
