### PR TITLE
BUG: declare `np.unstack` as subclass-safe (fix incompatibility with NumPy 2.1)

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -47,7 +47,12 @@ from astropy.units.core import (
     dimensionless_unscaled,
 )
 from astropy.utils import isiterable
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_24, NUMPY_LT_2_0
+from astropy.utils.compat import (
+    COPY_IF_NEEDED,
+    NUMPY_LT_1_24,
+    NUMPY_LT_2_0,
+    NUMPY_LT_2_1,
+)
 
 if NUMPY_LT_2_0:
     import numpy.core as np_core
@@ -109,7 +114,7 @@ if NUMPY_LT_2_0:
         np.product,  # noqa: NPY003, NPY201
         np.cumproduct,  # noqa: NPY003, NPY201
     }
-else:
+if not NUMPY_LT_2_0:
     # Array-API compatible versions (matrix axes always at end).
     SUBCLASS_SAFE_FUNCTIONS |= {
         np.matrix_transpose, np.linalg.matrix_transpose,
@@ -127,6 +132,8 @@ else:
 
     # trapz was renamed to trapezoid
     SUBCLASS_SAFE_FUNCTIONS |= {np.trapezoid}
+if not NUMPY_LT_2_1:
+    SUBCLASS_SAFE_FUNCTIONS |= {np.unstack}
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -25,6 +25,7 @@ from astropy.utils.compat import (
     NUMPY_LT_1_24,
     NUMPY_LT_1_25,
     NUMPY_LT_2_0,
+    NUMPY_LT_2_1,
 )
 
 if TYPE_CHECKING:
@@ -645,6 +646,10 @@ class TestSplit:
 
     def test_dsplit(self):
         self.check(np.dsplit, [1])
+
+    @pytest.mark.skipif(NUMPY_LT_2_1, reason="np.unstack is new in Numpy 2.1")
+    def test_unstack(self):
+        self.check(np.unstack)
 
 
 class TestUfuncReductions(InvariantUnitTestSetup):

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -15,7 +15,7 @@ import warnings
 import numpy as np
 
 from astropy.units.quantity_helper.function_helpers import FunctionAssigner
-from astropy.utils.compat import NUMPY_LT_1_24, NUMPY_LT_2_0
+from astropy.utils.compat import NUMPY_LT_1_24, NUMPY_LT_2_0, NUMPY_LT_2_1
 
 if NUMPY_LT_2_0:
     import numpy.core as np_core
@@ -141,13 +141,16 @@ if NUMPY_LT_2_0:
     MASKED_SAFE_FUNCTIONS |= {np.row_stack}  # noqa: NPY201
     # renamed in numpy 2.0
     MASKED_SAFE_FUNCTIONS |= {np.trapz}
-else:
+if not NUMPY_LT_2_0:
     # new in numpy 2.0
     MASKED_SAFE_FUNCTIONS |= {
         np.astype, np.trapezoid,
         np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
     }  # fmt: skip
-
+if not NUMPY_LT_2_1:
+    MASKED_SAFE_FUNCTIONS |= {
+        np.unstack,
+    }  # fmt: skip
 IGNORED_FUNCTIONS = {
     # I/O - useless for Masked, since no way to store the mask.
     np.save, np.savez, np.savetxt, np.savez_compressed,

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -606,6 +606,10 @@ class TestSplit:
     def test_dsplit(self):
         self.check(np.dsplit, [1])
 
+    @pytest.mark.skipif(NUMPY_LT_2_1, reason="np.unstack is new in Numpy 2.1")
+    def test_unstack(self):
+        self.check(np.unstack)
+
 
 class TestMethodLikes(MaskedArraySetup):
     def check(self, function, *args, method=None, **kwargs):

--- a/docs/changes/units/16640.bugfix.rst
+++ b/docs/changes/units/16640.bugfix.rst
@@ -1,0 +1,2 @@
+Declare ``np.unstack`` as subclass-safe (fix incompatibility between
+``Quantity`` and NumPy 2.1).

--- a/docs/changes/utils/16640.bugfix.rst
+++ b/docs/changes/utils/16640.bugfix.rst
@@ -1,0 +1,2 @@
+Declare ``np.unstack`` as subclass-safe (fix incompatibility between ``Masked``
+and NumPy 2.1).


### PR DESCRIPTION
### Description
Fixes an incoming incompatibility ([example logs](https://github.com/astropy/astropy/actions/runs/9730358857/job/26853352422))
xref: https://github.com/numpy/numpy/pull/26579

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
