### PR TITLE
Fix votable 1 3 check

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -609,7 +609,7 @@ class NumericArray(Array):
     def parse(self, value, config=None, pos=None):
         if config is None:
             config = {}
-        elif config["version_1_3_or_later"] and value == "":
+        elif config.get("version_1_3_or_later") and value == "":
             return np.zeros(self._arraysize, dtype=self._base.format), True
         parts = self._splitter(value, config, pos)
         if len(parts) != self._items:
@@ -832,7 +832,7 @@ class Integer(Numeric):
         if isinstance(value, str):
             value = value.lower()
             if value == "":
-                if config["version_1_3_or_later"]:
+                if config.get("version_1_3_or_later"):
                     mask = True
                 else:
                     warn_or_raise(W49, W49, (), config, pos)
@@ -1138,7 +1138,7 @@ class Bit(Converter):
             config = {}
         mapping = {"1": True, "0": False}
         if value is False or value.strip() == "":
-            if not config["version_1_3_or_later"]:
+            if not config.get("version_1_3_or_later"):
                 warn_or_raise(W49, W49, (), config, pos)
             return False, True
         else:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->


### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

When parsing VOTables (for instance) VOTables with empty integer literals in some places (e.g., MIN value="" in a VALUES element), astropy crashes with

```
KeyError: 'version_1_3_or_later'
```

This is a simple fix for the problem at hand, doing the key check in analogy to the other key checks of this sort in the few places where an index rather than the get method was used on the config object.

One *might* want to dig deeper, though; I am not exactly sure why the version_1_3_or_later key is missing on the example table from the bug report.  But I suspect (well: hope:-) that is not critical for the bug fix.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16825.