### PR TITLE
ENH: explicitly promote integer types in io.fits.fitsrec to reduce noise levels from NEP 50's warning

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -803,8 +803,8 @@ class FITS_rec(np.recarray):
             )
 
         for idx in range(len(self)):
-            offset = field[idx, 1] + self._heapoffset
-            count = field[idx, 0]
+            offset = int(field[idx, 1]) + self._heapoffset
+            count = int(field[idx, 0])
 
             if recformat.dtype == "S":
                 dt = np.dtype(recformat.dtype + str(1))


### PR DESCRIPTION
### Description
Fixes #16819

Following https://github.com/astropy/astropy/issues/16819#issuecomment-2286270836, this should probably use the extra-CI label

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
