### PR TITLE
Support zero-width columns

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -690,13 +690,6 @@ class FITS_rec(np.recarray):
         name = column.name
         format = column.format
 
-        if format.dtype.itemsize == 0:
-            warnings.warn(
-                f"Field {key!r} has a repeat count of 0 in its format code, "
-                "indicating an empty field."
-            )
-            return np.array([], dtype=format.dtype)
-
         # If field's base is a FITS_rec, we can run into trouble because it
         # contains a reference to the ._coldefs object of the original data;
         # this can lead to a circular reference; see ticket #49

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -248,11 +248,7 @@ No differences found.
         tmp_d = self.temp("sub/")
         assert fitsdiff.main(["-q", self.data_dir, tmp_d]) == 1
         assert fitsdiff.main(["-q", tmp_d, self.data_dir]) == 1
-        with pytest.warns(
-            UserWarning,
-            match=r"Field 'ORBPARM' has a repeat count of 0 in its format code",
-        ):
-            assert fitsdiff.main(["-q", self.data_dir, self.data_dir]) == 0
+        assert fitsdiff.main(["-q", self.data_dir, self.data_dir]) == 0
 
         # no match
         tmp_c = self.data("arange.fits")
@@ -261,11 +257,7 @@ No differences found.
         assert "'arange.fits' has no match in" in err
 
         # globbing
-        with pytest.warns(
-            UserWarning,
-            match=r"Field 'ORBPARM' has a repeat count of 0 in its format code",
-        ):
-            assert fitsdiff.main(["-q", self.data_dir + "/*.fits", self.data_dir]) == 0
+        assert fitsdiff.main(["-q", self.data_dir + "/*.fits", self.data_dir]) == 0
         assert fitsdiff.main(["-q", self.data_dir + "/g*.fits", tmp_d]) == 0
 
         # one file and a directory

--- a/docs/changes/io.fits/16894.bugfix.rst
+++ b/docs/changes/io.fits/16894.bugfix.rst
@@ -1,0 +1,1 @@
+Fix reading zero-width columns such as 0A fields.


### PR DESCRIPTION
Some catalogs written by TOPCAT contain zero-width string columns as such 0A fields, which is valid but `io.fits` refused to read it. Issue was reported in #7386. 
The fix here only addresses `io.fits` but reading such a file with `Table.read` will still lead to a crash, not sure how to fix it.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
