### PR TITLE
DEP: add missing lower bounds to dependencies from `oldestdeps-alldeps`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,33 +71,34 @@ all = [
     "astropy[ipython]",
     "astropy[jupyter]",
     # Install all remaining optional dependencies
-    "certifi",
-    "dask[array]>=2022.8.1",
-    "h5py",
+    "certifi>=2022.6.15.1",
+    "dask[array]>=2022.5.1",
+    "h5py>=3.8.0",
     "pyarrow>=10.0.1",
-    "beautifulsoup4",
-    "html5lib",
-    "bleach",
+    "beautifulsoup4>=4.9.3", # imposed by pandas==2.0
+    "html5lib>=1.1",
+    "bleach>=3.2.1",
     "pandas>=2.0",
-    "sortedcontainers",
-    "pytz",
-    "jplephem",
-    "mpmath",
+    "sortedcontainers>=1.5.7", # (older versions may work)
+    "pytz>=2016.10", # (older versions may work)
+    "jplephem>=2.6", # (older versions may work)
+    "mpmath>=1.2.1",
+    "asdf>=2.8.3", # via asdf-astropy==0.3.*
     "asdf-astropy>=0.3",
-    "bottleneck",
+    "bottleneck>=1.3.3",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
 ]
 # The base set of test-time dependencies.
 test = [
-    "coverage",
-    "pre-commit",
-    "pytest>=7.0",
+    "coverage>=6.4.4",
+    "pre-commit>=2.9.3", # lower bound is not tested beyond installation
+    "pytest>=7.3.0",
     "pytest-doctestplus>=0.12",
     "pytest-astropy-header>=0.2.1",
-    "pytest-astropy>=0.10",
-    "pytest-xdist",
-    "threadpoolctl",
+    "pytest-astropy>=0.10.0",
+    "pytest-xdist>=2.5.0",
+    "threadpoolctl>=3.0.0",
 ]
 test_all = [
     # Install grouped optional dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ deps =
     oldestdeps: ipython==8.0.0
     oldestdeps: pandas==2.0.*
     oldestdeps: pyarrow==10.0.1
-    oldestdeps: dask[array]==2022.8.1
+    oldestdeps: dask[array]==2022.5.1
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.


### PR DESCRIPTION
### Description

While working on #16950, I found that the proposed solution to use `uv pip install --resolution=lowest-direct` in `oldestdeps` only really worked for dependencies with an explicit lower bound, so, after a lot of trial and errors, here's all the missing metadata I was able to discover. I think it has value beyond the scope of #16950 so I'm proposing it as its own PR. It actually end up being *most* of the change needed to implement "`oldestdeps` with uv" (the rest of the work will happen over `tox.ini`).

I also threw in the release date for each of these dependencies that doesn't use calendar-based-versionning.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
