### PR TITLE
Fix treatment of 'BLANK' and `ignore_blank` for uncompressed integer images

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -374,7 +374,7 @@ class _BaseHDU:
     def writeto(self, name, output_verify="exception", overwrite=False, checksum=False):
         """
         Write the HDU to a new file. This is a convenience method to
-        provide a user easier output interface if only one HDU needs
+        provide a user friendly output interface if only one HDU needs
         to be written to a file.
 
         Parameters
@@ -1600,9 +1600,8 @@ class ExtensionHDU(_ValidHDU):
 
     def writeto(self, name, output_verify="exception", overwrite=False, checksum=False):
         """
-        Works similarly to the normal writeto(), but prepends a default
-        `PrimaryHDU` are required by extension HDUs (which cannot stand on
-        their own).
+        Works similarly to :func:`PrimaryHDU.writeto`, but prepends a default
+        `PrimaryHDU` as required by extension HDUs (which cannot be written on their own).
         """
         from .hdulist import HDUList
         from .image import PrimaryHDU

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1100,8 +1100,9 @@ class PrimaryHDU(_ImageBaseHDU):
 
         ignore_blank : bool, optional
             If `True`, the BLANK header keyword will be ignored if present.
-            Otherwise, pixels equal to this value will be replaced with
-            NaNs. (default: False)
+            Otherwise, integer data will be converted to float and pixels
+            originally equal to this value will be replaced with NaNs.
+            (default: False)
 
         uint : bool, optional
             Interpret signed integer data where ``BZERO`` is the
@@ -1186,6 +1187,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         name=None,
         do_not_scale_image_data=False,
         uint=True,
+        ignore_blank=False,
         scale_back=None,
         ver=None,
     ):
@@ -1208,6 +1210,12 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         do_not_scale_image_data : bool, optional
             If `True`, image data is not scaled using BSCALE/BZERO values
             when read. (default: False)
+
+        ignore_blank : bool, optional
+            If `True`, the BLANK header keyword will be ignored if present.
+            Otherwise, integer data will be converted to float and pixels
+            originally equal to this value will be replaced with NaNs.
+            (default: False)
 
         uint : bool, optional
             Interpret signed integer data where ``BZERO`` is the
@@ -1240,6 +1248,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
             name=name,
             do_not_scale_image_data=do_not_scale_image_data,
             uint=uint,
+            ignore_blank=ignore_blank,
             scale_back=scale_back,
             ver=ver,
         )

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -779,9 +779,9 @@ class _ImageBaseHDU(_ValidHDU):
         Handle "pseudo-unsigned" integers, if the user requested it.  Returns
         the converted data array if so; otherwise returns None.
 
-        In this case case, we don't need to handle BLANK to convert it to NAN,
-        since we can't do NaNs with integers, anyway, i.e. the user is
-        responsible for managing blanks.
+        Handling of BLANK is done outside of this function on the converted
+        uint data, meaning that BLANK needs to be shifted by BZERO as well
+        before conversion of the corresponding values to NaN.
         """
         dtype = self._dtype_for_bitpix()
         # bool(dtype) is always False--have to explicitly compare to None; this

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -827,6 +827,11 @@ class _ImageBaseHDU(_ValidHDU):
         data = None
         if not (self._orig_bzero == 0 and self._orig_bscale == 1):
             data = self._convert_pseudo_integer(raw_data)
+            if not (self._blank is None or data is None or data.dtype.kind != "u"):
+                raw_data = data
+                data = None
+                self._uint = False  # Reset this to enable conversion to float
+                self._blank += self._orig_bzero  # Same scaling to uint as for data
 
         if data is None:
             # In these cases, we end up with floating-point arrays and have to

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -757,23 +757,23 @@ class TestImageFunctions(FitsTestCase):
     @pytest.mark.parametrize(("ignore_blank"), (False, True))
     def test_blanks(self, ext, ignore_blank):
         """Test image data with blank spots in it (which should show up as
-        NaNs in the data array, unless 'ignore_blank' is set).
+        NaNs in the data array, unless ignore_blank is set to True).
         """
 
         arr = np.zeros((10, 10), dtype=np.int32)
         # One row will be blanks
-        arr[1] = 999
+        arr[1] = 99999
 
         if ext == 0:
             hdu = fits.PrimaryHDU(data=arr)
         else:
             hdu = fits.ImageHDU(data=arr)
-        hdu.header["BLANK"] = 999
+        hdu.header["BLANK"] = 99999
         hdu.writeto(self.temp("test_blank.fits"))
 
         with fits.open(self.temp("test_blank.fits"), ignore_blank=ignore_blank) as hdul:
             if ignore_blank:
-                assert hdul[ext].data.dtype == '>i4'
+                assert hdul[ext].data.dtype == ">i4"
                 assert (hdul[ext].data[1] == hdu.header["BLANK"]).all()
             else:
                 assert hdul[ext].data.dtype == np.float64
