### PR TITLE
Allow Masked instances as input for sigma clipping

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -610,20 +610,9 @@ class SigmaClip:
         """
         data = np.asanyarray(data)
 
-        if data.size == 0:
+        if data.size == 0 or np.all(getattr(data, "mask", np.False_)):
             if masked and not hasattr(data, "mask"):
                 result = np.ma.MaskedArray(data)
-            else:
-                result = data
-
-            if return_bounds:
-                return result, self._min_value, self._max_value
-            else:
-                return result
-
-        if isinstance(data, np.ma.MaskedArray) and data.mask.all():
-            if masked:
-                result = data
             else:
                 result = np.full(data.shape, np.nan)
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -243,6 +243,11 @@ def test_sigmaclip_fully_masked(masked_array):
     assert not hasattr(clipped_data, "mask")
     assert np.all(np.isnan(clipped_data))
 
+    clipped_data = sigma_clip(data, axis=1)
+    assert not isinstance(clipped_data, (Masked, np.ma.MaskedArray))
+    assert not hasattr(clipped_data, "mask")
+    assert np.all(np.isnan(clipped_data))
+
     clipped_data, low, high = sigma_clip(data, return_bounds=True)
     assert np.ma.allequal(data, clipped_data)
     assert np.isnan(low)

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -669,6 +669,11 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         """
         return self._data_cls
 
+    @property
+    def _data(self):
+        """Work-around for np.ma.getdata."""
+        return self.unmasked
+
     def view(self, dtype=None, type=None):
         """New view of the masked array.
 

--- a/docs/changes/stats/16876.feature.rst
+++ b/docs/changes/stats/16876.feature.rst
@@ -1,0 +1,1 @@
+``Masked`` instances can now be used in sigma clipping.


### PR DESCRIPTION
This pull request is to ensure that sigma clipping understands `Masked` instances -- part of the project to ensure that `Masked` can be used throughout astropy.

~It also fixes a small buglet in `Masked`, where if trying to determine the underlying data from a `MaskedColumn`, it would return a `MaskedArray` (because `MaskedColumn` overrides `data`).~ `stats` had a work-around for that which is now no longer needed.

~Note that this builds on #16875, so one can ignore the first commit.~ EDIT: with #16875 merged, this now stands on its own.

Opening as draft as I'm not sure the test coverage is quite up to snuff - I just made any tests with `MaskedArray` also run with `Masked`.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
