### PR TITLE
Fix bug in fitting and accessing the parameter array when setting Parameter.value

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -743,6 +743,7 @@ class Model(metaclass=_ModelMeta):
         # Remaining keyword args are either parameter values or invalid
         # Parameter values must be passed in as keyword arguments in order to
         # distinguish them
+        self._parameters = None
         self._initialize_parameters(args, kwargs)
         self._initialize_slices()
         self._initialize_unit_support()
@@ -2744,11 +2745,13 @@ class Model(metaclass=_ModelMeta):
             param_metrics[name]["shape"] = param_shape
             param_metrics[name]["size"] = param_size
             total_size += param_size
-        self._parameters = np.empty(total_size, dtype=np.float64)
+        if self._parameters is None or self._parameters.size != total_size:
+            self._parameters = np.empty(total_size, dtype=np.float64)
 
     def _parameters_to_array(self):
         # Now set the parameter values (this will also fill
         # self._parameters)
+        self._initialize_slices()
         param_metrics = self._param_metrics
         for name in self.param_names:
             param = getattr(self, name)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2745,6 +2745,8 @@ class Model(metaclass=_ModelMeta):
             param_metrics[name]["shape"] = param_shape
             param_metrics[name]["size"] = param_size
             total_size += param_size
+        # We avoid re-allocating the array if it is already allocated and has
+        # the right size, for performance.
         if self._parameters is None or self._parameters.size != total_size:
             self._parameters = np.empty(total_size, dtype=np.float64)
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1570,3 +1570,15 @@ def test_has_constraints_with_sync_constraints():
     model.sync_constraints = False
 
     assert model.has_fixed
+
+
+def test_set_parameter_values():
+    # Regression test for a bug that caused the parameters attribute to not
+    # be correct if parameter value shapes were changed.
+
+    poly = models.Polynomial1D(2, c0=[1, 2], c1=[2, 3], c2=[3, 4])
+    poly.c0.value = 1
+    poly.c1.value = 2
+    poly.c2.value = 3
+
+    assert_allclose(poly.parameters, [1, 2, 3])

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1581,4 +1581,4 @@ def test_set_parameter_values():
     poly.c1.value = 2
     poly.c2.value = 3
 
-    assert_allclose(poly.parameters, [1, 2, 3])
+    assert_equal(poly.parameters, [1, 2, 3])

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1521,14 +1521,14 @@ def test_fit_model_with_parameters_change_shape():
     # Regression test for a bug that caused fitting to fail if a user used
     # Parameter.value to change the shape of a parameter.
 
-    poly = models.Polynomial1D(2, c0=[1, 2], c1=[2, 3], c2=[3, 4])
-    poly.c0.value = 1
-    poly.c1.value = 2
-    poly.c2.value = 3
+    gauss = models.Gaussian1D(amplitude=[1, 2], mean=[2, 3], stddev=[3, 4])
+    gauss.amplitude.value = 1
+    gauss.mean.value = 2
+    gauss.stddev.value = 3
 
     fitter = LevMarLSQFitter()
-    poly_result = fitter(poly, [1, 2, 3, 4, 5], [4, 12, 26, 46, 72])
+    gauss_result = fitter(gauss, [1, 2, 3, 4, 5], [1, 2, 5, 2, 1])
 
-    assert_allclose(poly_result.c0.value, 2)
-    assert_allclose(poly_result.c1.value, -1)
-    assert_allclose(poly_result.c2.value, 3)
+    assert_allclose(gauss_result.amplitude.value, 4.742467378491489)
+    assert_allclose(gauss_result.mean.value, 3)
+    assert_allclose(gauss_result.stddev.value, 0.8430777585419369)

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1517,6 +1517,7 @@ def test_sync_constraints_after_fitting():
     assert m.fixed == {"amplitude": True, "mean": False, "stddev": False}
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_fit_model_with_parameters_change_shape():
     # Regression test for a bug that caused fitting to fail if a user used
     # Parameter.value to change the shape of a parameter.

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1515,3 +1515,20 @@ def test_sync_constraints_after_fitting():
     assert m.sync_constraints is True
     m.amplitude.fixed = True
     assert m.fixed == {"amplitude": True, "mean": False, "stddev": False}
+
+
+def test_fit_model_with_parameters_change_shape():
+    # Regression test for a bug that caused fitting to fail if a user used
+    # Parameter.value to change the shape of a parameter.
+
+    poly = models.Polynomial1D(2, c0=[1, 2], c1=[2, 3], c2=[3, 4])
+    poly.c0.value = 1
+    poly.c1.value = 2
+    poly.c2.value = 3
+
+    fitter = LevMarLSQFitter()
+    poly_result = fitter(poly, [1, 2, 3, 4, 5], [4, 12, 26, 46, 72])
+
+    assert_allclose(poly_result.c0.value, 2)
+    assert_allclose(poly_result.c1.value, -1)
+    assert_allclose(poly_result.c2.value, 3)

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1521,6 +1521,7 @@ def test_sync_constraints_after_fitting():
 def test_fit_model_with_parameters_change_shape():
     # Regression test for a bug that caused fitting to fail if a user used
     # Parameter.value to change the shape of a parameter.
+    # see https://github.com/astropy/astropy/pull/16710
 
     gauss = models.Gaussian1D(amplitude=[1, 2], mean=[2, 3], stddev=[3, 4])
     gauss.amplitude.value = 1

--- a/docs/changes/modeling/16710.bugfix.rst
+++ b/docs/changes/modeling/16710.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug that caused fitting models to fail if the parameter values were
+changed via Parameter.value to have a different shape.


### PR DESCRIPTION
It is currently possible to change the shape of parameters on a model by setting ``Parameter.value``:

```python
>>> from astropy.modeling.models import Polynomial1D
>>> poly = Polynomial1D(2, c0=[1, 2], c1=[2, 3], c2=[3, 4])
>>> poly.c0.value = 1
>>> poly.c1.value = 2
>>> poly.c2.value = 3
```

This is actually really helpful in order to solve https://github.com/astropy/astropy/issues/16593. However, one runs into a couple of bugs when doing this:

```python
>>> poly.parameters
array([1., 1., 2., 2., 3., 3.])
```

this is incorrect, as it should now be ``[1, 2, 3]``. And when fitting:

```python
>>> from astropy.modeling.fitting import LevMarLSQFitter
>>> poly_result = LevMarLSQFitter()(poly, [1, 2, 3, 4, 5], [4, 12, 26, 46, 72])
...
ValueError: shape mismatch: objects cannot be broadcast to a single shape.  Mismatch is between arg 0 with shape (5,) and arg 1 with shape (2,). self input argument 'x' of shape (5,) cannot be broadcast with parameter 'c0' of shape (2,).
```

These two bugs have the same root cause - ``Model._parameters_to_array`` assumes that the parameter shape never changes. The fix is simple: when calling ``_parameters_to_array``, we call ``_initialize_slices``, but we can be smart and avoid re-allocating ``self._parameters`` if the total size hasn't changed for performance.

In the process I noticed some code duplication which I've removed in https://github.com/astropy/astropy/pull/16709 

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
