### PR TITLE
Ensure exception notes are ignored for pytest < 8

### DIFF
--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -3,13 +3,15 @@
 Test Structured units and quantities specifically with the ERFA ufuncs.
 """
 
+import sys
+
 import numpy as np
 import pytest
 from erfa import ufunc as erfa_ufunc
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 
 
 def vvd(val, valok, dval, func, test, status):
@@ -127,7 +129,12 @@ class TestPVUfuncs:
         # Test for a useful error message - see gh-16873.
         # Non-quantity input should be treated as dimensionless and thus cannot
         # be converted to radians.
-        with pytest.raises(AttributeError, match="is treated as dimensionless"):
+        match = "'NoneType' object has no attribute 'get_converter'"
+        if not (PYTEST_LT_8_0 and sys.version_info >= (3, 11)):
+            # For python>=3.11, we use Exception.add_note, which
+            # pytest < 8 does not know how to deal with.
+            match += ".*\n.*treated as dimensionless"
+        with pytest.raises(AttributeError, match=match):
             erfa_ufunc.s2p(0.5, 0.5, 4 * u.km)
 
         # Except if we have the right equivalency in place.
@@ -542,7 +549,11 @@ class TestGeodetic:
     def test_unit_errors(self):
         """Test unit errors when dimensionless parameters are used"""
 
-        msg = "'NoneType'.*no attribute 'get_converter'.*\n.*treated as dimensionless"
+        msg = "'NoneType' object has no attribute 'get_converter'"
+        if not (PYTEST_LT_8_0 and sys.version_info >= (3, 11)):
+            # For python>=3.11, we use Exception.add_note, which
+            # pytest < 8 does not know how to deal with.
+            msg += ".*\n.*treated as dimensionless"
         with pytest.raises(AttributeError, match=msg):
             erfa_ufunc.gc2gde(self.equatorial_radius_value, self.flattening, self.xyz)
         with pytest.raises(AttributeError, match=msg):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import dataclasses
+import sys
 import warnings
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -14,6 +15,7 @@ from erfa import ufunc as erfa_ufunc
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
+from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
@@ -328,7 +330,12 @@ class TestQuantityTrigonometricFuncs:
         # Non-quantity input should be treated as dimensionless and thus cannot
         # be converted to radians.
         out = u.Quantity(0)
-        with pytest.raises(AttributeError, match="is treated as dimensionless"):
+        match = "'NoneType' object has no attribute 'get_converter'"
+        if not (PYTEST_LT_8_0 and sys.version_info >= (3, 11)):
+            # For python>=3.11, we use Exception.add_note, which
+            # pytest < 8 does not know how to deal with.
+            match += ".*\n.*treated as dimensionless"
+        with pytest.raises(AttributeError, match=match):
             np.sin(0.5, out=out)
 
         # Except if we have the right equivalency in place.


### PR DESCRIPTION
As an alternative to #16885, which requires pytest >=8, this PR ensures exception notes are ignored for pytest < 8. This maybe is the easiest fix, since #16885 really should include removing any usage of `PYTEST_LT_8_0`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16884

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
