### PR TITLE
MNT: cleanup a temporary workaround from #16798

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -6,4 +6,3 @@ dependencies:
   - python=3.11
   - pip
   - graphviz
-  - matplotlib


### PR DESCRIPTION
### Description
Follow up to #16798, now that matplotlib 3.9.1.post1 is out, this bit should not be needed.
Close #16804

also replaces #16808
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
