### PR TITLE
removed unnecessary helper functions from io.ascii test file

### DIFF
--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
+
 __all__ = [
     "setup_function",
     "teardown_function",
@@ -16,6 +17,7 @@ def setup_function(function):
 
 def teardown_function(function):
     os.chdir(CWD)
+
 
 def assert_equal_splitlines(arg1, arg2):
     __tracebackhide__ = True

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -5,9 +5,6 @@ import os
 import numpy as np
 
 __all__ = [
-    "assert_equal",
-    "assert_almost_equal",
-    "assert_true",
     "setup_function",
     "teardown_function",
 ]
@@ -22,20 +19,6 @@ def setup_function(function):
 
 def teardown_function(function):
     os.chdir(CWD)
-
-
-# Compatibility functions to convert from nose to pytest
-def assert_equal(a, b):
-    assert a == b
-
-
-def assert_almost_equal(a, b, **kwargs):
-    assert np.allclose(a, b, **kwargs)
-
-
-def assert_true(a):
-    assert a
-
 
 def assert_equal_splitlines(arg1, arg2):
     __tracebackhide__ = True

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -1,9 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-
-import numpy as np
-
 __all__ = [
     "setup_function",
     "teardown_function",

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -502,9 +502,7 @@ def test_write_extra_skycoord_cols():
     for a, b in zip(lines[-2:], exp_output[-2:]):
         assert a[:18] == b[:18]
         assert a[30:42] == b[30:42]
-        assert_allclose(
-            np.fromstring(a[2:], sep=" "), np.fromstring(b[2:], sep=" ")
-        )
+        assert_allclose(np.fromstring(a[2:], sep=" "), np.fromstring(b[2:], sep=" "))
 
 
 def test_write_skycoord_with_format():

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -18,8 +19,6 @@ from astropy.table import Column, MaskedColumn, QTable, Table
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyWarning
-
-from .common import assert_almost_equal
 
 test_dat = [
     "names e d s i",
@@ -503,7 +502,7 @@ def test_write_extra_skycoord_cols():
     for a, b in zip(lines[-2:], exp_output[-2:]):
         assert a[:18] == b[:18]
         assert a[30:42] == b[30:42]
-        assert_almost_equal(
+        assert_allclose(
             np.fromstring(a[2:], sep=" "), np.fromstring(b[2:], sep=" ")
         )
 

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -2,13 +2,12 @@
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from astropy import units as u
 from astropy.io import ascii
 
 from .common import (
-    assert_almost_equal,
-    assert_equal,
     setup_function,  # noqa: F401
     teardown_function,  # noqa: F401
 )
@@ -34,39 +33,33 @@ def test_description():
     data = "data/cds/description/table.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 2)
-        assert_equal(table["Cluster"].description, "Cluster name")
-        assert_equal(table["Star"].description, "")
-        assert_equal(table["Wave"].description, "wave ? Wavelength in Angstroms")
-        assert_equal(table["El"].description, "a")
-        assert_equal(
-            table["ion"].description, "- Ionization stage (1 for neutral element)"
-        )
-        assert_equal(
-            table["loggf"].description,
+        assert len(table) == 2
+        assert table["Cluster"].description == "Cluster name"
+        assert table["Star"].description == ""
+        assert table["Wave"].description == "wave ? Wavelength in Angstroms"
+        assert table["El"].description == "a"
+        assert table["ion"].description == "- Ionization stage (1 for neutral element)"
+        assert table["loggf"].description == (
             "log10 of the gf value - logarithm base 10 of stat. weight times "
             "oscillator strength",
         )
-        assert_equal(table["EW"].description, "Equivalent width (in mA)")
-        assert_equal(
-            table["Q"].description, "DAOSPEC quality parameter Q (large values are bad)"
-        )
-
+        assert table["EW"].description == "Equivalent width (in mA)"
+        assert table["Q"].description == "DAOSPEC quality parameter Q (large values are bad)"
 
 def test_multi_header():
     readme = "data/cds/multi/ReadMe"
     data = "data/cds/multi/lhs2065.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 18)
-        assert_almost_equal(table["Lambda"][-1], 6479.32)
-        assert_equal(table["Fnu"][-1], "0.285937")
+        assert len(table) == 18
+        assert_allclose(table["Lambda"][-1], 6479.32)
+        assert table["Fnu"][-1] == "0.285937"
     data = "data/cds/multi/lp944-20.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 18)
-        assert_almost_equal(table["Lambda"][0], 6476.09)
-        assert_equal(table["Fnu"][-1], "0.489005")
+        assert len(table) == 18
+        assert_allclose(table["Lambda"][0], 6476.09)
+        assert table["Fnu"][-1] == "0.489005"
 
 
 def test_glob_header():
@@ -74,9 +67,9 @@ def test_glob_header():
     data = "data/cds/glob/lmxbrefs.dat"
     for read_table in (read_table1, read_table2, read_table3):
         table = read_table(readme, data)
-        assert_equal(len(table), 291)
-        assert_equal(table["Name"][-1], "J1914+0953")
-        assert_equal(table["BibCode"][-2], "2005A&A...432..235R")
+        assert len(table) == 291
+        assert table["Name"][-1] == "J1914+0953"
+        assert table["BibCode"][-2] == "2005A&A...432..235R"
 
 
 def test_header_from_readme():
@@ -204,7 +197,7 @@ def test_cds_function_units2(reader_cls):
     assert table["vturb"].unit == u.km / u.s
     assert table["[Fe/H]"].unit == u.dex(u.one)
     assert table["e_[Fe/H]"].unit == u.dex(u.one)
-    assert_almost_equal(
+    assert_allclose(
         table["[Fe/H]"].to(u.one), 10.0 ** (np.array([-2.07, -1.50, -2.11, -1.64]))
     )
 
@@ -216,9 +209,9 @@ def test_cds_ignore_nullable():
     data = "data/cds/null/table.dat"
     r = ascii.Cds(readme)
     r.read(data)
-    assert_equal(r.header.cols[6].description, "Temperature class codified (10)")
-    assert_equal(r.header.cols[8].description, "Luminosity class codified (11)")
-    assert_equal(r.header.cols[5].description, "Pericenter position angle (18)")
+    assert r.header.cols[6].description == "Temperature class codified (10)"
+    assert r.header.cols[8].description == "Luminosity class codified (11)"
+    assert r.header.cols[5].description == "Pericenter position angle (18)"
 
 
 def test_cds_no_whitespace():
@@ -228,15 +221,14 @@ def test_cds_no_whitespace():
     data = "data/cds/null/table1.dat"
     r = ascii.Cds(readme)
     r.read(data)
-    assert_equal(r.header.cols[6].description, "Temperature class codified (10)")
-    assert_equal(r.header.cols[6].null, "")
-    assert_equal(r.header.cols[7].description, "Equivalent width (in mA)")
-    assert_equal(r.header.cols[7].null, "-9.9")
-    assert_equal(
-        r.header.cols[10].description,
+    assert r.header.cols[6].description == "Temperature class codified (10)"
+    assert r.header.cols[6].null == ""
+    assert r.header.cols[7].description == "Equivalent width (in mA)"
+    assert r.header.cols[7].null == "-9.9"
+    assert r.header.cols[10].description == (
         "DAOSPEC quality parameter Q (large values are bad)",
     )
-    assert_equal(r.header.cols[10].null, "-9.999")
+    assert r.header.cols[10].null == "-9.999"
 
 
 def test_cds_order():
@@ -246,6 +238,6 @@ def test_cds_order():
     data = "data/cds/null/table1.dat"
     r = ascii.Cds(readme)
     r.read(data)
-    assert_equal(r.header.cols[5].description, "Catalogue Identification Number")
-    assert_equal(r.header.cols[8].description, "Another equivalent width (in mA)")
-    assert_equal(r.header.cols[9].description, "Luminosity class codified (11)")
+    assert r.header.cols[5].description == "Catalogue Identification Number"
+    assert r.header.cols[8].description == "Another equivalent width (in mA)"
+    assert r.header.cols[9].description == "Luminosity class codified (11)"

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -41,7 +41,7 @@ def test_description():
         assert table["ion"].description == "- Ionization stage (1 for neutral element)"
         assert table["loggf"].description == (
             "log10 of the gf value - logarithm base 10 of stat. weight times "
-            "oscillator strength",
+            "oscillator strength"
         )
         assert table["EW"].description == "Equivalent width (in mA)"
         assert table["Q"].description == "DAOSPEC quality parameter Q (large values are bad)"
@@ -226,7 +226,7 @@ def test_cds_no_whitespace():
     assert r.header.cols[7].description == "Equivalent width (in mA)"
     assert r.header.cols[7].null == "-9.9"
     assert r.header.cols[10].description == (
-        "DAOSPEC quality parameter Q (large values are bad)",
+        "DAOSPEC quality parameter Q (large values are bad)"
     )
     assert r.header.cols[10].null == "-9.999"
 

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -44,7 +44,11 @@ def test_description():
             "oscillator strength"
         )
         assert table["EW"].description == "Equivalent width (in mA)"
-        assert table["Q"].description == "DAOSPEC quality parameter Q (large values are bad)"
+        assert (
+            table["Q"].description
+            == "DAOSPEC quality parameter Q (large values are bad)"
+        )
+
 
 def test_multi_header():
     readme = "data/cds/multi/ReadMe"

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -184,7 +184,7 @@ def test_read_no_header_names_NoHeader():
     dat = ascii.read(
         table, format="fixed_width_no_header", names=("Name", "Phone", "TCP")
     )
-    assert tuple(dat.dtype.names) ("Name", "Phone", "TCP")
+    assert tuple(dat.dtype.names) == ("Name", "Phone", "TCP")
     assert dat[1][0] == "Mary"
     assert dat[0][1] == "555-1234"
     assert dat[2][2] == "192.168.1.9"

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -5,11 +5,12 @@ from io import StringIO
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from astropy.io import ascii
 from astropy.io.ascii.core import InconsistentTableError
 
-from .common import assert_almost_equal, assert_equal, assert_equal_splitlines
+from .common import assert_equal_splitlines
 
 
 def test_read_normal():
@@ -22,10 +23,10 @@ def test_read_normal():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    assert dat.colnames == ["Col1", "Col2"]
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == '"hello"'
+    assert dat[1][1] == "'s worlds"
 
 
 def test_read_normal_names():
@@ -38,8 +39,8 @@ def test_read_normal_names():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth, names=("name1", "name2"))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name2"])
-    assert_almost_equal(dat[1][0], 2.4)
+    assert dat.colnames == ["name1", "name2"]
+    assert_allclose(dat[1][0], 2.4)
 
 
 def test_read_normal_names_include():
@@ -56,9 +57,9 @@ def test_read_normal_names_include():
         include_names=("name1", "name3"),
     )
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name3"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], 3)
+    assert dat.colnames == ["name1", "name3"]
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == 3
 
 
 def test_read_normal_exclude():
@@ -71,8 +72,8 @@ def test_read_normal_exclude():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth, exclude_names=("Col1",))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col2"])
-    assert_equal(dat[1][0], "'s worlds")
+    assert dat.colnames == ["Col2"]
+    assert dat[1][0] == "'s worlds"
 
 
 def test_read_weird():
@@ -84,10 +85,10 @@ def test_read_weird():
 """
     reader = ascii.get_reader(reader_cls=ascii.FixedWidth)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hel')
-    assert_equal(dat[1][1], "df's wo")
+    assert dat.colnames == ["Col1", "Col2"]
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == '"hel'
+    assert dat[1][1] == "df's wo"
 
 
 def test_read_double():
@@ -99,10 +100,10 @@ def test_read_double():
 |   Bob  | 555-4527 | 192.168.1.9X|
 """
     dat = ascii.read(table, format="fixed_width", guess=False)
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    assert tuple(dat.dtype.names) == ("Name", "Phone", "TCP")
+    assert dat[1][0] == "Mary"
+    assert dat[0][1] == "555-1234"
+    assert dat[2][2] == "192.168.1.9"
 
 
 def test_read_space_delimiter():
@@ -114,10 +115,10 @@ def test_read_space_delimiter():
   Bob  555-4527     192.168.1.9
 """
     dat = ascii.read(table, format="fixed_width", guess=False, delimiter=" ")
-    assert_equal(tuple(dat.dtype.names), ("Name", "--Phone-", "----TCP-----"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    assert tuple(dat.dtype.names) == ("Name", "--Phone-", "----TCP-----")
+    assert dat[1][0] == "Mary"
+    assert dat[0][1] == "555-1234"
+    assert dat[2][2] == "192.168.1.9"
 
 
 def test_read_no_header_autocolumn():
@@ -130,10 +131,10 @@ def test_read_no_header_autocolumn():
     dat = ascii.read(
         table, format="fixed_width", guess=False, header_start=None, data_start=0
     )
-    assert_equal(tuple(dat.dtype.names), ("col1", "col2", "col3"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    assert tuple(dat.dtype.names) == ("col1", "col2", "col3")
+    assert dat[1][0] == "Mary"
+    assert dat[0][1] == "555-1234"
+    assert dat[2][2] == "192.168.1.9"
 
 
 def test_read_no_header_names():
@@ -152,10 +153,10 @@ def test_read_no_header_names():
         data_start=0,
         names=("Name", "Phone", "TCP"),
     )
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    assert tuple(dat.dtype.names) == ("Name", "Phone", "TCP")
+    assert dat[1][0] == "Mary"
+    assert dat[0][1] == "555-1234"
+    assert dat[2][2] == "192.168.1.9"
 
 
 def test_read_no_header_autocolumn_NoHeader():
@@ -166,10 +167,10 @@ def test_read_no_header_autocolumn_NoHeader():
 |   Bob  | 555-4527 | 192.168.1.9|
 """
     dat = ascii.read(table, format="fixed_width_no_header")
-    assert_equal(tuple(dat.dtype.names), ("col1", "col2", "col3"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    assert tuple(dat.dtype.names) == ("col1", "col2", "col3")
+    assert dat[1][0] == "Mary"
+    assert dat[0][1] == "555-1234"
+    assert dat[2][2] == "192.168.1.9"
 
 
 def test_read_no_header_names_NoHeader():
@@ -183,10 +184,10 @@ def test_read_no_header_names_NoHeader():
     dat = ascii.read(
         table, format="fixed_width_no_header", names=("Name", "Phone", "TCP")
     )
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[0][1], "555-1234")
-    assert_equal(dat[2][2], "192.168.1.9")
+    assert tuple(dat.dtype.names) ("Name", "Phone", "TCP")
+    assert dat[1][0] == "Mary"
+    assert dat[0][1] == "555-1234"
+    assert dat[2][2] == "192.168.1.9"
 
 
 def test_read_col_starts():
@@ -205,11 +206,11 @@ def test_read_col_starts():
         col_starts=(0, 9, 18),
         col_ends=(5, 17, 28),
     )
-    assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-    assert_equal(dat[0][1], "555- 1234")
-    assert_equal(dat[1][0], "Mary")
-    assert_equal(dat[1][2], "192.168.1.")
-    assert_equal(dat[2][2], "192.168.1")  # col_end=28 cuts this column off
+    assert tuple(dat.dtype.names) == ("Name", "Phone", "TCP")
+    assert dat[0][1] == "555- 1234"
+    assert dat[1][0] == "Mary"
+    assert dat[1][2] == "192.168.1."
+    assert dat[2][2] == "192.168.1"  # col_end=28 cuts this column off
 
 
 def test_read_detect_col_starts_or_ends():
@@ -230,11 +231,11 @@ def test_read_detect_col_starts_or_ends():
             names=("Name", "Phone", "TCP"),
             **kwargs,
         )
-        assert_equal(tuple(dat.dtype.names), ("Name", "Phone", "TCP"))
-        assert_equal(dat[0][1], "555- 1234")
-        assert_equal(dat[1][0], "Mary")
-        assert_equal(dat[1][2], "192.168.1.123")
-        assert_equal(dat[3][2], "192.255.255.255")
+        assert tuple(dat.dtype.names) == ("Name", "Phone", "TCP")
+        assert dat[0][1] == "555- 1234"
+        assert dat[1][0] == "Mary"
+        assert dat[1][2] == "192.168.1.123"
+        assert dat[3][2] == "192.255.255.255"
 
 
 def test_read_fill_values_and_reassign_colname():
@@ -252,11 +253,11 @@ def test_read_fill_values_and_reassign_colname():
         fill_values=[("-999.0", "0", "b"), ("N/A", "0", "c"), ("N/A", "0", "b")],
         names=["a", "b", "c"],
     )
-    assert_equal(dat.colnames, ["a", "b", "c"])
+    assert dat.colnames == ["a", "b", "c"]
     assert dat[1][1] is np.ma.masked
     assert dat[1][2] is np.ma.masked
     assert dat[2][1] is np.ma.masked
-    assert_almost_equal(dat[0][1], 1.5)
+    assert_allclose(dat[0][1], 1.5)
 
 
 table = """\
@@ -418,10 +419,10 @@ def test_read_twoline_normal():
   2.4   's worlds
 """
     dat = ascii.read(table, format="fixed_width_two_line")
-    assert_equal(dat.dtype.names, ("Col1", "Col2"))
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    assert dat.dtype.names == ("Col1", "Col2")
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == '"hello"'
+    assert dat[1][1] == "'s worlds"
 
 
 def test_read_twoline_ReST():
@@ -441,10 +442,10 @@ def test_read_twoline_ReST():
         position_line=2,
         data_end=-1,
     )
