### PR TITLE
Shorten `astropy/coordinates/angles/__init__.py`

### DIFF
--- a/astropy/coordinates/angles/__init__.py
+++ b/astropy/coordinates/angles/__init__.py
@@ -9,13 +9,3 @@ between coordinate systems.
 from .core import *
 from .errors import *
 from .utils import *
-
-# isort: split
-from . import core as _core
-from . import errors as _errors
-from . import utils as _utils
-
-__all__ = []
-__all__ += _core.__all__
-__all__ += _errors.__all__
-__all__ += _utils.__all__


### PR DESCRIPTION
### Description

I am very much in favor of explicitly defining `__all__`, _except_ in `__init__.py` files. My reasoning is that if all the other files properly define `__all__` (like they do in `angles`) and `__init__.py` files only define a docstring and perform `from ... import *` (like it does in `angles`) then managing `__all__` in `__init__.py` is nothing but boilerplate code.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
