### PR TITLE
TST: adjust a `coordinates` test to avoid hardcoding exact data source url

### DIFF
--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -4,7 +4,6 @@
 This module contains tests for the name resolve convenience module.
 """
 
-import re
 import time
 import urllib.request
 
@@ -114,10 +113,8 @@ def test_names():
     # "all" choice should ask for SIMBAD, then NED, then Vizier: "SNV" in the url
     with pytest.raises(
         NameResolveError,
-        match=re.escape(
-            "Unable to find coordinates for name 'm87h34hhh' "
-            "using https://cds.unistra.fr/cgi-bin/nph-sesame/SNV?m87h34hhh"
-        ),
+        # avoid hard-coding an exact url as it might depend on external state
+        match=r"Unable to find coordinates for name 'm87h34hhh' using http.*SNV.*",
     ):
         get_icrs_coordinates("m87h34hhh")
 


### PR DESCRIPTION
### Description
Just noticed this one test failing in pre-deps jobs. I don't know what's the ultimate source of truth for what this url should be but let me try the naive update first.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
