### PR TITLE
Fix error message from download_file on SSL cert failure

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1237,7 +1237,7 @@ def _try_url_open(
                 "misconfigured or your local root CA certificates are "
                 "out-of-date; in the latter case this can usually be "
                 'addressed by installing the Python package "certifi" '
-                "(see the documentation for astropy.utils.data.download_url)"
+                "(see the documentation for astropy.utils.data.download_file)"
             )
             if not allow_insecure:
                 msg += (


### PR DESCRIPTION
### Description

`download_file` can fail a few different ways, and one of them triggers an error message that refers to `download_url` rather than `download_file` on its last line: 

https://github.com/astropy/astropy/blob/31fd2096b3d0d17d106873c00ae1069fb4fa7d5f/astropy/utils/data.py#L1234-L1241

This PR tweaks the error message.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