@@ -783,7 +783,7 @@ class TestImageFunctions(FitsTestCase):
     @pytest.mark.parametrize(("ignore_blank"), (False, True))
     def test_uint_blanks(self, ext, ignore_blank):
         """Test uint image data with blank spots in it (should be controlled
-        by 'ignore_blank' in the same way as for unscaled integers).
+        by ignore_blank in the same way as for unscaled integers).
         """
 
         arr = np.arange(100, dtype=np.uint16).reshape((10, 10))

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -753,20 +753,60 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp(filename)) as hdul:
             assert (hdul[0].data == 0).all()
 
-    def test_blanks(self):
+    @pytest.mark.parametrize(("ext"), (0, 1))
+    @pytest.mark.parametrize(("ignore_blank"), (False, True))
+    def test_blanks(self, ext, ignore_blank):
         """Test image data with blank spots in it (which should show up as
-        NaNs in the data array.
+        NaNs in the data array, unless 'ignore_blank' is set).
         """
 
         arr = np.zeros((10, 10), dtype=np.int32)
         # One row will be blanks
         arr[1] = 999
-        hdu = fits.ImageHDU(data=arr)
-        hdu.header["BLANK"] = 999
-        hdu.writeto(self.temp("test_new.fits"))
 
-        with fits.open(self.temp("test_new.fits")) as hdul:
-            assert np.isnan(hdul[1].data[1]).all()
+        if ext == 0:
+            hdu = fits.PrimaryHDU(data=arr)
+        else:
+            hdu = fits.ImageHDU(data=arr)
+        hdu.header["BLANK"] = 999
+        hdu.writeto(self.temp("test_blank.fits"))
+
+        with fits.open(self.temp("test_blank.fits"), ignore_blank=ignore_blank) as hdul:
+            if ignore_blank:
+                assert hdul[ext].data.dtype == '>i4'
+                assert (hdul[ext].data[1] == hdu.header["BLANK"]).all()
+            else:
+                assert hdul[ext].data.dtype == np.float64
+                assert np.isnan(hdul[ext].data[1]).all()
+
+    @pytest.mark.parametrize(("ext"), (0, 1))
+    @pytest.mark.parametrize(("ignore_blank"), (False, True))
+    def test_uint_blanks(self, ext, ignore_blank):
+        """Test uint image data with blank spots in it (should be controlled
+        by 'ignore_blank' in the same way as for unscaled integers).
+        """
+
+        arr = np.arange(100, dtype=np.uint16).reshape((10, 10))
+        # One row will be blanks - set to a value outside of the internal '>i2' range
+        # to test that BZERO offset is correctly added in.
+        blank = 65535
+        arr[-1] = blank
+
+        if ext == 0:
+            hdu = fits.PrimaryHDU(data=arr)
+        else:
+            hdu = fits.ImageHDU(data=arr)
+        hdu.header["BLANK"] = blank - hdu.header["BZERO"]
+        hdu.writeto(self.temp("test_blank.fits"))
+
+        with fits.open(self.temp("test_blank.fits"), ignore_blank=ignore_blank) as hdul:
+            if ignore_blank:
+                assert hdul[ext].data.dtype == np.uint16
+                assert hdul[ext].data.min() == 0
+                assert (hdul[ext].data[-1] == blank).all()
+            else:
+                assert hdul[ext].data.dtype == np.float32
+                assert np.isnan(hdul[ext].data[-1]).all()
 
     def test_invalid_blanks(self):
         """

--- a/docs/changes/io.fits/16636.bugfix.rst
+++ b/docs/changes/io.fits/16636.bugfix.rst
@@ -1,0 +1,4 @@
+Fix handling of ``ignore_blank`` keyword for uncompressed integer data.
+Set to True, will keep original integer data with 'BLANK' values,
+to False, convert to float with NaNs, for both signed and unsigned
+integers, and primary as well as extension HDUs.


### PR DESCRIPTION
### Description
Discussion of appropriate treatment of `BLANK` values in compressed image HDUs in #16550  revealed that in the _uncompressed_ case integer data with the `'BLANK'` keyword present are not handled consistently either, being converted to `float` with the invalid pixels set to `NaN` for signed integers, but left unmodified in the case of (unsigned) "scaled" integers. On updating the tests I also found that in the former case, the `ignore_blank=True` parameter setting for leaving the integer data unmodified is only honoured for `PrimaryHDU`, but silently ignored for images in an `ExtensionHDU`. I could not find any rationale for this other than `ImageHDU` having been missed when this kwarg was introduced in #2307.
There was [one suggestion](https://github.com/astropy/astropy/pull/993#issuecomment-136511510) that these operations should be set on a per-HDU basis, but since the arguments are passed at the `fits.open` level, this would be non-straightforward to implement.

This PR therefore leaves all integer-type HDU data unmodified for `ignore_blank=True`, and converts them to float otherwise, if a valid 'BLANK' is set in the header (as per the documentation, and as implemented for compressed HDUs in #16550).

Addresses #7789 insofar as conversion can now be reliably avoided with `ignore_blank`.
Should be reviewed and pulled in as appropriate before merging #15474 to ensure that blank treatment stays consistent in `CompImageHDU` as well (which does not have an `ignore_blank` option yet / in 6.1.x).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
