### PR TITLE
Make the OGIP parser less restrictive with `sqrt`

### DIFF
--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -219,7 +219,7 @@ class OGIP(generic.Generic):
 
             if len(p) == 7:
                 if p1_str == "sqrt":
-                    p[0] = p[1] * p[3] ** (0.5 * p[6])
+                    p[0] = p[3] ** (0.5 * p[6])
                 else:
                     p[0] = p[1] * p[3] ** p[6]
             elif len(p) == 6:

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -264,6 +264,12 @@ def test_ogip_grammar_fail(string):
         u_format.OGIP.parse(string)
 
 
+@pytest.mark.parametrize("string", ["sqrt(m)**3", "sqrt(m**3)", "(sqrt(m))**3"])
+def test_ogip_sqrt(string):
+    # Regression test for #16743 - sqrt(m)**3 caused a ValueError
+    assert u_format.OGIP.parse(string) == u.m ** Fraction(3, 2)
+
+
 class RoundtripBase:
     deprecated_units = set()
 

--- a/docs/changes/units/16743.bugfix.rst
+++ b/docs/changes/units/16743.bugfix.rst
@@ -1,0 +1,4 @@
+The OGIP parser is now less restrictive with strings that represent a unit that
+includes the ``sqrt`` function.
+For example, ``u.Unit("sqrt(m)**3", format="ogip")`` no longer causes a
+``ValueError``.


### PR DESCRIPTION
### Description

The OGIP unit parser is too restrictive with strings that contain `sqrt` raised to some power:
```python
>>> from astropy.units.format import OGIP
>>> OGIP.parse("sqrt(m)**3")
Traceback (most recent call last):
  ...
ValueError: 'sqrt' did not parse as unit: At col 0, sqrt is not a valid unit.  If this is meant...
```
The string can be parsed after removing some code:
```python
>>> from astropy.units.format import OGIP
>>> OGIP.parse("sqrt(m)**3")
Unit("m(3/2)")
```
If I've misunderstood something and the `ValueError` is in fact the expected outcome then there should be a test to ensure that.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
