### PR TITLE
API: allow lengths of non-scalar frames without data

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -704,21 +704,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def shape(self):
         return self._shape
 
-    # We have to override the ShapedLikeNDArray definitions, since our shape
-    # does not have to be that of the data.
-    def __len__(self):
-        return len(self.data)
-
     def __bool__(self):
         return self.has_data and self.size > 0
 
     @property
     def size(self):
         return self.data.size
-
-    @property
-    def isscalar(self):
-        return self.has_data and self.data.isscalar
 
     @classmethod
     def get_frame_attr_defaults(cls):

--- a/docs/changes/coordinates/16833.api.rst
+++ b/docs/changes/coordinates/16833.api.rst
@@ -1,0 +1,4 @@
+For non-scalar frames without data, ``len(frame)`` will now return the first
+element of its ``shape``, just like for frames with data (or arrays more
+generally).  For scalar frames, a ``TypeError`` will be raised.  Both these
+instead of raising a ``ValueError`` stating the frame has no data.


### PR DESCRIPTION
In #16831, we ran into the problem that frames without data do not have a length, even though the can have a shape. This means they cannot easily be stored in a `Table` without changing how mixin columns work in tables.

More generally, it is strange that something that has a shape cannot be iterated over in normal ways (`for i in range(len(frame)): <do something with frame[i]>`.

So, I here suggest to change the API so that for any frame, with or without data, it is true that `len(frame) == frame.shape[0]` (or a `TypeError` is raised if the frame is scalar).

It turns out that *no* tests actually relied on the existing behaviour! So, perhaps the API break is not very large. Furthermore, the changes just mean removing the definitions of `__len__` and `isscalar` -- i.e., instead relying on definitions from the `ShapedLikeNDArray` superclass.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
