### PR TITLE
Allow BaseCoordinateFrames to be stored in tables (by giving them .info)

### DIFF
--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -39,6 +39,7 @@ from astropy.coordinates.representation import (
     REPRESENTATION_CLASSES,
     CartesianDifferential,
 )
+from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
@@ -1755,3 +1756,22 @@ def test_spherical_offsets_with_wrap(shape):
 
     scom = sc.spherical_offsets_by(-2 * u.deg, 0 * u.deg)
     assert scom.shape == shape
+
+
+def test_insert():
+    # Tests are a subset of those in test_sky_coord.
+    c0 = ICRS([1, 2] * u.deg, [3, 4] * u.deg)
+    c1 = ICRS(5 * u.deg, 6 * u.deg)
+    c3 = ICRS([10, 20] * u.deg, [30, 40] * u.deg)
+
+    # Insert a scalar
+    c = c0.insert(1, c1)
+    assert skycoord_equal(c, ICRS([1, 5, 2] * u.deg, [3, 6, 4] * u.deg))
+
+    # Insert length=2 array at start of array
+    c = c0.insert(0, c3)
+    assert skycoord_equal(c, ICRS([10, 20, 1, 2] * u.deg, [30, 40, 3, 4] * u.deg))
+
+    # Insert length=2 array at end of array
+    c = c0.insert(2, c3)
+    assert skycoord_equal(c, ICRS([1, 2, 10, 20] * u.deg, [3, 4, 30, 40] * u.deg))

