### PR TITLE
Convert comment into unit test

### DIFF
--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -19,47 +19,6 @@ from . import basic, core
 
 
 def _line_type(line, delimiter=None):
-    """Interpret a QDP file line.
-
-    Parameters
-    ----------
-    line : str
-        a single line of the file
-
-    Returns
-    -------
-    type : str
-        Line type: "comment", "command", or "data"
-
-    Examples
-    --------
-    >>> _line_type("READ SERR 3")
-    'command'
-    >>> _line_type(" \\n    !some gibberish")
-    'comment'
-    >>> _line_type("   ")
-    'comment'
-    >>> _line_type(" 21345.45")
-    'data,1'
-    >>> _line_type(" 21345.45 1.53e-3 1e-3 .04 NO nan")
-    'data,6'
-    >>> _line_type(" 21345.45,1.53e-3,1e-3,.04,NO,nan", delimiter=',')
-    'data,6'
-    >>> _line_type(" 21345.45 ! a comment to disturb")
-    'data,1'
-    >>> _line_type("NO NO NO NO NO")
-    'new'
-    >>> _line_type("NO,NO,NO,NO,NO", delimiter=',')
-    'new'
-    >>> _line_type("N O N NOON OON O")
-    Traceback (most recent call last):
-        ...
-    ValueError: Unrecognized QDP line...
-    >>> _line_type(" some non-comment gibberish")
-    Traceback (most recent call last):
-        ...
-    ValueError: Unrecognized QDP line...
-    """
     _decimal_re = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
     _command_re = r"READ [TS]ERR(\s+[0-9]+)+"
 


### PR DESCRIPTION
This is how real unit test should look like. Please take them as an example. This is better than the docstrings as the examples are guaranteed to be correct.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
