### PR TITLE
Fixed bug with checksum on CompImageHDU if data was read in and written out straight away

### DIFF
--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -856,12 +856,7 @@ class CompImageHDU(BinTableHDU):
         if self._scale_back:
             self.scale(BITPIX2DTYPE[self._orig_bitpix])
 
-        if self._has_data:
-            self._update_compressed_data()
-
-            # Use methods in the superclass to update the header with
-            # scale/checksum keywords based on the data type of the image data
-            self._update_pseudo_int_scale_keywords()
+        if checksum and self.data is not None:
 
             # Shove the image header and data into a new ImageHDU and use that
             # to compute the image checksum
@@ -881,6 +876,14 @@ class CompImageHDU(BinTableHDU):
                     image_hdu.header["DATASUM"],
                     image_hdu.header.comments["DATASUM"],
                 )
+
+        if self._has_data:
+            self._update_compressed_data()
+
+            # Use methods in the superclass to update the header with
+            # scale/checksum keywords based on the data type of the image data
+            self._update_pseudo_int_scale_keywords()
+
             # Store a temporary backup of self.data in a different attribute;
             # see below
             self._imagedata = self.data

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -857,7 +857,6 @@ class CompImageHDU(BinTableHDU):
             self.scale(BITPIX2DTYPE[self._orig_bitpix])
 
         if checksum and self.data is not None:
-
             # Shove the image header and data into a new ImageHDU and use that
             # to compute the image checksum
             image_hdu = ImageHDU(data=self.data, header=self.header)

--- a/astropy/io/fits/hdu/compressed/tests/test_checksum.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_checksum.py
@@ -19,9 +19,9 @@ class TestChecksumFunctions(BaseChecksumTests):
                 assert "DATASUM" in h2[0].header
                 assert h2[0].header["DATASUM"] == "0"
                 assert "CHECKSUM" in h2[1].header
-                assert h2[1].header["CHECKSUM"] == "ZeAbdb8aZbAabb7a"
+                assert h2[1].header["CHECKSUM"] == "D2GXD29VD2EVD29V"
                 assert "DATASUM" in h2[1].header
