### PR TITLE
ENH: improve support for `Path` objects in `io.ascii.core.BaseInputter.get_lines`

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -308,7 +308,7 @@ class BaseInputter:
 
         The input table can be one of:
 
-        * File name
+        * File name (str or pathlike)
         * String (newline separated) with all header and data lines (must have at least 2 lines)
         * File-like object with read() method
         * List of strings
@@ -328,8 +328,10 @@ class BaseInputter:
             List of lines
         """
         try:
-            if hasattr(table, "read") or (
-                "\n" not in table + "" and "\r" not in table + ""
+            if (
+                hasattr(table, "read")
+                or isinstance(table, os.PathLike)
+                or ("\n" not in table + "" and "\r" not in table + "")
             ):
                 with get_readable_fileobj(table, encoding=self.encoding) as fileobj:
                     table = fileobj.read()

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -8,7 +8,9 @@ Requires `BeautifulSoup <http://www.crummy.com/software/BeautifulSoup/>`_
 to be installed.
 """
 
+import os
 from io import StringIO
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -301,17 +303,24 @@ def test_htmlsplitter():
         list(splitter([]))
 
 
+@pytest.mark.parametrize(
+    "get_table",
+    [
+        lambda path: os.fspath(path),
+        lambda path: Path(path),
+        lambda path: Path(path).read_text(),
+    ],
+)
 @pytest.mark.skipif(not HAS_BS4, reason="requires BeautifulSoup4")
-def test_htmlheader_start():
+def test_htmlheader_start(get_table):
     """
     Test to ensure that the start_line method of HTMLHeader
     returns the first line of header data. Uses t/html.html
     for sample input.
     """
 
-    f = "data/html.html"
-    with open(f) as fd:
-        table = fd.read()
+    table_file = "data/html.html"
+    table = get_table(table_file)
 
     inputter = html.HTMLInputter()
     inputter.html = {}

--- a/docs/changes/io.ascii/16930.feature.rst
+++ b/docs/changes/io.ascii/16930.feature.rst
@@ -1,0 +1,2 @@
+Add support for `pathlib.Path` objects in
+`astropy.io.ascii.core.BaseInputter.get_lines`.


### PR DESCRIPTION
### Description

Ref:  #14893

This relieves a specific pain point I encountered while working on #16928, and participates to unblock it.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

TODO:
- [x] add a test

