### PR TITLE
TST: Max pin pytest for jobs using matplotlib 3.3.4 on v6.1.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,8 @@ deps =
     mpl334: matplotlib==3.3.4
     # mpl 3.3.4 isn't compatible with numpy 2.0 but didn't include a pin
     mpl334: numpy<2.0
+    # mpl 3.3.4 does not have wheel for Python 3.10 and building from source incompatible with pytest 8.3.3
+    mpl334: pytest<8.3.3
 
     image: latex
     image: scipy
@@ -85,6 +87,8 @@ deps =
     oldestdeps: pyarrow==7.0.0
     # ipython did not pin traitlets, so we have to
     oldestdeps: traitlets<4.1  # ipython==4.2.*
+    # mpl 3.3.* does not have wheel for Python 3.10 and building from source incompatible with pytest 8.3.3
+    oldestdeps: pytest<8.3.3
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Max pin pytest for jobs using matplotlib 3.3.4 because those jobs run with Python 3.10 for which this mpl version has no wheel so we are building mpl from source but somehow that crashes with pytest 8.3.3. This is the most non-invasive solution as it does not change existing test matrices and that is okay because this branch will die when we cut v7.0.x in a couple of months.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16991

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
