### PR TITLE
MNT: Run PTH flake test in prep for supporting pathlib (stats)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -257,7 +257,6 @@ lint.unfixable = [
 ]
 "astropy/stats/*" = [
     "PLR0911",  # too-many-return-statements
-    "PTH",      # all flake8-use-pathlib
 ]
 "astropy/table/*" = [
     "PTH",      # all flake8-use-pathlib

--- a/astropy/stats/setup_package.py
+++ b/astropy/stats/setup_package.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 from numpy import get_include as get_numpy_include
 from setuptools import Extension
 
-ROOT = os.path.relpath(os.path.dirname(__file__))
+ROOT = Path(__file__).parent.resolve().relative_to(Path.cwd())
 SRCFILES = ["wirth_select.c", "compute_bounds.c", "fast_sigma_clip.c"]
-SRCFILES = [os.path.join(ROOT, "src", srcfile) for srcfile in SRCFILES]
+SRCFILES = [str(ROOT / "src" / srcfile) for srcfile in SRCFILES]
 
 
 def get_extensions() -> list[Extension, Extension]:
@@ -23,7 +23,7 @@ def get_extensions() -> list[Extension, Extension]:
     _stats_ext = Extension(
         name="astropy.stats._stats",
         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-        sources=[os.path.join(ROOT, "_stats.pyx")],
+        sources=[str(ROOT / "_stats.pyx")],
         include_dirs=[get_numpy_include()],
     )
 


### PR DESCRIPTION
### Description
Extracted from #16060, ~based off #16917 (only the last commit is exclusive to this branch)~

@larrybradley already approved this bit in https://github.com/astropy/astropy/pull/16060#pullrequestreview-1888630539


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
Co-authored-by: Mridul Seth <git@mriduls.com>