### PR TITLE
MNT: Remove complicated regex from modeling broadcast_shapes exception

### DIFF
--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -942,10 +942,7 @@ class TestParameterInitialization:
         assert t.e.shape == (2,)
 
     def test_single_model_1d_array_different_length_parameters(self):
-        MESSAGE = (
-            r"Parameter .* of shape .* cannot be broadcast with parameter .* of"
-            r" shape .*"
-        )
+        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with" " shape .*"
         with pytest.raises(InputParameterError, match=MESSAGE):
             # Not broadcastable
             TParModel([1, 2], [3, 4, 5])
@@ -1004,10 +1001,7 @@ class TestParameterInitialization:
         assert t2.e.shape == (2, 3)
 
         # Not broadcastable
-        MESSAGE = (
-            r"Parameter .* of shape .* cannot be broadcast with parameter .* of"
-            r" shape .*"
-        )
+        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with" " shape .*"
         with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff, e.T)
 
@@ -1110,10 +1104,7 @@ class TestParameterInitialization:
         assert t2.e.shape == (2, 3)
 
     def test_two_model_mixed_dimension_array_parameters(self):
-        MESSAGE = (
-            r"Parameter .* of shape .* cannot be broadcast with parameter .* of"
-            r" shape .*"
-        )
+        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with" " shape .*"
         with pytest.raises(InputParameterError, match=MESSAGE):
             # Can't broadcast different array shapes
             TParModel(
@@ -1242,10 +1233,7 @@ def test_non_broadcasting_parameters():
             return
 
     # a broadcasts with both b and c, but b does not broadcast with c
-    MESSAGE = (
-        r"Parameter '.*' of shape .* cannot be broadcast with parameter '.*' of"
-        r" shape .*"
-    )
+    MESSAGE = r"Mismatch is between arg \d with shape .* and arg \d with" " shape .*"
     for args in itertools.permutations((a, b, c)):
         with pytest.raises(InputParameterError, match=MESSAGE):
             TestModel(*args)

--- a/docs/changes/modeling/16770.api.rst
+++ b/docs/changes/modeling/16770.api.rst
@@ -1,0 +1,4 @@
+Exception message for when broadcast shapes mismatch has changed.
+Previously, it used complicated regex to maintain backward compatibility.
+To ease maintenance, this regex has been removed and now directly
+passes exception from ``numpy.broadcast_shapes`` function.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Remove complicated regex from modeling broadcast_shapes exception exception. This breaks backwards compatibility but only when that exception is encountered and only in the message content. No functionality change.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
