### PR TITLE
Add an announcement banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -246,6 +246,7 @@ html_theme_options.update(
         },
         # https://github.com/pydata/pydata-sphinx-theme/issues/1492
         "navigation_with_keys": False,
+        "announcement": "https://www.astropy.org/annoucement_banner.html",
     }
 )
 


### PR DESCRIPTION
As part of https://github.com/astropy/astropy-project/issues/431 this is a starter for an annoucement banner.

As is mentioned in their docs: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#insert-remote-html-with-javascript we might want to make this include a html file on the root astropy.org so that we can remove it without having to rebuild all the documentation.

I am opening this now so people can see what it will look like.