### PR TITLE
Ensure broadcast_arrays returns sequence also for single Masked instance

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -646,7 +646,7 @@ def broadcast_arrays(*args, subok=False):
     results = np.broadcast_arrays(*data, subok=subok)
 
     return_type = list if NUMPY_LT_2_0 else tuple
-    shape = results[0].shape if isinstance(results, return_type) else results.shape
+    shape = results[0].shape
     masks = [
         (np.broadcast_to(arg.mask, shape, subok=subok) if is_masked else None)
         for arg, is_masked in zip(args, are_masked)
@@ -655,7 +655,7 @@ def broadcast_arrays(*args, subok=False):
         (Masked(result, mask) if mask is not None else result)
         for (result, mask) in zip(results, masks)
     )
-    return (results if len(results) > 1 else results[0]), None, None
+    return results, None, None
 
 
 @apply_to_both

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -157,6 +157,13 @@ class TestShapeManipulation(BasicTestSetup):
     def test_broadcast_arrays(self):
         self.check2(np.broadcast_arrays)
         self.check2(np.broadcast_arrays, subok=False)
+        # Regression test for bug for single array
+        ba = np.broadcast_arrays(self.ma, subok=True)
+        assert isinstance(ba, list if NUMPY_LT_2_0 else tuple)
+        assert len(ba) == 1
+        assert_array_equal(ba[0].unmasked, self.a)
+        assert_array_equal(ba[0].mask, self.mask_a)
+        assert np.may_share_memory(ba[0], self.a)
 
 
 class TestArgFunctions(MaskedArraySetup):

--- a/docs/changes/utils/16842.bugfix.rst
+++ b/docs/changes/utils/16842.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the return type for ``np.broadcast_arrays`` on a single ``Masked``
+instance: it now correctly returns a 1-element sequence instead of a single
+array, just like would be the case with a regular array.


### PR DESCRIPTION
This pull request is to address a small bug in the implementation of `np.broadcast_arrays` for a single `Masked` element, ensuring a sequence is also returned in that case.
