### PR TITLE
WCSAxes: add ability to disable tick-label simplification

### DIFF
--- a/astropy/tests/figures/py310-test-image-mpl360-cov.json
+++ b/astropy/tests/figures/py310-test-image-mpl360-cov.json
@@ -49,6 +49,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "8908818b526d4a506505da890eff47121b23ee41656dc15dff3e19f7d03094af",
   "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "9d91bcf571af6dcc1425b6dfd76fb92e3e0180fb9fd0c852f9eba3fb06e079fc",
   "astropy.visualization.wcsaxes.tests.test_images.test_overlay_nondegree_unit": "aa9b85520da54dc61d4db2988883ff184fb59cd27c52a04899cb33599fcab4b7",
+  "astropy.visualization.wcsaxes.tests.test_images.test_nosimplify": "a00b1ccd640c53a92ca0856b9577b9408d0332cb0985db0662a4621e0c002e16",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/tests/figures/py310-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py310-test-image-mpldev-cov.json
@@ -49,6 +49,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_allsky_labels_wrap": "8908818b526d4a506505da890eff47121b23ee41656dc15dff3e19f7d03094af",
   "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "9d91bcf571af6dcc1425b6dfd76fb92e3e0180fb9fd0c852f9eba3fb06e079fc",
   "astropy.visualization.wcsaxes.tests.test_images.test_overlay_nondegree_unit": "aa9b85520da54dc61d4db2988883ff184fb59cd27c52a04899cb33599fcab4b7",
+  "astropy.visualization.wcsaxes.tests.test_images.test_nosimplify": "a00b1ccd640c53a92ca0856b9577b9408d0332cb0985db0662a4621e0c002e16",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -427,7 +427,14 @@ class CoordinateHelper:
         self.ticks.set_visible(visible)
 
     def set_ticklabel(
-        self, color=None, size=None, pad=None, exclude_overlapping=None, **kwargs
+        self,
+        color=None,
+        size=None,
+        pad=None,
+        exclude_overlapping=None,
+        *,
+        simplify=True,
+        **kwargs,
     ):
         """
         Set the visual properties for the tick labels.
@@ -442,6 +449,8 @@ class CoordinateHelper:
             Distance in points between tick and label.
         exclude_overlapping : bool, optional
             Whether to exclude tick labels that overlap over each other.
+        simplify : bool, optional
+            Whether to remove repeated parts of tick labels.
         **kwargs
             Other keyword arguments are passed to :class:`matplotlib.text.Text`.
         """
@@ -453,6 +462,7 @@ class CoordinateHelper:
             self.ticklabels.set_pad(pad)
         if exclude_overlapping is not None:
             self.ticklabels.set_exclude_overlapping(exclude_overlapping)
+        self.ticklabels.set_simplify(simplify)
         self.ticklabels.set(**kwargs)
 
     def set_ticklabel_position(self, position):

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -1339,3 +1339,37 @@ def test_overlay_nondegree_unit(nondegree_frame):
     overlay[1].grid(color="r", linestyle="dashed")
 
     return fig
+
+
+@figure_test
+def test_nosimplify():
+    wcs = WCS(
+        {
+            "ctype1": "RA---CAR",
+            "ctype2": "DEC--CAR",
+            "crval1": 0,
+            "crval2": 0,
+            "cdelt1": -1,
+            "cdelt2": 1,
+            "crpix1": 1,
+            "crpix2": 1,
+        }
+    )
+
+    fig = Figure(figsize=(7, 8))
+    ax = fig.add_subplot(projection=wcs)
+
+    ax.coords[0].set_ticks(spacing=0.25 * u.hourangle)
+    ax.coords[0].set_ticklabel(rotation=90, pad=25, simplify=False)
+    ax.coords[0].set_ticklabel_position("bt")
+
+    ax.coords[1].set_ticks(spacing=0.25 * u.deg)
+    ax.coords[1].set_ticklabel(simplify=False)
+    ax.coords[1].set_ticklabel_position("lr")
+
+    ax.set_xlim(-30, 30)
+    ax.set_ylim(-2, 2)
+    ax.set_aspect(15)
+    ax.grid()
+
+    return fig

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -26,6 +26,7 @@ class TickLabels(Text):
         self.set_visible_axes("all")
         self.set_pad(rcParams["xtick.major.pad"])
         self._exclude_overlapping = False
+        self._simplify = True
 
         # Mapping from axis > list[bounding boxes]
         self._axis_bboxes = defaultdict(list)
@@ -180,6 +181,9 @@ class TickLabels(Text):
     def set_exclude_overlapping(self, exclude_overlapping):
         self._exclude_overlapping = exclude_overlapping
 
+    def set_simplify(self, simplify):
+        self._simplify = simplify
+
     def _set_xy_alignments(self, renderer):
         """
         Compute and set the x, y positions and the horizontal/vertical alignment of
@@ -188,7 +192,8 @@ class TickLabels(Text):
         if not self._stale:
             return
 
-        self.simplify_labels()
+        if self._simplify:
+            self.simplify_labels()
         text_size = renderer.points_to_pixels(self.get_size())
 
         visible_axes = self.get_visible_axes()

--- a/docs/changes/visualization/16938.feature.rst
+++ b/docs/changes/visualization/16938.feature.rst
@@ -1,0 +1,2 @@
+Added the ability to disable the automatic simplification of WCSAxes tick labels
+by specifying ``simplify=False`` to ``set_ticklabel()`` for a coordinate axis.

--- a/docs/visualization/wcsaxes/ticks_labels_grid.rst
+++ b/docs/visualization/wcsaxes/ticks_labels_grid.rst
@@ -227,6 +227,19 @@ We can apply this to the previous example:
     lon.set_ticklabel(exclude_overlapping=True)
     lat.set_ticklabel(exclude_overlapping=True)
 
+By default, repeated parts of tick labels (e.g., the whole degrees or hour
+angle) are omitted to keep the tick labels shorter.  If this simplification
+results in confusing tick labels, this behavior can be disabled by specifying
+``simplify=False``:
+
+.. plot::
+   :context:
+   :include-source:
+   :align: center
+
+   lon.set_ticklabel(simplify=False)
+   lat.set_ticklabel(simplify=False)
+
 Minor ticks
 ***********
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The automatic simplification of WCSAxes tick labels – typically removes repeated whole degrees or hour angles – can result in confusing tick labels.  Consider for example this plot directly from the current docs:

![ticks_labels_grid-10](https://github.com/user-attachments/assets/3727f010-c1d5-43cf-b143-34f7d6d79234)

This PR provides the user a way to turn off the simplification by specifying `simplify=False` to `set_ticklabel()` (at the expense of longer tick labels):

![ticks_labels_grid-11](https://github.com/user-attachments/assets/b490205a-c46b-4a2c-96fd-6d8241dc7453)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
