### PR TITLE
Quantity input speed

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -59,9 +59,9 @@ def _validate_arg_value(
     # If dimensionless is an allowed unit and the argument is unit-less,
     #   allow numbers or numpy arrays with numeric dtypes
     if (
-        dimensionless_unscaled in allowed_units
-        and not strict_dimensionless
+        not strict_dimensionless
         and not hasattr(arg, "unit")
+        and dimensionless_unscaled in allowed_units
     ):
         if isinstance(arg, Number):
             return

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -2,6 +2,7 @@
 
 __all__ = ["quantity_input"]
 
+import contextlib
 import inspect
 import typing as T
 from collections.abc import Sequence
@@ -308,8 +309,15 @@ class QuantityInput:
                     self.strict_dimensionless,
                 )
 
+            if self.equivalencies:
+                equiv_context = add_enabled_equivalencies(self.equivalencies)
+            else:
+                # Avoid creating a duplicate registry if we don't have
+                # equivalencies to add. (If we're wrapping a short function,
+                # the time spent duplicating the registry is quite noticeable.)
+                equiv_context = contextlib.nullcontext()
             # Call the original function with any equivalencies in force.
-            with add_enabled_equivalencies(self.equivalencies):
+            with equiv_context:
                 return_ = wrapped_function(*func_args, **func_kwargs)
 
             # Return

--- a/docs/changes/units/16742.perf.rst
+++ b/docs/changes/units/16742.perf.rst
@@ -1,0 +1,1 @@
+The ``units.quantity_input`` decorator has been optimized, especially in the case that no equivalencies are provided to the decorator, and the speed-up is very noticeable when wrapping short functions.


### PR DESCRIPTION
### Description

I recently unit-ified some code of mine and added the `@quantity_input` decorator to some small functions which are sometimes called frequently (especially in my tests). I found that the decorator adds significant runtime to these short functions, so I spent some time trying to optimize it and I've found two impactful improvements. (When the decorator is applied to larger/slower functions, this will all be negligible.)

For profiling, I wrapped this very simple function:
```python
def wrapped_function(x: u.m, y: u.m, a, b):
    return x * y
```

The first change involves equivalencies and the unit registry (both of which I have little familiarity with). Profiling showed that the decorator spends only 15% of its time calling `wrapped_function`, and 60% of its time is in handling equivalencies. (This excerpt is for [this line](https://github.com/astropy/astropy/blob/e315900d55d99214a49a7e466e5cfb7523fe5ee9/astropy/units/decorators.py#L312))
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
<snip>
    94                                               # Call the original function with any equivalencies in force.
    95     20000 1660430926.0  83021.5     61.5      with add_enabled_equivalencies(self.equivalencies):
    96     10000  390368572.0  39036.9     14.5          return_ = wrapped_function(*func_args, **func_kwargs)
```
`add_enabled_equivalencies` creates a `_UnitContext` which creates a new `_UnitRegistry`, passing in the currently-active registry. `_UnitRegistry`'s constructor copies the contents of the currently-active registry, which is where the time is spent. When not adding equivalencies through `quantity_input` (which seems like a common use case), it seems a shame to spend time duplicating the unit registry when there's nothing to add to it, and so my first commit skips that work in that case.

This does make a slight change to the semantics of `quantity_input`, in that it appears that before, using this decorator meant the unit registry was copied and restored every time the wrapped function was entered and exited, so one could make changes to the registry inside the wrapped function that were later undone. With this proposed change, those changes would only be undone if new equivalencies were provided to `quantity_input`. I don't see that specific behavior documented and don't know if it's intended or important.

With that change made, the `quantity_input` wrapper spends 26% of its time calling `_validate_arg_value`, which spends 62% of its time in [this conditional](https://github.com/astropy/astropy/blob/e315900d55d99214a49a7e466e5cfb7523fe5ee9/astropy/units/decorators.py#L60):
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
<snip>
    35                                               if (
    36     20000  175202045.0   8760.1     62.7          dimensionless_unscaled in allowed_units
    37                                                   and not strict_dimensionless
    38                                                   and not hasattr(arg, "unit")
    39                                               ):
```
Of the three parts of the condition, `dimensionless_unscaled in allowed_units` appears to be the slowest, as it runs through all of `UnitBase.__eq__` for each allowed unit. If that first part is moved to be the third part of the `if X and Y and Z`, it won't run unless the other two conditions are `True`, and we can save time when one of them is `False`. (And the `not hasattr` will only be `True` in what I assume is the less-common case of numbers without units being passed in for an argument that does have required units specified, so I think this will be a frequent savings.)

This change should be free of side-effects.

Timing results:
```python
@u.quantity_input
def wrapped_function(x: u.m, y: u.m, a, b):
    return x * y
%timeit wrapped_function(1*u.m, 2*u.m, 1, 2)
```
Without the decorator: `19.4 μs ± 1.77 μs per loop`
With the decorator, before this PR: `254 μs ± 2.19 μs per loop`
With only the `UnitRegistry` change: `68.6 μs ± 589 ns per loop`
After this PR: `59.1 μs ± 845 ns per loop`

It adds up! Timing results for my actual code, which synthesizes an image while calling many small functions that have `@quantity_input`:
Without the decorator: 1.32 s
With the decorator, before this PR: 2.51 s
With only the `UnitRegistry` change: 1.59 s
After this PR: 1.41 s

And for a test that runs these small functions over a grid of possibilities:
Without the decorator: 4.17 s
With the decorator, before this PR: 15.5 s
With only the `UnitRegistry` change: 4.87 s
After this PR: 4.56 s

(I'm sure I could have re-arranged my code to go through `quantity_input` less often, but having more speed makes that work less necessary for me and anyone else in this kind of situation.)