### PR TITLE
Simplify `_generate_unit_names()` methods in unit formatters

### DIFF
--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -23,11 +23,7 @@ class FITS(generic.Generic):
 
         # add some units up-front for which we don't want to use prefixes
         # and that have different names from the astropy default.
-        names = {
-            "Celsius": u.deg_C,
-            "deg C": u.deg_C,
-        }
-        deprecated_names = set()
+        names = {"Celsius": u.deg_C, "deg C": u.deg_C}
         bases = [
             "m", "g", "s", "rad", "sr", "K", "A", "mol", "cd",
             "Hz", "J", "W", "V", "N", "Pa", "C", "Ohm", "S",
@@ -49,14 +45,9 @@ class FITS(generic.Generic):
             "ct", "photon", "ph", "pixel", "pix", "D", "Sun", "chan",
             "bin", "voxel", "adu", "beam", "erg", "Angstrom", "angstrom",
         ]  # fmt: skip
-        deprecated_units = []
+        names.update((unit, getattr(u, unit)) for unit in simple_units)
 
-        for unit in simple_units + deprecated_units:
-            names[unit] = getattr(u, unit)
-        for unit in deprecated_units:
-            deprecated_names.add(unit)
-
-        return names, deprecated_names
+        return names, set()
 
     @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -56,7 +56,7 @@ class FITS(generic.Generic):
         for unit in deprecated_units:
             deprecated_names.add(unit)
 
-        return names, deprecated_names, []
+        return names, deprecated_names
 
     @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -17,8 +17,8 @@ class FITS(generic.Generic):
     Standard <https://fits.gsfc.nasa.gov/fits_standard.html>`_.
     """
 
-    @staticmethod
-    def _generate_unit_names():
+    @classmethod
+    def _generate_unit_names(cls):
         from astropy import units as u
 
         # add some units up-front for which we don't want to use prefixes

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -72,10 +72,6 @@ class Generic(Base):
         return cls._all_units[1]
 
     @classproperty(lazy=True)
-    def _functions(cls):
-        return cls._all_units[2]
-
-    @classproperty(lazy=True)
     def _lexer(cls):
         tokens = cls._tokens
 

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -48,8 +48,8 @@ class OGIP(generic.Generic):
         "UNIT",
     )
 
-    @staticmethod
-    def _generate_unit_names():
+    @classmethod
+    def _generate_unit_names(cls):
         from astropy import units as u
 
         deprecated_names = set()

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -63,7 +63,6 @@ class OGIP(generic.Generic):
     def _generate_unit_names(cls):
         from astropy import units as u
 
-        deprecated_names = set()
         bases = [
             "A", "C", "cd", "eV", "F", "g", "H", "Hz", "J",
             "Jy", "K", "lm", "lx", "m", "mol", "N", "ohm", "Pa",
@@ -84,22 +83,16 @@ class OGIP(generic.Generic):
             "h", "lyr", "mag", "min", "photon", "pixel",
             "voxel", "yr",
         ]  # fmt: skip
-        for unit in simple_units:
-            names[unit] = getattr(u, unit)
+        names.update((unit, getattr(u, unit)) for unit in simple_units)
 
         # Create a separate, disconnected unit for the special case of
         # Crab and mCrab, since OGIP doesn't define their quantities.
-        Crab = u.def_unit(["Crab"], prefixes=False, doc="Crab (X-ray flux)")
-        mCrab = u.Unit(10**-3 * Crab)
-        names["Crab"] = Crab
-        names["mCrab"] = mCrab
+        names["Crab"] = u.def_unit(["Crab"], prefixes=False, doc="Crab (X-ray flux)")
+        names["mCrab"] = u.Unit(10**-3 * names["Crab"])
 
-        deprecated_units = ["Crab", "mCrab"]
-        for unit in deprecated_units:
-            deprecated_names.add(unit)
         names.update((name, name) for name in cls._functions)
 
-        return names, deprecated_names
+        return names, {"Crab", "mCrab"}
 
     @classproperty(lazy=True)
     def _lexer(cls):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -16,14 +16,20 @@ FITS files
 <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`__.
 """
 
+from __future__ import annotations
+
 import copy
 import math
 import warnings
 from fractions import Fraction
+from typing import TYPE_CHECKING
 
 from astropy.utils import classproperty, parsing
 
 from . import core, generic, utils
+
+if TYPE_CHECKING:
+    from typing import ClassVar
 
 
 class OGIP(generic.Generic):
@@ -47,6 +53,11 @@ class OGIP(generic.Generic):
         "UNKNOWN",
         "UNIT",
     )
+
+    _functions: ClassVar[list[str]] = [
+        "log", "ln", "exp", "sqrt", "sin", "cos", "tan",
+        "asin", "acos", "atan", "sinh", "cosh", "tanh",
+    ]  # fmt: skip
 
     @classmethod
     def _generate_unit_names(cls):
@@ -86,14 +97,9 @@ class OGIP(generic.Generic):
         deprecated_units = ["Crab", "mCrab"]
         for unit in deprecated_units:
             deprecated_names.add(unit)
-        functions = [
-            "log", "ln", "exp", "sqrt", "sin", "cos", "tan", "asin",
-            "acos", "atan", "sinh", "cosh", "tanh",
-        ]  # fmt: skip
-        for name in functions:
-            names[name] = name
+        names.update((name, name) for name in cls._functions)
 
-        return names, deprecated_names, functions
+        return names, deprecated_names
 
     @classproperty(lazy=True)
     def _lexer(cls):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -23,8 +23,8 @@ class VOUnit(generic.Generic):
     _space = "."
     _scale_unit_separator = ""
 
-    @staticmethod
-    def _generate_unit_names():
+    @classmethod
+    def _generate_unit_names(cls):
         from astropy import units as u
         from astropy.units import required_by_vounit as uvo
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -63,7 +63,7 @@ class VOUnit(generic.Generic):
         do_defines(binary_bases, si_prefixes + binary_prefixes, ["dB", "dbyte"])
         do_defines(simple_units, [""])
 
-        return names, deprecated_names, []
+        return names, deprecated_names
 
     @classmethod
     def parse(cls, s, debug=False):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -48,9 +48,7 @@ class VOUnit(generic.Generic):
         # While zebi and yobi are part of the standard for binary prefixes,
         # they are not implemented here due to computation limitations
         binary_prefixes = ["Ki", "Mi", "Gi", "Ti", "Pi", "Ei"]
-        deprecated_units = {
-            "angstrom", "Angstrom", "Ba", "barn", "erg", "G", "ta",
-        }  # fmt: skip
+        deprecated_units = {"angstrom", "Angstrom", "Ba", "barn", "erg", "G", "ta"}
 
         def do_defines(bases, prefixes, skips=[]):
             for key, base in utils.get_non_keyword_units(bases, prefixes):


### PR DESCRIPTION
### Description

Currently the `Generic` unit formatter defines a `_functions` property, which is inherited by its three subclasses, but the only formatter that needs it is `OGIP`.

UPDATE

At first this pull request shortened the `_generate_unit_names()` methods only by updating the parts related to setting up the `_functions` property, but now a variety of other changes are also applied, which shorten and simplify the methods.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.