### PR TITLE
Update documentation to not recommend LevMarLSQFitter as the default fitter

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1403,9 +1403,11 @@ class LevMarLSQFitter(_NonLinearLSQFitter):
     """
     Levenberg-Marquardt algorithm and least squares statistic.
 
-    This fitter is no longer recommended - instead you should make use of
-    `LMLSQFitter` if your model does not have bounds, or one of the other
-    non-linear fitters otherwise.
+    .. warning:
+    
+        This fitter is no longer recommended - instead you should make use of
+        `LMLSQFitter` if your model does not have bounds, or one of the other
+        non-linear fitters, such as `TRFLSQFitter` otherwise.
 
     Parameters
     ----------

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1407,7 +1407,8 @@ class LevMarLSQFitter(_NonLinearLSQFitter):
 
         This fitter is no longer recommended - instead you should make use of
         `LMLSQFitter` if your model does not have bounds, or one of the other
-        non-linear fitters, such as `TRFLSQFitter` otherwise.
+        non-linear fitters, such as `TRFLSQFitter` otherwise. For more details,
+        see the main documentation page on fitting.
 
     Parameters
     ----------

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1404,7 +1404,7 @@ class LevMarLSQFitter(_NonLinearLSQFitter):
     Levenberg-Marquardt algorithm and least squares statistic.
 
     .. warning:
-    
+
         This fitter is no longer recommended - instead you should make use of
         `LMLSQFitter` if your model does not have bounds, or one of the other
         non-linear fitters, such as `TRFLSQFitter` otherwise.

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1403,6 +1403,10 @@ class LevMarLSQFitter(_NonLinearLSQFitter):
     """
     Levenberg-Marquardt algorithm and least squares statistic.
 
+    This fitter is no longer recommended - instead you should make use of
+    `LMLSQFitter` if your model does not have bounds, or one of the other
+    non-linear fitters otherwise.
+
     Parameters
     ----------
     calc_uncertainties : bool

--- a/docs/modeling/example-fitting-constraints.rst
+++ b/docs/modeling/example-fitting-constraints.rst
@@ -71,7 +71,8 @@ attributes on a parameter. The following fitters support bounds internally:
 * `~astropy.modeling.fitting.SLSQPLSQFitter`
 
 The `~astropy.modeling.fitting.LevMarLSQFitter` algorithm uses an unsophisticated
-method of handling bounds and is no longer recommended.
+method of handling bounds and is no longer recommended (see
+:ref:`modeling-getting-started-nonlinear-notes` for more details).
 
 .. _tied:
 

--- a/docs/modeling/example-fitting-constraints.rst
+++ b/docs/modeling/example-fitting-constraints.rst
@@ -8,7 +8,7 @@ attribute shows the type of constraints supported by a specific fitter::
     >>> from astropy.modeling import fitting
     >>> fitting.LinearLSQFitter.supported_constraints
     ['fixed']
-    >>> fitting.LevMarLSQFitter.supported_constraints
+    >>> fitting.TRFLSQFitter.supported_constraints
     ['fixed', 'tied', 'bounds']
     >>> fitting.SLSQPLSQFitter.supported_constraints
     ['bounds', 'eqcons', 'ineqcons', 'fixed', 'tied']
@@ -64,11 +64,14 @@ Bounded Constraints
 
 Bounded fitting is supported through the ``bounds`` arguments to models or by
 setting `~astropy.modeling.Parameter.min` and `~astropy.modeling.Parameter.max`
-attributes on a parameter.  Bounds for the
-`~astropy.modeling.fitting.LevMarLSQFitter` are always exactly satisfied--if
-the value of the parameter is outside the fitting interval, it will be reset to
-the value at the bounds. The `~astropy.modeling.fitting.SLSQPLSQFitter` optimization
-algorithm handles bounds internally.
+attributes on a parameter. The following fitters support bounds internally:
+
+* `~astropy.modeling.fitting.TRFLSQFitter`
+* `~astropy.modeling.fitting.DogBoxLSQFitter`
+* `~astropy.modeling.fitting.SLSQPLSQFitter`
+
+The `~astropy.modeling.fitting.LevMarLSQFitter` algorithm uses an unsophisticated
+method of handling bounds and is no longer recommended.
 
 .. _tied:
 
@@ -141,7 +144,7 @@ linking the flux of the [OIII] λ4959 line to the [OIII] λ5007 line.
     hbeta_narrow.mean.tied = tie_hbeta_wave2
 
     # Simultaneously fit all the emission lines and continuum.
-    fitter = fitting.LevMarLSQFitter()
+    fitter = fitting.TRFLSQFitter()
     fitted_model = fitter(model, wave, flux)
     fitted_lines = fitted_model(wave)
 

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -70,7 +70,8 @@ fitters are:
   algorithm via the scipy legacy function `scipy.optimize.leastsq`. This fitter supports
   parameter bounds via an unsophisticated min/max condition which can cause parameters
   to "stick" to one of the bounds if during the fitting process the parameter gets close
