### PR TITLE
BUG: fix a bug where wcs_info_str's results would look different in numpy 2 VS numpy 1

### DIFF
--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -36,16 +36,21 @@ def deserialize_class(tpl, construct=True):
 def wcs_info_str(wcs):
     # Overall header
 
+    if wcs.array_shape is None:
+        array_shape = None
+    else:
+        array_shape = tuple(int(n) for n in wcs.array_shape)
+
     s = (
         f"{type(wcs).__name__} Transformation\n\n"
         f"This transformation has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} "
         "world dimensions\n\n"
-        f"Array shape (Numpy order): {wcs.array_shape}\n\n"
+        f"Array shape (Numpy order): {array_shape}\n\n"
     )
 
     # Pixel dimensions table
 
-    array_shape = wcs.array_shape or (0,)
+    array_shape = array_shape or (0,)
     pixel_shape = wcs.pixel_shape or (None,) * wcs.pixel_n_dim
 
     # Find largest between header size and value length
@@ -60,13 +65,24 @@ def wcs_info_str(wcs):
             'Bounds\n')
     # fmt: on
 
+    if wcs.pixel_bounds is None:
+        pixel_bounds = None
+    else:
+        # converting to scalar arrays and back to Python with np.array(val).item()
+        # guarantees that we end up with Python scalars (int or float) with
+        # simple reprs, while not making any unnecessary type promotion
+        # (e.g. int to float)
+        pixel_bounds = [
+            tuple(np.array(b).item() for b in bounds) for bounds in wcs.pixel_bounds
+        ]
+
     for ipix in range(wcs.pixel_n_dim):
         # fmt: off
         s += (('{0:' + str(pixel_dim_width) + 'g}').format(ipix) + '  ' +
                 ('{0:' + str(pixel_nam_width) + 's}').format(wcs.pixel_axis_names[ipix] or 'None') + '  ' +
                 (" " * 5 + str(None) if pixel_shape[ipix] is None else
                 ('{0:' + str(pixel_siz_width) + 'g}').format(pixel_shape[ipix])) + '  ' +
-                '{:s}'.format(str(None if wcs.pixel_bounds is None else wcs.pixel_bounds[ipix]) + '\n'))
+                '{:s}'.format(str(None if pixel_bounds is None else pixel_bounds[ipix]) + '\n'))
         # fmt: on
 
     s += "\n"

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -66,7 +66,7 @@ def wcs_info_str(wcs):
     # fmt: on
 
     if wcs.pixel_bounds is None:
-        pixel_bounds = None
+        pixel_bounds = [None for _ in range(wcs.pixel_n_dim)]
     else:
         # converting to scalar arrays and back to Python with np.array(val).item()
         # guarantees that we end up with Python scalars (int or float) with
@@ -82,7 +82,8 @@ def wcs_info_str(wcs):
                 ('{0:' + str(pixel_nam_width) + 's}').format(wcs.pixel_axis_names[ipix] or 'None') + '  ' +
                 (" " * 5 + str(None) if pixel_shape[ipix] is None else
                 ('{0:' + str(pixel_siz_width) + 'g}').format(pixel_shape[ipix])) + '  ' +
-                '{:s}'.format(str(None if pixel_bounds is None else pixel_bounds[ipix]) + '\n'))
+                f"{pixel_bounds[ipix]}\n"
+              )
         # fmt: on
 
     s += "\n"

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -702,6 +702,11 @@ HEADER_SPECTRAL_CUBE_NONE_TYPES = {
 WCS_SPECTRAL_CUBE_NONE_TYPES = WCS(header=HEADER_SPECTRAL_CUBE_NONE_TYPES)
 WCS_SPECTRAL_CUBE_NONE_TYPES.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
 
+WCS_SPECTRAL_CUBE_NONE_TYPES_NP = WCS(header=HEADER_SPECTRAL_CUBE_NONE_TYPES)
+WCS_SPECTRAL_CUBE_NONE_TYPES_NP.pixel_bounds = [
+    tuple(np.int64(b) for b in t) for t in WCS_SPECTRAL_CUBE_NONE_TYPES.pixel_bounds
+]
+
 
 EXPECTED_ELLIPSIS_REPR_NONE_TYPES = """
 SlicedLowLevelWCS Transformation
@@ -769,6 +774,10 @@ def test_ellipsis_none_types():
     assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
 
     assert str(wcs) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
+    assert EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip() in repr(wcs)
+
+    wcs_np = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE_NONE_TYPES_NP, Ellipsis)
+    assert str(wcs_np) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
     assert EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip() in repr(wcs)
 
 

--- a/docs/changes/wcs/16586.bugfix.rst
+++ b/docs/changes/wcs/16586.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug where ``wcs_info_str``'s results would look different in numpy 2 VS
+numpy 1.


### PR DESCRIPTION
### Description
Fixes #16585
I spent 20min trying to write a test for this but so far I couldn't find a simple example for setting up a non-trivial WCS object (e.g. `WCS()`, for which the bug isn't apparent).
In particular the example test in ndcube uses ndcube API so I can't take it straight from the report.
@Cadair, any pointers ?

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
