### PR TITLE
Fix Lorentz1D derivatives

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1574,12 +1574,12 @@ class Lorentz1D(Fittable1DModel):
     Parameters
     ----------
     amplitude : float or `~astropy.units.Quantity`.
-        Peak value - for a normalized profile (integrating to 1),
-        set amplitude = 2 / (np.pi * fwhm)
+        Peak value. For a normalized profile (integrating to 1),
+        set amplitude = 2 / (np.pi * fwhm).
     x_0 : float or `~astropy.units.Quantity`.
-        Position of the peak
+        Position of the peak.
     fwhm : float or `~astropy.units.Quantity`.
-        Full width at half maximum (FWHM)
+        Full width at half maximum (FWHM).
 
     See Also
     --------
@@ -1596,7 +1596,8 @@ class Lorentz1D(Fittable1DModel):
 
         f(x) = \\frac{A \\gamma^{2}}{\\gamma^{2} + \\left(x - x_{0}\\right)^{2}}
 
-    where :math:`\\gamma` is half of given FWHM.
+    where :math:`\\gamma` is the half width at half maximum (HWHM),
+    which is half the FWHM.
 
     Examples
     --------
@@ -1632,9 +1633,11 @@ class Lorentz1D(Fittable1DModel):
     @staticmethod
     def fit_deriv(x, amplitude, x_0, fwhm):
         """One dimensional Lorentzian model derivative with respect to parameters."""
-        d_amplitude = fwhm**2 / (fwhm**2 + (x - x_0) ** 2)
-        d_x_0 = amplitude * d_amplitude * (2 * x - 2 * x_0) / (fwhm**2 + (x - x_0) ** 2)
-        d_fwhm = 2 * amplitude * d_amplitude / fwhm * (1 - d_amplitude)
+        gamma = fwhm / 2.0
+        denom = gamma**2 + (x - x_0) ** 2
+        d_amplitude = gamma**2 / denom
+        d_x_0 = amplitude * gamma**2 * 2 * (x - x_0) / denom**2
+        d_fwhm = amplitude * gamma * (x - x_0) ** 2 / denom**2
         return [d_amplitude, d_x_0, d_fwhm]
 
     def bounding_box(self, factor=25):

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -169,6 +169,7 @@ models_1D = {
         "x_lim": [-10, 10],
         "integral": 1,
         "bbox_peak": True,
+        "deriv_initial": [10, 0.5, 4],
     },
     RickerWavelet1D: {
         "parameters": [1, 0, 1],

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -629,8 +629,14 @@ class Fittable1DModelTester:
         new_model_no_deriv = fitter_no_deriv(
             model_no_deriv, x, data, estimate_jacobian=True
         )
+
+        if isinstance(model_with_deriv, models.Lorentz1D):
+            atol = 1e-6
+        else:
+            atol = 0.15
+
         assert_allclose(
-            new_model_with_deriv.parameters, new_model_no_deriv.parameters, atol=0.15
+            new_model_with_deriv.parameters, new_model_no_deriv.parameters, atol=atol
         )
 
 

--- a/docs/changes/modeling/16794.bugfix.rst
+++ b/docs/changes/modeling/16794.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the ``fit_deriv`` calculations in the ``Lorentz1D`` model.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes the `fit_deriv` in the `Lorentz1D1` model.  The `d_A` and `d_x_0` values are incorrect.

Calculations here:
https://gist.github.com/larrybradley/4dcc41868c81a85754ee917aebe64ca6

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
