### PR TITLE
ENH/BUG: improve support for `pathlib.Path` inputs in `iers`

### DIFF
--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -58,7 +58,7 @@ class TestUpdateLeapSeconds:
             update_leap_seconds(["nonsense"])
 
     def test_auto_update_corrupt_file(self, tmp_path):
-        bad_file = str(tmp_path / "no_expiration")
+        bad_file = tmp_path / "no_expiration"
         with open(iers.IERS_LEAP_SECOND_FILE) as fh:
             lines = fh.readlines()
         with open(bad_file, "w") as fh:

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -9,9 +9,12 @@ celestial-to-terrestrial coordinate transformations
 (in `astropy.coordinates`).
 """
 
+from __future__ import annotations
+
 import os
 import re
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -42,6 +45,9 @@ from astropy.utils.data import (
 )
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.state import ScienceState
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = [
     "Conf",
@@ -604,15 +610,19 @@ class IERS_A(IERS):
         return table
 
     @classmethod
-    def read(cls, file=None, readme=None):
+    def read(
+        cls,
+        file: str | os.PathLike[str] | None = None,
+        readme: str | os.PathLike[str] | None = None,
+    ) -> Self:
         """Read IERS-A table from a finals2000a.* file provided by USNO.
 
         Parameters
         ----------
-        file : str
+        file : str or os.PathLike[str]
             full path to ascii file holding IERS-A data.
             Defaults to ``iers.IERS_A_FILE``.
-        readme : str
+        readme : str or os.PathLike[str]
             full path to ascii file holding CDS-style readme.
             Defaults to package version, ``iers.IERS_A_README``.
 
@@ -640,8 +650,12 @@ class IERS_A(IERS):
                 )
             else:
                 file = IERS_A_FILE
+        else:
+            file = os.fspath(file)
         if readme is None:
             readme = IERS_A_README
+        else:
+            readme = os.fspath(readme)
 
         iers_a = super().read(file, format="cds", readme=readme)
 
@@ -694,15 +708,20 @@ class IERS_B(IERS):
     iers_table = None
 
     @classmethod
-    def read(cls, file=None, readme=None, data_start=6):
+    def read(
+        cls,
+        file: str | os.PathLike[str] | None = None,
+        readme: str | os.PathLike[str] | None = None,
+        data_start: int = 6,
+    ) -> Self:
         """Read IERS-B table from a eopc04.* file provided by IERS.
 
         Parameters
         ----------
-        file : str
+        file : str or os.PathLike[str]
             full path to ascii file holding IERS-B data.
             Defaults to package version, ``iers.IERS_B_FILE``.
-        readme : str
+        readme : str or os.PathLike[str]
             full path to ascii file holding CDS-style readme.
             Defaults to package version, ``iers.IERS_B_README``.
         data_start : int
@@ -732,9 +751,12 @@ class IERS_B(IERS):
         """
         if file is None:
             file = IERS_B_FILE
+        else:
+            file = os.fspath(file)
         if readme is None:
             readme = IERS_B_README
-
+        else:
+            readme = os.fspath(readme)
         table = super().read(file, format="cds", readme=readme, data_start=data_start)
 
         table.meta["data_path"] = file

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1166,8 +1166,8 @@ class LeapSeconds(QTable):
             # configuration items, which we want to be sure are up to date).
             files = [getattr(conf, f, f) for f in cls._auto_open_files]
 
-        # Remove empty entries.
-        files = [f for f in files if f]
+        # Remove empty entries and normalize Path objects to string
+        files = [os.fspath(f) for f in files if f]
 
         # Our trials start with normal files and remote ones that are
         # already in cache.  The bools here indicate that the cache

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -96,7 +96,8 @@ class TestBasic:
         iers.IERS_A.close()
 
 
-def test_IERS_B_old_style_excerpt():
+@pytest.mark.parametrize("path_transform", [os.fspath, Path])
+def test_IERS_B_old_style_excerpt(path_transform):
     """Check that the instructions given in `IERS_B.read` actually work."""
     # If this test is changed, be sure to also adjust the instructions.
     #
@@ -104,8 +105,8 @@ def test_IERS_B_old_style_excerpt():
     # enough time has passed that old-style IERS_B files are simply
     # not around any more, say in 2025.  If so, also remove the excerpt
     # and the ReadMe.eopc04_IAU2000 file.
-    old_style_file = get_pkg_data_filename(
-        os.path.join("data", "iers_b_old_style_excerpt")
+    old_style_file = path_transform(
+        get_pkg_data_filename(os.path.join("data", "iers_b_old_style_excerpt"))
     )
     excerpt = iers.IERS_B.read(
         old_style_file,

--- a/docs/changes/utils/16931.feature.rst
+++ b/docs/changes/utils/16931.feature.rst
@@ -1,0 +1,2 @@
+Add support for specifying files as ``pathlib.Path`` objects in ``IERS_A.read``
+and ``IERS_B.read``.


### PR DESCRIPTION
### Description

Ref:  #14893

fixes #16929

This relieves a specific pain point I encountered while working on #16928, and participates to unblock it.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

TODO:
- [x] add a test
