### PR TITLE
Allow Unit.to to take and return dask arrays

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2684,19 +2684,17 @@ def _condition_arg(value):
     if isinstance(value, (np.ndarray, float, int, complex, np.void)):
         return value
 
-    if (
-        value.__class__.__module__ == "dask.array.core"
-        and value.__class__.__name__ == "Array"
-    ):
-        return value
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        value = np.array(value)
+        dtype = value.dtype
 
-    avalue = np.array(value)
-    if avalue.dtype.kind not in ["i", "f", "c"]:
+    if dtype.kind not in ["i", "f", "c"]:
         raise ValueError(
             "Value not scalar compatible or convertible to "
             "an int, float, or complex array"
         )
-    return avalue
+    return value
 
 
 def unit_scale_converter(val):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2684,6 +2684,12 @@ def _condition_arg(value):
     if isinstance(value, (np.ndarray, float, int, complex, np.void)):
         return value
 
+    if (
+        value.__class__.__module__ == "dask.array.core"
+        and value.__class__.__name__ == "Array"
+    ):
+        return value
+
     avalue = np.array(value)
     if avalue.dtype.kind not in ["i", "f", "c"]:
         raise ValueError(

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2689,7 +2689,7 @@ def _condition_arg(value):
         value = np.array(value)
         dtype = value.dtype
 
-    if dtype.kind not in ["i", "f", "c"]:
+    if dtype.kind not in "ifc":
         raise ValueError(
             "Value not scalar compatible or convertible to "
             "an int, float, or complex array"

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -983,3 +983,23 @@ def test_hash_represents_unit(unit, power):
     assert hash(tu) == hash(unit)
     tu2 = (unit ** (1 / power)) ** power
     assert hash(tu2) == hash(unit)
+
+
+def test_dask_arrays():
+    # Make sure that dask arrays can be passed in/out of Unit.to()
+
+    da = pytest.importorskip("dask.array")
+
+    data1 = da.from_array([1, 2, 3])
+
+    data2 = u.m.to(u.km, value=data1)
+
+    assert isinstance(data2, da.core.Array)
+
+    assert_allclose(data2.compute(), [0.001, 0.002, 0.003])
+
+    data3 = u.K.to(u.deg_C, value=data1, equivalencies=u.temperature())
+
+    assert isinstance(data3, da.core.Array)
+
+    assert_allclose(data3.compute(), [-272.15, -271.15, -270.15])

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -988,7 +988,6 @@ def test_hash_represents_unit(unit, power):
 
 @pytest.mark.skipif(not HAS_DASK, reason="tests dask.array")
 def test_dask_arrays():
-
     # Make sure that dask arrays can be passed in/out of Unit.to()
 
     from dask import array as da

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_allclose
 from astropy import constants as c
 from astropy import units as u
 from astropy.units import utils
+from astropy.utils.compat.optional_deps import HAS_DASK
 
 
 def test_initialisation():
@@ -985,10 +986,12 @@ def test_hash_represents_unit(unit, power):
     assert hash(tu2) == hash(unit)
 
 
+@pytest.mark.skipif(not HAS_DASK, reason="tests dask.array")
 def test_dask_arrays():
+
     # Make sure that dask arrays can be passed in/out of Unit.to()
 
-    da = pytest.importorskip("dask.array")
+    from dask import array as da
 
     data1 = da.from_array([1, 2, 3])
 

--- a/docs/changes/units/16613.api.rst
+++ b/docs/changes/units/16613.api.rst
@@ -1,0 +1,3 @@
+Conversion from one unit to another using ``old_unit.to(new_unit, value)`` no longer
+converts  ``value`` automatically to a numpy array, but passes through array duck types
+such as ``dask`` arrays, with equivalencies properly accounted for.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -121,6 +121,8 @@ value in ``Unit.to`` and have those arrays not be converted to Numpy arrays::
     >>> u.m.to(u.km, value=arr)
     dask.array<mul, shape=(10,), dtype=float64, chunksize=(10,), chunktype=numpy.ndarray>
 
+Note that it is not yet possible to use ``Quantity`` with dask arrays directly.
+
 Full change log
 ===============
 

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -113,7 +113,7 @@ Converting units on dask and other array-like objects
 It is now possible to pass in array-like objects such as dask arrays as the
 value in ``Unit.to`` and have those arrays not be converted to Numpy arrays::
 
-.. doctest-requires:: scipy
+.. doctest-requires:: dask
 
     >>> from dask import array as da
     >>> from astropy import units as u

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -17,6 +17,7 @@ In particular, this release includes:
 * :ref:`whatsnew_7_0_ecsv_meta_default_dict`
 * :ref:`whatsnew_7_0_contributor_doc_improvement`
 * :ref:`whatsnew_7_0_typing_stats`
+* :ref:`whatsnew_7_0_unit_conversion_array_like`
 
 In addition to these major changes, Astropy v7.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -103,6 +104,22 @@ Typing in astropy.stats
 
 The ``astropy.stats`` module is now fully typed. This is the first subpackage for
 which this the case.
+
+.. _whatsnew_7_0_unit_conversion_array_like:
+
+Converting units on dask and other array-like objects
+=====================================================
+
+It is now possible to pass in array-like objects such as dask arrays as the
+value in ``Unit.to`` and have those arrays not be converted to Numpy arrays::
+
+.. doctest-requires:: scipy
+
+    >>> from dask import array as da
+    >>> from astropy import units as u
+    >>> arr = da.arange(10)
+    >>> u.m.to(u.km, value=arr)
+    dask.array<mul, shape=(10,), dtype=float64, chunksize=(10,), chunktype=numpy.ndarray>
 
 Full change log
 ===============


### PR DESCRIPTION
Currently, passing dask arays to ``Unit.to`` works but returns a fully computed Numpy array:

```python
In [1]: from dask import array as da

In [2]: from astropy import units as u

In [3]: arr = da.random.random((128, 128))

In [4]: u.m.to(u.km, value=arr)
Out[4]: 
array([[8.69725975e-04, 4.21449273e-05, 2.80994213e-04, ...,
        9.26387720e-04, 9.92668553e-04, 6.58019135e-04],
       [4.65191904e-04, 4.84211322e-04, 3.77152599e-04, ...,
        5.25041228e-04, 8.79116310e-04, 5.87772793e-04],
       [5.39232545e-04, 5.68598748e-04, 6.74019409e-04, ...,
        4.39107884e-04, 5.11108538e-07, 5.31409098e-04],
       ...,
       [7.61933956e-04, 1.05132633e-04, 4.13602734e-04, ...,
        5.35902215e-04, 1.47536414e-05, 8.37497694e-04],
       [4.98088488e-04, 7.47539229e-04, 6.15754998e-04, ...,
        3.82088637e-04, 9.64737534e-04, 1.41038092e-04],
       [1.77515868e-04, 5.86372638e-04, 8.29504928e-04, ...,
        4.73694009e-04, 7.90443866e-04, 2.26563878e-04]])
```

With this PR, we do the "right thing" for dask arrays:

```python
In [1]: from dask import array as da
^[[A^[[A
In [2]: from astropy import units as u
^[[A
In [3]: arr = da.random.random((128, 128))

In [4]: u.m.to(u.km, value=arr)
Out[4]: dask.array<mul, shape=(128, 128), dtype=float64, chunksize=(128, 128), chunktype=numpy.ndarray>

In [5]: _.compute()
Out[5]: 
array([[5.55033000e-04, 1.30897501e-04, 5.21321289e-04, ...,
        1.59221712e-04, 5.03591860e-04, 2.58046299e-04],
       [1.57131779e-04, 4.20410973e-04, 7.51128593e-05, ...,
        6.33343495e-04, 6.66640889e-04, 5.13441092e-05],
       [5.51321745e-04, 4.88596558e-05, 1.66773257e-05, ...,
        3.37993400e-04, 3.28277017e-04, 9.52086320e-04],
       ...,
       [4.10671453e-04, 2.96688911e-04, 7.43569334e-04, ...,
        7.39290847e-04, 1.04082881e-05, 1.79362444e-04],
       [8.63774205e-04, 7.30536514e-04, 7.51621180e-04, ...,
        1.06043161e-04, 3.89517705e-04, 3.34328878e-04],
       [7.37070988e-04, 4.68716634e-04, 5.20774814e-04, ...,
        1.06913936e-04, 3.91570254e-04, 2.37304481e-04]])

```

I'm putting this up for discussion in particular with @nstarman and @mhvk as this provides a 'quick win' for supporting dask arrays with ``astropy.units`` before any kind of ``Quantity`` work.

This does break API for any users who were previously passing in dask arrays, but (a) I don't think there are many users using ``unit.to(..., value=...)`` as the main API is to use ``Quantity``, and (b) the new behavior in this PR is much more in line with what a dask user would expect.

I can add a changelog entry and more tests if people are generally on board with this.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
