### PR TITLE
TST: simplify redundant `tox.ini` sections enabling `pip_pre`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ setenv =
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
+    devdeps: PIP_VERBOSE = 1
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     mpldev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     fitsio: ASTROPY_ALWAYS_TEST_FITSIO = true
@@ -116,10 +117,6 @@ extras =
     alldeps: all
     alldeps: test_all
 
-install_command =
-    !devdeps: python -I -m pip install
-    devdeps: python -I -m pip install -v --pre
-
 commands =
     {list_dependencies_command}
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
@@ -128,8 +125,8 @@ commands =
     double: python -c 'import sys; from astropy import test; test(); sys.exit(test())'
 
 pip_pre =
+    devdeps: true
     predeps: true
-    !predeps: false
 
 
 # This lets developers use tox to build docs and ignores warnings.


### PR DESCRIPTION
### Description
Found this while working on #16950: the way we set `install_command` doesn't respect [recommendations from tox's docs](https://tox.wiki/en/latest/config.html#install_command)

> Must contain the substitution key {packages} which will be replaced by the package(s) to install. You should also accept {opts} – it will contain index server options such as --pre (configured as pip_pre)

It's also redundant to use `install_commands` to set pip's `--pre` flag, and it gets in the way of `tox-uv` (see #16950).

Other than that the change is a noop: it doesn't change anything[^1] to how test env behave, it's just written in a more tidy fashion, making the configuration more maintainable.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

[^1]: well, except that it removes a `-v` verbose flag from `pip install` in `devdeps`. Note that it's still possible to increase pip's verbosity with the [`PIP_VERBOSE`](https://pip.pypa.io/en/stable/cli/pip/#cmdoption-v) env var if needed.