### PR TITLE
BLD: update build-time upper bounds for Cython and NumPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,8 +156,8 @@ wcslint = "astropy.wcs.wcslint:main"
 [build-system]
 requires = ["setuptools",
             "setuptools_scm>=6.2",
-            "cython>=3.0.0,<3.1.0",
-            "numpy>=2.0.0",
+            "cython>=3.0.0, <4",
+            "numpy>=2.0.0, <3",
             "extension-helpers>=1,<2"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Description
Close #16751
I've checked locally that the build runs smoothly against Cython 3.1 (nightly).
I'd like to also have it validated in CI (be it weekly or daily cron) but maybe it feels out of place for `devdeps`. Thoughts ?

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
