### PR TITLE
BUG: solve problems for table with zero sized string columns

### DIFF
--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1116,3 +1116,14 @@ def test_unsigned_int_dtype_propagation_for_zero_length_table():
     hdu = BinTableHDU(tbl)
     tbl2 = Table.read(hdu)
     assert tbl.dtype == tbl2.dtype
+
+
+@pytest.mark.parametrize("table_type", [Table, QTable])
+def test_zero_length_string_columns_can_be_read_into_table(table_type, tmp_path):
+    filename = tmp_path / "zerodtable.fits"
+    data = np.array([("", 12)], dtype=[("a", "S"), ("b", "i4")])
+    hdu = fits.BinTableHDU(data)
+    hdu.writeto(filename)
+    t = table_type.read(filename)
+    assert t["a"].dtype.itemsize == 0
+    assert t["a"].dtype == data["a"].dtype

--- a/astropy/io/registry/core.py
+++ b/astropy/io/registry/core.py
@@ -225,7 +225,7 @@ class UnifiedInputRegistry(_UnifiedIORegistryBase):
                 # registered.  This returns the parent class, so try coercing
                 # to desired subclass.
                 try:
-                    data = cls(data)
+                    data = cls(data, copy=False)
                 except Exception:
                     raise TypeError(
                         f"could not convert reader output to {cls.__name__} class."

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -449,7 +449,10 @@ class TableFormatter:
             i_centers.append(n_header)
             n_header += 1
             if dtype is not None:
-                col_dtype = dtype_info_name((dtype, multidims))
+                # For zero-length strings, np.dtype((dtype, ())) does not work;
+                # see https://github.com/numpy/numpy/issues/27301
+                # As a work-around, just omit the shape if there is none.
+                col_dtype = dtype_info_name((dtype, multidims) if multidims else dtype)
             else:
                 col_dtype = col.__class__.__qualname__ or "object"
             yield col_dtype

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1145,3 +1145,23 @@ def test_masked_unit_conversion():
     c = table.MaskedColumn([3.5, 2.4, 1.7], name="test", unit=u.km)
     c.convert_unit_to(u.m)
     assert c.unit == (c * 2.0).unit
+
+
+@pytest.mark.parametrize(
+    "copy",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="See https://github.com/numpy/numpy/issues/27301"
+            ),
+        ),
+    ],
+)
+def test_zero_length_strings(Column, copy):
+    # Easiest way to get a zero-sized byte string is with a structured dtype.
+    data = np.array([("", 12)], dtype=[("a", "S"), ("b", "i4")])
+    col = Column(data["a"], name="a", copy=copy)
+    assert col.dtype.itemsize == 0
+    assert col.dtype == data.dtype["a"]

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -1086,3 +1086,15 @@ def test_multidims_with_zero_dim():
         "   b             ",
     ]
     assert t.pformat_all(show_dtype=True) == exp
+
+
+def test_zero_length_string():
+    data = np.array([("", 12)], dtype=[("a", "S"), ("b", "i4")])
+    t = Table(data, copy=False)
+    exp = [
+        "  a      b  ",
+        "bytes0 int32",
+        "------ -----",
+        "          12",
+    ]
+    assert t.pformat_all(show_dtype=True) == exp

--- a/docs/changes/io.fits/16898.bugfix.rst
+++ b/docs/changes/io.fits/16898.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that ``QTable``, like ``Table``, can read zero-length string columns,
+and not convert them to length 1 strings. In the process, avoid a needless
+copy of all the data for ``QTable``.

--- a/docs/changes/table/16898.bugfix.rst
+++ b/docs/changes/table/16898.bugfix.rst
@@ -1,0 +1,2 @@
+Pretty-printing of Tables now also works in the presence of zero-length string
+columns (which sometimes are present in FITS tables).


### PR DESCRIPTION
This pull request is to address problems with zero-length string columns (see #16897), that they couldn't be pretty-printed, and that `QTable.read()` would turn them into size-1 strings. The latter is actually due to a numpy bug (https://github.com/numpy/numpy/issues/27301) in copying arrays, but it was strange that a copy was made anyway, so this is fixed by avoiding that in `io`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16897

xref https://github.com/astropy/astropy/issues/16899

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
