### PR TITLE
Implement `UnitBase._hash` with `@cached_property`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -618,8 +618,6 @@ class UnitBase:
     # arrays to avoid element-wise multiplication.
     __array_priority__ = 1000
 
-    _hash = None
-
     def __deepcopy__(self, memo):
         # This may look odd, but the units conversion will be very
         # broken after deep-copying if we don't guarantee that a given
@@ -889,15 +887,14 @@ class UnitBase:
         )
         return NotImplemented
 
-    def __hash__(self):
-        if self._hash is None:
-            parts = (
-                [str(self.scale)]
-                + [x.name for x in self.bases]
-                + [str(x) for x in self.powers]
-            )
-            self._hash = hash(tuple(parts))
+    def __hash__(self) -> int:
         return self._hash
+
+    @cached_property
+    def _hash(self) -> int:
+        return hash(
+            (str(self.scale), *[x.name for x in self.bases], *map(str, self.powers))
+        )
 
     def __getstate__(self):
         # If we get pickled, we should *not* store the memoized members since
@@ -2244,10 +2241,9 @@ class Unit(NamedUnit, metaclass=_UnitMetaClass):
     def is_unity(self):
         return self._represents.is_unity()
 
-    def __hash__(self):
-        if self._hash is None:
-            self._hash = hash((self.name, self._represents))
-        return self._hash
+    @cached_property
+    def _hash(self) -> int:
+        return hash((self.name, self._represents))
 
     @classmethod
     def _from_physical_type_id(cls, physical_type_id):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -621,11 +621,11 @@ def test_pickle_does_not_keep_memoized_hash(unit):
     to mimic separate sessions in a simple test. See gh-11872.
     """
     unit_hash = hash(unit)
-    assert unit._hash is not None
+    assert "_hash" in vars(unit)
     unit_copy = pickle.loads(pickle.dumps(unit))
     # unit is not registered so we get a copy.
     assert unit_copy is not unit
-    assert unit_copy._hash is None
+    assert "_hash" not in vars(unit_copy)
     assert hash(unit_copy) == unit_hash
     with u.add_enabled_units([unit]):
         # unit is registered, so we get a reference.


### PR DESCRIPTION
### Description

Implementing `UnitBase._hash` using the [standard library `functools.cached_property`](https://docs.python.org/3/library/functools.html#functools.cached_property) (available since Python 3.8) is more idiomatic than the current usage.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.