### PR TITLE
TST: have `oldestdeps` trully pin every direct dependency using `uv`'s `--resolution=lowest-direct`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,13 @@ ipython = [
 ]
 jupyter = [  # these are optional dependencies for utils.console and table
     "astropy[ipython]",
-    "ipywidgets",
-    "ipykernel",
-    "ipydatagrid",
-    "pandas",
+    "ipywidgets>=7.7.3",
+    "ipykernel>=6.16.0",
+    "ipydatagrid>=1.1.13",
+    # jupyter-core is a transitive dependency via ipykernel, we declare it as
+    # a direct dependency in order to set a lower bound for oldest-deps testing
+    "jupyter-core>=4.11.2",
+    "pandas>=1.5.0",
 ]
 # This is ALL the run-time optional dependencies.
 all = [

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     build_docs
     linkcheck
     codestyle
+requires =
+    tox-uv
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
@@ -23,9 +25,9 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
-    devdeps: PIP_VERBOSE = 1
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    mpldev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    mpldev: UV_INDEX = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps, mpldev: UV_INDEX_STRATEGY = unsafe-best-match # match pip's behavior
     fitsio: ASTROPY_ALWAYS_TEST_FITSIO = true
 
 # Run the tests in a temporary directory to make sure that we don't import
@@ -46,7 +48,7 @@ description =
     alldeps: with all optional and test dependencies
     devdeps: with the latest developer version of key dependencies
     devinfra: like devdeps but also dev version of infrastructure
-    oldestdeps: with the oldest supported version of key dependencies
+    oldestdeps: with the oldest supported version of direct dependencies
     cov: and test coverage
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
@@ -72,23 +74,6 @@ deps =
 
     # Some FITS tests use fitsio as a comparison
     fitsio: fitsio
-
-    # The oldestdeps factor is intended to be used to install the oldest versions of all
-    # dependencies that have a minimum version.
-    oldestdeps: packaging==22.0.0
-    oldestdeps: pyerfa==2.0.1.1
-    oldestdeps: numpy==1.23.2
-    oldestdeps: matplotlib==3.6.0
-    oldestdeps: asdf==2.8.*  # asdf-astropy==0.3.*
-    oldestdeps: asdf-astropy==0.3.*
-    oldestdeps: attrs < 24.1.0  # ASDF_LT_3_4
-    oldestdeps: beautifulsoup4==4.9.3
-    oldestdeps: scipy==1.9.2
-    oldestdeps: pyyaml==6.0.0
-    oldestdeps: ipython==8.0.0
-    oldestdeps: pandas==2.0.*
-    oldestdeps: pyarrow==10.0.1
-    oldestdeps: dask[array]==2022.5.1
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
@@ -129,6 +114,10 @@ pip_pre =
     devdeps: true
     predeps: true
 
+uv_resolution =
+    # The oldestdeps factor is intended to be used to install
+    # the oldest versions of all dependencies
+    oldestdeps: lowest-direct
 
 # This lets developers use tox to build docs and ignores warnings.
 # This is not used in CI; For that, we have RTD PR builder.


### PR DESCRIPTION
### Description

~Based of #16960 #16973~, close #16950, close #15865.

~I should highlight that, even though this goes beyond the scope initially discussed for #16950 (restricting the use of uv to the `oldestdeps` factor), this is actually a minimal change: setting tox to use `pip` OR `uv` internally, depending on env factors, would require additional work and I should note that I already tried and couldn't figure it out)~.
**update:** fixed it. Now an tox will continue to work without tox-uv for except for `oldestdeps`.

gains:
- one source of truth for oldest supported versions (`pyproject.toml`)
- all dependencies included in the test job are actually pinned to what we claim is our oldest supported versions, not just core ones, avoiding issues like we've recently seen in, e.g., #16903 (see https://github.com/astropy/astropy/pull/16903#issuecomment-2330837485)

costs:
- `tox-uv` is now required to run `tox`
  
 It's a one-time install burden; once you have it installed, you don't need to do anything special when running tox, and it is fully transparent to anyone who relies on the `test_all` extra target. I should clarify that this solution *doesn't require* (and is not incompatible with) a system-wide install of uv*: installing tox-uv pulls uv from PyPI to your dev env.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


TODO:
- [x] fix *all* CI (including circle CI)
- [ ] adjust docs
