### PR TITLE
DEPR: add a `PendingDeprecationWarning` to `XMLWriter.xml_cleaning_method(method='bleach_clean')`

### DIFF
--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -93,6 +93,7 @@ def test_escape_xml_without_bleach():
             pass
 
 
+@pytest.mark.filterwarnings("ignore:The bleach package has been deprecated:")
 @pytest.mark.skipif(not HAS_BLEACH, reason="requires bleach")
 def test_escape_xml_with_bleach():
     fh = io.StringIO()

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -6,8 +6,10 @@ nicely-indented XML.
 
 import contextlib
 import textwrap
+import warnings
 
 from astropy.utils.compat.optional_deps import HAS_BLEACH
+from astropy.utils.exceptions import AstropyPendingDeprecationWarning
 
 from ._iterparser import escape_xml as xml_escape
 from ._iterparser import escape_xml_cdata as xml_escape_cdata
@@ -159,6 +161,15 @@ class XMLWriter:
         current_xml_escape_cdata = self.xml_escape_cdata
 
         if method == "bleach_clean":
+            warnings.warn(
+                "The bleach package has been deprecated. "
+                "Therefore, method='bleach_clean' will be deprecated in a future"
+                "version of astropy.\n"
+                "See https://github.com/astropy/astropy/issues/14316",
+                category=AstropyPendingDeprecationWarning,
+                stacklevel=2,
+            )
+
             # NOTE: bleach is imported locally to avoid importing it when
             # it is not necessary
             if not HAS_BLEACH:

--- a/docs/changes/utils/16776.api.rst
+++ b/docs/changes/utils/16776.api.rst
@@ -1,0 +1,2 @@
+Following the deprecation of the external package ``bleach``,
+``XMLWriter.xml_cleaning_method(method='bleach')`` is now pending deprecation.


### PR DESCRIPTION
### Description
As suggested by @pllim in #14316

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
