### PR TITLE
Create a separate module for `units` errors

### DIFF
--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -6,7 +6,8 @@ import warnings
 
 import numpy as np
 
-from astropy.units.core import Unit, UnitsError
+from astropy.units.core import Unit
+from astropy.units.errors import UnitsError
 from astropy.units.quantity import Quantity
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning

--- a/astropy/timeseries/io/tests/test_kepler.py
+++ b/astropy/timeseries/io/tests/test_kepler.py
@@ -6,7 +6,7 @@ import pytest
 
 from astropy.io.fits import BinTableHDU, HDUList, Header, PrimaryHDU
 from astropy.timeseries.io.kepler import kepler_fits_reader
-from astropy.units.core import UnitsWarning
+from astropy.units import UnitsWarning
 from astropy.utils.data import get_pkg_data_filename
 
 

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -11,8 +11,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time, TimeDelta
 from astropy.timeseries.periodograms import BoxLeastSquares, LombScargle
 from astropy.timeseries.sampled import TimeSeries
-from astropy.units import Quantity
-from astropy.units.core import UnitsWarning
+from astropy.units import Quantity, UnitsWarning
 from astropy.utils.data import get_pkg_data_filename
 
 INPUT_TIME = Time(["2016-03-22T12:30:31", "2015-01-21T12:30:32", "2016-03-22T12:30:40"])

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -15,6 +15,7 @@ from . import (
     cgs,
     core,
     decorators,
+    errors,
     misc,
     photometric,
     physical,
@@ -27,6 +28,7 @@ from .cgs import *
 from .core import *
 from .core import set_enabled_units
 from .decorators import *
+from .errors import *
 from .misc import *
 from .photometric import *
 from .physical import *
@@ -42,6 +44,7 @@ from .function import *
 
 __all__ = []
 __all__ += core.__all__
+__all__ += errors.__all__
 __all__ += quantity.__all__
 __all__ += decorators.__all__
 __all__ += structured.__all__

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -21,6 +21,7 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
 
 from . import format as unit_format
+from .errors import UnitConversionError, UnitsError, UnitsWarning
 from .utils import (
     is_effectively_unity,
     resolve_fractions,
@@ -33,11 +34,6 @@ if TYPE_CHECKING:
     from astropy.units.typing import UnitPower
 
 __all__ = [
-    "UnitsError",
-    "UnitsWarning",
-    "UnitConversionError",
-    "UnitScaleError",
-    "UnitTypeError",
     "UnitBase",
     "NamedUnit",
     "IrreducibleUnit",
@@ -606,41 +602,6 @@ def add_enabled_aliases(aliases):
     # in this new current registry, enable the further equivalencies requested
     get_current_unit_registry().add_enabled_aliases(aliases)
     return context
-
-
-class UnitsError(Exception):
-    """
-    The base class for unit-specific exceptions.
-    """
-
-
-class UnitScaleError(UnitsError, ValueError):
-    """
-    Used to catch the errors involving scaled units,
-    which are not recognized by FITS format.
-    """
-
-
-class UnitConversionError(UnitsError, ValueError):
-    """
-    Used specifically for errors related to converting between units or
-    interpreting units in terms of other units.
-    """
-
-
-class UnitTypeError(UnitsError, TypeError):
-    """
-    Used specifically for errors in setting to units not allowed by a class.
-
-    E.g., would be raised if the unit of an `~astropy.coordinates.Angle`
-    instances were set to a non-angular unit.
-    """
-
-
-class UnitsWarning(AstropyWarning):
-    """
-    The base class for unit-specific warnings.
-    """
 
 
 class UnitBase:
@@ -2713,7 +2674,3 @@ def unit_scale_converter(val):
 dimensionless_unscaled = CompositeUnit(1, [], [], _error_check=False)
 # Abbreviation of the above, see #1980
 one = dimensionless_unscaled
-
-# Maintain error in old location for backward compatibility
-# TODO: Is this still needed? Should there be a deprecation warning?
-unit_format.fits.UnitScaleError = UnitScaleError

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -11,13 +11,8 @@ from numbers import Number
 
 import numpy as np
 
-from .core import (
-    Unit,
-    UnitBase,
-    UnitsError,
-    add_enabled_equivalencies,
-    dimensionless_unscaled,
-)
+from .core import Unit, UnitBase, add_enabled_equivalencies, dimensionless_unscaled
+from .errors import UnitsError
 from .physical import PhysicalType, get_physical_type
 from .quantity import Quantity
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -16,7 +16,8 @@ from astropy.utils import deprecated_renamed_argument
 from astropy.utils.misc import isiterable
 
 from . import astrophys, cgs, dimensionless_unscaled, misc, si
-from .core import Unit, UnitsError
+from .core import Unit
+from .errors import UnitsError
 from .function import units as function_units
 
 __all__ = [

--- a/astropy/units/errors.py
+++ b/astropy/units/errors.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Custom errors and exceptions for astropy.units."""
+
+__all__ = [
+    "UnitsError",
+    "UnitConversionError",
+    "UnitScaleError",
+    "UnitTypeError",
+    "UnitsWarning",
+]
+
+from astropy.utils.exceptions import AstropyWarning
+
+
+class UnitsError(Exception):
+    """
+    The base class for unit-specific exceptions.
+    """
+
+
+class UnitConversionError(UnitsError, ValueError):
+    """
+    Used specifically for errors related to converting between units or
+    interpreting units in terms of other units.
+    """
+
+
+class UnitScaleError(UnitsError, ValueError):
+    """
+    Used to catch the errors involving scaled units,
+    which are not recognized by FITS format.
+    """
+
+
+class UnitTypeError(UnitsError, TypeError):
+    """
+    Used specifically for errors in setting to units not allowed by a class.
+
+    E.g., would be raised if the unit of an `~astropy.coordinates.Angle`
+    instances were set to a non-angular unit.
+    """
+
+
+class UnitsWarning(AstropyWarning):
+    """
+    The base class for unit-specific warnings.
+    """

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from astropy.units.errors import UnitScaleError
 from astropy.utils import classproperty
 
 from . import core, generic, utils
@@ -73,7 +74,7 @@ class FITS(generic.Generic):
         base = np.log10(unit.scale)
 
         if base % 1.0 != 0.0:
-            raise core.UnitScaleError(
+            raise UnitScaleError(
                 "The FITS unit format is not able to represent scales "
                 "that are not powers of 10.  Multiply your data by "
                 f"{unit.scale:e}."

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -24,6 +24,7 @@ from copy import copy
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
+from astropy.units.errors import UnitScaleError, UnitsWarning
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
@@ -563,7 +564,7 @@ class Generic(Base):
             warnings.warn(
                 f"'{s}' contains multiple slashes, which is "
                 "discouraged by the FITS standard",
-                core.UnitsWarning,
+                UnitsWarning,
             )
         return result
 
@@ -598,8 +599,6 @@ class Generic(Base):
                 )
             raise ValueError()
         if unit in cls._deprecated_units:
-            from astropy.units.core import UnitsWarning
-
             message = (
                 f"The unit '{unit}' has been deprecated in the {cls.__name__} standard."
             )
@@ -646,8 +645,6 @@ class Generic(Base):
 
     @classmethod
     def _to_decomposed_alternative(cls, unit: UnitBase) -> str:
-        from astropy.units.core import UnitScaleError
-
         try:
             return cls.to_string(unit)
         except UnitScaleError:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -24,6 +24,7 @@ import warnings
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
+from astropy.units.errors import UnitsWarning
 from astropy.utils import classproperty, parsing
 
 from . import core, generic, utils
@@ -256,8 +257,6 @@ class OGIP(generic.Generic):
                 p[0] = p[1]
             # Can't use np.log10 here, because p[0] may be a Python long.
             if math.log10(p[0]) % 1.0 != 0.0:
-                from astropy.units.core import UnitsWarning
-
                 warnings.warn(
                     f"'{p[0]}' scale should be a power of 10 in OGIP format",
                     UnitsWarning,
@@ -364,7 +363,7 @@ class OGIP(generic.Generic):
             if math.log10(unit.scale) % 1.0 != 0.0:
                 warnings.warn(
                     f"'{unit.scale}' scale should be a power of 10 in OGIP format",
-                    core.UnitsWarning,
+                    UnitsWarning,
                 )
 
         return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -9,6 +9,7 @@ import re
 import warnings
 from typing import TYPE_CHECKING
 
+from astropy.units.errors import UnitScaleError, UnitsWarning
 from astropy.utils import classproperty
 
 from . import core, generic, utils
@@ -87,7 +88,7 @@ class VOUnit(generic.Generic):
             return core.dimensionless_unscaled
         # Check for excess solidi, but exclude fractional exponents (allowed)
         if s.count("/") > 1 and s.count("/") - len(re.findall(r"\(\d+/\d+\)", s)) > 1:
-            raise core.UnitsError(
+            raise UnitsError(
                 f"'{s}' contains multiple slashes, which is "
                 "disallowed by the VOUnit standard."
             )
@@ -110,7 +111,7 @@ class VOUnit(generic.Generic):
                         f"Unit {t.value!r} not supported by the VOUnit standard. "
                         + cls._did_you_mean_units(t.value)
                     ),
-                    core.UnitsWarning,
+                    UnitsWarning,
                 )
 
                 return cls._def_custom_unit(t.value)
@@ -198,13 +199,11 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def to_string(cls, unit, fraction=False):
-        from astropy.units import core
-
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
 
         if unit.physical_type == "dimensionless" and unit.scale != 1:
-            raise core.UnitScaleError(
+            raise UnitScaleError(
                 "The VOUnit format is not able to "
                 "represent scale for dimensionless units. "
                 f"Multiply your data by {unit.scale:e}."

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -22,15 +22,8 @@ from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyWarning
 
-from .core import (
-    Unit,
-    UnitBase,
-    UnitConversionError,
-    UnitsError,
-    UnitTypeError,
-    dimensionless_unscaled,
-    get_current_unit_registry,
-)
+from .core import Unit, UnitBase, dimensionless_unscaled, get_current_unit_registry
+from .errors import UnitConversionError, UnitsError, UnitTypeError
 from .format import Base, Latex
 from .quantity_helper import can_have_arbitrary_unit, check_output, converters_and_unit
 from .quantity_helper.function_helpers import (

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -5,12 +5,8 @@ import threading
 
 import numpy as np
 
-from astropy.units.core import (
-    UnitConversionError,
-    UnitsError,
-    UnitTypeError,
-    dimensionless_unscaled,
-)
+from astropy.units.core import dimensionless_unscaled
+from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 
 __all__ = [
     "can_have_arbitrary_unit",

--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -5,7 +5,8 @@
 from erfa import dt_eraASTROM, dt_eraLDBODY, dt_pv
 from erfa import ufunc as erfa_ufunc
 
-from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
+from astropy.units.core import dimensionless_unscaled
+from astropy.units.errors import UnitsError, UnitTypeError
 from astropy.units.structured import StructuredUnit
 
 from . import UFUNC_HELPERS

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -40,12 +40,8 @@ import operator
 import numpy as np
 from numpy.lib import recfunctions as rfn
 
-from astropy.units.core import (
-    UnitConversionError,
-    UnitsError,
-    UnitTypeError,
-    dimensionless_unscaled,
-)
+from astropy.units.core import dimensionless_unscaled
+from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.utils import isiterable
 from astropy.utils.compat import (
     COPY_IF_NEEDED,

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -11,13 +11,8 @@ from fractions import Fraction
 
 import numpy as np
 
-from astropy.units.core import (
-    UnitConversionError,
-    UnitsError,
-    UnitTypeError,
-    dimensionless_unscaled,
-    unit_scale_converter,
-)
+from astropy.units.core import dimensionless_unscaled, unit_scale_converter
+from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1
 
 if NUMPY_LT_2_0:

--- a/astropy/units/quantity_helper/scipy_special.py
+++ b/astropy/units/quantity_helper/scipy_special.py
@@ -5,7 +5,8 @@ Available ufuncs in this module are at
 https://docs.scipy.org/doc/scipy/reference/special.html
 """
 
-from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
+from astropy.units.core import dimensionless_unscaled
+from astropy.units.errors import UnitsError, UnitTypeError
 
 from . import UFUNC_HELPERS
 from .helpers import (

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -11,7 +11,7 @@ from packaging.version import Version
 
 from astropy import units as u
 from astropy.io import fits
-from astropy.units.core import UnitsWarning
+from astropy.units import UnitsWarning
 from astropy.utils.data import (
     get_pkg_data_contents,
     get_pkg_data_filename,

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -27,8 +27,7 @@ from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
 from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.time import Time
-from astropy.units import Quantity
-from astropy.units.core import UnitsWarning
+from astropy.units import Quantity, UnitsWarning
 from astropy.utils import iers
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning


### PR DESCRIPTION
### Description

The custom exceptions and warnings `units` define are now in a separate `errors.py` file, analogous to e.g. [`astropy.coordinates.errors`](https://github.com/astropy/astropy/blob/814325422234527424bdc3b5942484cd776342ce/astropy/coordinates/errors.py) module. Moving them out from `units.core` helps avoiding import loops in `units` because importing unit exceptions and warnings no longer requires importing all of `core`. The change should be invisible for users because the exceptions and warnings are available from the `astropy.units` namespace both with and without this change. 

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
