### PR TITLE
MAINT: bump minimum pyarrow

### DIFF
--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -11,7 +11,6 @@ import warnings
 
 import numpy as np
 
-from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_PYARROW
 
 # NOTE: Do not import anything from astropy.table here.
@@ -116,7 +115,7 @@ def read_table_parquet(
         Table will have zero rows and only metadata information
         if schema_only is True.
     """
-    pa, parquet, _ = get_pyarrow()
+    pa, parquet = get_pyarrow()
 
     if not isinstance(input, (str, os.PathLike)):
         # The 'read' attribute is the key component of a generic
@@ -340,7 +339,7 @@ def write_table_parquet(table, output, overwrite=False):
     from astropy.table import meta, serialize
     from astropy.utils.data_info import serialize_context_as
 
-    pa, parquet, writer_version = get_pyarrow()
+    pa, parquet = get_pyarrow()
 
     if not isinstance(output, (str, os.PathLike)):
         raise TypeError(f"`output` should be a string or path-like, not {output}")
@@ -435,8 +434,7 @@ def write_table_parquet(table, output, overwrite=False):
         else:
             raise OSError(NOT_OVERWRITING_MSG.format(output))
 
-    # We use version='2.0' for full support of datatypes including uint32.
-    with parquet.ParquetWriter(output, schema, version=writer_version) as writer:
+    with parquet.ParquetWriter(output, schema, version="2.4") as writer:
         # Convert each Table column to a pyarrow array
         arrays = []
         for name in encode_table.dtype.names:
@@ -507,9 +505,4 @@ def get_pyarrow():
     import pyarrow as pa
     from pyarrow import parquet
 
-    if minversion(pa, "6.0.0"):
-        writer_version = "2.4"
-    else:
-        writer_version = "2.0"
-
-    return pa, parquet, writer_version
+    return pa, parquet

--- a/astropy/io/misc/tests/test_parquet.py
+++ b/astropy/io/misc/tests/test_parquet.py
@@ -966,9 +966,9 @@ def test_parquet_read_generic(tmp_path):
     ]
     schema = pyarrow.schema(type_list)
 
-    _, parquet, writer_version = get_pyarrow()
-    # We use version='2.0' for full support of datatypes including uint32.
-    with parquet.ParquetWriter(filename, schema, version=writer_version) as writer:
+    _, parquet = get_pyarrow()
+
+    with parquet.ParquetWriter(filename, schema, version="2.4") as writer:
         arrays = [pyarrow.array(t1[name].data) for name in names]
         writer.write_table(pyarrow.Table.from_arrays(arrays, schema=schema))
 
@@ -993,9 +993,7 @@ def test_parquet_read_pandas(tmp_path):
         t1.add_column(Column(name=str(dtype), data=np.array(values, dtype=dtype)))
 
     df = t1.to_pandas()
-    # We use version='2.0' for full support of datatypes including uint32.
-    _, _, writer_version = get_pyarrow()
-    df.to_parquet(filename, version=writer_version)
+    df.to_parquet(filename, version="2.4")
 
     with pytest.warns(AstropyUserWarning, match="No table::len"):
         t2 = Table.read(filename)

--- a/docs/changes/16785.other.rst
+++ b/docs/changes/16785.other.rst
@@ -1,0 +1,1 @@
+The minimum required version of PyArrow is now v7.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ all = [
     "certifi",
     "dask[array]",
     "h5py",
-    "pyarrow>=5.0.0",
+    "pyarrow>=7.0.0",
     "beautifulsoup4",
     "html5lib",
     "bleach",

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ deps =
     oldestdeps: pyyaml==3.13
     oldestdeps: ipython==4.2.*
     oldestdeps: pandas==2.0.*
+    oldestdeps: pyarrow==7.0.0
     # ipython did not pin traitlets, so we have to
     oldestdeps: traitlets<4.1
 


### PR DESCRIPTION
The declared minimum pyarrow doesn't work with the declared minimum python version.

I would advise adding an oldest deps CI job that pulls in all the minimum declared versions for all the dependencies and not just a selection of them.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
