### PR TITLE
UX: warn about any (broken) leftover references to closed memory map objects

### DIFF
--- a/docs/changes/io.fits/16581.bugfix.rst
+++ b/docs/changes/io.fits/16581.bugfix.rst
@@ -1,5 +1,5 @@
 Fixed a crash that occurred for files opened via
 ``fits.open(..., mode='update')``, on Windows, and with numpy 2.0 installed.
-It is possible, though unlikely, that this patch reveals memory issues
-for downstream code run under these exact conditions. Please report any
-regression found.
+A warning is now emitted in cases most likely to escalate into
+undefined behavior (e.g., segfaults), i.e., when a closed memory map object is
+still referenced by external code. Please report any regression found.


### PR DESCRIPTION
### Description
This is a follow up to #16581, suggested by @saimn in https://github.com/astropy/astropy/pull/16581/files#r1652506444

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
