### PR TITLE
BUG: skip un-portable hack on windows + numpy2

### DIFF
--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -24,6 +24,7 @@ from astropy.io.fits.util import (
 )
 from astropy.io.fits.verify import VerifyError, VerifyWarning, _ErrList, _Verify
 from astropy.utils import indent
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 # NOTE: Python can be built without bz2.
 from astropy.utils.compat.optional_deps import HAS_BZ2
@@ -1506,7 +1507,7 @@ class HDUList(list, _Verify):
                     del hdu.data
                 hdu._file = ffo
 
-            if sys.platform.startswith("win"):
+            if sys.platform.startswith("win") and NUMPY_LT_2_0:
                 # On Windows, all the original data mmaps were closed above.
                 # However, it's possible that the user still has references to
                 # the old data which would no longer work (possibly even cause
@@ -1517,6 +1518,8 @@ class HDUList(list, _Verify):
                 # lead to odd behavior in practice.  Better to just not keep
                 # references to data from files that had to be resized upon
                 # flushing (on Windows--again, this is no problem on Linux).
+                # Note that this hack is only possible on numpy 1.x:
+                # in 2.x, we cannot write directly to the data attribute
                 for idx, mmap, arr in mmaps:
                     if mmap is not None:
                         # https://github.com/numpy/numpy/issues/8628

--- a/docs/changes/io.fits/16581.bugfix.rst
+++ b/docs/changes/io.fits/16581.bugfix.rst
@@ -1,3 +1,5 @@
-Skip an un-portable hack for Windows if NumPy 2.0 or newer is installed.
-This fixes a crash that occurred for files oopened via
-``fits.open(..., mode='update')``.
+Fixed a crash that occurred for files opened via
+``fits.open(..., mode='update')``, on Windows, and with numpy 2.0 installed.
+It is possible, though unlikely, that this patch reveals memory issues
+for downstream code run under these exact conditions. Please report any
+regression found.

--- a/docs/changes/io.fits/16581.bugfix.rst
+++ b/docs/changes/io.fits/16581.bugfix.rst
@@ -1,0 +1,3 @@
+Skip an un-portable hack for Windows if NumPy 2.0 or newer is installed.
+This fixes a crash that occurred for files oopened via
+``fits.open(..., mode='update')``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,6 @@ keywords = [
 ]
 dependencies = [
     "numpy>=1.23",
-    # https://github.com/astropy/astropy/issues/16578
-    "numpy < 2.0 ; platform_system=='Windows'",
     "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2024.5.27.0.30.8",
     "PyYAML>=3.13",


### PR DESCRIPTION
### Description
This is meant to fix #16578

The problematic block of code is clearly marked as a hack and the long comment goes on to explain that it *shouldn't* even be needed in most scenarios, so I think it might be okay to just skip the hack entirely on numpy 2.0 where it's not applicable. Let's see what CI has to say.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
