### PR TITLE
Add option to limit the number of lines used for guessing in io.ascii

### DIFF
--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -63,3 +63,24 @@ from .qdp import QDP
 from .rst import RST
 from .sextractor import SExtractor
 from .ui import get_read_trace, get_reader, get_writer, read, set_guess, write
+
+
+from astropy import config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astropy.io.ascii`.
+    """
+
+    guess_limit_lines = _config.ConfigItem(
+        10000,
+        "When guessing the format of a table, this is the number of lines that "
+        "will be used for initial guessing. If the reading succeeds based on this "
+        "number of lines, then reading the full table will be attempted. If the reading "
+        "based on the subset of lines fails, the format will no longer be considered. "
+        "This can be set to `None` to disable the limit",
+    )
+
+
+conf = Conf()

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -2137,3 +2137,40 @@ def test_table_write_help_ascii_html():
     assert "Parameters" in doc
     assert "ASCII writer 'ascii.html' details" in doc
     assert "**htmldict** : Dictionary of parameters for HTML input/output." in doc
+
+
+def test_table_guess_limit_lines():
+    """
+    Make sure that the guess_limit_lines configuration item has an effect.
+    """
+
+    # First, check that we can read ipac.tbl with guessing
+    ascii.read("data/ipac.dat")
+
+    # If we set guess_limit_lines to a very small value such as the header
+    # gets truncated, the reading should fail
+    with ascii.conf.set_temp("guess_limit_lines", 3):
+        with pytest.raises(ascii.InconsistentTableError, match="Unable to guess"):
+            ascii.read("data/ipac.dat")
+
+    # Setting this to 10 should work
+    with ascii.conf.set_temp("guess_limit_lines", 10):
+        ascii.read("data/ipac.dat")
+
+    # Now pick an example where the limit cuts through the data
+    with ascii.conf.set_temp("guess_limit_lines", 7):
+        table = ascii.read("data/sextractor2.dat")
+
+    assert table.colnames == [
+        "NUMBER",
+        "XWIN_IMAGE",
+        "YWIN_IMAGE",
+        "MAG_AUTO",
+        "MAGERR_AUTO",
+        "FLAGS",
+        "X2_IMAGE",
+        "X_MAMA",
+        "MU_MAX",
+    ]
+
+    assert len(table) == 5

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -639,17 +639,22 @@ def _guess(table, read_kwargs, format, fast_reader):
     table_guess_subset = None
 
     if limit_lines:
-        # Now search for the position of the Nth line ending
-        pos = -1
-        for idx in range(limit_lines * 2):
-            pos = table.find('\n', pos + 1)
-            if pos == -1:
-                # Fewer than 2 * limit_lines line endings found so no guess subset.
-                break
-            if idx == limit_lines - 1:
-                pos_limit = pos
+
+        if isinstance(table, list):
+            if len(table) > 2 * limit_lines:
+                table_guess_subset = table[:limit_lines]
         else:
-            table_guess_subset = table[:pos_limit]
+            # Now search for the position of the Nth line ending
+            pos = -1
+            for idx in range(limit_lines * 2):
+                pos = table.find('\n', pos + 1)
+                if pos == -1:
+                    # Fewer than 2 * limit_lines line endings found so no guess subset.
+                    break
+                if idx == limit_lines - 1:
+                    pos_limit = pos
+            else:
+                table_guess_subset = table[:pos_limit]
 
     # Now cycle through each possible reader and associated keyword arguments.
     # Try to read the table using those args, and if an exception occurs then

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -632,7 +632,7 @@ def _guess(table, read_kwargs, format, fast_reader):
     # False if a file object was passed in.
     from astropy.io.ascii import conf  # avoid circular imports
 
-    limit_lines = conf.guess_limit_lines and not hasattr(table, 'read')
+    limit_lines = conf.guess_limit_lines if not hasattr(table, "read") else False
 
     # Don't limit the number of lines if there are fewer than this number of
     # lines in the table. In fact, we also don't limit the number of lines if
@@ -641,7 +641,6 @@ def _guess(table, read_kwargs, format, fast_reader):
     table_guess_subset = None
 
     if limit_lines:
-
         if isinstance(table, list):
             if len(table) > 2 * limit_lines:
                 table_guess_subset = table[:limit_lines]
@@ -649,7 +648,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             # Now search for the position of the Nth line ending
             pos = -1
             for idx in range(limit_lines * 2):
-                pos = table.find('\n', pos + 1)
+                pos = table.find("\n", pos + 1)
                 if pos == -1:
                     # Fewer than 2 * limit_lines line endings found so no guess subset.
                     break

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -432,7 +432,9 @@ def read(table, guess=None, guess_limit_lines=None, **kwargs):
         # then there was just one set of kwargs in the guess list so fall
         # through below to the non-guess way so that any problems result in a
         # more useful traceback.
-        dat = _guess(table, new_kwargs, format, fast_reader, limit_lines=guess_limit_lines)
+        dat = _guess(
+            table, new_kwargs, format, fast_reader, limit_lines=guess_limit_lines
+        )
         if dat is None:
             guess = False
 
@@ -643,14 +645,13 @@ def _guess(table, read_kwargs, format, fast_reader, limit_lines=None):
 
             reader.guessing = True
 
-            if limit_lines:
+            # Start off by checking what line endings are being used in file
+            line_ending = "\r\n" if "\r" in table else "\n"
 
+            if limit_lines:
                 # First try with subset of lines - if this fails we can skip this
                 # format early. If it works, we still proceed to check with the
                 # full table since we need to then return the read data.
-
-                # Start off by checking what line endings are being used in file
-                line_ending = '\r\n' if '\r' in table else '\n'
 
                 # Now search for the position of the Nth line ending
                 pos = 0
@@ -660,6 +661,15 @@ def _guess(table, read_kwargs, format, fast_reader, limit_lines=None):
                 # Try reading the subset of the table - if it fails, it will
                 # allow us to exit early.
                 dat = reader.read(table[:pos])
+
+            else:
+                if table.count(line_ending) > 10000:
+                    warnings.warn(
+                        "Input file contains many lines, so guessing the "
+                        "format may be slow. Consider setting ``guess_limit_lines``"
+                        "to limit the number of lines to use for guessing the format",
+                        UserWarning,
+                    )
 
             dat = reader.read(table)
             _read_trace.append(

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -627,9 +627,6 @@ def _guess(table, read_kwargs, format, fast_reader):
         cparser.CParserError,
     )
 
-    # Check what line endings are being used in file
-    line_ending = "\r\n" if "\r" in table else "\n"
-
     # Determine whether we should limit the number of lines used in the guessing
     from astropy.io.ascii import conf  # avoid circular imports
 
@@ -645,7 +642,7 @@ def _guess(table, read_kwargs, format, fast_reader):
         # Now search for the position of the Nth line ending
         pos = -1
         for idx in range(limit_lines * 2):
-            pos = table.find(line_ending, pos + 1)
+            pos = table.find('\n', pos + 1)
             if pos == -1:
                 # Fewer than 2 * limit_lines line endings found so no guess subset.
                 break

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -627,10 +627,12 @@ def _guess(table, read_kwargs, format, fast_reader):
         cparser.CParserError,
     )
 
-    # Determine whether we should limit the number of lines used in the guessing
+    # Determine whether we should limit the number of lines used in the guessing.
+    # Note that this does not currently work for file objects, so we set this to
+    # False if a file object was passed in.
     from astropy.io.ascii import conf  # avoid circular imports
 
-    limit_lines = conf.guess_limit_lines
+    limit_lines = conf.guess_limit_lines and not hasattr(table, 'read')
 
     # Don't limit the number of lines if there are fewer than this number of
     # lines in the table. In fact, we also don't limit the number of lines if

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -639,17 +639,20 @@ def _guess(table, read_kwargs, format, fast_reader):
     # lines in the table. In fact, we also don't limit the number of lines if
     # there are just above the number of lines compared to the limit, up to a
     # factor of 2, since it is fast to just go straight to the full table read.
-    if limit_lines and table.count(line_ending) > 2 * limit_lines:
+    table_guess_subset = None
+
+    if limit_lines:
         # Now search for the position of the Nth line ending
-        pos = 0
-        for iter in range(limit_lines):
-            pos = table.index(line_ending, pos + 1)
-
-        # Define table subset
-        table_guess_subset = table[:pos]
-
-    else:
-        table_guess_subset = None
+        pos = -1
+        for idx in range(limit_lines * 2):
+            pos = table.find(line_ending, pos + 1)
+            if pos == -1:
+                # Fewer than 2 * limit_lines line endings found so no guess subset.
+                break
+            if idx == limit_lines - 1:
+                pos_limit = pos
+        else:
+            table_guess_subset = table[:pos_limit]
 
     # Now cycle through each possible reader and associated keyword arguments.
     # Try to read the table using those args, and if an exception occurs then

--- a/docs/changes/io.ascii/16840.perf.rst
+++ b/docs/changes/io.ascii/16840.perf.rst
@@ -1,0 +1,4 @@
+Guessing of table formats when reading is now based by default on the first
+10000 lines of a file (if it is longer than this). This behavior can be
+configured using the ``astropy.io.ascii.conf.guess_limit_lines`` configuration
+item.

--- a/docs/changes/io.ascii/16840.perf.rst
+++ b/docs/changes/io.ascii/16840.perf.rst
@@ -1,4 +1,5 @@
-Guessing of table formats when reading is now based by default on the first
-10000 lines of a file (if it is longer than this). This behavior can be
-configured using the ``astropy.io.ascii.conf.guess_limit_lines`` configuration
-item.
+The performance of guessing the table format when reading large files with 
+``astropy.io.ascii`` has been improved. Now the process uses at most 
+10000 lines of the file to check if it matches the format. This behavior can 
+be configured using the ``astropy.io.ascii.conf.guess_limit_lines`` 
+configuration item, including disabling the limit entirely.

--- a/docs/changes/io.ascii/16840.perf.rst
+++ b/docs/changes/io.ascii/16840.perf.rst
@@ -1,5 +1,5 @@
-The performance of guessing the table format when reading large files with 
-``astropy.io.ascii`` has been improved. Now the process uses at most 
-10000 lines of the file to check if it matches the format. This behavior can 
-be configured using the ``astropy.io.ascii.conf.guess_limit_lines`` 
+The performance of guessing the table format when reading large files with
+``astropy.io.ascii`` has been improved. Now the process uses at most
+10000 lines of the file to check if it matches the format. This behavior can
+be configured using the ``astropy.io.ascii.conf.guess_limit_lines``
 configuration item, including disabling the limit entirely.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -26,6 +26,7 @@ In particular, this release includes:
 * :ref:`whatsnew_7_0_parallel_fitting`
 * :ref:`whatsnew_7_0_rgb_image_visualization_enhancement`
 * :ref:`whatsnew_7_0_lorentz2d_model`
+* :ref:`whatsnew_7_0_faster_io_ascii_guessing`
 * :ref:`whatsnew_7_0_votable_1_5`
 * :ref:`whatsnew_7_0_simplenorm`
 * :ref:`whatsnew_7_0_sigmaclippedstats`
@@ -360,6 +361,24 @@ New ``Lorentz2D`` model
 
 A new 2D Lorentzian model has been added to the ``astropy.modeling``
 package.
+
+.. _whatsnew_7_0_faster_io_ascii_guessing:
+
+Faster guessing of formats in ``astropy.io.ascii``
+==================================================
+
+When reading text-based tables with ``astropy.io.ascii`` and without specifying the
+table format, guessing the format should now be faster for large tables as it is now
+based on a subset of the table - by default the first 10000 lines of the file. If
+needed, this limit can be modified with the following configuration item:
+
+.. code-block:: python
+
+    >>> from astropy.io.ascii import conf
+    >>> conf.guess_limit_lines = 100000
+
+and the limit can be disabled by setting this value to `None`. For large tables, it
+is however preferable to specify the format of the table explicitly when reading.
 
 .. _whatsnew_7_0_votable_1_5:
 

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -367,10 +367,10 @@ package.
 Faster guessing of formats in ``astropy.io.ascii``
 ==================================================
 
-When reading text-based tables with ``astropy.io.ascii`` and without specifying the
-table format, guessing the format should now be faster for large tables as it is now
-based on a subset of the table - by default the first 10000 lines of the file. If
-needed, this limit can be modified with the following configuration item:
+The performance of guessing the table format when reading large files with
+``astropy.io.ascii`` has been improved. Now the process uses at most
+10000 lines of the file to check if it matches the format. This behavior can
+be configured, e.g.::
 
 .. code-block:: python
 

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -377,8 +377,8 @@ needed, this limit can be modified with the following configuration item:
     >>> from astropy.io.ascii import conf
     >>> conf.guess_limit_lines = 100000
 
-and the limit can be disabled by setting this value to `None`. For large tables, it
-is however preferable to specify the format of the table explicitly when reading.
+and the limit can be disabled by setting this value to `None`. When reading large tables
+you should specify the format of the table explicitly if possible.
 
 .. _whatsnew_7_0_votable_1_5:
 


### PR DESCRIPTION
I ran into the issue again today that when reading a large table with io.ascii, the guessing is very slow because each format uses the whole table to guess the format. However, in many cases, it is usually likely to be good enough to use the first say 1000 lines to guess the format. The approach I've tried here is that in the guessing, we first try the first N lines of the file, and if it works we try again with the full table to make sure, but this allows many non-matches to exit early.

Currently, this is opt-in, but with a warning for users not setting ``guess_limit_lines`` if the table is reasonably large, though arguably we may want to set a sensible default, say 1000 or 10000 lines by default, so that this benefits most users, instead of having the warning. Example usage with a table with 750k lines:

```python
In [1]: from astropy.io.ascii import read
   ...: 

