### PR TITLE
Fix removal of units from CompoundModel with * or / and fix fitting of these models

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4107,7 +4107,6 @@ class CompoundModel(Model):
         base method.
         """
         if self.op in ["*", "/"]:
-            model = self.copy()
             inputs = {inp: kwargs[inp] for inp in self.inputs}
 
             left_units = self.left.output_units(**kwargs)
@@ -4151,7 +4150,7 @@ class CompoundModel(Model):
                 right_kwargs["_right_kwargs"] = right[2]
                 right = right[0]
 
-            model._set_sub_models_and_parameter_units(left, right)
+            model = CompoundModel(self.op, left, right, name=self.name)
 
             return model, left_kwargs, right_kwargs
         else:

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -999,10 +999,14 @@ def test_fit_multiplied_compound_model_with_mixed_units():
     fit_output = fit(x)
 
     assert unfit_output.unit == fit_output.unit == (u.kg * u.m / u.s)
-    assert_allclose(unfit_output, fit_output)
 
-    for name in truth.param_names:
-        assert getattr(truth, name) == getattr(fit, name)
+    # The unfit model is 10 kg m^2 / s for x=0s and goes up to 60 kg m^2 / s
+    # for x=1s, whereas the actual data being fit goes from 5 to 10, so we need
+    # to correct this.
+    assert_allclose(unfit_output / 10 + 4 * u.kg * u.m / u.s, fit_output)
+
+    # There are degeneracies between the parameters of this model, so we cannot
+    # reliably check the values of the fit parameters.
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
@@ -1020,16 +1024,20 @@ def test_fit_multiplied_recursive_compound_model_with_mixed_units():
     m2 = Linear1D(slope=0.0 * u.kg / u.s, intercept=10.0 * u.kg)
     m3 = Linear1D(slope=0.0 * u.m / u.s, intercept=10.0 * u.m)
     truth = m1 * m2 * m3
-    fit = fitter(truth, x, y)
+    fit = fitter(truth, x, y, maxiter=1000)
 
     unfit_output = truth(x)
     fit_output = fit(x)
 
     assert unfit_output.unit == fit_output.unit == (u.kg * u.m * u.m / u.s)
-    assert_allclose(unfit_output, fit_output)
 
-    for name in truth.param_names:
-        assert getattr(truth, name) == getattr(fit, name)
+    # The unfit model is 100 kg m^2 / s for x=0s and goes up to 600 kg m^2 / s
+    # for x=1s, whereas the actual data being fit goes from 5 to 10, so we need
+    # to correct this.
+    assert_allclose(unfit_output / 100 + 4 * u.kg * u.m * u.m / u.s, fit_output)
+
+    # There are degeneracies between the parameters of this model, so we cannot
+    # reliably check the values of the fit parameters.
 
     x = np.linspace(0, 1, 101) * u.s
     y = np.linspace(5, 10, 101) * u.m * u.m * u.kg * u.kg / u.s
@@ -1041,16 +1049,20 @@ def test_fit_multiplied_recursive_compound_model_with_mixed_units():
     m11 = m1 * m2
     m22 = m3 * m4
     truth = m11 * m22
-    fit = fitter(truth, x, y)
+    fit = fitter(truth, x, y, maxiter=1000)
 
     unfit_output = truth(x)
     fit_output = fit(x)
 
     assert unfit_output.unit == fit_output.unit == (u.kg * u.kg * u.m * u.m / u.s)
-    assert_allclose(unfit_output, fit_output)
 
-    for name in truth.param_names:
-        assert getattr(truth, name) == getattr(fit, name)
+    # The unfit model is 1000 kg m^2 / s for x=0s and goes up to 6000 kg m^2 / s
+    # for x=1s, whereas the actual data being fit goes from 5 to 10, so we need
+    # to correct this.
+    assert_allclose(unfit_output / 1000 + 4 * u.kg * u.kg * u.m * u.m / u.s, fit_output)
+
+    # There are degeneracies between the parameters of this model, so we cannot
+    # reliably check the values of the fit parameters.
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
@@ -1066,16 +1078,20 @@ def test_fit_divided_compound_model_with_mixed_units():
     m1 = Linear1D(slope=5 * u.kg * u.m / u.s, intercept=1.0 * u.kg * u.m)
     m2 = Linear1D(slope=0.0 * u.s / u.s, intercept=10.0 * u.s)
     truth = m1 / m2
-    fit = fitter(truth, x, y)
+    fit = fitter(truth, x, y, maxiter=1000)
 
     unfit_output = truth(x)
     fit_output = fit(x)
 
     assert unfit_output.unit == fit_output.unit == (u.kg * u.m / u.s)
-    assert_allclose(unfit_output, fit_output)
 
-    for name in truth.param_names:
-        assert getattr(truth, name) == getattr(fit, name)
+    # The unfit model is 0.1 kg m / s for x=0s and goes up to 0.5 kg m / s for
+    # x=1s, whereas the actual data being fit goes from 5 to 10, so we need
+    # to correct this.
+    assert_allclose(unfit_output * 10 + 4 * u.kg * u.m / u.s, fit_output, rtol=1e-4)
+
+    # There are degeneracies between the parameters of this model, so we cannot
+    # reliably check the values of the fit parameters.
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
@@ -1093,16 +1109,20 @@ def test_fit_mixed_recursive_compound_model_with_mixed_units():
     m2 = Linear1D(slope=0.0 * u.s / u.s, intercept=10.0 * u.s)
     m3 = Linear1D(slope=0.0 * u.m / u.s, intercept=10.0 * u.m)
     truth = m1 / m2 * m3
-    fit = fitter(truth, x, y)
+    fit = fitter(truth, x, y, maxiter=1000)
 
     unfit_output = truth(x)
     fit_output = fit(x)
 
     assert unfit_output.unit == fit_output.unit == (u.kg * u.m * u.m / u.s)
-    assert_allclose(unfit_output, fit_output)
 
-    for name in truth.param_names:
-        assert getattr(truth, name) == getattr(fit, name)
+    # The unfit model is 1 kg m^2 / s for x=0s and goes up to 6 kg m^2 / s for
+    # x=1s, whereas the actual data being fit goes from 5 to 10, so we need
+    # to correct this.
+    assert_allclose(unfit_output + 4 * u.kg * u.m * u.m / u.s, fit_output)
+
+    # There are degeneracies between the parameters of this model, so we cannot
+    # reliably check the values of the fit parameters.
 
     x = np.linspace(0, 1, 101) * u.s
     y = np.linspace(5, 10, 101) * u.kg * u.kg * u.m * u.m / u.s
@@ -1114,13 +1134,18 @@ def test_fit_mixed_recursive_compound_model_with_mixed_units():
     m11 = m1 / m2
     m22 = m3 * m4
     truth = m11 * m22
-    fit = fitter(truth, x, y)
+    fit = fitter(truth, x, y, maxiter=1000)
 
     unfit_output = truth(x)
     fit_output = fit(x)
 
     assert unfit_output.unit == fit_output.unit == (u.kg * u.kg * u.m * u.m / u.s)
-    assert_allclose(unfit_output, fit_output)
 
-    for name in truth.param_names:
-        assert getattr(truth, name) == getattr(fit, name)
+    # The unfit model is 10 kg^2 m^2 / s for x=0s and goes up to 60 kg^2 m^2 / s
+    # for x=1s, whereas the actual data being fit goes from 5 to 10, so we need
+    # to correct this.
+
+    assert_allclose(unfit_output / 10 + 4 * u.kg * u.kg * u.m * u.m / u.s, fit_output)
+
+    # There are degeneracies between the parameters of this model, so we cannot
+    # reliably check the values of the fit parameters.

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -1049,7 +1049,7 @@ def test_fit_multiplied_recursive_compound_model_with_mixed_units():
     m11 = m1 * m2
     m22 = m3 * m4
     truth = m11 * m22
-    fit = fitter(truth, x, y, maxiter=1000)
+    fit = fitter(truth, x, y, maxiter=10000)
 
     unfit_output = truth(x)
     fit_output = fit(x)

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -1135,7 +1135,6 @@ def test_Schechter1D_errors():
 
 
 def test_compound_without_units_for_data_parameters():
-
     # Regression test for a bug that caused models returned by
     # CompoundModel.without_units_for_data to return a model that has top-level
     # parameters decoupled from the parameters on the individual models.
@@ -1145,10 +1144,10 @@ def test_compound_without_units_for_data_parameters():
 
     gg = g1 * g2
 
-    gg_nounit = gg.without_units_for_data(x=1 * u.nm, y=2 * u.Jy ** 2)[0]
+    gg_nounit = gg.without_units_for_data(x=1 * u.nm, y=2 * u.Jy**2)[0]
 
-    gg_nounit.amplitude_0=5
+    gg_nounit.amplitude_0 = 5
     assert gg_nounit.left.amplitude == 5
 
-    gg_nounit.amplitude_1=6
+    gg_nounit.amplitude_1 = 6
     assert gg_nounit.right.amplitude == 6

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -1132,3 +1132,23 @@ def test_Schechter1D_errors():
     )
     with pytest.raises(u.UnitsError, match=MESSAGE):
         model(-23 * u.mag)
+
+
+def test_compound_without_units_for_data_parameters():
+
+    # Regression test for a bug that caused models returned by
+    # CompoundModel.without_units_for_data to return a model that has top-level
+    # parameters decoupled from the parameters on the individual models.
+
+    g1 = Gaussian1D(amplitude=2 * u.Jy, stddev=4 * u.nm, mean=1000 * u.nm)
+    g2 = Gaussian1D(amplitude=1 * u.Jy, stddev=2 * u.nm, mean=500 * u.nm)
+
+    gg = g1 * g2
+
+    gg_nounit = gg.without_units_for_data(x=1 * u.nm, y=2 * u.Jy ** 2)[0]
+
+    gg_nounit.amplitude_0=5
+    assert gg_nounit.left.amplitude == 5
+
+    gg_nounit.amplitude_1=6
+    assert gg_nounit.right.amplitude == 6

--- a/docs/changes/modeling/16678.bugfix.rst
+++ b/docs/changes/modeling/16678.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug that caused ``CompoundModel.without_units_for_data`` to return an
+incorrectly constructed model when the compound model contained a * or /
+operation, and which also caused fitting to not work correctly with compound
+models that contained * or / operations.


### PR DESCRIPTION
This fixes a bug that caused compound models created via ``CompoundModel.without_units_for_data`` to be incorrect if the compound expression included ``*`` or ``/``, because the top-level parameters were decoupled from the parameters of the constituent models (see examples in https://github.com/astropy/astropy/issues/16675). The safer route is to instantiate a new ``CompoundModel`` rather than copy and modify. Example of incorrect behavior:

```python
In [1]: from astropy.modeling.models import Gaussian1D

In [2]: from astropy import units as u

In [3]: g1 = Gaussian1D(amplitude=2 * u.Jy, stddev=4 * u.nm, mean=1000 * u.nm)

In [4]: g2 = Gaussian1D(amplitude=1 * u.Jy, stddev=2 * u.nm, mean=500 * u.nm)

In [5]: gg = g1 * g2

In [6]: gg
Out[6]: <CompoundModel(amplitude_0=2. Jy, mean_0=1000. nm, stddev_0=4. nm, amplitude_1=1. Jy, mean_1=500. nm, stddev_1=2. nm)>

In [11]: gg_nounit = gg.without_units_for_data(x=1 * u.nm, y=2 * u.Jy ** 2)[0]

In [13]: print(gg_nounit)
Model: CompoundModel
Inputs: ('x',)
Outputs: ('y',)
Model set size: 1
Expression: [0] * [1]
Components: 
    [0]: <Gaussian1D(amplitude=2., mean=1000., stddev=4.)>

    [1]: <Gaussian1D(amplitude=1., mean=500., stddev=2.)>
Parameters:
    amplitude_0 mean_0 stddev_0 amplitude_1 mean_1 stddev_1
    ----------- ------ -------- ----------- ------ --------
            2.0 1000.0      4.0         1.0  500.0      2.0

In [14]: gg_nounit.amplitude_0=5

In [15]: print(gg_nounit)
Model: CompoundModel
Inputs: ('x',)
Outputs: ('y',)
Model set size: 1
Expression: [0] * [1]
Components: 
    [0]: <Gaussian1D(amplitude=5., mean=1000., stddev=4.)>

    [1]: <Gaussian1D(amplitude=1., mean=500., stddev=2.)>
Parameters:
    amplitude_0 mean_0 stddev_0 amplitude_1 mean_1 stddev_1
    ----------- ------ -------- ----------- ------ --------
            5.0 1000.0      4.0         1.0  500.0      2.0

In [16]: gg_nounit.left.amplitude
Out[16]: Parameter('amplitude', value=2.0)

In [17]: gg_nounit.right.amplitude
Out[17]: Parameter('amplitude', value=1.0)
```

As you can see, ``gg_nounit.left.amplitude`` was actually incorrect, as it should be 5 now. This is now fixed with this PR.

A more serious issue that this caused was that fitting was in fact completely broken for compound models with units and with a * or / - the fitting simply returned the same model as the original unfit one. There were several tests of the fitting which were incorrectly written and assumed the fit and unfit output should be the same, which it should not be, so I have now adjusted those tests so that they pass again.

Fixes https://github.com/astropy/astropy/issues/16675

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