-    assert_equal(dat.dtype.names, ("Col1", "Col2"))
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    assert dat.dtype.names == ("Col1", "Col2")
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == '"hello"'
+    assert dat[1][1] == "'s worlds"
 
 
 def test_read_twoline_human():
@@ -467,10 +468,10 @@ def test_read_twoline_human():
         data_start=3,
         data_end=-1,
     )
-    assert_equal(dat.dtype.names, ("Col1", "Col2"))
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    assert dat.dtype.names == ("Col1", "Col2")
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == '"hello"'
+    assert dat[1][1] == "'s worlds"
 
 
 def test_read_twoline_fail():

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -8,6 +8,7 @@ from io import BytesIO, StringIO
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from astropy import table
 from astropy.io import ascii
@@ -25,9 +26,6 @@ from astropy.utils.exceptions import AstropyWarning
 
 # setup/teardown function to have the tests run in the correct directory
 from .common import (
-    assert_almost_equal,
-    assert_equal,
-    assert_true,
     setup_function,  # noqa: F401
     teardown_function,  # noqa: F401
 )
@@ -219,9 +217,9 @@ def test_read_all_files(fast_reader, path_format, home_is_data):
                 if "inputter_cls" not in test_opts:  # fast reader doesn't allow this
                     test_opts["fast_reader"] = fast_reader
             table = ascii.read(testfile["name"], **test_opts)
