### PR TITLE
DOC: (v6.1.x) pin numpy<2.0 for consistency with astropy 6.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ docs = [
     "tomli; python_version < '3.11'",
     "sphinxcontrib-globalsubs >= 0.1.1",
     "matplotlib!=3.9.0",  # https://github.com/matplotlib/matplotlib/issues/28234
+    "numpy<2.0", # keep the docs consistent throughout branch history (v6.1.x)
 ]
 
 [project.urls]


### PR DESCRIPTION
### Description

As pointed out by @astrofrog in https://github.com/astropy/astropy/pull/16580, docs builds are broken on the backport branch. The immediate cause is that bottleneck doesn't have a numpy2-compatible stable release yet (which we have a workaround for on main since #16579), but even if we did backport the workaround, docs would still not build correctly on the backport branch because we didn't backport https://github.com/astropy/astropy/pull/15065, so I propose we just pin numpy<2.0 *for docs* on this branch.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
