### PR TITLE
DOC: drop unneeded changelog fragments from PR #16640

### DIFF
--- a/docs/changes/units/16640.bugfix.rst
+++ b/docs/changes/units/16640.bugfix.rst
@@ -1,2 +1,0 @@
-Declare ``np.unstack`` as subclass-safe (fix incompatibility between
-``Quantity`` and NumPy 2.1).

--- a/docs/changes/utils/16640.bugfix.rst
+++ b/docs/changes/utils/16640.bugfix.rst
@@ -1,2 +1,0 @@
-Declare ``np.unstack`` as subclass-safe (fix incompatibility between ``Masked``
-and NumPy 2.1).


### PR DESCRIPTION
### Description
Follow up to #16640 as requested by @pllim and @mhvk

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
