### PR TITLE
MNT: update ruff (0.5->0.6), adjust configuration, apply `PT001`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.7
+    rev: v0.6.2
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -116,7 +116,6 @@ lint.ignore = [
     "PLW2901",  # redefined-loop-name
 
     # flake8-pytest-style (PT)
-    "PT001",   # pytest-fixture-incorrect-parentheses-style # updated in ruff 0.6.0
     "PT003",   # pytest-extraneous-scope-function
     "PT004",   # pytest-missing-fixture-name-underscore # deprecated in ruff 0.6.0
     "PT006",   # pytest-parametrize-names-wrong-type
@@ -126,7 +125,6 @@ lint.ignore = [
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion
     "PT022",   # pytest-useless-yield-fixture
-    "PT023",   # pytest-incorrect-mark-parentheses-style # updated in ruff 0.6.0
 
     # flake8-use-pathlib (PTH)
     "PTH100",  # os-path-abspath

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -69,12 +69,12 @@ ROTATIONS = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def inputs():
     return 0.3, 0.4
 
 
-@pytest.fixture()
+@pytest.fixture
 def inputs_math():
     return 1, -0.5
 

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -228,7 +228,7 @@ def _get_test_table():
     return T
 
 
-@pytest.fixture()
+@pytest.fixture
 def T1b(request):
     """Basic table"""
     T = _get_test_table()

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1395,7 +1395,7 @@ def header_polarized():
     return Header.fromstring(HEADER_POLARIZED, sep="\n")
 
 
-@pytest.fixture()
+@pytest.fixture
 def wcs_polarized(header_polarized):
     return WCS(header_polarized)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -369,6 +369,10 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # pandas-vet (PD)
     "PD",
 
+    # pylint (PLR and PLW)
+    "PLR1730", # if-stmt-min-max (not always clearer, and sometimes slower)
+    "PLW0642", # self-or-cls-assignment (occasionally desirable, very rarely a mistake)
+
     # flake8-simplify (SIM)
     "SIM103", # needless-bool (cannot be safely applied in all contexts (np.True_ is not True))
 


### PR DESCRIPTION
### Description
Close #16863

rule `PT001` was changed in this version (see https://astral.sh/blog/ruff-v0.6.0#default-behavior-changed-for-flake8-pytest-style-rules), and now the autofix aligns with our dominant convention to write `@pytest.fixture` instead of `@pytest.fixture()`, so I un-ignored it and applied the auto fix.
Same goes with rule `PT023`, except that there's already nothing to fix.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
