### PR TITLE
Reduce duplication of CompoundModel._initialize_slices

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2740,6 +2740,8 @@ class Model(metaclass=_ModelMeta):
             param_size = np.size(value)
             param_shape = np.shape(value)
             param_slice = slice(total_size, total_size + param_size)
+            if name not in param_metrics:
+                param_metrics[name] = {}
             param_metrics[name]["slice"] = param_slice
             param_metrics[name]["shape"] = param_shape
             param_metrics[name]["size"] = param_size
@@ -3744,23 +3746,6 @@ class CompoundModel(Model):
         self._param_map_inverse = {v: k for k, v in param_map.items()}
         self._initialize_slices()
         self._param_names = tuple(self._param_names)
-
-    def _initialize_slices(self):
-        param_metrics = self._param_metrics
-        total_size = 0
-
-        for name in self.param_names:
-            param = getattr(self, name)
-            value = param.value
-            param_size = np.size(value)
-            param_shape = np.shape(value)
-            param_slice = slice(total_size, total_size + param_size)
-            param_metrics[name] = {}
-            param_metrics[name]["slice"] = param_slice
-            param_metrics[name]["shape"] = param_shape
-            param_metrics[name]["size"] = param_size
-            total_size += param_size
-        self._parameters = np.empty(total_size, dtype=np.float64)
 
     @staticmethod
     def _recursive_lookup(branch, adict, key):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2740,8 +2740,6 @@ class Model(metaclass=_ModelMeta):
             param_size = np.size(value)
             param_shape = np.shape(value)
             param_slice = slice(total_size, total_size + param_size)
-            if name not in param_metrics:
-                param_metrics[name] = {}
             param_metrics[name]["slice"] = param_slice
             param_metrics[name]["shape"] = param_shape
             param_metrics[name]["size"] = param_size
@@ -3741,7 +3739,7 @@ class CompoundModel(Model):
                     self._parameters_[new_param_name] = param
                     self._param_names.append(new_param_name)
                     param_map[new_param_name] = (lindex, param_name)
-        self._param_metrics = {}
+        self._param_metrics = defaultdict(dict)
         self._param_map = param_map
         self._param_map_inverse = {v: k for k, v in param_map.items()}
         self._initialize_slices()


### PR DESCRIPTION
Noticed that ``CompoundModel._initialize_slices`` was duplicating most of the cost of ``Model._initialize_slices``, so I've combined the two and all the tests seem to pass!

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
