### PR TITLE
Deprecate `format_exception()` utility

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -83,6 +83,7 @@ def silence():
     sys.stderr = old_stderr
 
 
+@deprecated(since="7.0")
 def format_exception(msg, *args, **kwargs):
     """Fill in information about the exception that occurred.
 

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -170,3 +170,8 @@ def test_dtype_bytes_or_chars():
 def test_indent_deprecation():
     with pytest.warns(AstropyDeprecationWarning, match=r"Use textwrap\.indent"):
         misc.indent("Obsolete since Python 3.3")
+
+
+def test_format_exception_deprecation():
+    with pytest.warns(AstropyDeprecationWarning):
+        misc.format_exception("this is deprecated")

--- a/docs/changes/utils/16807.api.rst
+++ b/docs/changes/utils/16807.api.rst
@@ -1,0 +1,2 @@
+``format_exception()`` is deprecated because it provides little benefit, if
+any, over normal Python tracebacks.


### PR DESCRIPTION
### Description

The function has not served any purpose since c642fe01ce82a535a8e5ce9688c458092462ec2a.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
