### PR TITLE
WCSAxes: Enable specifying that tick labels always include the sign

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -240,6 +240,8 @@ class CoordinateHelper:
         """
         Set the formatter to use for the major tick labels.
 
+        See :ref:`tick_label_format` for accepted format strings and examples.
+
         Parameters
         ----------
         formatter : str or `~matplotlib.ticker.Formatter`

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -197,6 +197,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
         self._decimal = decimal
         self._sep = None
         self.show_decimal_unit = show_decimal_unit
+        self._alwayssign = False
 
         super().__init__(
             values=values,
@@ -261,6 +262,10 @@ class AngleFormatterLocator(BaseFormatterLocator):
 
         if value is None:
             return
+
+        self._alwayssign = value.startswith("+")
+        if self._alwayssign:
+            value = value[1:]
 
         if DMS_RE.match(value) is not None:
             self._decimal = False
@@ -498,6 +503,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
                 fields=fields,
                 sep=sep,
                 format=fmt,
+                alwayssign=self._alwayssign,
             ).tolist()
 
             return _fix_minus(string)

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -139,6 +139,7 @@ class TestAngleFormatterLocator:
             ("dd", "15\xb0"),
             ("dd:mm", "15\xb024'"),
             ("dd:mm:ss", "15\xb023'32\""),
+            ("+dd:mm:ss", "+15\xb023'32\""),
             ("dd:mm:ss.s", "15\xb023'32.0\""),
             ("dd:mm:ss.ssss", "15\xb023'32.0316\""),
             ("hh", "1h"),
@@ -156,6 +157,7 @@ class TestAngleFormatterLocator:
             ("s", '55412"'),
             ("s.s", '55412.0"'),
             ("s.ss", '55412.03"'),
+            ("+s.ss", '+55412.03"'),
         ],
     )
     def test_format(self, format, string):

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -126,7 +126,7 @@ class TickLabels(Text):
         Figure out which parts of labels can be dropped to avoid repetition.
         """
         self.sort()
-        skippable_chars = "0123456789."
+        skippable_chars = "0123456789.+"
         if rcParams["axes.unicode_minus"] and not rcParams["text.usetex"]:
             skippable_chars += "\N{MINUS SIGN}"
         else:

--- a/docs/changes/visualization/16985.feature.rst
+++ b/docs/changes/visualization/16985.feature.rst
@@ -1,0 +1,3 @@
+Added the ability to specify that WCSAxes tick labels always include the sign
+(namely for positive values) by starting the format string with a ``+``
+character.

--- a/docs/visualization/wcsaxes/ticks_labels_grid.rst
+++ b/docs/visualization/wcsaxes/ticks_labels_grid.rst
@@ -167,6 +167,16 @@ angular coordinate axes, while the ``x...`` format or valid Python formats
 <https://docs.python.org/3/library/stdtypes.html#string-formatting>`_) should
 be used for non-angular coordinate axes.
 
+For any of the angular coordinate formats, one can prefix the format string
+with ``+`` to specify that the sign be included even for positive values, e.g.:
+
+==================== ====================
+       format              result
+==================== ====================
+``'+dd:mm:ss'``       ``'+15d23m32s'``
+``'+s.ss'``           ``'+55412.03'``
+==================== ====================
+
 The separators for angular coordinate tick labels can also be set by
 specifying a string or a tuple.
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Motivated by [this discussion thread](https://community.openastronomy.org/t/add-sign-for-positive-values-in-declination/1105), this PR adds the ability to specify that WCSAxes tick labels always include the sign (namely for positive values).  This behavior is enabled by prefixing the format string provided to `set_major_formatter()` with a `+` character.

Example:
```python
import matplotlib.pyplot as plt
from astropy.wcs import WCS

wcs = WCS({
    'CTYPE1': 'RA---CAR',
    'CTYPE2': 'DEC--CAR',
    'CRPIX1': 1,
    'CRPIX2': 1,
    'CDELT1': 1,
    'CDELT2': 1,
    'CRVAL1': 0,
    'CRVAL2': 0,
})

fig = plt.figure()
ax = fig.add_subplot(projection=wcs)
ax.coords[0].set_major_formatter('+hh')
ax.coords[1].set_major_formatter('+dd')
ax.set_xlim(-151, 149)
ax.set_ylim(-11, 9)
ax.set_title("Always have sign on tick labels")
plt.show()
```
![Figure_1](https://github.com/user-attachments/assets/b7fdefa1-913c-4875-9d8d-4a5e29f81527)


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
