### PR TITLE
fix: dict update, not setattr in cosmo params

### DIFF
--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -1658,8 +1658,8 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         # Make new instance, respecting args vs kwargs
         inst = self.__nonflatclass__(*ba.args, **ba.kwargs)
         # Because of machine precision, make sure parameters exactly match
-        for n in inst._parameters_all:
-            object.__setattr__(inst, "_" + n, getattr(self, n))
+        inst.__dict__.update(inst.parameters)
+        inst.__dict__.update(inst._derived_parameters)
         inst.__dict__["Ok0"] = self.Ok0
 
         return inst


### PR DESCRIPTION
@mhvk, can we sneak this one in, to fix the very recently merged #16846?
No test picked up the mistake because sometimes / often the parameters exactly match. The re-assignment is defensive programming for occasional machine imprecision.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
