### PR TITLE
MNT: New CFITSIO 4.5.0 released (no code change)

### DIFF
--- a/cextern/README.rst
+++ b/cextern/README.rst
@@ -5,4 +5,3 @@ This directory contains C libraries included with Astropy. Note that only C
 libraries without python-specific code  should be included in this directory.
 Cython or C code intended for use with Astropy or wrapper code should be in
 the Astropy source tree.
-

--- a/cextern/cfitsio/ChangeLog
+++ b/cextern/cfitsio/ChangeLog
@@ -1,5 +1,18 @@
                    Log of Changes Made to CFITSIO
                    
+Version 4.5.0 - Aug 2024
+
+  - Conversion of CFITSIO configure/build files to better conform with
+    automake and libtool.
+
+  - Bug fix for case of bit column output in string format on clang
+    compilers with high optimization.
+    
+  - Added compiler macro support to improve builds on loongarch64 and on
+    Gnu/Hurd kernels. 
+  
+  - Bug fix to fitsverify utility.
+                   
 Version 4.4.1 - Jun 2024
 
   - Removed NOSA license and restored previous license file

--- a/cextern/trim_cfitsio.sh
+++ b/cextern/trim_cfitsio.sh
@@ -4,7 +4,7 @@ set -euv
 
 # This script should be run every time cfitsio is updated.
 # This moves all the code needed for the actual library to lib
-# and deletes everything else (except License.txt and doc/changes.txt)
+# and deletes everything else (except License.txt and ChangeLog)
 
 # So, the standard update would be to execute, from this directory,
 # rm -rf cfitsio
@@ -23,6 +23,7 @@ mv cfitsio/quantize.c cfitsio/lib/
 mv cfitsio/ricecomp.c cfitsio/lib/
 
 rm -f cfitsio/README
+rm -f cfitsio/INSTALL
 rm -f cfitsio/configure
 rm -f cfitsio/install-sh
 rm -f cfitsio/docs/*.tex
@@ -30,8 +31,11 @@ rm -f cfitsio/docs/*.ps
 rm -f cfitsio/docs/*.pdf
 rm -f cfitsio/docs/*.doc
 rm -f cfitsio/docs/*.toc
+rm -f cfitsio/docs/*.odt
 rm -rf cfitsio/[^L]*.*
 rm -rf cfitsio/utilities
+rm -rf cfitsio/config
+rm -rf cfitsio/m4
 
 # We only use a very small subset of fitsio2.h, so here we generate that
 # file. If there are compilation issues after updating, it may be that


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to update script for CFITSIO 4.5.0. No real code is changed (assuming we do not need whatever they put in `config` or `m4`).

Version: 4.5.0
SONAME: 1

#### Change log

Version 4.5.0 - Aug 2024

  - Conversion of CFITSIO configure/build files to better conform with automake and libtool.
  - Bug fix for case of bit column output in string format on clang compilers with high optimization.
  - Added compiler macro support to improve builds on loongarch64 and on Gnu/Hurd kernels. 
  - Bug fix to fitsverify utility.
                   
(For complete change log information, see https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/docs/changes.txt .)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
