### PR TITLE
Allow representations to be masked, with possibly different masks for the components

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -532,7 +532,9 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
         The record array fields will have the component names.
         """
         coo_items = [(c, getattr(self, c)) for c in self.components]
-        result = np.empty(self.shape, [(c, coo.dtype) for c, coo in coo_items])
+        result = np.empty_like(
+            coo_items[0][1].value, dtype=[(c, coo.dtype) for c, coo in coo_items]
+        )
         for c, coo in coo_items:
             result[c] = coo.value
         return result

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -540,6 +540,16 @@ class SphericalRepresentation(BaseRepresentation):
                     lon=self.lon, lat=self.lat, differentials=diffs, copy=False
                 )
 
+            elif issubclass(other_class, RadialRepresentation):
+                diffs = self._re_represent_differentials(
+                    other_class, differential_class
+                )
+                return other_class(
+                    distance=self.distance,
+                    differentials=diffs,
+                    copy=False,
+                )
+
         return super().represent_as(other_class, differential_class)
 
     def to_cartesian(self):
@@ -751,6 +761,16 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
                     differentials=diffs,
                     copy=False,
                 )
+            elif issubclass(other_class, RadialRepresentation):
+                diffs = self._re_represent_differentials(
+                    other_class, differential_class
+                )
+                return other_class(
+                    distance=self.r,
+                    differentials=diffs,
+                    copy=False,
+                )
+
             from .cylindrical import CylindricalRepresentation
 
             if issubclass(other_class, CylindricalRepresentation):

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -1,0 +1,120 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import astropy.coordinates.representation as r
+import astropy.units as u
+from astropy.coordinates.tests.test_representation import representation_equal
+from astropy.utils.masked import Masked
+
+
+class TestSphericalRepresentationSeparateMasks:
+    """Tests for mask propagation for Spherical with separate masks."""
+
+    def setup_class(self):
+        self.lon = np.array([0.0, 3.0, 6.0, 12.0, 15.0, 18.0]) << u.hourangle
+        self.lat = np.array([-15.0, 30.0, 60.0, -60.0, 89.0, -80.0]) << u.deg
+        self.dis = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]) << u.pc
+        self.mask_lon = np.array([False, True, False, False, True, True])
+        self.mask_lat = np.array([False, False, True, False, True, True])
+        self.mask_dis = np.array([False, False, False, True, False, True])
+        self.mlon = Masked(self.lon, self.mask_lon)
+        self.mlat = Masked(self.lat, self.mask_lat)
+        self.mdis = Masked(self.dis, self.mask_dis)
+        self.msph = r.SphericalRepresentation(self.mlon, self.mlat, self.mdis)
+        self.mask_ang = self.mask_lon | self.mask_lat
+        self.mask = self.mask_ang | self.mask_dis
+
+    def test_initialization(self):
+        assert_array_equal(self.msph.lon.mask, self.mask_lon)
+        assert_array_equal(self.msph.lat.mask, self.mask_lat)
+        assert_array_equal(self.msph.distance.mask, self.mask_dis)
+        assert_array_equal(self.msph.unmasked.lon, self.lon)
+        assert_array_equal(self.msph.unmasked.lat, self.lat)
+        assert_array_equal(self.msph.unmasked.distance, self.dis)
+
+        assert_array_equal(self.msph.mask, self.mask)
+        assert_array_equal(self.msph.get_mask(), self.mask)
+        assert_array_equal(self.msph.get_mask("lon", "lat"), self.mask_ang)
+
+    def test_convert_to_cartesian(self):
+        mcart = self.msph.represent_as(r.CartesianRepresentation)
+        assert_array_equal(mcart.mask, self.mask)
+
+    def test_convert_to_unit_spherical(self):
+        musph = self.msph.represent_as(r.UnitSphericalRepresentation)
+        assert_array_equal(musph.lon.mask, self.mask_lon)
+        assert_array_equal(musph.lat.mask, self.mask_lat)
+        assert_array_equal(musph.mask, self.mask_ang)
+
+    def test_convert_to_radial(self):
+        mrad = r.RadialRepresentation.from_representation(self.msph)
+        assert_array_equal(mrad.mask, self.mask_dis)
+
+    def test_convert_to_physics_spherical(self):
+        mpsph = self.msph.represent_as(r.PhysicsSphericalRepresentation)
+        assert_array_equal(mpsph.phi.mask, self.mask_lon)
+        assert_array_equal(mpsph.theta.mask, self.mask_lat)
+        assert_array_equal(mpsph.r.mask, self.mask_dis)
+        assert_array_equal(mpsph.mask, self.mask)
+        assert_array_equal(mpsph.get_mask("phi", "theta"), self.mask_ang)
+
+    def test_set_mask(self):
+        msph = self.msph.copy()
+        msph[0] = np.ma.masked
+        assert_array_equal(msph.mask, np.concatenate(([True], self.mask[1:])))
+        msph[0] = np.ma.nomask
+        assert_array_equal(msph.mask, self.mask)
+
+    def test_setitem(self):
+        msph = self.msph.copy()
+        msph[0] = self.msph[1]
+        assert_array_equal(msph.mask, np.concatenate(([True], self.mask[1:])))
+        assert_array_equal(
+            msph.unmasked.lon, np.concatenate((msph.lon[1:2], self.lon[1:]))
+        )
+        msph[0] = self.msph[0]
+        assert_array_equal(msph.mask, self.mask)
+        assert_array_equal(msph.unmasked.lon, self.lon)
+
+    def test_set_masked_item_on_unmasked_instance(self):
+        sph = self.msph.copy().unmasked
+        sph[0] = self.msph[1]
+        assert sph.masked
+        assert_array_equal(
+            sph.mask, np.concatenate(([True], np.zeros_like(self.mask[1:])))
+        )
+        assert_array_equal(
+            sph.unmasked.lon, np.concatenate((sph.lon[1:2], self.lon[1:]))
+        )
+        sph[0] = self.msph[0].unmasked
+        assert sph.masked  # Does not get reset
+        assert_array_equal(sph.mask, np.zeros_like(self.mask))
+        assert_array_equal(sph.unmasked.lon, self.lon)
+
+    def test_set_np_ma_masked_on_unmasked_instance(self):
+        sph = self.msph.copy().unmasked
+        sph[0] = np.ma.masked
+        assert sph.masked
+        assert_array_equal(
+            sph.mask, np.concatenate(([True], np.zeros_like(self.mask[1:])))
+        )
+        assert_array_equal(sph.unmasked.lon, self.lon)
+        sph[0] = np.ma.nomask
+        assert sph.masked  # Does not get reset
+        assert_array_equal(sph.mask, np.zeros_like(self.mask))
+        assert_array_equal(sph.unmasked.lon, self.lon)
+
+    def test_set_np_ma_nomasked_on_unmasked_instance(self):
+        sph = self.msph.copy().unmasked
+        sph[0] = np.ma.nomask
+        assert not sph.masked
+        assert_array_equal(sph.unmasked.lon, self.lon)
+
+    def test_filled(self):
+        unmasked = self.msph.unmasked
+        sph = self.msph.filled(unmasked[1])
+        expected = unmasked.copy()
+        expected[self.mask] = unmasked[1]
+        assert np.all(representation_equal(sph, expected))

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -37,6 +37,15 @@ class TestSphericalRepresentationSeparateMasks:
         assert_array_equal(self.msph.mask, self.mask)
         assert_array_equal(self.msph.get_mask(), self.mask)
         assert_array_equal(self.msph.get_mask("lon", "lat"), self.mask_ang)
+        assert repr(self.msph) == (
+            "<SphericalRepresentation (lon, lat, distance) in (hourangle, deg, pc)\n"
+            "    [( 0., -15., 10.), (———,  30., 20.), ( 6.,  ———, 30.),\n"
+            "     (12., -60., ———), (———,  ———, 50.), (———,  ———, ———)]>"
+        )
+        assert str(self.msph) == (
+            "[( 0., -15., 10.), (———,  30., 20.), ( 6.,  ———, 30.), (12., -60., ———),\n"
+            " (———,  ———, 50.), (———,  ———, ———)] (hourangle, deg, pc)"
+        )
 
     def test_convert_to_cartesian(self):
         mcart = self.msph.represent_as(r.CartesianRepresentation)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -394,6 +394,13 @@ class TestSphericalRepresentation:
         )
         assert representation_equal_up_to_angular_type(got, expected)
 
+        got = sph.represent_as(RadialRepresentation, RadialDifferential)
+        assert np.may_share_memory(sph.distance, got.distance)
+        expected = BaseRepresentation.represent_as(
+            sph, RadialRepresentation, RadialDifferential
+        )
+        assert representation_equal_up_to_angular_type(got, expected)
+
     def test_transform(self):
         """Test ``.transform()`` on rotation and general matrices."""
         # set up representation
@@ -850,6 +857,13 @@ class TestPhysicsSphericalRepresentation:
         assert_allclose_quantity(got.rho, expected.rho, atol=5e-17 * u.kpc)
         assert_allclose_quantity(got.phi, expected.phi, atol=3e-16 * u.deg)
         assert_array_equal(got.z, expected.z)
+
+        got = sph.represent_as(RadialRepresentation, RadialDifferential)
+        assert np.may_share_memory(sph.r, got.distance)
+        expected = BaseRepresentation.represent_as(
+            sph, RadialRepresentation, RadialDifferential
+        )
+        assert representation_equal_up_to_angular_type(got, expected)
 
     def test_to_cylindrical_at_the_origin(self):
         """Test that the transformation to cylindrical at the origin preserves phi."""

--- a/docs/changes/coordinates/16845.feature.rst
+++ b/docs/changes/coordinates/16845.feature.rst
@@ -1,0 +1,6 @@
+Representations now interact properly with ``Masked`` underlying data,
+combining their masks in a new ``.mask`` property. One can also check whether
+the data are masked using ``.masked`` and get an unmasked version out via
+``.unmasked``. In general, the procedure is similar to that of ``Time``,
+except that the mask is not shared between all components, to enable holding,
+e.g., a catalogue of objects in which only some have associated distances.


### PR DESCRIPTION
This pull request is the first step in making `SkyCoord` able to deal with masks, by giving representations a mask. In general, I tried to make the behaviour similar to that of `Time`, which means, e.g., that the mask strictly refers to that of the data, not any associated differentials (similarly, for frames, the `mask` will not include information from any attributes, just like `Time` does not include information from `location`).

One difference is that the mask is *not* shared between the three components. This is because I *think* we want to be able to support `SkyCoord` of catalogues in which some of the sources do not have an associated distance. Most logical is for those just to have a masked distance, but unmasked longitude and latitude. But to support that, the components of `SphericalRepresentation` need to have independent masks. (I went some way in seeing if the angles still could have a shared mask, but ended up feeling this became too complex and fragile)

So, right now, the representations have a `.mask` property which just or's everything together, as well as a `get_mask` method, which allows one to select specific components.

EDIT: This is a follow up of #16844 ~Note that this builds on #16842 and #16844. The most important commit is the last one. Opening as draft for now to allow comments on the general idea first.~

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
