### PR TITLE
Make OGIP unit parser reject invalid multiplications

### DIFF
--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -216,19 +216,27 @@ class OGIP(generic.Generic):
                     f"The function '{p[1]}' is valid in OGIP, but not understood "
                     "by astropy.units."
                 )
+            bad_multiplication_message = (
+                "if '{0}{1}' was meant to be a multiplication, "
+                "it should have been written as '{0} {1}'."
+            )
 
             if len(p) == 7:
                 if p1_str == "sqrt":
                     p[0] = p[3] ** (0.5 * p[6])
                 else:
-                    p[0] = p[1] * p[3] ** p[6]
+                    raise ValueError(
+                        bad_multiplication_message.format(p[1], f"({p[3]})**{p[6]}")
+                    )
             elif len(p) == 6:
                 p[0] = p[2] ** p[5]
             elif len(p) == 5:
                 if p1_str == "sqrt":
                     p[0] = p[3] ** 0.5
                 else:
-                    p[0] = p[1] * p[3]
+                    raise ValueError(
+                        bad_multiplication_message.format(p[1], f"({p[3]})")
+                    )
             elif len(p) == 4:
                 p[0] = p[2]
             else:

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -270,6 +270,12 @@ def test_ogip_sqrt(string):
     assert u_format.OGIP.parse(string) == u.m ** Fraction(3, 2)
 
 
+@pytest.mark.parametrize("string", ["m(s)**2", "m(s)"])
+def test_ogip_invalid_multiplication(string):
+    with pytest.raises(ValueError):
+        u_format.OGIP.parse(string)
+
+
 class RoundtripBase:
     deprecated_units = set()
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -270,9 +270,30 @@ def test_ogip_sqrt(string):
     assert u_format.OGIP.parse(string) == u.m ** Fraction(3, 2)
 
 
-@pytest.mark.parametrize("string", ["m(s)**2", "m(s)"])
-def test_ogip_invalid_multiplication(string):
-    with pytest.raises(ValueError):
+@pytest.mark.parametrize(
+    "string,message",
+    [
+        pytest.param(
+            "m(s)**2",
+            (
+                r"^if 'm\(s\)\*\*2' was meant to be a multiplication, "
+                r"it should have been written as 'm \(s\)\*\*2'.$"
+            ),
+            id="m(s)**2",
+        ),
+        pytest.param(
+            "m(s)",
+            (
+                r"^if 'm\(s\)' was meant to be a multiplication, "
+                r"it should have been written as 'm \(s\)'.$"
+            ),
+            id="m(s)",
+        ),
+    ],
+)
+def test_ogip_invalid_multiplication(string, message):
+    # Regression test for #16749
+    with pytest.raises(ValueError, match=message):
         u_format.OGIP.parse(string)
 
 

--- a/docs/changes/units/16749.bugfix.rst
+++ b/docs/changes/units/16749.bugfix.rst
@@ -1,0 +1,4 @@
+The OGIP unit parser no longer accepts strings where a component unit is
+followed by a parenthesized unit without a separator in between, such as
+``'m(s)'`` or ``'m(s)**2'``.
+Such strings are not allowed by the OGIP standard.


### PR DESCRIPTION
### Description

I noticed that there is some code in the OGIP unit parser that is not being tested. When I investigated closer I realized that the untested code successfully parses multiplications that the [OGIP unit standard](https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/) does not allow. There are two ways how to handle this, and I'm not sure which one we should take.

1) Update the parser so that the invalid multiplications cause a `ValueError`. This would make `astropy` comply better with the OGIP standard, but would be a backwards incompatible change for anyone using these invalid multiplications. 

2) Follow the [robustness principle (aka Postel's law)](https://en.wikipedia.org/wiki/Robustness_principle) and parse them anyways. In that case we wouldn't need to change the parser, but we should add tests for the invalid multiplications to record the fact that this is not an oversight and that we have deliberately decided to parse them.

UPDATE: we decided to go with option 1.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
