### PR TITLE
Speed up `OGIP` unit parser for composite units

### DIFF
--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -264,6 +264,11 @@ def test_ogip_grammar_fail(string):
         u_format.OGIP.parse(string)
 
 
+@pytest.mark.xfail(reason="'acos' is not understood by astropy", raises=ValueError)
+def test_ogip_unusable_function():
+    u_format.OGIP.parse("acos(m)**2")
+
+
 @pytest.mark.parametrize("string", ["sqrt(m)**3", "sqrt(m**3)", "(sqrt(m))**3"])
 def test_ogip_sqrt(string):
     # Regression test for #16743 - sqrt(m)**3 caused a ValueError

--- a/docs/changes/units/16761.perf.rst
+++ b/docs/changes/units/16761.perf.rst
@@ -1,0 +1,1 @@
+Parsing composite units with the OGIP formatter is now up to 25% faster.


### PR DESCRIPTION
### Description

Setup code: `ipython -i -c 'from astropy import units as u'`

Timings on current `main`:
```
Python 3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.26.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %timeit u.Unit("m", format="ogip")
1.98 μs ± 3.35 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit u.Unit("cm", format="ogip")
2.01 μs ± 4.86 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit u.Unit("sqrt(m)", format="ogip")
31.6 μs ± 132 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit u.Unit("cm kg**3", format="ogip")
45.2 μs ± 169 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [5]: %timeit u.Unit("m s**(-2)", format="ogip")
55.5 μs ± 166 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Timings with this patch:
```
...
In [1]: %timeit u.Unit("m", format="ogip")
2.02 μs ± 8.74 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit u.Unit("cm", format="ogip")
2.02 μs ± 13.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit u.Unit("sqrt(m)", format="ogip")
26.5 μs ± 174 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit u.Unit("cm kg**3", format="ogip")
36.8 μs ± 222 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [5]: %timeit u.Unit("m s**(-2)", format="ogip")
46.3 μs ± 292 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
