### PR TITLE
Draft: Replace usage of hashlib.md5 with hashlib.sha256 for FIPS compliance

### DIFF
--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -23,7 +23,7 @@ from astropy.io.votable import exceptions, table, xmlutil
 class Result:
     def __init__(self, url, root="results", timeout=10):
         self.url = url
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(url)
         self._hash = m.hexdigest()
         self._root = root

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -952,7 +952,7 @@ def get_pkg_data_fileobjs(datadir, package=None, pattern="*", encoding=None):
 
 
 def compute_hash(localfn):
-    """Computes the MD5 hash for a file.
+    """Computes the SHA256 hash for a file.
 
     The hash for a data file is used for looking up data files in a unique
     fashion. This is of particular use for tests; a test may require a
@@ -977,7 +977,7 @@ def compute_hash(localfn):
         ``localfn`` file.
     """
     with open(localfn, "rb") as f:
-        h = hashlib.md5()
+        h = hashlib.sha256()
         block = f.read(conf.compute_hash_block_size)
         while block:
             h.update(block)
@@ -1854,7 +1854,7 @@ def clear_download_cache(hashorurl=None, pkgname="astropy"):
                 filepath = os.path.join(dldir, d)
             if os.path.exists(filepath):
                 _rmtree(filepath)
-            elif len(hashorurl) == 2 * hashlib.md5().digest_size and re.match(
+            elif len(hashorurl) == 2 * hashlib.sha256().digest_size and re.match(
                 r"[0-9a-f]+", hashorurl
             ):
                 # It's the hash of some file contents, we have to find the right file
@@ -1914,7 +1914,7 @@ def _url_to_dirname(url):
     if urlobj[0].lower() in ["http", "https"] and urlobj[1] and urlobj[2] == "":
         urlobj[2] = "/"
     url_c = urllib.parse.urlunsplit(urlobj)
-    return hashlib.md5(url_c.encode("utf-8")).hexdigest()
+    return hashlib.sha256(url_c.encode("utf-8")).hexdigest()
 
 
 class ReadOnlyDict(dict):

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1025,7 +1025,7 @@ def test_compute_hash(tmp_path):
         ntf.flush()
 
     chhash = compute_hash(filename)
-    shash = hashlib.md5(rands).hexdigest()
+    shash = hashlib.sha256(rands).hexdigest()
 
     assert chhash == shash
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address FIPS compliance in astropy. The main culprit violating FIPS is the usage of `hashlib.md5`, as md5 hashing is disallowed by FIPS. See the mention of FIPS in the [python hashlib docs](https://docs.python.org/3/library/hashlib.html).

While FIPS compliance is a non-issue for everyday users it is required by most US government agencies; this limits astropy's usefulness in those environments.

To reproduce a FIPS-related error:
1. Install a Linux OS with FIPS compliance. I used AlmaLinux 9, then enabled FIPS with `sudo  fips-mode-setup --enable`
2. Run the `plot_obs-planning.py` example.
3. Observe the exception:
```
File "/home/bryan/.local/lib/python3.9/site-packages/astropy/utils/data.py", line 1917, in _url_to_dirname
    return hashlib.md5(url_c.encode("utf-8")).hexdigest()
ValueError: [digital envelope routines] unsupported
```

This PR addresses this by replacing instances of hashlib.md5 with hashlib.sha256, which is allowed by FIPS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->
