### PR TITLE
BUG: Fix test_plt_scatter_masked matplotlib check that broke pyinstaller job

### DIFF
--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
-from astropy.utils import minversion
 from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
@@ -1565,12 +1564,13 @@ class TestMaskedQuantityInteractionWithNumpyMA(
     pass
 
 
-# For grep'ing: test requires MATPLOTLIB_LT_3_8
-@pytest.mark.skipif(
-    not HAS_PLT or not minversion("matplotlib", "3.8"),
-    reason="requires matplotlib.pyplot and never worked before matplotlib 3.8",
-)
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
 def test_plt_scatter_masked():
+    from astropy.visualization.wcsaxes.utils import MATPLOTLIB_LT_3_8
+
+    if MATPLOTLIB_LT_3_8:
+        pytest.skip("never worked before matplotlib 3.8")
+
     # check that plotting Masked data doesn't raise an exception
     # see https://github.com/astropy/astropy/issues/12481
     import matplotlib.pyplot as plt


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The check was originally modified in https://github.com/astropy/astropy/pull/16820 but that caused other tests to be skipped when they are not supposed to when matplotlib is not installed (can't say I grok why at the time of writing this). So https://github.com/astropy/astropy/pull/16843 was done but it caused pyinstaller job to fail with `E   KeyError: 'matplotlib'` during test collection. This PR is an attempt to skip only `test_plt_scatter_masked` when matplotlib conditions are not satisfied *and* to not break pyinstaller job doing that.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
