### PR TITLE
MNT: remove temporary pin for bottleneck

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,7 @@ all = [
     "jplephem",
     "mpmath",
     "asdf-astropy>=0.3",
-    # https://github.com/astropy/astropy/issues/16574
-    "bottleneck>=1.4.0rc5",
+    "bottleneck",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
 ]


### PR DESCRIPTION
### Description
reverts part of #16579
Fixes #16574

This should be okay now that bottleneck 1.4.0 was released

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
