### PR TITLE
Shuffle unit formatter `format_exponential_notation()` methods

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -62,13 +62,17 @@ class Base:
         str
             The value in exponential notation in a this class's format.
         """
-        m, ex = utils.split_mantissa_exponent(val, format_spec)
-        parts = []
-        if m := cls._format_mantissa(m):
-            parts.append(m)
-        if ex:
-            parts.append(f"10{cls._format_superscript(ex)}")
-        return cls._times.join(parts)
+        x = format(val, format_spec).split("e")
+        if len(x) != 2:
+            return cls._format_mantissa(x[0])  # no exponent
+        ex = x[1].lstrip("0+")
+        if not ex:
+            return cls._format_mantissa(x[0])  # exponent was zero
+        if ex.startswith("-"):
+            ex = "-" + ex[1:].lstrip("0")
+        ex = f"10{cls._format_superscript(ex)}"
+        m = cls._format_mantissa("" if x[0].rstrip("0") == "1." else x[0])
+        return f"{m}{cls._times}{ex}" if m else ex
 
     @classmethod
     def _format_mantissa(cls, m: str) -> str:

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -24,6 +24,7 @@ class Base:
     registry: ClassVar[dict[str, type[Base]]] = {}
     _space: ClassVar[str] = " "
     _scale_unit_separator: ClassVar[str] = " "
+    _times: ClassVar[str] = "*"
     name: ClassVar[str]  # Set by __init_subclass__ by the latest
 
     def __new__(cls, *args, **kwargs):
@@ -43,7 +44,7 @@ class Base:
 
     @classmethod
     def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = "g"
+        cls, val: float | np.number, format_spec: str = ".8g"
     ) -> str:
         """
         Formats a value in exponential notation.
@@ -61,7 +62,17 @@ class Base:
         str
             The value in exponential notation in a this class's format.
         """
-        return format(val, format_spec)
+        m, ex = utils.split_mantissa_exponent(val, format_spec)
+        parts = []
+        if m := cls._format_mantissa(m):
+            parts.append(m)
+        if ex:
+            parts.append(f"10{cls._format_superscript(ex)}")
+        return cls._times.join(parts)
+
+    @classmethod
+    def _format_mantissa(cls, m: str) -> str:
+        return m
 
     @classmethod
     def _format_superscript(cls, number: str) -> str:

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -27,8 +27,6 @@ from .base import Base
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
-    import numpy as np
-
     from astropy.extern.ply.lex import Lexer, LexToken
     from astropy.units import UnitBase
     from astropy.utils.parsing import ThreadSafeParser
@@ -310,22 +308,12 @@ class CDS(Base):
                     raise ValueError("Syntax error")
 
     @classmethod
-    def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = ".8g"
-    ) -> str:
-        m, ex = utils.split_mantissa_exponent(val)
-        parts = []
-        if m not in ("", "1"):
-            parts.append(m)
-        if ex:
-            if not ex.startswith("-"):
-                ex = "+" + ex
-            parts.append(f"10{cls._format_superscript(ex)}")
-        return cls._times.join(parts)
+    def _format_mantissa(cls, m: str) -> str:
+        return "" if m == "1" else m
 
     @classmethod
     def _format_superscript(cls, number: str) -> str:
-        return number
+        return number if number.startswith("-") else "+" + number
 
     @classmethod
     def to_string(

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import base, utils
+from . import base
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
-
-    import numpy as np
 
     from astropy.units import UnitBase
 
@@ -36,32 +34,12 @@ class Console(base.Base):
       2.1798721*10^-18 m^2 kg / s^2
     """
 
-    _times: ClassVar[str] = "*"
     _line: ClassVar[str] = "-"
     _space: ClassVar[str] = " "
 
     @classmethod
-    def _format_mantissa(cls, m: str) -> str:
-        return m
-
-    @classmethod
     def _format_superscript(cls, number: str) -> str:
         return f"^{number}"
