### PR TITLE
Automatically select fastest varying world coordinates to show along each axis in WCSAxes

### DIFF
--- a/astropy/tests/figures/py311-test-image-mpl360-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpl360-cov.json
@@ -12,8 +12,8 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contour_overlay": "44fd1a202f8baa894a289bac150b3b0eda9b069a06fc8f49ce14d77e743481e0",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contourf_overlay": "fa928ab57291e8a128009320323ffb8955cd75d28b2a589074defb7b0889b3eb",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_overlay_features_image": "30d5562cb7a2484db0b898bc886253829de884fbf92bc0e6575f091438ec5f32",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_curvilinear_grid_patches_image": "ad0a985a324a73b5bea839a231f7537075306c874c279c6a6ea2cfe16529d815",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_cube_slice_image": "822d96a93eb4ab59b1a0095384bb315b025b481a18821b3c558e4a937c77f489",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_curvilinear_grid_patches_image": "ed8d72c6ee7cf13a1731c0d88265a1e8fe09856367641b30656894aa46a2188f",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_cube_slice_image": "7db580546abc0af9aa5da9a1b70dead3d029ec189544aa34c4c15851bcf25df1",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_cube_slice_image_lonlat": "224f7e2f7d106ab028584bdc51c73296e277a211b7f3ed36a0452eb4842afa5b",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_plot_coord": "9352d254af8add2918f98fb8a8d6d220bb95ab8096a1c56584d6c80ff3d5de39",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_scatter_coord": "9352d254af8add2918f98fb8a8d6d220bb95ab8096a1c56584d6c80ff3d5de39",
@@ -39,6 +39,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_hms_labels": "1047e944e3cb798a39702be44c9612cb27a26e4fd246a5cf0abe047a51985d5c",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_latex_labels": "22c900ff73a60d58fbc29ee61485cad76aa483e3c8efa89bffbdf6d660d0bf9f",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_params": "78bdce5072b3e9ac87b7e76832f3fc889c115aef3f894004a50b7eeba0d32ebd",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_auto_world_placement": "be9e33561348c12792ba547ec07388377e8c969a8180d75a3b524f411f8b0f7d",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_1d_wcs": "190a14699654f7eae01556013f4fee1bbcddd3b34e62e9e3d92a92f7ce9a7695",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_1d_wcs_format_unit": "e0eea94f0ca0e37e96d903c3f441ecf0eb20b6870bfbd8a3426ad3e8305d1cee",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_2d_wcs_correlated": "c2fd3acaa4739844288e1ce23dcb0a70b71aaf190d85f4a9164e7ab90836a76b",
@@ -54,6 +55,6 @@
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",
-  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "d2dd2f7efef595a5819906c3f4f77f68d70d29efca5851d19528aecb0e3f8035",
+  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "40630e936a9374f63ad628a0695fb4bbe9fb6e048b3f5dd919ef97706e69b1ee",
   "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_2d_celestial_arcsec": "4b743d645a85d7516decbcf4a831c127af5a1800072597c2a1299d17fb186adb"
 }

--- a/astropy/tests/figures/py311-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpldev-cov.json
@@ -12,8 +12,8 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contour_overlay": "8679305e8a8b5b3f5b896343f4e16dfc65e9289c31505e3b35ef773d7837c8ea",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contourf_overlay": "fa928ab57291e8a128009320323ffb8955cd75d28b2a589074defb7b0889b3eb",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_overlay_features_image": "30d5562cb7a2484db0b898bc886253829de884fbf92bc0e6575f091438ec5f32",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_curvilinear_grid_patches_image": "ad0a985a324a73b5bea839a231f7537075306c874c279c6a6ea2cfe16529d815",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_cube_slice_image": "822d96a93eb4ab59b1a0095384bb315b025b481a18821b3c558e4a937c77f489",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_curvilinear_grid_patches_image": "ed8d72c6ee7cf13a1731c0d88265a1e8fe09856367641b30656894aa46a2188f",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_cube_slice_image": "7db580546abc0af9aa5da9a1b70dead3d029ec189544aa34c4c15851bcf25df1",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_cube_slice_image_lonlat": "224f7e2f7d106ab028584bdc51c73296e277a211b7f3ed36a0452eb4842afa5b",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_plot_coord": "9352d254af8add2918f98fb8a8d6d220bb95ab8096a1c56584d6c80ff3d5de39",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_scatter_coord": "9352d254af8add2918f98fb8a8d6d220bb95ab8096a1c56584d6c80ff3d5de39",
@@ -39,6 +39,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_hms_labels": "1047e944e3cb798a39702be44c9612cb27a26e4fd246a5cf0abe047a51985d5c",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_latex_labels": "22c900ff73a60d58fbc29ee61485cad76aa483e3c8efa89bffbdf6d660d0bf9f",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_tick_params": "78bdce5072b3e9ac87b7e76832f3fc889c115aef3f894004a50b7eeba0d32ebd",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_auto_world_placement": "be9e33561348c12792ba547ec07388377e8c969a8180d75a3b524f411f8b0f7d",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_1d_wcs": "190a14699654f7eae01556013f4fee1bbcddd3b34e62e9e3d92a92f7ce9a7695",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_1d_wcs_format_unit": "e0eea94f0ca0e37e96d903c3f441ecf0eb20b6870bfbd8a3426ad3e8305d1cee",
   "astropy.visualization.wcsaxes.tests.test_images.test_1d_plot_2d_wcs_correlated": "c2fd3acaa4739844288e1ce23dcb0a70b71aaf190d85f4a9164e7ab90836a76b",
