### PR TITLE
Improve performance of biwieght stats and median_absolute_deviation

### DIFF
--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from .funcs import median_absolute_deviation
+from astropy.stats.funcs import median_absolute_deviation
+from astropy.stats.nanfunctions import nanmedian
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -37,7 +38,7 @@ def _stat_functions(
         median_func = np.ma.median
         sum_func = np.ma.sum
     elif ignore_nan:
-        median_func = np.nanmedian
+        median_func = nanmedian
         sum_func = np.nansum
     else:
         median_func = np.median

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from astropy.stats.funcs import median_absolute_deviation
-from astropy.stats.nanfunctions import nanmedian
+from astropy.stats.nanfunctions import nanmedian, nansum
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,7 +39,7 @@ def _stat_functions(
         sum_func = np.ma.sum
     elif ignore_nan:
         median_func = nanmedian
-        sum_func = np.nansum
+        sum_func = nansum
     else:
         median_func = np.median
         sum_func = np.sum

--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -79,11 +79,13 @@ if HAS_BOTTLENECK:
         else:
             return result
 
+    nansum = functools.partial(_apply_bottleneck, bottleneck.nansum)
     nanmean = functools.partial(_apply_bottleneck, bottleneck.nanmean)
     nanmedian = functools.partial(_apply_bottleneck, bottleneck.nanmedian)
     nanstd = functools.partial(_apply_bottleneck, bottleneck.nanstd)
 
 else:
+    nansum = np.nansum
     nanmean = np.nanmean
     nanmedian = np.nanmedian
     nanstd = np.nanstd

--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -1,0 +1,97 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from astropy.stats.funcs import mad_std
+from astropy.units import Quantity
+from astropy.utils.compat.optional_deps import HAS_BOTTLENECK
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import ArrayLike, NDArray
+
+
+if HAS_BOTTLENECK:
+    import bottleneck
+
+    def _move_tuple_axes_last(
+        array: ArrayLike,
+        axis: tuple[int, ...] | None = None,
+    ) -> ArrayLike:
+        """
+        Move the specified axes of a NumPy array to the last positions
+        and combine them.
+
+        Bottleneck can only take integer axis, not tuple, so this
+        function takes all the axes to be operated on and combines them
+        into the last dimension of the array so that we can then use
+        axis=-1.
+
+        Parameters
+        ----------
+        array : `~numpy.ndarray`
+            The input array.
+
+        axis : tuple of int
+            The axes on which to move and combine.
+
+        Returns
+        -------
+        array_new : `~numpy.ndarray`
+            Array with the axes being operated on moved into the last
+            dimension.
+        """
+        other_axes = tuple(i for i in range(array.ndim) if i not in axis)
+
+        # Move the specified axes to the last positions
+        array_new = np.transpose(array, other_axes + axis)
+
+        # Reshape the array by combining the moved axes
+        return array_new.reshape(array_new.shape[: len(other_axes)] + (-1,))
+
+    def _apply_bottleneck(
+        function: Callable,
+        array: ArrayLike,
+        axis: int | tuple[int, ...] | None = None,
+        **kwargs,
+    ) -> float | NDArray | Quantity:
+        """Wrap bottleneck function to handle tuple axis.
+
+        Also takes care to ensure the output is of the expected type,
+        i.e., a quantity, numpy array, or numpy scalar.
+        """
+        if isinstance(axis, tuple):
+            array = _move_tuple_axes_last(array, axis=axis)
+            axis = -1
+
+        result = function(array, axis=axis, **kwargs)
+        if isinstance(array, Quantity):
+            return array.__array_wrap__(result)
+        elif isinstance(result, float):
+            # For compatibility with numpy, always return a numpy scalar.
+            return np.float64(result)
+        else:
+            return result
+
+    nanmean = functools.partial(_apply_bottleneck, bottleneck.nanmean)
+    nanmedian = functools.partial(_apply_bottleneck, bottleneck.nanmedian)
+    nanstd = functools.partial(_apply_bottleneck, bottleneck.nanstd)
+
+else:
+    nanmean = np.nanmean
+    nanmedian = np.nanmedian
+    nanstd = np.nanstd
+
+
+def nanmadstd(
+    array: ArrayLike,
+    axis: int | tuple[int, ...] | None = None,
+) -> float | NDArray:
+    """mad_std function that ignores NaNs by default."""
+    return mad_std(array, axis=axis, ignore_nan=True)

--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -1,4 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+The functions in this module provide faster versions of np.nan*
+functions using the optional bottleneck package if it is installed. If
+bottleneck is not installed, then the np.nan* functions are used.
+"""
 
 from __future__ import annotations
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from astropy import units as u
 from astropy.stats import funcs
-from astropy.utils.compat.optional_deps import HAS_MPMATH, HAS_SCIPY
+from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_MPMATH, HAS_SCIPY
 from astropy.utils.misc import NumpyRNGContext
 
 
@@ -397,17 +397,24 @@ def test_mad_std_with_axis_and_nan():
     result_axis0 = np.array([2.22390333, 0.74130111, 0.74130111, 2.22390333, np.nan])
     result_axis1 = np.array([1.48260222, 1.48260222])
 
-    with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
+    if HAS_BOTTLENECK:
         assert_allclose(funcs.mad_std(data, axis=0, ignore_nan=True), result_axis0)
         assert_allclose(funcs.mad_std(data, axis=1, ignore_nan=True), result_axis1)
+    else:
+        with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
+            assert_allclose(funcs.mad_std(data, axis=0, ignore_nan=True), result_axis0)
+            assert_allclose(funcs.mad_std(data, axis=1, ignore_nan=True), result_axis1)
 
 
 def test_mad_std_with_axis_and_nan_array_type():
     # mad_std should return a masked array if given one, and not otherwise
     data = np.array([[1, 2, 3, 4, np.nan], [4, 3, 2, 1, np.nan]])
 
-    with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
+    if HAS_BOTTLENECK:
         result = funcs.mad_std(data, axis=0, ignore_nan=True)
+    else:
+        with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
+            result = funcs.mad_std(data, axis=0, ignore_nan=True)
     assert not np.ma.isMaskedArray(result)
 
     data = np.ma.masked_where(np.isnan(data), data)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The PR  significantly improves the peformance of biweight stats and the `median_absolution_deviation` function if `bottleneck` is installed by using the existing `_nanmedian` function and a newly-added `_nansum` functions.  This PR also puts the `_nan*` functions in a separate module.

@mhvk 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
