### PR TITLE
Stop mentioning unit formatter instances

### DIFF
--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -101,12 +101,12 @@ def parse(
         Therefore, *filename* is only required when source is a
         file-like object.
 
-    unit_format : str, astropy.units.format.Base instance or None, optional
+    unit_format : str, astropy.units.format.Base subclass or None, optional
         The unit format to use when parsing unit attributes.  If a
         string, must be the name of a unit formatter. The built-in
         formats include ``generic``, ``fits``, ``cds``, and
         ``vounit``.  A custom formatter may be provided by passing a
-        `~astropy.units.UnitBase` instance.  If `None` (default),
+        `~astropy.units.format.Base` subclass.  If `None` (default),
         the unit format to use will be the one specified by the
         VOTable specification (which is ``cds`` up to version 1.3 of
         VOTable, and ``vounit`` in more recent versions of the spec).

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -749,8 +749,8 @@ class UnitBase:
 
         Parameters
         ----------
-        format : `astropy.units.format.Base` instance or str
-            The name of a format or a formatter object.  If not
+        format : `astropy.units.format.Base` subclass or str
+            The name of a format or a formatter class.  If not
             provided, defaults to the generic format.
 
         **kwargs

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -79,13 +79,12 @@ def get_format(format=None):
 
     Parameters
     ----------
-    format : str or `astropy.units.format.Base` instance or subclass
-        The name of the format, or the format instance or subclass
-        itself.
+    format : str or `astropy.units.format.Base` subclass
+        The name of the format, or the formatter class itself.
 
     Returns
     -------
-    format : `astropy.units.format.Base` instance
+    format : `astropy.units.format.Base` subclass
         The requested formatter.
     """
     if format is None:
@@ -95,8 +94,7 @@ def get_format(format=None):
         return format
     elif not (isinstance(format, str) or format is None):
         raise TypeError(
-            f"Formatter must a subclass or instance of a subclass of {Base!r} "
-            f"or a string giving the name of the formatter. {_known_formats()}."
+            f"Expected a formatter name, not {format!r}.  {_known_formats()}."
         )
 
     format_lower = format.lower()

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -393,8 +393,8 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
         Parameters
         ----------
-        format : `astropy.units.format.Base` instance or str
-            The name of a format or a formatter object.  If not
+        format : `astropy.units.format.Base` subclass or str
+            The name of a format or a formatter class.  If not
             provided, defaults to the generic format.
         """
         supported_formats = (

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -424,8 +424,8 @@ class StructuredUnit:
 
         Parameters
         ----------
-        format : `astropy.units.format.Base` instance or str
-            The name of a format or a formatter object.  If not
+        format : `astropy.units.format.Base` subclass or str
+            The name of a format or a formatter class.  If not
             provided, defaults to the generic format.
 
         Notes

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -26,8 +26,8 @@ def quantity_support(format="latex_inline"):
 
     Parameters
     ----------
-    format : `astropy.units.format.Base` instance or str
-        The name of a format or a formatter object.  If not
+    format : `astropy.units.format.Base` subclass or str
+        The name of a format or a formatter class.  If not
         provided, defaults to ``latex_inline``.
 
     """


### PR DESCRIPTION
### Description

It is not possible to create unit formatter instances: https://github.com/astropy/astropy/blob/9855fc57aad429d0be81fa993ea0c837eb939357/astropy/units/format/base.py#L29-L33

```python
>>> from astropy.units.format import Latex
>>> isinstance(Latex(), Latex)
False
```

Despite that, `git grep '\.Base[^A-Z].*instance'` reveals several mentions of them. This pull request replaces their mentions with mentions of unit formatter classes because that change can be backported, but we should consider removing support for accepting formatter classes as argument values. The formatter classes are not well documented and unit format names are more convenient because they don't have to be imported and they can be used in more places (e.g. in f-strings like `f"{5 * u.km / u.m:unicode}"`). The formatter classes are public so that it would be simpler to implement new formatters by inheriting from one of ours, but there are no good reasons for using them directly for formatting.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
