### PR TITLE
WIP: Add fast validation to `io.ascii`

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -76,7 +76,8 @@ class Basic(core.BaseReader):
             List of table lines
 
         """
-        lines = core.get_lines_iter(source, encoding=self.encoding)
+        max_lines = core.MAX_VALIDATION_LINES_GUESSING if guessing else None
+        lines = core.get_lines_iter(source, encoding=self.encoding, max_lines=max_lines)
         start_line = core._get_line_index(
             self.header.start_line, self.header.process_lines(lines)
         )
@@ -91,11 +92,11 @@ class Basic(core.BaseReader):
                     "No data lines found so cannot autogenerate column names"
                 )
             n_data_cols = len(first_data_vals)
-            print(f"first_data_vals: {first_data_vals}")
-            print(f"n_data_cols: {n_data_cols}")
 
         else:
-            lines = core.get_lines_iter(source, encoding=self.encoding)
+            lines = core.get_lines_iter(
+                source, encoding=self.encoding, max_lines=max_lines
+            )
             for i, line in enumerate(self.header.process_lines(lines)):
                 if i == start_line:
                     break

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -26,50 +26,6 @@ class BasicHeader(core.BaseHeader):
     comment = r"\s*#"
     write_comment = "# "
 
-    def validate(self, source, guessing=False, strict_names=False):
-        """Initialize the header Column objects from the table ``lines``.
-
-        Based on the previously set Header attributes find or create the column names.
-        Sets ``self.cols`` with the list of Columns.
-
-        Parameters
-        ----------
-        lines : list
-            List of table lines
-
-        """
-        lines = core.get_lines_iter(source, encoding=self.encoding)
-        start_line = core._get_line_index(self.start_line, self.process_lines(lines))
-        if start_line is None:
-            # No header line so auto-generate names from n_data_cols
-            # Get the data values from the first line of table data to determine n_data_cols
-            try:
-                data_lines = self.data.get_data_lines_iter(source)
-                first_data_vals = next(self.data.splitter(data_lines))
-            except StopIteration:
-                raise core.InconsistentTableError(
-                    "No data lines found so cannot autogenerate column names"
-                )
-            n_data_cols = len(first_data_vals)
-
-        else:
-            lines = core.get_lines_iter(source, encoding=self.encoding)
-            for i, line in enumerate(self.process_lines(lines)):
-                if i == start_line:
-                    break
-            else:  # No header line matching
-                raise ValueError("No header line found in table")
-
-            names = next(self.splitter([line]))
-            n_data_cols = len(names)
-            self.check_column_names(None, strict_names, guessing, colnames=names)
-
-        if guessing and n_data_cols <= 1:
-            raise core.InconsistentTableError(
-                "Table format guessing requires at least two columns, "
-                f"got {n_data_cols}"
-            )
-
 
 class BasicData(core.BaseData):
     """
@@ -107,6 +63,55 @@ class Basic(core.BaseReader):
 
     header_class = BasicHeader
     data_class = BasicData
