### PR TITLE
Make the OGIP unit parser reject negative powers without parenthesis

### DIFF
--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -119,7 +119,7 @@ class OGIP(generic.Generic):
 
         def t_SIGN(t):
             r"[+-](?=\d)"
-            t.value = float(t.value + "1")
+            t.value = int(t.value + "1")
             return t
 
         def t_X(t):  # multiplication for factor in front of unit
@@ -307,6 +307,11 @@ class OGIP(generic.Generic):
                 p[0] = Fraction(int(p[2]), int(p[4]))
             elif len(p) == 4:
                 p[0] = p[2]
+            elif p[1] < 0:
+                raise ValueError(
+                    "negative exponents must be enclosed in parenthesis. "
+                    f"Expected '**({p[1]})' instead of '**{p[1]}'."
+                )
             else:
                 p[0] = p[1]
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -302,6 +302,26 @@ def test_ogip_invalid_multiplication(string, message):
         u_format.OGIP.parse(string)
 
 
+@pytest.mark.parametrize(
+    "string,power",
+    [
+        pytest.param("s**-1", "-1", id="int_unit_power"),
+        pytest.param("m**-2.0", "-2.0", id="float_unit_power"),
+        pytest.param("10**-3 kg", "-3", id="int_scale_power"),
+    ],
+)
+def test_ogip_negative_exponent_parenthesis(string, power):
+    # Regression test for #16788 - negative powers without parenthesis were accepted
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^negative exponents must be enclosed in parenthesis\. "
+            rf"Expected '\*\*\({power}\)' instead of '\*\*{power}'\.$"
+        ),
+    ):
+        u_format.OGIP.parse(string)
+
+
 class RoundtripBase:
     deprecated_units = set()
 

--- a/docs/changes/units/16788.bugfix.rst
+++ b/docs/changes/units/16788.bugfix.rst
@@ -1,0 +1,4 @@
+The OGIP unit parser no longer accepts negative powers that are not enclosed in
+parenthesis.
+For example, ``u.Unit("s**-1", format="ogip")`` now raises an error because the
+OGIP standard expects the string to be written as ``"s**(-1)"`` instead.


### PR DESCRIPTION
### Description

The [OGIP unit standard](https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/) makes it clear that negative powers must be surrounded by parenthesis, but `astropy` currently nonetheless accepts negative powers without parenthesis. The patch here makes our OGIP parser reject such powers with a helpful error message. A small change was required in the OGIP lexer to ensure that integer powers are not converted to floats in that message.

This pull request does fix a bug, but if #16749 was not backported then this should not be backported either.

It looks like when the OGIP unit format was implemented, the examples from the OGIP standard were included as unit tests. This is a reasonably good way to ensure that strings allowed by the OGIP standard can indeed be parsed, but it does little to guard against strings forbidden by the standard from being parsed as well. It is possible that we will find more cases of our OGIP parser being too generous.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
