### PR TITLE
MNT: Numpy 2.1 compatibility for HDF5 table reader

### DIFF
--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -150,7 +150,7 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
     # Create a Table object
     from astropy.table import Table, meta, serialize
 
-    table = Table(np.array(input))
+    table = Table(np.array(input, copy=True), copy=False)
 
     # Read the meta-data from the file. For back-compatibility, we can read
     # the old file format where the serialized metadata were saved in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,8 @@ filterwarnings = [
     "ignore:numpy\\.ufunc size changed:RuntimeWarning",
     "ignore:numpy\\.ndarray size changed:RuntimeWarning",
     "ignore:matplotlibrc text\\.usetex:UserWarning:matplotlib",
+    # https://github.com/h5py/h5py/pull/2416
+    "ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Numpy 2.1 compatibility for HDF5 table reader. This ignores the warning for now because https://github.com/h5py/h5py/pull/2416 is not released yet but we are picking up numpy 2.1rc in the pre-deps job.

Noticed the failure in daily cron. Example log: https://github.com/astropy/astropy/actions/runs/10345199740/job/28631875521

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
