### PR TITLE
CI: resolve two issues with dependencies (docs builds and `oldestdeps`)

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -6,3 +6,4 @@ dependencies:
   - python=3.11
   - pip
   - graphviz
+  - matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docs = [
     "Jinja2>=3.1.3",
     "tomli; python_version < '3.11'",
     "sphinxcontrib-globalsubs >= 0.1.1",
-    "matplotlib>=3.9.1",  # https://github.com/matplotlib/matplotlib/issues/28234
+    "matplotlib==3.9.1",  # https://github.com/matplotlib/matplotlib/issues/28234 # TODO: switch to >=3.9.2 when available (3.9.1 is yanked)
 ]
 # These group together all the dependencies needed for developing in Astropy.
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docs = [
     "Jinja2>=3.1.3",
     "tomli; python_version < '3.11'",
     "sphinxcontrib-globalsubs >= 0.1.1",
-    "matplotlib==3.9.1",  # https://github.com/matplotlib/matplotlib/issues/28234 # TODO: switch to >=3.9.2 when available (3.9.1 is yanked)
+    "matplotlib>=3.9.1",  # https://github.com/matplotlib/matplotlib/issues/28234
 ]
 # These group together all the dependencies needed for developing in Astropy.
 dev = [

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ deps =
     oldestdeps: pyerfa==2.0.*
     oldestdeps: numpy==1.23.*
     oldestdeps: matplotlib==3.3.*
+    oldestdeps: asdf==2.8.*  # asdf-astropy==0.3.*
     oldestdeps: asdf-astropy==0.3.*
     oldestdeps: attrs < 24.1.0  # ASDF_LT_3_4
     oldestdeps: scipy==1.8.*
@@ -84,7 +85,7 @@ deps =
     oldestdeps: pandas==2.0.*
     oldestdeps: pyarrow==7.0.0
     # ipython did not pin traitlets, so we have to
-    oldestdeps: traitlets<4.1
+    oldestdeps: traitlets<4.1  # ipython==4.2.*
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     oldestdeps: numpy==1.23.*
     oldestdeps: matplotlib==3.3.*
     oldestdeps: asdf-astropy==0.3.*
+    oldestdeps: attrs < 24.1.0  # ASDF_LT_3_4
     oldestdeps: scipy==1.8.*
     oldestdeps: pyyaml==3.13
     oldestdeps: ipython==4.2.*


### PR DESCRIPTION
### Description
~This is a quick-and-dirty workaround to make CI useful again until the real problem is addressed upstream.~

[example logs](https://github.com/astropy/astropy/actions/runs/10234365497)
[upstream patch](https://github.com/asdf-format/asdf/pull/1815)

edit: since my upstream patch was released very quickly, this is now only targetting oldestdeps, and I do not consider this a temporary patch anymore (at least not until asdf < 3.4.0 is dropped)

edit again: this PR has slightly moved in scope as 2 different situations unfolded at the same time. It's final scope is "get *all* CI back to green". Here are the two problems addressed here:
- `attrs` v24.1.0 deprecated an option that was used in `asdf` (which is an indirect dependency to us). I helped resolve the issue upstream, but we still need to take action here specifically in `oldestdeps` so we don't get a broken install
- `matplotlib` 3.9.1 was yanked (https://github.com/matplotlib/matplotlib/issues/28551), which broke our docs builds

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
