### PR TITLE
CLN: cleanup an unused `tick_out` argument

### DIFF
--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -38,7 +38,7 @@ class Ticks(Line2D):
         the locations of the ticks for that axis.
     """
 
-    def __init__(self, ticksize=None, tick_out=None, **kwargs):
+    def __init__(self, ticksize=None, **kwargs):
         if ticksize is None:
             ticksize = rcParams["xtick.major.size"]
         self.set_ticksize(ticksize)


### PR DESCRIPTION
### Description

Randomly discovered by reading this class

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
