### PR TITLE
Remove `np.ndarray.ptp()` mention from the docs

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1659,9 +1659,9 @@ class TimeBase(ShapedLikeNDArray):
     def ptp(self, axis=None, out=None, keepdims=False):
         """Peak to peak (maximum - minimum) along a given axis.
 
-        This is similar to :meth:`~numpy.ndarray.ptp`, but adapted to ensure
-        that the full precision given by the two doubles ``jd1`` and ``jd2``
-        is used.
+        This method is similar to the :func:`numpy.ptp` function, but
+        adapted to ensure that the full precision given by the two doubles
+        ``jd1`` and ``jd2`` is used.
 
         Note that the ``out`` argument is present only for compatibility with
         `~numpy.ptp`; since `Time` instances are immutable, it is not possible


### PR DESCRIPTION
### Description

The `numpy.ndarray.ptp()` method was removed in 2.0, so trying to refer to it is causing documentation build failures.

This should be backported, but `astropy` 6.1.1 has already been released and the branch and milestone for 6.1.2 has not been created yet.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
