### PR TITLE
Provide a way to reinitialize the parameter values of a model

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2529,7 +2529,7 @@ class Model(metaclass=_ModelMeta):
             values = kwargs.pop(constraint, [])
             self._mconstraints[constraint] = values
 
-    def reset_parameters(self, *args, **kwargs):
+    def _reset_parameters(self, *args, **kwargs):
         """
         Reset parameters on the models to those specified.
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2529,6 +2529,17 @@ class Model(metaclass=_ModelMeta):
             values = kwargs.pop(constraint, [])
             self._mconstraints[constraint] = values
 
+    def reset_parameters(self, *args, **kwargs):
+        """
+        Reset parameters on the models to those specified.
+
+        Parameters can be specified either as positional arguments or keyword
+        arguments, as in the model initializer. Any parameters not specified
+        will be reset to their default values.
+        """
+        self._initialize_parameters(args, kwargs)
+        self._initialize_slices()
+
     def _initialize_parameters(self, args, kwargs):
         """
         Initialize the _parameters array that stores raw parameter values for

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1573,29 +1573,33 @@ def test_has_constraints_with_sync_constraints():
 
 
 def test_reset_parameters_simple():
+
+    # We test this as if it was a public method as once it has been used
+    # successfully internally we may make it public.
+
     g = models.Gaussian1D(4, 2, 3)
 
     # Check that calling reset_parameters with no arguments resets the
     # parameters to default values
-    g.reset_parameters()
+    g._reset_parameters()
     assert g.amplitude == 1
     assert g.mean == 0
     assert g.stddev == 1
 
     # Set parameters via positional arguments
-    g.reset_parameters(5, 6, 7)
+    g._reset_parameters(5, 6, 7)
     assert g.amplitude == 5
     assert g.mean == 6
     assert g.stddev == 7
 
     # Set only some of the parameters via keyword arguments
-    g.reset_parameters(mean=8)
+    g._reset_parameters(mean=8)
     assert g.amplitude == 1
     assert g.mean == 8
     assert g.stddev == 1
 
     # Set one of the parameters to an array
-    g.reset_parameters(amplitude=np.ones((2, 3, 4)))
+    g._reset_parameters(amplitude=np.ones((2, 3, 4)))
     assert_equal(g.amplitude, np.ones((2, 3, 4)))
     assert g.mean == 0
     assert g.stddev == 1
@@ -1607,33 +1611,36 @@ def test_reset_parameters_simple():
             "All parameter arrays must have shapes that are mutually compatible "
         ),
     ):
-        g.reset_parameters(amplitude=np.ones((2, 3, 4)), stddev=np.ones((8,)))
+        g._reset_parameters(amplitude=np.ones((2, 3, 4)), stddev=np.ones((8,)))
 
 
 def test_reset_parameters_compound():
+
+    # As above, but for compound models
+
     c = models.Gaussian1D(4, 2, 3) + models.Const1D(9)
 
     # Check that calling reset_parameters with no arguments resets the
     # parameters to default values
-    c.reset_parameters()
+    c._reset_parameters()
     assert c.amplitude_0 == 1
     assert c.mean_0 == 0
     assert c.stddev_0 == 1
 
     # Set parameters via positional arguments
-    c.reset_parameters(5, 6, 7)
+    c._reset_parameters(5, 6, 7)
     assert c.amplitude_0 == 5
     assert c.mean_0 == 6
     assert c.stddev_0 == 7
 
     # Set only some of the parameters via keyword arguments
-    c.reset_parameters(mean_0=8)
+    c._reset_parameters(mean_0=8)
     assert c.amplitude_0 == 1
     assert c.mean_0 == 8
     assert c.stddev_0 == 1
 
     # Set one of the parameters to an array
-    c.reset_parameters(amplitude_0=np.ones((2, 3, 4)))
+    c._reset_parameters(amplitude_0=np.ones((2, 3, 4)))
     assert_equal(c.amplitude_0, np.ones((2, 3, 4)))
     assert c.mean_0 == 0
     assert c.stddev_0 == 1
@@ -1645,4 +1652,4 @@ def test_reset_parameters_compound():
             "All parameter arrays must have shapes that are mutually compatible "
         ),
     ):
-        c.reset_parameters(amplitude_0=np.ones((2, 3, 4)), stddev_0=np.ones((8,)))
+        c._reset_parameters(amplitude_0=np.ones((2, 3, 4)), stddev_0=np.ones((8,)))

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1573,7 +1573,6 @@ def test_has_constraints_with_sync_constraints():
 
 
 def test_reset_parameters_simple():
-
     # We test this as if it was a public method as once it has been used
     # successfully internally we may make it public.
 
@@ -1615,7 +1614,6 @@ def test_reset_parameters_simple():
 
 
 def test_reset_parameters_compound():
-
     # As above, but for compound models
 
     c = models.Gaussian1D(4, 2, 3) + models.Const1D(9)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -26,7 +26,7 @@ from astropy.modeling.core import (
     custom_model,
     fix_inputs,
 )
-from astropy.modeling.parameters import Parameter
+from astropy.modeling.parameters import InputParameterError, Parameter
 from astropy.modeling.separable import separability_matrix
 from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
