### PR TITLE
Do not split CDS and MRT table sections when a regular row starts with 6 dashes or more in `io.ascii`

### DIFF
--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -216,8 +216,13 @@ class CdsData(core.BaseData):
         # attribute.
         if self.header.readme and self.table_name:
             return lines
+        # Check that line starts with either 6 "-" or "="
+        # and that it contains only a single repeated character.
+        # Latter condition fixes cases where a regular row starts with 6 "-"
         i_sections = [
-            i for i, x in enumerate(lines) if x.startswith(("------", "======="))
+            i
+            for i, x in enumerate(lines)
+            if x.startswith(("------", "=======")) and len(set(x)) == 1
         ]
         if not i_sections:
             raise core.InconsistentTableError(

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -39,6 +39,9 @@ def _is_section_delimiter(line):
         True if the line is a section delimiter, False otherwise.
 
     """
+    # Check that line starts with either 6 "-" or "="
+    # and that it contains only a single repeated character.
+    # Latter condition fixes cases where a regular row starts with 6 "-".
     return line.startswith(("------", "=======")) and len(set(line.strip())) == 1
 
 
@@ -237,9 +240,6 @@ class CdsData(core.BaseData):
         # attribute.
         if self.header.readme and self.table_name:
             return lines
-        # Check that line starts with either 6 "-" or "="
-        # and that it contains only a single repeated character.
-        # Latter condition fixes cases where a regular row starts with 6 "-"
         i_sections = [i for i, x in enumerate(lines) if _is_section_delimiter(x)]
         if not i_sections:
             raise core.InconsistentTableError(

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -22,7 +22,7 @@ __doctest_skip__ = ["*"]
 
 
 def _is_section_delimiter(line):
-    """Check if line is a section delimiter
+    """Check if line is a section delimiter.
 
     CDS/MRT tables use dashes or equal signs ("------" or "======") to
     separate sections. This function checks if a line contains only either
@@ -35,7 +35,7 @@ def _is_section_delimiter(line):
 
     Returns
     -------
-    bool
+    status : bool
         True if the line is a section delimiter, False otherwise.
 
     """

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -39,7 +39,7 @@ def _is_section_delimiter(line):
         True if the line is a section delimiter, False otherwise.
 
     """
-    return line.startswith(("------", "=======")) and len(set(line)) == 1
+    return line.startswith(("------", "=======")) and len(set(line.strip())) == 1
 
 
 class CdsHeader(core.BaseHeader):

--- a/astropy/io/ascii/tests/data/cds_mrt_dashes.txt
+++ b/astropy/io/ascii/tests/data/cds_mrt_dashes.txt
@@ -1,0 +1,22 @@
+﻿Title: The Initial Mass Function Based on the Full-sky 20-pc Census of
+    ~3,600 Stars and Brown Dwarfs 
+Authors: Kirkpatrick, J. D.; et al.
+Table: The 20-pc Census
+================================================================================
+Byte-by-byte Description of file: apjsad24e2t4_mrt.txt
+--------------------------------------------------------------------------------
+   Bytes Format Units    Label                   Explanations
+--------------------------------------------------------------------------------
+   1-  85 A85    ---      DefaultName             Default name(s) in SIMBAD, ampersand delimited for systems, See Section 3.6.4 for component formalism
+  87-  87 I1     ---      #CompsOnThisRow         Number of known components for this row 
+--------------------------------------------------------------------------------
+Note (1): This is a subset from Table 4 of Kirkpatrick et al. 2024 (https://content.cld.iop.org/journals/0067-0049/271/2/55/revision2/apjsad24e2t4_mrt.txt)
+--------------------------------------------------------------------------------
+Sun                                                                                   1
+--LP 704-15                                                                           3
+----LP 704-15 Aa                                                                      2
+------LP 704-15 Aa1                                                                   1
+------LP 704-15 Aa2                                                                   1
+----LP 704-15 Ab                                                                      1
+--LP 704-14                                                                           1
+G 129-47                                                                              1

--- a/astropy/io/ascii/tests/data/cds_mrt_dashes.txt
+++ b/astropy/io/ascii/tests/data/cds_mrt_dashes.txt
@@ -11,7 +11,8 @@ Byte-by-byte Description of file: apjsad24e2t4_mrt.txt
   87-  87 I1     ---      #CompsOnThisRow         Number of known components for this row 
 --------------------------------------------------------------------------------
 Note (1): This is a subset from Table 4 of Kirkpatrick et al. 2024 (https://content.cld.iop.org/journals/0067-0049/271/2/55/revision2/apjsad24e2t4_mrt.txt)
---------------------------------------------------------------------------------
+Note (2): The separator line below has trailing spaces for testing purposes. Please do not remove them.
+--------------------------------------------------------------------------------    
 Sun                                                                                   1
 --LP 704-15                                                                           3
 ----LP 704-15 Aa                                                                      2

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -618,6 +618,14 @@ def test_masking_Cds_Mrt():
         assert not hasattr(data["Fit"], "mask")
 
 
+def test_dashes_Cds_Mrt():
+    f = "data/cds_mrt_dashes.txt"
+    for testfile in get_testfiles(f):
+        data = ascii.read(f, **testfile["opts"])
+        assert len(data) == testfile["nrows"]
+        print(data)
+
+
 def test_null_Ipac():
     f = "data/ipac.dat"
     testfile = get_testfiles(f)[0]
@@ -788,6 +796,24 @@ def get_testfiles(name=None):
             "name": "data/cds.dat",
             "nrows": 1,
             "opts": {"format": "mrt"},
+        },
+        {
+            "cols": (
+                "DefaultName",
+                "#CompsOnThisRow",
+            ),
+            "name": "data/cds_mrt_dashes.txt",
+            "nrows": 8,
+            "opts": {"format": "mrt"},
+        },
+        {
+            "cols": (
+                "DefaultName",
+                "#CompsOnThisRow",
+            ),
+            "name": "data/cds_mrt_dashes.txt",
+            "nrows": 8,
+            "opts": {"format": "cds"},
         },
         # Test malformed CDS file (issues #2241 #467)
         {

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -618,13 +618,6 @@ def test_masking_Cds_Mrt():
         assert not hasattr(data["Fit"], "mask")
 
 
-def test_dashes_Cds_Mrt():
-    f = "data/cds_mrt_dashes.txt"
-    for testfile in get_testfiles(f):
-        data = ascii.read(f, **testfile["opts"])
-        assert len(data) == testfile["nrows"]
-
-
 def test_null_Ipac():
     f = "data/ipac.dat"
     testfile = get_testfiles(f)[0]
@@ -796,6 +789,7 @@ def get_testfiles(name=None):
             "nrows": 1,
             "opts": {"format": "mrt"},
         },
+        # Test CDS and MRT files with dashes in column name
         {
             "cols": (
                 "DefaultName",

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -623,7 +623,6 @@ def test_dashes_Cds_Mrt():
     for testfile in get_testfiles(f):
         data = ascii.read(f, **testfile["opts"])
         assert len(data) == testfile["nrows"]
-        print(data)
 
 
 def test_null_Ipac():

--- a/docs/changes/io.ascii/16735.bugfix.rst
+++ b/docs/changes/io.ascii/16735.bugfix.rst
@@ -1,0 +1,2 @@
+When reading CDS and MRT files, only interpret a line as a section delimiter if
+it contains exclusively dashes or equal signs. This enables rows starting with dashes.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a problem I encountered when reading Table 4 of [Kirkpatrick et al. (2024)](https://ui.adsabs.harvard.edu/abs/2024ApJS..271...55K/abstract) ([link to table in .txt format](https://content.cld.iop.org/journals/0067-0049/271/2/55/revision2/apjsad24e2t4_mrt.txt)). Only the last 18 rows of the table were read. I realized this was because the [`CdsData`](https://github.com/astropy/astropy/blob/177da898ddc7686a5a757225e73011e94db31b10/astropy/io/ascii/cds.py?plain=1#L205) class defines section delimiters as lines starting with 6 dashes (`-`) or equal signs (`=`). The table mentioned above uses dashes at the start of line to indicate indentation and has lines with 6 or more dashes before a regular row.

I added a minimal version of the table to the test cases for `test_read.py`. I also added a simple fix that keeps the existing `x.startswith("------")` check but adds `len(set(x)) == 1` to ensure that the line only contains dashes. I implemented this fix in a private function as there where 3 instances of this check.

This fix assumes that section delimiter lines will always only contain equals or dashes. **I am not sure this assumption is correct** (but I think so, based on what documentation I could find for CDS and MRT formats). If it is not, we would need to check that what comes after the dashes or equals is not a regular row (I'm not sure how to do that but the existing column and splitter definitions would probably help).

This is my first PR, so let me know if there are things I should add or do differently!

Thank you!