### PR TITLE
Added a 'perf' changelog entry type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,10 +114,10 @@ repos:
         name: changelog filenames
         language: fail
         entry: >-
-          changelog files must be named <sub-package>/####.(bugfix|feature|api).rst
+          changelog files must be named <sub-package>/####.(bugfix|feature|api|perf).rst
           or ####.other.rst (in the root directory only)
         exclude: >-
-          ^docs/changes/[\w\.]+/(\d+\.(bugfix|feature|api)(\.\d)?.rst|.gitkeep)
+          ^docs/changes/[\w\.]+/(\d+\.(bugfix|feature|api|perf)(\.\d)?.rst|.gitkeep)
         files: ^docs/changes/[\w\.]+/
       - id: changelogs-rst-other
         name: changelog filenames for other category

--- a/docs/changes/README.rst
+++ b/docs/changes/README.rst
@@ -14,6 +14,7 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 * ``feature``: New feature.
 * ``api``: API change.
 * ``bugfix``: Bug fix.
+* ``perf``: Performance improvement.
 * ``other``: Other changes and additions.
 
 If the change concerns a sub-package, the file should go in the sub-directory

--- a/docs/changes/README.rst
+++ b/docs/changes/README.rst
@@ -14,7 +14,7 @@ Each file should be named like ``<PULL REQUEST>.<TYPE>.rst``, where
 * ``feature``: New feature.
 * ``api``: API change.
 * ``bugfix``: Bug fix.
-* ``perf``: Performance improvement.
+* ``perf``: Performance improvement (this should be significant enough to be measurable using the public API).
 * ``other``: Other changes and additions.
 
 If the change concerns a sub-package, the file should go in the sub-directory

--- a/docs/development/development_details.rst
+++ b/docs/development/development_details.rst
@@ -143,6 +143,7 @@ number, and ``<TYPE>`` is one of:
 * ``feature``: New feature.
 * ``api``: API change.
 * ``bugfix``: Bug fix.
+* ``perf``: Performance improvement (this should be significant enough to be measurable using the public API).
 * ``other``: Other changes and additions.
 
 An example entry, for the changes in `PR 1845

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -452,6 +452,11 @@ ignore = [
         showcontent = true
 
     [[tool.towncrier.type]]
+        directory = "perf"
+        name = "Performance Improvements"
+        showcontent = true
+
+    [[tool.towncrier.type]]
         directory = "other"
         name = "Other Changes and Additions"
         showcontent = true


### PR DESCRIPTION
As discussed in https://github.com/astropy/astropy/issues/16679

Fix #16679

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
