### PR TITLE
Set minimum pytest version to 8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ all = [
 test = [
     "coverage[toml]",
     "pre-commit",
-    "pytest>=7.0",
+    "pytest>=8.0",
     "pytest-doctestplus>=0.12",
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10",
@@ -116,7 +116,7 @@ docs = [
     "astropy[recommended]",  # installs the [recommended] dependencies
     "sphinx",
     "sphinx-astropy[confv2]>=1.9.1",
-    "pytest>=7.0",
+    "pytest>=8.0",
     "sphinx-changelog>=1.2.0",
     "sphinx_design",
     "Jinja2>=3.1.3",
@@ -191,7 +191,7 @@ namespaces = true
 write_to = "astropy/_version.py"
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "8.0"
 testpaths = [
     "astropy",
     "docs",


### PR DESCRIPTION
In recent tests, we are using `exc.add_note()`, which is available in python >=3.11. It turns out it is not supported by pytest < 8, however, so this PR increases the minimum pytest version to make it work.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16884

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