-                assert h2[1].header["DATASUM"] == "113055149"
+                assert h2[1].header["DATASUM"] == "2189405276"
 
     def test_failing_compressed_datasum(self):
         """

--- a/docs/changes/io.fits/16957.bugfix.rst
+++ b/docs/changes/io.fits/16957.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that occurred when reading in a compressed FITS file and writing it out
+immediately without touching the data but requesting the checksum to be calculated.
+In this situation, ZHECKSUM and ZDATASUM were missing from the output header.


### PR DESCRIPTION
While discussing checksums with @saimn in https://github.com/astropy/astropy/issues/14753 I realised that that bug only occurs under a very specific condition - if we read in data and write it out straight away, and that in fact everything works as expected if one modifies the data or sets the data. The fix ends for this issue on ``main`` actually ends up being simple, and is done in this PR.

Essentially, if a compressed FITS file is read in and written out straight away, ZHECKSUM/ZDATASUM are missing compared to cases where the data is set or modified.

The following script illustrates the problem:

```python
import numpy as np
from astropy.io import fits

from astropy.io.fits.hdu.base import _ValidHDU
_ValidHDU._get_timestamp = lambda self: "2013-12-20T13:36:10"


def show_checksums(filename):
    with open(filename, 'rb') as f:
        header = f.read()
    found = False
    for i in range(2880, len(header), 80):
        if b'SUM' in header[i:i+8]:
            print(header[i:i+80].decode('ascii'))
            found = True
    if not found:
        print('No checksum keywords found')


data = np.arange(40).reshape((5, 8))

print('-' * 72)
print('Original, export without checksum')

hdu1 = fits.CompImageHDU(data)
hdu1.writeto('original_nochecksum.fits', overwrite=True)

show_checksums('original_nochecksum.fits')

print('-' * 72)
print('Original, export with checksum')

hdu2 = fits.CompImageHDU(data)
hdu2.writeto('original_checksum.fits', checksum=True, overwrite=True)

show_checksums('original_checksum.fits')

print('-' * 72)
print('Read in original_nochecksum.fits, export with checksum (no change to data)')

with fits.open('original_nochecksum.fits') as hdulist:
    hdulist.writeto('read_and_exported_checksum.fits', checksum=True, overwrite=True)

show_checksums('read_and_exported_checksum.fits')

print('-' * 72)
print('Read in original_nochecksum.fits, export with checksum re-assigning data to itself')

with fits.open('original_nochecksum.fits') as hdulist:
    hdulist[1].data = hdulist[1].data.copy()
    hdulist.writeto('read_reassign_and_exported_checksum.fits', checksum=True, overwrite=True)

show_checksums('read_reassign_and_exported_checksum.fits')

print('-' * 72)
print('Read in original_nochecksum.fits, export with checksum and changing data')

with fits.open('original_nochecksum.fits') as hdulist:
    hdulist[1].data = data * 2
    hdulist.writeto('read_modify_and_exported_checksum.fits', checksum=True, overwrite=True)

show_checksums('read_modify_and_exported_checksum.fits')
```

Running this on ``main`` gives:

```
------------------------------------------------------------------------
Original, export without checksum
No checksum keywords found
------------------------------------------------------------------------
Original, export with checksum
ZHECKSUM= 'M1PqM1OnM1OnM1On'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '780     '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'ADGBBDF9ADFAADF9'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '1054568040'         / data unit checksum updated 2013-12-20T13:36:10 
------------------------------------------------------------------------
Read in original_nochecksum.fits, export with checksum (no change to data)
CHECKSUM= 'JKH9LJ98JJE8JJ98'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '1054568040'         / data unit checksum updated 2013-12-20T13:36:10 
------------------------------------------------------------------------
Read in original_nochecksum.fits, export with checksum re-assigning data to itself
ZHECKSUM= 'M1PqM1OnM1OnM1On'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '780     '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'ADGBBDF9ADFAADF9'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '1054568040'         / data unit checksum updated 2013-12-20T13:36:10 
------------------------------------------------------------------------
Read in original_nochecksum.fits, export with checksum and changing data
ZHECKSUM= 'K4PjM1MjK1MjK1Mj'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '1560    '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'S5a4T2X4S2a4S2U4'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '2240124460'         / data unit checksum updated 2013-12-20T13:36:10 
```

In the first case, there is no checksum, which is expected. In the second case the decompressed HDU checksum and datasum are computed and stored in ZHECKSUM/ZDATASUM. However, if we read in the file with no checksums and export it immediately without touching data, then ZHECKSUM/ZDATASUM are missing, which is inconsistent. Furthermore, as shown in the fourth case, if we read the file in and reassign the data to itself, then ZHECKSUM/ZDATASUM are back, and if we change the data then of course the checksums change (fifth case).

The bug here was that the image checksums in ``CompImageHDU._prewriteto`` were computed only if ``self._has_data`` is ``True``, but if you just read in a compressed file and don't interact with the data, it is never loadded and ``self._has_data`` is ``False``, even though in principle there **is** data that could be used to compute a checksum. I have therefore re-arranged the code slightly to compute the image checksum regardless of ``self._has_data`` but instead doing it only if ``checksum`` is specified and if ``self.data`` is not ``None`` (the check of ``checksum`` is needed because accessing ``self.data`` is expensive as it might trigger the whole data to decompress - we need to do this in any case if we are computing the checksum, but might as well avoid hitting self.data if ``checksum=False``. With this minor change, the output is then:

```
------------------------------------------------------------------------
Original, export without checksum
No checksum keywords found
------------------------------------------------------------------------
Original, export with checksum
ZHECKSUM= 'M1PqM1OnM1OnM1On'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '780     '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'ADGBBDF9ADFAADF9'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '1054568040'         / data unit checksum updated 2013-12-20T13:36:10 
------------------------------------------------------------------------
Read in original_nochecksum.fits, export with checksum (no change to data)
ZHECKSUM= 'M1PqM1OnM1OnM1On'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '780     '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'ADGBBDF9ADFAADF9'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '1054568040'         / data unit checksum updated 2013-12-20T13:36:10 
------------------------------------------------------------------------
Read in original_nochecksum.fits, export with checksum re-assigning data to itself
ZHECKSUM= 'M1PqM1OnM1OnM1On'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '780     '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'ADGBBDF9ADFAADF9'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '1054568040'         / data unit checksum updated 2013-12-20T13:36:10 
------------------------------------------------------------------------
Read in original_nochecksum.fits, export with checksum and changing data
ZHECKSUM= 'K4PjM1MjK1MjK1Mj'   / HDU checksum updated 2013-12-20T13:36:10       
ZDATASUM= '1560    '           / data unit checksum updated 2013-12-20T13:36:10 
CHECKSUM= 'S5a4T2X4S2a4S2U4'   / HDU checksum updated 2013-12-20T13:36:10       
DATASUM = '2240124460'         / data unit checksum updated 2013-12-20T13:36:10 
```

The checksums are the same in the second, third, and fourth case.