### PR TITLE
TST: various adjustments following the release of numpy 2.0

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -62,10 +62,8 @@ jobs:
       envs: |
         # NOTE: this coverage test is needed for tests and code that
         #       run only with minimal dependencies.
-        # 2024-05-30: added predeps to ensure new PRs do not break numpy 2.0
-        # docs.  Fine to remove once numpy 2.0 is released (if problematic).
         - name: Python 3.12 with minimal dependencies and full coverage
-          linux: py312-test-cov-predeps
+          linux: py312-test-cov
           coverage: codecov
 
         - name: Python 3.11 in Parallel with all optional dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,8 @@ all = [
     "jplephem",
     "mpmath",
     "asdf-astropy>=0.3",
-    "bottleneck",
+    # https://github.com/astropy/astropy/issues/16574
+    "bottleneck>=1.4.0rc5",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ keywords = [
 ]
 dependencies = [
     "numpy>=1.23",
+    # https://github.com/astropy/astropy/issues/16578
+    "numpy < 2.0 ; platform_system=='Windows'",
     "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2024.5.27.0.30.8",
     "PyYAML>=3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ wcslint = "astropy.wcs.wcslint:main"
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0,<3.1.0",
-            "numpy>=2.0.0rc1", # see https://github.com/astropy/astropy/issues/16257
+            "numpy>=2.0.0",
             "extension-helpers==1.*"]
 build-backend = "setuptools.build_meta"
 

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ deps =
     numpy125: numpy==1.25.*
 
     mpl360: matplotlib==3.6.0
+    # mpl 3.6.0 isn't compatible with numpy 2.0 but didn't include a pin
+    mpl360: numpy<2.0
 
     image: latex
     image: scipy


### PR DESCRIPTION
### Description

This PR combines patches from #16571, #16572, #16573 and #16575, which together should get CI back to green

close #16512 
close #16257
close #16571 
close #16572 
close #16573 
close #16575

follow up issues:
- https://github.com/astropy/astropy/issues/16574
- https://github.com/astropy/astropy/issues/16578
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
