### PR TITLE
Make `UnitScaleError` available from `astropy.units`

### DIFF
--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -24,8 +24,8 @@ from astropy.io.tests.mixin_columns import compare_attrs, mixin_cols, serialized
 from astropy.table import Column, MaskedColumn, QTable, Table
 from astropy.table.table_helpers import simple_table
 from astropy.time import Time
+from astropy.units import UnitScaleError
 from astropy.units import allclose as quantity_allclose
-from astropy.units.format.fits import UnitScaleError
 from astropy.units.quantity import QuantityInfo
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -36,6 +36,7 @@ __all__ = [
     "UnitsError",
     "UnitsWarning",
     "UnitConversionError",
+    "UnitScaleError",
     "UnitTypeError",
     "UnitBase",
     "NamedUnit",

--- a/docs/changes/units/16861.bugfix.rst
+++ b/docs/changes/units/16861.bugfix.rst
@@ -1,0 +1,1 @@
+``UnitScaleError`` can now be imported from the ``astropy.units`` namespace.


### PR DESCRIPTION
### Description

`UnitScaleError` can be produced by the public API, for example
```python
>>> from astropy import units as u
>>> u.Unit("5 * u.m").to_string(format="fits")
Traceback (most recent call last):
  ...
astropy.units.core.UnitScaleError: The FITS unit format is not able...
```
but despite that the error cannot be imported from `astropy.units` and it is not included in our documentation. The first commit modifies the tests to reveal the mistake, the second commit fixes it.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
