### PR TITLE
CLN: cleanup `Model.n_inputs` and `Model.n_outputs` properties

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -665,11 +665,6 @@ class Model(metaclass=_ModelMeta):
     in the class body.
     """
 
-    n_inputs = 0
-    """The number of inputs."""
-    n_outputs = 0
-    """ The number of outputs."""
-
     standard_broadcasting = True
     fittable = False
     linear = True
@@ -807,40 +802,14 @@ class Model(metaclass=_ModelMeta):
         self._outputs = val
 
     @property
-    def n_inputs(self):
+    def n_inputs(self) -> int:
         """The number of inputs."""
-        # TODO: remove the code in the ``if`` block when support
-        # for models with ``inputs`` as class variables is removed.
-        if hasattr(self.__class__, "n_inputs") and isinstance(
-            self.__class__.n_inputs, property
-        ):
-            try:
-                return len(self.__class__.inputs)
-            except TypeError:
-                try:
-                    return len(self.inputs)
-                except AttributeError:
-                    return 0
-
-        return self.__class__.n_inputs
+        return len(getattr(self, "inputs", ()))
 
     @property
-    def n_outputs(self):
+    def n_outputs(self) -> int:
         """The number of outputs."""
-        # TODO: remove the code in the ``if`` block when support
-        # for models with ``outputs`` as class variables is removed.
-        if hasattr(self.__class__, "n_outputs") and isinstance(
-            self.__class__.n_outputs, property
-        ):
-            try:
-                return len(self.__class__.outputs)
-            except TypeError:
-                try:
-                    return len(self.outputs)
-                except AttributeError:
-                    return 0
-
-        return self.__class__.n_outputs
+        return len(getattr(self, "outputs", ()))
 
     def _calculate_separability_matrix(self):
         """

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -371,7 +371,7 @@ def test_custom_inverse_reset():
 
     class TestModel(Model):
         n_inputs = 0
-        outputs = ("y",)
+        _outputs = ("y",)
 
         @property
         def inverse(self):

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -1048,7 +1048,7 @@ class TInputFormatter(Model):
 
     n_inputs = 2
     n_outputs = 2
-    outputs = ("x", "y")
+    _outputs = ("x", "y")
 
     @staticmethod
     def evaluate(x, y):

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -40,7 +40,7 @@ class TParModel(Model):
 
     # standard_broadasting = False
     n_inputs = 1
-    outputs = ("x",)
+    _outputs = ("x",)
     coeff = Parameter()
     e = Parameter()
 


### PR DESCRIPTION
### Description
This is a follow up to #9298, and cleans up code that was introduced in 4.0 to mitigate a deprecation that was concluded in 5.0

For context, I discovered this while working on #16630, from which this is extracted.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
