### PR TITLE
TST: fix a test for compatibility with Python 3.13

### DIFF
--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -6,7 +6,6 @@ Tests models.parameters
 
 import functools
 import itertools
-import sys
 import unittest.mock as mk
 
 import numpy as np
@@ -755,14 +754,6 @@ class TestParameters:
         param._internal_value = 4
         assert param._raw_value == 4
 
-    @pytest.mark.xfail(
-        sys.version_info >= (3, 13),
-        reason=(
-            "this test is known-broken in Python 3.13.0rc1 "
-            "and we don't want it to start passing silently. "
-            "Reference https://github.com/astropy/astropy/pull/16659"
-        ),
-    )
     def test__create_value_wrapper(self):
         param = Parameter(name="test", default=[1, 2, 3, 4])
 
@@ -800,10 +791,12 @@ class TestParameters:
         # model is not None
         param._model_required = False
         model = mk.MagicMock()
-        with mk.patch.object(functools, "partial", autospec=True) as mkPartial:
-            assert (
-                param._create_value_wrapper(wrapper2, model) == mkPartial.return_value
-            )
+        partial_wrapper = param._create_value_wrapper(wrapper2, model)
+        assert isinstance(partial_wrapper, functools.partial)
+        assert partial_wrapper.func is wrapper2
+        assert partial_wrapper.args == ()
+        assert list(partial_wrapper.keywords.keys()) == ["b"]
+        assert partial_wrapper.keywords["b"] is model
 
         # wrapper with more than 2 arguments
         def wrapper3(a, b, c):


### PR DESCRIPTION
### Description
This pull request is to address the only known incompatibility with Python 3.13 in our test suite (see #16600)
xref upstream issue: https://github.com/python/cpython/issues/121257 (in particular https://github.com/python/cpython/issues/121257#issuecomment-2202716988)

The problematic (long) test was introduced in a large PR (#12232) so I can only guess that mocking was used only as a convenience and expanding the assertion is really equivalent (just more verbose and incidentally, more reliable).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
