### PR TITLE
Implement TableElement.pop to allow deletion from VOTables

### DIFF
--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3509,6 +3509,32 @@ class TableElement(
     def iter_info(self):
         yield from self.infos
 
+    def pop(self, index=-1):
+        """
+        Remove and return item at index (default last).
+
+        Raises IndexError if list is empty or index is out of range.
+        """
+        # Ensure we're within bounds of the array
+        if abs(index) > len(self.array.data):
+            raise IndexError("pop index out of range")
+        # If negative indexing, convert to true index
+        elif index < 0:
+            index = len(self.array) + index
+
+        # Cache requested element before deletion
+        requested_element = np.ma.getdata(self.array)[index]
+
+        # Construct new copy of array without requested element
+        new_array = np.ma.masked_array(
+            np.delete(self.array, index), mask=np.delete(self.array.mask, index)
+        )
+        self.array = new_array
+        self._nrows = len(new_array)
+
+        # Return element that was popped
+        return requested_element
+
 
 class MivotBlock(Element):
     """

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2644,6 +2644,7 @@ class TableElement(
             mask = np.zeros((nrows,), dtype=descr_mask)
 
         self.array = ma.array(array, mask=mask)
+        self._nrows = nrows
 
     def _resize_strategy(self, size):
         """


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Hi Astropy Maintainers!

This pull request implements the ability to "pop" rows from the TableElement class in the VOTable implementation in astropy.

Specifically, this addresses a concern raised in https://github.com/astropy/pyvo/pull/470:

> I need to remove rows from registry query results. That's nasty because RegistryResults reads from the astropy.VOTable instance, and that doesn't support dropping rows so far for all I can see.

in an attempt to support the use case described by @trjaffe described [here](https://github.com/astropy/pyvo/pull/470#issuecomment-2230942121):

> Just to confirm, I think the other issue I ran into is something you mentioned in your blog post that is currently unsolved: doing a registry search, making some selection among the records, and then handing that edited list to the discoverer. I also show what I want to be able to do in the example code below... It’s part of a broader awkwardness handling these PyVO objects that are like lists but perhaps not enough like lists. This probably needs a separate issue and PR to address.

```
records = []
for s in services:
  # Doesn't matter what this is, just make a selection of a subset of services:  
  if "rosat" in s.res_description.lower() and "rass" in s.res_description.lower():
    records.append(s)
# How to create a RegistryResults object from a list of RegistryResource objects? 
selected_services = pyvo.registry.regtap.RegistryResults(records)
im_discoverer.set_services(selected_services)
```

From the external perspective, I seemed like a fairly glaring oversight that there wasn't any ability to actually modify which entries are in the VOTable without drilling all the way to editing the actual array values themselves. This PR is intended to implement the first of possibly a few different methods to conveniently allow users to drop rows (others could be `remove` and support index splicing) and spark discussion in case there were some historical reason why this may have been avoided in the past. The documentation explicitly says this table can be used to manipulate VOTables:

> [VOTableFile](https://docs.astropy.org/en/stable/api/astropy.io.votable.tree.VOTableFile.html#astropy.io.votable.tree.VOTableFile) object, which can be used to retrieve and manipulate the data and save it back out to disk. [(link)](https://docs.astropy.org/en/v6.1.3/io/votable/)

so I don't see any ethical reason why this should be barred. I also got an implicit go-ahead check from @tomdonaldson:

> I agree that removing a row from the VOTable is conceptually straightforward with no dimensions beyond rows and columns (FIELDs), much the same as deleting a row from a database table.

Unfortunately because ndarray's are immutable, the only way to implement this was to generate a brand new copy of the underlying array every time `pop` is called, which is less than performant, but understandable...

Thanks for considering and reviewing!