### PR TITLE
Use correct UCD for air wavelengths

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -132,7 +132,7 @@ CTYPE_TO_UCD1 = {
     "VRAD": "spect.dopplerVeloc.radio",  # Radio velocity
     "VOPT": "spect.dopplerVeloc.opt",  # Optical velocity
     "ZOPT": "src.redshift",  # Redshift
-    "AWAV": "em.wl",  # Air wavelength
+    "AWAV": "em.wl;obs.atmos",  # Air wavelength
     "VELO": "spect.dopplerVeloc",  # Apparent radial velocity
     "BETA": "custom:spect.doplerVeloc.beta",  # Beta factor (v/c)
     "STOKES": "phys.polarization.stokes",  # STOKES parameters


### PR DESCRIPTION
This PR corrects the universal content descriptor (UCD) that is assigned for wavelengths recorded in air. The existing `astropy` behaviour is incorrect.

The FITS standard uses 'AWAV' to indicate air wavelengths, and 'WAVE' to indicate vacuum wavelengths. When `astropy` creates a world coordinate system it specifies a UCD for the data. The [IVOA spectral data model](https://www.ivoa.net/documents/REC/DM/SpectrumDM-20071029.pdf) recommends that `em.wl` be used for vacuum wavelengths, and `em.wl;obs.atmos` be used to represent air wavelengths.

Currently, `astropy` ignores that and specifies the same UCD (`em.wl`) for wavelengths recorded in both air and vacuum. This means after the WCS is created, the user would need to go back to the original metadata to check whether it was recorded in air or vacuum.