### PR TITLE
TST: fix running a regression test with pytest 7

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -252,10 +252,11 @@ def test_regression_futuretimes_4302():
     else:
         ctx1 = nullcontext()
 
+    ctx2 = pytest.warns(ErfaWarning, match=".*dubious year.*")
+
     if PYTEST_LT_8_0:
-        ctx2 = ctx3 = nullcontext()
+        ctx3 = nullcontext()
     else:
-        ctx2 = pytest.warns(ErfaWarning, match=".*dubious year.*")
         ctx3 = pytest.warns(AstropyWarning, match=".*times after IERS data is valid.*")
 
     with ctx1, ctx2, ctx3:


### PR DESCRIPTION
### Description
This pull request is to address a spurious warning that gets in the way in the context of #16724 and which can be reproduced even on non-exotic archs with pytest 7.4.4:
```
$ pytest astropy/coordinates/tests/test_regression.py::test_regression_futuretimes_4302
...
============================== short test summary info ==============================
FAILED astropy/coordinates/tests/test_regression.py::test_regression_futuretimes_4302 - erfa.core.ErfaWarning: ERFA function "dtf2d" yielded 1 of "dubious year (Note 6)"
================================= 1 failed in 0.54s =================================
```

Fix https://github.com/astropy/astropy/issues/16724

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
