### PR TITLE
feat: uni-modal cosmology wrt Ob0

### DIFF
--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -159,8 +159,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
     Ob0 : float or None, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
@@ -205,7 +204,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         equivalencies=u.mass_energy(),
     )
     Ob0: Parameter = Parameter(
-        default=None,
+        default=0.0,
         doc="Omega baryon; baryonic matter density/critical density at z=0.",
     )
 
@@ -267,9 +266,15 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
     @Ob0.validator
     def Ob0(self, param, value):
-        """Validate baryon density to None or positive float > matter density."""
+        """Validate baryon density to a non-negative float > matter density."""
         if value is None:
-            return value
+            warnings.warn(
+                "Ob0=None is deprecated, use Ob0=0 instead, "
+                "which never causes methods to raise exceptions.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return 0.0
 
         value = _validate_non_negative(self, param, value)
         if value > self.Om0:
@@ -487,8 +492,6 @@ class FLRW(Cosmology, _ScaleFactorMixin):
         ValueError
             If ``Ob0`` is `None`.
         """
-        if self.Ob0 is None:
-            raise ValueError("Baryon density not set for this cosmology")
         z = aszarr(z)
         return self.Ob0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 

--- a/docs/changes/cosmology/16847.api.rst
+++ b/docs/changes/cosmology/16847.api.rst
@@ -1,0 +1,5 @@
+Setting ``Ob0 = None`` in FLRW cosmologies has been deprecated in favor of ``Ob0 =
+0.0``. Conceptually this is a change in that baryons are now always a component of the
+cosmology. Practically, the only change (besides that ``Ob0`` is never ``None``) is that
+methods relying on ``Ob0`` always work, rather than sometimes raising an exception,
+instead by default taking the contribution of the baryons to be negligible.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -81,7 +81,7 @@ classes::
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
   >>> print(cosmo)  # doctest: +FLOAT_CMP
   FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=2.725 K,
-                Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=None)
+                Neff=3.04, m_nu=[0. 0. 0.] eV, Ob0=0.0)
 
 Note the presence of additional cosmological parameters (e.g., ``Neff``, the
 number of effective neutrino species) with default values; these can also be
@@ -133,7 +133,7 @@ parameter and Omega matter (both at z=0)::
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
   >>> print(cosmo)
   FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=0.0 K,
-                Neff=3.04, m_nu=None, Ob0=None)
+                Neff=3.04, m_nu=None, Ob0=0.0)
 
 This can also be done more explicitly using units, which is recommended::
 
@@ -207,19 +207,18 @@ instantiation by passing the keyword argument ``Ob0``::
   FlatLambdaCDM(H0=70.0 km / (Mpc s), Om0=0.3, Tcmb0=0.0 K,
                 Neff=3.04, m_nu=None, Ob0=0.05)
 
-In this case the dark matter-only density at redshift 0 is available as class
-attribute ``Odm0`` and the redshift evolution of dark and baryonic matter
-densities can be computed using the methods ``Odm`` and ``Ob``, respectively.
-If ``Ob0`` is not specified at class instantiation, it defaults to ``None`` and
-any method relying on it being specified will raise a ``ValueError``:
+In this case the dark matter-only density at redshift 0 is available as class attribute
+``Odm0`` and the redshift evolution of dark and baryonic matter densities can be
+computed using the methods ``Odm`` and ``Ob``, respectively. If ``Ob0`` is not
+specified, it will be set to 0 and thus ignored in further calculations.
 
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
   >>> cosmo.Odm(1)
-  Traceback (most recent call last):
-  ...
-  ValueError: Baryonic density not set for this cosmology, unclear
-  meaning of dark matter density
+  np.float64(0.7741935483870968)
+
+  >>> cosmo.Ob(1)
+  np.float64(0.0)
 
 Cosmological instances have an optional ``name`` attribute which can be used to
 describe the cosmology::
@@ -228,7 +227,7 @@ describe the cosmology::
   >>> cosmo = FlatwCDM(name='SNLS3+WMAP7', H0=71.58, Om0=0.262, w0=-1.016)
   >>> print(cosmo)
   FlatwCDM(name="SNLS3+WMAP7", H0=71.58 km / (Mpc s), Om0=0.262, Tcmb0=0.0 K, Neff=3.04,
-           m_nu=None, Ob0=None, w0=-1.016)
+           m_nu=None, Ob0=0.0, w0=-1.016)
 
 ..
   EXAMPLE END


### PR DESCRIPTION
Deprecates `Ob0=None`, changing it to `Ob0=0`.
Currently FLRW is multi-modal in that it supports both a cosmology with no baryon component and also one with a baryon component. Except that the no-baryon cosmology is implemented as an attribute that always raises an exception. This is not an ideal code pattern. From a code perspective the best is to have two different classes, each representing one of these modalities. Pragmatically, at least for now, just having `Ob0 = 0` fulfills the same requirements without adding a new class nor all the child classes for the dark energy EoS. Longer term, one of the
goals of the [cosmology API](https://cosmology.readthedocs.io/projects/api/en/latest/) project and its application to Astropy is to make defining new cosmology classes significantly easier through more modular components. Then we can have true no-baryon cosmologies, not just baryons=0.

This is a breaking change since `Ob0 = None` is now `Ob0 = 0` and no longer ever errors.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
