### PR TITLE
Ensure any input masks to Masked are not ignored.

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -54,6 +54,7 @@ class Masked(NDArrayShapeMethods):
         a subclass of the type of ``data``.
     mask : array-like of bool, optional
         The initial mask to assign.  If not given, taken from the data.
+        If the data already has a mask, the masks are combined.
     copy : bool
         Whether the data and mask should be copied. Default: `False`.
 
@@ -121,6 +122,8 @@ class Masked(NDArrayShapeMethods):
         data, data_mask = cls._get_data_and_mask(data)
         if mask is None:
             mask = False if data_mask is None else data_mask
+        elif data_mask is not None:
+            mask = mask | data_mask
 
         masked_cls = cls._get_masked_cls(data.__class__)
         return masked_cls.from_unmasked(data, mask, copy)

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -122,6 +122,15 @@ class TestMaskedArrayInitialization(ArraySetup):
         assert ma.mask is not self.mask_sa
         assert np.may_share_memory(ma.mask, self.mask_sa)
 
+    def test_masked_input(self):
+        ma = Masked(self.a, mask=self.mask_a)
+        mab = Masked(ma, mask=self.mask_b)
+        assert isinstance(mab, np.ndarray)
+        assert isinstance(mab, type(self.sa))
+        assert isinstance(mab, Masked)
+        assert_array_equal(mab.unmasked, self.a)
+        assert_array_equal(mab.mask, self.mask_a | self.mask_b)
+
 
 def test_masked_ndarray_init():
     # Note: as a straight ndarray subclass, MaskedNDArray passes on

--- a/docs/changes/units/16875.api.rst
+++ b/docs/changes/units/16875.api.rst
@@ -1,0 +1,2 @@
+For ``Masked`` initialization in which a mask is passed in, ensure that that
+mask is combined with any mask present on the input.


### PR DESCRIPTION
Currently, if one runs `Masked(a, mask=m)`, the resulting masked array will have its mask set to `m`, independently of whether the input already had a mask. However, if no mask is given, the input mask is used. This seems rather illogical (and probably an oversight on my part).

EDIT: I'd consider this a bug fix if it didn't clearly change API as well, hence the API change label and 7.0 milestone.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
