### PR TITLE
Add repo and citation stats to README, docs; restructure README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,11 +30,13 @@ For more detailed instructions, see the `install guide
 Contributing
 ============
 
+```html
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
   <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
   <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
 </picture>
+```
 
 The Astropy Project is made both by and for its users, so we welcome and
 encourage contributions of many kinds. Our goal is to keep this a positive,

--- a/README.rst
+++ b/README.rst
@@ -31,10 +31,11 @@ Contributing
 ============
 
 .. raw:: html
+
     <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
-    <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
+      <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+      <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
     </picture>
 
 The Astropy Project is made both by and for its users, so we welcome and

--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,16 @@
 
 |User Stats|
 ----
-The Astropy Project (https://astropy.org/; documentation at https://docs.astropy.org/) is a community effort to develop a
-single core package for astronomy in Python and foster interoperability between packages used in astronomy and astrophysics.
+The Astropy Project is a community effort to develop a
+single core package for astronomy in Python and foster interoperability between packages used in the field.
 This repository contains the core library.
+
+* `Website <astropy.org ≤https://astropy.org/>`
+* `Documentation <docs.astropy.org <https://docs.astropy.org/>`_
+* `Slack <astropy.slack.com <https://astropy.slack.com/>`_
+* `Open Astronomy Discourse <https://community.openastronomy.org/c/astropy/8>`_
+* `Astropy users mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
+* `Astropy developers mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
 
 Installation
 ============
@@ -40,16 +47,16 @@ and there's a `summary of contribution guidelines <CONTRIBUTING.md>`_.
 Developing with Codespaces
 ==========================
 
-GitHub Codespaces is a cloud development environment that can host a browser version of Visual Studio Code.
-This is a convenient way to quickly start developing Astropy, with our `dev container <.devcontainer/devcontainer.json>`_ configured
+GitHub Codespaces is a cloud development environment using Visual Studio Code in your browser.
+This is a convenient way to start developing Astropy, using our `dev container <.devcontainer/devcontainer.json>`_ configured
 with the required packages. For help, see the `GitHub Codespaces
 docs <https://docs.github.com/en/codespaces>`_.
 
 |Codespaces|
 
-Acknowledging and citing
+Acknowledging and Citing
 ========================
-See the `acknowledgement and citation guide <https://www.astropy.org/acknowledging.html>`_ or the `CITATION file <https://github.com/astropy/astropy/blob/main/astropy/CITATION>`_.
+See the `acknowledgement and citation guide <https://www.astropy.org/acknowledging.html>`_ and the `CITATION <https://github.com/astropy/astropy/blob/main/astropy/CITATION>`_ file.
 
 Supporting the Project
 ======================

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,5 @@
 |Astropy Logo|
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
-  <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
-</picture>
-
 ----
 
 |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
@@ -35,6 +29,12 @@ For more detailed instructions, see the `install guide
 
 Contributing
 ============
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+  <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+</picture>
 
 The Astropy Project is made both by and for its users, so we welcome and
 encourage contributions of many kinds. Our goal is to keep this a positive,

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
     :alt: Astropy
 
 .. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_user_stats_dark.png
-    :target: https://docs.astropy.org/en/stable/
+    :target: https://docs.astropy.org/en/latest/impact_health.html
     :alt: Astropy User Statistics
 
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
     :target: https://www.astropy.org/
     :alt: Astropy
 
-.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png
+.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats.png
     :target: https://docs.astropy.org/en/latest/impact_health.html
     :alt: Astropy User Statistics
 

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,6 @@ This repository contains the core library.
 * `Open Astronomy Discourse <https://community.openastronomy.org/c/astropy/8>`_
 * `Astropy users mailing list <https://mail.python.org/mailman/listinfo/astropy>`_
 * `Astropy developers mailing list <https://groups.google.com/g/astropy-dev>`_
-* `Astropy community engagement study <https://zenodo.org/records/10603049>`_
-* `Astropy diversity, equity and inclusion study <https://astropy-dei.orgmycology.com/>`_
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,7 @@
 
 ----
 
-|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status|
-|Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
 ----
 The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,14 @@
 |Astropy Logo|
 ----
 
+|User Stats|
+
+----
+
 .. container::
 
     |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
 
-----
-
-|User Stats|
 ----
 The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between packages used in the field.

--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,12 @@ For more detailed instructions, see the `install guide
 Contributing
 ============
 
-```html
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
-  <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
-</picture>
-```
+.. raw:: html
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+    <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+    </picture>
 
 The Astropy Project is made both by and for its users, so we welcome and
 encourage contributions of many kinds. Our goal is to keep this a positive,

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,10 @@
 |Astropy Logo|
-----
-
-.. container::
-
-    |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
-
-----
 
 |User Stats|
+
+----
+
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
 ----
 The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between packages used in the field.

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,10 @@ docs <https://docs.github.com/en/codespaces>`_.
 
 |Codespaces|
 
