### PR TITLE
Fix the caching of the table constructed using bundled IERS-A and IERS-B files

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -792,7 +792,7 @@ class IERS_Auto(IERS_A):
         if not conf.auto_download:
             # If auto_download is changed to False mid-session, iers_table may have already been
             # made from non-bundled files, so it should be remade from bundled files
-            if not getattr(cls, "_iers_table_bundled", None):
+            if not hasattr(cls, "_iers_table_bundled"):
                 cls._iers_table_bundled = cls.read()
             cls.iers_table = cls._iers_table_bundled
             return cls.iers_table

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -790,7 +790,11 @@ class IERS_Auto(IERS_A):
 
         """
         if not conf.auto_download:
-            cls.iers_table = cls.read()
+            # If auto_download is changed to False mid-session, iers_table may have already been
+            # made from non-bundled files, so it should be remade from bundled files
+            if not getattr(cls, "_iers_table_bundled", None):
+                cls._iers_table_bundled = cls.read()
+            cls.iers_table = cls._iers_table_bundled
             return cls.iers_table
 
         all_urls = (conf.iers_auto_url, conf.iers_auto_url_mirror)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -480,7 +480,7 @@ def test_iers_download_error_handling(tmp_path):
                     "malformed IERS table from https://google.com"
                 )
                 assert str(record[2].message).startswith(
-                    "unable to download valid IERS file, using local IERS-A"
+                    "unable to download valid IERS file, using bundled IERS-A"
                 )
 
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes two problems with the recently merged #16187:

- The table constructed from bundled IERS-A and IERS-B files was not being stored for re-use, so performance tanked as the table was being constructed again and again with every access of IERS data.
- A unit test wasn't updated (see https://github.com/astropy/astropy/issues/16693#issuecomment-2219816334)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16693

Close #16695

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
