### PR TITLE
Fix model Parameter __repr__ for dimensionless_unscaled

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -14,7 +14,7 @@ import operator
 
 import numpy as np
 
-from astropy.units import MagUnit, Quantity
+from astropy.units import MagUnit, Quantity, dimensionless_unscaled
 from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED
 
@@ -315,7 +315,7 @@ class Parameter:
         args = f"'{self._name}'"
         args += f", value={self.value}"
 
-        if self.unit is not None:
+        if self.unit is not None and self.unit != dimensionless_unscaled:
             args += f", unit={self.unit}"
 
         for cons in self.constraints:
@@ -768,7 +768,7 @@ def param_repr_oneline(param):
     rendering parameters with units like quantities.
     """
     out = array_repr_oneline(param.value)
-    if param.unit is not None:
+    if param.unit is not None and param.unit != dimensionless_unscaled:
         out = f"{out} {param.unit!s}"
     return out
 

--- a/docs/changes/modeling/16829.bugfix.rst
+++ b/docs/changes/modeling/16829.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the output representation of models with parameters that have
+units of ``dimensionless_unscaled``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

I noticed when fitting models with units that a trailing space appears behind parameter values that (seemingly) have no units, e.g.,:

```python
>>> import astropy.units as u
>>> from astropy.modeling.models import Gaussian2D
>>> from astropy.modeling.fitting import LevMarLSQFitter

>>> yy, xx = np.mgrid[-25:25, -25:25]
>>> g = Gaussian2D(theta=10*u.deg)
>>> data = g(xx, yy)
>>> fitter = LevMarLSQFitter()
>>> gfit = fitter(g, xx, yy, data)

>>> gfit  # note the extra spaces compared to g
<Gaussian2D(amplitude=1. , x_mean=0. , y_mean=0. , x_stddev=1. , y_stddev=1. , theta=0.17453293 rad)>

>>> g
<Gaussian2D(amplitude=1., x_mean=0., y_mean=0., x_stddev=1., y_stddev=1., theta=10. deg)>

>>> g.amplitude
Parameter('amplitude', value=1.0)

>>> gfit.amplitude  # note the blank unit
Parameter('amplitude', value=1.0, unit=)

>>> gfit.amplitude.unit == u.dimensionless_unscaled
True
```

I've fixed this by removing the trailing space and "unit=" if the unit is `dimensionless_unscaled`.  I'm not sure if this is the correct approach because a larger question is should those unitless model parameters have `dimensionless_unscaled` units applied to them.

Or perhaps it could be nice to have some kind of `str` for `dimensionless_unscaled` so it doesn't appear as a plain number when printing?

```python
>>> a = 1 * u.dimensionless_unscaled
>>> a
1
>>> print(a)
1.0
>>> repr(a)
'<Quantity 1.>'
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
