### PR TITLE
Simplify construction of new CompoundModel in with_units_for_data

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4123,24 +4123,6 @@ class CompoundModel(Model):
         else:
             raise ValueError(f"No submodels found named {name}")
 
-    def _set_sub_models_and_parameter_units(self, left, right):
-        """
-        Provides a work-around to properly set the sub models and respective
-        parameters's units/values when using ``without_units_for_data``
-        or ``without_units_for_data`` methods.
-        """
-        model = CompoundModel(self.op, left, right)
-
-        self.left = left
-        self.right = right
-
-        for name in model.param_names:
-            model_parameter = getattr(model, name)
-            parameter = getattr(self, name)
-
-            parameter.value = model_parameter.value
-            parameter._set_unit(model_parameter.unit, force=True)
-
     def without_units_for_data(self, **kwargs):
         """
         See `~astropy.modeling.Model.without_units_for_data` for overview
@@ -4238,10 +4220,8 @@ class CompoundModel(Model):
             left = self.left.with_units_from_data(**left_kwargs)
             right = self.right.with_units_from_data(**right_kwargs)
 
-            model = self.copy()
-            model._set_sub_models_and_parameter_units(left, right)
+            return CompoundModel(self.op, left, right, name=self.name)
 
-            return model
         else:
             return super().with_units_from_data(**kwargs)
 


### PR DESCRIPTION
This doesn't fix a bug but simplifies the CompoundModel creation as in https://github.com/astropy/astropy/pull/16678 and removes a method that then becomes unnecessary.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
