### PR TITLE
Fix problem using round() with astropy Quantities

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1364,6 +1364,10 @@ class Quantity(np.ndarray):
                 "converted to Python scalars"
             )
 
+    def __round__(self, ndigits=0):
+        """Called by built-in function round()"""
+        return self.round(decimals=ndigits)
+
     def __index__(self):
         # for indices, we do not want to mess around with scaling at all,
         # so unlike for float, int, we insist here on unscaled dimensionless

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -749,6 +749,12 @@ def test_quantity_ilshift():  # in-place conversion
     assert np.isclose(q, 10 * u.rad)
 
 
+def test_quantity_round():
+    q = u.Quantity(10.1289, unit=u.s)
+    assert np.isclose(round(q), 10 * u.s)
+    assert np.isclose(round(q, 2), 10.13 * u.s)
+
+
 def test_regression_12964():
     # This will fail if the fix to
     # https://github.com/astropy/astropy/issues/12964 doesn't work.

--- a/docs/changes/units/16784.api.rst
+++ b/docs/changes/units/16784.api.rst
@@ -1,0 +1,2 @@
+Added a __round__() dunder method to ``Quantity``
+in order to support the built-in round() function.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address this error when using the Python built-in round() function with an astropy Quantity argument:

```
>>> import astropy.units as u
>>> value = 10.2 * u.s
>>> round(value)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: type Quantity doesn't define __round__ method
>>> 
```

This because the round() built-in delegates the work to a __round__() dunder method and astropy Quantities, even if they have a round() method, do not define the dunder method.
This PR adds a Quantity.__round__() method that calls Quantity.round() to do the work.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
