### PR TITLE
Improve fitting performance of most non-linear fitters

### DIFF
--- a/docs/changes/modeling/16673.perf.rst
+++ b/docs/changes/modeling/16673.perf.rst
@@ -1,0 +1,1 @@
+Performance of most non-linear fitters has been significantly improved by reducing the overhead in evaluating models inside the objective function.


### PR DESCRIPTION
This PR significantly speeds up fitting of models for most of the non-linear fitters. When profiling this, we found that a lot of the overhead was in the fact that the fitters evaluate the model using call, which includes several time-consuming pre- and post-evaluation steps. However, in the non-linear fitters, the models always have scalar parameters and we have control over the inputs to the models, so these checks are unnecessary. We can therefore call Model.evaluate directly which speeds things up a lot. For compound models, this can speed up the fitting by factors of 4x or more.

For a simple 1D Gaussian unconstrained fit:

<details>
<summary>Fit example</summary>

```python
import time
import numpy as np
from astropy.modeling.models import Gaussian1D
from astropy.modeling.fitting import TRFLSQFitter

g = Gaussian1D()
fitter = TRFLSQFitter()

np.random.seed(12345)

x = np.linspace(-10, 10, 100)
y = np.exp(-(x - 1.1) ** 2 / 3) + np.random.uniform(-0.2, 0.2, 100)

start = time.time()
for iter in range(1000):
    g_fit = fitter(g, x, y)
end = time.time()

print(f"{end-start}")
```

</details>

This takes the run time for me from 3.02s on main to 2.19s on this PR.

With `use_min_max_constraints` and bounds set it goes from 3.64s to 2.2s.

If you change the model being fit to `g = Gaussian1D() + Gaussian1D()` then it takes 27.9s on main and 9.4s on this PR.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
