### PR TITLE
Remove `signal_number_to_name()`

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -11,7 +11,6 @@ import json
 import locale
 import os
 import re
-import signal
 import sys
 import threading
 import traceback
@@ -289,21 +288,6 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
         webbrowser.open(resurl)
 
     return resurl
-
-
-def signal_number_to_name(signum):
-    """
-    Given an OS signal number, returns a signal name.  If the signal
-    number is unknown, returns ``'UNKNOWN'``.
-    """
-    # Since these numbers and names are platform specific, we use the
-    # builtin signal module and build a reverse mapping.
-
-    signal_to_name_map = {
-        k: v for v, k in signal.__dict__.items() if v.startswith("SIG")
-    }
-
-    return signal_to_name_map.get(signum, "UNKNOWN")
 
 
 # _has_hidden_attribute() can be deleted together with deprecated is_path_hidden() and

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -23,12 +23,6 @@ def test_isiterable():
     assert misc.isiterable(np.array([1, 2, 3])) is True
 
 
-def test_signal_number_to_name_no_failure():
-    # Regression test for #5340: ensure signal_number_to_name throws no
-    # AttributeError (it used ".iteritems()" which was removed in Python3).
-    misc.signal_number_to_name(0)
-
-
 @pytest.mark.remote_data
 def test_api_lookup():
     try:

--- a/astropy/utils/xml/validate.py
+++ b/astropy/utils/xml/validate.py
@@ -9,6 +9,7 @@ found.
 
 import os
 import subprocess
+from signal import Signals
 
 
 def validate_schema(filename, schema_file):
@@ -47,10 +48,8 @@ def validate_schema(filename, schema_file):
     if p.returncode == 127:
         raise OSError("xmllint not found, so can not validate schema")
     elif p.returncode < 0:
-        from astropy.utils.misc import signal_number_to_name
-
         raise OSError(
-            f"xmllint was terminated by signal '{signal_number_to_name(-p.returncode)}'"
+            f"xmllint was terminated by signal '{Signals(-p.returncode).name}'"
         )
 
     return p.returncode, stdout, stderr


### PR DESCRIPTION
### Description

The function can be easily replaced with the standard library [`signal.Signals`](https://docs.python.org/3/library/signal.html#signal.Signals), available since Python 3.5. There is a difference regarding invalid signal numbers. `signal_number_to_name()` returns `'UNKNOWN'`, whereas `Signals` raises an error. However, the operating system sending a signal that Python cannot recognize is exceptional enough to deserve an error.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
