### PR TITLE
Make What's new prominent

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@
 astropy: A Community Python Library for Astronomy
 #################################################
 
-**Version**: |release|
+**Version**: |release| - :ref:`whatsnew-7.0`
 
 **Useful links**:
 :ref:`Installation <installing-astropy>` |


### PR DESCRIPTION
Before the documentation theme refactor, the What's new was one of the most prominent links - and so it should be as it is the main user facing way for people to find out about new functionality. It should not just be in 'Project Details'. With this PR:

![image](https://github.com/user-attachments/assets/6dcd7589-b304-4d6f-ad0a-e89f53c5d0b8)

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
