### PR TITLE
Make the `CDS` unit formatter a subclass of `Generic`

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -21,18 +21,18 @@ from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
-from . import core, utils
-from .base import Base
+from . import utils
+from .generic import Generic
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
-    from astropy.extern.ply.lex import Lexer, LexToken
+    from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class CDS(Base):
+class CDS(Generic):
     """
     Support the `Centre de Données astronomiques de Strasbourg
     <https://cds.unistra.fr/>`_ `Standards for Astronomical
@@ -263,17 +263,6 @@ class CDS(Base):
         return parsing.yacc(tabmodule="cds_parsetab", package="astropy/units")
 
     @classmethod
-    def _get_unit(cls, t: LexToken) -> UnitBase:
-        try:
-            return cls._parse_unit(t.value)
-        except ValueError as e:
-            registry = core.get_current_unit_registry()
-            if t.value in registry.aliases:
-                return registry.aliases[t.value]
-
-            raise ValueError(f"At col {t.lexpos}, {str(e)}")
-
-    @classmethod
     def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
         if unit not in cls._units:
             if detailed_exception:
@@ -314,6 +303,12 @@ class CDS(Base):
     @classmethod
     def _format_superscript(cls, number: str) -> str:
         return number if number.startswith("-") else "+" + number
+
+    @classmethod
+    def format_exponential_notation(
+        cls, val: float | np.number, format_spec: str = ".8g"
+    ) -> str:
+        return super(Generic, cls).format_exponential_notation(val, format_spec)
 
     @classmethod
     def to_string(

--- a/docs/changes/units/16789.api.rst
+++ b/docs/changes/units/16789.api.rst
@@ -1,0 +1,1 @@
+The ``CDS`` unit formatter is now a subclass of the ``Generic`` formatter.


### PR DESCRIPTION
### Description

The first commit here makes `CDS` a subclass of `Generic`. With this change `Base` is left with two direct subclasses: `Generic`, which implements parsing, and `Console`, which implements multiline formatting.

The fact that all unit formatters that implement parsing are now subclasses of `Generic` should allow for reducing code duplication by implementing the common functionality in `Generic`. ~The second commit is one example of such simplifications that are now possible, although it should be pointed out that this changes an error message very slightly.
On current `main`:~
```python
>>> from astropy.units.format import CDS
>>> CDS.parse("hamandspam")
Traceback (most recent call last):
  ...
ValueError: At col 0, Unit 'hamandspam' not supported by the CDS SAC standard.
```
~With these changes:~
```python
ValueError: At col 0, Unit 'hamandspam' not supported by the CDS standard.
```
#### UPDATE

The changes to `CDS._parse_unit()` that cause the changes in the error message are left for a future pull request. Deleting the `_get_unit()` implementation from `CDS` is a cleaner example of the code simplifications that are now possible.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