-            assert_equal(table.dtype.names, testfile["cols"])
+            assert table.dtype.names == testfile["cols"]
             for colname in table.dtype.names:
-                assert_equal(len(table[colname]), testfile["nrows"])
+                assert len(table[colname]) == testfile["nrows"]
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -249,9 +247,9 @@ def test_read_all_files_via_table(fast_reader, path_format, home_is_data):
             if f"fast_{format}" in core.FAST_CLASSES:
                 test_opts["fast_reader"] = fast_reader
             table = Table.read(testfile["name"], format=format, **test_opts)
-            assert_equal(table.dtype.names, testfile["cols"])
+            assert table.dtype.names == testfile["cols"]
             for colname in table.dtype.names:
-                assert_equal(len(table[colname]), testfile["nrows"])
+                assert len(table[colname]) == testfile["nrows"]
 
 
 def test_guess_all_files():
@@ -268,9 +266,9 @@ def test_guess_all_files():
                 k: v for k, v in testfile["opts"].items() if k not in filter_read_opts
             }
             table = ascii.read(testfile["name"], guess=True, **guess_opts)
-            assert_equal(table.dtype.names, testfile["cols"])
+            assert table.dtype.names == testfile["cols"]
             for colname in table.dtype.names:
-                assert_equal(len(table[colname]), testfile["nrows"])
+                assert len(table[colname]) == testfile["nrows"]
 
 
 def test_validate_read_kwargs():
