### PR TITLE
Allow custom atol in model fit derivatives tests

### DIFF
--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -40,10 +40,6 @@ Explanation of keywords of the dictionaries:
 "integral" : float
     Approximate value of the integral in the range x_lim (and y_lim).
 
-"deriv_parameters" : list
-    If given the test of the derivative will use these parameters to create a
-    model (optional)
-
 "deriv_initial" : list
     If given the test of the derivative will use these parameters as initial
     values for the fit (optional).
@@ -206,7 +202,6 @@ models_1D = {
         "y_values": [1.0, 0.25, 0.25, 0.01, 0.01],
         "x_lim": [-10, 10],
         "integral": 1,
-        "deriv_parameters": [23.4, 1.2, 2.1, 2.3],
         "deriv_initial": [10, 1, 1, 1],
     },
     PowerLaw1D: {
@@ -341,7 +336,6 @@ models_2D = {
         "x_lim": [-10, 10],
         "y_lim": [-10, 10],
         "integral": 2 * np.pi,
-        "deriv_parameters": [137.0, 5.1, 5.4, 1.5, 2.0, np.pi / 4],
         "deriv_initial": [10, 5, 5, 4, 4, 0.5],
         "bbox_peak": True,
     },

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -46,7 +46,11 @@ Explanation of keywords of the dictionaries:
 
 "deriv_initial" : list
     If given the test of the derivative will use these parameters as initial
-    values for the fit (optional)
+    values for the fit (optional).
+
+"deriv_atol" : float
+    If given the test of the derivative will use this value as the
+    absolute tolerance for the fit (optional).
 """
 
 import numpy as np
@@ -171,6 +175,7 @@ models_1D = {
         "integral": 1,
         "bbox_peak": True,
         "deriv_initial": [10, 0.5, 4],
+        "deriv_atol": 1e-6,
     },
     RickerWavelet1D: {
         "parameters": [1, 0, 1],
@@ -412,6 +417,7 @@ models_2D = {
         "x_lim": [-10, 10],
         "y_lim": [-10, 10],
         "deriv_initial": [10, 5, 5, 4],
+        "deriv_atol": 1e-6,
     },
     Polynomial2D: {
         "parameters": {"degree": 1, "c0_0": 1.0, "c1_0": 1.0, "c0_1": 1.0},

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -17,7 +17,7 @@ from astropy import units as u
 from astropy.modeling import fitting, models
 from astropy.modeling.bounding_box import ModelBoundingBox
 from astropy.modeling.core import FittableModel, Model, _ModelMeta
-from astropy.modeling.models import Gaussian2D, Lorentz2D
+from astropy.modeling.models import Gaussian2D
 from astropy.modeling.parameters import InputParameterError, Parameter
 from astropy.modeling.polynomial import PolynomialBase
 from astropy.modeling.powerlaws import (
@@ -391,15 +391,12 @@ class Fittable2DModelTester:
             rtol=1e-2,
         )
 
-        if isinstance(model_with_deriv, Lorentz2D):
-            atol = 1e-6
-        else:
-            atol = 0.1
         if model_class != Gaussian2D:
+            deriv_atol = test_parameters.get("deriv_atol", 0.1)
             assert_allclose(
                 new_model_with_deriv.parameters,
                 new_model_no_deriv.parameters,
-                rtol=atol,
+                rtol=deriv_atol,
             )
 
 
@@ -628,13 +625,11 @@ class Fittable1DModelTester:
             model_no_deriv, x, data, estimate_jacobian=True
         )
 
-        if isinstance(model_with_deriv, models.Lorentz1D):
-            atol = 1e-6
-        else:
-            atol = 0.15
-
+        deriv_atol = test_parameters.get("deriv_atol", 0.15)
         assert_allclose(
-            new_model_with_deriv.parameters, new_model_no_deriv.parameters, atol=atol
+            new_model_with_deriv.parameters,
+            new_model_no_deriv.parameters,
+            atol=deriv_atol,
         )
 
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR is inspired by #16794 and #16800 to generalize the ability to add a custom `atol` for individual model derivative tests.  

This PR also removes the unused ``deriv_parameters`` in model tests.

~After #16794 is merged, I will update and rebase this PR and it can go in v6.1.3.~ Rebased.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
