### PR TITLE
BUG: declare `np.cumulative_prod` and `np.cumulative_sum` as subclass-safe and test them (fix incompatibility with NumPy 2.1)

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -133,7 +133,7 @@ if not NUMPY_LT_2_0:
     # trapz was renamed to trapezoid
     SUBCLASS_SAFE_FUNCTIONS |= {np.trapezoid}
 if not NUMPY_LT_2_1:
-    SUBCLASS_SAFE_FUNCTIONS |= {np.unstack}
+    SUBCLASS_SAFE_FUNCTIONS |= {np.unstack, np.cumulative_prod, np.cumulative_sum}
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -671,6 +671,10 @@ class TestUfuncReductions(InvariantUnitTestSetup):
     def test_cumsum(self):
         self.check(np.cumsum)
 
+    @pytest.mark.skipif(NUMPY_LT_2_1, reason="np.cumulative_sum is new in NumPy 2.1")
+    def test_cumulative_sum(self):
+        self.check(np.cumulative_sum, axis=1)
+
     def test_any(self):
         with pytest.raises(TypeError):
             np.any(self.q)
@@ -712,6 +716,11 @@ class TestUfuncReductions(InvariantUnitTestSetup):
     def test_cumproduct(self):
         with pytest.raises(u.UnitsError):
             np.cumproduct(self.q)  # noqa: NPY003, NPY201
+
+    @pytest.mark.skipif(NUMPY_LT_2_1, reason="np.cumulative_prod is new in NumPy 2.1")
+    def test_cumulative_prod(self):
+        with pytest.raises(u.UnitsError):
+            np.cumulative_prod(self.q, axis=1)
 
 
 class TestUfuncLike(InvariantUnitTestSetup):


### PR DESCRIPTION
### Description

[example logs](https://github.com/astropy/astropy/actions/runs/9772796551/job/26977807893)
xref: https://github.com/numpy/numpy/pull/26724

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
