### PR TITLE
ENH: implement `np.einsum` for `MaskedNDArray`

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -186,7 +186,7 @@ IGNORED_FUNCTIONS |= {
     np.histogram, np.histogram2d, np.histogramdd, np.histogram_bin_edges,
     # TODO!!
     np.dot, np.vdot, np.inner, np.tensordot, np.cross,
-    np.einsum, np.einsum_path,
+    np.einsum_path,
 }  # fmt: skip
 
 # Explicitly unsupported functions
@@ -1479,6 +1479,145 @@ def setdiff1d(ar1, ar2, assume_unique=False):
         ar1 = np.unique(ar1)
         ar2 = np.unique(ar2)
     return ar1[np.isin(ar1, ar2, assume_unique=True, invert=True)], None, None
+
+
+@dispatched_function
+def einsum(*operands, out=None, **kwargs):
+    from astropy.utils.masked import Masked, MaskedNDArray
+
+    # input validation
+    subscripts, *operands = operands
+
+    if not isinstance(subscripts, str):
+        raise ValueError('only "subscripts" string mode supported for einsum.')
+
+    kwargs_with_out = kwargs.copy()
+    if out is not None:
+        if not isinstance(out, MaskedNDArray):
+            raise NotImplementedError
+
+        else:
+            kwargs_with_out["out"] = out.unmasked.view(np.ndarray)
+
+    # compute the unmasked result
+    # doing this first ensures that subscripts are validated by numpy
+
+    def as_masked_ndarray(input):
+        if hasattr(input, "mask"):
+            if hasattr(input.mask, "shape"):
+                return input
+            else:
+                mask = np.full_like(input.unmasked, fill_value=input.mask, dtype=bool)
+                return Masked(input.unmasked, mask=mask)
+        else:
+            mask = np.full_like(input, fill_value=False, dtype=bool)
+            return Masked(input, mask=mask)
+
+    mas = tuple(as_masked_ndarray(op) for op in operands)
+    arrays = tuple(ma.unmasked for ma in mas)
+    retv = np.einsum(subscripts, *arrays, **kwargs_with_out)
+
+    # now combine masks
+    # this complex operation is decomposed as
+    # 1) Compute intermediate masks
+    #   1.1) select diagonals (e.g. 'ii')
+    #   1.2) contract mask along summation axes
+    # 2) combine intermediate masks
+
+    masks = tuple(ma.mask for ma in mas)
+
+    from collections import Counter
+    from functools import reduce
+    from operator import add
+
+    # ellispis '...' is the only meaningful token that's not
+    # a single character, we replace it with an unused char ('?') to simplify parsing.
+    monochar_subscripts = subscripts.replace("...", "?")
+    input_subscripts, arrow_id, output_subscripts = monochar_subscripts.partition("->")
+    einsum_mode = "explicit" if arrow_id else "implicit"
+
+    input_labels = input_subscripts.split(",")
+    input_labels_counters = [Counter(labels) for labels in input_labels]
+
+    # diagonal indices are important for mask propagation in that we want
+    # to extract diagonals in masks too (this should be step one)
+    diagonal_labels = [
+        [label for label in c if label != "?" and c[label] > 1]
+        for c in input_labels_counters
+    ]
+
+    # preserves order of unique values
+    unique_input_labels = [list(c.keys()) for c in input_labels_counters]
+    unique_input_subscripts = ["".join(labels) for labels in unique_input_labels]
+    for labels in unique_input_labels:
+        # sanity check: no input should contain more than one ellispis
+        assert labels.count("?") <= 1
+
+    label_count: Counter[str] = reduce(add, input_labels_counters)
+    repeated_labels = {
+        char for char in label_count if char != "?" and label_count[char] > 1
+    }
+
+    if einsum_mode == "implicit":
+        summation_labels = repeated_labels
+    elif einsum_mode == "explicit":
+        if output_subscripts:
+            summation_labels = repeated_labels - set(output_subscripts)
+        else:
+            summation_labels = set(input_labels) - {"?"}
+    else:
+        raise RuntimeError
+
+    def extract_diagonal(mask, op_position: int):
+        input = input_labels[op_position]
+        output = unique_input_subscripts[op_position]
+        exp = f"{input}->{output}".replace("?", "...")
+        # use explicit mode to disable any summation here
+        return np.einsum(exp, mask)
+
+    def contract(mask, op_position: int):
+        labels = input_labels[op_position]
+        summation_axes = tuple(labels.index(L) for L in labels if L in summation_labels)
+        shape = list(mask.shape)
+        for n in range(len(shape)):
+            if n in summation_axes:
+                shape[n] = 1
+        ret_mask = mask.max(tuple(set(summation_axes)))
+        return ret_mask.reshape(shape)
+
+    def reduce_mask(mask, op_position: int):
+        if diagonal_labels[op_position]:
+            mask = extract_diagonal(mask, op_position)
+        return contract(mask, op_position)
+
+    def combine_masks(masks):
+        reduced_masks_inv = tuple(~reduce_mask(m, pos) for pos, m in enumerate(masks))
+        reduced_subscripts = ",".join(unique_input_subscripts)
+        if einsum_mode == "explicit":
+            reduced_subscripts += f"->{output_subscripts}"
+        reduced_subscripts = reduced_subscripts.replace("?", "...")
+        return ~np.einsum(reduced_subscripts, *reduced_masks_inv, **kwargs)
+
+    mask = combine_masks(masks)
+
+    # sanity check
+    # assert np.broadcast_shapes(mask.shape, retv.shape) == retv.shape
+
+    # reduce mask to a bool if it's uniform
+    if np.all(mask):
+        mask = True
+    elif not np.any(mask):
+        mask = False
+
+    if out is not None:
+        result = out
+        result.mask[:] = mask
+        mask = None
+    else:
+        result = retv
+
+    # TODO: understand what the third item is supposed to be
+    return result, mask, None
 
 
 # Add any dispatched or helper function that has a docstring to

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1026,6 +1026,204 @@ class TestReductionLikeFunctions(MaskedArraySetup):
         expected = np.count_nonzero(self.ma.filled(0), axis=axis)
         assert_array_equal(o, expected)
 