@@ -54,6 +55,6 @@
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",
-  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "d2dd2f7efef595a5819906c3f4f77f68d70d29efca5851d19528aecb0e3f8035",
+  "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_5d_with_names": "40630e936a9374f63ad628a0695fb4bbe9fb6e048b3f5dd919ef97706e69b1ee",
   "astropy.visualization.wcsaxes.tests.test_wcsapi.test_wcsapi_2d_celestial_arcsec": "4b743d645a85d7516decbcf4a831c127af5a1800072597c2a1299d17fb186adb"
 }

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -1060,23 +1060,23 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-
     @figure_test
     def test_auto_world_placement(self):
-
         wcs = WCS(naxis=3)
-        wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
+        wcs.wcs.ctype = "RA---TAN", "DEC--TAN", "FREQ"
         wcs.wcs.crval = 10, 20, 30
         wcs.wcs.crpix = 30, 30, 30
         wcs.wcs.cdelt = 0.1, 0.1, 0.01
-        wcs.wcs.cunit = 'deg', 'deg', 'GHz'
+        wcs.wcs.cunit = "deg", "deg", "GHz"
         wcs.wcs.set()
 
         fig = plt.figure()
         for iangle, angle in enumerate((0, 45, 70, 89)):
             wcs2 = wcs.deepcopy()
             wcs2.wcs.crota = 0, angle, 0
-            ax = fig.add_subplot(2, 2, iangle + 1, projection=wcs2, slices=('x', 'y', 0))
+            ax = fig.add_subplot(
+                2, 2, iangle + 1, projection=wcs2, slices=("x", "y", 0)
+            )
             ax.coords.grid()
 
         return fig

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -1061,6 +1061,27 @@ class TestBasic(BaseImageTests):
         return fig
 
 
+    @figure_test
+    def test_auto_world_placement(self):
+
+        wcs = WCS(naxis=3)
+        wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
+        wcs.wcs.crval = 10, 20, 30
+        wcs.wcs.crpix = 30, 30, 30
+        wcs.wcs.cdelt = 0.1, 0.1, 0.01
+        wcs.wcs.cunit = 'deg', 'deg', 'GHz'
+        wcs.wcs.set()
+
+        fig = plt.figure()
+        for iangle, angle in enumerate((0, 45, 70, 89)):
+            wcs2 = wcs.deepcopy()
+            wcs2.wcs.crota = 0, angle, 0
+            ax = fig.add_subplot(2, 2, iangle + 1, projection=wcs2, slices=('x', 'y', 0))
+            ax.coords.grid()
+
+        return fig
+
+
 @pytest.fixture
 def wave_wcs_1d():
     wcs = WCS(naxis=1)

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -158,6 +158,9 @@ def test_set_label_properties(ignore_matplotlibrc):
 
     ax = plt.subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
 
+    ax.coords[0].set_axislabel_position("b")
+    ax.coords[1].set_axislabel_position("l")
+
     ax.set_xlabel("Test x label", labelpad=2, color="red")
     ax.set_ylabel("Test y label", labelpad=3, color="green")
 
@@ -560,6 +563,12 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
 
     wcs = WCS(header)
     fig, ax = plt.subplots(subplot_kw=dict(frame_class=frame_class, projection=wcs))
+
+    if frame_class is RectangularFrame:
+        # Do not use default "auto" positioning
+        ax.coords[0].set_axislabel_position("b")
+        ax.coords[1].set_axislabel_position("l")
+
     ax.set_xlabel(labels[0])
     ax.set_ylabel(labels[1])
 

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -146,9 +146,9 @@ def test_coord_type_from_ctype(cube_wcs):
     ticks_position = coord_meta["default_ticks_position"]
 
     # These axes are swapped due to the pixel derivatives
