### PR TITLE
Move `decompose_to_known_units()` implementation to `Generic`

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -21,14 +21,13 @@ from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
-from . import utils
 from .generic import Generic
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
     from astropy.extern.ply.lex import Lexer
-    from astropy.units import UnitBase
+    from astropy.units import NamedUnit, UnitBase
     from astropy.utils.parsing import ThreadSafeParser
 
 
@@ -278,6 +277,10 @@ class CDS(Generic):
         return cls._do_parse(s, debug)
 
     @classmethod
+    def _get_unit_name(cls, unit: NamedUnit) -> str:
+        return unit.get_format_name(cls.name)
+
+    @classmethod
     def _format_mantissa(cls, m: str) -> str:
         return "" if m == "1" else m
 
@@ -296,9 +299,7 @@ class CDS(Generic):
         cls, unit: UnitBase, fraction: bool | Literal["inline"] = False
     ) -> str:
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(
-            unit, lambda x: x.get_format_name(cls.name)
-        )
+        unit = cls._decompose_to_known_units(unit)
 
         if not unit.bases:
             if unit.scale == 1:

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -67,7 +67,7 @@ class FITS(generic.Generic):
     @classmethod
     def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
+        unit = cls._decompose_to_known_units(unit)
 
         parts = []
 

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -356,7 +356,7 @@ class OGIP(generic.Generic):
     @classmethod
     def to_string(cls, unit, fraction="inline"):
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
+        unit = cls._decompose_to_known_units(unit)
 
         if isinstance(unit, core.CompositeUnit):
             # Can't use np.log10 here, because p[0] may be a Python long.
@@ -371,7 +371,7 @@ class OGIP(generic.Generic):
     @classmethod
     def _to_decomposed_alternative(cls, unit):
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
+        unit = cls._decompose_to_known_units(unit)
 
         if isinstance(unit, core.CompositeUnit):
             # Can't use np.log10 here, because p[0] may be a Python long.

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -12,52 +12,9 @@ from typing import TYPE_CHECKING
 from astropy.units.utils import maybe_simple_fraction
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable, Sequence
+    from collections.abc import Generator, Iterable, Sequence
 
-    from astropy.units import UnitBase
     from astropy.units.typing import Real
-
-
-def decompose_to_known_units(
-    unit: UnitBase, func: Callable[[UnitBase], None]
-) -> UnitBase:
-    """
-    Partially decomposes a unit so it is only composed of units that
-    are "known" to a given format.
-
-    Parameters
-    ----------
-    unit : `~astropy.units.UnitBase` instance
-
-    func : callable
-        This function will be called to determine if a given unit is
-        "known".  If the unit is not known, this function should raise a
-        `ValueError`.
-
-    Returns
-    -------
-    unit : `~astropy.units.UnitBase` instance
-        A flattened unit.
-    """
-    from astropy.units import core
-
-    if isinstance(unit, core.CompositeUnit):
-        new_unit = core.Unit(unit.scale)
-        for base, power in zip(unit.bases, unit.powers):
-            new_unit = new_unit * decompose_to_known_units(base, func) ** power
-        return new_unit
-    elif isinstance(unit, core.NamedUnit):
-        try:
-            func(unit)
-        except ValueError:
-            if isinstance(unit, core.Unit):
-                return decompose_to_known_units(unit._represents, func)
-            raise
-        return unit
-    else:
-        raise TypeError(
-            f"unit argument must be a 'NamedUnit' or 'CompositeUnit', not {type(unit)}"
-        )
 
 
 def format_power(power: Real) -> str:

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -200,7 +200,7 @@ class VOUnit(generic.Generic):
     @classmethod
     def to_string(cls, unit, fraction=False):
         # Remove units that aren't known to the format
-        unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
+        unit = cls._decompose_to_known_units(unit)
 
         if unit.physical_type == "dimensionless" and unit.scale != 1:
             raise UnitScaleError(


### PR DESCRIPTION
### Description

Until now the function has been a unit formatter utility, but after implementing a very simple `_get_unit_name()` in the `CDS` formatter the utility would only ever be called with `cls._get_unit_name` as its second argument. The function should therefore be implemented as a class method in `Generic` instead.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