+Acknowledging and citing
+========================
+See the `acknowledgement and citation guide <https://www.astropy.org/acknowledging.html>`_ or the `CITATION file <https://github.com/astropy/astropy/blob/main/astropy/CITATION>`_.
+
 Supporting the Project
 ======================
 

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@
 
     |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
 
+----
+
+|User Stats|
+----
 The Astropy Project (https://astropy.org/) is a community effort to develop a
 single core package for Astronomy in Python and foster interoperability between
 Python astronomy packages. This repository contains the core package which is
@@ -90,9 +94,15 @@ Astropy is licensed under a 3-clause BSD style license - see the
 
 
 .. |Astropy Logo| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_banner_light.svg
-   :target: https://www.astropy.org/
-   :alt: Astropy
-    :align: center
+    :target: https://www.astropy.org/
+    :alt: Astropy
+     :align: center
+
+.. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_readme_stats.png
+    :target: https://docs.astropy.org/en/stable/
+    :alt: Astropy User Statistics
+     :align: center
+
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg
     :target: https://github.com/astropy/astropy/actions
     :alt: Astropy's GitHub Actions CI Status

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 |Astropy Logo|
 ----
 
-|User Stats|
-
-----
-
 .. container::
 
     |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
+
+----
+
+|User Stats|
 ----
 The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between packages used in the field.

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ This repository contains the core library.
 * `Slack <https://astropy.slack.com/>`_
 * `Open Astronomy Discourse <https://community.openastronomy.org/c/astropy/8>`_
 * `Astropy users mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
-* `Astropy developers mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
+* `Astropy developers mailing list <https://groups.google.com/g/astropy-dev>`_
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
 
-.. |Astropy Logo| image:: https://github.com/astropy/repo_stats/blob/main/dashboard_template/astropy_banner_light.svg
+.. |Astropy Logo| image:: https://github.com/astropy/astropy/blob/main/docs/_static/astropy_banner.svg
     :target: https://www.astropy.org/
     :alt: Astropy
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 |Astropy Logo|
 
-|User Stats|
+<picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true" target="https://docs.astropy.org/en/latest/impact_health.html">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true" target="https://docs.astropy.org/en/latest/impact_health.html">
+    <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true" target="https://docs.astropy.org/en/latest/impact_health.html">
+</picture>
 
 ----
 
@@ -82,10 +86,6 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |Astropy Logo| image:: https://github.com/astropy/repo_stats/blob/main/dashboard_template/astropy_banner_gray.svg
     :target: https://www.astropy.org/
     :alt: Astropy
-
-.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_transparent.png
-    :target: https://docs.astropy.org/en/latest/impact_health.html
-    :alt: Astropy User Statistics
 
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg
     :target: https://github.com/astropy/astropy/actions

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This repository contains the core library.
 * `Documentation <https://docs.astropy.org/>`_
 * `Slack <https://astropy.slack.com/>`_
 * `Open Astronomy Discourse <https://community.openastronomy.org/c/astropy/8>`_
-* `Astropy users mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
+* `Astropy users mailing list <https://mail.python.org/mailman/listinfo/astropy>`_
 * `Astropy developers mailing list <https://groups.google.com/g/astropy-dev>`_
 * `Astropy community engagement study <https://zenodo.org/records/10603049>`_
 * `Astropy diversity, equity and inclusion study <https://astropy-dei.orgmycology.com/>`_

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 |Astropy Logo|
 
+|User Stats|
+
 ----
 
 |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
@@ -80,6 +82,10 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |Astropy Logo| image:: https://github.com/astropy/repo_stats/blob/main/dashboard_template/astropy_banner_gray.svg
     :target: https://www.astropy.org/
     :alt: Astropy
+
+.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_transparent.png
+    :target: https://docs.astropy.org/en/latest/impact_health.html
+    :alt: Astropy User Statistics
 
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg
     :target: https://github.com/astropy/astropy/actions

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-=======
-Astropy
-=======
+|Astropy Logo|
+----
 
 .. container::
 
@@ -90,6 +89,10 @@ Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
 
+.. |Astropy Logo| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_banner_light.svg
+   :target: https://www.astropy.org/
+   :alt: Astropy
+    :align: center
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg
     :target: https://github.com/astropy/astropy/actions
     :alt: Astropy's GitHub Actions CI Status

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 |Astropy Logo|
 
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
-    <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+  <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
 </picture>
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
 
-.. |Astropy Logo| image:: https://github.com/astropy/astropy/blob/main/docs/_static/astropy_banner.svg
+.. |Astropy Logo| image:: https://github.com/astropy/repo_stats/blob/main/dashboard_template/astropy_banner_gray.svg
     :target: https://www.astropy.org/
     :alt: Astropy
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,6 @@
 .. container::
 
     |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
-
 ----
 The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between packages used in the field.

--- a/README.rst
+++ b/README.rst
@@ -9,31 +9,12 @@
 
 |User Stats|
 ----
-The Astropy Project (https://astropy.org/) is a community effort to develop a
-single core package for Astronomy in Python and foster interoperability between
-Python astronomy packages. This repository contains the core package which is
-intended to contain much of the core functionality and some common tools needed
-for performing astronomy and astrophysics with Python.
-
-Table of Contents
-=================
-
-- `Installation <#installation>`_
-- `Contributing <#contributing>`_
-- `Getting Started with GitHub Codespaces <#getting-started-with-github-codespaces>`_
-- `Supporting the Project <#supporting-the-project>`_
-- `License <#license>`_
+The Astropy Project (https://astropy.org/; documentation at https://docs.astropy.org/) is a community effort to develop a
+single core package for astronomy in Python and foster interoperability between packages used in astronomy and astrophysics.
+This repository contains the core library.
 
 Installation
 ============
-
-Releases are `registered on PyPI <https://pypi.org/project/astropy>`_,
-and development is occurring at the
-`project's GitHub page <https://github.com/astropy/astropy>`_.
-
-For detailed installation instructions, see the
-`online documentation <https://docs.astropy.org/>`_
-or `docs/install.rst <docs/install.rst>`_ in this source distribution.
 
 To install `astropy` from PyPI, use:
 
@@ -41,39 +22,30 @@ To install `astropy` from PyPI, use:
 
     pip install astropy
 
+For more detailed instructions, see the `install guide <https://docs.astropy.org/en/stable/install.html>`_ in the docs.
+
 Contributing
 ============
 
 The Astropy Project is made both by and for its users, so we welcome and
 encourage contributions of many kinds. Our goal is to keep this a positive,
-inclusive, successful, and growing community by abiding with the
+inclusive, successful, and growing community that abides by the
 `Astropy Community Code of Conduct <https://www.astropy.org/about.html#codeofconduct>`_.
 
-More detailed information on contributing to the project or submitting feedback
-can be found on the `contributions page <https://www.astropy.org/contribute.html>`_.
-A `summary of contribution guidelines <CONTRIBUTING.md>`_ can also be
-used as a quick reference when you are ready to start writing or validating
-code for submission.
+For more detailed information on contributing to the project or submitting feedback, see the
+`contributions page <https://www.astropy.org/contribute.html>`_.
+The developer docs have a `guide <https://docs.astropy.org/en/latest/index_dev.html>`_ for contributing code,
+and there's a `summary of contribution guidelines <CONTRIBUTING.md>`_.
 
-Getting Started with GitHub Codespaces
-======================================
+Developing with Codespaces
+==========================
 
-Codespaces is a cloud development environment supported by GitHub.
-None of the Astropy build machinery depends on it, but it is a
-convenient way to quickly get started doing development on Astropy.
-
-To get started, create a codespace for this repository by clicking this:
+GitHub Codespaces is a cloud development environment that can host a browser version of Visual Studio Code.
+This is a convenient way to quickly start developing Astropy, with our `dev container <.devcontainer/devcontainer.json>`_ configured
+with the required packages. For help, see the `GitHub Codespaces
+docs <https://docs.github.com/en/codespaces>`_.
 
 |Codespaces|
-
-A codespace will open in a web-based version of Visual Studio Code.
-The `dev container <.devcontainer/devcontainer.json>`_ is fully configured
-with software needed for this project. For help, see the `GitHub Codespaces
-Support page <https://docs.github.com/en/codespaces>`_.
-
-**Note**: Dev containers is an open spec which is supported by
-`GitHub Codespaces <https://github.com/codespaces>`_ and
-`other tools <https://containers.dev/supporting>`_.
 
 Supporting the Project
 ======================
@@ -120,16 +92,16 @@ Astropy is licensed under a 3-clause BSD style license - see the
     :alt: Astropy's PyPI Status
 
 .. |Zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4670728.svg
-   :target: https://doi.org/10.5281/zenodo.4670728
-   :alt: Zenodo DOI
+    :target: https://doi.org/10.5281/zenodo.4670728
+    :alt: Zenodo DOI
 
 .. |Documentation Status| image:: https://img.shields.io/readthedocs/astropy/latest.svg?logo=read%20the%20docs&logoColor=white&label=Docs&version=stable
     :target: https://docs.astropy.org/en/stable/?badge=stable
     :alt: Documentation Status
 
 .. |Pre-Commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
-   :target: https://github.com/pre-commit/pre-commit
-   :alt: pre-commit
+    :target: https://github.com/pre-commit/pre-commit
+    :alt: pre-commit
 
 .. |Ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
     :target: https://github.com/astral-sh/ruff

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
     :target: https://www.astropy.org/
     :alt: Astropy
 
-.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats.png
+.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_transparent.png
     :target: https://docs.astropy.org/en/latest/impact_health.html
     :alt: Astropy User Statistics
 

--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,10 @@ encourage contributions of many kinds. Our goal is to keep this a positive,
 inclusive, successful, and growing community that abides by the
 `Astropy Community Code of Conduct <https://www.astropy.org/about.html#codeofconduct>`_.
 
-For more detailed information on contributing to the project or submitting feedback, see the
+For guidance on contributing to or submitting feedback for the Astropy Project, see the
 `contributions page <https://www.astropy.org/contribute.html>`_.
-The developer docs have a `guide <https://docs.astropy.org/en/latest/index_dev.html>`_ for contributing code,
-and there's a `summary of contribution guidelines <CONTRIBUTING.md>`_.
+For contributing code specifically, the developer docs have a `guide <https://docs.astropy.org/en/latest/index_dev.html>`_ with a quickstart.
+There's also a `summary of contribution guidelines <CONTRIBUTING.md>`_.
 
 Developing with Codespaces
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -79,12 +79,10 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |Astropy Logo| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_banner_light.svg
     :target: https://www.astropy.org/
     :alt: Astropy
-     :align: center
 
 .. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_readme_stats.png
     :target: https://docs.astropy.org/en/stable/
     :alt: Astropy User Statistics
-     :align: center
 
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg
     :target: https://github.com/astropy/astropy/actions

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 |Astropy Logo|
 
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true" target="https://docs.astropy.org/en/latest/impact_health.html">
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true" target="https://docs.astropy.org/en/latest/impact_health.html">
-    <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true" target="https://docs.astropy.org/en/latest/impact_health.html">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
+    <img alt="Astropy user statistics" src="https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true">
 </picture>
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,5 @@
 |Astropy Logo|
 
-|User Stats|
-
 ----
 
 |Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
@@ -82,10 +80,6 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |Astropy Logo| image:: https://github.com/astropy/repo_stats/blob/main/dashboard_template/astropy_banner_gray.svg
     :target: https://www.astropy.org/
     :alt: Astropy
-
-.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_transparent.png
-    :target: https://docs.astropy.org/en/latest/impact_health.html
-    :alt: Astropy User Statistics
 
 .. |Actions Status| image:: https://github.com/astropy/astropy/actions/workflows/ci_workflows.yml/badge.svg
     :target: https://github.com/astropy/astropy/actions

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,8 @@ This repository contains the core library.
 * `Open Astronomy Discourse <https://community.openastronomy.org/c/astropy/8>`_
 * `Astropy users mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
 * `Astropy developers mailing list <https://groups.google.com/g/astropy-dev>`_
+* `Astropy community engagement study <https://zenodo.org/records/10603049>`_
+* `Astropy diversity, equity and inclusion study <https://astropy-dei.orgmycology.com/>`_
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,12 @@
 
 ----
 
-|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status|
+|Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
 ----
 The Astropy Project is a community effort to develop a
-single core package for astronomy in Python and foster interoperability between packages used in the field.
-This repository contains the core library.
+single core package for astronomy in Python and foster interoperability between
+packages used in the field. This repository contains the core library.
 
 * `Website <https://astropy.org/>`_
 * `Documentation <https://docs.astropy.org/>`_
@@ -26,7 +27,8 @@ To install `astropy` from PyPI, use:
 
     pip install astropy
 
-For more detailed instructions, see the `install guide <https://docs.astropy.org/en/stable/install.html>`_ in the docs.
+For more detailed instructions, see the `install guide
+<https://docs.astropy.org/en/stable/install.html>`_ in the docs.
 
 Contributing
 ============
@@ -34,18 +36,21 @@ Contributing
 The Astropy Project is made both by and for its users, so we welcome and
 encourage contributions of many kinds. Our goal is to keep this a positive,
 inclusive, successful, and growing community that abides by the
-`Astropy Community Code of Conduct <https://www.astropy.org/about.html#codeofconduct>`_.
+`Astropy Community Code of Conduct
+<https://www.astropy.org/about.html#codeofconduct>`_.
 
-For guidance on contributing to or submitting feedback for the Astropy Project, see the
-`contributions page <https://www.astropy.org/contribute.html>`_.
-For contributing code specifically, the developer docs have a `guide <https://docs.astropy.org/en/latest/index_dev.html>`_ with a quickstart.
+For guidance on contributing to or submitting feedback for the Astropy Project,
+see the `contributions page <https://www.astropy.org/contribute.html>`_.
+For contributing code specifically, the developer docs have a
+`guide <https://docs.astropy.org/en/latest/index_dev.html>`_ with a quickstart.
 There's also a `summary of contribution guidelines <CONTRIBUTING.md>`_.
 
 Developing with Codespaces
 ==========================
 
-GitHub Codespaces is a cloud development environment using Visual Studio Code in your browser.
-This is a convenient way to start developing Astropy, using our `dev container <.devcontainer/devcontainer.json>`_ configured
+GitHub Codespaces is a cloud development environment using Visual Studio Code
+in your browser. This is a convenient way to start developing Astropy, using
+our `dev container <.devcontainer/devcontainer.json>`_ configured
 with the required packages. For help, see the `GitHub Codespaces
 docs <https://docs.github.com/en/codespaces>`_.
 
@@ -53,7 +58,9 @@ docs <https://docs.github.com/en/codespaces>`_.
 
 Acknowledging and Citing
 ========================
-See the `acknowledgement and citation guide <https://www.astropy.org/acknowledging.html>`_ and the `CITATION <https://github.com/astropy/astropy/blob/main/astropy/CITATION>`_ file.
+See the `acknowledgement and citation guide
+<https://www.astropy.org/acknowledging.html>`_ and the `CITATION
+<https://github.com/astropy/astropy/blob/main/astropy/CITATION>`_ file.
 
 Supporting the Project
 ======================

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between packages used in the field.
 This repository contains the core library.
 
-* `Website <astropy.org ≤https://astropy.org/>`
-* `Documentation <docs.astropy.org <https://docs.astropy.org/>`_
-* `Slack <astropy.slack.com <https://astropy.slack.com/>`_
+* `Website <https://astropy.org/>`_
+* `Documentation <https://docs.astropy.org/>`_
+* `Slack <https://astropy.slack.com/>`_
 * `Open Astronomy Discourse <https://community.openastronomy.org/c/astropy/8>`_
 * `Astropy users mailing list <http://mail.python.org/mailman/listinfo/astropy>`_
 * `Astropy developers mailing list <http://mail.python.org/mailman/listinfo/astropy>`_

--- a/README.rst
+++ b/README.rst
@@ -77,11 +77,11 @@ Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
 
-.. |Astropy Logo| image:: https://github.com/jeffjennings/repo_stats/blob/main/dashboard_template/astropy_banner_light.svg
+.. |Astropy Logo| image:: https://github.com/astropy/repo_stats/blob/main/dashboard_template/astropy_banner_light.svg
     :target: https://www.astropy.org/
     :alt: Astropy
 
-.. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_user_stats_dark.png
+.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png
     :target: https://docs.astropy.org/en/latest/impact_health.html
     :alt: Astropy User Statistics
 

--- a/README.rst
+++ b/README.rst
@@ -76,11 +76,11 @@ Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
 
-.. |Astropy Logo| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_banner_light.svg
+.. |Astropy Logo| image:: https://github.com/jeffjennings/repo_stats/blob/main/dashboard_template/astropy_banner_light.svg
     :target: https://www.astropy.org/
     :alt: Astropy
 
-.. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/main/images/astropy/astropy_readme_stats.png
+.. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_user_stats_dark.png
     :target: https://docs.astropy.org/en/stable/
     :alt: Astropy User Statistics
 

--- a/docs/impact_health.rst
+++ b/docs/impact_health.rst
@@ -1,0 +1,37 @@
+###########################
+astropy's Impact and Health
+###########################
+
+The figures on this page give a sense of the level of impact astropy has on the astronomy community and research in the field, as well as the amount of development effort contributed over time (the codebase's "health"). A major positive trend is that citations to astropy, and by proxy its usage in research, has been consistently growing since The Astropy Project was created. However, the amount of developer resources has remained small, with a limited number of volunteer maintainers met with an increasing amount of development responsibility.
+
+First considering the citations, this figure estimates astropy's usage in astronomy research by its yearly publication impact, using citations drawn from the NASA ADS database. The continual growth in citations shows the broad and increasing usage of astropy in astronomy and scientific research, as well as the high impact that contributions to astropy can have.
+
+|Citation figure|
+
+To next visualize the size of the developer community contributing to the astropy core library, this figure shows the number of people authoring commits over time. While each year astropy is cited more in papers, the amount of developers and especially those contributing multiple times is modest and largely static.
+
+|Commits figure|
+
+The workload to maintain astropy can be traced through the number of issues and pull requests open and closed in the astropy core library over time. The long-term increase in overall pull requests, along with a comparable amount of opens and closes on average, shows that the small number of maintainers is increasingly taxed. The discrepancy between issue opens and closes over time reinforces this.
+
+|Issue PR history figure|
+
+In short, astropy would greatly benefit from more developers, whose contributions would reach a significant fraction of research in astronomy. This figure shows the number of open issues and pull requests for each subpackage in astropy. In addition to indicating which functionalities are used more heavily by the community at present, it gives a sense of where you could start if you're interested in contributing to astropy.
+
+|Open issue PR figure|
+
+.. |Citation figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_citations.png?raw=true
+  :width: 800
+  :alt: Astropy citations
+
+.. |Commits figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_authors.png?raw=true
+  :width: 800
+  :alt: Astropy commit author history
+
+.. |Issue PR history figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_issues_PRs.png?raw=true
+  :width: 800
+  :alt: Astropy issue and pull request history
+
+.. |Open issue PR figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_open_items.png?raw=true
+  :width: 800
+  :alt: Astropy open issues and pull requests

--- a/docs/impact_health.rst
+++ b/docs/impact_health.rst
@@ -8,8 +8,10 @@ the amount of development effort contributed over time (the codebase's "health")
 Assessments of The Astropy Project's engagement with the diverse astronomy
 community are an equally important but separate consideration and are detailed
 in:
-* `Astropy community engagement study <https://zenodo.org/records/10603049>`_
-* `Astropy diversity, equity and inclusion study <https://astropy-dei.orgmycology.com/>`_
+
+- `Astropy community engagement study <https://zenodo.org/records/10603049>`_
+
+- `Astropy diversity, equity and inclusion study <https://astropy-dei.orgmycology.com/>`_
 
 Concerning the codebase, a major positive trend is that citations to ``astropy``,
 as a proxy for its usage in research, have been consistently growing since The

--- a/docs/impact_health.rst
+++ b/docs/impact_health.rst
@@ -2,14 +2,21 @@
 Impact and Health
 #################
 
-The figures on this page give a sense of the level of impact ``astropy`` has on the
-astronomy community and research in the field, as well as the amount of
-development effort contributed over time (the codebase's "health"). A major
-positive trend is that citations to ``astropy``, and by proxy its usage in
-research, has been consistently growing since The Astropy Project was created.
-However, the amount of developer resources has remained small, with a limited
-number of volunteer maintainers met with an increasing amount of development
-responsibility. Hence, we welcome any help that you can give!
+The figures on this page give a sense of the level of impact the ``astropy``
+codebase has on the astronomy community and research in the field, as well as
+the amount of development effort contributed over time (the codebase's "health").
+Assessments of The Astropy Project's engagement with the diverse astronomy
+community are an equally important but separate consideration and are detailed
+in:
+* `Astropy community engagement study <https://zenodo.org/records/10603049>`_
+* `Astropy diversity, equity and inclusion study <https://astropy-dei.orgmycology.com/>`_
+
+Concerning the codebase, a major positive trend is that citations to ``astropy``,
+as a proxy for its usage in research, have been consistently growing since The
+Astropy Project was created. However, the amount of developer resources has
+remained small, with a limited number of volunteer maintainers met with an
+increasing amount of development responsibility. Hence, we welcome any help
+that you can give!
 
 First considering the citations, this figure estimates ``astropy``'s usage in
 astronomy research by its yearly publication impact, using citations drawn from

--- a/docs/impact_health.rst
+++ b/docs/impact_health.rst
@@ -45,18 +45,18 @@ you're interested in contributing to astropy.
 
 |Open issue PR figure|
 
-.. |Citation figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_citations.png?raw=true
+.. |Citation figure| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_citations.png?raw=true
   :width: 800
   :alt: Astropy citations
 
-.. |Commits figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_authors.png?raw=true
+.. |Commits figure| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_authors.png?raw=true
   :width: 800
   :alt: Astropy commit author history
 
-.. |Issue PR history figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_issues_PRs.png?raw=true
+.. |Issue PR history figure| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_issues_PRs.png?raw=true
   :width: 800
   :alt: Astropy issue and pull request history
 
-.. |Open issue PR figure| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_open_items.png?raw=true
+.. |Open issue PR figure| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_open_items.png?raw=true
   :width: 800
   :alt: Astropy open issues and pull requests

--- a/docs/impact_health.rst
+++ b/docs/impact_health.rst
@@ -1,34 +1,34 @@
-###########################
-astropy's Impact and Health
-###########################
+#################
+Impact and Health
+#################
 
-The figures on this page give a sense of the level of impact astropy has on the
+The figures on this page give a sense of the level of impact ``astropy`` has on the
 astronomy community and research in the field, as well as the amount of
 development effort contributed over time (the codebase's "health"). A major
-positive trend is that citations to astropy, and by proxy its usage in
+positive trend is that citations to ``astropy``, and by proxy its usage in
 research, has been consistently growing since The Astropy Project was created.
 However, the amount of developer resources has remained small, with a limited
 number of volunteer maintainers met with an increasing amount of development
 responsibility. Hence, we welcome any help that you can give!
 
-First considering the citations, this figure estimates astropy's usage in
+First considering the citations, this figure estimates ``astropy``'s usage in
 astronomy research by its yearly publication impact, using citations drawn from
 the NASA ADS database. The continual growth in citations shows the broad and
-increasing usage of astropy in astronomy and scientific research, as well as
-the high impact that contributions to astropy can have.
+increasing usage of ``astropy`` in astronomy and scientific research, as well as
+the high impact that contributions to ``astropy`` can have.
 
 |Citation figure|
 
 To next visualize the size of the developer community contributing to the
-astropy core library, this figure shows the number of people authoring commits
-over time. While each year astropy is cited more in papers, the amount of
+``astropy`` core library, this figure shows the number of people authoring commits
+over time. While each year ``astropy`` is cited more in papers, the amount of
 developers and especially those contributing multiple times is modest and
 largely static.
 
 |Commits figure|
 
-The workload to maintain astropy can be traced through the number of issues and
-pull requests open and closed in the astropy core library over time. The
+The workload to maintain ``astropy`` can be traced through the number of issues and
+pull requests open and closed in the ``astropy`` core library over time. The
 long-term increase in overall pull requests, along with a comparable amount of
 opens and closes on average, shows that the small number of maintainers is
 increasingly taxed. The discrepancy between issue opens and closes over time
@@ -36,12 +36,12 @@ reinforces this.
 
 |Issue PR history figure|
 
-In short, astropy would greatly benefit from more developers, whose
+In short, ``astropy`` would greatly benefit from more developers, whose
 contributions would reach a significant fraction of research in astronomy. This
 figure shows the number of open issues and pull requests for each subpackage in
-astropy. In addition to indicating which functionalities are used more heavily
+``astropy``. In addition to indicating which functionalities are used more heavily
 by the community at present, it gives a sense of where you could start if
-you're interested in contributing to astropy.
+you're interested in contributing to ``astropy``.
 
 |Open issue PR figure|
 

--- a/docs/impact_health.rst
+++ b/docs/impact_health.rst
@@ -2,21 +2,46 @@
 astropy's Impact and Health
 ###########################
 
-The figures on this page give a sense of the level of impact astropy has on the astronomy community and research in the field, as well as the amount of development effort contributed over time (the codebase's "health"). A major positive trend is that citations to astropy, and by proxy its usage in research, has been consistently growing since The Astropy Project was created. However, the amount of developer resources has remained small, with a limited number of volunteer maintainers met with an increasing amount of development responsibility.
+The figures on this page give a sense of the level of impact astropy has on the
+astronomy community and research in the field, as well as the amount of
+development effort contributed over time (the codebase's "health"). A major
+positive trend is that citations to astropy, and by proxy its usage in
+research, has been consistently growing since The Astropy Project was created.
+However, the amount of developer resources has remained small, with a limited
+number of volunteer maintainers met with an increasing amount of development
+responsibility. Hence, we welcome any help that you can give!
 
-First considering the citations, this figure estimates astropy's usage in astronomy research by its yearly publication impact, using citations drawn from the NASA ADS database. The continual growth in citations shows the broad and increasing usage of astropy in astronomy and scientific research, as well as the high impact that contributions to astropy can have.
+First considering the citations, this figure estimates astropy's usage in
+astronomy research by its yearly publication impact, using citations drawn from
+the NASA ADS database. The continual growth in citations shows the broad and
+increasing usage of astropy in astronomy and scientific research, as well as
+the high impact that contributions to astropy can have.
 
 |Citation figure|
 
-To next visualize the size of the developer community contributing to the astropy core library, this figure shows the number of people authoring commits over time. While each year astropy is cited more in papers, the amount of developers and especially those contributing multiple times is modest and largely static.
+To next visualize the size of the developer community contributing to the
+astropy core library, this figure shows the number of people authoring commits
+over time. While each year astropy is cited more in papers, the amount of
+developers and especially those contributing multiple times is modest and
+largely static.
 
 |Commits figure|
 
-The workload to maintain astropy can be traced through the number of issues and pull requests open and closed in the astropy core library over time. The long-term increase in overall pull requests, along with a comparable amount of opens and closes on average, shows that the small number of maintainers is increasingly taxed. The discrepancy between issue opens and closes over time reinforces this.
+The workload to maintain astropy can be traced through the number of issues and
+pull requests open and closed in the astropy core library over time. The
+long-term increase in overall pull requests, along with a comparable amount of
+opens and closes on average, shows that the small number of maintainers is
+increasingly taxed. The discrepancy between issue opens and closes over time
+reinforces this.
 
 |Issue PR history figure|
 
-In short, astropy would greatly benefit from more developers, whose contributions would reach a significant fraction of research in astronomy. This figure shows the number of open issues and pull requests for each subpackage in astropy. In addition to indicating which functionalities are used more heavily by the community at present, it gives a sense of where you could start if you're interested in contributing to astropy.
+In short, astropy would greatly benefit from more developers, whose
+contributions would reach a significant fraction of research in astronomy. This
+figure shows the number of open issues and pull requests for each subpackage in
+astropy. In addition to indicating which functionalities are used more heavily
+by the community at present, it gives a sense of where you could start if
+you're interested in contributing to astropy.
 
 |Open issue PR figure|
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,8 @@ processing, and data analysis.
    software or `affiliated packages`_ that depend on the astropy
    core package.
 
+|User Stats|
+
 .. toctree::
    :maxdepth: 1
    :hidden:
@@ -120,3 +122,7 @@ processing, and data analysis.
 
 .. _feedback@astropy.org: mailto:feedback@astropy.org
 .. _affiliated packages: https://www.astropy.org/affiliated/
+
+.. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true
+    :target: https://docs.astropy.org/en/latest/impact_health.html
+    :alt: Astropy User Statistics

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,11 +118,15 @@ processing, and data analysis.
 
             To the project details
 
-|User Stats|
+.. image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true
+    :class: only-light
+    :target: https://docs.astropy.org/en/latest/impact_health.html
+    :alt: Astropy User Statistics
+
+.. image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_dark.png?raw=true
+    :class: only-dark
+    :target: https://docs.astropy.org/en/latest/impact_health.html
+    :alt: Astropy User Statistics
 
 .. _feedback@astropy.org: mailto:feedback@astropy.org
 .. _affiliated packages: https://www.astropy.org/affiliated/
-
-.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats.png?raw=true
-    :target: https://docs.astropy.org/en/latest/impact_health.html
-    :alt: Astropy User Statistics

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,6 +123,6 @@ processing, and data analysis.
 .. _feedback@astropy.org: mailto:feedback@astropy.org
 .. _affiliated packages: https://www.astropy.org/affiliated/
 
-.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true
+.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats.png?raw=true
     :target: https://docs.astropy.org/en/latest/impact_health.html
     :alt: Astropy User Statistics

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,6 +123,6 @@ processing, and data analysis.
 .. _feedback@astropy.org: mailto:feedback@astropy.org
 .. _affiliated packages: https://www.astropy.org/affiliated/
 
-.. |User Stats| image:: https://github.com/jeffjennings/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true
+.. |User Stats| image:: https://github.com/astropy/repo_stats/blob/cache/cache/astropy_user_stats_light.png?raw=true
     :target: https://docs.astropy.org/en/latest/impact_health.html
     :alt: Astropy User Statistics

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,8 +31,6 @@ processing, and data analysis.
    software or `affiliated packages`_ that depend on the astropy
    core package.
 
-|User Stats|
-
 .. toctree::
    :maxdepth: 1
    :hidden:
@@ -119,6 +117,8 @@ processing, and data analysis.
             :click-parent:
 
             To the project details
+
+|User Stats|
 
 .. _feedback@astropy.org: mailto:feedback@astropy.org
 .. _affiliated packages: https://www.astropy.org/affiliated/

--- a/docs/index_project_details.rst
+++ b/docs/index_project_details.rst
@@ -12,4 +12,5 @@ Project Details
    lts_policy
    known_issues
    credits
+   impact_health
    license


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

**Motivation:** Increase the transition of astropy users to contributors. Give users a quick, clear view of how heavily the package is used in astronomy research, and how actively the codebase is being developed, in order to give them a sense that their contributions have a big impact. Give their contributions more visibility to increase recognition.

**Changes:** This PR does three closely related things: 
- Adds a 'user stats' image to the README and to the main index in the docs, showing statistics for the astropy/astropy repo and astropy papers
- Adds an 'astropy impact and health' page to the docs (linked from the user stats images) with plots and some narrative on trends in repo and citation stats. 
- Updates the README to be more succinct and more similar in style to the NumPy README (with the goal of being a bit more useful as a quick reference and more engaging to users)
- All changes are viewable in a local build of the docs. Or view the content of the README [here](https://github.com/jeffjennings/astropy/tree/readme_user_dashboard?tab=readme-ov-file), of the 'astropy impact and health' page [here](https://github.com/jeffjennings/astropy/blob/readme_user_dashboard/docs/impact_health.rst), and of the docs main index in the image at the end of this comment.

**Implementation details:** 
- Neither the user stats image nor the figures are generated in astropy. They're all linked to images generated by a repo I made for this, [repo_stats](https://github.com/astropy/repo_stats). That code queries GitHub's GraphQL API and the NASA ADS API daily to update and cache the necessary stats, then generates timestamped images. 
- ~I'm ok to leave that repo where it is, but if necessary I could instead transfer ownership of it to the astropy organization. I don't have any organization permissions so would need to coordinate with someone to set up the github actions workflow secrets and update the image links.~ [Update: the repo is now astropy/repo_stats]
- The images generated by `repo_stats` could be generated for any repo and set of papers (e.g. for coordinated packages). A .json parameter file just needs to be updated with the repo owner/name and paper bibcodes. If people are interested in this, please let me know for which packages/papers and I could open a PR in the relevant repo.
- If there are other plots you'd like to have generated and/or added to the 'astropy impact and health' docs page, I'd suggest that go in a separate issue. If you'd like the underlying data or image files, the most recent cache of stats and images can always be downloaded from the `cache` orphan branch in `repo_stats`.
- If you have any other questions about or issues with the implementation in `repo_stats`, let me know!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

**Related issues:** #16560 (addresses but may not close), [Astropy Project issue 188](https://github.com/astropy/astropy-project/issues/188) (closes, I'd say - I'm not able to link that issue to this PR directly without permissions)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

<img width="531" alt="Screenshot 2024-08-13 at 1 13 23 PM" src="https://github.com/user-attachments/assets/85f0e373-e1b8-4b10-a13a-a0ab18699685">