### PR TITLE
BUG/API: properly retrieve numpy's printoptions dict in utils.masked

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1226,22 +1226,14 @@ def array2string(
     legacy=None,
 ):
     # Copied from numpy.core.arrayprint, but using _array2string above.
-    if NUMPY_LT_2_1:
-        if NUMPY_LT_2_0:
-            from numpy.core.arrayprint import _format_options
-        else:
-            from numpy._core.arrayprint import _format_options
-        options = _format_options.copy()
-    else:
-        from numpy._core.printoptions import format_options
-
-        options = format_options.get().copy()
-
     if NUMPY_LT_2_0:
-        from numpy.core.arrayprint import _make_options_dict
+        from numpy.core.arrayprint import _format_options, _make_options_dict
+
+        options = _format_options.copy()
     else:
         from numpy._core.arrayprint import _make_options_dict
 
+        options = np.get_printoptions()
     overrides = _make_options_dict(
         precision,
         threshold,
@@ -1289,15 +1281,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
             from numpy._core.arrayprint import StructuredVoidFormat
 
             # Following numpy._core.arrayprint._void_scalar_to_string
-            if NUMPY_LT_2_1:
-                from numpy._core.arrayprint import _format_options
-
-                options = _format_options.copy()
-            else:
-                from numpy._core.printoptions import format_options
-
-                options = format_options.get().copy()
-
+            options = np.get_printoptions()
             if options.get("formatter") is None:
                 options["formatter"] = {}
             options["formatter"].setdefault("float_kind", str)

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1271,7 +1271,11 @@ class TestStringFunctions:
         assert out == "MaskedNDArray([—, 1, 2])"
         ma2 = self.ma.astype("f4")
         out2 = np.array_repr(ma2)
-        assert out2 == "MaskedNDArray([——, 1., 2.], dtype=float32)"
+        assert (
+            out2 == "MaskedNDArray([——, 1., 2.], dtype=float32)"
+            if NUMPY_LT_2_0
+            else "MaskedNDArray([———,  1.,  2.], dtype=float32)"
+        )
 
     def test_array_str(self):
         out = np.array_str(self.ma)

--- a/docs/changes/utils/16759.bugfix.rst
+++ b/docs/changes/utils/16759.bugfix.rst
@@ -1,0 +1,3 @@
+Array printing methods now properly retrieve numpy printing options.
+In some cases, this may slightly affect the string representation of masked
+objects.

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -92,7 +92,7 @@ Slicing or indexing (:ref:`nddata_slicing`) is possible (with warnings issued if
 some attribute cannot be sliced)::
 
     >>> ndd2[2:]  # discard the first two elements  # doctest: +FLOAT_CMP
-    NDDataRef([———, ———], unit='erg / s')
+    NDDataRef([ ———,  ———], unit='erg / s')
     >>> ndd2[1]   # get the second element  # doctest: +FLOAT_CMP
     NDDataRef(-1.5, unit='erg / s')
 

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -455,7 +455,7 @@ the first example in this section, we see that the underlying
 masked ones::
 
     >>> sum_axis_1  # doctest: +FLOAT_CMP
-    NDDataArray([——, 9.], unit='m')
+    NDDataArray([———,  9.], unit='m')
 
 where the first data element is masked. We can instead get the sum
 for only unmasked values with the ``operation_ignores_mask`` option::
@@ -517,4 +517,4 @@ Converting the ``data``, ``unit``, and ``mask`` to a ``MaskedQuantity``::
 
     >>> from astropy.utils.masked import Masked
     >>> Masked(u.Quantity(ndd.data, ndd.unit), ndd.mask)  # doctest: +FLOAT_CMP
-    <MaskedQuantity [——, 2., 3., ——] m>
+    <MaskedQuantity [———,  2.,  3., ———] m>

--- a/docs/utils/masked/index.rst
+++ b/docs/utils/masked/index.rst
@@ -34,10 +34,10 @@ as addition, etc.::
   >>> from astropy.utils.masked import Masked
   >>> ma = Masked([1., 2., 3.], mask=[False, False, True])
   >>> ma
-  MaskedNDArray([1., 2., ——])
+  MaskedNDArray([ 1.,  2., ———])
   >>> mq = ma * u.m
   >>> mq + 25 * u.cm
-  <MaskedQuantity [1.25, 2.25,  ———] m>
+  <MaskedQuantity [ 1.25,  2.25,   ———] m>
 
 You can get the values without the mask using
 `~astropy.utils.masked.Masked.unmasked`, or, if you need to control what
@@ -54,9 +54,9 @@ done directly::
 
   >>> ma = Masked([[0., 1.], [2., 3.]], mask=[[False, True], [False, False]])
   >>> ma.sum(axis=-1)
-  MaskedNDArray([——, 5.])
+  MaskedNDArray([———,  5.])
   >>> ma.sum()
-  MaskedNDArray(——)
+  MaskedNDArray(———)
 
 You might wonder why masked elements are propagated, instead of just being
 skipped (as is done in `~numpy.ma.MaskedArray`; see :ref:`below
@@ -100,7 +100,7 @@ have if the operations were done on the individual elements::
   >>> np_ma[0] * np_ma[1] * np_ma[2]
   masked
   >>> Masked(np_ma).prod()
-  MaskedNDArray(——)
+  MaskedNDArray(———)
 
 The rationale for this becomes clear again by thinking about subclasses like a
 masked |Quantity|.  For instance, consider an array ``s`` of lengths with


### PR DESCRIPTION
### Description
This is a (probably) non-backportable follow up to #16755. See that PR for full details, but in summary:
we rely on private APIs to retrive print options from numpy, which is both fragile (the exact import statement needed has changed at least twice so far), and arguably incorrect: as I hinted to in https://github.com/astropy/astropy/pull/16755#issuecomment-2245262789, using the private API `np.get_printoptions` actually gives different results (because with private APIs it is possible to get an uninitialized -yet deterministic- value for the `legacy` option).

I propose to simplify this code to bring more stability in these area, at the cost of a minor change in how maksed arrays are represented, which I think we can get away with if we ship it in astropy 7.0.0

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
