### PR TITLE
MNT: Run PTH flake test in prep for supporting pathlib (io.registry)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -239,7 +239,6 @@ lint.unfixable = [
 "astropy/io/misc/*" = [
 ]
 "astropy/io/registry/*" = [
-    "PTH",
 ]
 "astropy/io/votable/*" = [
     "PTH",

--- a/astropy/io/registry/base.py
+++ b/astropy/io/registry/base.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import contextlib
+import os
 import re
 import warnings
 from operator import itemgetter
@@ -350,6 +351,8 @@ class _UnifiedIORegistryBase:
         Returns the first valid format that can be used to read/write the data in
         question.  Mode can be either 'read' or 'write'.
         """
+        if path is not None:
+            path = os.fspath(path)
         valid_formats = self.identify_format(mode, cls, path, fileobj, args, kwargs)
 
         if len(valid_formats) == 0:


### PR DESCRIPTION
### Description
Ref #16924
This is in the continuation of #16060

~~Based off, and blocked by #16955~~
From local testing, it looks like I'll also need to tackle `io.votable` before I can undraft this one.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
