### PR TITLE
TEST: ensure Masked tests run also without matplotlib installed

### DIFF
--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -14,10 +14,10 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
+from astropy.utils import minversion
 from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
-from astropy.visualization.wcsaxes.utils import MATPLOTLIB_LT_3_8
 
 
 def assert_masked_equal(a, b):
@@ -1565,8 +1565,9 @@ class TestMaskedQuantityInteractionWithNumpyMA(
     pass
 
 
+# For grep'ing: test requires MATPLOTLIB_LT_3_8
 @pytest.mark.skipif(
-    (not HAS_PLT) or MATPLOTLIB_LT_3_8,
+    not HAS_PLT or not minversion("matplotlib", "3.8"),
     reason="requires matplotlib.pyplot and never worked before matplotlib 3.8",
 )
 def test_plt_scatter_masked():


### PR DESCRIPTION
This pull request is a subtle bug introduced in #16820, where an import of `MATPLOTLIB_LT_3_8` in a masked test file causes the tests to be skipped altogether if matplotlib is not installed.

In review, should make sure that the masked tests are all run also in the minimal dependencies case.
