### PR TITLE
Implement `UnitBase.components()`

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -841,10 +841,7 @@ def pixel_scale(pixscale):
     pixscale : `~astropy.units.Quantity`
         The pixel scale either in units of <unit>/pixel or pixel/<unit>.
     """
-    decomposed = pixscale.unit.decompose()
-    dimensions = dict(zip(decomposed.bases, decomposed.powers))
-    pix_power = dimensions.get(misc.pix, 0)
-
+    pix_power = dict(pixscale.unit.decompose().components()).get(misc.pix, 0)
     if pix_power == -1:
         physical_unit = Unit(pixscale * misc.pix)
     elif pix_power == 1:

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -166,7 +166,7 @@ class Base:
                     unit.bases, unit.powers
                 )
             else:
-                numerator = list(zip(unit.bases, unit.powers))
+                numerator = list(unit.components())
                 denominator = []
             if len(denominator):
                 if len(numerator):

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -79,7 +79,7 @@ def decompose_to_known_units(
 
     if isinstance(unit, core.CompositeUnit):
         new_unit = core.Unit(unit.scale)
-        for base, power in zip(unit.bases, unit.powers):
+        for base, power in unit.components():
             new_unit = new_unit * decompose_to_known_units(base, func) ** power
         return new_unit
     elif isinstance(unit, core.NamedUnit):

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["QuantityLike"]
+__all__ = ["QuantityLike", "UnitPower"]
 
 
 from fractions import Fraction
@@ -76,3 +76,4 @@ Real: TypeAlias = int | float | Fraction | np.integer | np.floating
 Complex: TypeAlias = Real | complex | np.complexfloating
 
 UnitPower: TypeAlias = int | float | Fraction
+"""A type alias for the possible powers of a unit."""

--- a/docs/changes/units/16783.feature.rst
+++ b/docs/changes/units/16783.feature.rst
@@ -1,0 +1,2 @@
+``UnitBase`` instances now have a ``components()`` method, which enables
+convenient looping over the bases and powers of the unit.

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -90,6 +90,8 @@ py:class NDArray
 py:class ArrayLike
 # np.ma
 py:class np.ma.MaskedArray
+# astropy.units.typing
+py:class UnitPower
 # locally defined type variable for ndarray dtype
 py:class DT
 

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -25,11 +25,9 @@ To decompose a unit with :meth:`~astropy.units.core.UnitBase.decompose`::
   Unit("2.17987e-18 m2 kg / s2")
 
 To get the list of units in the decomposition, the
-`~astropy.units.core.UnitBase.bases` and `~astropy.units.core.UnitBase.powers`
-properties can be used::
+:meth:`~astropy.units.core.UnitBase.components` method can be used::
 
-  >>> Ry = u.Ry.decompose()
-  >>> [unit**power for unit, power in zip(Ry.bases, Ry.powers)]
+  >>> [unit**power for unit, power in u.Ry.decompose().components()]
   [Unit("m2"), Unit("kg"), Unit("1 / s2")]
 
 You can limit the selection of units that you want to decompose by


### PR DESCRIPTION
### Description

The new method provides a convenient way of looping over the bases and powers of a unit, which previously required accessing both its `bases` and `powers` properties. In some cases this avoids having to store the unit in a variable so that the two properties could be called separately. It also enables [specifying `zip()` with `strict=True`](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/) once in the definition of `components` instead of having to write out `strict` every time `bases` and `powers` are zipped together.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