+    @pytest.mark.parametrize(
+        "subscripts, operands, kwargs, expected_out_mask",
+        [
+            pytest.param(
+                "ii",
+                Masked(
+                    np.arange(4.0).reshape(2, 2),
+                    mask=[
+                        [0, 1],
+                        [1, 0],
+                    ],
+                ),
+                {},
+                False,
+                id="2x2 trace (unmasked)",
+            ),
+            pytest.param(
+                "ii",
+                Masked(
+                    np.arange(4.0).reshape(2, 2),
+                    mask=[
+                        [0, 0],
+                        [0, 1],
+                    ],
+                ),
+                {},
+                True,
+                id="2x2 trace (masked)",
+            ),
+            pytest.param(
+                "ii->i",
+                Masked(
+                    np.arange(9.0).reshape(3, 3),
+                    mask=[
+                        [0, 1, 1],
+                        [1, 0, 1],
+                        [1, 1, 0],
+                    ],
+                ),
+                {},
+                False,
+                id="3x3 diagonal (unmasked)",
+            ),
+            pytest.param(
+                "ii->i",
+                Masked(
+                    np.arange(9.0).reshape(3, 3),
+                    mask=[
+                        [0, 0, 0],
+                        [0, 0, 0],
+                        [0, 0, 1],
+                    ],
+                ),
+                {},
+                [0, 0, 1],
+                id="3x3 diagonal (masked)",
+            ),
+            pytest.param(
+                "ij,jk",
+                (
+                    Masked(
+                        np.arange(12).reshape(3, 4),
+                        mask=[
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 0],
+                            [0, 0, 0, 0],
+                        ],
+                    ),
+                    Masked(
+                        np.arange(8).reshape(4, 2),
+                        mask=[
+                            [0, 0],
+                            [0, 0],
+                            [1, 0],
+                            [0, 0],
+                        ],
+                    ),
+                ),
+                {"out": Masked(np.empty((3, 2)))},
+                [
+                    [1, 1],
+                    [1, 0],
+                    [1, 0],
+                ],
+                id="2D matmul",
+            ),
+            pytest.param(
+                "ij,kj",
+                (
+                    Masked(
+                        np.arange(12).reshape(3, 4),
+                        mask=[
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 0],
+                            [0, 0, 0, 0],
+                        ],
+                    ),
+                    Masked(
+                        np.arange(8).reshape(4, 2),
+                        mask=[
+                            [0, 0],
+                            [0, 0],
+                            [1, 0],
+                            [0, 0],
+                        ],
+                    ).transpose(),
+                ),
+                {"out": Masked(np.empty((3, 2)))},
+                [
+                    [1, 1],
+                    [1, 0],
+                    [1, 0],
+                ],
+                id="2D matmul w/ transposition",
+            ),
+            pytest.param(
+                "i->",
+                Masked(np.arange(4.0), mask=False),
+                {},
+                False,
+                id="sum(arr, axis=-1)",
+            ),
+            pytest.param(
+                "ji",
+                Masked(
+                    np.arange(4.0).reshape(2, 2),
+                    mask=[
+                        [0, 0],
+                        [1, 0],
+                    ],
+                ),
+                {},
+                [
+                    [0, 1],
+                    [0, 0],
+                ],
+                id="2x2 transposition",
+            ),
+            pytest.param(
+                "jki",
+                Masked(
+                    np.arange(6).reshape(1, 2, 3),
+                    mask=[[[0, 1, 0], [1, 0, 0]]],
+                ),
+                {},
+                [[[0, 1]], [[1, 0]], [[0, 0]]],
+                id="1x2x3->3x1x2 transposition",
+            ),
+            pytest.param(
+                "...i",
+                Masked(np.arange(4.0).reshape(2, 2), mask=[[0, 1], [0, 0]]),
+                {},
+                [[0, 1], [0, 0]],
+                id="identity (via ellipsis)",
+            ),
+            pytest.param(
+                "i...",
+                Masked(np.arange(4.0).reshape(2, 2), mask=[[0, 1], [0, 0]]),
+                {},
+                [[0, 0], [1, 0]],
+                id="transposition (via ellipsis)",
+            ),
+            pytest.param(
+                "i...i",
+                Masked(
+                    np.arange(8.0).reshape(2, 2, 2),
+                    mask=[[[0, 1], [0, 1]], [[1, 0], [1, 1]]],
+                ),
+                {},
+                [0, 1],
+                id="trace along first and last axes",
+            ),
+            # missing test cases
+            # - 'ij...,jk...->ik...' (matrix-matrix product with the left-most indices instead of rightmost)
+        ],
+    )
+    def test_einsum(self, subscripts, operands, kwargs, expected_out_mask):
+        if not isinstance(operands, tuple):
+            operands = (operands,)
+        res = np.einsum(subscripts, *operands, **kwargs)
+        assert_array_equal(res.mask, expected_out_mask)
+        kwargs_copy = kwargs.copy()
+        if "out" in kwargs:
+            assert res is kwargs["out"]
+            # remove out args to avoid pollution in the rest of the test
+            kwargs_copy.pop("out")
+
+        def as_ndarray(arr):
+            if isinstance(arr, MaskedNDArray):
+                return arr.unmasked
+            else:
+                return arr
+
+        expected_unmasked = np.einsum(
+            subscripts, *(as_ndarray(op) for op in operands), **kwargs_copy
+        )
+        assert_array_equal(res.unmasked, expected_unmasked)
+
 
 @pytest.mark.filterwarnings("ignore:all-nan")
 class TestPartitionLikeFunctions:


### PR DESCRIPTION
### Description

This is a work in progress.
Rationale:
- the lack of support for `np.einsum` for `MaskedNDArray` is currently blocking #16070 and @mhvk has expressed interest in supporting it 
- the function is currently marked as "TODO" in a comment, alongside a bunch of other product-like functions that we could all get almost for free if we just get this one right.

Now, clearly, I didn't know what I was getting myself into when I proposed doing this, but I'm making progress. I'm opening this draft PR at a relatively early stage so it doesn't get lost in my constant context-switching dance.
At the time of writing, only the last test is failing. Fixing this is my next priority.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