@@ -332,9 +330,9 @@ def test_daophot_header_keywords():
     keywords = table.meta["keywords"]  # Ordered dict of keyword structures
     for name, value, units, format_ in expected_keywords:
         keyword = keywords[name]
-        assert_equal(keyword["value"], value)
-        assert_equal(keyword["units"], units)
-        assert_equal(keyword["format"], format_)
+        assert keyword["value"] == value
+        assert keyword["units"] == units
+        assert keyword["format"] == format_
 
 
 def test_daophot_multiple_aperture():
@@ -395,7 +393,7 @@ def test_set_names(fast_reader):
     data = ascii.read(
         "data/simple3.txt", names=names, delimiter="|", fast_reader=fast_reader
     )
-    assert_equal(data.dtype.names, names)
+    assert data.dtype.names == names
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -409,7 +407,7 @@ def test_set_include_names(fast_reader):
         delimiter="|",
         fast_reader=fast_reader,
     )
-    assert_equal(data.dtype.names, include_names)
+    assert data.dtype.names == include_names
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -421,19 +419,19 @@ def test_set_exclude_names(fast_reader):
         delimiter="|",
         fast_reader=fast_reader,
     )
-    assert_equal(data.dtype.names, ("obsid", "redshift", "X", "rad"))
+    assert data.dtype.names == ("obsid", "redshift", "X", "rad")
 
 
 def test_include_names_daophot():
     include_names = ("ID", "MAG", "PIER")
     data = ascii.read("data/daophot.dat", include_names=include_names)