In [2]: %time read('test.csv')
/home/tom/Code/astropy/astropy/io/ascii/ui.py:668: UserWarning: Input file contains many lines,
so guessing the format may be slow. Consider setting ``guess_limit_lines``to limit the number of
lines to use for guessing the format
  warnings.warn(
CPU times: user 11.7 s, sys: 886 ms, total: 12.6 s
Wall time: 12.6 s
Out[2]: 
<Table length=786432>
         x                    y                    z                  l                  b                  d         
      float64              float64              float64            float64            float64            float64      
-------------------- -------------------- ------------------- ------------------ ------------------ ------------------
  0.4363633036730489   0.4363633036730488   193.4849355151462               45.0  89.81725848475484  193.4859196354243
-0.43813116612984976   0.4381311661298498   194.2688115894507              135.0  89.81725848475484 194.26979969674898
...

In [3]: %time read('test.csv', guess_limit_lines=1000)
CPU times: user 1.08 s, sys: 32.1 ms, total: 1.11 s
Wall time: 1.11 s
Out[3]: 
<Table length=786432>
         x                    y                    z                  l                  b                  d         
      float64              float64              float64            float64            float64            float64      
-------------------- -------------------- ------------------- ------------------ ------------------ ------------------
  0.4363633036730489   0.4363633036730488   193.4849355151462               45.0  89.81725848475484  193.4859196354243
-0.43813116612984976   0.4381311661298498   194.2688115894507              135.0  89.81725848475484 194.26979969674898
...
```

@taldcroft if you are on board with this kind of approach, I can add tests and docs, but didn't want to waste too much time if you think it is not going to be robust. Let me know what you think about whether we should have this be opt-in with a warning as done here, or opt-out?

Fixes https://github.com/astropy/astropy/issues/7977 
Related: https://github.com/astropy/astropy/issues/7976

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
