### PR TITLE
Add ``has_tied``, ``has_fixed`` and ``has_bounds`` properties to ``Model``

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1176,7 +1176,7 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         if weights is None:
             weights = 1.0
 
-        if any(model.fixed.values()) or any(model.tied.values()):
+        if model.has_fixed or model.has_tied:
             # update the parameters with the current values from the fitter
             fitter_to_model_params(model, params)
             if z is None:
@@ -2002,9 +2002,9 @@ def fitter_to_model_params(model, fps, use_min_max_bounds=True):
     """
     _, fit_param_indices, _ = model_to_fit_params(model)
 
-    has_tied = any(model.tied.values())
-    has_fixed = any(model.fixed.values())
-    has_bound = any(b != (None, None) for b in model.bounds.values())
+    has_tied = model.has_tied
+    has_fixed = model.has_fixed
+    has_bound = model.has_bounds
     parameters = model.parameters
 
     if not (has_tied or has_fixed or has_bound):
@@ -2069,7 +2069,7 @@ def model_to_fit_params(model):
     fitparam_indices = list(range(len(model.param_names)))
     model_params = model.parameters
     model_bounds = list(model.bounds.values())
-    if any(model.fixed.values()) or any(model.tied.values()):
+    if model.has_fixed or model.has_tied:
         params = list(model_params)
         param_metrics = model._param_metrics
         for idx, name in list(enumerate(model.param_names))[::-1]:
@@ -2100,16 +2100,13 @@ def _validate_constraints(supported_constraints, model):
     """Make sure model constraints are supported by the current fitter."""
     message = "Optimizer cannot handle {0} constraints."
 
-    if any(model.fixed.values()) and "fixed" not in supported_constraints:
+    if model.has_fixed and "fixed" not in supported_constraints:
         raise UnsupportedConstraintError(message.format("fixed parameter"))
 
-    if any(model.tied.values()) and "tied" not in supported_constraints:
+    if model.has_tied and "tied" not in supported_constraints:
         raise UnsupportedConstraintError(message.format("tied parameter"))
 
-    if (
-        any(tuple(b) != (None, None) for b in model.bounds.values())
-        and "bounds" not in supported_constraints
-    ):
+    if model.has_bounds and "bounds" not in supported_constraints:
         raise UnsupportedConstraintError(message.format("bound parameter"))
 
     if model.eqcons and "eqcons" not in supported_constraints:

--- a/docs/changes/modeling/16677.feature.rst
+++ b/docs/changes/modeling/16677.feature.rst
@@ -1,0 +1,3 @@
+Added ``Model.has_tied``, ``Model.has_fixed``, and ``Model.has_bounds`` attributes to make
+it easy to check whether models have various kinds of constraints set without having to
+inspect ``Model.tied``, ``Model.fixed``, and ``Model.bounds`` in detail.


### PR DESCRIPTION
*This has been split out from #16673 for ease of review*

Models include ``tied``, ``fixed``, and ``bounds`` properties that return dictionaries with a summary of which parameters have constraints. However, sometimes one wants to quickly know whether there are any specified ``tied``, ``fixed``, or ``bounds`` constraints, and the main way to do that is:

```python
 any(model.fixed.values())
 any(model.tied.values())
 any(b != (None, None) for b in model.bounds.values())
```

These appear notably in the fitting code - this turns out to be reasonably expensive operations especially in the fitting code, where they might be called every time the objective function is called, and it is also clunky to repeat this logic several times in different places.

This PR adds:

```python
Model.has_fixed
Model.has_tied
Model.has_bounds
```

which simplifies this. In addition, these properties, like ``fixed``, ``tied``, and ``bounds`` are cached and the cached version is used when ``sync_constraints`` is ``False`` (typically during fitting), removing any performance impact. But beyond this, these properties could be generically useful to users, similarly to how we have e.g. ``has_units``, hence why I made these public.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
