### PR TITLE
Correctly fail CI if asv has any errors

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -83,14 +83,7 @@ jobs:
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR --conf asv.ci.conf.json"
-          python -m asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
-              | sed "/Traceback \|failed$\|PERFORMANCE DECREASED/ s/^/::error::/" \
-              | tee benchmarks.log
-
-          # Error out the action
-          if grep -q "Traceback \|failed\|PERFORMANCE DECREASED" benchmarks.log ; then
-              exit 1
-          fi
+          python -m asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
 
       - name: "Check ccache performance"
         shell: bash -l {0}
@@ -103,4 +96,3 @@ jobs:
           name: asv-benchmark-results
           path: |
             results/
-            benchmarks.log

--- a/asv.ci.conf.json
+++ b/asv.ci.conf.json
@@ -1,13 +1,13 @@
  {
    "version": 1,
    "project": "astropy",
-   "project_url": "http://www.astropy.org/",
+   "project_url": "https://www.astropy.org/",
    "repo": ".",
    "install_command": [
      "pip install . matplotlib scipy"
    ],
    "branches": ["main"],
-   "show_commit_url": "http://github.com/astropy/astropy/commit/",
+   "show_commit_url": "https://github.com/astropy/astropy/commit/",
    "pythons": ["3.11"],
    "environment_type": "virtualenv",
    "benchmark_dir": "astropy-benchmarks/benchmarks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0,<3.1.0",
             "numpy>=2.0.0",
-            "extension-helpers==1.*"]
+            "extension-helpers>=1,<2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This is still experimental, but all the piping of the asv command output was hiding the asv exit code, so going to try and see if it works without all that. I need to understand whether the asv exit code depends on failures, performance regressions, etc.

From what I can see, asv returns the correct exit code if the output contains 'failed' or 'PERFORMANCE DECREASED' so I think we should be ok. The only purpose of having the benchmarks.log was to inject ``::error:`` to make the CI output prettier, but it's more important that the exit codes are correct.

Fix #16671

Close #16672

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
