### PR TITLE
Unit formatter typing adjustments

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -9,7 +9,7 @@ from . import utils
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from numbers import Real
-    from typing import Literal
+    from typing import ClassVar, Literal
 
     from astropy.units import NamedUnit, UnitBase
 
@@ -19,9 +19,10 @@ class Base:
     The abstract base class of all unit formats.
     """
 
-    registry = {}
-    _space = " "
-    _scale_unit_separator = " "
+    registry: ClassVar[dict[str, type[Base]]] = {}
+    _space: ClassVar[str] = " "
+    _scale_unit_separator: ClassVar[str] = " "
+    name: ClassVar[str]  # Set by __init_subclass__ by the latest
 
     def __new__(cls, *args, **kwargs):
         # This __new__ is to make it clear that there is no reason to

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from numbers import Real
     from typing import ClassVar, Literal
 
+    import numpy as np
+
     from astropy.units import NamedUnit, UnitBase
 
 
@@ -40,7 +42,9 @@ class Base:
         super().__init_subclass__(**kwargs)
 
     @classmethod
-    def format_exponential_notation(cls, val: float, format_spec: str = "g") -> str:
+    def format_exponential_notation(
+        cls, val: float | np.number, format_spec: str = "g"
+    ) -> str:
         """
         Formats a value in exponential notation.
 

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -25,8 +25,9 @@ from . import core, utils
 from .base import Base
 
 if TYPE_CHECKING:
-    from numbers import Real
     from typing import ClassVar, Literal
+
+    import numpy as np
 
     from astropy.extern.ply.lex import Lexer, LexToken
     from astropy.units import UnitBase
@@ -309,7 +310,9 @@ class CDS(Base):
                     raise ValueError("Syntax error")
 
     @classmethod
-    def format_exponential_notation(cls, val: Real, format_spec: str = ".8g") -> str:
+    def format_exponential_notation(
+        cls, val: float | np.number, format_spec: str = ".8g"
+    ) -> str:
         m, ex = utils.split_mantissa_exponent(val)
         parts = []
         if m not in ("", "1"):

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -66,6 +66,7 @@ class Console(base.Base):
         scale: str,
         numerator: str,
         denominator: str,
+        *,
         fraction: Literal[True, "inline", "multiline"] = "multiline",
     ) -> str:
         if fraction != "multiline":

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING
 from . import base, utils
 
 if TYPE_CHECKING:
-    from numbers import Real
     from typing import ClassVar, Literal
+
+    import numpy as np
 
     from astropy.units import UnitBase
 
@@ -48,7 +49,9 @@ class Console(base.Base):
         return f"^{number}"
 
     @classmethod
-    def format_exponential_notation(cls, val: Real, format_spec: str = ".8g") -> str:
+    def format_exponential_notation(
+        cls, val: float | np.number, format_spec: str = ".8g"
+    ) -> str:
         m, ex = utils.split_mantissa_exponent(val, format_spec)
 
         parts = []

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from numbers import Real
     from typing import TypeVar
 
+    import numpy as np
+
     from astropy.units import UnitBase
 
     T = TypeVar("T")
@@ -54,7 +56,9 @@ def get_grouped_by_powers(
     return positive, negative
 
 
-def split_mantissa_exponent(v: Real, format_spec: str = ".8g") -> tuple[str, str]:
+def split_mantissa_exponent(
+    v: float | np.number, format_spec: str = ".8g"
+) -> tuple[str, str]:
     """
     Given a number, split it into its mantissa and base 10 exponent
     parts, each as strings.  If the exponent is too small, it may be

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -131,6 +131,8 @@ py:class reference target not found: (k, v)
 py:class EllipsisType
 py:class ModuleType
 py:class Real
+# numpy
+py:class np.number
 # numpy.typing
 py:class NDArray
 # locally defined type variable for ndarray dtype


### PR DESCRIPTION
### Description

I am making three changes that are independent from each other, but small enough that reviewing them in a single pull request should not be a problem.

1. We have annotated class variables in most of the unit formatter classes, but we didn't do that in the `Base` class, so I'm doing it now.

2. All the unit formatter classes except `Console` required the `fraction` argument of their `_format_fraction()` method to be keyword-only. I am not aware of any good reasons why `Console` should be different. See also the thread starting with https://github.com/astropy/astropy/pull/16547#discussion_r1631591823 This inconsistency originates from the actual code, not from type annotations, but no human ever noticed it until `mypy` pointed it out (I'm sure other type checkers could have pointed it out too, I just happen to use `mypy` out of habit).

3. The type annotations of a handful of unit formatting functions allowed passing in `Fraction` instances, but that is incompatible with their default `format_spec` values, so a narrower type must be used. I chose to use `float | np.number`. An alternative would be to use `float`, which would be simpler at the cost of being less correct, but I thought that `float | np.number` is simple enough.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
