### PR TITLE
Remove the `pep8` option from `TestRunner`

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -95,12 +95,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             "Run tests that download remote data. Should be "
             "one of none/astropy/any (defaults to none).",
         ),
-        (
-            "pep8",
-            "8",
-            "Enable PEP8 checking and disable regular tests. "
-            "Requires the pytest-pep8 plugin.",
-        ),
         ("pdb", "d", "Start the interactive Python debugger on errors."),
         ("coverage", "c", "Create a coverage report. Requires the coverage package."),
         (
@@ -150,7 +144,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         self.pastebin = None
         self.args = None
         self.remote_data = "none"
-        self.pep8 = False
         self.pdb = False
         self.coverage = False
         self.parallel = 0
@@ -190,7 +183,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
             "verbose={1.verbose_results!r}, "
             "pastebin={1.pastebin!r}, "
             "remote_data={1.remote_data!r}, "
-            "pep8={1.pep8!r}, "
             "pdb={1.pdb!r}, "
             "parallel={1.parallel!r}, "
             "docs_path={1.docs_path!r}, "

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -493,26 +493,6 @@ class TestRunner(TestRunnerBase):
         return [f"--remote-data={remote_data}"]
 
     @keyword()
-    def pep8(self, pep8, kwargs):
-        """
-        pep8 : bool, optional
-            Turn on PEP8 checking via the pytest-pep8 plugin and disable normal
-            tests. Same as specifying ``--pep8 -k pep8`` in ``args``.
-        """
-        if pep8:
-            try:
-                import pytest_pep8  # noqa: F401
-            except ImportError:
-                raise ImportError(
-                    "PEP8 checking requires pytest-pep8 plugin: "
-                    "https://pypi.org/project/pytest-pep8"
-                )
-            else:
-                return ["--pep8", "-k", "pep8"]
-
-        return []
-
-    @keyword()
     def pdb(self, pdb, kwargs):
         """
         pdb : bool, optional


### PR DESCRIPTION
### Description

The `pep8` option depends on the [`pytest-pep8`](https://pypi.org/project/pytest-pep8/) plugin, [which has had no releases for over a decade](https://pypi.org/project/pytest-pep8/#history). It is not likely that it still works with modern `pytest` (although I haven't checked), it wouldn't know about modern Python features and there are no reasons to prefer this to modern formatters (e.g. Ruff formatter or Black).

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
