### PR TITLE
BUG: Pass config to min/max parsing in VO table

### DIFF
--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -90,6 +90,31 @@ def test_namespace_warning():
     parse(io.BytesIO(good_namespace_13), verify="exception")
 
 
+def test_votable_values_empty_min_max():
+    """Regression test for https://github.com/astropy/astropy/issues/16825"""
+    with_empty_minmax = b"""<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" version="1.4">
+        <RESOURCE type="results">
+          <TABLE name="main">
+            <PARAM name="break" datatype="int" value=""/>
+          <FIELD ID="hd" datatype="int" name="hd" ucd="meta.id;meta.main">
+            <DESCRIPTION>HD number for this object</DESCRIPTION>
+            <VALUES null="-2147483648">
+              <MIN value=""/>
+              <MAX value=""/>
+            </VALUES>
+          </FIELD>
+          <DATA>
+            <BINARY>
+              <STREAM encoding="base64">AAMNIg==</STREAM>
+            </BINARY>
+          </DATA>
+        </TABLE>
+      </RESOURCE>
+    </VOTABLE>
+    """
+    parse(io.BytesIO(with_empty_minmax), verify="exception")
+
+
 def test_version():
     """
     VOTableFile.__init__ allows versions of '1.1', '1.2', '1.3' and '1.4'.

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1053,7 +1053,7 @@ class Values(Element, _IDProperty):
     @min.setter
     def min(self, min):
         if hasattr(self._field, "converter") and min is not None:
-            self._min = self._field.converter.parse(min)[0]
+            self._min = self._field.converter.parse(min, config=self._config)[0]
         else:
             self._min = min
 
@@ -1089,7 +1089,7 @@ class Values(Element, _IDProperty):
     @max.setter
     def max(self, max):
         if hasattr(self._field, "converter") and max is not None:
-            self._max = self._field.converter.parse(max)[0]
+            self._max = self._field.converter.parse(max, config=self._config)[0]
         else:
             self._max = max
 

--- a/docs/changes/io.votable/16830.bugfix.rst
+++ b/docs/changes/io.votable/16830.bugfix.rst
@@ -1,0 +1,1 @@
+Fix KeyError when parsing certain VOTables.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to pass `config` into some of the parsers deep within VOTable bowels so they can find the keys and not throw `KeyError`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16825
Closes #16826

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
