### PR TITLE
DEPR: deprecate passing redshift (`z`) as a keyword argument

### DIFF
--- a/astropy/cosmology/_signature_deprecations.c
+++ b/astropy/cosmology/_signature_deprecations.c
@@ -1,0 +1,244 @@
+// This extension is adapted from the positional_defaults PyPI package
+// https://pypi.org/project/positional-defaults/ version 2023.4.19
+// MIT. see licenses/POSITIONAL_DEFAULTS.rst
+
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <structmember.h>
+
+#define SINCE_CHAR_SIZE 32
+#define NAMES_CHAR_SIZE 128
+#define MSG_SIZE 512
+
+typedef struct {
+    PyObject_HEAD
+    PyObject* dict;
+    PyObject* wrapped;
+    PyObject* names;
+    PyObject* since;
+} DeprKwsObject;
+
+
+
+static void
+depr_kws_wrap_dealloc(DeprKwsObject* self)
+{
+    Py_XDECREF(self->wrapped);
+    Py_XDECREF(self->names);
+    Py_XDECREF(self->since);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+static PyObject*
+depr_kws_wrap_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    DeprKwsObject* self = (DeprKwsObject*)type->tp_alloc(type, 0);
+
+    if (self != NULL) {
+        self->names = PyTuple_New(0);
+        if (self->names == NULL) {
+            Py_DECREF(self);
+            return NULL;
+        }
+
+        Py_INCREF(Py_None);
+        self->wrapped = Py_None;
+
+        Py_INCREF(Py_None);
+        self->since = Py_None;
+    }
+
+    return (PyObject*)self;
+}
+
+
+static int
+depr_kws_wrap_init(DeprKwsObject* self, PyObject* args, PyObject* kwds)
+{
+    static char *kwlist[] = {"wrapped", "names", "since", NULL};
+    Py_ssize_t i, n_names;
+    PyObject* wrapped, *names, *since, *tmp;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOO:wrap", kwlist,
+                                     &wrapped, &names, &since))
+        return -1;
+
+    if (!PyTuple_Check(names)) {
+        PyErr_SetString(PyExc_TypeError, "names must be a tuple");
+        return -1;
+    }
+
+    n_names = PyTuple_GET_SIZE(names);
+
+    for (i = 0; i < n_names; ++i) {
+        PyObject* name = PyTuple_GET_ITEM(names, i);
+        if (!PyUnicode_Check(name)) {
+            PyErr_Format(PyExc_TypeError, "names[%zd] must be a string", i);
+            return -1;
+        }
+    }
+
+    if (!PyUnicode_Check(since)) {
+        PyErr_Format(PyExc_TypeError, "since must be a string", i);
+        return -1;
+    }
+
+    tmp = self->wrapped;
+    Py_INCREF(wrapped);
+    self->wrapped = wrapped;
+    Py_XDECREF(tmp);
+
+    tmp = self->names;
+    Py_INCREF(names);
+    self->names = names;
+    Py_XDECREF(tmp);
+
+    tmp = self->since;
+    Py_INCREF(since);
+    self->since = since;
+    Py_XDECREF(tmp);
+    return 0;
+}
+
+
+static PyMemberDef depr_kws_wrap_members[] = {
+    {"__dict__", T_OBJECT, offsetof(DeprKwsObject, dict), READONLY},
+    {"wrapped", T_OBJECT, offsetof(DeprKwsObject, wrapped), READONLY},
+    {"names", T_OBJECT, offsetof(DeprKwsObject, names), READONLY},
+    {"since", T_OBJECT, offsetof(DeprKwsObject, since), READONLY},
+    {NULL}
+};
+
+
+static PyObject*
+depr_kws_wrap_call(DeprKwsObject* self, PyObject* args, PyObject* kwds) {
+    // step 0: return early whenever possible
+    if (self->wrapped == NULL)
+        Py_RETURN_NONE;
+
+    if (kwds == NULL)
+        return PyObject_Call(self->wrapped, args, kwds);
+
+    // step 1: detect any deprecated keyword arguments, return if none.
+    Py_ssize_t n_names = PyTuple_GET_SIZE(self->names);
+    PyObject *deprecated_kwargs = PyList_New(n_names);
+    Py_INCREF(deprecated_kwargs);
+    PyObject *name = NULL;
+    Py_ssize_t i = 0;
+    int has_kw = -2;
+
+    Py_ssize_t n_depr = 0;
+    for (i=0 ; i < n_names ; ++i) {
+        name = PyTuple_GET_ITEM(self->names, i);
+        has_kw = PyDict_Contains(kwds, name);
+        if (has_kw) {
+            PyList_SET_ITEM(deprecated_kwargs, n_depr, name);
+            ++n_depr;
+        }
+    }
+
+    if (n_depr == 0)
+        return PyObject_Call(self->wrapped, args, kwds);
+
+    // step 2: create and emit warning message
+    char names_char[NAMES_CHAR_SIZE];
+    char *s, *arguments, *respectively, *pronoun;
+
+    PyObject *names_unicode;
+    if (n_depr > 1) {
+        names_unicode = PyObject_Str(PyList_GetSlice(deprecated_kwargs, 0, n_depr));
+        s = "s";
+        arguments = " arguments";
+        respectively = ", respectively";
+        pronoun = "them";
+    } else {
+        names_unicode = PyObject_Repr(PyList_GET_ITEM(deprecated_kwargs, 0));
+        s = arguments = respectively = "";
+        pronoun = "it";
+    }
+    const char* names_utf8 = PyUnicode_AsUTF8(names_unicode);
+    snprintf(names_char, NAMES_CHAR_SIZE, "%s", names_utf8);
+
+    PyObject *since_unicode = PyObject_Str(self->since);
+    const char* since_utf8 = PyUnicode_AsUTF8(since_unicode);
+    char since_char[SINCE_CHAR_SIZE];
+    snprintf(since_char, SINCE_CHAR_SIZE, "%s", since_utf8);
+
+    char msg[MSG_SIZE];
+    snprintf(
+        msg,
+        MSG_SIZE,
+        "Passing %s%s as keyword%s "
+        "is deprecated since version %s "
+        "and will stop working in a future release. "
+        "Pass %s positionally to suppress this warning.",
+        names_char, arguments, s, since_char, pronoun
+    );
+    const char* msg_ptr = msg;
+
+    int status = PyErr_WarnEx(PyExc_FutureWarning, msg_ptr, 2);
+    if (status == -1) {
+        // avoid leaking memory if Warning is promoted to Exception
+        Py_DECREF(deprecated_kwargs);
+    }
+
+    return PyObject_Call(self->wrapped, args, kwds);
+}
+
+
+static PyObject*
+depr_kws_wrap_get(PyObject* self, PyObject* obj, PyObject* type) {
+    if (obj == Py_None || obj == NULL) {
+        Py_INCREF(self);
+        return self;
+    }
+    return PyMethod_New(self, obj);
+}
+
+
+static PyTypeObject DeprKwsWrap = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_signature_deprecations.wrap",
+    .tp_doc = PyDoc_STR("wrap a function with deprecated keyword arguments"),
+    .tp_basicsize = sizeof(DeprKwsObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_dictoffset = offsetof(DeprKwsObject, dict),
+    .tp_new = depr_kws_wrap_new,
+    .tp_init = (initproc)depr_kws_wrap_init,
+    .tp_dealloc = (destructor)depr_kws_wrap_dealloc,
+    .tp_members = depr_kws_wrap_members,
+    .tp_call = (ternaryfunc)depr_kws_wrap_call,
+    .tp_descr_get = depr_kws_wrap_get,
+};
+
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_signature_deprecations",
+    .m_doc = PyDoc_STR("fast decorators to mark signature details as deprecated"),
+    .m_size = -1,
+};
+
+
+PyMODINIT_FUNC
+PyInit__signature_deprecations(void) {
+    PyObject* m;
+
+    if (PyType_Ready(&DeprKwsWrap) < 0)
+        return NULL;
+
+    m = PyModule_Create(&module);
+    if (m == NULL)
+        return NULL;
+
+    Py_INCREF(&DeprKwsWrap);
+    if (PyModule_AddObject(m, "_depr_kws_wrap", (PyObject*)&DeprKwsWrap) < 0) {
+        Py_DECREF(&DeprKwsWrap);
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    return m;
+}

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -19,7 +19,11 @@ from numpy import inf, sin
 
 import astropy.constants as const
 import astropy.units as u
-from astropy.cosmology._utils import aszarr, vectorize_redshift_method
+from astropy.cosmology._utils import (
+    aszarr,
+    deprecated_keywords,
+    vectorize_redshift_method,
+)
 from astropy.cosmology.core import Cosmology, FlatCosmologyMixin, dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 from astropy.cosmology.parameter._converter import (
@@ -84,18 +88,19 @@ class _ScaleFactorMixin:
         """
         return u.Quantity(self.scale_factor(0), unit=u.one)
 
-    def scale_factor(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def scale_factor(self, z):
         """Scale factor at redshift ``z``.
 
         The scale factor is defined as :math:`a = 1 / (1 + z)`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -415,16 +420,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     # ---------------------------------------------------------------
 
     @abstractmethod
-    def w(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
         r"""The dark energy equation of state.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -443,16 +449,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         raise NotImplementedError("w(z) is not implemented")
 
-    def Otot(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Otot(self, z):
         """The total density parameter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshifts.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -462,16 +469,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self.Om(z) + self.Ogamma(z) + self.Onu(z) + self.Ode(z) + self.Ok(z)
 
-    def Om(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Om(self, z):
         """Return the density parameter for non-relativistic matter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -488,16 +496,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Om0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
-    def Ob(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Ob(self, z):
         """Return the density parameter for baryonic matter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -516,16 +525,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Ob0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
-    def Odm(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Odm(self, z):
         """Return the density parameter for dark matter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -552,16 +562,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Odm0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
-    def Ok(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Ok(self, z):
         """Return the equivalent density parameter for curvature at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -574,16 +585,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self._Ok0 * (z + 1.0) ** 2 * self.inv_efunc(z) ** 2
 
-    def Ode(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Ode(self, z):
         """Return the density parameter for dark energy at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -597,16 +609,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self._Ode0 * self.de_density_scale(z) * self.inv_efunc(z) ** 2
 
-    def Ogamma(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Ogamma(self, z):
         """Return the density parameter for photons at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -618,16 +631,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Ogamma0 * (z + 1.0) ** 4 * self.inv_efunc(z) ** 2
 
-    def Onu(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Onu(self, z):
         r"""Return the density parameter for neutrinos at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -644,16 +658,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self.Ogamma(z) * self.nu_relative_density(z)
 
-    def Tcmb(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Tcmb(self, z):
         """Return the CMB temperature at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -662,16 +677,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._Tcmb0 * (aszarr(z) + 1.0)
 
-    def Tnu(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Tnu(self, z):
         """Return the neutrino temperature at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -680,16 +696,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._Tnu0 * (aszarr(z) + 1.0)
 
-    def nu_relative_density(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def nu_relative_density(self, z):
         r"""Neutrino density function relative to the energy density in photons.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -760,7 +777,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             Assumes scalar input, since this should only be called inside an
             integral.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         References
@@ -770,16 +787,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return 1.0 + self.w(exp(ln1pz) - 1.0)
 
-    def de_density_scale(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -824,16 +842,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             ival = quad(self._w_integrand, 0, log(z + 1.0))[0]
             return exp(3 * ival)
 
-    def efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -859,16 +878,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             + self._Ode0 * self.de_density_scale(z)
         )
 
-    def inv_efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def inv_efunc(self, z):
         """Inverse of ``efunc``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -897,7 +917,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : float, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -912,16 +932,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._inv_efunc_scalar(z, *self._inv_efunc_scalar_args) / (z + 1.0)
 
-    def lookback_time_integrand(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def lookback_time_integrand(self, z):
         """Integrand of the lookback time (equation 30 of [1]_).
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -944,7 +965,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -958,16 +979,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return (z + 1.0) ** 2 * self._inv_efunc_scalar(z, *self._inv_efunc_scalar_args)
 
-    def abs_distance_integrand(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def abs_distance_integrand(self, z):
         """Integrand of the absorption distance (eq. 4, [1]_).
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -981,16 +1003,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return (z + 1.0) ** 2 * self.inv_efunc(z)
 
-    def H(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def H(self, z):
         """Hubble parameter (km/s/Mpc) at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -999,7 +1022,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._H0 * self.efunc(z)
 
-    def lookback_time(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def lookback_time(self, z):
         """Lookback time in Gyr to redshift ``z``.
 
         The lookback time is the difference between the age of the Universe now
@@ -1007,11 +1031,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1035,7 +1059,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -1057,7 +1081,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -1068,7 +1092,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._lookback_time_integrand_scalar, 0, z)[0]
 
-    def lookback_distance(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def lookback_distance(self, z):
         """The lookback distance is the light travel time distance to a given redshift.
 
         It is simply c * lookback_time. It may be used to calculate
@@ -1077,11 +1102,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1090,16 +1115,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return (self.lookback_time(z) * const.c).to(u.Mpc)
 
-    def age(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def age(self, z):
         """Age of the universe in Gyr at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1122,7 +1148,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -1143,9 +1169,6 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
-
         Returns
         -------
         t : float or ndarray
@@ -1158,16 +1181,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._lookback_time_integrand_scalar, z, inf)[0]
 
-    def critical_density(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def critical_density(self, z):
         """Critical density in grams per cubic cm at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1176,7 +1200,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._critical_density0 * (self.efunc(z)) ** 2
 
-    def comoving_distance(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def comoving_distance(self, z):
         """Comoving line-of-sight distance in Mpc at a given redshift.
 
         The comoving distance along the line-of-sight between two objects
@@ -1184,11 +1209,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1208,8 +1233,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z1, z2 : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1230,8 +1255,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z1, z2 : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1252,8 +1277,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1262,7 +1287,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._hubble_distance * self._integral_comoving_distance_z1z2_scalar(z1, z2)  # fmt: skip
 
-    def comoving_transverse_distance(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def comoving_transverse_distance(self, z):
         r"""Comoving transverse distance in Mpc at a given redshift.
 
         This value is the transverse comoving distance at redshift ``z``
@@ -1272,11 +1298,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1302,8 +1328,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z1, z2 : Quantity-like ['redshift'], array-like, positional-only
             Input redshifts.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1325,7 +1351,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         else:
             return dh / sqrtOk0 * sin(sqrtOk0 * dc.value / dh.value)
 
-    def angular_diameter_distance(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def angular_diameter_distance(self, z):
         """Angular diameter distance in Mpc at a given redshift.
 
         This gives the proper (sometimes called 'physical') transverse
@@ -1334,11 +1361,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1354,7 +1381,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self.comoving_transverse_distance(z) / (z + 1.0)
 
-    def luminosity_distance(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def luminosity_distance(self, z):
         """Luminosity distance in Mpc at redshift ``z``.
 
         This is the distance to use when converting between the bolometric flux
@@ -1362,11 +1390,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1392,7 +1420,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z1, z2 : Quantity-like ['redshift'], array-like
             Input redshifts. For most practical applications such as
             gravitational lensing, ``z2`` should be larger than ``z1``. The
             method will work for ``z2 < z1``; however, this will return
@@ -1426,9 +1454,6 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
-
         Returns
         -------
         X : float or ndarray
@@ -1441,7 +1466,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._abs_distance_integrand_scalar, 0, z)[0]
 
-    def distmod(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def distmod(self, z):
         """Distance modulus at redshift ``z``.
 
         The distance modulus is defined as the (apparent magnitude - absolute
@@ -1449,11 +1475,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1471,7 +1497,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         val = 5.0 * np.log10(abs(self.luminosity_distance(z).value)) + 25.0
         return u.Quantity(val, u.mag)
 
-    def comoving_volume(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def comoving_volume(self, z):
         r"""Comoving volume in cubic Mpc at redshift ``z``.
 
         This is the volume of the universe encompassed by redshifts less than
@@ -1480,11 +1507,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1506,7 +1533,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         else:
             return term1 * (term2 - 1.0 / sqrt(abs(Ok0)) * np.arcsin(term3))
 
-    def differential_comoving_volume(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def differential_comoving_volume(self, z):
         """Differential comoving volume at redshift z.
 
         Useful for calculating the effective comoving volume.
@@ -1517,11 +1545,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1532,16 +1560,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         dm = self.comoving_transverse_distance(z)
         return self._hubble_distance * (dm**2.0) / (self.efunc(z) << u.steradian)
 
-    def kpc_comoving_per_arcmin(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def kpc_comoving_per_arcmin(self, z):
         """Separation in transverse comoving kpc equal to an arcmin at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1551,16 +1580,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self.comoving_transverse_distance(z).to(u.kpc) / _radian_in_arcmin
 
-    def kpc_proper_per_arcmin(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def kpc_proper_per_arcmin(self, z):
         """Separation in transverse proper kpc equal to an arcminute at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1570,16 +1600,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self.angular_diameter_distance(z).to(u.kpc) / _radian_in_arcmin
 
-    def arcsec_per_kpc_comoving(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def arcsec_per_kpc_comoving(self, z):
         """Angular separation in arcsec equal to a comoving kpc at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1589,16 +1620,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return _radian_in_arcsec / self.comoving_transverse_distance(z).to(u.kpc)
 
-    def arcsec_per_kpc_proper(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def arcsec_per_kpc_proper(self, z):
         """Angular separation in arcsec corresponding to a proper kpc at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -1671,16 +1703,17 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         """Omega total; the total density/critical density at z=0."""
         return 1.0
 
-    def Otot(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def Otot(self, z):
         """The total density parameter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -84,15 +84,18 @@ class _ScaleFactorMixin:
         """
         return u.Quantity(self.scale_factor(0), unit=u.one)
 
-    def scale_factor(self, z):
+    def scale_factor(self, z, /):
         """Scale factor at redshift ``z``.
 
         The scale factor is defined as :math:`a = 1 / (1 + z)`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -412,13 +415,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     # ---------------------------------------------------------------
 
     @abstractmethod
-    def w(self, z):
+    def w(self, z, /):
         r"""The dark energy equation of state.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -437,13 +443,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         raise NotImplementedError("w(z) is not implemented")
 
-    def Otot(self, z):
+    def Otot(self, z, /):
         """The total density parameter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshifts.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -453,13 +462,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self.Om(z) + self.Ogamma(z) + self.Onu(z) + self.Ode(z) + self.Ok(z)
 
-    def Om(self, z):
+    def Om(self, z, /):
         """Return the density parameter for non-relativistic matter at redshift ``z``.
 
         Parameters
         ----------
         z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -476,13 +488,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Om0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
-    def Ob(self, z):
+    def Ob(self, z, /):
         """Return the density parameter for baryonic matter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -501,13 +516,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Ob0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
-    def Odm(self, z):
+    def Odm(self, z, /):
         """Return the density parameter for dark matter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -534,13 +552,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Odm0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 
-    def Ok(self, z):
+    def Ok(self, z, /):
         """Return the equivalent density parameter for curvature at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -553,13 +574,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self._Ok0 * (z + 1.0) ** 2 * self.inv_efunc(z) ** 2
 
-    def Ode(self, z):
+    def Ode(self, z, /):
         """Return the density parameter for dark energy at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -573,13 +597,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self._Ode0 * self.de_density_scale(z) * self.inv_efunc(z) ** 2
 
-    def Ogamma(self, z):
+    def Ogamma(self, z, /):
         """Return the density parameter for photons at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -591,13 +618,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self._Ogamma0 * (z + 1.0) ** 4 * self.inv_efunc(z) ** 2
 
-    def Onu(self, z):
+    def Onu(self, z, /):
         r"""Return the density parameter for neutrinos at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -614,13 +644,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self.Ogamma(z) * self.nu_relative_density(z)
 
-    def Tcmb(self, z):
+    def Tcmb(self, z, /):
         """Return the CMB temperature at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -629,13 +662,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._Tcmb0 * (aszarr(z) + 1.0)
 
-    def Tnu(self, z):
+    def Tnu(self, z, /):
         """Return the neutrino temperature at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -644,13 +680,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._Tnu0 * (aszarr(z) + 1.0)
 
-    def nu_relative_density(self, z):
+    def nu_relative_density(self, z, /):
         r"""Neutrino density function relative to the energy density in photons.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -712,14 +751,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         return prefac * self._neff_per_nu * rel_mass
 
-    def _w_integrand(self, ln1pz):
+    def _w_integrand(self, ln1pz, /):
         """Internal convenience function for w(z) integral (eq. 5 of [1]_).
 
         Parameters
         ----------
-        ln1pz : `~numbers.Number` or scalar ndarray
+        ln1pz : `~numbers.Number` or scalar ndarray, positional-only
             Assumes scalar input, since this should only be called inside an
             integral.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         References
         ----------
@@ -728,13 +770,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return 1.0 + self.w(exp(ln1pz) - 1.0)
 
-    def de_density_scale(self, z):
+    def de_density_scale(self, z, /):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -779,13 +824,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             ival = quad(self._w_integrand, 0, log(z + 1.0))[0]
             return exp(3 * ival)
 
-    def efunc(self, z):
+    def efunc(self, z, /):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -811,13 +859,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             + self._Ode0 * self.de_density_scale(z)
         )
 
-    def inv_efunc(self, z):
+    def inv_efunc(self, z, /):
         """Inverse of ``efunc``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -838,13 +889,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
             + self._Ode0 * self.de_density_scale(z)
         ) ** (-0.5)
 
-    def _lookback_time_integrand_scalar(self, z):
+    def _lookback_time_integrand_scalar(self, z, /):
         """Integrand of the lookback time (equation 30 of [1]_).
 
         Parameters
         ----------
-        z : float
+        z : float, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -858,13 +912,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._inv_efunc_scalar(z, *self._inv_efunc_scalar_args) / (z + 1.0)
 
-    def lookback_time_integrand(self, z):
+    def lookback_time_integrand(self, z, /):
         """Integrand of the lookback time (equation 30 of [1]_).
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -879,13 +936,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self.inv_efunc(z) / (z + 1.0)
 
-    def _abs_distance_integrand_scalar(self, z):
+    def _abs_distance_integrand_scalar(self, z, /):
         """Integrand of the absorption distance (eq. 4, [1]_).
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -898,13 +958,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return (z + 1.0) ** 2 * self._inv_efunc_scalar(z, *self._inv_efunc_scalar_args)
 
-    def abs_distance_integrand(self, z):
+    def abs_distance_integrand(self, z, /):
         """Integrand of the absorption distance (eq. 4, [1]_).
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -918,13 +981,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return (z + 1.0) ** 2 * self.inv_efunc(z)
 
-    def H(self, z):
+    def H(self, z, /):
         """Hubble parameter (km/s/Mpc) at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -933,7 +999,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._H0 * self.efunc(z)
 
-    def lookback_time(self, z):
+    def lookback_time(self, z, /):
         """Lookback time in Gyr to redshift ``z``.
 
         The lookback time is the difference between the age of the Universe now
@@ -941,8 +1007,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -955,7 +1024,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._lookback_time(z)
 
-    def _lookback_time(self, z):
+    def _lookback_time(self, z, /):
         """Lookback time in Gyr to redshift ``z``.
 
         The lookback time is the difference between the age of the Universe now
@@ -963,8 +1032,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -982,8 +1054,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -993,7 +1068,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._lookback_time_integrand_scalar, 0, z)[0]
 
-    def lookback_distance(self, z):
+    def lookback_distance(self, z, /):
         """The lookback distance is the light travel time distance to a given redshift.
 
         It is simply c * lookback_time. It may be used to calculate
@@ -1002,8 +1077,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1012,13 +1090,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return (self.lookback_time(z) * const.c).to(u.Mpc)
 
-    def age(self, z):
+    def age(self, z, /):
         """Age of the universe in Gyr at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1031,15 +1112,18 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._age(z)
 
-    def _age(self, z):
+    def _age(self, z, /):
         """Age of the universe in Gyr at redshift ``z``.
 
         This internal function exists to be re-defined for optimizations.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1056,8 +1140,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1071,13 +1158,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._lookback_time_integrand_scalar, z, inf)[0]
 
-    def critical_density(self, z):
+    def critical_density(self, z, /):
         """Critical density in grams per cubic cm at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1086,7 +1176,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._critical_density0 * (self.efunc(z)) ** 2
 
-    def comoving_distance(self, z):
+    def comoving_distance(self, z, /):
         """Comoving line-of-sight distance in Mpc at a given redshift.
 
         The comoving distance along the line-of-sight between two objects
@@ -1094,8 +1184,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1104,7 +1197,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._comoving_distance_z1z2(0, z)
 
-    def _comoving_distance_z1z2(self, z1, z2):
+    def _comoving_distance_z1z2(self, z1, z2, /):
         """Comoving line-of-sight distance in Mpc between redshifts ``z1`` and ``z2``.
 
         The comoving distance along the line-of-sight between two objects
@@ -1112,8 +1205,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
-            Input redshifts.
+        z1, z2 : Quantity-like ['redshift'], array-like, positional-only
+            Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1131,8 +1227,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
-            Input redshifts.
+        z1, z2 : Quantity-like ['redshift'], array-like, positional-only
+            Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1142,7 +1241,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._inv_efunc_scalar, z1, z2, args=self._inv_efunc_scalar_args)[0]
 
-    def _integral_comoving_distance_z1z2(self, z1, z2):
+    def _integral_comoving_distance_z1z2(self, z1, z2, /):
         """Comoving line-of-sight distance in Mpc between objects at redshifts ``z1`` and ``z2``.
 
         The comoving distance along the line-of-sight between two objects remains
@@ -1150,8 +1249,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'] or array-like
-            Input redshifts.
+        z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
+            Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1160,7 +1262,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._hubble_distance * self._integral_comoving_distance_z1z2_scalar(z1, z2)  # fmt: skip
 
-    def comoving_transverse_distance(self, z):
+    def comoving_transverse_distance(self, z, /):
         r"""Comoving transverse distance in Mpc at a given redshift.
 
         This value is the transverse comoving distance at redshift ``z``
@@ -1170,8 +1272,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1184,7 +1289,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self._comoving_transverse_distance_z1z2(0, z)
 
-    def _comoving_transverse_distance_z1z2(self, z1, z2):
+    def _comoving_transverse_distance_z1z2(self, z1, z2, /):
         r"""Comoving transverse distance in Mpc between two redshifts.
 
         This value is the transverse comoving distance at redshift ``z2`` as
@@ -1194,8 +1299,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z1, z2 : Quantity-like ['redshift'], array-like, positional-only
             Input redshifts.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1217,7 +1325,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         else:
             return dh / sqrtOk0 * sin(sqrtOk0 * dc.value / dh.value)
 
-    def angular_diameter_distance(self, z):
+    def angular_diameter_distance(self, z, /):
         """Angular diameter distance in Mpc at a given redshift.
 
         This gives the proper (sometimes called 'physical') transverse
@@ -1226,8 +1334,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1243,7 +1354,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         z = aszarr(z)
         return self.comoving_transverse_distance(z) / (z + 1.0)
 
-    def luminosity_distance(self, z):
+    def luminosity_distance(self, z, /):
         """Luminosity distance in Mpc at redshift ``z``.
 
         This is the distance to use when converting between the bolometric flux
@@ -1251,8 +1362,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1309,8 +1423,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1324,7 +1441,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return quad(self._abs_distance_integrand_scalar, 0, z)[0]
 
-    def distmod(self, z):
+    def distmod(self, z, /):
         """Distance modulus at redshift ``z``.
 
         The distance modulus is defined as the (apparent magnitude - absolute
@@ -1332,8 +1449,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1351,7 +1471,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         val = 5.0 * np.log10(abs(self.luminosity_distance(z).value)) + 25.0
         return u.Quantity(val, u.mag)
 
-    def comoving_volume(self, z):
+    def comoving_volume(self, z, /):
         r"""Comoving volume in cubic Mpc at redshift ``z``.
 
         This is the volume of the universe encompassed by redshifts less than
@@ -1360,8 +1480,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1383,7 +1506,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         else:
             return term1 * (term2 - 1.0 / sqrt(abs(Ok0)) * np.arcsin(term3))
 
-    def differential_comoving_volume(self, z):
+    def differential_comoving_volume(self, z, /):
         """Differential comoving volume at redshift z.
 
         Useful for calculating the effective comoving volume.
@@ -1394,8 +1517,11 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1406,13 +1532,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         dm = self.comoving_transverse_distance(z)
         return self._hubble_distance * (dm**2.0) / (self.efunc(z) << u.steradian)
 
-    def kpc_comoving_per_arcmin(self, z):
+    def kpc_comoving_per_arcmin(self, z, /):
         """Separation in transverse comoving kpc equal to an arcmin at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1422,13 +1551,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self.comoving_transverse_distance(z).to(u.kpc) / _radian_in_arcmin
 
-    def kpc_proper_per_arcmin(self, z):
+    def kpc_proper_per_arcmin(self, z, /):
         """Separation in transverse proper kpc equal to an arcminute at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1438,13 +1570,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return self.angular_diameter_distance(z).to(u.kpc) / _radian_in_arcmin
 
-    def arcsec_per_kpc_comoving(self, z):
+    def arcsec_per_kpc_comoving(self, z, /):
         """Angular separation in arcsec equal to a comoving kpc at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1454,13 +1589,16 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         """
         return _radian_in_arcsec / self.comoving_transverse_distance(z).to(u.kpc)
 
-    def arcsec_per_kpc_proper(self, z):
+    def arcsec_per_kpc_proper(self, z, /):
         """Angular separation in arcsec corresponding to a proper kpc at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -1533,13 +1671,16 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         """Omega total; the total density/critical density at z=0."""
         return 1.0
 
-    def Otot(self, z):
+    def Otot(self, z, /):
         """The total density parameter at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
-            Input redshifts.
+        z : Quantity-like ['redshift'], array-like, positional-only
+            Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -6,7 +6,7 @@ from numbers import Number
 import numpy as np
 from numpy import log
 
-from astropy.cosmology._utils import aszarr
+from astropy.cosmology._utils import aszarr, deprecated_keywords
 from astropy.cosmology.core import dataclass_decorator
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
@@ -150,16 +150,17 @@ class LambdaCDM(FLRW):
         object.__setattr__(self, "_age", age)
         object.__setattr__(self, "_lookback_time", lookback_time)
 
-    def w(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -177,16 +178,17 @@ class LambdaCDM(FLRW):
         z = aszarr(z)
         return -1.0 * (np.ones(z.shape) if hasattr(z, "shape") else 1.0)
 
-    def de_density_scale(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -219,8 +221,8 @@ class LambdaCDM(FLRW):
         z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -299,8 +301,8 @@ class LambdaCDM(FLRW):
         z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshifts. Must be 1D or scalar.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -332,8 +334,8 @@ class LambdaCDM(FLRW):
         z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshifts. Must be 1D or scalar.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -365,8 +367,8 @@ class LambdaCDM(FLRW):
         z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshifts.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -424,7 +426,7 @@ class LambdaCDM(FLRW):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -446,7 +448,7 @@ class LambdaCDM(FLRW):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -472,7 +474,7 @@ class LambdaCDM(FLRW):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -508,7 +510,7 @@ class LambdaCDM(FLRW):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -538,7 +540,7 @@ class LambdaCDM(FLRW):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -563,7 +565,7 @@ class LambdaCDM(FLRW):
         z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
+            .. versionchanged:: 7.0
                 The argument is positional-only.
 
         Returns
@@ -573,16 +575,17 @@ class LambdaCDM(FLRW):
         """
         return self._flat_age(0) - self._flat_age(z)
 
-    def efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -602,16 +605,17 @@ class LambdaCDM(FLRW):
 
         return np.sqrt(zp1**2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) + self._Ode0)
 
-    def inv_efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def inv_efunc(self, z):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -724,16 +728,17 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -753,16 +758,17 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
 
         return np.sqrt(zp1**3 * (Or * zp1 + self._Om0) + self._Ode0)
 
-    def inv_efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def inv_efunc(self, z):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -150,13 +150,16 @@ class LambdaCDM(FLRW):
         object.__setattr__(self, "_age", age)
         object.__setattr__(self, "_lookback_time", lookback_time)
 
-    def w(self, z):
+    def w(self, z, /):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -174,13 +177,16 @@ class LambdaCDM(FLRW):
         z = aszarr(z)
         return -1.0 * (np.ones(z.shape) if hasattr(z, "shape") else 1.0)
 
-    def de_density_scale(self, z):
+    def de_density_scale(self, z, /):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -196,7 +202,7 @@ class LambdaCDM(FLRW):
         z = aszarr(z)
         return np.ones(z.shape) if hasattr(z, "shape") else 1.0
 
-    def _elliptic_comoving_distance_z1z2(self, z1, z2):
+    def _elliptic_comoving_distance_z1z2(self, z1, z2, /):
         r"""Comoving transverse distance in Mpc between two redshifts.
 
         This value is the transverse comoving distance at redshift ``z``
@@ -210,8 +216,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
-            Input redshifts.
+        z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
+            Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -237,7 +246,7 @@ class LambdaCDM(FLRW):
         kappa = b / abs(b)
         if (b < 0) or (2 < b):
 
-            def phi_z(Om0, Ok0, kappa, y1, A, z):
+            def phi_z(Om0, Ok0, kappa, y1, A, z, /):
                 return np.arccos(
                     ((z + 1.0) * Om0 / abs(Ok0) + kappa * y1 - A)
                     / ((z + 1.0) * Om0 / abs(Ok0) + kappa * y1 + A)
@@ -255,7 +264,7 @@ class LambdaCDM(FLRW):
         # Fot the upper-left 0<b<2 solution the Big Bang didn't happen.
         elif (0 < b) and (b < 2) and self._Om0 > self._Ode0:
 
-            def phi_z(Om0, Ok0, y1, y2, z):
+            def phi_z(Om0, Ok0, y1, y2, z, /):
                 return np.arcsin(np.sqrt((y1 - y2) / ((z + 1.0) * Om0 / abs(Ok0) + y1)))
 
             yb = cos(acos(1 - b) / 3)
@@ -273,7 +282,7 @@ class LambdaCDM(FLRW):
         prefactor = self._hubble_distance / sqrt(abs(self._Ok0))
         return prefactor * g * (ellipkinc(phi_z1, k2) - ellipkinc(phi_z2, k2))
 
-    def _dS_comoving_distance_z1z2(self, z1, z2):
+    def _dS_comoving_distance_z1z2(self, z1, z2, /):
         r"""De Sitter comoving LoS distance in Mpc between two redshifts.
 
         The Comoving line-of-sight distance in Mpc between objects at
@@ -287,8 +296,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshifts. Must be 1D or scalar.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -302,7 +314,7 @@ class LambdaCDM(FLRW):
 
         return self._hubble_distance * (z2 - z1)
 
-    def _EdS_comoving_distance_z1z2(self, z1, z2):
+    def _EdS_comoving_distance_z1z2(self, z1, z2, /):
         r"""Einstein-de Sitter comoving LoS distance in Mpc between two redshifts.
 
         The Comoving line-of-sight distance in Mpc between objects at
@@ -317,8 +329,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshifts. Must be 1D or scalar.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -333,7 +348,7 @@ class LambdaCDM(FLRW):
         prefactor = 2 * self._hubble_distance
         return prefactor * ((z1 + 1.0) ** (-1.0 / 2) - (z2 + 1.0) ** (-1.0 / 2))
 
-    def _hypergeometric_comoving_distance_z1z2(self, z1, z2):
+    def _hypergeometric_comoving_distance_z1z2(self, z1, z2, /):
         r"""Hypergeoemtric comoving LoS distance in Mpc between two redshifts.
 
         The Comoving line-of-sight distance in Mpc at redshifts ``z1`` and
@@ -347,8 +362,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z1, z2 : Quantity-like ['redshift'] or array-like, positional-only
             Input redshifts.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -374,7 +392,7 @@ class LambdaCDM(FLRW):
             - self._T_hypergeometric(s / (z2 + 1.0))
         )
 
-    def _T_hypergeometric(self, x):
+    def _T_hypergeometric(self, x, /):
         r"""Compute value using Gauss Hypergeometric function 2F1.
 
         .. math::
@@ -396,15 +414,18 @@ class LambdaCDM(FLRW):
         """
         return 2 * np.sqrt(x) * hyp2f1(1.0 / 6, 1.0 / 2, 7.0 / 6, -(x**3))
 
-    def _dS_age(self, z):
+    def _dS_age(self, z, /):
         """Age of the universe in Gyr at redshift ``z``.
 
         The age of a de Sitter Universe is infinite.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -414,7 +435,7 @@ class LambdaCDM(FLRW):
         t = inf if isinstance(z, Number) else np.full_like(z, inf, dtype=float)
         return self._hubble_time * t
 
-    def _EdS_age(self, z):
+    def _EdS_age(self, z, /):
         r"""Age of the universe in Gyr at redshift ``z``.
 
         For :math:`\Omega_{rad} = 0` (:math:`T_{CMB} = 0`; massless neutrinos)
@@ -422,8 +443,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -437,7 +461,7 @@ class LambdaCDM(FLRW):
         """
         return (2.0 / 3) * self._hubble_time * (aszarr(z) + 1.0) ** (-1.5)
 
-    def _flat_age(self, z):
+    def _flat_age(self, z, /):
         r"""Age of the universe in Gyr at redshift ``z``.
 
         For :math:`\Omega_{rad} = 0` (:math:`T_{CMB} = 0`; massless neutrinos)
@@ -445,8 +469,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -466,7 +493,7 @@ class LambdaCDM(FLRW):
         )
         return (prefactor * arg).real
 
-    def _EdS_lookback_time(self, z):
+    def _EdS_lookback_time(self, z, /):
         r"""Lookback time in Gyr to redshift ``z``.
 
         The lookback time is the difference between the age of the Universe now
@@ -478,8 +505,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -488,7 +518,7 @@ class LambdaCDM(FLRW):
         """
         return self._EdS_age(0) - self._EdS_age(z)
 
-    def _dS_lookback_time(self, z):
+    def _dS_lookback_time(self, z, /):
         r"""Lookback time in Gyr to redshift ``z``.
 
         The lookback time is the difference between the age of the Universe now
@@ -505,8 +535,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -515,7 +548,7 @@ class LambdaCDM(FLRW):
         """
         return self._hubble_time * log(aszarr(z) + 1.0)
 
-    def _flat_lookback_time(self, z):
+    def _flat_lookback_time(self, z, /):
         r"""Lookback time in Gyr to redshift ``z``.
 
         The lookback time is the difference between the age of the Universe now
@@ -527,8 +560,11 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -537,13 +573,16 @@ class LambdaCDM(FLRW):
         """
         return self._flat_age(0) - self._flat_age(z)
 
-    def efunc(self, z):
+    def efunc(self, z, /):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -563,13 +602,16 @@ class LambdaCDM(FLRW):
 
         return np.sqrt(zp1**2 * ((Or * zp1 + self._Om0) * zp1 + self._Ok0) + self._Ode0)
 
-    def inv_efunc(self, z):
+    def inv_efunc(self, z, /):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -682,13 +724,16 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def efunc(self, z):
+    def efunc(self, z, /):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -708,13 +753,16 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
 
         return np.sqrt(zp1**3 * (Or * zp1 + self._Om0) + self._Ode0)
 
-    def inv_efunc(self, z):
+    def inv_efunc(self, z, /):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/tests/test_lambdacdm.py
+++ b/astropy/cosmology/flrw/tests/test_lambdacdm.py
@@ -956,16 +956,16 @@ def test_age_in_special_cosmologies():
     Some analytic solutions fail at these critical points.
     """
     c_dS = FlatLambdaCDM(100, 0, Tcmb0=0)
-    assert u.allclose(c_dS.age(z=0), np.inf * u.Gyr)
-    assert u.allclose(c_dS.age(z=1), np.inf * u.Gyr)
-    assert u.allclose(c_dS.lookback_time(z=0), 0 * u.Gyr)
-    assert u.allclose(c_dS.lookback_time(z=1), 6.777539216261741 * u.Gyr)
+    assert u.allclose(c_dS.age(0), np.inf * u.Gyr)
+    assert u.allclose(c_dS.age(1), np.inf * u.Gyr)
+    assert u.allclose(c_dS.lookback_time(0), 0 * u.Gyr)
+    assert u.allclose(c_dS.lookback_time(1), 6.777539216261741 * u.Gyr)
 
     c_EdS = FlatLambdaCDM(100, 1, Tcmb0=0)
-    assert u.allclose(c_EdS.age(z=0), 6.518614811154189 * u.Gyr)
-    assert u.allclose(c_EdS.age(z=1), 2.3046783684542738 * u.Gyr)
-    assert u.allclose(c_EdS.lookback_time(z=0), 0 * u.Gyr)
-    assert u.allclose(c_EdS.lookback_time(z=1), 4.213936442699092 * u.Gyr)
+    assert u.allclose(c_EdS.age(0), 6.518614811154189 * u.Gyr)
+    assert u.allclose(c_EdS.age(1), 2.3046783684542738 * u.Gyr)
+    assert u.allclose(c_EdS.lookback_time(0), 0 * u.Gyr)
+    assert u.allclose(c_EdS.lookback_time(1), 4.213936442699092 * u.Gyr)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
@@ -975,20 +975,20 @@ def test_distance_in_special_cosmologies():
     Some analytic solutions fail at these critical points.
     """
     c_dS = FlatLambdaCDM(100, 0, Tcmb0=0)
-    assert u.allclose(c_dS.comoving_distance(z=0), 0 * u.Mpc)
-    assert u.allclose(c_dS.comoving_distance(z=1), 2997.92458 * u.Mpc)
+    assert u.allclose(c_dS.comoving_distance(0), 0 * u.Mpc)
+    assert u.allclose(c_dS.comoving_distance(1), 2997.92458 * u.Mpc)
 
     c_EdS = FlatLambdaCDM(100, 1, Tcmb0=0)
-    assert u.allclose(c_EdS.comoving_distance(z=0), 0 * u.Mpc)
-    assert u.allclose(c_EdS.comoving_distance(z=1), 1756.1435599923348 * u.Mpc)
+    assert u.allclose(c_EdS.comoving_distance(0), 0 * u.Mpc)
+    assert u.allclose(c_EdS.comoving_distance(1), 1756.1435599923348 * u.Mpc)
 
     c_dS = LambdaCDM(100, 0, 1, Tcmb0=0)
-    assert u.allclose(c_dS.comoving_distance(z=0), 0 * u.Mpc)
-    assert u.allclose(c_dS.comoving_distance(z=1), 2997.92458 * u.Mpc)
+    assert u.allclose(c_dS.comoving_distance(0), 0 * u.Mpc)
+    assert u.allclose(c_dS.comoving_distance(1), 2997.92458 * u.Mpc)
 
     c_EdS = LambdaCDM(100, 1, 0, Tcmb0=0)
-    assert u.allclose(c_EdS.comoving_distance(z=0), 0 * u.Mpc)
-    assert u.allclose(c_EdS.comoving_distance(z=1), 1756.1435599923348 * u.Mpc)
+    assert u.allclose(c_EdS.comoving_distance(0), 0 * u.Mpc)
+    assert u.allclose(c_EdS.comoving_distance(1), 1756.1435599923348 * u.Mpc)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -5,7 +5,7 @@
 import numpy as np
 from numpy import sqrt
 
-from astropy.cosmology._utils import aszarr
+from astropy.cosmology._utils import aszarr, deprecated_keywords
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
@@ -117,16 +117,17 @@ class wCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -144,16 +145,17 @@ class wCDM(FLRW):
         z = aszarr(z)
         return self._w0 * (np.ones(z.shape) if hasattr(z, "shape") else 1.0)
 
-    def de_density_scale(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -169,16 +171,17 @@ class wCDM(FLRW):
         """
         return (aszarr(z) + 1.0) ** (3.0 * (1.0 + self._w0))
 
-    def efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -199,16 +202,17 @@ class wCDM(FLRW):
             + self._Ode0 * zp1 ** (3.0 * (1.0 + self._w0))
         )
 
-    def inv_efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def inv_efunc(self, z):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -325,16 +329,17 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def efunc(self, z):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -354,16 +359,17 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
             zp1**3 * (Or * zp1 + self._Om0) + self._Ode0 * zp1 ** (3.0 * (1 + self._w0))
         )
 
-    def inv_efunc(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def inv_efunc(self, z):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, positional-only
+        z : Quantity-like ['redshift'], array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only.
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/w0cdm.py
+++ b/astropy/cosmology/flrw/w0cdm.py
@@ -117,13 +117,16 @@ class wCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z):
+    def w(self, z, /):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -141,13 +144,16 @@ class wCDM(FLRW):
         z = aszarr(z)
         return self._w0 * (np.ones(z.shape) if hasattr(z, "shape") else 1.0)
 
-    def de_density_scale(self, z):
+    def de_density_scale(self, z, /):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -163,13 +169,16 @@ class wCDM(FLRW):
         """
         return (aszarr(z) + 1.0) ** (3.0 * (1.0 + self._w0))
 
-    def efunc(self, z):
+    def efunc(self, z, /):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -190,13 +199,16 @@ class wCDM(FLRW):
             + self._Ode0 * zp1 ** (3.0 * (1.0 + self._w0))
         )
 
-    def inv_efunc(self, z):
+    def inv_efunc(self, z, /):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -313,13 +325,16 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def efunc(self, z):
+    def efunc(self, z, /):
         """Function used to calculate H(z), the Hubble parameter.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------
@@ -339,13 +354,16 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
             zp1**3 * (Or * zp1 + self._Om0) + self._Ode0 * zp1 ** (3.0 * (1 + self._w0))
         )
 
-    def inv_efunc(self, z):
+    def inv_efunc(self, z, /):
         r"""Function used to calculate :math:`\frac{1}{H_z}`.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'], array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -4,7 +4,7 @@
 
 from numpy import exp
 
-from astropy.cosmology._utils import aszarr
+from astropy.cosmology._utils import aszarr, deprecated_keywords
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
@@ -141,16 +141,17 @@ class w0waCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -169,7 +170,8 @@ class w0waCDM(FLRW):
         z = aszarr(z)
         return self._w0 + self._wa * z / (z + 1.0)
 
-    def de_density_scale(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
@@ -177,8 +179,8 @@ class w0waCDM(FLRW):
         z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/w0wacdm.py
+++ b/astropy/cosmology/flrw/w0wacdm.py
@@ -141,13 +141,16 @@ class w0waCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z):
+    def w(self, z, /):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only
 
         Returns
         -------
@@ -166,13 +169,16 @@ class w0waCDM(FLRW):
         z = aszarr(z)
         return self._w0 + self._wa * z / (z + 1.0)
 
-    def de_density_scale(self, z):
+    def de_density_scale(self, z, /):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only
 
         Returns
         -------

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -4,7 +4,7 @@
 
 from numpy import exp
 
-from astropy.cosmology._utils import aszarr
+from astropy.cosmology._utils import aszarr, deprecated_keywords
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
@@ -134,16 +134,17 @@ class w0wzCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -160,16 +161,17 @@ class w0wzCDM(FLRW):
         """
         return self._w0 + self._wz * aszarr(z)
 
-    def de_density_scale(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------

--- a/astropy/cosmology/flrw/w0wzcdm.py
+++ b/astropy/cosmology/flrw/w0wzcdm.py
@@ -134,13 +134,16 @@ class w0wzCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z):
+    def w(self, z, /):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only
 
         Returns
         -------
@@ -157,13 +160,16 @@ class w0wzCDM(FLRW):
         """
         return self._w0 + self._wz * aszarr(z)
 
-    def de_density_scale(self, z):
+    def de_density_scale(self, z, /):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only
 
         Returns
         -------

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -161,13 +161,16 @@ class wpwaCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z):
+    def w(self, z, /):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only
 
         Returns
         -------
@@ -186,13 +189,16 @@ class wpwaCDM(FLRW):
         apiv = 1.0 / (1.0 + self._zp.value)
         return self._wp + self._wa * (apiv - 1.0 / (aszarr(z) + 1.0))
 
-    def de_density_scale(self, z):
+    def de_density_scale(self, z, /):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like, or `~numbers.Number`
+        z : Quantity-like ['redshift'] or array-like, positional-only
             Input redshift.
+
+            .. versionchanged:: 6.1
+                The argument is positional-only
 
         Returns
         -------

--- a/astropy/cosmology/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/flrw/wpwazpcdm.py
@@ -5,7 +5,7 @@
 from numpy import exp
 
 from astropy.cosmology import units as cu
-from astropy.cosmology._utils import aszarr
+from astropy.cosmology._utils import aszarr, deprecated_keywords
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
 
@@ -161,16 +161,17 @@ class wpwaCDM(FLRW):
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
 
-    def w(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
         r"""Returns dark energy equation of state at redshift ``z``.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------
@@ -189,16 +190,17 @@ class wpwaCDM(FLRW):
         apiv = 1.0 / (1.0 + self._zp.value)
         return self._wp + self._wa * (apiv - 1.0 / (aszarr(z) + 1.0))
 
-    def de_density_scale(self, z, /):
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
         r"""Evaluates the redshift dependence of the dark energy density.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'] or array-like, positional-only
+        z : Quantity-like ['redshift'] or array-like
             Input redshift.
 
-            .. versionchanged:: 6.1
-                The argument is positional-only
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
 
         Returns
         -------

--- a/astropy/cosmology/setup_package.py
+++ b/astropy/cosmology/setup_package.py
@@ -1,0 +1,28 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import sys
+from os.path import dirname, join, relpath
+
+from setuptools import Extension
+
+ASTROPY_COSMOLOGY_ROOT = dirname(__file__)
+
+
+if sys.platform.startswith("win"):
+    # on windows, -Werror (and possibly -Wall too) isn't recognized
+    extra_compile_args = []
+else:
+    # be extra careful with this extension as it calls PyErr_WarnEx
+    # with a formatted message whose size cannot be determined at compile time,
+    # which is never done within the standard library
+    extra_compile_args = ["-Werror", "-Wall"]
+
+
+def get_extensions():
+    return [
+        Extension(
+            "astropy.cosmology._signature_deprecations",
+            [relpath(join(ASTROPY_COSMOLOGY_ROOT, "_signature_deprecations.c"))],
+            extra_compile_args=extra_compile_args,
+        ),
+    ]

--- a/docs/changes/cosmology/15859.api.rst
+++ b/docs/changes/cosmology/15859.api.rst
@@ -1,1 +1,0 @@
-Redshift methods are now positional-only.

--- a/docs/changes/cosmology/15859.api.rst
+++ b/docs/changes/cosmology/15859.api.rst
@@ -1,0 +1,1 @@
+Redshift methods are now positional-only.

--- a/docs/changes/cosmology/16597.api.rst
+++ b/docs/changes/cosmology/16597.api.rst
@@ -1,0 +1,1 @@
+Passing redshift arguments as keywords is deprecated in many methods.

--- a/licenses/POSITIONAL_DEFAULTS.rst
+++ b/licenses/POSITIONAL_DEFAULTS.rst
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Nicolas Tessore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### Description
This is the continuation (and revival) of @nstarman's work in #15859. See that PR for motivation.

~It is still a work in progress as I haven't applied my decorator anywhere yet. I'm opening as a draft to check for compilation and other installation errors on all platforms.~
Close #15859
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

TODO:
- [x] pass existing CI
- [x] add tests (I already wrote some, just need to port them to this PR)
- [x] add a docstring (and any documentation required)
- [x] apply decorator instead of making arguments positional only directly
- [x] edit changelog


