### PR TITLE
TST: generalize pip freeze-like command in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ install_command =
     devdeps: python -I -m pip install -v --pre
 
 commands =
-    pip freeze
+    {list_dependencies_command}
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
 
@@ -139,7 +139,7 @@ changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
-    pip freeze
+    {list_dependencies_command}
     sphinx-build -b html . _build/html {posargs:-j auto}
 
 [testenv:linkcheck]
@@ -147,7 +147,7 @@ changedir = docs
 description = check the links in the HTML docs
 extras = docs
 commands =
-    pip freeze
+    {list_dependencies_command}
     sphinx-build -b linkcheck . _build/html {posargs:-W}
 
 [testenv:codestyle]


### PR DESCRIPTION
### Description

This makes calling `pip freeze` more general:
- the default command is `pip freeze --all`, the same as `pip freeze`, except that it also shows the versions of build packages (`setuptools`, `distribute`, `pip`, `wheel`), so it's sligthtly more useful
- increases portability if we want to use `tox-uv` (see #16950)

See https://tox.wiki/en/latest/config.html#list_dependencies_command

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
