### PR TITLE
Add function to carry out parallel fitting on N-dimensional datasets

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -43,6 +43,8 @@ from .spline import (
 from .statistic import leastsquare
 from .utils import _combine_equivalency_dict, poly_map_domain
 
+from .fitting_parallel import parallel_fit_dask
+
 __all__ = [
     "LinearLSQFitter",
     "LevMarLSQFitter",
@@ -60,6 +62,7 @@ __all__ = [
     "SplineInterpolateFitter",
     "SplineSmoothingFitter",
     "SplineSplrepFitter",
+    "parallel_fit_dask",
 ]
 
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -33,6 +33,7 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
 
+from .fitting_parallel import parallel_fit_dask
 from .optimizers import DEFAULT_ACC, DEFAULT_EPS, DEFAULT_MAXITER, SLSQP, Simplex
 from .spline import (
     SplineExactKnotsFitter,
@@ -42,8 +43,6 @@ from .spline import (
 )
 from .statistic import leastsquare
 from .utils import _combine_equivalency_dict, poly_map_domain
-
-from .fitting_parallel import parallel_fit_dask
 
 __all__ = [
     "LinearLSQFitter",

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -326,7 +326,7 @@ def parallel_fit_dask(
     try:
         import dask
         import dask.array as da
-    except ImportError:
+    except ImportError:  # pragma: no cover
         raise ImportError("dask is required for this function")
 
     if scheduler is None:

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -436,7 +436,6 @@ def parallel_fit_model_nd(
         combined_array,
         enforce_ndim=True,
         dtype=float,
-        new_axis=0,
         drop_axis=fitting_axes,
         model=simple_model,
         fitter=fitter,

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -30,6 +30,7 @@ def _wcs_to_world_dask(wcs, data):
     representing the world coordinates of the array.
     """
     import dask.array as da
+
     pixel = tuple([np.arange(size) for size in data.shape])
     pixel_nd = da.meshgrid(*pixel, indexing="ij")
     world = da.map_blocks(
@@ -322,7 +323,6 @@ def parallel_fit_dask(
         If `True`, the native data chunks will be used, although an error will
         be raised if this chunk size does not include the whole fitting axes.
     """
-
     try:
         import dask
         import dask.array as da
@@ -362,7 +362,7 @@ def parallel_fit_dask(
             raise TypeError(
                 "Can only set preserve_native_chunks=True if input data is a dask array"
             )
-        if weights and not isinstance(weights, da.core.Array):
+        if weights is not None and not isinstance(weights, da.core.Array):
             raise TypeError(
                 "Can only set preserve_native_chunks=True if input weights is a dask array (if specified)"
             )

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -164,7 +164,7 @@ def _fit_models_to_chunk(
                 all_warnings.extend(w)
         except Exception as exc:
             model_fit = None
-            if diagnostics == "error":
+            if diagnostics.startswith("error"):
                 output = True
             error = traceback.format_exc()
             for ipar, name in enumerate(model_i.param_names):

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -95,7 +95,7 @@ def fit_models_to_chunk(
     # by fitting axes
     original_axes = tuple([0] + [idx + 1 for idx in (iterating_axes + fitting_axes)])
     new_axes = tuple(range(combined.ndim))
-    combined = da.moveaxis(combined, original_axes, new_axes)
+    combined = np.moveaxis(combined, original_axes, new_axes)
 
     data = combined[0]
     if world is None:

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -307,7 +307,7 @@ def parallel_fit_model_nd(
     if isinstance(world, BaseLowLevelWCS):
         if world.pixel_n_dim != data.ndim:
             raise ValueError(
-                "The WCS pixel_n_dim ({world.pixel_n_dim}) does not match the data dimensionality ({data.ndim})"
+                f"The WCS pixel_n_dim ({world.pixel_n_dim}) does not match the data dimensionality ({data.ndim})"
             )
 
         # Note that in future we could in principle consider supporting cases

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -447,6 +447,7 @@ def parallel_fit_model_nd(
         iterating_axes=iterating_axes,
         fitting_axes=fitting_axes,
         fitter_kwargs=fitter_kwargs,
+        name='fitting-results'
     )
 
     if scheduler == "default":

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -78,11 +78,15 @@ def fit_models_to_chunk(
     diagnostics=None,
     diagnostics_path=None,
     iterating_shape=None,
+    fitter_kwargs=None,
 ):
     """
     Function that gets passed to map_blocks and will fit models to a specific
     chunk of the data.
     """
+    if fitter_kwargs is None:
+        fitter_kwargs = {}
+
     if world == "arrays":
         ndim = model.n_inputs
         world_arrays = arrays[:ndim]
@@ -127,7 +131,7 @@ def fit_models_to_chunk(
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
-                model_fit = fitter(model_i, *world_values, data[i])
+                model_fit = fitter(model_i, *world_values, data[i], **fitter_kwargs)
                 all_warnings.extend(w)
         except Exception as exc:
             model_fit = None
@@ -214,6 +218,7 @@ def parallel_fit_model_nd(
     diagnostics=None,
     diagnostics_path=None,
     scheduler=None,
+    fitter_kwargs=None,
 ):
     """
     Fit a model in parallel to an N-dimensional dataset.
@@ -260,6 +265,8 @@ def parallel_fit_model_nd(
         used. If ``'default'``, whatever is the current default scheduler will be
         used. You can also set this to anything that would be passed to
         ``array.compute(scheduler=...)``
+    fitter_kwargs : None or dict
+        Keyword arguments to pass to the fitting when it is called.
     """
     if scheduler is None:
         scheduler = "synchronous"
@@ -421,6 +428,7 @@ def parallel_fit_model_nd(
         diagnostics=diagnostics,
         diagnostics_path=diagnostics_path,
         iterating_shape=iterating_shape,
+        fitter_kwargs=fitter_kwargs,
     )
 
     if scheduler == "default":

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -91,7 +91,7 @@ def parallel_fit_model_nd(
     ndim = data.ndim
     if not isinstance(fitting_axes, tuple):
         fitting_axes = (fitting_axes,)
-    fitting_axes = tuple([(fi if fi > 0 else ndim - fi) for fi in fitting_axes])
+    fitting_axes = tuple([(fi if fi >= 0 else ndim - fi) for fi in fitting_axes])
     iterating_axes = tuple([i for i in range(ndim) if i not in fitting_axes])
 
     # Determine the shape along the fitting dimensions and the iterating dimensions

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -1,0 +1,31 @@
+def parallel_fit_model_nd(*, model, fitter, data, fitting_axes, world, method='dask'):
+    """
+    Fit a model in parallel to an N-dimensional dataset.
+
+    Axes in the N-dimensional dataset are considered to be either 'fitting
+    axes' or 'iterating axes'. As a specific example, if fitting a
+    spectral cube with two celestial and one spectral axis, then if fitting a
+    1D model to each spectrum in the cube, the spectral axis would be a fitting
+    axis and the celestial axes would be iterating axes.
+
+    Parameters
+    ----------
+    model : :class:`astropy.modeling.Model`
+        The model to fit, specifying the initial parameter values. The shape
+        of the parameters should be broadcastable to the shape of the iterating
+        axes.
+    fitter : :class:`astropy.modeling.Fitter`
+        The fitter to use in the fitting process.
+    data : `numpy.ndarray` or `dask.array.core.Array`
+        The N-dimensional data to fit.
+    fitting_axes : int or tuple
+        The axes to keep for the fitting (other axes will be sliced/iterated over)
+    world : dict or APE-14-WCS
+        This can be specified either as a dictionary mapping fitting axes to
+        world axis values, or as a WCS for the whole cube. If the former, then
+        the values in the dictionary can be either 1D arrays, or can be given
+        as N-dimensional arrays with shape broadcastable to the data shape.
+    method : { 'dask' }
+        The framework to use for the parallelization.
+        """
+    pass

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -4,9 +4,7 @@ import warnings
 from copy import deepcopy
 from math import ceil, log10, prod
 
-import dask
 import numpy as np
-from dask import array as da
 
 import astropy.units as u
 from astropy.modeling.utils import _combine_equivalency_dict
@@ -31,6 +29,7 @@ def _wcs_to_world_dask(wcs, data):
     Given a WCS and a data shape, return an iterable of dask arrays
     representing the world coordinates of the array.
     """
+    import dask.array as da
     pixel = tuple([np.arange(size) for size in data.shape])
     pixel_nd = da.meshgrid(*pixel, indexing="ij")
     world = da.map_blocks(
@@ -323,6 +322,13 @@ def parallel_fit_dask(
         If `True`, the native data chunks will be used, although an error will
         be raised if this chunk size does not include the whole fitting axes.
     """
+
+    try:
+        import dask
+        import dask.array as da
+    except ImportError:
+        raise ImportError("dask is required for this function")
+
     if scheduler is None:
         scheduler = "processes"
 

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -275,7 +275,7 @@ def parallel_fit_model_nd(
         Keyword arguments to pass to the fitting when it is called.
     """
     if scheduler is None:
-        scheduler = "synchronous"
+        scheduler = "processes"
 
     if diagnostics in (None, "failed", "failed+warn", "all"):
         if diagnostics is not None:

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -72,7 +72,7 @@ def _compound_model_with_array_parameters(model, shape):
         return _copy_with_new_parameters(model, parameters)
 
 
-def fit_models_to_chunk(
+def _fit_models_to_chunk(
     data,
     *arrays,
     block_info=None,
@@ -381,7 +381,7 @@ def parallel_fit_model_nd(
                 raise ValueError(
                     "When using preserve_native_chunks=True, the chunk size should match the data size along the fitting axes"
                 )
-        if data.chunksize != weights.chunksize:
+        if weights is not None and data.chunksize != weights.chunksize:
             raise ValueError(
                 "When using preserve_native_chunks=True, the weights should have the same chunk size as the data"
             )
@@ -552,14 +552,14 @@ def parallel_fit_model_nd(
             )
         )
 
-    # Define a model with default parameters to pass in to fit_models_to_chunk without copying all the parameter data
+    # Define a model with default parameters to pass in to _fit_models_to_chunk without copying all the parameter data
 
     simple_model = _copy_with_new_parameters(model, {})
 
     weights_array = [] if weights is None else [weights]
 
     result = da.map_blocks(
-        fit_models_to_chunk,
+        _fit_models_to_chunk,
         data,
         *weights_array,
         *parameter_arrays,

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -1,4 +1,59 @@
-def parallel_fit_model_nd(*, model, fitter, data, fitting_axes, world, method='dask'):
+from math import prod
+
+import numpy as np
+from dask import array as da
+
+__all__ = ["parallel_fit_model_nd"]
+
+
+def fit_models_to_chunk(
+    data,
+    *parameters,
+    block_info=None,
+    model=None,
+    fitter=None,
+    world=None,
+):
+    """
+    Function that gets passed to map_blocks and will fit models to a specific
+    chunk of the data.
+    """
+    if data.ndim == 0 or data.size == 0 or block_info is None or block_info == []:
+        return np.array(parameters)
+
+    # BUG: fitter doesn't work correctly if pickled/unpickled
+    from astropy.modeling.fitting import LMLSQFitter
+
+    fitter = LMLSQFitter()
+
+    # Iterate over the first axis and fit each model in turn
+    for i in range(data.shape[0]):
+        # Make a copy of the reference model and inject parameters
+        model_i = model.copy()
+        for ipar, name in enumerate(model_i.param_names):
+            setattr(model_i, name, parameters[ipar][i])
+
+        # Do the actual fitting
+        model_fit = fitter(model_i, *world, data[i])
+
+        # Put fitted parameters back into parameters arrays. These arrays are
+        # created in-memory by dask and are local to this process so should be
+        # safe to modify in-place
+        for ipar, name in enumerate(model_fit.param_names):
+            parameters[ipar][i] = getattr(model_fit, name).value
+
+    return np.array(parameters)
+
+
+def parallel_fit_model_nd(
+    *,
+    model,
+    fitter,
+    data,
+    fitting_axes,
+    world,
+    chunk_n_max=None,
+):
     """
     Fit a model in parallel to an N-dimensional dataset.
 
@@ -27,5 +82,90 @@ def parallel_fit_model_nd(*, model, fitter, data, fitting_axes, world, method='d
         as N-dimensional arrays with shape broadcastable to the data shape.
     method : { 'dask' }
         The framework to use for the parallelization.
-        """
-    pass
+    chunk_n_max : int
+        Maximum number of fits to include in a chunk. If this is made too large,
+        then the workload will not be split properly over processes, and if it is
+        too small it may be inefficient.
+    """
+    # Sanitize fitting_axes and determine iterating_axes
+    ndim = data.ndim
+    if not isinstance(fitting_axes, tuple):
+        fitting_axes = (fitting_axes,)
+    fitting_axes = tuple([(fi if fi > 0 else ndim - fi) for fi in fitting_axes])
+    iterating_axes = tuple([i for i in range(ndim) if i not in fitting_axes])
+
+    # Determine the shape along the fitting dimensions and the iterating dimensions
+    fitting_shape = tuple([data.shape[i] for i in fitting_axes])
+    iterating_shape = tuple([data.shape[i] for i in iterating_axes])
+
+    # Make sure the input array is a dask array
+    data = da.asarray(data)
+
+    # Move all iterating dimensions to the front and flatten. We do this so
+    # that fit_models_to_chunk can be agnostic of the complexity of the
+    # iterating dimensions.
+    original_axes = iterating_axes + fitting_axes
+    new_axes = tuple(range(ndim))
+    data = da.moveaxis(data, original_axes, new_axes)
+    data = data.reshape((prod(iterating_shape),) + fitting_shape)
+
+    # Re-index world if a dict, make it a tuple in order of fitting_axes
+    if isinstance(world, dict):
+        world = tuple([world[axis] for axis in fitting_axes])
+
+    # Rechunk the array so that it is not chunked along the fitting axes
+    chunk_shape = ("auto",) + (-1,) * len(fitting_axes)
+    if chunk_n_max:
+        data = data.rechunk(
+            chunk_shape, block_size_limit=chunk_n_max * data.dtype.itemsize
+        )
+    else:
+        data = data.rechunk(chunk_shape)
+
+    # Extract the parameters arrays from the model, in the order in which they
+    # appear in param_names, convert to dask arrays, and broadcast to shape of
+    # iterable axes. We need to rechunk to the same chunk shape as the data
+    # so that chunks line up and for map_blocks to work properly.
+    parameter_arrays = []
+    for name in model.param_names:
+        values = getattr(model, name).value
+        array = (
+            da.broadcast_to(da.from_array(values), iterating_shape)
+            .reshape(iterating_shape)
+            .ravel()
+            .rechunk(data.chunksize)
+        )
+        parameter_arrays.append(array)
+
+    # Define a model with default parameters to pass in to fit_models_to_chunk without copying all the parameter data
+
+    constraints = {}
+    for constraint in model.parameter_constraints:
+        constraints[constraint] = getattr(model, constraint)
+
+    simple_model = model.__class__(**constraints)
+
+    result = da.map_blocks(
+        fit_models_to_chunk,
+        data,
+        *parameter_arrays,
+        chunks=(3,) + data.chunksize,
+        enforce_ndim=True,
+        dtype=float,
+        new_axis=0,
+        model=simple_model,
+        fitter=fitter,
+        world=world,
+    )
+
+    parameter_arrays_fitted = result.compute(scheduler="processes")
+
+    # Set up new parameter arrays with fitted values
+    parameters = {}
+    for i, name in enumerate(model.param_names):
+        parameters[name] = parameter_arrays_fitted[i].reshape(iterating_shape)
+
+    # Instantiate new fitted model
+    model_fitted = model.__class__(**parameters, **constraints)
+
+    return model_fitted

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -176,7 +176,7 @@ def fit_models_to_chunk(
             # index.
 
             index_abs = np.array(index) + np.array(
-                [block_info[0]["array-location"][idx + 1][0] for idx in iterating_axes]
+                [block_info[0]["array-location"][idx][0] for idx in iterating_axes]
             )
             # index = tuple(int(idx) for idx in np.unravel_index(i_abs, iterating_shape))
             maxlen = int(ceil(log10(max(iterating_shape))))

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -177,7 +177,7 @@ def fit_models_to_chunk(
                 fig = plt.figure()
                 ax = fig.add_subplot(1, 1, 1)
                 ax.set_title(str(index))
-                ax.plot(world[0], data[i], "k.")
+                ax.plot(world_values[0], data[i], "k.")
                 if model_fit is None:
                     ax.text(0.1, 0.9, "Fit failed!", color="r", transform=ax.transAxes)
                 else:

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -21,17 +21,14 @@ def fit_models_to_chunk(
     if data.ndim == 0 or data.size == 0 or block_info is None or block_info == []:
         return np.array(parameters)
 
-    # BUG: fitter doesn't work correctly if pickled/unpickled
-    from astropy.modeling.fitting import LMLSQFitter
-
-    fitter = LMLSQFitter()
+    parameters = np.array(parameters)
 
     # Iterate over the first axis and fit each model in turn
     for i in range(data.shape[0]):
         # Make a copy of the reference model and inject parameters
         model_i = model.copy()
         for ipar, name in enumerate(model_i.param_names):
-            setattr(model_i, name, parameters[ipar][i])
+            setattr(model_i, name, parameters[ipar, i])
 
         # Do the actual fitting
         model_fit = fitter(model_i, *world, data[i])
@@ -40,9 +37,9 @@ def fit_models_to_chunk(
         # created in-memory by dask and are local to this process so should be
         # safe to modify in-place
         for ipar, name in enumerate(model_fit.param_names):
-            parameters[ipar][i] = getattr(model_fit, name).value
+            parameters[ipar, i] = getattr(model_fit, name).value
 
-    return np.array(parameters)
+    return parameters
 
 
 def parallel_fit_model_nd(

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -70,7 +70,7 @@ def _copy_with_new_parameters(model, parameters, shape=None):
         # We hard-code the fix for Polynomial1D but other models will need a
         # similar treatment. However, rather than hard-coding all possible
         # models here we should fix the underlying issue that would make this
-        # whole function unecessary.
+        # whole function unnecessary.
         if isinstance(model, models.Polynomial1D):
             args = (model.degree,)
         else:
@@ -544,7 +544,9 @@ def parallel_fit_dask(
         if model.input_units is None:
             target_units = world_units[:]
         else:
-            target_units = [model.input_units[model.inputs[i]] for i in range(model.n_inputs)]
+            target_units = [
+                model.input_units[model.inputs[i]] for i in range(model.n_inputs)
+            ]
             world = [
                 unit.to(
                     target_units[i],

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -421,10 +421,11 @@ def parallel_fit_model_nd(
         # or it should be one dimensional and the broadcasting can happen later
         if len(world) != len(fitting_axes):
             raise ValueError("Number of world arrays must match number of fitting axes")
+        world = list(world)
         world_units = []
-        for w in world:
+        for iw, w in enumerate(world):
             if (unit := getattr(w, "unit", None)) is not None:
-                w = w.value
+                world[iw] = w.value
             world_units.append(unit)
 
         if all(w.ndim == 1 for w in world):

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -411,9 +411,7 @@ def parallel_fit_model_nd(
             .ravel()
         )
         array = array.reshape(array.shape + (1,) * len(fitting_shape))
-        array = da.broadcast_to(array, array.shape[:1] + fitting_shape).rechunk(
-            data.chunksize
-        )
+        array = array.rechunk(data.chunksize)
         parameter_arrays.append(array)
 
     # Define a model with default parameters to pass in to fit_models_to_chunk without copying all the parameter data

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -14,7 +14,7 @@ from astropy.modeling.utils import _combine_equivalency_dict
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 
-__all__ = ["parallel_fit_model_nd"]
+__all__ = ["parallel_fit_dask"]
 
 
 def _pixel_to_world_values_block(*pixel, wcs=None):
@@ -249,7 +249,7 @@ class ParameterContainer:
         return values[item]
 
 
-def parallel_fit_model_nd(
+def parallel_fit_dask(
     *,
     model,
     fitter,

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -107,7 +107,8 @@ def fit_models_to_chunk(
             # i a 1-d index but we need to re-convert it back to an N-dimensional
             # index.
 
-            index = tuple(int(idx) for idx in np.unravel_index(i, iterating_shape))
+            i_abs = i + block_info[0]["array-location"][0][0]
+            index = tuple(int(idx) for idx in np.unravel_index(i_abs, iterating_shape))
             maxlen = int(ceil(log10(max(iterating_shape))))
             fmt = "{0:0" + str(maxlen) + "d}"
             index_folder = os.path.join(
@@ -136,7 +137,9 @@ def fit_models_to_chunk(
                 if model_fit is None:
                     ax.text(0.1, 0.9, "Fit failed!", color="r", transform=ax.transAxes)
                 else:
-                    xmodel = np.linspace(*ax.get_xlim(), 100) * world[0].unit
+                    xmodel = np.linspace(*ax.get_xlim(), 100)
+                    if hasattr(world[0], "unit"):
+                        xmodel = xmodel * world[0].unit
                     ax.plot(xmodel, model_fit(xmodel), color="r")
                 fig.savefig(os.path.join(index_folder, "fit.png"))
                 plt.close(fig)
@@ -146,7 +149,9 @@ def fit_models_to_chunk(
     # and in principle we should be able to use drop_axis in map_blocks to
     # indicate that we no longer need these extra dimensions.
     parameters = parameters.reshape((parameters.shape[0], parameters.shape[1], 1))
-    parameters = np.broadcast_to(parameters, (parameters.shape[0], parameters.shape[1]) + data.shape[1:])
+    parameters = np.broadcast_to(
+        parameters, (parameters.shape[0], parameters.shape[1]) + data.shape[1:]
+    )
 
     return parameters
 

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -115,6 +115,12 @@ def fit_models_to_chunk(
 
     # Iterate over the first axis and fit each model in turn
     for i in range(data.shape[0]):
+        # If all data values are NaN, just set parameters to NaN and move on
+        if np.all(np.isnan(data[i])):
+            for ipar, name in enumerate(model.param_names):
+                parameters[ipar, i] = np.nan
+            continue
+
         # Make a copy of the reference model and inject parameters
         model_i = model.copy()
         for ipar, name in enumerate(model_i.param_names):

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -120,7 +120,7 @@ def _fit_models_to_chunk(
 
     # Start off by re-ordering axes so that iterating axes come first followed
     # by fitting axes
-    original_axes = tuple([idx for idx in (iterating_axes + fitting_axes)])
+    original_axes = tuple(idx for idx in (iterating_axes + fitting_axes))
     new_axes = tuple(range(data.ndim))
     data = np.moveaxis(data, original_axes, new_axes)
     arrays = [np.moveaxis(array, original_axes, new_axes) for array in arrays]
@@ -478,7 +478,7 @@ def parallel_fit_dask(
                 f"({fitting_world.world_n_dim}) does not match the number of fitting axes ({len(fitting_axes)})"
             )
 
-        world_units = [u.Unit(world.world_axis_units[idx]) for idx in fitting_axes]
+        world_units = list(map(u.Unit, fitting_world.world_axis_units[::-1]))
 
         # Construct dask arrays of world coordinates for every pixel in the cube.
         # We will then iterate over this in map_blocks.

--- a/astropy/modeling/fitting_parallel.py
+++ b/astropy/modeling/fitting_parallel.py
@@ -141,9 +141,14 @@ def fit_models_to_chunk(
                 fig.savefig(os.path.join(index_folder, "fit.png"))
                 plt.close(fig)
 
+    # HACK: for now we need to return chunks with an extra dimension at the start
+    # of the shape, then the rest of the data shape. However, this is wasteful
+    # and in principle we should be able to use drop_axis in map_blocks to
+    # indicate that we no longer need these extra dimensions.
     parameters = parameters.reshape((parameters.shape[0], parameters.shape[1], 1))
+    parameters = np.broadcast_to(parameters, (parameters.shape[0], parameters.shape[1]) + data.shape[1:])
 
-    return np.broadcast_to(parameters, (parameters.shape[0],) + data.shape)
+    return parameters
 
 
 def parallel_fit_model_nd(
@@ -281,7 +286,6 @@ def parallel_fit_model_nd(
         fit_models_to_chunk,
         data,
         *parameter_arrays,
-        # chunks=(len(parameter_arrays),) + data.chunksize,
         enforce_ndim=True,
         dtype=float,
         new_axis=0,

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -6,16 +6,21 @@ import re
 import pytest
 
 pytest.importorskip("dask")
-import numpy as np
-from dask import array as da
-from numpy.testing import assert_allclose
+import numpy as np  # noqa: E402
+from dask import array as da  # noqa: E402
+from numpy.testing import assert_allclose  # noqa: E402
 
-from astropy import units as u
-from astropy.modeling.fitting import LevMarLSQFitter, TRFLSQFitter
-from astropy.modeling.fitting_parallel import parallel_fit_dask
-from astropy.modeling.models import Const1D, Gaussian1D, Linear1D, Planar2D
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.wcs import WCS
+from astropy import units as u  # noqa: E402
+from astropy.modeling.fitting import LevMarLSQFitter, TRFLSQFitter  # noqa: E402
+from astropy.modeling.fitting_parallel import parallel_fit_dask  # noqa: E402
+from astropy.modeling.models import (  # noqa: E402
+    Const1D,
+    Gaussian1D,
+    Linear1D,
+    Planar2D,
+)
+from astropy.tests.helper import assert_quantity_allclose  # noqa: E402
+from astropy.wcs import WCS  # noqa: E402
 
 
 def gaussian(x, amplitude, mean, stddev):

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -69,3 +69,39 @@ def test_1d_model_fit_axes(iterating_shape, swapaxes_data, swapaxes_parameters, 
     assert_allclose(model_fit.amplitude.value, modify_axes(amplitude, iterating_shape, swapaxes_parameters))
     assert_allclose(model_fit.mean.value, modify_axes(mean, iterating_shape, swapaxes_parameters))
     assert_allclose(model_fit.stddev.value, modify_axes(stddev, iterating_shape, swapaxes_parameters))
+
+
+def test_2d_model_fit_axes():
+    # As for test_1d_model_fit_axes but fitting a 2D model, this checks that the
+    # fitting axes logic works when there is more than one fitting axis.
+    pass
+
+
+def test_no_world():
+    # Test not specifying world
+    pass
+
+
+def test_wcs_world():
+    # Test specifying world as a WCS
+    pass
+
+
+def test_world_array():
+    # Test specifying world as an array with dimensions matching the data
+    pass
+
+
+def test_diagnostics():
+    pass
+
+
+def test_dask_scheduler():
+    # Try all the different dask schedulers
+    pass
+
+
+def test_compound_model():
+    # Compound models have to be treated a little differently so check they
+    # work fine.
+    pass

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -1,12 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import pytest
+import re
+
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from astropy.modeling.models import Gaussian1D
-from astropy.modeling.fitting_parallel import parallel_fit_model_nd
 from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting_parallel import parallel_fit_model_nd
+from astropy.modeling.models import Gaussian1D, Linear1D, Planar2D
+from astropy.wcs import WCS
 
 
 def gaussian(x, amplitude, mean, stddev):
@@ -20,23 +23,29 @@ def modify_axes(array, shape, swapaxes):
     return array
 
 
-@pytest.mark.parametrize('iterating_shape,swapaxes_data,swapaxes_parameters,fitting_axes', [
-    ((120,), None, None, 0),
-    ((2, 3, 4, 5), None, None, 0),
-    ((2, 3, 4, 5), (0, 1), None, 1),
-    ((2, 3, 4, 5), (0, 2), (0, 1), 2),
-])
-def test_1d_model_fit_axes(iterating_shape, swapaxes_data, swapaxes_parameters, fitting_axes):
-
+@pytest.mark.parametrize(
+    "iterating_shape,swapaxes_data,swapaxes_parameters,fitting_axes",
+    [
+        ((120,), None, None, 0),
+        ((2, 3, 4, 5), None, None, 0),
+        ((2, 3, 4, 5), (0, 1), None, 1),
+        ((2, 3, 4, 5), (0, 2), (0, 1), 2),
+    ],
+)
+def test_1d_model_fit_axes(
+    iterating_shape, swapaxes_data, swapaxes_parameters, fitting_axes
+):
     # Test that different iterating and fitting axes work. We start off by
-    # creating an array with one fitting and one iterating dimension:
+    # creating an array with one fitting and one iterating dimension and we then
+    # modify the array dimensionality and order of the dimensions to test
+    # different scenarios.
 
     N = 120
-    M = 20
+    P = 20
 
     rng = np.random.default_rng(12345)
 
-    x = np.linspace(-5, 30, M)
+    x = np.linspace(-5, 30, P)
 
     amplitude = rng.uniform(1, 10, N)
     mean = rng.uniform(0, 25, N)
@@ -44,15 +53,21 @@ def test_1d_model_fit_axes(iterating_shape, swapaxes_data, swapaxes_parameters, 
 
     data = gaussian(x[:, None], amplitude, mean, stddev)
 
-    # Modify the axes by reshaping and swaping axes
+    # At this point, the data has shape (P, N)
+
+    # Modify the axes by reshaping and swapping axes
     data = modify_axes(data, data.shape[0:1] + iterating_shape, swapaxes_data)
 
     # Set initial parameters to be close to but not exactly equal to true parameters
 
     model = Gaussian1D(
-        amplitude=modify_axes(amplitude * rng.random(N), iterating_shape, swapaxes_parameters),
+        amplitude=modify_axes(
+            amplitude * rng.random(N), iterating_shape, swapaxes_parameters
+        ),
         mean=modify_axes(mean + rng.random(N), iterating_shape, swapaxes_parameters),
-        stddev=modify_axes(stddev + rng.random(N), iterating_shape, swapaxes_parameters)
+        stddev=modify_axes(
+            stddev + rng.random(N), iterating_shape, swapaxes_parameters
+        ),
     )
     fitter = LevMarLSQFitter()
 
@@ -66,30 +81,161 @@ def test_1d_model_fit_axes(iterating_shape, swapaxes_data, swapaxes_parameters, 
 
     # Check that shape and values match
 
-    assert_allclose(model_fit.amplitude.value, modify_axes(amplitude, iterating_shape, swapaxes_parameters))
-    assert_allclose(model_fit.mean.value, modify_axes(mean, iterating_shape, swapaxes_parameters))
-    assert_allclose(model_fit.stddev.value, modify_axes(stddev, iterating_shape, swapaxes_parameters))
+    assert_allclose(
+        model_fit.amplitude.value,
+        modify_axes(amplitude, iterating_shape, swapaxes_parameters),
+    )
+    assert_allclose(
+        model_fit.mean.value, modify_axes(mean, iterating_shape, swapaxes_parameters)
+    )
+    assert_allclose(
+        model_fit.stddev.value,
+        modify_axes(stddev, iterating_shape, swapaxes_parameters),
+    )
 
 
-def test_2d_model_fit_axes():
-    # As for test_1d_model_fit_axes but fitting a 2D model, this checks that the
-    # fitting axes logic works when there is more than one fitting axis.
-    pass
+@pytest.mark.parametrize(
+    "iterating_shape,swapaxes_data,swapaxes_parameters,fitting_axes",
+    [
+        ((120,), None, None, (0, 1)),
+        ((2, 3, 4, 5), None, None, (0, 1)),  # make iterating dimensions N-d
+        ((2, 3, 4, 5), (0, 1), None, (1, 0)),  # swap data axes to be (y, x)
+        ((2, 3, 4, 5), (1, 2), None, (0, 2)),  # start mixing up axes
+        ((2, 3, 4, 5), (0, 3), (0, 1), (3, 1)),  # iterating axes out of order
+    ],
+)
+def test_2d_model_fit_axes(
+    iterating_shape, swapaxes_data, swapaxes_parameters, fitting_axes
+):
+    N = 120
+    P = 20
+    Q = 10
+
+    rng = np.random.default_rng(12345)
+
+    x = np.linspace(-5, 30, P)
+    y = np.linspace(5, 20, Q)
+
+    slope_x = rng.uniform(1, 5, N)
+    slope_y = rng.uniform(1, 5, N)
+    intercept = rng.uniform(-2, 2, N)
+
+    data = slope_x * x[:, None, None] + slope_y * y[None, :, None] + intercept
+
+    # At this point, the data has shape (P, Q, N)
+
+    # Modify the axes by reshaping and swapping axes
+    data = modify_axes(data, data.shape[0:2] + iterating_shape, swapaxes_data)
+
+    # Set initial parameters to be close to but not exactly equal to true parameters
+
+    model = Planar2D(
+        slope_x=modify_axes(
+            slope_x * rng.random(N), iterating_shape, swapaxes_parameters
+        ),
+        slope_y=modify_axes(
+            slope_y + rng.random(N), iterating_shape, swapaxes_parameters
+        ),
+        intercept=modify_axes(
+            intercept + rng.random(N), iterating_shape, swapaxes_parameters
+        ),
+    )
+    fitter = LevMarLSQFitter()
+
+    model_fit = parallel_fit_model_nd(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=fitting_axes,
+        world={fitting_axes[0]: x, fitting_axes[1]: y},
+    )
+
+    # Check that shape and values match
+
+    assert_allclose(
+        model_fit.slope_x.value,
+        modify_axes(slope_x, iterating_shape, swapaxes_parameters),
+    )
+    assert_allclose(
+        model_fit.slope_y.value,
+        modify_axes(slope_y, iterating_shape, swapaxes_parameters),
+    )
+    assert_allclose(
+        model_fit.intercept.value,
+        modify_axes(intercept, iterating_shape, swapaxes_parameters),
+    )
 
 
 def test_no_world():
-    # Test not specifying world
-    pass
+    # This also doubles as a test when there are no iterating dimensions
+    data = gaussian(np.arange(20), 2, 10, 1)
+    model = Gaussian1D(amplitude=1.5, mean=12, stddev=1.5)
+    fitter = LevMarLSQFitter()
+    model_fit = parallel_fit_model_nd(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=0,
+    )
+    assert_allclose(model_fit.amplitude.value, 2)
+    assert_allclose(model_fit.mean.value, 10)
+    assert_allclose(model_fit.stddev.value, 1)
 
 
-def test_wcs_world():
-    # Test specifying world as a WCS
-    pass
+def test_wcs_world_1d():
+    # Test specifying world as a WCS, for the 1D model case
+
+    # TODO: decide if WCS dimensionality should match cube or just the fitting
+    # dimensions.
+
+    data = gaussian(
+        np.arange(20)[:, None],
+        np.array([2, 1.8]),
+        np.array([10, 11]),
+        np.array([1, 1.1]),
+    )
+    model = Gaussian1D(amplitude=1.5, mean=1.2, stddev=0.15)
+    fitter = LevMarLSQFitter()
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = "OFFSET", "WAVE"
+    wcs.wcs.crval = 10, 0.1
+    wcs.wcs.crpix = 1, 1
+    wcs.wcs.cdelt = 10, 0.1
+
+    model_fit = parallel_fit_model_nd(
+        data=data, model=model, fitter=fitter, fitting_axes=0, world=wcs
+    )
+    assert_allclose(model_fit.amplitude.value, [2, 1.8])
+    assert_allclose(model_fit.mean.value, [1.1, 1.2])
+    assert_allclose(model_fit.stddev.value, [0.1, 0.11])
 
 
 def test_world_array():
-    # Test specifying world as an array with dimensions matching the data
-    pass
+    # Test specifying world as a tuple of arrays with dimensions matching the data
+
+    # TODO: decide if should pass as many arrays as dimensions in cube or
+    # fitting dimensions.
+
+    data = gaussian(
+        np.arange(21)[:, None],
+        np.array([2, 1.8]),
+        np.array([10, 10]),
+        np.array([1, 1.1]),
+    )
+    model = Gaussian1D(amplitude=1.5, mean=7, stddev=2)
+    fitter = LevMarLSQFitter()
+
+    world1 = np.array([np.linspace(0, 10, 21), np.linspace(5, 15, 21)]).T
+
+    world2 = np.broadcast_to(np.array([1, 2]), data.shape)
+
+    model_fit = parallel_fit_model_nd(
+        data=data, model=model, fitter=fitter, fitting_axes=0, world=(world1, world2)
+    )
+    assert_allclose(model_fit.amplitude.value, [2, 1.8])
+    assert_allclose(model_fit.mean.value, [5, 10])
+    assert_allclose(model_fit.stddev.value, [0.5, 0.55])
 
 
 def test_diagnostics():
@@ -105,3 +251,72 @@ def test_compound_model():
     # Compound models have to be treated a little differently so check they
     # work fine.
     pass
+
+
+def test_model_dimension_mismatch():
+    model = Planar2D()
+    data = np.empty((20, 10, 5))
+    fitter = LevMarLSQFitter()
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Model is 2-dimensional, but got 1 value(s) in fitting_axes="),
+    ):
+        parallel_fit_model_nd(
+            data=data,
+            model=model,
+            fitter=fitter,
+            fitting_axes=0,
+        )
+
+    model = Linear1D()
+    data = np.empty((20, 10, 5))
+    fitter = LevMarLSQFitter()
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Model is 1-dimensional, but got 2 value(s) in fitting_axes="),
+    ):
+        parallel_fit_model_nd(
+            data=data,
+            model=model,
+            fitter=fitter,
+            fitting_axes=(1, 2),
+        )
+
+
+def test_data_dimension_mismatch():
+    model = Planar2D()
+    data = np.empty((20, 10, 5))
+    fitter = LevMarLSQFitter()
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Fitting index 4 out of range for 3-dimensional data"),
+    ):
+        parallel_fit_model_nd(
+            data=data,
+            model=model,
+            fitter=fitter,
+            fitting_axes=(1, 4),
+        )
+
+
+def test_world_dimension_mismatch():
+    model = Planar2D()
+    data = np.empty((20, 10, 5))
+    fitter = LevMarLSQFitter()
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "world[2] has length 6 but data along dimension 2 has length 5"
+        ),
+    ):
+        parallel_fit_model_nd(
+            data=data,
+            model=model,
+            fitter=fitter,
+            fitting_axes=(1, 2),
+            world={1: np.arange(10), 2: np.arange(6)},
+        )

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -578,7 +578,7 @@ def test_units():
         * u.Jy
     )
 
-    model = Gaussian1D(amplitude=1.5 * u.Jy, mean=7 * u.um, stddev=2 * u.um)
+    model = Gaussian1D(amplitude=1.5 * u.Jy, mean=7 * u.um, stddev=0.002 * u.mm)
     fitter = LevMarLSQFitter()
 
     model_fit = parallel_fit_model_nd(
@@ -586,8 +586,9 @@ def test_units():
         model=model,
         fitter=fitter,
         fitting_axes=0,
-        world=(np.arange(21) * u.nm,),
+        world=(1000 * np.arange(21) * u.nm,),
     )
-    assert_quantity_allclose(model_fit.amplitude.value, [2, 1.8] * u.Jy)
-    assert_quantity_allclose(model_fit.mean.value, [5, 10] * u.um)
-    assert_quantity_allclose(model_fit.stddev.value, [1.0, 1.1] * u.um)
+
+    assert_quantity_allclose(model_fit.amplitude.quantity, [2, 1.8] * u.Jy)
+    assert_quantity_allclose(model_fit.mean.quantity, [5, 10] * u.um)
+    assert_quantity_allclose(model_fit.stddev.quantity, [1.0, 1.1] * u.um)

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -276,7 +276,7 @@ def test_diagnostics(tmp_path):
         model=model,
         fitter=fitter,
         fitting_axes=0,
-        diagnostics="failed",
+        diagnostics="error",
         diagnostics_path=tmp_path / "diag1",
     )
 
@@ -302,7 +302,7 @@ def test_diagnostics(tmp_path):
         fitter=fitter,
         fitting_axes=0,
         world=WCS(naxis=2),
-        diagnostics="failed",
+        diagnostics="error",
         diagnostics_path=tmp_path / "diag3",
     )
 
@@ -327,7 +327,7 @@ def test_diagnostics(tmp_path):
         fitter=fitter,
         fitting_axes=0,
         world=WCS(naxis=2),
-        diagnostics="failed",
+        diagnostics="error",
         diagnostics_path=tmp_path / "diag4",
         diagnostics_callable=custom_callable,
     )

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -3,8 +3,8 @@
 import os
 import re
 
-
 import pytest
+
 pytest.importorskip("dask")
 
 import numpy as np
@@ -240,6 +240,28 @@ def test_world_array():
     assert_allclose(model_fit.amplitude.value, [2, 1.8])
     assert_allclose(model_fit.mean.value, [5, 10])
     assert_allclose(model_fit.stddev.value, [0.5, 0.55])
+
+
+def test_fitter_kwargs(tmp_path):
+    data = gaussian(np.arange(20), 2, 10, 1)
+    data = np.broadcast_to(data.reshape((20, 1)), (20, 3)).copy()
+
+    data[0, 0] = np.nan
+
+    model = Gaussian1D(amplitude=1.5, mean=12, stddev=1.5)
+    fitter = LevMarLSQFitter()
+
+    model_fit = parallel_fit_model_nd(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=0,
+        fitter_kwargs={"filter_non_finite": True},
+    )
+
+    assert_allclose(model_fit.amplitude.value, 2)
+    assert_allclose(model_fit.mean.value, 10)
+    assert_allclose(model_fit.stddev.value, 1)
 
 
 def test_diagnostics(tmp_path):

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -274,6 +274,21 @@ def test_diagnostics(tmp_path):
 
     assert sorted(os.listdir(tmp_path / "diag2")) == ["0", "1", "2"]
 
+    # Make sure things world also with world=wcs
+
+    parallel_fit_model_nd(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=0,
+        world=WCS(naxis=2),
+        diagnostics="failed",
+        diagnostics_path=tmp_path / "diag3",
+    )
+
+    assert os.listdir(tmp_path / "diag3") == ["0"]
+    assert sorted(os.listdir(tmp_path / "diag3" / "0")) == ["error.log", "fit.png"]
+
 
 @pytest.mark.parametrize(
     "scheduler", ("synchronous", "processes", "threads", "default")

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose
 
 from astropy import units as u
 from astropy.modeling.fitting import LevMarLSQFitter
-from astropy.modeling.fitting_parallel import parallel_fit_model_nd
+from astropy.modeling.fitting_parallel import parallel_fit_dask
 from astropy.modeling.models import Const1D, Gaussian1D, Linear1D, Planar2D
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.wcs import WCS
@@ -77,7 +77,7 @@ def test_1d_model_fit_axes(
     )
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -148,7 +148,7 @@ def test_2d_model_fit_axes(
     )
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -177,7 +177,7 @@ def test_no_world():
     data = gaussian(np.arange(20), 2, 10, 1)
     model = Gaussian1D(amplitude=1.5, mean=12, stddev=1.5)
     fitter = LevMarLSQFitter()
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -206,7 +206,7 @@ def test_wcs_world_1d():
     wcs.wcs.crpix = 1, 1
     wcs.wcs.cdelt = 10, 0.1
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data, model=model, fitter=fitter, fitting_axes=0, world=wcs
     )
     assert_allclose(model_fit.amplitude.value, [2, 1.8])
@@ -228,7 +228,7 @@ def test_world_array():
 
     world1 = np.array([np.linspace(0, 10, 21), np.linspace(5, 15, 21)]).T
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data, model=model, fitter=fitter, fitting_axes=0, world=(world1,)
     )
     assert_allclose(model_fit.amplitude.value, [2, 1.8])
@@ -245,7 +245,7 @@ def test_fitter_kwargs(tmp_path):
     model = Gaussian1D(amplitude=1.5, mean=12, stddev=1.5)
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -267,7 +267,7 @@ def test_diagnostics(tmp_path):
     model = Gaussian1D(amplitude=1.5, mean=12, stddev=1.5)
     fitter = LevMarLSQFitter()
 
-    parallel_fit_model_nd(
+    parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -279,7 +279,7 @@ def test_diagnostics(tmp_path):
     assert os.listdir(tmp_path / "diag1") == ["0"]
     assert sorted(os.listdir(tmp_path / "diag1" / "0")) == ["error.log"]
 
-    parallel_fit_model_nd(
+    parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -292,7 +292,7 @@ def test_diagnostics(tmp_path):
 
     # Make sure things world also with world=wcs
 
-    parallel_fit_model_nd(
+    parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -317,7 +317,7 @@ def test_diagnostics(tmp_path):
         fig.savefig(os.path.join(path, "fit.png"))
         plt.close(fig)
 
-    parallel_fit_model_nd(
+    parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -359,7 +359,7 @@ def test_dask_scheduler(scheduler):
     )
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -402,7 +402,7 @@ def test_compound_model():
     wcs.wcs.crpix = 1, 1
     wcs.wcs.cdelt = 10, 0.1
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data, model=model, fitter=fitter, fitting_axes=0, world=wcs
     )
     assert_allclose(model_fit.amplitude_0.value, [2, 1.8])
@@ -415,7 +415,7 @@ def test_compound_model():
     model.amplitude_1 = 2
     model.amplitude_1.fixed = True
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data, model=model, fitter=fitter, fitting_axes=0, world=wcs
     )
 
@@ -434,7 +434,7 @@ def test_model_dimension_mismatch():
         ValueError,
         match=re.escape("Model is 2-dimensional, but got 1 value(s) in fitting_axes="),
     ):
-        parallel_fit_model_nd(
+        parallel_fit_dask(
             data=data,
             model=model,
             fitter=fitter,
@@ -449,7 +449,7 @@ def test_model_dimension_mismatch():
         ValueError,
         match=re.escape("Model is 1-dimensional, but got 2 value(s) in fitting_axes="),
     ):
-        parallel_fit_model_nd(
+        parallel_fit_dask(
             data=data,
             model=model,
             fitter=fitter,
@@ -466,7 +466,7 @@ def test_data_dimension_mismatch():
         ValueError,
         match=re.escape("Fitting index 4 out of range for 3-dimensional data"),
     ):
-        parallel_fit_model_nd(
+        parallel_fit_dask(
             data=data,
             model=model,
             fitter=fitter,
@@ -485,7 +485,7 @@ def test_world_dimension_mismatch():
             "world[2] has length 6 but data along dimension 2 has length 5"
         ),
     ):
-        parallel_fit_model_nd(
+        parallel_fit_dask(
             data=data,
             model=model,
             fitter=fitter,
@@ -502,7 +502,7 @@ def test_preserve_native_chunks():
     model = Gaussian1D(amplitude=1.5, mean=12, stddev=1.5)
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,
@@ -526,7 +526,7 @@ def test_preserve_native_chunks_invalid():
     with pytest.raises(
         ValueError, match=re.escape("When using preserve_native_chunks=True")
     ):
-        parallel_fit_model_nd(
+        parallel_fit_dask(
             data=data,
             model=model,
             fitter=fitter,
@@ -553,7 +553,7 @@ def test_weights():
     model = Gaussian1D(amplitude=1.5, mean=7, stddev=2)
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         weights=weights,
         model=model,
@@ -581,7 +581,7 @@ def test_units():
     model = Gaussian1D(amplitude=1.5 * u.Jy, mean=7 * u.um, stddev=0.002 * u.mm)
     fitter = LevMarLSQFitter()
 
-    model_fit = parallel_fit_model_nd(
+    model_fit = parallel_fit_dask(
         data=data,
         model=model,
         fitter=fitter,

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -275,7 +275,7 @@ def test_diagnostics(tmp_path):
     )
 
     assert os.listdir(tmp_path / "diag1") == ["0"]
-    assert sorted(os.listdir(tmp_path / "diag1" / "0")) == ["error.log", "fit.png"]
+    assert sorted(os.listdir(tmp_path / "diag1" / "0")) == ["error.log"]
 
     parallel_fit_model_nd(
         data=data,
@@ -301,7 +301,33 @@ def test_diagnostics(tmp_path):
     )
 
     assert os.listdir(tmp_path / "diag3") == ["0"]
-    assert sorted(os.listdir(tmp_path / "diag3" / "0")) == ["error.log", "fit.png"]
+    assert sorted(os.listdir(tmp_path / "diag3" / "0")) == ["error.log"]
+
+    # And check that we can pass in a callable
+
+    def custom_callable(path, world, data, weights, model, fitting_kwargs):
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure()
+        ax = fig.add_subplot(1, 1, 1)
+        ax.plot(world[0], data, "k.")
+        ax.text(0.1, 0.9, "Fit failed!", color="r", transform=ax.transAxes)
+        fig.savefig(os.path.join(path, "fit.png"))
+        plt.close(fig)
+
+    parallel_fit_model_nd(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=0,
+        world=WCS(naxis=2),
+        diagnostics="failed",
+        diagnostics_path=tmp_path / "diag4",
+        diagnostics_callable=custom_callable,
+    )
+
+    assert os.listdir(tmp_path / "diag4") == ["0"]
+    assert sorted(os.listdir(tmp_path / "diag4" / "0")) == ["error.log", "fit.png"]
 
 
 @pytest.mark.parametrize(

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -80,7 +80,7 @@ def test_1d_model_fit_axes(
         model=model,
         fitter=fitter,
         fitting_axes=fitting_axes,
-        world={fitting_axes: x},
+        world=(x,),
     )
 
     # Check that shape and values match
@@ -151,7 +151,7 @@ def test_2d_model_fit_axes(
         model=model,
         fitter=fitter,
         fitting_axes=fitting_axes,
-        world={fitting_axes[0]: x, fitting_axes[1]: y},
+        world=(x, y),
     )
 
     # Check that shape and values match
@@ -232,10 +232,8 @@ def test_world_array():
 
     world1 = np.array([np.linspace(0, 10, 21), np.linspace(5, 15, 21)]).T
 
-    world2 = np.broadcast_to(np.array([1, 2]), data.shape)
-
     model_fit = parallel_fit_model_nd(
-        data=data, model=model, fitter=fitter, fitting_axes=0, world=(world1, world2)
+        data=data, model=model, fitter=fitter, fitting_axes=0, world=(world1,)
     )
     assert_allclose(model_fit.amplitude.value, [2, 1.8])
     assert_allclose(model_fit.mean.value, [5, 10])
@@ -344,7 +342,7 @@ def test_dask_scheduler(scheduler):
         model=model,
         fitter=fitter,
         fitting_axes=0,
-        world={0: x},
+        world=(x,),
         scheduler=scheduler,
     )
 
@@ -470,5 +468,5 @@ def test_world_dimension_mismatch():
             model=model,
             fitter=fitter,
             fitting_axes=(1, 2),
-            world={1: np.arange(10), 2: np.arange(6)},
+            world=(np.arange(10), np.arange(6)),
         )

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -1,0 +1,71 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+from astropy.modeling.models import Gaussian1D
+from astropy.modeling.fitting_parallel import parallel_fit_model_nd
+from astropy.modeling.fitting import LevMarLSQFitter
+
+
+def gaussian(x, amplitude, mean, stddev):
+    return amplitude * np.exp(-((x - mean) ** 2) / 2 / stddev**2)
+
+
+def modify_axes(array, shape, swapaxes):
+    array = array.reshape(shape)
+    if swapaxes is not None:
+        array = array.swapaxes(*swapaxes)
+    return array
+
+
+@pytest.mark.parametrize('iterating_shape,swapaxes_data,swapaxes_parameters,fitting_axes', [
+    ((120,), None, None, 0),
+    ((2, 3, 4, 5), None, None, 0),
+    ((2, 3, 4, 5), (0, 1), None, 1),
+    ((2, 3, 4, 5), (0, 2), (0, 1), 2),
+])
+def test_1d_model_fit_axes(iterating_shape, swapaxes_data, swapaxes_parameters, fitting_axes):
+
+    # Test that different iterating and fitting axes work. We start off by
+    # creating an array with one fitting and one iterating dimension:
+
+    N = 120
+    M = 20
+
+    rng = np.random.default_rng(12345)
+
+    x = np.linspace(-5, 30, M)
+
+    amplitude = rng.uniform(1, 10, N)
+    mean = rng.uniform(0, 25, N)
+    stddev = rng.uniform(1, 4, N)
+
+    data = gaussian(x[:, None], amplitude, mean, stddev)
+
+    # Modify the axes by reshaping and swaping axes
+    data = modify_axes(data, data.shape[0:1] + iterating_shape, swapaxes_data)
+
+    # Set initial parameters to be close to but not exactly equal to true parameters
+
+    model = Gaussian1D(
+        amplitude=modify_axes(amplitude * rng.random(N), iterating_shape, swapaxes_parameters),
+        mean=modify_axes(mean + rng.random(N), iterating_shape, swapaxes_parameters),
+        stddev=modify_axes(stddev + rng.random(N), iterating_shape, swapaxes_parameters)
+    )
+    fitter = LevMarLSQFitter()
+
+    model_fit = parallel_fit_model_nd(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=fitting_axes,
+        world={fitting_axes: x},
+    )
+
+    # Check that shape and values match
+
+    assert_allclose(model_fit.amplitude.value, modify_axes(amplitude, iterating_shape, swapaxes_parameters))
+    assert_allclose(model_fit.mean.value, modify_axes(mean, iterating_shape, swapaxes_parameters))
+    assert_allclose(model_fit.stddev.value, modify_axes(stddev, iterating_shape, swapaxes_parameters))

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -592,3 +592,24 @@ def test_units():
     assert_quantity_allclose(model_fit.amplitude.quantity, [2, 1.8] * u.Jy)
     assert_quantity_allclose(model_fit.mean.quantity, [5, 10] * u.um)
     assert_quantity_allclose(model_fit.stddev.quantity, [1.0, 1.1] * u.um)
+
+
+def test_units_no_input_units():
+    # Make sure that fitting with units works for models without input_units defined
+
+    data = (np.repeat(3, 20) * u.Jy).reshape((20, 1))
+
+    model = Const1D(1 * u.mJy)
+    fitter = LevMarLSQFitter()
+
+    assert not model.input_units
+
+    model_fit = parallel_fit_dask(
+        data=data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=0,
+        world=(1000 * np.arange(20) * u.nm,),
+    )
+
+    assert_quantity_allclose(model_fit.amplitude.quantity, 3 * u.Jy)

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -3,8 +3,11 @@
 import os
 import re
 
-import numpy as np
+
 import pytest
+pytest.importorskip("dask")
+
+import numpy as np
 from numpy.testing import assert_allclose
 
 from astropy.modeling.fitting import LevMarLSQFitter

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -511,3 +511,7 @@ def test_preserve_native_chunks_invalid():
             fitting_axes=0,
             preserve_native_chunks=True,
         )
+
+
+# Add a test to make sure that units are never passed to the fitter - perhaps
+# we could create a custom fitter callable and check the arguments.

--- a/docs/changes/modeling/16696.feature.rst
+++ b/docs/changes/modeling/16696.feature.rst
@@ -1,0 +1,3 @@
+Added a new ``parallel_fit_dask`` function that can be used to fit models to
+many sections (e.g. spectra, image slices) on an N-dimensional array in
+parallel.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,6 +122,7 @@ intersphinx_mapping.update(
         "asdf-astropy": ("https://asdf-astropy.readthedocs.io/en/latest/", None),
         "fsspec": ("https://filesystem-spec.readthedocs.io/en/latest/", None),
         "cycler": ("https://matplotlib.org/cycler/", None),
+        "dask": ("https://docs.dask.org/en/stable/", None),
     }
 )
 

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -87,6 +87,7 @@ Advanced Topics
    Extending Fitters <new-fitter.rst>
    Adding support for units to models <add-units.rst>
    Joint Fitting <jointfitter.rst>
+   Parallel Fitting <parallel-fitting.rst>
 
 
 Pre-Defined Models

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -208,13 +208,13 @@ We can now take a look at the parameter maps:
     >>> fig = plt.figure(figsize=(10, 5))
     >>> ax = fig.add_subplot(1, 3, 1)
     >>> ax.set_title('Amplitude')  # doctest: +IGNORE_OUTPUT
-    >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')
+    >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')  # doctest: +IGNORE_OUTPUT
     >>> ax = fig.add_subplot(1, 3, 2)
     >>> ax.set_title('Mean')  # doctest: +IGNORE_OUTPUT
-    >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')
+    >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')  # doctest: +IGNORE_OUTPUT
     >>> ax = fig.add_subplot(1, 3, 3)
     >>> ax.set_title('Standard deviation')  # doctest: +IGNORE_OUTPUT
-    >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')
+    >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')  # doctest: +IGNORE_OUTPUT
 
 There are a number of pixels that appear to have issues. Inspecting the
 histogram of means, we can see that a lot of values are not at all in
@@ -256,13 +256,13 @@ and we can visualize the results:
     >>> fig = plt.figure(figsize=(10, 5))
     >>> ax = fig.add_subplot(1, 3, 1)
     >>> ax.set_title('Amplitude')  # doctest: +IGNORE_OUTPUT
-    >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')
+    >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')  # doctest: +IGNORE_OUTPUT
     >>> ax = fig.add_subplot(1, 3, 2)
     >>> ax.set_title('Mean')  # doctest: +IGNORE_OUTPUT
-    >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')
+    >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')  # doctest: +IGNORE_OUTPUT
     >>> ax = fig.add_subplot(1, 3, 3)
     >>> ax.set_title('Standard deviation')  # doctest: +IGNORE_OUTPUT
-    >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')
+    >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')  # doctest: +IGNORE_OUTPUT
 
 The amplitude map no longer contains any problematic pixels.
 

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -1,0 +1,319 @@
+.. _parallel-fitting:
+
+Fitting a model many times in parallel
+**************************************
+
+In some cases, you may want to fit a model many times to data. For example, you
+may have a spectral cube (with two celestial axes and one spectral axis) and you
+want to fit a 1D model (which could be either a simple Gaussian model or a
+complex compound model with multiple lines and a continuum) to each individual
+spectrum in the cube. Alternatively, you may have a cube with two celestial
+axes, one spectral axis, and one time axis, and you want to fit a 2D model to
+each 2D celestial plane in the cube. Provided each model fit can be treated as
+independent, there are significant performance benefits to carrying out these
+model fits in parallel.
+
+The :func:`~astropy.modeling.fitting.parallel_fit_dask` function is ideally
+suited to these use cases. It makes it simple to set up fitting of M-dimensional
+models to N-dimensional datasets and leverages the power of the `dask
+<https://www.dask.org/>`_ package to efficiently parallelize the problem,
+running it either on multiple processes of a single machine or in a distributed
+environment.
+
+Note that you do not need to know how to use dask in order to use this function,
+but you will need to make sure you have `dask <https://www.dask.org/>`_
+installed.
+
+Getting started
+===============
+
+To demonstrate the use of this function, we will work through a simple
+example of fitting a 1D model to a small spectral cube (if you are
+interested in accessing the file, you can find it at
+:download:`l1448_13co.fits <http://www.astropy.org/astropy-data/l1448/l1448_13co.fits>`,
+but the code below will automatically download it).
+
+We start by downloading the cube and extracting the data and WCS:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> from astropy.wcs import WCS
+    >>> from astropy.io import fits
+    >>> from astropy.utils.data import get_pkg_data_filename
+
+    >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')
+    >>> with fits.open(filename) as hdulist:
+    ...     data = hdulist[0].data
+    ...     wcs = WCS(hdulist[0].header)
+
+We extract a sub-cube spatially for the purpose of demonstration:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> data = data[:, 25:75, 35:85]
+    >>> wcs = wcs[:, 25:75, 35:85]
+
+This is a cube of a star-formation region traced by the 13CO line. We can look
+at one of the channels:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :align: center
+
+    >>> import matplotlib.pyplot as plt
+    >>> ax = plt.subplot(1, 1, 1, projection=wcs, slices=('x', 'y', 20))
+    >>> ax.imshow(data[20, :, :])  # doctest: +IGNORE_OUTPUT
+
+We can also extract a spectrum for one of the celestial positions:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :align: center
+
+    >>> ax = plt.subplot(1, 1, 1, projection=wcs, slices=(5, 5, 'x'))
+    >>> ax.plot(data[:, 5, 5])  # doctest: +IGNORE_OUTPUT
+
+We now set up a model to fit this; we will use a simple Gaussian model,
+with some reasonable initial guesses for the parameters:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> from astropy import units as u
+    >>> from astropy.modeling.models import Gaussian1D
+    >>> model = Gaussian1D(amplitude=1 * u.one, mean=4000 * u.m / u.s, stddev=500 * u.m / u.s)
+
+The data does not have any units in this case, so we use ``u.one`` as
+the unit, which indicates it is dimensionless.
+
+Before fitting this to all spectra in the cube, it’s a good idea to test
+the model with at least one of the spectra manually. To do this, we need to extract the x-axis of the spectra:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> import numpy as np
+    >>> x = wcs.pixel_to_world(0, 0, np.arange(data.shape[0]))[1]
+    >>> x
+    <SpectralCoord
+       (target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
+                    (57.66, 0., 1000.)
+                 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+                    (0., 0., 0.)>)
+      [2528.19489695, 2594.61850695, 2661.04211695, 2727.46572695,
+       2793.88933695, 2860.31294695, 2926.73655695, 2993.16016695,
+       ...
+       5716.52817695, 5782.95178695, 5849.37539695, 5915.79900695,
+       5982.22261695] m / s>
+
+We can now carry out the fit:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> from astropy.modeling.fitting import LMLSQFitter
+    >>> fitter = LMLSQFitter()
+    >>> model_fit_single = fitter(model, x, data[:, 5, 5])
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :align: center
+
+    >>> ax = plt.subplot(1, 1, 1)
+    >>> ax.plot(x, data[:, 5, 5], '.', label='data')  # doctest: +IGNORE_OUTPUT
+    >>> ax.plot(x, model(x), label='initial model')  # doctest: +IGNORE_OUTPUT
+    >>> ax.plot(x, model_fit_single(x), label='fitted model')  # doctest: +IGNORE_OUTPUT
+    >>> ax.legend()  # doctest: +IGNORE_OUTPUT
+
+The model seems to work! We can now use the
+:func:`~astropy.modeling.fitting.parallel_fit_dask` function
+to fit all spectra in the cube:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> from astropy.modeling.fitting import parallel_fit_dask
+    >>> model_fit = parallel_fit_dask(model=model,
+    ...                               fitter=fitter,
+    ...                               data=data,
+    ...                               world=wcs,
+    ...                               fitting_axes=0,
+    ...                               data_unit=u.one)  # doctest: +SKIP
+
+The arguments in this case are as follows:
+
+*  ``model=`` is the initial model. While in our case the initial
+   parameters were specified as scalars, it is possible to pass in a
+   model that has array parameters if you want to have different initial
+   parameters as a function of location in the dataset.
+*  ``fitter=`` is the fitter instance.
+*  ``data=`` is the N-dimensional dataset, in our case the 3D spectral
+   cube.
+*  ``world=`` provides information about the world coordinates for the
+   fit, for example the spectral coordinates for a spectrum. This can be
+   specified in different ways, but above we have chosen to pass in the
+   WCS object for the dataset, from which the spectral axis coordinates
+   will be extracted.
+*  ``fitting_axes=`` specifies which axis or axes include the data to
+   fit. In our example, we are fitting the spectra,
+   which in NumPy notation is the first axis in the cube, so we specify
+   ``fitting_axes=0``.
+*  ``data_unit=`` specifies the unit to use for the data. In our case,
+   the data has no unit, but because we are using units for the spectral
+   axis, we need to specify ``u.one`` here.
+
+We can now take a look at the parameter maps:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :align: center
+
+    >>> fig = plt.figure(figsize=(10, 5))
+    >>> ax = fig.add_subplot(1, 3, 1)
+    >>> ax.set_title('Amplitude')  # doctest: +IGNORE_OUTPUT
+    >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')
+    >>> ax = fig.add_subplot(1, 3, 2)
+    >>> ax.set_title('Mean')  # doctest: +IGNORE_OUTPUT
+    >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')
+    >>> ax = fig.add_subplot(1, 3, 3)
+    >>> ax.set_title('Standard deviation')  # doctest: +IGNORE_OUTPUT
+    >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')
+
+There are a number of pixels that appear to have issues. Inspecting the
+histogram of means, we can see that a lot of values are not at all in
+the spectral range we are fitting:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :align: center
+
+    >>> _ = plt.hist(model_fit.mean.value.ravel(), bins=100)
+    >>> plt.yscale('log')
+    >>> plt.xlabel('mean')
+    >>> plt.ylabel('number')
+
+We can set the bounds on the mean and try the fit again
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :nofigs:
+
+    >>> model.mean.bounds = (3000, 6000) * u.km / u.s
+    >>> model_fit = parallel_fit_dask(model=model,
+    ...                               fitter=fitter,
+    ...                               data=data,
+    ...                               world=wcs,
+    ...                               fitting_axes=0,
+    ...                               data_unit=u.one)  # doctest: +SKIP
+
+and we can visualize the results:
+
+.. plot::
+   :context: close-figs
+   :include-source:
+   :align: center
+
+    >>> fig = plt.figure(figsize=(10, 5))
+    >>> ax = fig.add_subplot(1, 3, 1)
+    >>> ax.set_title('Amplitude')
+    >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')
+    >>> ax = fig.add_subplot(1, 3, 2)
+    >>> ax.set_title('Mean')
+    >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')
+    >>> ax = fig.add_subplot(1, 3, 3)
+    >>> ax.set_title('Standard deviation')
+    >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')
+
+The amplitude map no longer contains any problematic pixels.
+
+Performance
+===========
+
+The :func:`~astropy.modeling.fitting.parallel_fit_dask` function splits the data
+into chunks, each of which is then sent to a different process. The size of
+these chunks is critical to obtaining good performance. If we split the data
+into one chunk per fit, the process would be inefficient due to significant
+overhead from inter-process communication. Conversely, if we split the data into
+fewer chunks than there are available processes, we will not utilize all the
+available computational power. If we split the data into slightly more chunks
+than there are processes, inefficiencies can arise as well. For example,
+splitting the data into five chunks with four available processes means the four
+processes will first fit four chunks, and then a single process will be held up
+fitting the remaining chunk. Therefore, it is important to carefully consider
+how the data is split.
+
+To control the splitting of the data, use the ``chunk_n_max=`` keyword argument.
+This determines how many individual fits will be carried out in each chunk. For
+example, when fitting a model to individual spectra in a spectral cube, setting
+``chunk_n_max=100`` means each chunk will contain 100 spectra. As a general
+guide, you will likely want to set this to be roughly the number of fits to be
+carried out in the data divided by several times the number of available
+processes. For example, if you need to fit 100,000 spectra and have 8 processes
+available, setting ``chunk_n_max=1000`` would be reasonable. This configuration
+would break the data into 100 chunks, meaning each process will need to handle
+approximately a dozen chunks. Additionally, fitting 1,000 spectra per chunk will
+take enough time to avoid being dominated by communication overhead.
+
+The default value for ``chunk_n_max`` is 500.
+
+Diagnostics
+===========
+
+One of the challenges of fitting a model many different times is understanding
+what went wrong when issues arise. By default, if a fit fails with a warning or
+an exception, the parameters for that fit will be set to NaN, and no warning or
+exception will be shown to the user. However, it can be helpful to have more
+information, such as the specific error or exception that occurred.
+
+You can control this by setting the ``diagnostics=`` argument. This allows you
+to choose whether to output information about:
+
+* Failed fits with errors (``diagnostics='error'``),
+* Fits with errors or warnings (``diagnostics='error+warn'``), or
+* All fits (``diagnostics='all'``).
+
+If the ``diagnositcs`` option is specified, you will also need to specify
+``diagnostics_path``, which should be the path to a folder that will contain all
+the output. Each fit that needs to be output will be assigned a sub-folder named
+after the indices along the axes of the data (excluding the fitting axes). The
+output will include (if appropriate):
+
+* ``error.log``, containing details of any exceptions that occurred
+* ``warn.log``, containing any warnings
+
+You may also want to automatically create a plot of the fit, inspect the data
+being fit, or examine the model. To do this, you can pass a function to
+``diagnostics_callable``. See :func:`~astropy.modeling.fitting.parallel_fit_dask`
+for more information about the arguments this function should accept.
+
+Schedulers
+==========
+
+By default, :func:`~astropy.modeling.fitting.parallel_fit_dask` will make use of
+the ``'processes'`` scheduler, which means that multiple processes on your local
+machine can be used. You can override the scheduler being used with the
+``scheduler=`` keyword argument. You can either set this to the name of a
+scheduler (such as ``'synchronous'``), or you can set it to ``'default'`` in order
+to make use of whatever is the currently active dask scheduler, which allows
+you for example to set up a `dask.distributed
+<https://distributed.dask.org/en/stable/>`_ scheduler.

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -312,7 +312,7 @@ to choose whether to output information about:
 * Fits with errors or warnings (``diagnostics='error+warn'``), or
 * All fits (``diagnostics='all'``).
 
-If the ``diagnositcs`` option is specified, you will also need to specify
+If the ``diagnostics`` option is specified, you will also need to specify
 ``diagnostics_path``, which should be the path to a folder that will contain all
 the output. Each fit that needs to be output will be assigned a sub-folder named
 after the indices along the axes of the data (excluding the fitting axes). The

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -155,7 +155,8 @@ to fit all spectra in the cube:
     ...                               data=data,
     ...                               world=wcs,
     ...                               fitting_axes=0,
-    ...                               data_unit=u.one)  # doctest: +SKIP
+    ...                               data_unit=u.one,
+    ...                               scheduler='synchronous')  # doctest: +SKIP
 
 The arguments in this case are as follows:
 
@@ -224,7 +225,8 @@ We can set the bounds on the mean and try the fit again
     ...                               data=data,
     ...                               world=wcs,
     ...                               fitting_axes=0,
-    ...                               data_unit=u.one)  # doctest: +SKIP
+    ...                               data_unit=u.one,
+    ...                               scheduler='synchronous')  # doctest: +SKIP
 
 and we can visualize the results:
 

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -1,7 +1,7 @@
 .. _parallel-fitting:
 
-Fitting a model many times in parallel
-**************************************
+Fitting models in parallel with N-dimensional data
+**************************************************
 
 In some cases, you may want to fit a model many times to data. For example, you
 may have a spectral cube (with two celestial axes and one spectral axis) and you
@@ -18,11 +18,15 @@ suited to these use cases. It makes it simple to set up fitting of M-dimensional
 models to N-dimensional datasets and leverages the power of the `dask
 <https://www.dask.org/>`_ package to efficiently parallelize the problem,
 running it either on multiple processes of a single machine or in a distributed
-environment.
-
-Note that you do not need to know how to use dask in order to use this function,
+environment. You do not need to know how to use dask in order to use this function,
 but you will need to make sure you have `dask <https://www.dask.org/>`_
 installed.
+
+Note that the approach here is different from *model sets* which are described
+in :ref:`example-fitting-model-sets`, which are a way of fitting a linear model
+with a vector of parameters to a data array, as in that specific case the
+fitting can be truly vectorized, and will likely not benefit from the approach
+described here.
 
 Getting started
 ===============
@@ -265,6 +269,34 @@ and we can visualize the results:
     >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')  # doctest: +IGNORE_OUTPUT
 
 The amplitude map no longer contains any problematic pixels.
+
+World input
+===========
+
+The example above demonstrated that it is possible to pass in a
+:class:`astropy.wcs.WCS` object to the ``world=`` argument in order to determine
+the world coordinates for the fit (e.g. the spectral axis values for a spectral
+fit). It is also possible to pass in a tuple of arrays - if you do this, the
+tuple should have one item per fitting axis. It is most efficient to pass in a
+tuple of 1D arrays, but if the world coordinates vary over the axes being
+iterated over, you can also pass in a tuple of N-d arrays, giving the
+coordinates of each individual pixel (it is also possible to pass in arrays that
+are not 1D but also not fully N-d as long as they can be broadcasted to the data
+shape).
+
+Multiprocessing
+===============
+
+By default, :func:`~astropy.modeling.fitting.parallel_fit_dask` will make use
+of multi-processing to parallelize the fitting. If you write a script to
+carry out the fitting, you will likely need to move your code inside a::
+
+    if __name__ == "__main__":
+
+        ...
+
+clause as otherwise Python will execute the whole code in the script many times,
+and potentially recursively, rather than just parallelizing the fitting.
 
 Performance
 ===========

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -33,6 +33,24 @@ interested in accessing the file, you can find it at
 :download:`l1448_13co.fits <http://www.astropy.org/astropy-data/l1448/l1448_13co.fits>`,
 but the code below will automatically download it).
 
+.. The following block is to make sure 'data' and 'wcs' are defined if we are not running with --remote-data
+
+.. plot::
+   :context: close-figs
+   :nofigs:
+
+    >>> import numpy as np
+    >>> from astropy.wcs import WCS
+    >>> wcs = WCS(naxis=3)
+    >>> wcs.wcs.ctype =  ['RA---SFL', 'DEC--SFL', 'VOPT']
+    >>> wcs.wcs.crval = [57.66, 0., -9959.44378305]
+    >>> wcs.wcs.crpix =  [-799.0, -4741.913, -187.0]
+    >>> wcs.wcs.cdelt = [-0.006388889, 0.006388889, 66.42361]
+    >>> wcs.wcs.cunit = ['deg', 'deg', 'm s-1']
+    >>> wcs._naxis = [105, 105, 53]
+    >>> wcs.wcs.set()
+    >>> data = np.broadcast_to(np.exp(-(np.arange(53) - 25)**2 / 6 ** 2).reshape((53, 1, 1)), (53, 105, 105))
+
 We start by downloading the cube and extracting the data and WCS:
 
 .. plot::
@@ -44,10 +62,10 @@ We start by downloading the cube and extracting the data and WCS:
     >>> from astropy.io import fits
     >>> from astropy.utils.data import get_pkg_data_filename
 
-    >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')
+    >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')  # doctest: +REMOTE_DATA
     >>> with fits.open(filename) as hdulist:
     ...     data = hdulist[0].data
-    ...     wcs = WCS(hdulist[0].header)
+    ...     wcs = WCS(hdulist[0].header)  # doctest: +REMOTE_DATA
 
 We extract a sub-cube spatially for the purpose of demonstration:
 
@@ -156,7 +174,7 @@ to fit all spectra in the cube:
     ...                               world=wcs,
     ...                               fitting_axes=0,
     ...                               data_unit=u.one,
-    ...                               scheduler='synchronous')  # doctest: +SKIP
+    ...                               scheduler='synchronous')
 
 The arguments in this case are as follows:
 
@@ -209,8 +227,8 @@ the spectral range we are fitting:
 
     >>> _ = plt.hist(model_fit.mean.value.ravel(), bins=100)
     >>> plt.yscale('log')
-    >>> plt.xlabel('mean')
-    >>> plt.ylabel('number')
+    >>> plt.xlabel('mean')  # doctest: +IGNORE_OUTPUT
+    >>> plt.ylabel('number')  # doctest: +IGNORE_OUTPUT
 
 We can set the bounds on the mean and try the fit again
 
@@ -226,7 +244,7 @@ We can set the bounds on the mean and try the fit again
     ...                               world=wcs,
     ...                               fitting_axes=0,
     ...                               data_unit=u.one,
-    ...                               scheduler='synchronous')  # doctest: +SKIP
+    ...                               scheduler='synchronous')
 
 and we can visualize the results:
 
@@ -237,13 +255,13 @@ and we can visualize the results:
 
     >>> fig = plt.figure(figsize=(10, 5))
     >>> ax = fig.add_subplot(1, 3, 1)
-    >>> ax.set_title('Amplitude')
+    >>> ax.set_title('Amplitude')  # doctest: +IGNORE_OUTPUT
     >>> ax.imshow(model_fit.amplitude.value, vmin=0, vmax=5, origin='lower')
     >>> ax = fig.add_subplot(1, 3, 2)
-    >>> ax.set_title('Mean')
+    >>> ax.set_title('Mean')  # doctest: +IGNORE_OUTPUT
     >>> ax.imshow(model_fit.mean.value, vmin=2500, vmax=6000, origin='lower')
     >>> ax = fig.add_subplot(1, 3, 3)
-    >>> ax.set_title('Standard deviation')
+    >>> ax.set_title('Standard deviation')  # doctest: +IGNORE_OUTPUT
     >>> ax.imshow(model_fit.stddev.value, vmin=0, vmax=2000, origin='lower')
 
 The amplitude map no longer contains any problematic pixels.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -18,6 +18,7 @@ In particular, this release includes:
 * :ref:`whatsnew_7_0_contributor_doc_improvement`
 * :ref:`whatsnew_7_0_typing_stats`
 * :ref:`whatsnew_7_0_unit_conversion_array_like`
+* :ref:`whatsnew_7_0_parallel_fitting`
 
 In addition to these major changes, Astropy v7.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -122,6 +123,33 @@ value in ``Unit.to`` and have those arrays not be converted to Numpy arrays::
     dask.array<mul, shape=(10,), dtype=float64, chunksize=(10,), chunktype=numpy.ndarray>
 
 Note that it is not yet possible to use ``Quantity`` with dask arrays directly.
+
+.. _whatsnew_7_0_parallel_fitting:
+
+Fitting models in parallel with N-dimensional data
+==================================================
+
+A new function, :func:`~astropy.modeling.fitting.parallel_fit_dask`, has been
+added to the :mod:`astropy.modeling` module. This function makes it easy to fit
+many parts of an N-dimensional array in parallel, such as fitting all the
+spectra in a spectral cube. This makes use of the `dask
+<https://www.dask.org/>`_ package to efficiently parallelize the problem,
+running it either on multiple processes of a single machine or in a distributed
+environment. A simple example might be:
+
+.. doctest-skip::
+
+    >>> from astropy.modeling.models import Gaussian1D
+    >>> from astropy.modeling.fitting import parallel_fit_dask, LevMarLSQFitter
+    >>> model_fit = parallel_fit_dask(model=Gaussian1D(),
+    ...                               fitter=LevMarLSQFitter(),
+    ...                               data=data,
+    ...                               world=wcs,
+    ...                               fitting_axes=0)
+
+where ``data`` is a 3-D array, and ``wcs`` is the :class:`~astropy.wcs.WCS`
+object associated with the data. A full example can be found at
+:ref:`parallel-fitting`.
 
 Full change log
 ===============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,7 @@ doctest_subpackage_requires = [
     "astropy/timeseries/periodograms/bls/core.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/timeseries/periodograms/lombscargle/core.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/units/structured.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
+    "astropy/modeling/fitting_parallel.py = dask",
 ]
 markers = [
     "mpl_image_compare",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,7 @@ doctest_subpackage_requires = [
     "astropy/timeseries/periodograms/lombscargle/core.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/units/structured.py = numpy>=2.0.0rc1",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/modeling/fitting_parallel.py = dask",
+    "docs/modeling/parallel-fitting.rst = dask",
 ]
 markers = [
     "mpl_image_compare",


### PR DESCRIPTION
_This is a collaborative PR between myself and @Cadair_

### Background

A commonly requested feature (at least one that @Cadair and I have heard a lot) these days is the ability to fit a model in parallel to many parts of a dataset, for example fitting a model to all the individual spectra in a spectral cube. This PR implements a helper function that can fit 1- or 2-dimensional models to N-dimensional datasets. The documentation and test suite could be expanded, but we are opening this pull request to allow people to already try this out and give early feedback.

The goal of the function is two-fold:

* To make it easy to carry out many fits in a data cube
* To provide easy parallelization, by default using multiple processes to speed things up

This is written in a very generic way so as to work with N-dimensional datasets, and any astropy.modeling model or fitter, so we hope that you agree that this belongs in astropy.modeling. This goes towards several of the items on the 2024 roadmap:

* _Improve and/or maintain interoperability with performant I/O file formats and libraries such as HDF5 and Dask._ (this adds integration of astropy.modeling with dask)
* _Improve support for using Astropy tools in heterogeneous computing environments such as cloud environments or GPU systems._ (this allows model fits to be carried out on any kind of distributed environment supported by dask, including clusters in the cloud)


### Simple example

A simple example of this in action, fitting all the spectra in a spectral cube with a simple Gaussian model:

```python
from astropy.io import fits

import matplotlib.pyplot as plt

from astropy.modeling.models import Gaussian1D
from astropy.modeling.fitting import LMLSQFitter
from astropy.modeling.fitting_parallel import parallel_fit_dask

if __name__ == "__main__":

    data = fits.getdata("l1448_13co.fits")

    g_init = Gaussian1D(mean=25, stddev=10, amplitude=1)
    g_init.mean.bounds = (0, 53)

    g_fit = parallel_fit_dask(
        model=g_init,
        fitter=LMLSQFitter(),
        data=data,
        fitting_axes=0,
    )

    fig = plt.figure(figsize=(10, 5))
    ax = fig.add_subplot(1, 3, 1)
    ax.imshow(g_fit.amplitude.value, vmin=0, vmax=5)
    ax = fig.add_subplot(1, 3, 2)
    ax.imshow(g_fit.mean.value, vmin=0, vmax=50)
    ax = fig.add_subplot(1, 3, 3)
    ax.imshow(g_fit.stddev.value, vmin=0, vmax=20)
    fig.savefig("results_no_world.png")
```


![results_no_world](https://github.com/astropy/astropy/assets/314716/03911a36-b311-498c-8ee2-b8509c6383a1)

### Features so far

* Fit 1- or 2-dimensional models to any of the axes of an N-dimensional data cube.
* The dataset is broken up efficiently into chunks, each of which is processed inside e.g. a process or thread
* No understanding of dask required (it just needs to be installed)
* Designed to be able to work with large datasets, including dask datasets that might be larger than memory. We've tested this on larger cubes with over a million compound model fits to be carried out, and it worked nicely.
* Ability to specify the world coordinates (used for the x or x/y axes in the fitting) via 1D arrays, ND arrays, or any APE-14-compliant WCS, or just use pixel coordinates
* Ability to output information about failed fits or fits that emit warnings
* Ability to use this with any dask scheduler, including dask.distributed. We've tested this out with a cloud-based dask cluster (via https://www.coiled.io/) and it worked, although of course the efficiency of this depends on how fast one can send/receive data from the cloud.

You can take a look at the RTD preview as well as the docstring of the function to see what can be done.

### Discussion points

* This implementation makes use of dask, and requires dask to be installed (it is an optional astropy dependency). We have named the function ``parallel_fit_dask`` to make this clear, and also to allow other parallel implementations to be added in future. For example, we could imagine having ``parallel_fit_multiprocessing``, which could use the built-in multiprocessing library. Adding these shouldn't be **too** much work but we also would prefer to defer this to a follow-up pull request to keep things simple. A reasonable amount of the code in this PR could be re-used in a multiprocessing implementation. We could imagine renaming the function to ``parallel_fit`` and having the method be a kwarg, but this is not ideal as different methods might require different kwargs, and the function will end up taking many arguments and be messy.
* <s>Currently if ``n_chunk_max`` (the number of fits to carry out in a chunk) is not specified, the default is related to the default dask chunk size which isn't necessarily optimal - if the array is not very large, the data will just be broken up into a single chunk which won't benefit from parallelization. We could instead actually have n_chunk_max default to e.g. 100 or 1000 which would probably be better than the dask default. Alternatively, we could simply have it be a required argument to force the user to think about this.</s> - I've set the default to 500 instead of using the dask chunk size. I think this should be reasonable?

### Detailed TODOs

* [x] Remove hack for copying models with new parameters once #16593 is resolved
* [x] Make sure we have good test coverage
* [x] Expand documentation to explain different ways to specify world coordinates
* [x] Make sure we fail gracefully if dask is not installed, ensure function can still be imported
* [x] Added changelog entry and what's new
* [x] Explain in docs about ``__name__ == '__main__'`` being needed for multiprocessing
* [x] Fix the CI
* [x] Explain in docs how this is different from model sets

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
