### PR TITLE
STY: permanently ignore ruff rule `PTH123` (`builtin-open`)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -306,7 +306,7 @@ nitpicky = True
 show_warning_types = True
 # See docs/nitpick-exceptions file for the actual listing.
 nitpick_ignore = []
-for line in open("nitpick-exceptions"):  # noqa: PTH123
+for line in open("nitpick-exceptions"):
     if line.strip() == "" or line.startswith("#"):
         continue
     dtype, target = line.split(None, 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -369,6 +369,9 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "PLR1730", # if-stmt-min-max (not always clearer, and sometimes slower)
     "PLW0642", # self-or-cls-assignment (occasionally desirable, very rarely a mistake)
 
+    # flake8-use-pathlib (PTH)
+    "PTH123", # builtin-open (not worth creating a Path object, builtin open is fine)
+
     # flake8-simplify (SIM)
     "SIM103", # needless-bool (cannot be safely applied in all contexts (np.True_ is not True))
 


### PR DESCRIPTION
### Description

This is in response to [@taldcroft's review of #16954](https://github.com/astropy/astropy/pull/16954#pullrequestreview-2287465998), that I'll also quote here:

> Overall in the Path migration I think you should mostly avoid doing a blind replacement of open(...) with Path().read/write_text().
>
> There is nothing wrong with open() and the two cases here show that open() is often preferable because it is a streaming interface.

ref #16924
I'll move all affected PRs from #16924 to draft until this point is resolved.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
