### PR TITLE
Clarify exception message for non-quantity input to ufuncs

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -323,6 +323,21 @@ class TestQuantityTrigonometricFuncs:
     def test_testwarns(self, tw):
         return test_testwarn(tw)
 
+    def test_sin_with_quantity_out(self):
+        # Test for a useful error message - see gh-16873.
+        # Non-quantity input should be treated as dimensionless and thus cannot
+        # be converted to radians.
+        out = u.Quantity(0)
+        with pytest.raises(AttributeError, match="is treated as dimensionless"):
+            np.sin(0.5, out=out)
+
+        # Except if we have the right equivalency in place.
+        with u.add_enabled_equivalencies(u.dimensionless_angles()):
+            result = np.sin(0.5, out=out)
+
+        assert result is out
+        assert result == np.sin(0.5) * u.dimensionless_unscaled
+
 
 class TestQuantityMathFuncs:
     """


### PR DESCRIPTION
This pull request is to improve the puzzling error message one can get if passing in both numbers and quantities to ufuncs, by adding an explanation (on purpose, the exception type and start of the message are not changed, to ensure this is not an API change -- there were tests in the unit package relying on it). cc @maxnoe

Before:
```
from erfa.ufunc import s2p
import astropy.units as u
s2p(0.5, 0.5, 5 * u.km)
AttributeError: 'NoneType' object has no attribute 'get_converter'
```
Now
```
AttributeError: 'NoneType' object has no attribute 'get_converter' (input without a 'unit' attribute? Such input is treated as dimensionless and cannot be converted to rad).
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16873

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
