### PR TITLE
TST: enable weekly testing against CPython 3.13

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -60,6 +60,11 @@ jobs:
             python: '3.12'
             toxenv: py312-test-devinfra
 
+          - name: Python 3.13-dev with dev versions of key dependencies
+            os: ubuntu-latest
+            python: '3.13-dev'
+            toxenv: py313-test-devdeps
+
           - name: Python 3.12 on macOS (x86_64) with all optional dependencies
             os: macos-13
             python: '3.12'


### PR DESCRIPTION
### Description
Address the first item on #16595
Extracted from #16596

As discussed in https://github.com/astropy/astropy/pull/16596#discussion_r1649380905, the job currently fails (one test, or 20 variants of it, is failing), but a new beta is expected to drop sometimes next week so status may change soon.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