-    assert_equal(data.dtype.names, include_names)
+    assert data.dtype.names == include_names
 
 
 def test_exclude_names_daophot():
     exclude_names = ("ID", "YCENTER", "MERR", "NITER", "CHI", "PERROR")
     data = ascii.read("data/daophot.dat", exclude_names=exclude_names)
-    assert_equal(data.dtype.names, ("XCENTER", "MAG", "MSKY", "SHARPNESS", "PIER"))
+    assert data.dtype.names == ("XCENTER", "MAG", "MSKY", "SHARPNESS", "PIER")
 
 
 def test_custom_process_lines():
@@ -445,8 +443,8 @@ def test_custom_process_lines():
     reader = ascii.get_reader(delimiter="|")
     reader.inputter.process_lines = process_lines
     data = reader.read("data/bars_at_ends.txt")
-    assert_equal(data.dtype.names, ("obsid", "redshift", "X", "Y", "object", "rad"))
-    assert_equal(len(data), 3)
+    assert data.dtype.names == ("obsid", "redshift", "X", "Y", "object", "rad")
+    assert len(data) == 3
 
 
 def test_custom_process_line():
@@ -459,7 +457,7 @@ def test_custom_process_line():
     reader.data.splitter.process_line = process_line
     data = reader.read("data/nls1_stackinfo.dbout")
     cols = get_testfiles("data/nls1_stackinfo.dbout")["cols"]
