### PR TITLE
Simplify unit formatter code related to `_try_decomposed()`

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -627,16 +627,11 @@ class Generic(Base):
         msg : str
             A message with alternatives, or the empty string.
         """
+        return did_you_mean(unit, cls._units, fix=cls._fix_deprecated)
 
-        def fix_deprecated(x: str) -> list[str]:
-            if x not in cls._deprecated_units:
-                return [x]
-            results = [x + " (deprecated)"]
-            if (decomposed := cls._try_decomposed(cls._units[x])) is not None:
-                results.append(decomposed)
-            return results
-
-        return did_you_mean(unit, cls._units, fix=fix_deprecated)
+    @classmethod
+    def _fix_deprecated(cls, x: str) -> list[str]:
+        return [x + " (deprecated)" if x in cls._deprecated_units else x]
 
     @classmethod
     def _try_decomposed(cls, unit: UnitBase) -> str | None:

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -19,12 +19,10 @@ from __future__ import annotations
 import re
 import unicodedata
 import warnings
-from contextlib import suppress
-from copy import copy
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
-from astropy.units.errors import UnitScaleError, UnitsWarning
+from astropy.units.errors import UnitsWarning
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
@@ -642,23 +640,7 @@ class Generic(Base):
 
     @classmethod
     def _try_decomposed(cls, unit: UnitBase) -> str | None:
-        if (represents := getattr(unit, "_represents", None)) is not None:
-            with suppress(ValueError):
-                return cls._to_decomposed_alternative(represents)
-        if (decomposed := unit.decompose()) is not unit:
-            with suppress(ValueError):
-                return cls._to_decomposed_alternative(decomposed)
         return None
-
-    @classmethod
-    def _to_decomposed_alternative(cls, unit: UnitBase) -> str:
-        try:
-            return cls.to_string(unit)
-        except UnitScaleError:
-            scale = unit.scale
-            unit = copy(unit)
-            unit._scale = 1.0
-            return f"{cls.to_string(unit)} (with data multiplied by {scale})"
 
     @classmethod
     def _decompose_to_known_units(cls, unit: CompositeUnit | NamedUnit) -> UnitBase:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -18,7 +18,6 @@ FITS files
 
 from __future__ import annotations
 
-import copy
 import math
 import warnings
 from fractions import Fraction
@@ -367,20 +366,3 @@ class OGIP(generic.Generic):
                 )
 
         return super().to_string(unit, fraction=fraction)
-
-    @classmethod
-    def _to_decomposed_alternative(cls, unit):
-        # Remove units that aren't known to the format
-        unit = cls._decompose_to_known_units(unit)
-
-        if isinstance(unit, core.CompositeUnit):
-            # Can't use np.log10 here, because p[0] may be a Python long.
-            if math.log10(unit.scale) % 1.0 != 0.0:
-                scale = unit.scale
-                unit = copy.copy(unit)
-                unit._scale = 1.0
-                return (
-                    f"{generic._to_string(cls, unit)} (with data multiplied by {scale})"
-                )
-
-        return super().to_string(unit)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -210,3 +210,7 @@ class VOUnit(generic.Generic):
             )
 
         return super().to_string(unit, fraction=fraction)
+
+    @classmethod
+    def _try_decomposed(cls, unit: UnitBase) -> str:
+        return cls.to_string(unit._represents)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -212,5 +212,13 @@ class VOUnit(generic.Generic):
         return super().to_string(unit, fraction=fraction)
 
     @classmethod
+    def _fix_deprecated(cls, x: str) -> list[str]:
+        return (
+            [f"{x} (deprecated)", cls.to_string(cls._units[x]._represents)]
+            if x in cls._deprecated_units
+            else [x]
+        )
+
+    @classmethod
     def _try_decomposed(cls, unit: UnitBase) -> str:
         return cls.to_string(unit._represents)


### PR DESCRIPTION
### Description

The `Generic._try_decomposed()` method is only called with deprecated units (see `git grep --context=4 '\._try_decomposed'`). The following code example demonstrates that the current method can be replaced with a one-liner in `Generic` and a second one-liner implemented in `VOUnit`:
```python
from astropy.units.format import Generic, CDS, FITS, OGIP, VOUnit
for format_ in (Generic, CDS, FITS, OGIP):
    for unit in format_._deprecated_units:
        assert format_._try_decomposed(format_._units[unit]) is None
for unit_str in VOUnit._deprecated_units:
    unit = VOUnit._units[unit_str]
    assert VOUnit._try_decomposed(unit) == VOUnit.to_string(unit._represents)
```
Because `_try_decompose()` is the only code that calls `_to_decomposed_alternative()` then the implementations of the latter (in `Generic` and `OGIP`) can be safely removed.

The simpler `_try_decomposed()` implementations also allow the `fix_deprecated()` closure in `Generic._did_you_mean_units()` to be converted to class methods in `Generic` and `VOUnit`, neither of which has to call `_try_decomposed()` at runtime.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
