### PR TITLE
DOC: Remove astropy-dev intersphinx (try 2)

### DIFF
--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -19,6 +19,6 @@ class ICRS(BaseRADecFrame):
     very close (within tens of milliarcseconds) to J2000 equatorial.
 
     For more background on the ICRS and related coordinate transformations, see
-    the references provided in the  :ref:`astropy:astropy-coordinates-seealso`
+    the references provided in the :ref:`astropy:astropy-coordinates-seealso`
     section of the documentation.
     """

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -121,21 +121,17 @@ class Parameter:
     This class represents a model's parameter (in a somewhat broad sense). It
     serves a number of purposes:
 
-    1) A type to be recognized by models and treated specially at class
+    #. A type to be recognized by models and treated specially at class
     initialization (i.e., if it is found that there is a class definition
     of a Parameter, the model initializer makes a copy at the instance level).
-
-    2) Managing the handling of allowable parameter values and once defined,
+    #. Managing the handling of allowable parameter values and once defined,
     ensuring updates are consistent with the Parameter definition. This
     includes the optional use of units and quantities as well as transforming
     values to an internally consistent representation (e.g., from degrees to
     radians through the use of getters and setters).
-
-    3) Holding attributes of parameters relevant to fitting, such as whether
+    #. Holding attributes of parameters relevant to fitting, such as whether
     the parameter may be varied in fitting, or whether there are constraints
     that must be satisfied.
-
-
 
     See :ref:`astropy:modeling-parameters` for more details.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,6 @@ del intersphinx_mapping["astropy"]
 # add any custom intersphinx for astropy
 intersphinx_mapping.update(
     {
-        "astropy-dev": ("https://docs.astropy.org/en/latest/", None),
         "pyerfa": ("https://pyerfa.readthedocs.io/en/stable/", None),
         "pytest": ("https://docs.pytest.org/en/stable/", None),
         "ipython": ("https://ipython.readthedocs.io/en/stable/", None),
@@ -385,29 +384,21 @@ def rstjinja(app, docname, source):
         source[0] = rendered
 
 
-def resolve_astropy_and_dev_reference(app, env, node, contnode):
+def resolve_astropy_reference(app, env, node, contnode):
     """
-    Reference targets for ``astropy:`` and ``astropy-dev:`` are special cases.
+    Reference targets for ``astropy:`` are special cases.
 
     Documentation links in astropy can be set up as intersphinx links so that
     affiliate packages do not have to override the docstrings when building
     the docs.
-
-    If we are building the development docs it is a local ref targeting the
-    label ``astropy-dev:<label>``, but for stable docs it should be an
-    intersphinx resolution to the development docs.
-
-    See https://github.com/astropy/astropy/issues/11366
     """
     # should the node be processed?
     reftarget = node.get("reftarget")  # str or None
     if str(reftarget).startswith("astropy:"):
         # This allows Astropy to use intersphinx links to itself and have
         # them resolve to local links. Downstream packages will see intersphinx.
-        # TODO! deprecate this if sphinx-doc/sphinx/issues/9169 is implemented.
+        # TODO: Remove this when https://github.com/sphinx-doc/sphinx/issues/9169 is implemented upstream.
         process, replace = True, "astropy:"
-    elif dev and str(reftarget).startswith("astropy-dev:"):
-        process, replace = True, "astropy-dev:"
     else:
         process, replace = False, ""
 
@@ -591,6 +582,6 @@ def setup(app):
     # Generate the page from Jinja template
     app.connect("source-read", rstjinja)
     # Set this to higher priority than intersphinx; this way when building
-    # dev docs astropy-dev: targets will go to the local docs instead of the
+    # docs astropy: targets will go to the local docs instead of the
     # intersphinx mapping
-    app.connect("missing-reference", resolve_astropy_and_dev_reference, priority=400)
+    app.connect("missing-reference", resolve_astropy_reference, priority=400)

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -68,7 +68,7 @@ the standard Astropy docstring format.
   When built in Astropy, links starting with 'astropy' resolve to the current
   build. In affiliate packages using ``sphinx-astropy``'s intersphinx mapping,
   the links resolve to the stable version of Astropy. For linking to the
-  development version, use the intersphinx target 'astropy-dev'.
+  development version, use direct URL linking.
 
 * Examples and/or tutorials are strongly encouraged for typical use-cases of a
   particular module or class.

--- a/docs/index_dev.rst
+++ b/docs/index_dev.rst
@@ -37,8 +37,7 @@ There are some additional tools, mostly of use for maintainers, in the
 
 {%else%}
 
-To read the developer documentation, you will need to go to the :ref:`latest
-developer version of the documentation
-<astropy-dev:developer-docs>`.
+To read the developer documentation, you will need to go to the
+`latest developer version of the documentation <https://docs.astropy.org/en/latest/index_dev.html>`_.
 
 {%endif%}

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,7 +56,7 @@ documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
 Alternatively, if you intend to do development on other software that uses
 ``astropy``, such as an affiliated package, consider installing ``astropy``
-into a :ref:`virtualenv <astropy-dev:virtual_envs>`.
+into a `virtualenv <https://docs.astropy.org/en/latest/development/workflow/virtual_pythons.html#virtual-envs>`_.
 
 Do **not** install ``astropy`` or other third-party packages using ``sudo``
 unless you are fully aware of the risks.
@@ -123,8 +123,7 @@ source code directory, or :ref:`running-tests` for more details.
 
 {%else%}
 
-See the :ref:`latest documentation on how to test your installed version of
-astropy <astropy-dev:testing_installed_astropy>`.
+See the `latest documentation on how to test your installed version of astropy <https://docs.astropy.org/en/latest/install.html#testing-an-installed-astropy>`_.
 
 {%endif%}
 
@@ -549,7 +548,6 @@ would like more control over the testing process.
 
 {%else%}
 
-See the :ref:`latest documentation on how to run the tests in a source
-checkout of astropy <astropy-dev:sourcebuildtest>`
+See the `latest documentation on how to run the tests in a source checkout of astropy <https://docs.astropy.org/en/latest/install.html#testing-a-source-code-build-of-astropy>`_.
 
 {%endif%}


### PR DESCRIPTION
### Blocked by

* https://github.com/astropy/astropy/pull/16561

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to remove `astropy-dev` intersphinx target added in https://github.com/astropy/astropy/pull/11622 because it causes failures in some doc changes that do not appear until PR is merged and also over-complicates the intersphinx linking situation for astropy.

I don't think this needs backporting.

Fixes https://github.com/astropy/astropy/issues/16531

Supersedes #16549

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
