### PR TITLE
Add pkgname keyword to astropy.utils.data.get_readable_fileobj

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -207,6 +207,7 @@ def get_readable_fileobj(
     sources=None,
     http_headers=None,
     *,
+    pkgname="astropy",
     use_fsspec=None,
     fsspec_kwargs=None,
     close_files=True,
@@ -279,6 +280,11 @@ def get_readable_fileobj(
         is not a remote HTTP URL.) In the default case (None), the headers are
         ``User-Agent: some_value`` and ``Accept: */*``, where ``some_value``
         is set by ``astropy.utils.data.conf.default_http_user_agent``.
+
+    pkgname : `str`, optional
+        The package name to use to locate the download cache. i.e. for
+        ``pkgname='astropy'`` the default cache location is
+        ``~/.astropy/cache``.
 
     use_fsspec : bool, optional
         Use `fsspec.open` to open the file? Defaults to `False` unless
@@ -361,6 +367,7 @@ def get_readable_fileobj(
                     timeout=remote_timeout,
                     sources=sources,
                     http_headers=http_headers,
+                    pkgname=pkgname,
                 )
             fileobj = io.FileIO(name_or_obj, "r")
             if is_url and not cache:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the lack of a `pkgname` argument in the `astropy.utils.data.get_readable_fileobj` function.

Being able to use `pkgname='mypackage'` enables isolating the download cache for that package from the download cache for Astropy, or any other package that uses astropy's (excellent) file downloaders. This can simplify manual cache cleanup and inspection of disk usage by a package.

This was originally proposed way back in #11812 (by me) but I clearly got distracted or scared by someone asking a question, and the bot cleaned it up eventually.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
