### PR TITLE
DOC: shift emphasis in known issues, clarify that linspace works

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -146,7 +146,7 @@ Workarounds include moving the units outside of the call to
     >>> np.arange(0, 10, 1) * u.m
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>
 
-Also, `~numpy.linspace` does work:
+Additionally, `~numpy.linspace` _does_ work:
 
     >>> np.linspace(0 * u.m, 9 * u.m, 10)
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

Update documentation on array creation routines and units: `numpy.linspace` is known to work with quantity input.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
