### PR TITLE
Remove code that duplicates `Generic._do_parse()`

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -279,22 +279,9 @@ class CDS(Generic):
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
         if " " in s:
             raise ValueError("CDS unit must not contain whitespace")
-
         if not isinstance(s, str):
             s = s.decode("ascii")
-
-        # This is a short circuit for the case where the string
-        # is just a single unit name
-        try:
-            return cls._parse_unit(s, detailed_exception=False)
-        except ValueError:
-            try:
-                return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
-            except ValueError as e:
-                if str(e):
-                    raise ValueError(str(e))
-                else:
-                    raise ValueError("Syntax error")
+        return cls._do_parse(s, debug)
 
     @classmethod
     def _format_mantissa(cls, m: str) -> str:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -345,19 +345,7 @@ class OGIP(generic.Generic):
 
     @classmethod
     def parse(cls, s, debug=False):
-        s = s.strip()
-        try:
-            # This is a short circuit for the case where the string is
-            # just a single unit name
-            return cls._parse_unit(s, detailed_exception=False)
-        except ValueError:
-            try:
-                return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
-            except ValueError as e:
-                if str(e):
-                    raise
-                else:
-                    raise ValueError(f"Syntax error parsing unit '{s}'")
+        return cls._do_parse(s.strip(), debug)
 
     @classmethod
     def _format_superscript(cls, number):


### PR DESCRIPTION
### Description

This simplifies the `CDS` and `OGIP` unit formatters.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