-    assert axislabel_position == ["l", "r", "b"]
-    assert ticklabel_position == ["l", "r", "b"]
-    assert ticks_position == ["l", "r", "b"]
+    assert axislabel_position == ["r", "l", "b"]
+    assert ticklabel_position == ["r", "l", "b"]
+    assert ticks_position == ["r", "l", "b"]
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ["GLON-TAN", "GLAT-TAN"]
@@ -190,9 +190,8 @@ def test_coord_type_from_ctype(cube_wcs):
     ticklabel_position = coord_meta["default_ticklabel_position"]
     ticks_position = coord_meta["default_ticks_position"]
 
-    # These axes should be swapped because of slices
-    assert axislabel_position == ["l", "b"]
-    assert ticklabel_position == ["l", "b"]
+    assert axislabel_position == ["b", "l"]
+    assert ticklabel_position == ["b", "l"]
     assert ticks_position == ["bltr", "bltr"]
 
     wcs = WCS(naxis=2)
@@ -539,9 +538,9 @@ def test_coord_meta_wcsapi():
         u.Unit("deg"),
         u.one,
     ]
-    assert coord_meta["default_axislabel_position"] == ["b", "l", "t", "r", ""]
-    assert coord_meta["default_ticklabel_position"] == ["b", "l", "t", "r", ""]
-    assert coord_meta["default_ticks_position"] == ["b", "l", "t", "r", ""]
+    assert coord_meta["default_axislabel_position"] == ["", "r", "b", "l", "t"]
+    assert coord_meta["default_ticklabel_position"] == ["", "r", "b", "l", "t"]
+    assert coord_meta["default_ticks_position"] == ["", "r", "b", "l", "t"]
     assert coord_meta["default_axis_label"] == [
         "Frequency",
         "time",

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -23,7 +23,7 @@ IDENTITY.wcs.crval = [0.0, 0.0]
 IDENTITY.wcs.crpix = [1.0, 1.0]
 IDENTITY.wcs.cdelt = [1.0, 1.0]
 
-SPINE_PIXEL_INDEX = {'b': 0, 'l': 1, 't': 0, 'r': 1}
+SPINE_PIXEL_INDEX = {"b": 0, "l": 1, "t": 0, "r": 1}
 
 
 def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
@@ -170,11 +170,10 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
         m = m[:, ::-1]
 
     if frame_class in (RectangularFrame, RectangularFrame1D):
-
         # For the regular rectangular frame, we can show coordinates on all
         # four spines, whereas for 1D plotting we can show world coordinates on
         # on the bottom or top spine.
-        spines = 'bltr' if frame_class is RectangularFrame else 'bt'
+        spines = "bltr" if frame_class is RectangularFrame else "bt"
 
         # Estimate the local partial derivative matrix with shape (world_n_dim,
         # pixel_n_dim) where each entry [i, j] is the partial derivative
@@ -189,7 +188,6 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
         )
 
         for i, spine_name in enumerate(spines):
-
             # Determine which pixel index the spine corresponds to
             pix_index = SPINE_PIXEL_INDEX[spine_name]
 
@@ -197,7 +195,7 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
             # that pixel axis.
             pos = np.nonzero(m[:, pix_index])[0]
 
-            # Order the world coorinates from the ones that have the largest
+            # Order the world coordinates from the ones that have the largest
             # to the smallest derivative.
             order = np.argsort(derivs[pos, pix_index])[::-1]
             pos = pos[order]
@@ -212,10 +210,11 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
         # In the special and common case where the frame is rectangular and
         # we are dealing with 2-d WCS (after slicing), we show all ticks on
         # all axes.
-        if ((frame_class is RectangularFrame and len(world_map) == 2)
-            or (frame_class is RectangularFrame1D and len(world_map) == 1)):
-                for index in world_map:
-                    coord_meta["default_ticks_position"][index] = spines
+        if (frame_class is RectangularFrame and len(world_map) == 2) or (
+            frame_class is RectangularFrame1D and len(world_map) == 1
+        ):
+            for index in world_map:
+                coord_meta["default_ticks_position"][index] = spines
 
     elif frame_class is EllipticalFrame:
         if "longitude" in coord_meta["type"]:

--- a/docs/changes/visualization/16984.feature.rst
+++ b/docs/changes/visualization/16984.feature.rst
@@ -1,0 +1,3 @@
+WCSAxes will now automatically select the fastest varying coordinate to show
+along each axis, rather than picking them in the order they are listed in the
+WCS.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -24,6 +24,7 @@ In particular, this release includes:
 * :ref:`whatsnew_7_0_rgb_image_visualization_enhancement`
 * :ref:`whatsnew_7_0_lorentz2d_model`
 * :ref:`whatsnew_7_0_votable_1_5`
