### PR TITLE
API: remove deprecated matrix_product function

### DIFF
--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -4,31 +4,11 @@
 Utililies used for constructing and inspecting rotation matrices.
 """
 
-from functools import reduce
-
 import numpy as np
 
 from astropy import units as u
-from astropy.utils import deprecated
 
 from .angles import Angle
-
-
-@deprecated("5.2", alternative="@")
-def matrix_product(*matrices):
-    """Matrix multiply all arguments together.
-
-    Arguments should have dimension 2 or larger. Larger dimensional objects
-    are interpreted as stacks of matrices residing in the last two dimensions.
-
-    This function mostly exists for readability: using `~numpy.matmul`
-    directly, one would have ``matmul(matmul(m1, m2), m3)``, etc. For even
-    better readability, one might consider using `~numpy.matrix` for the
-    arguments (so that one could write ``m1 * m2 * m3``), but then it is not
-    possible to handle stacks of matrices. Once only python >=3.5 is supported,
-    this function can be replaced by ``m1 @ m2 @ m3``.
-    """
-    return reduce(np.matmul, matrices)
 
 
 def matrix_transpose(matrix):

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose
 
 from astropy import units as u
@@ -8,10 +7,8 @@ from astropy.coordinates.matrix_utilities import (
     angle_axis,
     is_O3,
     is_rotation,
-    matrix_product,
     rotation_matrix,
 )
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_rotation_matrix():
@@ -123,8 +120,3 @@ def test_is_rotation():
     # and (M, 3, 3)
     n3 = np.stack((m1, m3))
     assert tuple(is_rotation(n3)) == (True, False)  # (show the broadcasting)
-
-
-def test_matrix_product_deprecation():
-    with pytest.warns(AstropyDeprecationWarning, match=r"Use @ instead\.$"):
-        matrix_product(np.eye(2))


### PR DESCRIPTION
### Description
Fixes #16943

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
