### PR TITLE
MNT: set minimal Python requirement in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@ ci:
   autofix_prs: false
   autoupdate_schedule: 'monthly'
 
+default_language_version:
+  python: python3.11
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -56,8 +59,6 @@ repos:
     hooks:
       - id: codespell
         args: ["--write-changes"]
-        additional_dependencies:
-          - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3
@@ -75,7 +76,6 @@ repos:
     rev: v1.7.5
     hooks:
       - id: docformatter
-        additional_dependencies: [tomli]
         args: [--in-place, --config, ./pyproject.toml]
         exclude: |
           (?x)(


### PR DESCRIPTION
### Description

Removing `tomli` as an extra dependency in some pre-commit hooks was initially proposed by @pllim as part of #16903.
I reverted it there after I pointed out that `pre-commit` could be run without being installed as part of the virtual env, so the version of Python it uses may be older than 3.11 even if `astropy` requires it.
Now I *think* this is how one tells pre-commit to use a specific Python for hooks, but it may not be portable either: I don't know how it behaves on a system that only has, e.g., Python 3.12 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