+
+    def validate(self, source, guessing=False, strict_names=False):
+        """Initialize the header Column objects from the table ``lines``.
+
+        Based on the previously set Header attributes find or create the column names.
+        Sets ``self.cols`` with the list of Columns.
+
+        Parameters
+        ----------
+        lines : list
+            List of table lines
+
+        """
+        lines = core.get_lines_iter(source, encoding=self.encoding)
+        start_line = core._get_line_index(
+            self.header.start_line, self.header.process_lines(lines)
+        )
+        if start_line is None:
+            # No header line so auto-generate names from n_data_cols
+            # Get the data values from the first line of table data to determine n_data_cols
+            try:
+                data_lines = self.data.get_data_lines_iter(source)
+                first_data_vals = next(self.data.splitter(data_lines))
+            except StopIteration:
+                raise core.InconsistentTableError(
+                    "No data lines found so cannot autogenerate column names"
+                )
+            n_data_cols = len(first_data_vals)
+            print(f"first_data_vals: {first_data_vals}")
+            print(f"n_data_cols: {n_data_cols}")
+
+        else:
+            lines = core.get_lines_iter(source, encoding=self.encoding)
+            for i, line in enumerate(self.header.process_lines(lines)):
+                if i == start_line:
+                    break
+            else:  # No header line matching
+                raise ValueError("No header line found in table")
+
+            names = next(self.header.splitter([line]))
+            n_data_cols = len(names)
+            self.header.check_column_names(None, strict_names, guessing, colnames=names)
+
+        if guessing and n_data_cols <= 1:
+            print("Raise core.InconsistentTableError")
+            raise core.InconsistentTableError(
+                "Table format guessing requires at least two columns, "
+                f"got {n_data_cols}"
+            )
 
 
 class NoHeaderHeader(BasicHeader):

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -612,7 +612,7 @@ class DefaultSplitter(BaseSplitter):
 
         """
         if self.process_line:
-            lines = [self.process_line(x) for x in lines]
+            lines = (self.process_line(x) for x in lines)
 
         delimiter = " " if self.delimiter == r"\s" else self.delimiter
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1587,8 +1587,8 @@ class BaseReader(metaclass=MetaBaseReader):
         # for performance, mostly when guessing. The validate method might not catch all
         # possible errors but it must never produce a false positive (raising an
         # InconsistentTableError).
-        if hasattr(self.header, "validate"):
-            self.header.validate(table, self.guessing, self.strict_names)
+        if hasattr(self, "validate"):
+            self.validate(table, self.guessing, self.strict_names)
 
         # If ``table`` is a file then store the name in the ``data``
         # attribute. The ``table`` is a "file" if it is a string

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -85,6 +85,8 @@ def detect_source_type(source: SourceType) -> str:
     source_type : str
         The type of source input: 'filename', 'data-str', 'file-like', or 'data-list'.
     """
+    from . import cparser
+
     if isinstance(source, str):
         # Either a filename or a string of data.
         if "\n" in source or "\r" in source:
@@ -93,6 +95,8 @@ def detect_source_type(source: SourceType) -> str:
             source_type = "filename"
     elif hasattr(source, "read"):
         source_type = "file-like"
+    elif isinstance(source, cparser.FileString):
+        source_type = "cparser-filestring"
     else:
         # Check if it is list-like (supports indexing, slicing, iteration) and with at
         # least one string-like element
