### PR TITLE
DOC: New extension to use mpltype custom role in doc build to avoid warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,12 @@ if "templates_path" not in locals():  # in case parent conf.py defines it
     templates_path = []
 templates_path.append("_templates")
 
-extensions += ["sphinx_changelog", "sphinx_design", "sphinxcontrib.globalsubs"]
+extensions += [
+    "matplotlib.sphinxext.roles",
+    "sphinx_changelog",
+    "sphinx_design",
+    "sphinxcontrib.globalsubs",
+]
 
 # Grab minversion from pyproject.toml
 with (Path(__file__).parents[1] / "pyproject.toml").open("rb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docs = [
     "Jinja2>=3.1.3",
     "tomli; python_version < '3.11'",
     "sphinxcontrib-globalsubs >= 0.1.1",
-    "matplotlib!=3.9.0",  # https://github.com/matplotlib/matplotlib/issues/28234
+    "matplotlib>=3.9.1",  # https://github.com/matplotlib/matplotlib/issues/28234
 ]
 # These group together all the dependencies needed for developing in Astropy.
 dev = [


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to actually take advantage of the patch (https://github.com/matplotlib/matplotlib/pull/28289) that caused https://github.com/matplotlib/matplotlib/issues/28234 .

RTD must be green for this to be acceptable. I will let CI run too, just in case the pin causes trouble elsewhere.

xref https://github.com/astropy/astropy/pull/16468

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
