### PR TITLE
BLD: fix building against setuptools 68

### DIFF
--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -17,7 +17,7 @@ def get_extensions():
         Extension(
             name=f"astropy.table.{source.stem}",
             define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-            sources=sources,
+            sources=[str(s) for s in sources],
             include_dirs=include_dirs,
         )
         for source in sources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ volint = "astropy.io.votable.volint:main"
 wcslint = "astropy.wcs.wcslint:main"
 
 [build-system]
-requires = ["setuptools>=72.2.0",
+requires = ["setuptools",
             "setuptools_scm>=6.2",
             "cython>=3.0.0, <4",
             "numpy>=2.0.0, <3",


### PR DESCRIPTION
### Description
Hotfix following #16939 which, as noted by @pllim (https://github.com/astropy/astropy/pull/16939/files#r1744178178) broke building on exotic archs.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