-
-    @classmethod
-    def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = ".8g"
-    ) -> str:
-        m, ex = utils.split_mantissa_exponent(val, format_spec)
-
-        parts = []
-        if m:
-            parts.append(cls._format_mantissa(m))
-
-        if ex:
-            parts.append(f"10{cls._format_superscript(ex)}")
-
-        return cls._times.join(parts)
 
     @classmethod
     def _format_fraction(

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -31,6 +31,8 @@ from . import core
 from .base import Base
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from astropy.units import NamedUnit, UnitBase
 
 
@@ -661,3 +663,9 @@ class Generic(Base):
             unit = copy(unit)
             unit._scale = 1.0
             return f"{cls.to_string(unit)} (with data multiplied by {scale})"
+
+    @classmethod
+    def format_exponential_notation(
+        cls, val: float | np.number, format_spec: str = "g"
+    ) -> str:
+        return format(val, format_spec)

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
     from numbers import Real
     from typing import TypeVar
 
-    import numpy as np
-
     from astropy.units import UnitBase
 
     T = TypeVar("T")
@@ -54,42 +52,6 @@ def get_grouped_by_powers(
         else:
             raise ValueError("Unit with 0 power")
     return positive, negative
-
-
-def split_mantissa_exponent(
-    v: float | np.number, format_spec: str = ".8g"
-) -> tuple[str, str]:
-    """
-    Given a number, split it into its mantissa and base 10 exponent
-    parts, each as strings.  If the exponent is too small, it may be
-    returned as the empty string.
-
-    Parameters
-    ----------
-    v : number
-
-    format_spec : str, optional
-        Number representation formatting string
-
-    Returns
-    -------
-    mantissa, exponent : str
-    """
-    x = format(v, format_spec).split("e")
-
-    if len(x) == 2:
-        ex = x[1].lstrip("0+")
-        if len(ex) > 0 and ex[0] == "-":
-            ex = "-" + ex[1:].lstrip("0")
-    else:
-        ex = ""
-
-    if ex == "" or (x[0] != "1." + "0" * (len(x[0]) - 2)):
-        m = x[0]
-    else:
-        m = ""
-
-    return m, ex
 
 
 def decompose_to_known_units(

--- a/docs/changes/units/16676.api.rst
+++ b/docs/changes/units/16676.api.rst
@@ -1,0 +1,16 @@
+The ``format_exponential_notation()`` method of the ``Base`` unit formatter has
+changed.
+Any unit formatters that inherit directly from ``Base`` but have not
+implemented their own ``format_exponential_notation()`` and wish to retain
+previous behavior should implement it as:
+
+.. code-block:: python
+
+    def format_exponential_notation(cls, val, format_spec):
+        return format(val, format_spec)
+
+Any formatters that inherit directly from ``Base`` and call
+``super().format_exponential_notation(val, format_spec)`` should instead call
+``format(val, format_spec)``
+The specific unit formatters in ``astropy.units`` and custom formatters that
+inherit from any of them are not affected.


### PR DESCRIPTION
### Description

In `astropy.units` the `Base` unit formatter has three direct subclasses: `CDS`, `Console` and `Generic`. `Generic` inherits its `format_exponential_notation()` method from `Base`, and `CDS` and `Console` implement their own, but their implementations are very similar. With only very small changes it is possible to have a common implementation for both `CDS` and `Console` in `Base`, with `Generic` having its own (very simple) implementation. This does change how `Base.format_exponential_notation()` behaves, so it is backwards-incompatible for any class that inherits directly from `Base` without implementing its own `format_exponential_notation()` (or implementing it using `super().format_exponential_notation()`), but migration is very simple because any such class can replace `Base.format_exponential_notation()` calls with calls of the built-in `format()` function (like `Generic` does in this pull request).

I have opened this as a draft to figure out if the change in `Base.format_exponential_notation()` is acceptable or not. If it is not then this needs to be scaled down, but the new `CDS._format_mantissa()` and `CDS._format_superscript()` would be good to merge regardless. If we do choose to go ahead with changing `Base.format_exponential_notation()` then it needs to be announced (change log entry?, What's New entry?, message in mailing list?).

It is also possible to have a Boolean switch in `Base.format_exponential_notation()` that would allow `CDS`, `Console` and `Generic` all inherit `format_exponential_notation()` from `Base` using different default values for the switch. This would solve the backwards-compatibility problem, but it doesn't sound very elegant to me.

If we do update `Base.format_exponential_notation()` then it will also become possible to inline the `astropy.units.format.utils.split_mantissa_exponent()` call and the utility function could be removed. This could enable additional code simplification.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
