### PR TITLE
Remove `UnitBase._type_id` attribute

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Function Units and Quantities."""
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
+from functools import cached_property
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -20,6 +24,9 @@ if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
 else:
     from numpy._core import umath as np_umath
+
+if TYPE_CHECKING:
+    from astropy.units.typing import UnitPower
 
 __all__ = ["FunctionUnitBase", "FunctionQuantity"]
 
@@ -184,9 +191,10 @@ class FunctionUnitBase(metaclass=ABCMeta):
         """Copy the current function unit with the physical unit in CGS."""
         return self._copy(self.physical_unit.cgs)
 
-    def _get_physical_type_id(self):
+    @cached_property
+    def _physical_type_id(self) -> tuple[tuple[str, UnitPower], ...]:
         """Get physical type corresponding to physical unit."""
-        return self.physical_unit._get_physical_type_id()
+        return self.physical_unit._physical_type_id
 
     @property
     def physical_type(self):

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -176,7 +176,7 @@ def _replace_temperatures_with_kelvin(unit):
     physical type.  Replacing the different temperature units with
     kelvin allows the physical type to be treated consistently.
     """
-    physical_type_id = unit._get_physical_type_id()
+    physical_type_id = unit._physical_type_id
 
     physical_type_id_components = []
     substitution_was_made = False
@@ -328,7 +328,6 @@ class PhysicalType:
 
     def __init__(self, unit, physical_types):
         self._unit = _replace_temperatures_with_kelvin(unit)
-        self._physical_type_id = self._unit._get_physical_type_id()
         self._physical_type = _standardize_physical_type_names(physical_types)
         self._physical_type_list = sorted(self._physical_type)
 
@@ -341,7 +340,7 @@ class PhysicalType:
         consistent with the physical type of the `PhysicalType` instance.
         """
         if isinstance(other, PhysicalType):
-            return self._physical_type_id == other._physical_type_id
+            return self._unit._physical_type_id == other._unit._physical_type_id
         elif isinstance(other, str):
             other = _standardize_physical_type_names(other)
             return other.issubset(self._physical_type)
@@ -414,7 +413,7 @@ class PhysicalType:
         return (self._unit**power).physical_type
 
     def __hash__(self):
-        return hash(self._physical_type_id)
+        return hash(self._unit._physical_type_id)
 
     def __len__(self):
         return len(self._physical_type)
@@ -455,7 +454,7 @@ def def_physical_type(unit, name):
     -----
     For a list of physical types, see `astropy.units.physical`.
     """
-    physical_type_id = unit._get_physical_type_id()
+    physical_type_id = unit._physical_type_id
     physical_type_names = _standardize_physical_type_names(name)
 
     if "unknown" in physical_type_names:
@@ -552,7 +551,7 @@ def get_physical_type(obj):
             raise TypeError(f"{obj} does not correspond to a physical type.") from exc
 
     unit = _replace_temperatures_with_kelvin(unit)
-    physical_type_id = unit._get_physical_type_id()
+    physical_type_id = unit._physical_type_id
     unit_has_known_physical_type = physical_type_id in _physical_unit_mapping
 
     if unit_has_known_physical_type:

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -5,6 +5,7 @@ This module defines structured units and quantities.
 
 # Standard library
 import operator
+from functools import cached_property
 
 import numpy as np
 
@@ -297,9 +298,10 @@ class StructuredUnit:
         return self._recursively_apply(operator.attrgetter("cgs"))
 
     # Needed to pass through Unit initializer, so might as well use it.
-    def _get_physical_type_id(self):
+    @cached_property
+    def _physical_type_id(self):
         return self._recursively_apply(
-            operator.methodcaller("_get_physical_type_id"), cls=Structure
+            operator.attrgetter("_physical_type_id"), cls=Structure
         )
 
     @property

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -485,7 +485,7 @@ class TestDefPhysType:
         """Reset the physical type of unit to "unknown"."""
         for name in list(unit.physical_type):
             del physical._unit_physical_mapping[name]
-        del physical._physical_unit_mapping[unit._get_physical_type_id()]
+        del physical._physical_unit_mapping[unit._physical_type_id]
         assert unit.physical_type == "unknown"
 
     def teardown_method(self):

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -289,11 +289,11 @@ class TestStructuredUnitAsMapping(StructuredTestBaseWithUnits):
 
 class TestStructuredUnitMethods(StructuredTestBaseWithUnits):
     def test_physical_type_id(self):
-        pv_ptid = self.pv_unit._get_physical_type_id()
+        pv_ptid = self.pv_unit._physical_type_id
         assert len(pv_ptid) == 2
         assert pv_ptid.dtype.names == ("p", "v")
-        p_ptid = self.pv_unit["p"]._get_physical_type_id()
-        v_ptid = self.pv_unit["v"]._get_physical_type_id()
+        p_ptid = self.pv_unit["p"]._physical_type_id
+        v_ptid = self.pv_unit["v"]._physical_type_id
         # Expected should be (subclass of) void, with structured object dtype.
         expected = np.array((p_ptid, v_ptid), [("p", "O"), ("v", "O")])[()]
         assert pv_ptid == expected
@@ -305,8 +305,8 @@ class TestStructuredUnitMethods(StructuredTestBaseWithUnits):
         assert pv_ptid[0] == p_ptid
         assert pv_ptid[1] == v_ptid
         # More complicated version.
-        pv_t_ptid = self.pv_t_unit._get_physical_type_id()
-        t_ptid = self.t_unit._get_physical_type_id()
+        pv_t_ptid = self.pv_t_unit._physical_type_id
+        t_ptid = self.t_unit._physical_type_id
         assert pv_t_ptid == np.array((pv_ptid, t_ptid), "O,O")[()]
         assert pv_t_ptid["pv"] == pv_ptid
         assert pv_t_ptid["t"] == t_ptid


### PR DESCRIPTION
### Description

`_type_id` is used for caching the `UnitBase._get_physical_type_id()` output, but decorating the method with the standard library [`functools.cached_property`](https://docs.python.org/3/library/functools.html#functools.cached_property) removes the need for the attribute. Analogous methods in other classes should be changed to properties to maintain consistency and all should be renamed to `_physical_type_id`, because that is a more appropriate name for a property. The current `PhysicalType._physical_type_id` should be renamed to `_id` so that it would have a different name than the renamed properties.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
