### PR TITLE
Tidy up a few unit formatter tests

### DIFF
--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -41,7 +41,6 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 )
 def test_unit_grammar(strings, unit):
     for s in strings:
-        print(s)
         unit2 = u_format.Generic.parse(s)
         assert unit2 == unit
 
@@ -51,7 +50,6 @@ def test_unit_grammar(strings, unit):
 )
 def test_unit_grammar_fail(string):
     with pytest.raises(ValueError):
-        print(string)
         u_format.Generic.parse(string)
 
 
@@ -100,7 +98,6 @@ def test_unit_grammar_fail(string):
 )
 def test_cds_grammar(strings, unit):
     for s in strings:
-        print(s)
         unit2 = u_format.CDS.parse(s)
         assert unit2 == unit
 
@@ -134,7 +131,6 @@ def test_cds_grammar(strings, unit):
 )
 def test_cds_grammar_fail(string):
     with pytest.raises(ValueError):
-        print(string)
         u_format.CDS.parse(string)
 
 
@@ -221,7 +217,6 @@ def test_cds_log10_dimensionless():
 )
 def test_ogip_grammar(strings, unit):
     for s in strings:
-        print(s)
         unit2 = u_format.OGIP.parse(s)
         assert unit2 == unit
 
@@ -239,7 +234,6 @@ def test_ogip_grammar(strings, unit):
 )
 def test_ogip_grammar_fail(string):
     with pytest.raises(ValueError):
-        print(string)
         u_format.OGIP.parse(string)
 
 
@@ -650,7 +644,6 @@ def test_deprecated_did_you_mean_units():
 def test_fits_function(string):
     # Function units cannot be written, so ensure they're not parsed either.
     with pytest.raises(ValueError):
-        print(string)
         u_format.FITS().parse(string)
 
 


### PR DESCRIPTION
### Description

I'm starting to tidy up the unit formatter tests. The first commit removes useless `print()` calls which don't add anything useful to the tracebacks `pytest` would produce. The second replaces `for`-loops within a few tests with better parametrization. This is an improvement because a failure of one parametrized test does not prevent others from running, and it is much simpler to assign good ids to tests without `for`-loops. I introduced a `NamedTuple` to store the parameters for these tests. By implementing a small helper function I was even able to avoid changing the indentation levels in the parametrizations despite that.

If the maintainers think it's reasonable then I can continue pushing more commits to this pull request, or they can merge this one and I can open new pull requests for the next changes.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
