### PR TITLE
Fix tabular_model example

### DIFF
--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -303,10 +303,8 @@ def tabular_model(dim, name=None):
 
     Examples
     --------
-    >>> table = np.array([[3., 0., 0.],
-    ...                   [0., 2., 0.],
-    ...                   [0., 0., 0.]])
-
+    >>> import numpy as np
+    >>> from astropy.modeling.models import tabular_model
     >>> tab = tabular_model(2, name='Tabular2D')
     >>> print(tab)
     <class 'astropy.modeling.tabular.Tabular2D'>
@@ -314,16 +312,17 @@ def tabular_model(dim, name=None):
     N_inputs: 2
     N_outputs: 1
 
+    Setting ``fill_value`` to `None` allows extrapolation.
+
     >>> points = ([1, 2, 3], [1, 2, 3])
-
-    Setting fill_value to None, allows extrapolation.
-    >>> m = tab(points, lookup_table=table, name='my_table',
-    ...         bounds_error=False, fill_value=None, method='nearest')
-
+    >>> table = np.array([[3., 0., 0.],
+    ...                   [0., 2., 0.],
+    ...                   [0., 0., 0.]])
+    >>> model = tab(points, lookup_table=table, name='my_table',
+    ...             bounds_error=False, fill_value=None, method='nearest')
     >>> xinterp = [0, 1, 1.5, 2.72, 3.14]
-    >>> m(xinterp, xinterp)  # doctest: +FLOAT_CMP
+    >>> model(xinterp, xinterp)  # doctest: +FLOAT_CMP
     array([3., 3., 3., 0., 0.])
-
     """
     if dim < 1:
         raise ValueError("Lookup table must have at least one dimension.")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes the example in `tablular_model`, which is not currently rendered properly.  It also adds the missing imports to run as a self-contained example.

**Before:**
<img width="610" alt="before" src="https://github.com/user-attachments/assets/3cdabe80-59ed-40e6-b3b3-78ad49247d22">

**After:** 
<img width="611" alt="after2" src="https://github.com/user-attachments/assets/462638c2-01ae-4072-a89a-5cc959ed8ab0">


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
