### PR TITLE
Remove needless Ruff rule E402 violations

### DIFF
--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -8,6 +8,9 @@ from astropy import units as u
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat import COPY_IF_NEEDED
 
+from .earth import EarthLocation
+from .representation import BaseDifferential, CartesianRepresentation
+
 __all__ = [
     "Attribute",
     "TimeAttribute",
@@ -566,8 +569,3 @@ class DifferentialAttribute(Attribute):
                 )
 
         return value, True
-
-
-# do this here to prevent a series of complicated circular imports
-from .earth import EarthLocation  # noqa: E402
-from .representation import BaseDifferential, CartesianRepresentation  # noqa: E402


### PR DESCRIPTION
### Description

There are a few Ruff rule [E402 (module-import-not-at-top-of-file)](https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/) violations in `coordinates` that are currently being suppressed with [`noqa` instructions](https://docs.astral.sh/ruff/linter/#error-suppression). A 7 year old comment warns against moving the imports to the top of the file, but if we move them anyways it becomes apparent that the comment is outdated.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
