### PR TITLE
Fix typo in _NonLinearLSQFitter.__call__

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1371,7 +1371,7 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
             model_copy, y, init_values, cov_x, fitparams, farg, weights
         )
 
-        model.sync_constraints = True
+        model_copy.sync_constraints = True
         return model_copy
 
 

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1503,7 +1503,6 @@ def test_non_linear_fit_zero_degree_polynomial_with_weights(fitter):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_sync_constraints_after_fitting():
-
     # Check that Model.sync_constraints is True after fitting - this is a
     # regression test for a bug that caused sync_constraints to be False
     # after fitting a model with some non-linear fitters.
@@ -1515,4 +1514,4 @@ def test_sync_constraints_after_fitting():
     m = fitter(m_init, x, y)
     assert m.sync_constraints is True
     m.amplitude.fixed = True
-    assert m.fixed == {'amplitude': True, 'mean': False, 'stddev': False}
+    assert m.fixed == {"amplitude": True, "mean": False, "stddev": False}

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1499,3 +1499,19 @@ def test_non_linear_fit_zero_degree_polynomial_with_weights(fitter):
 
     fit = fitter(model, x, y, weights=weights)
     assert_almost_equal(fit.c0, 1.0)
+
+
+def test_sync_constraints_after_fitting():
+
+    # Check that Model.sync_constraints is True after fitting - this is a
+    # regression test for a bug that caused sync_constraints to be False
+    # after fitting a model with some non-linear fitters.
+
+    x = np.arange(10, dtype=float)
+    y = np.ones((10,))
+    m_init = models.Gaussian1D()
+    fitter = TRFLSQFitter()
+    m = fitter(m_init, x, y)
+    assert m.sync_constraints is True
+    m.amplitude.fixed = True
+    assert m.fixed == {'amplitude': True, 'mean': False, 'stddev': False}

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1501,6 +1501,7 @@ def test_non_linear_fit_zero_degree_polynomial_with_weights(fitter):
     assert_almost_equal(fit.c0, 1.0)
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_sync_constraints_after_fitting():
 
     # Check that Model.sync_constraints is True after fitting - this is a

--- a/docs/changes/modeling/16664.bugfix.rst
+++ b/docs/changes/modeling/16664.bugfix.rst
@@ -1,4 +1,3 @@
 Fixed a bug that caused models returned by non-linear fitters to have
-sync_constraints set to `False`, which caused constraints accessed through e.g.
-``Model.fixed`` to not be in sync with the ``fixed`` attribute of the
-parameters.
+``sync_constraints`` set to `False`, which caused constraints accessed through, e.g.,
+``Model.fixed`` to not be in sync with the ``fixed`` attribute of the parameters.

--- a/docs/changes/modeling/16664.bugfix.rst
+++ b/docs/changes/modeling/16664.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug that caused models returned by non-linear fitters to have
+sync_constraints set to `False`, which caused constraints accessed through e.g.
+``Model.fixed`` to not be in sync with the ``fixed`` attribute of the
+parameters.


### PR DESCRIPTION
I *think* this is a typo, but not 100% sure - maybe @nden can confirm? I don't know of any bug that this caused in practice but it seems wrong.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
