### PR TITLE
Speed up parsing units with scale factors

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -153,10 +153,10 @@ class CDS(Generic):
                  | factor
             """
             from astropy.units import dex
-            from astropy.units.core import Unit
+            from astropy.units.core import CompositeUnit, Unit
 
             if len(p) == 3:
-                p[0] = Unit(p[1] * p[2])
+                p[0] = CompositeUnit(p[1] * p[2].scale, p[2].bases, p[2].powers)
             elif len(p) == 4:
                 p[0] = dex(p[2])
             else:

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -214,14 +214,14 @@ class Generic(Base):
                  | factor product inverse_unit
                  | factor
             """
-            from astropy.units.core import Unit
+            from astropy.units.core import CompositeUnit, Unit
 
             if len(p) == 2:
                 p[0] = Unit(p[1])
             elif len(p) == 3:
-                p[0] = Unit(p[1] * p[2])
+                p[0] = CompositeUnit(p[1] * p[2].scale, p[2].bases, p[2].powers)
             elif len(p) == 4:
-                p[0] = Unit(p[1] * p[3])
+                p[0] = CompositeUnit(p[1] * p[3].scale, p[3].bases, p[3].powers)
 
         def p_division_product_of_units(p):
             """

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -168,9 +168,9 @@ class OGIP(generic.Generic):
                  | scale_factor WHITESPACE complete_expression
             """
             if len(p) == 4:
-                p[0] = p[1] * p[3]
+                p[0] = core.CompositeUnit(p[1] * p[3].scale, p[3].bases, p[3].powers)
             elif len(p) == 3:
-                p[0] = p[1] * p[2]
+                p[0] = core.CompositeUnit(p[1] * p[2].scale, p[2].bases, p[2].powers)
             else:
                 p[0] = p[1]
 
@@ -352,7 +352,7 @@ class OGIP(generic.Generic):
             return cls._parse_unit(s, detailed_exception=False)
         except ValueError:
             try:
-                return core.Unit(cls._parser.parse(s, lexer=cls._lexer, debug=debug))
+                return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
             except ValueError as e:
                 if str(e):
                     raise

--- a/docs/changes/units/16813.perf.rst
+++ b/docs/changes/units/16813.perf.rst
@@ -1,0 +1,1 @@
+Parsing units with scale factors is now up to 50% faster.


### PR DESCRIPTION
### Description

Setup:
```
ipython -i -c 'from astropy import units as u'
```
On current `main`:
```
Python 3.10.12 (main, Jul 29 2024, 16:56:48) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.26.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: %timeit u.Unit("1000m", format="cds")
31.9 μs ± 1.29 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [2]: %timeit u.Unit("10**3 m", format="fits")
38 μs ± 92.4 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit u.Unit("10**3 m", format="generic")
40.1 μs ± 1.94 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit u.Unit("10**3 m", format="ogip")
38.4 μs ± 212 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [5]: %timeit u.Unit("10**3 m", format="vounit")
38.2 μs ± 150 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

With the patch here:
```
In [1]: %timeit u.Unit("1000m", format="cds")
16.6 μs ± 80.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit u.Unit("10**3 m", format="fits")
26.6 μs ± 1.18 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit u.Unit("10**3 m", format="generic")
24.1 μs ± 110 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit u.Unit("10**3 m", format="ogip")
24.6 μs ± 395 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [5]: %timeit u.Unit("10**3 m", format="vounit")
25.9 μs ± 63.2 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