--- a/astropy/io/tests/mixin_columns.py
+++ b/astropy/io/tests/mixin_columns.py
@@ -46,6 +46,24 @@ scpmrv = coordinates.SkyCoord(
 scrv = coordinates.SkyCoord(
     [1, 2], [3, 4], [5, 6], unit="deg,deg,pc", radial_velocity=[11, 12] * u.km / u.s
 )
+icrs = coordinates.ICRS([1, 2] * u.deg, [3, 4] * u.deg)
+altaz = coordinates.AltAz(
+    [1, 2] * u.deg,
+    [3, 4] * u.deg,
+    obstime=time.Time("2010-11-12T13:14:15"),
+    location=el,
+)
+so = coordinates.SkyOffsetFrame(
+    [-1, -2] * u.deg,
+    [-3, -4] * u.deg,
+    origin=altaz,
+    rotation=[5, 6] * u.deg,
+)
+sond = coordinates.SkyOffsetFrame(
+    origin=icrs,
+    rotation=[5, 6] * u.deg,
+)
+
 tm = time.Time(
     [51000.5, 51001.5], format="mjd", scale="tai", precision=5, location=el[0]
 )
@@ -78,6 +96,10 @@ mixin_cols = {
     "scpm": scpm,
     "scpmrv": scpmrv,
     "scrv": scrv,
+    "icrs": icrs,
+    "altaz": altaz,
+    "so": so,
+    "sond": sond,
     "x": [1, 2] * u.m,
     "qdb": [10, 20] * u.dB(u.mW),
     "qdex": [4.5, 5.5] * u.dex(u.cm / u.s**2),
@@ -141,6 +163,10 @@ compare_attrs = {
         "representation_type",
         "frame.name",
     ],
+    "icrs": ["ra", "dec", "representation_type"],
+    "altaz": ["alt", "az", "obstime", "location", "representation_type"],
+    "so": ["lon", "lat", "rotation", "origin"],
+    "sond": ["rotation", "origin"],
     "x": ["value", "unit"],
     "qdb": ["value", "unit"],
     "qdex": ["value", "unit"],
@@ -190,6 +216,25 @@ non_trivial_names = {
         "scpmrv.radial_velocity",
     ],
     "scrv": ["scrv.ra", "scrv.dec", "scrv.distance", "scrv.radial_velocity"],
+    "icrs": ["icrs.ra", "icrs.dec"],
+    "altaz": [
+        "altaz.az",
+        "altaz.alt",
+        "altaz.location.x",
+        "altaz.location.y",
+        "altaz.location.z",
+    ],
+    "so": [
+        "so.lon",
+        "so.lat",
+        "so.rotation",
+        "so.origin.az",
+        "so.origin.alt",
+        "so.origin.location.x",
+        "so.origin.location.y",
+        "so.origin.location.z",
+    ],
+    "sond": ["sond.rotation", "sond.origin.ra", "sond.origin.dec"],
     "sd": ["sd.d_lon_coslat", "sd.d_lat", "sd.d_distance"],
     "sr": ["sr.lon", "sr.lat", "sr.distance"],
     "srd": [

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -336,7 +336,14 @@ def _construct_mixin_from_obj_attrs_and_info(obj_attrs, info):
         mixin.info.name = info["name"]
         return mixin
 
-    if cls_full_name not in __construct_mixin_classes:
+    # We translate locally created skyoffset frames and treat all
+    # built-in frames as known.
+    if cls_full_name.startswith("abc.SkyOffset"):
+        cls_full_name = "astropy.coordinates.SkyOffsetFrame"
+    elif (
+        cls_full_name not in __construct_mixin_classes
+        and not cls_full_name.startswith("astropy.coordinates.builtin_frames")
+    ):
         raise ValueError(f"unsupported class for construct {cls_full_name}")
 
     mod_name, _, cls_name = cls_full_name.rpartition(".")

--- a/docs/changes/coordinates/16831.feature.rst
+++ b/docs/changes/coordinates/16831.feature.rst
@@ -1,0 +1,5 @@
+``BaseCoordinateFrame`` instances such as ``ICRS``, ``SkyOffsetFrame``, etc.,
+can now be stored directly in tables (previously, they were stored as
+``object`` type columns). Furthermore, storage in tables is now also possible
+for frames that have no data (but which have attributes with the correct shape
+to fit in the table).

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -13,6 +13,7 @@ the 6.1 release.
 In particular, this release includes:
 
 * :ref:`whatsnew-7.0-table-masked-quantity`
+* :ref:`whatsnew-7.0-table-frames`
 * :ref:`whatsnew_7_0_quantity_to_string_formatter`
 * :ref:`whatsnew_7_0_ecsv_meta_default_dict`
 * :ref:`whatsnew_7_0_contributor_doc_improvement`
@@ -40,6 +41,20 @@ a work-around where a normal ``Quantity`` was used with a stub of a mask, and
 fixes functions like reading of table data from a list of dict that includes
 quantities with missing entries, and aggregation of ``MaskedQuantity`` in
 table groups.
+
+.. _whatsnew-7.0-table-frames:
+
+Coordinate frames can now be stored in tables
+=============================================
+
+Coordinate frames like ``ICRS`` and ``AltAz`` can now be stored in tables, as
+was already the case for ``SkyCoord`` and the underlying representations such
+as ``SphericalRepresentation``.
+
+This includes all frames, also those that do not have associated data, such as
+a ``SkyOffsetFrame`` in which the RA, Dec of the origin might represent a
+pointing directions for a tiled observation, and the position angle the roll of
+a spacecraft.
 
 .. _whatsnew_7_0_quantity_to_string_formatter:
 


### PR DESCRIPTION
This pull request is to address the fact that coordinate frames cannot be written to tables (with or without data). It does this in two commits:
1. Let BaseCoordinateFrame have an `.info` attribute. Here, since the code is almost the same as that for SkyCoord, I base `SkyCoordInfo` on the new `CoordinateFrameInfo`.  Also, to avoid duplication of `.insert` methods, I define an `_insert` method on the info class, which can be used for both `BaseCoordinateFrame` and `SkyCoord`.
2. Allow the use of `BaseCoordinateFrame` in tables, including tests for `SkyOffsetFrame` with and without associated data. 

To get this to work, ~`Table` can no longer rely on the input having a `len` - since data-less coordinate frames raise on that. So, instead it prefers `col.shape[0]` if that is available. Obviously, instead one could~ we decided the best route was to give data-less frames a `len` (see #16833) ~, but that seemed a rather big API change (even though it is perhaps reasonable)~ (EDITED). Furthermore, since `SkyOffsetFrame` classes are defined on the fly, I treat these as special cases in the white list of allowed classes for serialization.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16823

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
