### PR TITLE
TST: add a filter for unactionable warning on windows+numpy2

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -19,6 +19,9 @@ from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 from .conftest import FitsTestCase
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Memory map object was closed but appears to still be referenced:UserWarning"
+)
 class TestHDUListFunctions(FitsTestCase):
     def test_update_name(self):
         with fits.open(self.data("o4sp040b0_raw.fits")) as hdul:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -234,6 +234,9 @@ class TestImageFunctions(FitsTestCase):
         with fits.open(self.temp("test.fits")) as hdul:
             assert hdul[0].name == "XPRIMARY2"
 
+    @pytest.mark.filterwarnings(
+        "ignore:Memory map object was closed but appears to still be referenced:UserWarning"
+    )
     def test_io_manipulation(self):
         # Get a keyword value.  An extension can be referred by name or by
         # number.  Both extension and keyword names are case insensitive.


### PR DESCRIPTION
### Description
Follow up to #16581 and #16608
Fixes #16765

I think filtering is our only course of action here: the warning happens in the exact situation we identified as potentially problematic (i.e., calling `io.fits.open(..., mode="update")` on windows + numpy 2), but it needs to go off before any actual undefined behavior is triggered, so it's bound to also be emitted in applications that are actually safe, like the four tests that we've seen emitting it.

This problem affects v6.1.x so this PR needs to be backported.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