@@ -174,6 +178,8 @@ def get_lines_iter(
         yield from islice(get_lines_from_str_iter(source, newline), max_lines)
     elif source_type == "data-list":
         yield from islice(source, max_lines)
+    elif source_type == "cparser-filestring":
+        yield from islice(source.splitlines(), max_lines)
     else:
         raise ValueError(f"unsupported source type {source_type}")
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1494,6 +1494,10 @@ class BaseReader(metaclass=MetaBaseReader):
             Output table
 
         """
+        # If possible, validate the header without fully processing the table
+        if hasattr(self.header, "validate"):
+            self.header.validate(table)
+
         # If ``table`` is a file then store the name in the ``data``
         # attribute. The ``table`` is a "file" if it is a string
         # without the new line specific to the OS.

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -164,21 +164,18 @@ def get_lines_iter(
     lines : iterator
         Iterator over the table lines.
     """
+    islice = itertools.islice
+
     source_type = detect_source_type(source)
     if source_type in ("filename", "file-like"):
         with get_readable_fileobj(source, encoding=encoding) as fileobj:
-            lines = (line.rstrip("\r\n") for line in fileobj)
+            yield from islice((line.rstrip("\r\n") for line in fileobj), max_lines)
     elif source_type == "data-str":
-        lines = get_lines_from_str_iter(source, newline)
+        yield from islice(get_lines_from_str_iter(source, newline), max_lines)
     elif source_type == "data-list":
-        lines = source
+        yield from islice(source, max_lines)
     else:
         raise ValueError(f"unsupported source type {source_type}")
-
-    if max_lines is not None:
-        lines = itertools.islice(lines, max_lines)
-
-    yield from lines
 
 
 def slice_lines_iter(

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -390,5 +390,27 @@ class Daophot(core.BaseReader):
         # The inputter needs to know about the data (see DaophotInputter.process_lines)
         self.inputter.data = self.data
 
+    def validate(self, source, guessing=False, strict_names=False):
+        """Validate the DAOphot table format.
+
+        This is strict, assuming output from the IRAF DAOphot routine which includes
+        all four header lines (#K, #N, #U, #F).
+        """
+        max_lines = core.MAX_VALIDATION_LINES_GUESSING if guessing else None
+        lines = core.get_lines_iter(source, encoding=self.encoding, max_lines=max_lines)
+
+        header_types = set()
+        for line in lines:
+            # Check for line starting with "#[NUF] " and set the header type
+            match = re.match(r"#([NUF])\s", line)
+            if match:
+                header_types.add(match.group(1))
+
+        # Require
+        if len(header_types) != 3:
+            raise core.InconsistentTableError(
+                "DAOphot table must have all four header types (#N, #U, #F)"
+            )
+
     def write(self, table=None):
         raise NotImplementedError

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -47,7 +47,7 @@ class InvalidEcsvDatatypeWarning(AstropyUserWarning):
 class EcsvHeader(basic.BasicHeader):
     """ECSV Header class"""
 
-    def validate(self, source):
+    def validate(self, source: core.SourceType) -> None:
         """Validate that this is a ECSV file.
 
         Raises InconsistentTableError if the header is not present or does not match

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -47,7 +47,12 @@ class InvalidEcsvDatatypeWarning(AstropyUserWarning):
 class EcsvHeader(basic.BasicHeader):
     """ECSV Header class"""
 
-    def validate(self, source: core.SourceType) -> None:
+    def validate(
+        self,
+        source: core.SourceType,
+        guessing: bool = False,
+        strict_names: bool = False,
+    ) -> None:
         """Validate that this is a ECSV file.
 
         Raises InconsistentTableError if the header is not present or does not match

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -315,7 +315,8 @@ class FastCommentedHeader(FastBasic):
         tmp = self.engine.source
         commented_lines = []
 
-        for line in tmp.splitlines():
+        max_lines = core.MAX_VALIDATION_LINES_GUESSING if self.guessing else None
+        for line in core.get_lines_iter(tmp, max_lines=max_lines):
             line = line.lstrip()
             if line and line[0] == self.comment:  # line begins with a comment
                 commented_lines.append(line[1:])
@@ -358,7 +359,8 @@ class FastRdb(FastBasic):
         tmp = self.engine.source
         line1 = ""
         line2 = ""
-        for line in tmp.splitlines():
+        max_lines = core.MAX_VALIDATION_LINES_GUESSING if self.guessing else None
+        for line in core.get_lines_iter(tmp, max_lines=max_lines):
             # valid non-comment line
             if not line1 and line.strip() and line.lstrip()[0] != self.comment:
                 line1 = line

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -80,7 +80,12 @@ class FixedWidthHeader(basic.BasicHeader):
             raise InconsistentTableError("No header line found in table")
         return line
 
-    def validate(self, source: core.SourceType) -> None:
+    def validate(
+        self,
+        source: core.SourceType,
+        guessing: bool = False,
+        strict_names: bool = False,
+    ) -> None:
         """Validate that ``source`` appears to be a fixed width table.
 
         Raises InconsistentTableError if the header is not present or does not match

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -80,105 +80,6 @@ class FixedWidthHeader(basic.BasicHeader):
             raise InconsistentTableError("No header line found in table")
         return line
 
-    def validate(
-        self,
-        source: core.SourceType,
-        guessing: bool = False,
-        strict_names: bool = False,
-    ) -> None:
-        """Validate that ``source`` appears to be a fixed width table.
-
-        Raises InconsistentTableError if the header is not present or does not match
-        the fixed width format.
-
-        This is called early in the process of reading a table to determine if the
-        input source is a valid fixed width file.
-
-        This method is adapted from ``get_cols()`` but uses iterators over the original
-        ``source`` and should run quickly.
-
-        Parameters
-        ----------
-        source : str, file-like, list
-            Can be either a file name, string (newline separated) with all header and data
-            lines (must have at least 2 lines), a file-like object with a
-            ``read()`` method, or a list of strings.
-
-        """
-        header_rows = getattr(self, "header_rows", ["name"])
-
-        # See "else" clause below for explanation of start_line and position_line.
-        # Note that process_lines() returns an iterator so we need to call it each time.
-        start_line = core._get_line_index(
-            self.start_line, self.process_lines(core.get_lines_iter(source))
-        )
-        position_line = core._get_line_index(
-            self.position_line, self.process_lines(core.get_lines_iter(source))
-        )
-
-        # If start_line is none then there is no header line.  Column positions are
-        # determined from first data line and column names are either supplied by user
-        # or auto-generated.
-        if start_line is None:
-            if position_line is not None:
-                raise ValueError(
-                    "Cannot set position_line without also setting header_start"
-                )
-
-            # data.data_lines attribute already set via self.data.get_data_lines(lines)
-            # in BaseReader.read().  This includes slicing for data_start / data_end.
-            data_lines = self.data.get_data_lines_iter(source)
-
-            try:
-                vals, _, _ = self.get_fixedwidth_params(next(data_lines))
-            except StopIteration:
-                raise InconsistentTableError(
-                    "No data lines found so cannot autogenerate column names"
-                )
-
-            self.names = [self.auto_format.format(i) for i in range(1, len(vals) + 1)]
-
-        else:
-            # This bit of code handles two cases:
-            # start_line = <index> and position_line = None
-            #    Single header line where that line is used to determine both the
-            #    column positions and names.
-            # start_line = <index> and position_line = <index2>
-            #    Two header lines where the first line defines the column names and
-            #    the second line defines the column positions
-
-            if position_line is not None:
-                # Define self.col_starts and self.col_ends so that the call to
-                # get_fixedwidth_params below will use those to find the header
-                # column names.  Note that get_fixedwidth_params returns Python
-                # slice col_ends but expects inclusive col_ends on input (for
-                # more intuitive user interface).
-                line = self.get_line(core.get_lines_iter(source), position_line)
-                if len(set(line) - {self.splitter.delimiter, " "}) != 1:
-                    raise InconsistentTableError(
-                        "Position line should only contain delimiters and "
-                        'one other character, e.g. "--- ------- ---".'
-                    )
-                    # The line above lies. It accepts white space as well.
-                    # We don't want to encourage using three different
-                    # characters, because that can cause ambiguities, but white
-                    # spaces are so common everywhere that practicality beats
-                    # purity here.
-                charset = self.set_of_position_line_characters.union(
-                    {self.splitter.delimiter, " "}
-                )
-                if not set(line).issubset(charset):
-                    raise InconsistentTableError(
-                        f"Characters in position line must be part of {charset}"
-                    )
-                self.get_fixedwidth_params(line)
-
-            # Get the column names from the header line
-            line = self.get_line(
-                core.get_lines_iter(source), start_line + header_rows.index("name")
-            )
-            self.get_fixedwidth_params(line)
-
     def get_cols(self, lines):
         """
         Initialize the header Column objects from the table ``lines``.
@@ -450,6 +351,110 @@ class FixedWidth(basic.Basic):
         self.data.header_rows = header_rows
         if self.data.start_line is None:
             self.data.start_line = len(header_rows)
+
+    def validate(
+        self,
+        source: core.SourceType,
+        guessing: bool = False,
+        strict_names: bool = False,
+    ) -> None:
+        """Validate that ``source`` appears to be a fixed width table.
+
+        Raises InconsistentTableError if the header is not present or does not match
+        the fixed width format.
+
+        This is called early in the process of reading a table to determine if the
+        input source is a valid fixed width file.
+
+        This method is adapted from ``get_cols()`` but uses iterators over the original
+        ``source`` and should run quickly.
+
+        Parameters
+        ----------
+        source : str, file-like, list
+            Can be either a file name, string (newline separated) with all header and data
+            lines (must have at least 2 lines), a file-like object with a
+            ``read()`` method, or a list of strings.
+
+        """
+        header_rows = getattr(self, "header_rows", ["name"])
+
+        # See "else" clause below for explanation of start_line and position_line.
+        # Note that process_lines() returns an iterator so we need to call it each time.
+        start_line = core._get_line_index(
+            self.header.start_line,
+            self.header.process_lines(core.get_lines_iter(source)),
+        )
+        position_line = core._get_line_index(
+            self.header.position_line,
+            self.header.process_lines(core.get_lines_iter(source)),
+        )
+
+        # If start_line is none then there is no header line.  Column positions are
+        # determined from first data line and column names are either supplied by user
+        # or auto-generated.
+        if start_line is None:
+            if position_line is not None:
+                raise ValueError(
+                    "Cannot set position_line without also setting header_start"
+                )
+
+            # data.data_lines attribute already set via self.data.get_data_lines(lines)
+            # in BaseReader.read().  This includes slicing for data_start / data_end.
+            data_lines = self.data.get_data_lines_iter(source)
+
+            try:
+                vals, _, _ = self.header.get_fixedwidth_params(next(data_lines))
+            except StopIteration:
+                raise InconsistentTableError(
+                    "No data lines found so cannot autogenerate column names"
+                )
+
+            # FIXME: should this be setting names?
+            self.header.names = [
+                self.header.auto_format.format(i) for i in range(1, len(vals) + 1)
+            ]
+
+        else:
+            # This bit of code handles two cases:
+            # start_line = <index> and position_line = None
+            #    Single header line where that line is used to determine both the
+            #    column positions and names.
+            # start_line = <index> and position_line = <index2>
+            #    Two header lines where the first line defines the column names and
+            #    the second line defines the column positions
+
+            if position_line is not None:
+                # Define self.col_starts and self.col_ends so that the call to
+                # get_fixedwidth_params below will use those to find the header
+                # column names.  Note that get_fixedwidth_params returns Python
+                # slice col_ends but expects inclusive col_ends on input (for
+                # more intuitive user interface).
+                line = self.header.get_line(core.get_lines_iter(source), position_line)
+                if len(set(line) - {self.header.splitter.delimiter, " "}) != 1:
+                    raise InconsistentTableError(
+                        "Position line should only contain delimiters and "
+                        'one other character, e.g. "--- ------- ---".'
+                    )
+                    # The line above lies. It accepts white space as well.
+                    # We don't want to encourage using three different
+                    # characters, because that can cause ambiguities, but white
+                    # spaces are so common everywhere that practicality beats
+                    # purity here.
+                charset = self.header.set_of_position_line_characters.union(
+                    {self.header.splitter.delimiter, " "}
+                )
+                if not set(line).issubset(charset):
+                    raise InconsistentTableError(
+                        f"Characters in position line must be part of {charset}"
+                    )
+                self.header.get_fixedwidth_params(line)
+
+            # Get the column names from the header line
+            line = self.header.get_line(
+                core.get_lines_iter(source), start_line + header_rows.index("name")
+            )
+            self.header.get_fixedwidth_params(line)
 
 
 class FixedWidthNoHeaderHeader(FixedWidthHeader):

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -80,7 +80,7 @@ class FixedWidthHeader(basic.BasicHeader):
             raise InconsistentTableError("No header line found in table")
         return line
 
-    def validate(self, source):
+    def validate(self, source: core.SourceType) -> None:
         """Validate that ``source`` appears to be a fixed width table.
 
         Raises InconsistentTableError if the header is not present or does not match

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -83,9 +83,14 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
     definition = "ignore"
     start_line = None
 
-    def validate(self, source):
+    def validate(self, source: core.SourceType) -> None:
         lines = core.get_lines_iter(source)
-        header_lines = self.process_lines(lines)
+        # Collect up to the first 10 IPAC header lines. This means discarding blank
+        # lines or comment lines (starting with "\") and stopping after 10 lines are
+        # returned.
+        header_lines = [
+            line for line, _ in zip(self.process_lines(lines), range(10), strict=False)
+        ]
         header_vals = list(self.splitter(header_lines))
         if len(header_vals) == 0:
             raise ValueError(

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -83,6 +83,17 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
     definition = "ignore"
     start_line = None
 
+    def validate(self, source):
+        lines = core.get_lines_iter(source)
+        header_lines = self.process_lines(lines)
+        header_vals = list(self.splitter(header_lines))
+        if len(header_vals) == 0:
+            raise ValueError(
+                "At least one header line beginning and ending with delimiter required"
+            )
+        elif len(header_vals) > 4:
+            raise ValueError("More than four header lines were found")
+
     def process_lines(self, lines):
         """Generator to yield IPAC header lines, i.e. those starting and ending with
         delimiter character (with trailing whitespace stripped).

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -472,7 +472,8 @@ class Ipac(basic.Basic):
         guessing: bool = False,
         strict_names: bool = False,
     ) -> None:
-        lines = core.get_lines_iter(source, encoding=self.encoding)
+        max_lines = core.MAX_VALIDATION_LINES_GUESSING if guessing else None
+        lines = core.get_lines_iter(source, encoding=self.encoding, max_lines=max_lines)
         # Collect up to the first 10 IPAC header lines. This means discarding blank
         # lines or comment lines (starting with "\") and stopping after 10 lines are
         # returned.

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -83,27 +83,6 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
     definition = "ignore"
     start_line = None
 
-    def validate(
-        self,
-        source: core.SourceType,
-        guessing: bool = False,
-        strict_names: bool = False,
-    ) -> None:
-        lines = core.get_lines_iter(source)
-        # Collect up to the first 10 IPAC header lines. This means discarding blank
-        # lines or comment lines (starting with "\") and stopping after 10 lines are
-        # returned.
-        header_lines = [
-            line for line, _ in zip(self.process_lines(lines), range(10), strict=False)
-        ]
-        header_vals = list(self.splitter(header_lines))
-        if len(header_vals) == 0:
-            raise ValueError(
-                "At least one header line beginning and ending with delimiter required"
-            )
-        elif len(header_vals) > 4:
-            raise ValueError("More than four header lines were found")
-
     def process_lines(self, lines):
         """Generator to yield IPAC header lines, i.e. those starting and ending with
         delimiter character (with trailing whitespace stripped).
@@ -486,6 +465,30 @@ class Ipac(basic.Basic):
         else:
             raise ValueError("definition should be one of ignore/left/right")
         self.header.DBMS = DBMS
+
+    def validate(
+        self,
+        source: core.SourceType,
+        guessing: bool = False,
+        strict_names: bool = False,
+    ) -> None:
+        lines = core.get_lines_iter(source, encoding=self.encoding)
+        # Collect up to the first 10 IPAC header lines. This means discarding blank
+        # lines or comment lines (starting with "\") and stopping after 10 lines are
+        # returned.
+        header_lines = [
+            line
+            for line, _ in zip(
+                self.header.process_lines(lines), range(10), strict=False
+            )
+        ]
+        header_vals = list(self.header.splitter(header_lines))
+        if len(header_vals) == 0:
+            raise ValueError(
+                "At least one header line beginning and ending with delimiter required"
+            )
+        elif len(header_vals) > 4:
+            raise ValueError("More than four header lines were found")
 
     def write(self, table):
         """

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -83,7 +83,12 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
     definition = "ignore"
     start_line = None
 
-    def validate(self, source: core.SourceType) -> None:
+    def validate(
+        self,
+        source: core.SourceType,
+        guessing: bool = False,
+        strict_names: bool = False,
+    ) -> None:
         lines = core.get_lines_iter(source)
         # Collect up to the first 10 IPAC header lines. This means discarding blank
         # lines or comment lines (starting with "\") and stopping after 10 lines are


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is a proof-of-concept for fast validation (i.e. short-circuiting) of formats, particularly when guessing.

The key feature is adding a `validate()` method to each `Reader` class that implements custom logic to check whether the source input appears to be valid for the reader. This can take logic from the `get_cols()` for formats with specialized headers.

In addition to the new `validate()` methods, this adds helper functions and methods to allow iterator-based access to the source data lines. This allows efficient processing of a limited number of lines at the head of the table.

The goal is to add robust validation for every class, which might remove the need for #16840. However, I'm not sure this will be possible. This PR is a bit experimental!

For timing see: https://gist.github.com/taldcroft/e2f276e84b17cfaf6fb6604ee8a10655

cc: @astrofrog @mhvk

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
