### PR TITLE
Fix a test that allows tweaking `BaseCoordinateFrame._data_repr()`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1429,9 +1429,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             data = self.data
             data_repr = repr(self.data)
 
-        if data_repr.startswith(class_prefix := f"<{type(data).__name__}"):
-            # `class_prefix` can be followed by at least " " or ":" which we remove too
-            data_repr = data_repr.removeprefix(class_prefix)[1:].removesuffix(">")
+        if data_repr.startswith(class_prefix := f"<{type(data).__name__} "):
+            data_repr = data_repr.removeprefix(class_prefix).removesuffix(">")
         else:
             data_repr = "Data:\n" + data_repr
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1330,14 +1330,14 @@ def test_representation_subclass():
         attr_classes = r.UnitSphericalRepresentation.attr_classes
 
         def __repr__(self):
-            return "<NewUnitSphericalRepresentation: spam spam spam>"
+            return "<NewUnitSphericalRepresentation spam spam spam>"
 
     frame = FK5(
         NewUnitSphericalRepresentation(lon=32 * u.deg, lat=20 * u.deg),
         representation_type=NewSphericalRepresentation,
     )
 
-    assert repr(frame) == "<FK5 Coordinate (equinox=J2000.000):  spam spam spam>"
+    assert repr(frame) == "<FK5 Coordinate (equinox=J2000.000): spam spam spam>"
 
 
 def test_getitem_representation():


### PR DESCRIPTION
### Description

[In a previous pull request I had pointed out that trusting a comment caused test failures](https://github.com/astropy/astropy/pull/16337#discussion_r1578316208), but I wasn't sure if the comment was lying or if the problem was in the tests. I've now had the time to look into it, and it turns out that a `UnitSphericalRepresentation` subclass defined in a test used a colon in its `__repr__()` where `BaseRepresentationOrDifferential` does not:
https://github.com/astropy/astropy/blob/bc9129e451bbb2a21f39af225eafc6a442fe3381/astropy/coordinates/representation/base.py#L507

Removing the colon from the test class allows simplifying `BaseCoordinateFrame._data_repr()` because it does not have to handle this artificial special case anymore.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
