### PR TITLE
MNT: unignore PTH checks in astropy.units (noop)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -278,7 +278,6 @@ lint.unfixable = [
     "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
-    "PTH",      # all flake8-use-pathlib
     "TRY300",  # Consider `else` block
 ]
 "astropy/uncertainty/*" = [


### PR DESCRIPTION
### Description
Ref #16924
revert part of #16917 which I apparently added by mistake (nothing to be done here)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
