### PR TITLE
Allow ruff to check for undefined names in units

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -286,7 +286,6 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/units/*" = [
-    "F821",  # undefined-name
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
     "TRY300",  # Consider `else` block

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -4,6 +4,8 @@
 This package defines the astrophysics-specific units. They are also
 available in (and should be used through) the `astropy.units` namespace.
 """
+# avoid ruff complaints about undefined names defined by def_unit
+# ruff: noqa: F821
 
 import numpy as np
 

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -3,6 +3,8 @@
 This package defines the CGS units.  They are also available in
 (and should be used through) the `astropy.units` namespace.
 """
+# avoid ruff complaints about undefined names defined by def_unit
+# ruff: noqa: F821
 
 from fractions import Fraction
 

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -26,6 +26,8 @@ from .generic import Generic
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
+    import numpy as np
+
     from astropy.extern.ply.lex import Lexer
     from astropy.units import NamedUnit, UnitBase
     from astropy.utils.parsing import ThreadSafeParser

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -16,6 +16,8 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
     >>> import astropy.units as u
     >>> u.imperial.enable()  # doctest: +SKIP
 """
+# avoid ruff complaints about undefined names defined by def_unit
+# ruff: noqa: F821
 
 __all__: list[str] = []  #  Units are added at the end
 

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -4,6 +4,8 @@
 This package defines miscellaneous units. They are also available in
 (and should be used through) the `astropy.units` namespace.
 """
+# avoid ruff complaints about undefined names defined by def_unit
+# ruff: noqa: F821
 
 import numpy as np
 

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -10,6 +10,8 @@ Both the units and magnitudes are available in (and should be used
 through) the `astropy.units` namespace.
 
 """
+# avoid ruff complaints about undefined names defined by def_unit
+# ruff: noqa: F821
 
 import numpy as np
 

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -3,6 +3,8 @@
 This package defines the SI units.  They are also available in
 (and should be used through) the `astropy.units` namespace.
 """
+# avoid ruff complaints about undefined names defined by def_unit
+# ruff: noqa: F821
 
 import numpy as np
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -348,7 +348,7 @@ def test_default_value_check():
 
 def test_str_unit_typo():
     @u.quantity_input
-    def myfunc_args(x: "kilograam"):
+    def myfunc_args(x: "kilograam"):  # noqa: F821
         return x
 
     with pytest.raises(ValueError):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -36,10 +36,10 @@ class testcase(NamedTuple):
     f: Callable
     """The ufunc to test."""
 
-    q_in: tuple[Quantity]
+    q_in: tuple[u.Quantity]
     """The input quantities."""
 
-    q_out: tuple[Quantity]
+    q_out: tuple[u.Quantity]
     """The expected output quantities."""
 
 
@@ -49,7 +49,7 @@ class testexc(NamedTuple):
     f: Callable
     """The ufunc to test."""
 
-    q_in: tuple[Quantity]
+    q_in: tuple[u.Quantity]
     """The input quantities."""
 
     exc: type
@@ -65,7 +65,7 @@ class testwarn(NamedTuple):
     f: Callable
     """The ufunc to test."""
 
-    q_in: tuple[Quantity]
+    q_in: tuple[u.Quantity]
     """The input quantities."""
 
     wfilter: str


### PR DESCRIPTION
We had disabled the `ruff` check on undefined names (F821) since in our unit definition files, `def_unit` introduces a *lot* of what look like undefined names. This has caused some bugs to be missed - #16977. With more recent ruff (https://github.com/astral-sh/ruff/pull/2978), one can easily mark specific files as out-of-scope for F821, so this PR does that and fixes the few remaining problems that were found. Now, future PRs can no longer introduce this type of annoying bug in most of `units`.

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
