### PR TITLE
TST: switch Python 3.11 jobs to 3.12

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -66,8 +66,8 @@ jobs:
           linux: py312-test-cov
           coverage: codecov
 
-        - name: Python 3.11 in Parallel with all optional dependencies
-          linux: py311-test-alldeps-fitsio
+        - name: Python 3.12 in Parallel with all optional dependencies
+          linux: py312-test-alldeps-fitsio
           libraries:
             apt:
               - language-pack-fr
@@ -81,12 +81,12 @@ jobs:
           posargs: --remote-data=astropy
           coverage: codecov
 
-        - name: Python 3.11 with all optional dependencies (Windows)
-          windows: py311-test-alldeps
+        - name: Python 3.12 with all optional dependencies (Windows)
+          windows: py312-test-alldeps
           posargs: --durations=50
 
-        - name: Python 3.11 with all optional dependencies (MacOS X)
-          macos: py311-test-alldeps
+        - name: Python 3.12 with all optional dependencies (MacOS X)
+          macos: py312-test-alldeps
           posargs: --durations=50 --run-slow
           runs-on: macos-latest
 


### PR DESCRIPTION
### Description
Python 3.12 should be old enough by now that we can count on a widespread support from the rest of the ecosystem, let's try switching regular CI (not just most bleeding-edge jobs) to it.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
