### PR TITLE
Fixed a WCSAxes bug when overlaying a frame with default units that are not degrees

### DIFF
--- a/astropy/tests/figures/py310-test-image-mpl360-cov.json
+++ b/astropy/tests/figures/py310-test-image-mpl360-cov.json
@@ -48,6 +48,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices1-hplt]": "0a14e5153eb91e2a3a96501f02a21581effc7d6b7ae31e29a402a3abf30d5b12",
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "8908818b526d4a506505da890eff47121b23ee41656dc15dff3e19f7d03094af",
   "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "9d91bcf571af6dcc1425b6dfd76fb92e3e0180fb9fd0c852f9eba3fb06e079fc",
+  "astropy.visualization.wcsaxes.tests.test_images.test_overlay_nondegree_unit": "aa9b85520da54dc61d4db2988883ff184fb59cd27c52a04899cb33599fcab4b7",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/tests/figures/py310-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py310-test-image-mpldev-cov.json
@@ -48,6 +48,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_put_varying_axis_on_bottom_lon[slices1-hplt]": "0a14e5153eb91e2a3a96501f02a21581effc7d6b7ae31e29a402a3abf30d5b12",
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "8908818b526d4a506505da890eff47121b23ee41656dc15dff3e19f7d03094af",
   "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "9d91bcf571af6dcc1425b6dfd76fb92e3e0180fb9fd0c852f9eba3fb06e079fc",
+  "astropy.visualization.wcsaxes.tests.test_images.test_overlay_nondegree_unit": "aa9b85520da54dc61d4db2988883ff184fb59cd27c52a04899cb33599fcab4b7",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/visualization/wcsaxes/tests/test_utils.py
+++ b/astropy/visualization/wcsaxes/tests/test_utils.py
@@ -84,4 +84,5 @@ def test_get_coord_meta():
     hadec_meta = get_coord_meta(HADec)
     assert hadec_meta["name"] == ["ha", "dec"]
     assert hadec_meta["wrap"] == (Angle(180 * u.deg), None)
-    assert hadec_meta["unit"] == (u.hourangle, u.deg)
+    assert hadec_meta["unit"] == (u.deg, u.deg)
+    assert hadec_meta["format_unit"] == (u.hourangle, u.deg)

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -112,7 +112,8 @@ def get_coord_meta(frame):
     # Add dummy data to the frame to determine the longitude wrap angle and the units
     frame = frame.realize_frame(UnitSphericalRepresentation(0 * u.deg, 0 * u.deg))
     coord_meta["wrap"] = (frame.spherical.lon.wrap_angle, None)
-    coord_meta["unit"] = (frame.spherical.lon.unit, frame.spherical.lat.unit)
+    coord_meta["unit"] = (u.deg, u.deg)
+    coord_meta["format_unit"] = (frame.spherical.lon.unit, frame.spherical.lat.unit)
 
     return coord_meta
 

--- a/docs/changes/visualization/16662.bugfix.rst
+++ b/docs/changes/visualization/16662.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a WCSAxes bug when overlaying a frame with default units that are not degrees.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes a bug in WCSAxes ticks/labels when overlaying a coordinate frame where a default unit is not degrees (hour angle, arcminutes, etc.).  The WCSAxes internal transformations work in degrees, but `coord_meta` was being loaded as if the internal transformations worked in the default unit.  The result was that the tick labels claim to be in the default units but have values in degree units.

The figure test in this PR overlays ICRS (top and right) on top of ICRS (bottom and left).  Before the fix in this PR:
![before](https://github.com/astropy/astropy/assets/991759/cfbc9215-1755-4498-8e7d-3a24f8db5eab)

After the fix in this PR:
![after](https://github.com/astropy/astropy/assets/991759/4dd733be-a8ca-491c-a103-3aa9e83336b2)


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