-    assert_equal(data.dtype.names, cols[1:])
+    assert data.dtype.names == cols[1:]
 
 
 def test_custom_splitters():
@@ -469,20 +467,20 @@ def test_custom_splitters():
     f = "data/test4.dat"
     data = reader.read(f)
     testfile = get_testfiles(f)
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
-    assert_almost_equal(data.field("zabs1.nh")[2], 0.0839710433091)
-    assert_almost_equal(data.field("p1.gamma")[2], 1.25997502704)
-    assert_almost_equal(data.field("p1.ampl")[2], 0.000696444029148)
-    assert_equal(data.field("statname")[2], "chi2modvar")
-    assert_almost_equal(data.field("statval")[2], 497.56468441)
+    assert data.dtype.names == testfile["cols"]
+    assert len(data) == testfile["nrows"]
+    assert_allclose(data.field("zabs1.nh")[2], 0.0839710433091)
+    assert_allclose(data.field("p1.gamma")[2], 1.25997502704)
+    assert_allclose(data.field("p1.ampl")[2], 0.000696444029148)
+    assert data.field("statname")[2] == "chi2modvar"
+    assert_allclose(data.field("statval")[2], 497.56468441)
 
 
 def test_start_end():
     data = ascii.read("data/test5.dat", header_start=1, data_start=3, data_end=-5)
-    assert_equal(len(data), 13)
-    assert_equal(data.field("statname")[0], "chi2xspecvar")
-    assert_equal(data.field("statname")[-1], "chi2gehrels")
+    assert len(data) == 13
+    assert data.field("statname")[0] == "chi2xspecvar"
+    assert data.field("statname")[-1] == "chi2gehrels"
 
 
 def test_set_converters():
@@ -491,8 +489,8 @@ def test_set_converters():
         "p1.gamma": [ascii.convert_numpy("str")],
     }
     data = ascii.read("data/test4.dat", converters=converters)
