### PR TITLE
Reduce the number of private properties in `Generic` unit formatter and subclasses

### DIFF
--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -4,9 +4,18 @@
 Handles the "FITS" unit format.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 
+from astropy.utils import classproperty
+
 from . import core, generic, utils
+
+if TYPE_CHECKING:
+    from astropy.units import UnitBase
 
 
 class FITS(generic.Generic):
@@ -17,8 +26,8 @@ class FITS(generic.Generic):
     Standard <https://fits.gsfc.nasa.gov/fits_standard.html>`_.
     """
 
-    @classmethod
-    def _generate_unit_names(cls):
+    @classproperty(lazy=True)
+    def _units(cls) -> dict[str, UnitBase]:
         from astropy import units as u
 
         # add some units up-front for which we don't want to use prefixes
@@ -47,7 +56,7 @@ class FITS(generic.Generic):
         ]  # fmt: skip
         names.update((unit, getattr(u, unit)) for unit in simple_units)
 
-        return names, set()
+        return names
 
     @classmethod
     def _parse_unit(cls, unit, detailed_exception=True):

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -31,6 +31,8 @@ from . import core
 from .base import Base
 
 if TYPE_CHECKING:
+    from typing import ClassVar
+
     import numpy as np
 
     from astropy.units import NamedUnit, UnitBase
@@ -61,17 +63,7 @@ class Generic(Base):
         "UFLOAT",
     )
 
-    @classproperty(lazy=True)
-    def _all_units(cls):
-        return cls._generate_unit_names()
-
-    @classproperty(lazy=True)
-    def _units(cls):
-        return cls._all_units[0]
-
-    @classproperty(lazy=True)
-    def _deprecated_units(cls):
-        return cls._all_units[1]
+    _deprecated_units: ClassVar[frozenset[str]] = frozenset()
 
     @classproperty(lazy=True)
     def _lexer(cls):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -31,6 +31,8 @@ from . import core, generic, utils
 if TYPE_CHECKING:
     from typing import ClassVar
 
+    from astropy.units import UnitBase
+
 
 class OGIP(generic.Generic):
     """
@@ -54,13 +56,14 @@ class OGIP(generic.Generic):
         "UNIT",
     )
 
+    _deprecated_units: ClassVar[frozenset[str]] = frozenset(("Crab", "mCrab"))
     _functions: ClassVar[frozenset[str]] = frozenset((
         "log", "ln", "exp", "sqrt", "sin", "cos", "tan",
         "asin", "acos", "atan", "sinh", "cosh", "tanh",
     ))  # fmt: skip
 
-    @classmethod
-    def _generate_unit_names(cls):
+    @classproperty(lazy=True)
+    def _units(cls) -> dict[str, UnitBase]:
         from astropy import units as u
 
         bases = [
@@ -92,7 +95,7 @@ class OGIP(generic.Generic):
 
         names.update((name, name) for name in cls._functions)
 
-        return names, {"Crab", "mCrab"}
+        return names
 
     @classproperty(lazy=True)
     def _lexer(cls):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -3,10 +3,18 @@
 Handles the "VOUnit" unit format.
 """
 
+from __future__ import annotations
+
 import re
 import warnings
+from typing import TYPE_CHECKING
+
+from astropy.utils import classproperty
 
 from . import core, generic, utils
+
+if TYPE_CHECKING:
+    from astropy.units import UnitBase
 
 
 class VOUnit(generic.Generic):
@@ -23,8 +31,8 @@ class VOUnit(generic.Generic):
     _space = "."
     _scale_unit_separator = ""
 
-    @classmethod
-    def _generate_unit_names(cls):
+    @classproperty(lazy=True)
+    def _all_units(cls) -> tuple[dict[str, UnitBase], frozenset[str]]:
         from astropy import units as u
         from astropy.units import required_by_vounit as uvo
 
@@ -61,7 +69,15 @@ class VOUnit(generic.Generic):
         do_defines(binary_bases, si_prefixes + binary_prefixes, ["dB", "dbyte"])
         do_defines(simple_units, [""])
 
-        return names, deprecated_names
+        return names, frozenset(deprecated_names)
+
+    @classproperty(lazy=True)
+    def _units(cls) -> dict[str, UnitBase]:
+        return cls._all_units[0]
+
+    @classproperty(lazy=True)
+    def _deprecated_units(cls) -> frozenset[str]:
+        return cls._all_units[1]
 
     @classmethod
     def parse(cls, s, debug=False):


### PR DESCRIPTION
### Description

Moving a few lines of code from `Generic` unit formatter to `VOUnit` simplifies `Generic` and its subclasses. None of them have a `_generate_unit_names()` method anymore and only `VOUnit` still has an `_all_units` class property.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
