### PR TITLE
Added a utility function to copy a model with new parameter values

### DIFF
--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -174,3 +174,11 @@ def test_copy_with_new_parameter_values(model):
     # Check the result
     assert_allclose(getattr(new_model, first_parameter), array)
     assert new_model.fixed[first_parameter]
+
+    for name in new_model.param_names:
+        print(name, first_parameter)
+        if name != first_parameter:
+            original_value = getattr(model, name).value
+            new_value = getattr(new_model, name).value
+            assert new_value.shape == (2, 3, 4)
+            assert np.all(original_value == new_value)

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -360,9 +360,7 @@ def copy_with_new_parameter_values(model, **parameters):
     # TODO: detect case where new parameter shapes are not compatible with
     # shape of existing parameters which will not get replaced.
 
-    shape = np.broadcast_shapes(
-        *list(np.shape(value) for value in parameters.values())
-    )
+    shape = np.broadcast_shapes(*list(np.shape(value) for value in parameters.values()))
 
     if isinstance(model, CompoundModel):
         new_model = _compound_model_with_array_parameters(model, shape)


### PR DESCRIPTION
This is an experimental PR which aims to solve https://github.com/astropy/astropy/issues/16593 and is an alternative to https://github.com/astropy/astropy/issues/16593

With this PR, we can copy a model, replacing the parameter values with new ones. If the new parameter values are arrays, all existing parameters are also broadcasted to the same array shape. Example usage:

```
In [1]: from astropy.modeling.models import Gaussian1D

In [2]: g = Gaussian1D()

In [3]: g
Out[3]: <Gaussian1D(amplitude=1., mean=0., stddev=1.)>

In [4]: from astropy.modeling.utils import copy_with_new_parameter_values

In [5]: import numpy as np

In [6]: g2 = copy_with_new_parameter_values(g, mean=np.array([[1, 2, 3], [4, 5, 6]]))

In [7]: g2
Out[7]: <Gaussian1D(amplitude=[[1., 1., 1.], [1., 1., 1.]], mean=[[1., 2., 3.], [4., 5., 6.]], stddev=[[1., 1., 1.], [1., 1., 1.]])>

In [8]: g3 = copy_with_new_parameter_values(g, mean=1, amplitude=2, stddev=3)

In [9]: g3
Out[9]: <Gaussian1D(amplitude=2., mean=1., stddev=3.)>
```

Putting this up for discussion with @Cadair, @nden and @perrygreenfield 

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