-    assert_equal(str(data["zabs1.nh"].dtype), "float32")
-    assert_equal(data["p1.gamma"][0], "1.26764500000")
+    assert str(data["zabs1.nh"].dtype) == "float32"
+    assert data["p1.gamma"][0] == "1.26764500000"
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -502,8 +500,8 @@ def test_from_string(fast_reader):
         table = fd.read()
     testfile = get_testfiles(f)[0]
     data = ascii.read(table, fast_reader=fast_reader, **testfile["opts"])
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
+    assert data.dtype.names == testfile["cols"]
+    assert len(data) == testfile["nrows"]
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -512,8 +510,8 @@ def test_from_filelike(fast_reader):
     testfile = get_testfiles(f)[0]
     with open(f, "rb") as fd:
         data = ascii.read(fd, fast_reader=fast_reader, **testfile["opts"])
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
+    assert data.dtype.names == testfile["cols"]
+    assert len(data) == testfile["nrows"]
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -523,15 +521,15 @@ def test_from_lines(fast_reader):
         table = fd.readlines()
     testfile = get_testfiles(f)[0]
     data = ascii.read(table, fast_reader=fast_reader, **testfile["opts"])
-    assert_equal(data.dtype.names, testfile["cols"])
-    assert_equal(len(data), testfile["nrows"])
+    assert data.dtype.names == testfile["cols"]
+    assert len(data) == testfile["nrows"]
 
 
 def test_comment_lines():
     table = ascii.get_reader(reader_cls=ascii.Rdb)
     data = table.read("data/apostrophe.rdb")
-    assert_equal(table.comment_lines, ["# first comment", "  # second comment"])
-    assert_equal(data.meta["comments"], ["first comment", "second comment"])
+    assert table.comment_lines == ["# first comment", "  # second comment"]
+    assert data.meta["comments"] == ["first comment", "second comment"]
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -541,10 +539,10 @@ def test_fill_values(fast_reader):
     data = ascii.read(
         f, fill_values=("a", "1"), fast_reader=fast_reader, **testfile["opts"]
     )
-    assert_true((data["a"].mask == [False, True]).all())
-    assert_true((data["a"] == [1, 1]).all())
-    assert_true((data["b"].mask == [False, True]).all())
-    assert_true((data["b"] == [2, 1]).all())
+    assert (data["a"].mask == [False, True]).all()
+    assert (data["a"] == [1, 1]).all()
+    assert (data["b"].mask == [False, True]).all()
+    assert (data["b"] == [2, 1]).all()
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -588,12 +586,12 @@ def test_fill_values_exclude_names(fast_reader):
 def check_fill_values(data):
     """compare array column by column with expectation"""
     assert not hasattr(data["a"], "mask")
-    assert_true((data["a"] == ["1", "a"]).all())
-    assert_true((data["b"].mask == [False, True]).all())
+    assert (data["a"] == ["1", "a"]).all()
+    assert (data["b"].mask == [False, True]).all()
     # Check that masked value is "do not care" in comparison
-    assert_true((data["b"] == [2, -999]).all())
+    assert (data["b"] == [2, -999]).all()
     data["b"].mask = False  # explicitly unmask for comparison
-    assert_true((data["b"] == [2, 1]).all())
+    assert (data["b"] == [2, 1]).all()
 
 
 @pytest.mark.parametrize("fast_reader", [True, False, "force"])
@@ -607,14 +605,14 @@ def test_fill_values_list(fast_reader):
         **testfile["opts"],
     )
     data["a"].mask = False  # explicitly unmask for comparison
-    assert_true((data["a"] == [42, 42]).all())
+    assert (data["a"] == [42, 42]).all()
 
 
 def test_masking_Cds_Mrt():
     f = "data/cds.dat"  # Tested for CDS and MRT
     for testfile in get_testfiles(f):
         data = ascii.read(f, **testfile["opts"])
-        assert_true(data["AK"].mask[0])
+        assert data["AK"].mask[0]
         assert not hasattr(data["Fit"], "mask")
 
 

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -3,12 +3,13 @@
 from io import StringIO
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 import astropy.units as u
 from astropy.io import ascii
 from astropy.table import QTable
 
-from .common import assert_almost_equal, assert_equal, assert_equal_splitlines
+from .common import assert_equal_splitlines
 
 
 def test_read_normal():
@@ -24,10 +25,10 @@ def test_read_normal():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], '"hello"')
-    assert_equal(dat[1][1], "'s worlds")
+    assert dat.colnames == ["Col1", "Col2"]
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == '"hello"'
+    assert dat[1][1] == "'s worlds"
 
 
 def test_read_normal_names():
