### PR TITLE
Refactor unit formatter `to_string()` workings

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -299,7 +299,7 @@ class CDS(Generic):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
+        cls, unit: UnitBase, fraction: bool | Literal["inline"] = False
     ) -> str:
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from astropy.utils import classproperty
+
 from . import base
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import ClassVar, Literal
 
     from astropy.units import UnitBase
@@ -37,24 +40,20 @@ class Console(base.Base):
     _line: ClassVar[str] = "-"
     _space: ClassVar[str] = " "
 
+    @classproperty(lazy=True)
+    def _fraction_formatters(cls) -> dict[bool | str, Callable[[str, str, str], str]]:
+        return super()._fraction_formatters | {
+            "multiline": cls._format_multiline_fraction
+        }
+
     @classmethod
     def _format_superscript(cls, number: str) -> str:
         return f"^{number}"
 
     @classmethod
-    def _format_fraction(
-        cls,
-        scale: str,
-        numerator: str,
-        denominator: str,
-        *,
-        fraction: Literal[True, "inline", "multiline"] = "multiline",
+    def _format_multiline_fraction(
+        cls, scale: str, numerator: str, denominator: str
     ) -> str:
-        if fraction != "multiline":
-            return super()._format_fraction(
-                scale, numerator, denominator, fraction=fraction
-            )
-
         fraclength = max(len(numerator), len(denominator))
         f = f"{{0:<{len(scale)}s}}{{1:^{fraclength}s}}"
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -57,19 +57,9 @@ class Latex(console.Console):
         return name
 
     @classmethod
-    def _format_fraction(
-        cls,
-        scale: str,
-        numerator: str,
-        denominator: str,
-        *,
-        fraction: Literal[True, "inline", "multiline"] = "multiline",
+    def _format_multiline_fraction(
+        cls, scale: str, numerator: str, denominator: str
     ) -> str:
-        if fraction != "multiline":
-            return super()._format_fraction(
-                scale, numerator, denominator, fraction=fraction
-            )
-
         return rf"{scale}\frac{{{numerator}}}{{{denominator}}}"
 
     @classmethod

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -13,45 +13,9 @@ from astropy.units.utils import maybe_simple_fraction
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Sequence
-    from typing import TypeVar
 
     from astropy.units import UnitBase
     from astropy.units.typing import Real
-
-    T = TypeVar("T")
-
-
-def get_grouped_by_powers(
-    bases: Sequence[T], powers: Sequence[int]
-) -> tuple[list[tuple[T, int]], list[tuple[T, int]]]:
-    """
-    Groups the powers and bases in the given
-    `~astropy.units.CompositeUnit` into positive powers and
-    negative powers for easy display on either side of a solidus.
-
-    Parameters
-    ----------
-    bases : list of `astropy.units.UnitBase` instances
-
-    powers : list of int
-
-    Returns
-    -------
-    positives, negatives : list of tuple of |Unit| and power
-       Each element in each list is tuple of the form (*base*,
-       *power*).  The negatives have the sign of their power reversed
-       (i.e. the powers are all positive).
-    """
-    positive = []
-    negative = []
-    for base, power in zip(bases, powers):
-        if power < 0:
-            negative.append((base, -power))
-        elif power > 0:
-            positive.append((base, power))
-        else:
-            raise ValueError("Unit with 0 power")
-    return positive, negative
 
 
 def decompose_to_known_units(

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -171,13 +171,9 @@ class VOUnit(generic.Generic):
         return super().format_exponential_notation(val, format_spec)
 
     @classmethod
-    def _format_fraction(cls, scale, numerator, denominator, *, fraction="inline"):
-        if not (fraction is True or fraction == "inline"):
-            raise ValueError(
-                "format {cls.name!r} only supports inline fractions,"
-                f"not fraction={fraction!r}."
-            )
-
+    def _format_inline_fraction(
+        cls, scale: str, numerator: str, denominator: str
+    ) -> str:
         if cls._space in denominator:
             denominator = f"({denominator})"
         if scale and numerator == "1":

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -569,17 +569,26 @@ def test_format_styles_non_default_fraction(format_spec, fraction, string, decom
 @pytest.mark.parametrize("format_spec", ["generic", "cds", "fits", "ogip", "vounit"])
 def test_no_multiline_fraction(format_spec):
     fluxunit = u.W / u.m**2
-    with pytest.raises(ValueError, match="only supports.*not fraction='multiline'"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"^'{format_spec}' format only supports 'inline' fractions, "
+            r"not fraction='multiline'\.$"
+        ),
+    ):
         fluxunit.to_string(format_spec, fraction="multiline")
 
 
-@pytest.mark.parametrize(
-    "format_spec",
-    ["generic", "cds", "fits", "ogip", "vounit", "latex", "console", "unicode"],
-)
+@pytest.mark.parametrize("format_spec", ["latex", "console", "unicode"])
 def test_unknown_fraction_style(format_spec):
     fluxunit = u.W / u.m**2
-    with pytest.raises(ValueError, match="only supports.*parrot"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"^'{format_spec}' format only supports 'inline' or 'multiline' fractions, "
+            r"not fraction='parrot'\.$"
+        ),
+    ):
         fluxunit.to_string(format_spec, fraction="parrot")
 
 


### PR DESCRIPTION
Currently `Base.to_string()` converts units to strings if there are no fractions to worry about and calls `cls._format_fraction()` to handle inline and optionally multiline fractions if needed. The updated code splits the previous `_format_fraction()` methods to `_format_inline_fraction()` and `_format_multiline_fraction()` methods and has `to_string()` decide which to call (if needed) based on the `fraction` argument and the new `_fraction_formatters` class property. The keys of the dictionary that the property returns are also used for creating the error message if an invalid `fraction` value is specified. The updates to the tests demonstrate that the current error messages can be misleading.

Because I was rewriting `Base.to_string()` anyways I also inlined `units.format.utils.get_grouped_by_powers()`, so the fourth commit closes #16424 (either we speed up the code now or we conclude that it's fast enough already).
 
- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
