### PR TITLE
Fix the error message from VOUnit about strings with multiple slashes

### DIFF
--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -9,7 +9,7 @@ import re
 import warnings
 from typing import TYPE_CHECKING
 
-from astropy.units.errors import UnitScaleError, UnitsWarning
+from astropy.units.errors import UnitScaleError, UnitsError, UnitsWarning
 from astropy.utils import classproperty
 
 from . import core, generic, utils

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -186,7 +186,7 @@ def test_multiple_solidus():
     ):
         assert u.Unit("m/s/kg").to_string() == "m / (kg s)"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="contains multiple slashes"):
         u.Unit("m/s/kg", format="vounit")
 
     # Regression test for #9000: solidi in exponents do not count towards this.


### PR DESCRIPTION
### Description

9ce5864120f2eea734d01fb72e9c08869564a25d missed an import, so when the code was supposed to raise a `UnitsError` it raised a `NameError` instead. However, this went unnoticed by our tests despite being covered by them because the machinery in `u.Unit()` converted the `NameError` to a `ValueError` anyways and our tests did not check the error message at all.
```
$ git switch --detach 9ce5864120f2eea734d01fb72e9c08869564a25d^
HEAD is now at 8143254222...
$ python -c "from astropy.units import Unit; Unit('m / s / s', format='vounit')"
Traceback (most recent call last):
  ...
ValueError: 'm / s / s' did not parse as vounit unit: 'm / s / s' contains multiple slashes, which is disallowed by the VOUnit standard...
$ git switch --detach 9ce5864120f2eea734d01fb72e9c08869564a25d
Previous HEAD position was 8143254222...
$ python -c "from astropy.units import Unit; Unit('m / s / s', format='vounit')"
Traceback (most recent call last):
  ...
ValueError: 'm / s / s' did not parse as vounit unit: name 'UnitsError' is not defined...
```
The first commit reveals the bug, the second fixes it. There have been no `astropy` releases with this bug, so a change log entry isn't needed.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