@@ -43,8 +44,8 @@ def test_read_normal_names():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST, names=("name1", "name2"))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name2"])
-    assert_almost_equal(dat[1][0], 2.4)
+    assert dat.colnames == ["name1", "name2"]
+    assert_allclose(dat[1][0], 2.4)
 
 
 def test_read_normal_names_include():
@@ -64,9 +65,9 @@ def test_read_normal_names_include():
         include_names=("name1", "name3"),
     )
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["name1", "name3"])
-    assert_almost_equal(dat[1][0], 2.4)
-    assert_equal(dat[0][1], 3)
+    assert dat.colnames == ["name1", "name3"]
+    assert_allclose(dat[1][0], 2.4)
+    assert dat[0][1] == 3
 
 
 def test_read_normal_exclude():
@@ -81,8 +82,8 @@ def test_read_normal_exclude():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST, exclude_names=("Col1",))
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col2"])
-    assert_equal(dat[1][0], "'s worlds")
+    assert dat.colnames == ["Col2"]
+    assert dat[1][0] == "'s worlds"
 
 
 def test_read_unbounded_right_column():
@@ -98,8 +99,8 @@ def test_read_unbounded_right_column():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat[0][2], "Hello")
-    assert_equal(dat[1][2], "Worlds")
+    assert dat[0][2] == "Hello"
+    assert dat[1][2] == "Worlds"
 
 
 def test_read_unbounded_right_column_header():
@@ -115,7 +116,7 @@ def test_read_unbounded_right_column_header():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames[-1], "Col3Long")
+    assert dat.colnames[-1] == "Col3Long"
 
 
 def test_read_right_indented_table():
@@ -131,9 +132,9 @@ def test_read_right_indented_table():
 """
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
-    assert_equal(dat[0][2], "foo")
-    assert_equal(dat[1][0], 1)
+    assert dat.colnames == ["Col1", "Col2", "Col3"]
+    assert dat[0][2] == "foo"
+    assert dat[1][0] == 1
 
 
 def test_trailing_spaces_in_row_definition():
@@ -154,9 +155,9 @@ def test_trailing_spaces_in_row_definition():
 
     reader = ascii.get_reader(reader_cls=ascii.RST)
     dat = reader.read(table)
-    assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])
-    assert_equal(dat[0][2], "foo")
-    assert_equal(dat[1][0], 1)
+    assert dat.colnames == ["Col1", "Col2", "Col3"]
+    assert dat[0][2] == "foo"
+    assert dat[1][0] == 1
 
 
 table = """\

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -8,8 +8,6 @@ import pytest
 
 from astropy.io import ascii
 
-from .common import assert_equal
-
 
 def test_types_from_dat():
     converters = {"a": [ascii.convert_numpy(float)], "e": [ascii.convert_numpy(str)]}
@@ -30,7 +28,7 @@ def test_rdb_write_types():
     out = StringIO()
     ascii.write(dat, out, format="rdb")
     outs = out.getvalue().splitlines()
-    assert_equal(outs[1], "N\tN\tS\tN")
+    assert outs[1] == "N\tN\tS\tN"
 
 
 def test_ipac_read_types():
@@ -51,7 +49,7 @@ def test_ipac_read_types():
         ascii.StrType,
     ]
     for col, expected_type in zip(reader.cols, types):
-        assert_equal(col.type, expected_type)
+        assert col.type == expected_type
 
 
 def test_ipac_read_long_columns():

--- a/docs/changes/io.ascii/16908.bugfix.rst
+++ b/docs/changes/io.ascii/16908.bugfix.rst
@@ -1,0 +1,2 @@
+Removed needless functions from an io.ascii test helper file
+This PR addresses this issue and changes all instances of the removed functions in the test files.

--- a/docs/changes/io.ascii/16908.bugfix.rst
+++ b/docs/changes/io.ascii/16908.bugfix.rst
@@ -1,2 +1,0 @@
-Removed needless functions from an io.ascii test helper file
-This PR addresses this issue and changes all instances of the removed functions in the test files.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the needless functions in a helper file for io.ascii.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #15782

- assert_equal, assert_true and assert_almost_equal are removed from common.py
- all instances in test files are changed

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
