### PR TITLE
Implement `Real` and `Complex` type aliases

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -8,12 +8,12 @@ from . import utils
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from numbers import Real
     from typing import ClassVar, Literal
 
     import numpy as np
 
     from astropy.units import NamedUnit, UnitBase
+    from astropy.units.typing import Real
 
 
 class Base:

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING
 from . import console, utils
 
 if TYPE_CHECKING:
-    from numbers import Real
     from typing import ClassVar, Literal
 
     from astropy.units import NamedUnit, UnitBase
+    from astropy.units.typing import Real
 
 
 class Latex(console.Console):

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -11,10 +11,10 @@ from typing import TYPE_CHECKING
 from . import console, utils
 
 if TYPE_CHECKING:
-    from numbers import Real
     from typing import ClassVar
 
     from astropy.units import NamedUnit
+    from astropy.units.typing import Real
 
 
 class Unicode(console.Console):

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -13,10 +13,10 @@ from astropy.units.utils import maybe_simple_fraction
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterable, Sequence
-    from numbers import Real
     from typing import TypeVar
 
     from astropy.units import UnitBase
+    from astropy.units.typing import Real
 
     T = TypeVar("T")
 

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 __all__ = ["QuantityLike"]
 
 
+from fractions import Fraction
 from typing import TYPE_CHECKING
 
+import numpy as np
 import numpy.typing as npt
 
 from astropy.units import Quantity
@@ -64,3 +66,11 @@ Strings:
 For more examples see the :mod:`numpy.typing` definition of
 :obj:`numpy.typing.ArrayLike`.
 """
+
+
+# The classes from the standard library `numbers` module are not suitable for
+# type checking (https://github.com/python/mypy/issues/3186). For now we define
+# our own number types, but if a good definition becomes available upstream
+# then we should switch to that.
+Real: TypeAlias = int | float | Fraction | np.integer | np.floating
+Complex: TypeAlias = Real | complex | np.complexfloating

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -18,10 +18,11 @@ from numpy import finfo
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
-    from numbers import Complex, Real
     from typing import Literal, SupportsFloat, TypeVar
 
     from numpy.typing import ArrayLike, NDArray
+
+    from astropy.units.typing import Complex, Real
 
     from .core import UnitBase
     from .quantity import Quantity

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -83,7 +83,6 @@ py:class a shallow copy of D
 # types
 py:class EllipsisType
 py:class ModuleType
-py:class Real
 # numpy
 py:class np.number
 # numpy.typing


### PR DESCRIPTION
### Description

The [Python standard library `numbers` module](https://docs.python.org/3/library/numbers.html) defines abstract base classes for different types of numbers, but those classes are not suitable for type checking (at least not with [mypy](https://github.com/python/mypy/issues/3186) or [Pyright](https://github.com/microsoft/pyright/issues/4616)), so `astropy` should define these types itself.

Additionally, Sphinx has had trouble figuring out how to link to [`numbers.Real`](https://docs.python.org/3/library/numbers.html#numbers.Real) even though it is part of the standard library. If we define `Real` ourselves then Sphinx should be able to link to that definition without problems, which would be helpful for anyone reading our documentation. However, our public API does not refer to `Real` since 64ecceea06097bfa22aa27330a3f503f2ba83a54, so this benefit is not immediately obvious, but it might become relevant when more of `astropy` gets annotated.

One more thing worth thinking about is whether we should define `Bool: TypeAlias = bool | np.bool_`, but maybe that deserves a separate pull request.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
