### PR TITLE
Backport PR 16758 onto v6.1.x (BaseCoordinateFrame docstring links are not resolving in affiliated package)

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1835,7 +1835,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         Computes on-sky separation between this coordinate and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1881,7 +1881,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         and another.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1297,7 +1297,7 @@ class SkyCoord(ShapedLikeNDArray):
         catalog coordinates.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1366,7 +1366,7 @@ class SkyCoord(ShapedLikeNDArray):
         ``catalogcoord`` object.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1435,7 +1435,7 @@ class SkyCoord(ShapedLikeNDArray):
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------
@@ -1495,7 +1495,7 @@ class SkyCoord(ShapedLikeNDArray):
         :meth:`~astropy.coordinates.BaseCoordinateFrame.separation_3d`.
 
         For more on how to use this (and related) functionality, see the
-        examples in :doc:`astropy:/coordinates/matchsep`.
+        examples in :ref:`astropy-coordinates-separations-matching`.
 
         Parameters
         ----------


### PR DESCRIPTION
Manual backport of https://github.com/astropy/astropy/pull/16758 onto v6.1.x because bot was having a crisis.