### PR TITLE
ENH: (free-threading Python) avoid C APIs returning borrowed references (⏰ wait for discussion #16839)

### DIFF
--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -101,7 +101,9 @@ PyUnitListProxy_New(
     return NULL;
   }
 
+#if PY_VERSION_HEX < 0x030d00c1
   Py_INCREF(unit_class);
+#endif
 
   self = (PyUnitListProxy*)PyUnitListProxyType.tp_alloc(
       &PyUnitListProxyType, 0);
@@ -114,10 +116,6 @@ PyUnitListProxy_New(
   self->size = size;
   self->array = array;
   self->unit_class = unit_class;
-
-#if PY_VERSION_HEX >= 0x030d00c1
-  Py_DECREF(unit_class);
-#endif
   return (PyObject*)self;
 }
 

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -91,8 +91,11 @@ PyUnitListProxy_New(
   if (units_dict == NULL) {
     return NULL;
   }
-
+#if PY_VERSION_HEX >= 0x030d00c1
+  PyDict_GetItemStringRef(units_dict, "Unit", &unit_class);
+#else
   unit_class = PyDict_GetItemString(units_dict, "Unit");
+#endif
   if (unit_class == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Could not import Unit class");
     return NULL;
@@ -111,6 +114,10 @@ PyUnitListProxy_New(
   self->size = size;
   self->array = array;
   self->unit_class = unit_class;
+
+#if PY_VERSION_HEX >= 0x030d00c1
+  Py_DECREF(unit_class);
+#endif
   return (PyObject*)self;
 }
 

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -92,7 +92,13 @@ PyUnitListProxy_New(
     return NULL;
   }
 #if PY_VERSION_HEX >= 0x030d00c1
-  PyDict_GetItemStringRef(units_dict, "Unit", &unit_class);
+  int ret = PyDict_GetItemStringRef(units_dict, "Unit", &unit_class);
+  if(ret == -1) {
+    return NULL; // an exception is already raised ?
+  } else if(ret == 0) {
+    PyErr_SetString(PyExc_KeyError, "cannot find Unit in astropy.units");
+    return NULL;
+  }
 #else
   unit_class = PyDict_GetItemString(units_dict, "Unit");
 #endif

--- a/astropy/wcs/src/wcslib_celprm_wrap.c
+++ b/astropy/wcs/src/wcslib_celprm_wrap.c
@@ -341,7 +341,13 @@ static int PyCelprm_set_ref(PyCelprm* self, PyObject* value, void* closure)
 
     if (PyList_Check(value)) {
         for (i = 0; i < size; i++) {
+#if PY_VERSION_HEX >= 0x030d00c1
+            PyObject* item = PyList_GetItemRef(value, i);
+            skip[i] = (PyList_GetItemRef(value, i) == Py_None);
+            Py_DECREF(item);
+#else
             skip[i] = (PyList_GetItem(value, i) == Py_None);
+#endif
         }
     }
 

--- a/astropy/wcs/src/wcslib_prjprm_wrap.c
+++ b/astropy/wcs/src/wcslib_prjprm_wrap.c
@@ -571,7 +571,13 @@ static int PyPrjprm_set_pv(PyPrjprm* self, PyObject* value, void* closure)
 
     if (PyList_Check(value)) {
         for (k = 0; k < size; k++) {
+#if PY_VERSION_HEX >= 0x030d00c1
+            PyObject* item = PyList_GetItemRef(value, i);
+            skip[i] = (PyList_GetItemRef(value, i) == Py_None);
+            Py_DECREF(item);
+#else
             skip[k] = (PyList_GetItem(value, k) == Py_None);
+#endif
         }
     } else if (PyTuple_Check(value)) {
         for (k = 0; k < size; k++) {

--- a/astropy/wcs/src/wcslib_prjprm_wrap.c
+++ b/astropy/wcs/src/wcslib_prjprm_wrap.c
@@ -572,8 +572,8 @@ static int PyPrjprm_set_pv(PyPrjprm* self, PyObject* value, void* closure)
     if (PyList_Check(value)) {
         for (k = 0; k < size; k++) {
 #if PY_VERSION_HEX >= 0x030d00c1
-            PyObject* item = PyList_GetItemRef(value, i);
-            skip[i] = (PyList_GetItemRef(value, i) == Py_None);
+            PyObject* item = PyList_GetItemRef(value, k);
+            skip[k] = (PyList_GetItemRef(value, k) == Py_None);
             Py_DECREF(item);
 #else
             skip[k] = (PyList_GetItem(value, k) == Py_None);


### PR DESCRIPTION
### Description

Although a bit early to start testing on the free-threaded build of Python 3.13, my prep involved reading through https://docs.python.org/3.13/howto/free-threading-extensions.html#borrowed-references, so I gave it a look and found only 3 lines of code using APIs that return borrowed reference (thread unsafe), so it seemed worth fixing them while I was at it.

### Blocked by

* #16839

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
