### PR TITLE
WCSAxes: Fix the allowed types for set_major_formatter()

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -11,7 +11,6 @@ import numpy as np
 from matplotlib import rcParams
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
-from matplotlib.ticker import Formatter
 from matplotlib.transforms import Affine2D, ScaledTranslation
 
 from astropy import units as u
@@ -238,19 +237,18 @@ class CoordinateHelper:
 
     def set_major_formatter(self, formatter):
         """
-        Set the formatter to use for the major tick labels.
+        Set the format string to use for the major tick labels.
 
         Parameters
         ----------
-        formatter : str or `~matplotlib.ticker.Formatter`
-            The format or formatter to use.
+        formatter : str
+            The format string to use.
         """
-        if isinstance(formatter, Formatter):
-            raise NotImplementedError()  # figure out how to swap out formatter
-        elif isinstance(formatter, str):
+        # TODO: Figure out how to accept a Formatter instance
+        if isinstance(formatter, str):
             self._formatter_locator.format = formatter
         else:
-            raise TypeError("formatter should be a string or a Formatter instance")
+            raise TypeError("formatter should be a string")
 
     def format_coord(self, value, format="auto"):
         """


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The docstring for `CoordinateHelper.set_major_formatter()` claims that the method can accept a matplotlib `Formatter` instance, but that input type simply raises a `NotImplementedError`, and has done so for the past 11 years.  How to implement support for a matplotlib `Formatter` instance is non-obvious, so it makes sense that this aspirational claim has never been made real.  This PR fixes the docstring, but retains the aspiration as a TODO comment for some enterprising developer in the future.

I don't know whether a changelog entry is even warranted here.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