@@ -1570,3 +1570,79 @@ def test_has_constraints_with_sync_constraints():
     model.sync_constraints = False
 
     assert model.has_fixed
+
+
+def test_reset_parameters_simple():
+    g = models.Gaussian1D(4, 2, 3)
+
+    # Check that calling reset_parameters with no arguments resets the
+    # parameters to default values
+    g.reset_parameters()
+    assert g.amplitude == 1
+    assert g.mean == 0
+    assert g.stddev == 1
+
+    # Set parameters via positional arguments
+    g.reset_parameters(5, 6, 7)
+    assert g.amplitude == 5
+    assert g.mean == 6
+    assert g.stddev == 7
+
+    # Set only some of the parameters via keyword arguments
+    g.reset_parameters(mean=8)
+    assert g.amplitude == 1
+    assert g.mean == 8
+    assert g.stddev == 1
+
+    # Set one of the parameters to an array
+    g.reset_parameters(amplitude=np.ones((2, 3, 4)))
+    assert_equal(g.amplitude, np.ones((2, 3, 4)))
+    assert g.mean == 0
+    assert g.stddev == 1
+
+    # Make sure we don't allow incompatible shapes to be passed
+    with pytest.raises(
+        InputParameterError,
+        match=re.escape(
+            "All parameter arrays must have shapes that are mutually compatible "
+        ),
+    ):
+        g.reset_parameters(amplitude=np.ones((2, 3, 4)), stddev=np.ones((8,)))
+
+
+def test_reset_parameters_compound():
+    c = models.Gaussian1D(4, 2, 3) + models.Const1D(9)
+
+    # Check that calling reset_parameters with no arguments resets the
+    # parameters to default values
+    c.reset_parameters()
+    assert c.amplitude_0 == 1
+    assert c.mean_0 == 0
+    assert c.stddev_0 == 1
+
+    # Set parameters via positional arguments
+    c.reset_parameters(5, 6, 7)
+    assert c.amplitude_0 == 5
+    assert c.mean_0 == 6
+    assert c.stddev_0 == 7
+
+    # Set only some of the parameters via keyword arguments
+    c.reset_parameters(mean_0=8)
+    assert c.amplitude_0 == 1
+    assert c.mean_0 == 8
+    assert c.stddev_0 == 1
+
+    # Set one of the parameters to an array
+    c.reset_parameters(amplitude_0=np.ones((2, 3, 4)))
+    assert_equal(c.amplitude_0, np.ones((2, 3, 4)))
+    assert c.mean_0 == 0
+    assert c.stddev_0 == 1
+
+    # Make sure we don't allow incompatible shapes to be passed
+    with pytest.raises(
+        InputParameterError,
+        match=re.escape(
+            "All parameter arrays must have shapes that are mutually compatible "
+        ),
+    ):
+        c.reset_parameters(amplitude_0=np.ones((2, 3, 4)), stddev_0=np.ones((8,)))

--- a/docs/changes/modeling/16812.feature.rst
+++ b/docs/changes/modeling/16812.feature.rst
@@ -1,0 +1,4 @@
+Added ``Model.reset_parameters``, which can be used to reset
+parameters either to their default values, if not specified,
+or to specific new values given as positional or keyword
+arguments.

--- a/docs/changes/modeling/16812.feature.rst
+++ b/docs/changes/modeling/16812.feature.rst
@@ -1,4 +1,0 @@
-Added ``Model.reset_parameters``, which can be used to reset
-parameters either to their default values, if not specified,
-or to specific new values given as positional or keyword
-arguments.


### PR DESCRIPTION
This provides a (simple) public method to reinitialize parameters in a model either to default values, or to specific values in the same way as through the model initializer. For example:

```python
In [1]: from astropy.modeling.models import Gaussian1D

In [3]: g = Gaussian1D(2, 3, 4)

In [4]: g.reset_parameters()

In [5]: g
Out[5]: <Gaussian1D(amplitude=1., mean=0., stddev=1.)>

In [6]: g.reset_parameters(5, 6, 7)

In [7]: g
Out[7]: <Gaussian1D(amplitude=5., mean=6., stddev=7.)>

In [8]: g.reset_parameters(mean=3)  # all other parameters reset to default

In [9]: g
Out[9]: <Gaussian1D(amplitude=1., mean=3., stddev=1.)>

In [10]: g.reset_parameters(amplitude=[1, 2, 3])  # setting to array

In [11]: g
Out[11]: <Gaussian1D(amplitude=[1., 2., 3.], mean=0., stddev=1.)>

In [14]: g.reset_parameters(amplitude=3 * u.Jy)  # adding units

In [15]: g
Out[15]: <Gaussian1D(amplitude=3. Jy, mean=0., stddev=1.)>

In [16]: g.reset_parameters(amplitude=3 * u.m)  # changing to different units

In [17]: g
Out[17]: <Gaussian1D(amplitude=3. m, mean=0., stddev=1.)>
```

This is an alternative to https://github.com/astropy/astropy/pull/16806 and https://github.com/astropy/astropy/issues/16710

Closes #16806
Closes #16710
Closes #16593

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
