### PR TITLE
Backport PR 16579 on branch v6.1.x (various adjustments following the release of numpy 2.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ keywords = [
 ]
 dependencies = [
     "numpy>=1.23",
+    # https://github.com/astropy/astropy/issues/16578
+    "numpy < 2.0 ; platform_system=='Windows'",
     "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2024.5.27.0.30.8",
     "PyYAML>=3.13",
@@ -127,7 +129,7 @@ wcslint = "astropy.wcs.wcslint:main"
 requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0,<3.1.0",
-            "numpy>=2.0.0rc1", # see https://github.com/astropy/astropy/issues/16257
+            "numpy>=2.0.0",
             "extension-helpers==1.*"]
 build-backend = "setuptools.build_meta"
 

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,8 @@ deps =
     numpy125: numpy==1.25.*
 
     mpl334: matplotlib==3.3.4
+    # mpl 3.3.4 isn't compatible with numpy 2.0 but didn't include a pin
+    mpl334: numpy<2.0
 
     image: latex
     image: scipy


### PR DESCRIPTION
### Description
Manual and partial backport for #16579. I've explicitly excluded 4f45f53318ae88a820a57fa3c3c544640b6f9ca4, and other changes that are not applicable (no-ops) to the backport branch.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