+* :ref:`whatsnew_7_0_wcsaxes_default_axes`
 
 In addition to these major changes, Astropy v7.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -300,6 +301,64 @@ now supports version 1.5 of the VOTable standard.  The main new feature is that 
 
 At this writing, version 1.5 is a proposed standard, but it is expected to be approved as an
 official recommendation soon.
+
+.. whatsnew_7_0_wcsaxes_default_axes:
+
+Automatic placement of axis and tick labels for ``WCSAxes``
+===========================================================
+
+``WCSAxes`` now automatically selects which coordinates are displayed on which axes
+of a plot, a change from the previous behavior of using the ordering of the
+world axes in the WCS object.
+
+The selection is done by taking the derivatives of the world coordinates along
+the axes and then displaying them in order of fastest varying. This addresses the
+situation where ticks are shown along an axis where the world coordinate hardly
+varies when it varies substantially along the other axis.
+
+When there are multiple axes, especially with different units, this new
+selection process can make substantially different choices to the previous
+order, the default can be overridden with
+`~.CoordinateHelper.set_axislabel_position` and
+`~.CoordinateHelper.set_ticklabel_position`.
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+
+    from astropy.wcs import WCS
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN'
+    wcs.wcs.crval = 10, 20
+    wcs.wcs.crpix = 30, 30
+    wcs.wcs.cdelt = 0.1, 0.1
+    wcs.wcs.cunit = 'deg', 'deg'
+    wcs.wcs.crota = 0, 89
+    wcs.wcs.set()
+
+    fig = plt.figure(figsize=(10, 5))
+    ax0 = fig.add_subplot(1, 2, 1, projection=wcs)
+    ax0.set_title("Previous default")
+    ax0.coords[0].set_axislabel_position("b")
+    ax0.coords[0].set_ticklabel_position("b")
+    ax0.coords[1].set_axislabel_position("l")
+    ax0.coords[1].set_ticklabel_position("l")
+    ax0.coords[0].tick_params(color="red", labelcolor="red")
+    ax0.coords[0].set_axislabel(ax0.coords[0].get_axislabel(), color="red")
+    ax0.coords[1].tick_params(color="blue", labelcolor="blue")
+    ax0.coords[1].set_axislabel(ax0.coords[1].get_axislabel(), color="blue")
+    ax0.coords.grid()
+
+    ax1 = fig.add_subplot(1, 2, 2, projection=wcs)
+    ax1.set_title("New default")
+    ax1.coords.grid()
+    ax1.coords[0].tick_params(color="red", labelcolor="red")
+    ax1.coords[0].set_axislabel(ax1.coords[0].get_axislabel(), color="red")
+    ax1.coords[1].tick_params(color="blue", labelcolor="blue")
+    ax1.coords[1].set_axislabel(ax1.coords[1].get_axislabel(), color="blue")
+
+    fig.tight_layout()
 
 Full change log
 ===============


### PR DESCRIPTION
A common issue reported by users is the lack of ticks/tick labels for images that have significant rotation:

* https://github.com/astropy/astropy/issues/7180 (which includes a number of different user reports)
* https://github.com/astropy/astropy/issues/13458
* https://github.com/astropy/astropy/issues/8521
* https://github.com/astropy/astropy/issues/9117

This PR as-is makes it so that we find the fastest varying coordinate and put that on the x axis, then put the fastest remaining coordinate on the left axis, then on the top axis, and so on. Example:

```python
        wcs = WCS(naxis=3)
        wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
        wcs.wcs.crval = 10, 20, 30
        wcs.wcs.crpix = 30, 30, 30
        wcs.wcs.cdelt = 0.1, 0.1, 0.01
        wcs.wcs.cunit = 'deg', 'deg', 'GHz'
        wcs.wcs.set()

        fig = plt.figure()
        for iangle, angle in enumerate((0, 45, 70, 89)):
            wcs2 = wcs.deepcopy()
            wcs2.wcs.crota = 0, angle, 0
            ax = fig.add_subplot(2, 2, iangle + 1, projection=wcs2, slices=('x', 'y', 0))
            ax.coords.grid()
```

**Before**
![before](https://github.com/user-attachments/assets/028085e7-400d-47fd-a5b8-08cc04aafe13)

**After**
![after](https://github.com/user-attachments/assets/7ca1bf6e-7a01-45b3-b979-45be683d119f)

For now this changes the default behaviour, which I think is probably desirable as it is such a common pitfall. It shouldn't break anyone's code although it might change the output.

Do we want to preserve the ability to use the old behavior? If so, what do people think makes sense API-wise? Should the old behavior be the default, or the new one?

If people want the default behavior to not change, we could actually run both algorithms, and print out a warning if they give different answers, recommending that users enable the 'auto' mode.


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
