### PR TITLE
DOC: ensure created FITS file length is a multiple of 2880 bytes

### DIFF
--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -325,7 +325,11 @@ like so:
         # (this example is assuming a 64-bit float)
         # The -1 is to account for the final byte that we are about to
         # write:
-        fobj.seek(len(header.tostring()) + (40000 * 40000 * 8) - 1)
+        file_length = len(header.tostring()) + (40000 * 40000 * 8) - 1
+        # FITS files must be a multiple of 2880 bytes long
+        if file_length % 2880 != 0:
+            file_length = (file_length // 2880 + 1) * 2880
+        fobj.seek(file_length)
         fobj.write(b"\0")
 
 More generally, this can be written:
@@ -334,9 +338,10 @@ More generally, this can be written:
 
     shape = tuple(header[f"NAXIS{ii}"] for ii in range(1, header["NAXIS"] + 1))
     with open("large.fits", "rb+") as fobj:
-        fobj.seek(
-            len(header.tostring()) + (np.prod(shape) * np.abs(header["BITPIX"] // 8)) - 1
-        )
+        file_length = len(header.tostring()) + (np.prod(shape) * np.abs(header["BITPIX"] // 8)) - 1
+        if file_length % 2880 != 0:
+            file_length = (file_length // 2880 + 1) * 2880
+        fobj.seek(file_length)
         fobj.write(b"\0")
 
 On modern operating systems this will cause the file (past the header) to be

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -323,12 +323,10 @@ like so:
         # Data we want to write.
         # 8 is the number of bytes per value, i.e. abs(header['BITPIX'])/8
         # (this example is assuming a 64-bit float)
-        # The -1 is to account for the final byte that we are about to
-        # write:
-        file_length = len(header.tostring()) + (40000 * 40000 * 8) - 1
-        # FITS files must be a multiple of 2880 bytes long
-        if file_length % 2880 != 0:
-            file_length = (file_length // 2880 + 1) * 2880
+        file_length = len(header.tostring()) + (40000 * 40000 * 8)
+        # FITS files must be a multiple of 2880 bytes long; the final -1
+        # is to account for the final byte that we are about to write.
+        file_length = ((file_length + 2880 - 1) // 2880) * 2880 - 1
         fobj.seek(file_length)
         fobj.write(b"\0")
 
@@ -338,9 +336,8 @@ More generally, this can be written:
 
     shape = tuple(header[f"NAXIS{ii}"] for ii in range(1, header["NAXIS"] + 1))
     with open("large.fits", "rb+") as fobj:
-        file_length = len(header.tostring()) + (np.prod(shape) * np.abs(header["BITPIX"] // 8)) - 1
-        if file_length % 2880 != 0:
-            file_length = (file_length // 2880 + 1) * 2880
+        file_length = len(header.tostring()) + (np.prod(shape) * np.abs(header["BITPIX"] // 8))
+        file_length = ((file_length + 2880 - 1) // 2880) * 2880 - 1
         fobj.seek(file_length)
         fobj.write(b"\0")
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

I used the code provided in the FAQ to create a large FITS file (see the code block below). However, when I open the created FITS file, I get an `AstropyUserWarning: File may have been truncated: actual file length (400002880) is smaller than the expected size (400003200)`. I then learned the fact that  

> FITS file should always be written with blocks of 2880 bytes

from https://github.com/astropy/astropy/issues/13356#issuecomment-1159813796.

https://github.com/astropy/astropy/blob/f72f8664c32f4fb84a15d242c8f516e2fd057fd4/docs/io/fits/appendix/faq.rst?plain=1#L249-L370

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to make sure the file length was a multiple of 2880 bytes before creating the FITS file.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
