### PR TITLE
BaseCoordinateFrame docstring links are not resolving in affiliated package

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1759,7 +1759,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Computes on-sky separation between this coordinate and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :doc:`astropy:coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1805,7 +1805,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :doc:`astropy:coordinates/matchsep`.
 
         Parameters
         ----------

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1759,7 +1759,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Computes on-sky separation between this coordinate and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1805,7 +1805,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1297,7 +1297,7 @@ class SkyCoord(ShapedLikeNDArray):
         catalog coordinates.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1366,7 +1366,7 @@ class SkyCoord(ShapedLikeNDArray):
         ``catalogcoord`` object.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1435,7 +1435,7 @@ class SkyCoord(ShapedLikeNDArray):
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1495,7 +1495,7 @@ class SkyCoord(ShapedLikeNDArray):
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation_3d`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1297,7 +1297,7 @@ class SkyCoord(ShapedLikeNDArray):
         catalog coordinates.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :doc:`astropy:coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1366,7 +1366,7 @@ class SkyCoord(ShapedLikeNDArray):
         ``catalogcoord`` object.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :doc:`astropy:coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1435,7 +1435,7 @@ class SkyCoord(ShapedLikeNDArray):
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :doc:`astropy:coordinates/matchsep`.
 
         Parameters
         ----------
@@ -1495,7 +1495,7 @@ class SkyCoord(ShapedLikeNDArray):
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation_3d`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :doc:`astropy:coordinates/matchsep`.
 
         Parameters
         ----------


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Intersphinx linking in `sbpy`'s documentation is failing to resolve documents referenced in `astropy.coordinates.baseframe.BaseCoordinateFrame`:

/home/docs/checkouts/readthedocs.org/user_builds/sbpy/envs/394/lib/python3.10/site-packages/astropy/coordinates/baseframe.py:docstring of astropy.coordinates.baseframe.BaseCoordinateFrame.separation_3d:5: WARNING: unknown document: 'astropy:/coordinates/matchsep'

The issue is the leading "/" in the path.  Instead the document reference should be 'astropy:coordinates/matchsep'.  Inspecting the documentation inventory will verify this (note first line):

```
$ python -m sphinx.ext.intersphinx https://docs.astropy.org/en/latest/objects.inv|grep matchsep
    coordinates/matchsep                     Separations, Offsets, Catalog Matching, and Related Functionality: coordinates/matchsep.html
    astropy-coordinates-matching             Matching Catalogs                       : coordinates/matchsep.html#astropy-coordinates-matching
    astropy-coordinates-separations-matching Separations, Offsets, Catalog Matching, and Related Functionality: coordinates/matchsep.html#astropy-coordinates-separations-matching
    astropy-searching-coordinates            Searching around Coordinates            : coordinates/matchsep.html#astropy-searching-coordinates
    astropy-skyoffset-frames                 “Sky Offset” Frames                     : coordinates/matchsep.html#astropy-skyoffset-frames
```

A failing sbpy build log at: https://readthedocs.org/projects/sbpy/builds/25080437/

I've applied a fix in our code, after which the RTD build was successful: 

* The fix (ArbitraryFrame inherets the erroneous doc strings from BaseCoordinateFrame.separation and BaseCoordinateFrame.separation_3d): https://github.com/NASA-Planetary-Science/sbpy/pull/394/commits/0855a87bf66c156d57fc5021b7bbe1ae21aa8ffa
* Succesfull build: https://readthedocs.org/projects/sbpy/builds/25086661/

This PR propagates that fix

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
