### PR TITLE
MNT: ignore PTH linting ruleset by subpackage instead of globally

### DIFF
--- a/.github/workflows/update_astropy_iers_data_pin.py
+++ b/.github/workflows/update_astropy_iers_data_pin.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import requests
 
@@ -7,10 +8,9 @@ metadata = requests.get(
 ).json()
 
 last_version = metadata["info"]["version"]
-project_file = "pyproject.toml"
+project_file = Path("pyproject.toml")
 
-with open(project_file) as f:
-    lines = f.readlines()
+lines = project_file.read_text().splitlines()
 
 changed_lines = 0
 
@@ -26,6 +26,4 @@ elif changed_lines > 1:
     print(f"More than one line found containing astropy-iers-data in {project_file}")
     sys.exit(1)
 
-
-with open(project_file, "w") as f:
-    f.writelines(lines)
+project_file.write_text("\n".join(lines))

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -126,27 +126,6 @@ lint.ignore = [
     "PT018",   # pytest-composite-assertion
     "PT022",   # pytest-useless-yield-fixture
 
-    # flake8-use-pathlib (PTH)
-    "PTH100",  # os-path-abspath
-    "PTH101",  # os-chmod
-    "PTH102",  # os-mkdir
-    "PTH103",  # os-makedirs
-    "PTH104",  # os-rename
-    "PTH107",  # os-remove
-    "PTH108",  # os-unlink
-    "PTH109",  # os-getcwd
-    "PTH110",  # os-path-exists
-    "PTH111",  # os-path-expanduser
-    "PTH112",  # os-path-isdir
-    "PTH113",  # os-path-isfile
-    "PTH118",  # os-path-join
-    "PTH119",  # os-path-basename
-    "PTH120",  # os-path-dirname
-    "PTH122",  # os-path-splitext
-    "PTH123",  # builtin-open
-    "PTH202",  # `os.path.getsize` should be replaced by `Path.stat().st_size`
-    "PTH207",  # Replace `glob` with `Path.glob` or `Path.rglob`
-
     # flake8-return (RET)
     "RET501",  # unnecessary-return-none
     "RET502",  # implicit-return-value
@@ -217,6 +196,7 @@ lint.unfixable = [
 [lint.extend-per-file-ignores]
 "__init__.py" = ["E402", "F401", "F403"]
 "test_*.py" = [
+    "PTH", # all flake8-use-pathlib
     "RUF015",  # Prefer next({iterable}) over single element slice
 ]
 # TODO: fix these, on a per-subpackage basis.
@@ -224,21 +204,24 @@ lint.unfixable = [
 # is better to fix for subpackages individually. The general exclusion should be
 # copied to these subpackage sections and fixed there.
 "astropy/config/*" = [
-    "PTH114",  # os-path-islink
+    "PTH",     # all flake8-use-pathlib
     "PTH206",  # Replace `.split(os.sep)` with `Path.parts`
 ]
 "astropy/constants/*" = [
-    "N817",  # camelcase-imported-as-acronym
+    "N817",    # camelcase-imported-as-acronym
     "RET505",  # superfluous-else-return
 ]
 "astropy/convolution/*" = [
+    "PTH",      # all flake8-use-pathlib
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/coordinates/*" = [
+    "PTH",     # all flake8-use-pathlib
     "DTZ007",  # call-datetime-strptime-without-zone
     "RET505",  # superfluous-else-return
 ]
 "astropy/cosmology/*" = [
+    "PTH",     # all flake8-use-pathlib
     "C408",  # unnecessary-collection-call
     "PT019",   # pytest-fixture-param-without-value
 ]
@@ -248,14 +231,20 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
     "PTH116",  # os-stat
     "PTH117",  # os-path-isabs
+    "PTH",      # all flake8-use-pathlib
     "SLOT000",  # Subclasses of `str` should define `__slots__`
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception
     "TRY300",  # Consider `else` block
 ]
-"astropy/logger.py" = ["C408", "RET505"]
+"astropy/logger.py" = [
+    "C408",
+    "PTH",      # all flake8-use-pathlib
+    "RET505",
+]
 "astropy/modeling/*" = [
     "PLR0911",  # too-many-return-statements
+    "PTH",      # all flake8-use-pathlib
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
     "TRY300",  # Consider `else` block
     "F811",  # see https://github.com/astropy/astropy/pull/16633
@@ -264,26 +253,36 @@ lint.unfixable = [
     "C408",
 ]
 "astropy/samp/*" = [
+    "PTH",      # all flake8-use-pathlib
 ]
 "astropy/stats/*" = [
     "PLR0911",  # too-many-return-statements
+    "PTH",      # all flake8-use-pathlib
 ]
 "astropy/table/*" = [
+    "PTH",      # all flake8-use-pathlib
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
 ]
-"astropy/tests/*" = ["C408", "RET505"]
+"astropy/tests/*" = [
+    "C408",
+    "PTH",      # all flake8-use-pathlib
+    "RET505"
+]
 "astropy/time/*" = [
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
+    "PTH",      # all flake8-use-pathlib
 ]
 "astropy/timeseries/*" = [
     "PLR0911",  # too-many-return-statements
+    "PTH",      # all flake8-use-pathlib
 ]
 "astropy/units/*" = [
     "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
+    "PTH",      # all flake8-use-pathlib
     "TRY300",  # Consider `else` block
 ]
 "astropy/uncertainty/*" = [
@@ -292,19 +291,24 @@ lint.unfixable = [
 "astropy/utils/*" = [
     "N811",  # constant-imported-as-non-constant
     "PLR0911",  # too-many-return-statements
+    "PTH",      # all flake8-use-pathlib
     "S321",  # Suspicious-ftp-lib-usage
     "TRY300",  # Consider `else` block
 ]
 "astropy/visualization/*" = [
     "B015",
     "PLR0911",  # too-many-return-statements
+    "PTH",      # all flake8-use-pathlib
 ]
 "astropy/wcs/*" = [
     "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
+    "PTH",      # all flake8-use-pathlib
     "S608",  # Posslibe SQL injection
     "SIM202",  # NegateNotEqualOp
     "TRY300",  # Consider `else` block
 ]
 "docs/*" = []
 "examples/coordinates/*" = []
+
+".pyinstaller/*.py" = ["PTH"]

--- a/astropy/_dev/scm_version.py
+++ b/astropy/_dev/scm_version.py
@@ -1,10 +1,10 @@
 # Try to use setuptools_scm to get the current version; this is only used
 # in development installations from the git repository.
-import os.path as pth
+from pathlib import Path
 
 try:
     from setuptools_scm import get_version
 
-    version = get_version(root=pth.join("..", ".."), relative_to=__file__)
+    version = get_version(root=Path(__file__).parents[1], relative_to=__file__)
 except Exception:
     raise ImportError("setuptools_scm broken or not installed")

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import warnings
+from pathlib import Path
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -88,8 +89,8 @@ def pytest_configure(config):
     os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
     os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
 
-    os.mkdir(os.path.join(os.environ["XDG_CONFIG_HOME"], "astropy"))
-    os.mkdir(os.path.join(os.environ["XDG_CACHE_HOME"], "astropy"))
+    Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
+    Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
 
     config.option.astropy_header = True
     PYTEST_HEADER_MODULES["PyERFA"] = "erfa"

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import hypothesis
 
@@ -65,8 +66,8 @@ hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", default))
 os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
 os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
 
-os.mkdir(os.path.join(os.environ["XDG_CONFIG_HOME"], "astropy"))
-os.mkdir(os.path.join(os.environ["XDG_CACHE_HOME"], "astropy"))
+Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
+Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
 
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -310,7 +310,7 @@ nitpicky = True
 show_warning_types = True
 # See docs/nitpick-exceptions file for the actual listing.
 nitpick_ignore = []
-for line in open("nitpick-exceptions"):
+for line in open("nitpick-exceptions"):  # noqa: PTH123
     if line.strip() == "" or line.startswith("#"):
         continue
     dtype, target = line.split(None, 1)

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,6 +7,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -16,8 +17,8 @@ import pytest
 os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
 os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
 
-os.mkdir(os.path.join(os.environ["XDG_CONFIG_HOME"], "astropy"))
-os.mkdir(os.path.join(os.environ["XDG_CACHE_HOME"], "astropy"))
+Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
+Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
 
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the
@@ -34,7 +35,7 @@ def _docdir(request):
         # Don't apply this fixture to io.rst.  It reads files and doesn't write.
         # Implementation from https://github.com/pytest-dev/pytest/discussions/10437
         if "io.rst" not in request.node.name:
-            old_cwd = os.getcwd()
+            old_cwd = Path.cwd()
             tmp_path = request.getfixturevalue("tmp_path")
             os.chdir(tmp_path)
             yield


### PR DESCRIPTION
### Description
This is step 0 in my plan to revive #16060: I plan to re-issue this PR in smaller bits targetting specific subpackages to make it easier to cycle.

I intend to keep @MridulS as a commit co-author every step of the way :)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
