### PR TITLE
Fix edge cases that allow unit powers to be `numpy` numbers

### DIFF
--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -74,3 +74,5 @@ For more examples see the :mod:`numpy.typing` definition of
 # then we should switch to that.
 Real: TypeAlias = int | float | Fraction | np.integer | np.floating
 Complex: TypeAlias = Real | complex | np.complexfloating
+
+UnitPower: TypeAlias = int | float | Fraction

--- a/docs/changes/units/16779.bugfix.rst
+++ b/docs/changes/units/16779.bugfix.rst
@@ -1,0 +1,3 @@
+A few edge cases that could result in a power of a unit to be a numerical value
+from ``numpy``, instead of the intended Python ``int``, ``float`` or
+``fractions.Fraction`` instance, have been fixed.


### PR DESCRIPTION
### Description

In several places `astropy.units` checks if a power of a unit is an `int`, `float` or `fractions.Fraction` instance, e.g. https://github.com/astropy/astropy/blob/9d42e676a887eec99a0e08878b048e1a63dc3968/astropy/units/utils.py#L235 https://github.com/astropy/astropy/blob/9d42e676a887eec99a0e08878b048e1a63dc3968/astropy/units/utils.py#L272 https://github.com/astropy/astropy/blob/9d42e676a887eec99a0e08878b048e1a63dc3968/astropy/units/utils.py#L340

This means that a `numpy.floating` instance takes a different code path than a `float` and a `numpy.integer` takes a different code path than an `int`. Replacing those checks with `isinstance()` calls is not a solution:
```python
>>> import numpy as np
>>> isinstance(np.float32(5), float)
False
>>> isinstance(np.int64(5), int)
False
```

`astropy.units.utils.sanitize_power()` was meant to prevent such confusing behavior by ensuring that a power is a Python `int`, `float` or `Fraction`, but the first commit here demonstrates that it missed several edge cases. The second commit fixes those edge cases and implements a new `UnitPower` type alias, which helps both humans reading the code and also type checkers.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
