### PR TITLE
Make `NamedUnit.get_format_name()` private

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from astropy.utils.compat import COPY_IF_NEEDED
-from astropy.utils.decorators import lazyproperty
+from astropy.utils.decorators import deprecated, lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
 
@@ -1806,6 +1806,7 @@ class NamedUnit(UnitBase):
         else:
             return names[0]
 
+    @deprecated(since="7.0", alternative="to_string()")
     def get_format_name(self, format):
         """
         Get a name for this unit that is specific to a particular
@@ -1824,6 +1825,9 @@ class NamedUnit(UnitBase):
         name : str
             The name of the unit for the given format.
         """
+        return self._get_format_name(format)
+
+    def _get_format_name(self, format: str) -> str:
         return self._format.get(format, self.name)
 
     @property
@@ -2013,7 +2017,7 @@ class UnrecognizedUnit(IrreducibleUnit):
             "to other units."
         )
 
-    def get_format_name(self, format):
+    def _get_format_name(self, format: str) -> str:
         return self.name
 
     def is_unity(self):
@@ -2524,8 +2528,8 @@ def _add_prefixes(u, excludes=[], namespace=None, prefixes=False):
                 # This is a hack to use Greek mu as a prefix
                 # for some formatters.
                 if prefix == "u":
-                    format["latex"] = r"\mu " + u.get_format_name("latex")
-                    format["unicode"] = "\N{MICRO SIGN}" + u.get_format_name("unicode")
+                    format["latex"] = r"\mu " + u._get_format_name("latex")
+                    format["unicode"] = "\N{MICRO SIGN}" + u._get_format_name("unicode")
 
                 for key, val in u._format.items():
                     format.setdefault(key, prefix + val)

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -98,7 +98,7 @@ class Base:
         This is overridden in Latex where the name of the unit can depend on the power
         (e.g., for degrees).
         """
-        name = unit.get_format_name(cls.name)
+        name = unit._get_format_name(cls.name)
         if power != 1:
             name += cls._format_superscript(utils.format_power(power))
         return name

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -278,7 +278,7 @@ class CDS(Generic):
 
     @classmethod
     def _get_unit_name(cls, unit: NamedUnit) -> str:
-        return unit.get_format_name(cls.name)
+        return unit._get_format_name(cls.name)
 
     @classmethod
     def _format_mantissa(cls, m: str) -> str:

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -590,7 +590,7 @@ class Generic(Base):
 
     @classmethod
     def _get_unit_name(cls, unit: NamedUnit) -> str:
-        name = unit.get_format_name(cls.name)
+        name = unit._get_format_name(cls.name)
         cls._validate_unit(name)
         return name
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -40,7 +40,7 @@ class Latex(console.Console):
 
     @classmethod
     def _format_unit_power(cls, unit: NamedUnit, power: Real = 1) -> str:
-        name = unit.get_format_name("latex")
+        name = unit._get_format_name("latex")
         if name == unit.name:
             # This doesn't escape arbitrary LaTeX strings, but it should
             # be good enough for unit names which are required to be alpha

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -44,7 +44,7 @@ class Unicode(console.Console):
 
     @classmethod
     def _format_unit_power(cls, unit: NamedUnit, power: Real = 1) -> str:
-        name = unit.get_format_name(cls.name)
+        name = unit._get_format_name(cls.name)
         # Check for superscript units
         if power != 1:
             if name in ("°", "e⁻", "″", "′", "ʰ"):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -13,6 +13,7 @@ from astropy import constants as c
 from astropy import units as u
 from astropy.units import utils
 from astropy.utils.compat.optional_deps import HAS_DASK
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_initialisation():
@@ -554,7 +555,7 @@ def test_pickling():
 
     assert other is u.m
 
-    new_unit = u.IrreducibleUnit(["foo"], format={"baz": "bar"})
+    new_unit = u.IrreducibleUnit(["foo"], format={"unicode": "bar"})
     # This is local, so the unit should not be registered.
     assert "foo" not in u.get_current_unit_registry().registry
 
@@ -563,7 +564,7 @@ def test_pickling():
     new_unit_copy = pickle.loads(p)
     assert new_unit_copy is not new_unit
     assert new_unit_copy.names == ["foo"]
-    assert new_unit_copy.get_format_name("baz") == "bar"
+    assert new_unit_copy.to_string("unicode") == "bar"
     # It should still not be registered.
     assert "foo" not in u.get_current_unit_registry().registry
 
@@ -580,7 +581,7 @@ def test_pickling():
         new_unit_copy = pickle.loads(p)
         assert new_unit_copy is not new_unit
         assert new_unit_copy.names == ["foo"]
-        assert new_unit_copy.get_format_name("baz") == "bar"
+        assert new_unit_copy.to_string("unicode") == "bar"
         assert "foo" in u.get_current_unit_registry().registry
 
     # And just to be sure, that it gets removed outside of the context.
@@ -1016,3 +1017,8 @@ def test_dask_arrays():
     assert isinstance(data3, da.core.Array)
 
     assert_allclose(data3.compute(), [-272.15, -271.15, -270.15])
+
+
+def test_get_format_name_deprecation():
+    with pytest.warns(AstropyDeprecationWarning, match=r"Use to_string\(\) instead\.$"):
+        assert u.m.get_format_name("fits") == "m"

--- a/docs/changes/units/16958.api.rst
+++ b/docs/changes/units/16958.api.rst
@@ -1,0 +1,3 @@
+The ``get_format_name()`` method of ``NamedUnit`` and its subclasses is
+deprecated.
+The ``to_string()`` method can be used instead.


### PR DESCRIPTION
### Description

On one hand it is very simple to make a mistake using `NamedUnit.get_format_name()`:
```python
>>> from astropy import units as u
>>> from astropy.units.format import CDS, FITS
>>> u.deg_C.get_format_name(FITS)
'deg_C'
>>> u.deg_C.get_format_name("fits")
'Celsius'
u.percent.get_format_name("cds")
'%'
>>> u.percent.get_format_name(CDS)
'percent'
```
On the other hand using the [`to_string()` method or Python string formatting](https://docs.astropy.org/en/stable/units/format.html#converting-to-strings) is more convenient anyways because those options work for both `NamedUnit` and `CompositeUnit`, whereas `get_format_name()` is only available with the former:
```python
>>> (u.m / u.s).get_format_name("latex")
Traceback (most recent call last):
  ...
AttributeError: 'CompositeUnit' object has no attribute 'get_format_name'
```

The `NamedUnit.get_format_name()` should be made private and the public version should be deprecated.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