-  to the bound during some of the intermediate fitting operations.
+  to the bound during some of the intermediate fitting operations. This fitter is no
+  longer recommended, and you should use one of the ones below depending on your use case.
 
 * :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
   (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
@@ -101,7 +102,7 @@ Simple 1-D model fitting
 In this section, we look at a simple example of fitting a Gaussian to a
 simulated dataset. We use the `~astropy.modeling.functional_models.Gaussian1D`
 and `~astropy.modeling.functional_models.Trapezoid1D` models and the
-`~astropy.modeling.fitting.LevMarLSQFitter` fitter to fit the data:
+`~astropy.modeling.fitting.TRFLSQFitter` fitter to fit the data:
 
 .. plot::
    :include-source:
@@ -120,12 +121,12 @@ and `~astropy.modeling.functional_models.Trapezoid1D` models and the
     # Bounds are not really needed but included here to demonstrate usage.
     t_init = models.Trapezoid1D(amplitude=1., x_0=0., width=1., slope=0.5,
                                 bounds={"x_0": (-5., 5.)})
-    fit_t = fitting.LevMarLSQFitter()
+    fit_t = fitting.TRFLSQFitter()
     t = fit_t(t_init, x, y, maxiter=200)
 
     # Fit the data using a Gaussian
     g_init = models.Gaussian1D(amplitude=1., mean=0, stddev=1.)
-    fit_g = fitting.LevMarLSQFitter()
+    fit_g = fitting.TRFLSQFitter()
     g = fit_g(g_init, x, y)
 
     # Plot the data with the best-fit model
@@ -167,7 +168,7 @@ background in an image.
 
     # Fit the data using astropy.modeling
     p_init = models.Polynomial2D(degree=2)
-    fit_p = fitting.LevMarLSQFitter()
+    fit_p = fitting.LMLSQFitter()
 
     with warnings.catch_warnings():
         # Ignore model linearity warning from the fitter

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -62,16 +62,16 @@ The rules for passing input to fitters are:
 Notes on non-linear fitting
 ---------------------------
 
-There are several non-linear fitters, which rely on several different optimization
-algorithms now. Choice of algorithm is problem dependent. The main non-linear
-fitters are:
+There are several non-linear fitters, which rely on several different
+optimization algorithms. Which one you should choose will depend on the problem
+you are trying to solve. The main recommended non-linear fitters are:
 
-* :class:`~astropy.modeling.fitting.LevMarLSQFitter`, which uses the Levenberg-Marquardt
-  algorithm via the scipy legacy function `scipy.optimize.leastsq`. This fitter supports
-  parameter bounds via an unsophisticated min/max condition which can cause parameters
-  to "stick" to one of the bounds if during the fitting process the parameter gets close
-  to the bound during some of the intermediate fitting operations. This fitter is no
-  longer recommended, and you should use one of the ones below depending on your use case.
+* :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
+  algorithm as implemented by `scipy.optimize.least_squares`. Does not handle bounds and/or
+  sparse Jacobians. Usually the most efficient method for small unconstrained problems.
+  If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
+  you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it
+  makes use of the recommended version of this algorithm in scipy.
 
 * :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
   (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
@@ -87,12 +87,18 @@ fitters are:
   for more details. This fitter supports bounds in the same fashion that
   :class:`~astropy.modeling.fitting.TRFLSQFitter` does.
 
-* :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
-  algorithm as implemented by `scipy.optimize.least_squares`. Does not handle bounds and/or
-  sparse Jacobians. Usually the most efficient method for small unconstrained problems.
-  If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
-  you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it
-  makes use of the recommended version of this algorithm in scipy.
+Note that the :class:`~astropy.modeling.fitting.LevMarLSQFitter` fitter, which
+uses the Levenberg-Marquardt algorithm via the scipy legacy function
+`scipy.optimize.leastsq`, is no longer recommended. This fitter supports
+parameter bounds via an unsophisticated min/max condition whereby during each
+step of the fitting, parameters that are out of bounds are simply reset to the
+min or max of the bounds. This can cause parameters to "stick" to one of the
+bounds if during the fitting process the parameter gets close to the bound. If
+the models you are fitting make use of bounds, you should make use of one of the
+other fitters such as :class:`~astropy.modeling.fitting.TRFLSQFitter` or
+:class:`~astropy.modeling.fitting.DogBoxLSQFitter`, and if you do not need
+bounds and specifically want to use the Levenberg-Marquardt algorithm, you
+should use :class:`~astropy.modeling.fitting.LMLSQFitter`.
 
 .. _modeling-getting-started-1d-fitting:
 

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -66,26 +66,23 @@ There are several non-linear fitters, which rely on several different
 optimization algorithms. Which one you should choose will depend on the problem
 you are trying to solve. The main recommended non-linear fitters are:
 
+* :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
+  (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
+  `scipy.optimize.least_squares` for more details.
+
+* :class:`~astropy.modeling.fitting.DogBoxLSQFitter`, which uses the dogleg algorithm
+  with rectangular trust regions, typical use case is small problems with bounds. Not
+  recommended for problems with rank-deficient Jacobian, see `scipy.optimize.least_squares`
+  for more details.
+
 * :class:`~astropy.modeling.fitting.LMLSQFitter`, which uses the Levenberg-Marquardt (LM)
   algorithm as implemented by `scipy.optimize.least_squares`. Does not handle bounds and/or
   sparse Jacobians. Usually the most efficient method for small unconstrained problems.
   If a Levenberg-Marquardt algorithm is desired for your problem, it is now recommended that
   you use this fitter instead of :class:`~astropy.modeling.fitting.LevMarLSQFitter` as it
-  makes use of the recommended version of this algorithm in scipy.
-
-* :class:`~astropy.modeling.fitting.TRFLSQFitter`, which uses the Trust Region Reflective
-  (TRF) algorithm that is particularly suitable for large sparse problems with bounds, see
-  `scipy.optimize.least_squares` for more details. Note that this fitter supports parameter
-  bounds in a sophisticated fashion which prevents fitting from "sticking" to one of the
-  bounds provided. This fitter can be switched over to using the min/max bound method
-  by setting ``use_min_max_bounds=False`` when initializing the fitter. This is the recommended
-  algorithm by scipy.
-
-* :class:`~astropy.modeling.fitting.DogBoxLSQFitter`, which uses the dogleg algorithm
-  with rectangular trust regions, typical use case is small problems with bounds. Not
-  recommended for problems with rank-deficient Jacobian, see `scipy.optimize.least_squares`
-  for more details. This fitter supports bounds in the same fashion that
-  :class:`~astropy.modeling.fitting.TRFLSQFitter` does.
+  makes use of the recommended version of this algorithm in scipy. However, if your problem
+  makes use of bounds, you should use another non-linear fitter instead such as
+  :class:`~astropy.modeling.fitting.TRFLSQFitter` or :class:`~astropy.modeling.fitting.DogBoxLSQFitter`
 
 Note that the :class:`~astropy.modeling.fitting.LevMarLSQFitter` fitter, which
 uses the Levenberg-Marquardt algorithm via the scipy legacy function

--- a/docs/modeling/new-model.rst
+++ b/docs/modeling/new-model.rst
@@ -27,7 +27,7 @@ of two Gaussians:
     import numpy as np
     import matplotlib.pyplot as plt
     from astropy.modeling.models import custom_model
-    from astropy.modeling.fitting import LevMarLSQFitter
+    from astropy.modeling.fitting import TRFLSQFitter
 
     # Define model
     @custom_model
@@ -45,7 +45,7 @@ of two Gaussians:
 
     # Fit model to data
     m_init = sum_of_gaussians()
-    fit = LevMarLSQFitter()
+    fit = TRFLSQFitter()
     m = fit(m_init, x, y)
 
     # Plot the data and the best fit

--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -147,8 +147,8 @@ We can now carry out the fit:
    :include-source:
    :nofigs:
 
-    >>> from astropy.modeling.fitting import LMLSQFitter
-    >>> fitter = LMLSQFitter()
+    >>> from astropy.modeling.fitting import TRFLSQFitter
+    >>> fitter = TRFLSQFitter()
     >>> model_fit_single = fitter(model, x, data[:, 5, 5])
 
 .. plot::

--- a/docs/modeling/units.rst
+++ b/docs/modeling/units.rst
@@ -167,7 +167,7 @@ we would without any units:
 
     g5 = models.Gaussian1D(mean=3 * u.micron, stddev=1 * u.micron, amplitude=1 * u.Jy)
 
-    fitter = fitting.LevMarLSQFitter()
+    fitter = fitting.TRFLSQFitter()
 
     g5_fit = fitter(g5, x, y)
 

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -155,9 +155,9 @@ environment. A simple example might be:
 .. doctest-skip::
 
     >>> from astropy.modeling.models import Gaussian1D
-    >>> from astropy.modeling.fitting import parallel_fit_dask, LevMarLSQFitter
+    >>> from astropy.modeling.fitting import parallel_fit_dask, TRFLSQFitter
     >>> model_fit = parallel_fit_dask(model=Gaussian1D(),
-    ...                               fitter=LevMarLSQFitter(),
+    ...                               fitter=TRFLSQFitter(),
     ...                               data=data,
     ...                               world=wcs,
     ...                               fitting_axes=0)


### PR DESCRIPTION
As described in https://github.com/astropy/astropy/issues/16607, ``LevMarLSQFitter`` should not really be recommended anymore. However, we use it in a number of places in our docs in basic examples, making it seem like it is the default fitter to use.

This PR does **not** deprecate ``LevMarLSQFitter`` at this time as we will need to think more carefully about whether/how to
do this, but we should immediately stop making it look like the default in all our documentation examples, and mentions that it is not recommended. This PR therefore focuses solely on updating the documentation to minimize new usage of the old fitter.

In a number of places I did not change ``LevMarLSQFitter`` to ``LMLSQFitter`` because many of the examples use gaussians, and the gaussian model has bounds by default (on stddev) and ``LMLSQFitter`` does not properly support bounds (just using the
same unsophisticated method present in ``LevMarLSQFitter``) so we should be instead recommending a fitter that can properly
deal with bounds.