### PR TITLE
Move code from unit formatter utilites to the `Generic` class

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -28,7 +28,7 @@ from astropy.utils.misc import did_you_mean
 
 from . import core
 from .base import Base
-from .utils import _try_decomposed, unit_deprecation_warning
+from .utils import _try_decomposed
 
 if TYPE_CHECKING:
     from astropy.units import NamedUnit, UnitBase
@@ -608,9 +608,17 @@ class Generic(Base):
                 )
             raise ValueError()
         if unit in cls._deprecated_units:
-            unit_deprecation_warning(
-                unit, cls._units[unit], cls.__name__, cls._to_decomposed_alternative
+            from astropy.units.core import UnitsWarning
+
+            message = (
+                f"The unit '{unit}' has been deprecated in the {cls.__name__} standard."
             )
+            decomposed = _try_decomposed(
+                cls._units[unit], cls._to_decomposed_alternative
+            )
+            if decomposed is not None:
+                message += f" Suggested: {decomposed}."
+            warnings.warn(message, UnitsWarning)
 
     @classmethod
     def _did_you_mean_units(cls, unit: str) -> str:

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -144,30 +144,6 @@ def format_power(power: Real) -> str:
     return str(power)
 
 
-def _try_decomposed(
-    unit: UnitBase, format_decomposed: Callable[[UnitBase], str | None]
-) -> str | None:
-    represents = getattr(unit, "_represents", None)
-    if represents is not None:
-        try:
-            represents_string = format_decomposed(represents)
-        except ValueError:
-            pass
-        else:
-            return represents_string
-
-    decomposed = unit.decompose()
-    if decomposed is not unit:
-        try:
-            decompose_string = format_decomposed(decomposed)
-        except ValueError:
-            pass
-        else:
-            return decompose_string
-
-    return None
-
-
 def get_non_keyword_units(
     bases: Iterable[str], prefixes: Sequence[str]
 ) -> Generator[tuple[str, str], None, None]:

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -11,17 +11,9 @@ from keyword import iskeyword
 from typing import TYPE_CHECKING
 
 from astropy.units.utils import maybe_simple_fraction
-from astropy.utils.misc import did_you_mean
 
 if TYPE_CHECKING:
-    from collections.abc import (
-        Callable,
-        Container,
-        Generator,
-        Iterable,
-        Mapping,
-        Sequence,
-    )
+    from collections.abc import Callable, Generator, Iterable, Sequence
     from numbers import Real
     from typing import TypeVar
 
@@ -175,50 +167,6 @@ def _try_decomposed(
             return decompose_string
 
     return None
-
-
-def did_you_mean_units(
-    s: str,
-    all_units: Mapping[str, UnitBase],
-    deprecated_units: Container[str],
-    format_decomposed: Callable[[UnitBase], str | None],
-) -> str:
-    """
-    A wrapper around `astropy.utils.misc.did_you_mean` that deals with
-    the display of deprecated units.
-
-    Parameters
-    ----------
-    s : str
-        The invalid unit string
-
-    all_units : dict
-        A mapping from valid unit names to unit objects.
-
-    deprecated_units : sequence
-        The deprecated unit names
-
-    format_decomposed : callable
-        A function to turn a decomposed version of the unit into a
-        string.  Should return `None` if not possible
-
-    Returns
-    -------
-    msg : str
-        A string message with a list of alternatives, or the empty
-        string.
-    """
-
-    def fix_deprecated(x: str) -> list[str] | tuple[str]:
-        if x in deprecated_units:
-            results = [x + " (deprecated)"]
-            decomposed = _try_decomposed(all_units[x], format_decomposed)
-            if decomposed is not None:
-                results.append(decomposed)
-            return results
-        return (x,)
-
-    return did_you_mean(s, all_units, fix=fix_deprecated)
 
 
 def unit_deprecation_warning(

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -6,7 +6,6 @@ Utilities shared by the different formats.
 
 from __future__ import annotations
 
-import warnings
 from keyword import iskeyword
 from typing import TYPE_CHECKING
 
@@ -167,40 +166,6 @@ def _try_decomposed(
             return decompose_string
 
     return None
-
-
-def unit_deprecation_warning(
-    s: str,
-    unit: UnitBase,
-    standard_name: str,
-    format_decomposed: Callable[[UnitBase], str | None],
-) -> None:
-    """
-    Raises a UnitsWarning about a deprecated unit in a given format.
-    Suggests a decomposed alternative if one is available.
-
-    Parameters
-    ----------
-    s : str
-        The deprecated unit name.
-
-    unit : astropy.units.core.UnitBase
-        The unit object.
-
-    standard_name : str
-        The name of the format for which the unit is deprecated.
-
-    format_decomposed : callable
-        A function to turn a decomposed version of the unit into a
-        string.  Should return `None` if not possible
-    """
-    from astropy.units.core import UnitsWarning
-
-    message = f"The unit '{s}' has been deprecated in the {standard_name} standard."
-    decomposed = _try_decomposed(unit, format_decomposed)
-    if decomposed is not None:
-        message += f" Suggested: {decomposed}."
-    warnings.warn(message, UnitsWarning)
 
 
 def get_non_keyword_units(

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -92,12 +92,9 @@ class VOUnit(generic.Generic):
 
             if cls._custom_unit_regex.match(t.value):
                 warnings.warn(
-                    f"Unit {t.value!r} not supported by the VOUnit standard. "
-                    + utils.did_you_mean_units(
-                        t.value,
-                        cls._units,
-                        cls._deprecated_units,
-                        cls._to_decomposed_alternative,
+                    (
+                        f"Unit {t.value!r} not supported by the VOUnit standard. "
+                        + cls._did_you_mean_units(t.value)
                     ),
                     core.UnitsWarning,
                 )

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -105,14 +105,7 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):
-        if unit not in cls._units:
-            raise ValueError()
-
-        if unit in cls._deprecated_units:
-            utils.unit_deprecation_warning(
-                unit, cls._units[unit], "VOUnit", cls._to_decomposed_alternative
-            )
-
+        super()._validate_unit(unit, detailed_exception=False)
         return cls._units[unit]
 
     @classmethod


### PR DESCRIPTION
### Description

Currently the [`did_you_mean_units()`] function is a unit formatter utility function, but it is only called in the `Generic` formatter (and its subclasses). Making the function a class method in `Generic` allows it to access relevant values from the classes directly, instead of having to receive them as explicit arguments.

UPDATE

After opening this pull request I realized that there's more code that could be moved from the unit formatter utilities to `Generic`, so I've added a few more commits.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
