### PR TITLE
Fix a type checking import mistake in `units`

### DIFF
--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
 
     from numpy.typing import ArrayLike, NDArray
 
-    from .core import Quantity, UnitBase
+    from .core import UnitBase
+    from .quantity import Quantity
 
     DType = TypeVar("DType", bound=np.generic)
     FloatLike = TypeVar("FloatLike", bound=SupportsFloat)


### PR DESCRIPTION
- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
