### PR TITLE
Fixes to biweight stat functions

### DIFF
--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -489,7 +489,7 @@ def biweight_midvariance(
         where_func = np.where
         if isinstance(data, np.ma.MaskedArray):
             where_func = np.ma.where  # return MaskedArray
-        return where_func(mad.squeeze() == 0, 0.0, value)
+        return where_func(mad.squeeze(axis=axis) == 0, 0.0, value)
 
 
 def biweight_midcovariance(

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -171,14 +171,16 @@ def biweight_location(
     # the median value along that axis.
     # Ignore RuntimeWarnings for divide by zero
     with np.errstate(divide="ignore", invalid="ignore"):
-        value = M.squeeze() + (sum_func(d * u, axis=axis) / sum_func(u, axis=axis))
+        value = M.squeeze(axis=axis) + (
+            sum_func(d * u, axis=axis) / sum_func(u, axis=axis)
+        )
         if np.isscalar(value):
             return value
 
         where_func = np.where
         if isinstance(data, np.ma.MaskedArray):
             where_func = np.ma.where  # return MaskedArray
-        return where_func(mad.squeeze() == 0, M.squeeze(), value)
+        return where_func(mad.squeeze(axis=axis) == 0, M.squeeze(axis=axis), value)
 
 
 def biweight_scale(

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -149,10 +149,11 @@ def biweight_location(
     # set up the weighting
     mad = median_absolute_deviation(data, axis=axis, ignore_nan=ignore_nan)
 
+    # np.ndim(mad) = 0 means axis is None or contains all axes
     # mad = 0 means data is constant or mostly constant
     # mad = np.nan means data contains NaNs and ignore_nan=False
-    if axis is None and (mad == 0.0 or np.isnan(mad)):
-        return M
+    if np.ndim(mad) == 0 and (mad == 0.0 or np.isnan(mad)):
+        return M.squeeze(axis=axis)
 
     if axis is not None:
         mad = np.expand_dims(mad, axis=axis)
@@ -440,12 +441,13 @@ def biweight_midvariance(
     # set up the weighting
     mad = median_absolute_deviation(data, axis=axis, ignore_nan=ignore_nan)
 
-    if axis is None:
-        # data is constant or mostly constant OR
-        # data contains NaNs and ignore_nan=False
-        if mad == 0.0 or np.isnan(mad):
-            return mad**2  # variance units
-    else:
+    # np.ndim(mad) = 0 means axis is None or contains all axes
+    # mad = 0 means data is constant or mostly constant
+    # mad = np.nan means data contains NaNs and ignore_nan=False
+    if np.ndim(mad) == 0 and (mad == 0.0 or np.isnan(mad)):
+        return mad**2  # variance units
+
+    if axis is not None:
         mad = np.expand_dims(mad, axis=axis)
 
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -20,22 +20,25 @@ def test_biweight_location():
     with NumpyRNGContext(12345):
         # test that it runs
         randvar = np.random.randn(10000)
-        cbl = biweight_location(randvar)
-        assert abs(cbl - 0) < 1e-2
+        val = biweight_location(randvar)
+        assert abs(val) < 1e-2
 
 
 def test_biweight_location_constant():
-    cbl = biweight_location(np.ones((10, 5)))
-    assert cbl == 1.0
+    arr = np.ones((10, 5))
+    val = biweight_location(arr)
+    assert val == 1.0
+    val = biweight_location(arr, axis=(0, 1))
+    assert val == 1.0
 
 
 def test_biweight_location_constant_axis_2d():
     shape = (10, 5)
     data = np.ones(shape)
-    cbl = biweight_location(data, axis=0)
-    assert_allclose(cbl, np.ones(shape[1]))
-    cbl = biweight_location(data, axis=1)
-    assert_allclose(cbl, np.ones(shape[0]))
+    val = biweight_location(data, axis=0)
+    assert_allclose(val, np.ones(shape[1]))
+    val = biweight_location(data, axis=1)
+    assert_allclose(val, np.ones(shape[0]))
 
     val1 = 100.0
     val2 = 2.0
@@ -44,21 +47,21 @@ def test_biweight_location_constant_axis_2d():
     data[2] = val1
     data[7] = val2
     data[8] = [val3, 0.8, val3, -0.8, val3]
-    cbl = biweight_location(data, axis=1)
-    assert_allclose(cbl[2], val1)
-    assert_allclose(cbl[7], val2)
-    assert_allclose(cbl[8], val3)
+    val = biweight_location(data, axis=1)
+    assert_allclose(val[2], val1)
+    assert_allclose(val[7], val2)
+    assert_allclose(val[8], val3)
 
 
 def test_biweight_location_constant_axis_3d():
     shape = (10, 5, 2)
     data = np.ones(shape)
-    cbl = biweight_location(data, axis=0)
-    assert_allclose(cbl, np.ones((shape[1], shape[2])))
-    cbl = biweight_location(data, axis=1)
-    assert_allclose(cbl, np.ones((shape[0], shape[2])))
-    cbl = biweight_location(data, axis=2)
-    assert_allclose(cbl, np.ones((shape[0], shape[1])))
+    val = biweight_location(data, axis=0)
+    assert_allclose(val, np.ones((shape[1], shape[2])))
+    val = biweight_location(data, axis=1)
+    assert_allclose(val, np.ones((shape[0], shape[2])))
+    val = biweight_location(data, axis=2)
+    assert_allclose(val, np.ones((shape[0], shape[1])))
 
 
 def test_biweight_location_small():
@@ -88,12 +91,10 @@ def test_biweight_location_axis():
         assert_allclose(bw, bwi)
 
 
-def test_biweight_location_axis_3d():
+@pytest.mark.parametrize("nx, ny, nz", [(5, 4, 3), (5, 1, 3), (1, 4, 3), (1, 1, 5)])
+def test_biweight_location_axis_3d(nx, ny, nz):
     """Test a 3D array with the axis keyword."""
     with NumpyRNGContext(12345):
-        nz = 3
-        ny = 4
-        nx = 5
         data = np.random.normal(5, 2, (nz, ny, nx))
         bw = biweight_location(data, axis=0)
         assert bw.shape == (ny, nx)
@@ -106,10 +107,11 @@ def test_biweight_location_axis_3d():
         assert_allclose(bw[y], bwi)
 
 
-def test_biweight_location_axis_tuple():
+@pytest.mark.parametrize("shape", [(2, 3, 4), (12, 1, 2), (1, 12, 2), (1, 1, 24)])
+def test_biweight_location_axis_tuple(shape):
     """Test a 3D array with a tuple axis keyword."""
 
-    data = np.arange(24).reshape(2, 3, 4)
+    data = np.arange(24).reshape(shape)
     data[0, 0] = 100.0
 
     assert_equal(biweight_location(data, axis=0), biweight_location(data, axis=(0,)))
@@ -274,12 +276,10 @@ def test_biweight_midvariance_axis():
         assert_allclose(bw, bwi)
 
 
-def test_biweight_midvariance_axis_3d():
+@pytest.mark.parametrize("nx, ny, nz", [(5, 4, 3), (5, 1, 3), (1, 4, 3), (1, 1, 5)])
+def test_biweight_midvariance_axis_3d(nx, ny, nz):
     """Test a 3D array with the axis keyword."""
     with NumpyRNGContext(12345):
-        nz = 3
-        ny = 4
-        nx = 5
         data = np.random.normal(5, 2, (nz, ny, nx))
         bw = biweight_midvariance(data, axis=0)
         assert bw.shape == (ny, nx)

--- a/docs/changes/stats/16964.bugfix.rst
+++ b/docs/changes/stats/16964.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed a bug in biweight_location, biweight_scale, and
+biweight_midvariance where the returned array shape would be wrong if
+the input array had an axis length of 1 along any axis that was not
+included in the axis keyword. Also fixed a bug in these same functions
+where for constant data and axis set to a tuple containing all axes, the
+returned value would be NaN instead of the constant value.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes two separate issues in the biweight stats functions `biweight_location`, `biweight_scale`, and `biweight_midvariance`:

* the returned array shape would be wrong if the input array had an axis length of 1 along any axis that was not included in the axis keyword
* for constant input data and axis set to a tuple containing all axes, the returned value would be NaN instead of the constant value.

Examples with `biweight_location`:
```python
>>> from astropy.stats import biweight_location
>>> arr = np.ones((5, 1, 10))
>>> val = biweight_location(arr, axis=-1)
>>> val.shape  # should be (5, 1)!
(5, 5)

>>> arr = np.ones((5, 1, 4, 10))
>>> val = biweight_location(arr, axis=-1)
>>> val.shape  # should be (5, 1, 4)!
(5, 5, 4)
```

```python
>>> arr = np.ones((5, 1, 10))
>>> biweight_location(arr, axis=None)
np.float64(1.0)
>>> biweight_location(arr, axis=(0, 1, 2))
np.float64(nan)  # should be 1.0
```

Pinging @mhvk for review since I'm the only `astropy.stats` maintainer.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
