### PR TITLE
Deprecate use of LMLSQFitter for models with bounds

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1674,11 +1674,12 @@ class LMLSQFitter(_NLLSQFitter):
         if model.has_bounds:
             warnings.warn(
                 "Using LMLSQFitter for models with bounds is now "
-                "deprecated. We recommend you use another non-linear "
+                "deprecated since astropy 7.0. We recommend you use another non-linear "
                 "fitter such as TRFLSQFitter or DogBoxLSQFitter instead "
                 "as these have full support for fitting models with "
                 "bounds",
                 AstropyDeprecationWarning,
+                stacklevel=2,
             )
         return super().__call__(model, *args, **kwargs)
 

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -47,6 +47,7 @@ if HAS_SCIPY:
 
 fitters = [SimplexLSQFitter, SLSQPLSQFitter]
 non_linear_fitters = [LevMarLSQFitter, TRFLSQFitter, LMLSQFitter, DogBoxLSQFitter]
+non_linear_fitters_bounds = [LevMarLSQFitter, TRFLSQFitter, DogBoxLSQFitter]
 
 _RANDOM_SEED = 0x1337
 
@@ -394,13 +395,14 @@ class TestNonLinearFitters:
         self.ydata = func(self.initial_values, self.xdata) + yerror
         self.gauss = models.Gaussian1D(100, 5, stddev=1)
 
-    @pytest.mark.parametrize("fitter0", non_linear_fitters)
-    @pytest.mark.parametrize("fitter1", non_linear_fitters)
+    @pytest.mark.parametrize("fitter0", non_linear_fitters_bounds)
+    @pytest.mark.parametrize("fitter1", non_linear_fitters_bounds)
     def test_estimated_vs_analytic_deriv(self, fitter0, fitter1):
         """
         Runs `LevMarLSQFitter` and `TRFLSQFitter` with estimated and
         analytic derivatives of a `Gaussian1D`.
         """
+
         fitter0 = fitter0()
         model = fitter0(self.gauss, self.xdata, self.ydata)
         g1e = models.Gaussian1D(100, 5.0, stddev=1)
@@ -409,8 +411,8 @@ class TestNonLinearFitters:
         emodel = fitter1(g1e, self.xdata, self.ydata, estimate_jacobian=True)
         assert_allclose(model.parameters, emodel.parameters, rtol=10 ** (-3))
 
-    @pytest.mark.parametrize("fitter0", non_linear_fitters)
-    @pytest.mark.parametrize("fitter1", non_linear_fitters)
+    @pytest.mark.parametrize("fitter0", non_linear_fitters_bounds)
+    @pytest.mark.parametrize("fitter1", non_linear_fitters_bounds)
     def test_estimated_vs_analytic_deriv_with_weights(self, fitter0, fitter1):
         """
         Runs `LevMarLSQFitter` and `TRFLSQFitter` with estimated and
@@ -429,7 +431,7 @@ class TestNonLinearFitters:
         )
         assert_allclose(model.parameters, emodel.parameters, rtol=10 ** (-3))
 
-    @pytest.mark.parametrize("fitter", non_linear_fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
     def test_with_optimize(self, fitter):
         """
         Tests results from `LevMarLSQFitter` and `TRFLSQFitter` against
@@ -450,7 +452,7 @@ class TestNonLinearFitters:
         )
         assert_allclose(model.parameters, result[0], rtol=10 ** (-3))
 
-    @pytest.mark.parametrize("fitter", non_linear_fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
     def test_with_weights(self, fitter):
         """
         Tests results from `LevMarLSQFitter` and `TRFLSQFitter` with weights.
@@ -489,7 +491,7 @@ class TestNonLinearFitters:
         r"clipping to bounds"
     )
     @pytest.mark.parametrize("fitter_class", fitters)
-    @pytest.mark.parametrize("fitter", non_linear_fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
     def test_fitter_against_LevMar(self, fitter_class, fitter):
         """
         Tests results from non-linear fitters against `LevMarLSQFitter`
@@ -508,7 +510,7 @@ class TestNonLinearFitters:
         r"ignore:Values in x were outside bounds during a minimize step, "
         r"clipping to bounds"
     )
-    @pytest.mark.parametrize("fitter", non_linear_fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
     def test_LSQ_SLSQP_with_constraints(self, fitter):
         """
         Runs `LevMarLSQFitter`/`TRFLSQFitter` and `SLSQPLSQFitter` on a
@@ -523,7 +525,7 @@ class TestNonLinearFitters:
         model = fitter(g1, self.xdata, self.ydata)
         assert_allclose(model.parameters, slsqp_model.parameters, rtol=10 ** (-4))
 
-    @pytest.mark.parametrize("fitter", non_linear_fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
     def test_non_linear_lsq_fitter_with_weights(self, fitter):
         """
         Tests that issue #11581 has been solved.
@@ -755,7 +757,7 @@ class Test1DFittingWithOutlierRemoval:
         r"ignore:Values in x were outside bounds during a minimize step, "
         r"clipping to bounds"
     )
-    @pytest.mark.parametrize("fitter", non_linear_fitters + fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds + fitters)
     def test_with_fitters_and_sigma_clip(self, fitter):
         import scipy.stats as stats
 
@@ -815,7 +817,7 @@ class Test2DFittingWithOutlierRemoval:
         r"ignore:Values in x were outside bounds during a minimize step, "
         r"clipping to bounds"
     )
-    @pytest.mark.parametrize("fitter", non_linear_fitters + fitters)
+    @pytest.mark.parametrize("fitter", non_linear_fitters_bounds + fitters)
     def test_with_fitters_and_sigma_clip(self, fitter):
         import scipy.stats as stats
 
@@ -1123,7 +1125,7 @@ def test_linear_fitter_with_weights_flat():
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.filterwarnings("ignore:The fit may be unsuccessful")
-@pytest.mark.parametrize("fitter", non_linear_fitters + fitters)
+@pytest.mark.parametrize("fitter", non_linear_fitters_bounds + fitters)
 def test_fitters_interface(fitter):
     """
     Test that ``**kwargs`` work with all optimizers.
@@ -1403,7 +1405,7 @@ class TestFittingUncertanties:
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", non_linear_fitters)
+@pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
 @pytest.mark.parametrize("weights", [np.ones(8), None])
 def test_non_finite_error(fitter, weights):
     """Regression test error introduced to solve issues #3575 and #12809"""
@@ -1422,7 +1424,7 @@ def test_non_finite_error(fitter, weights):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", non_linear_fitters)
+@pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
 @pytest.mark.parametrize("weights", [np.ones(8), None])
 def test_non_finite_filter_1D(fitter, weights):
     """Regression test filter introduced to remove non-finte values from data"""
@@ -1444,7 +1446,7 @@ def test_non_finite_filter_1D(fitter, weights):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", non_linear_fitters)
+@pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
 @pytest.mark.parametrize("weights", [np.ones((10, 10)), None])
 def test_non_finite_filter_2D(fitter, weights):
     """Regression test filter introduced to remove non-finte values from data"""

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -20,6 +20,12 @@ fitters = [
     fitting.DogBoxLSQFitter,
 ]
 
+fitters_bounds = [
+    fitting.LevMarLSQFitter,
+    fitting.TRFLSQFitter,
+    fitting.DogBoxLSQFitter,
+]
+
 
 def test_sigma_constant():
     """
@@ -552,7 +558,7 @@ def test_Voigt1D_method():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_KingProjectedAnalytic1D_fit(fitter):
     fitter = fitter()
 

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -33,6 +33,12 @@ fitters = [
     fitting.DogBoxLSQFitter,
 ]
 
+fitters_bounds = [
+    fitting.LevMarLSQFitter,
+    fitting.TRFLSQFitter,
+    fitting.DogBoxLSQFitter,
+]
+
 
 class TestInputType:
     """
@@ -188,7 +194,7 @@ class TestFitting:
         assert_allclose(model.param_sets, expected, atol=10 ** (-7))
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-    @pytest.mark.parametrize("fitter", fitters)
+    @pytest.mark.parametrize("fitter", fitters_bounds)
     def test_nonlinear_lsqt_1set_1d(self, fitter):
         """1 set 1D x, 1 set 1D y, 1 pset NonLinearFitter"""
         fitter = fitter()
@@ -199,7 +205,7 @@ class TestFitting:
         assert_allclose(model.parameters, [10, 3, 0.2])
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-    @pytest.mark.parametrize("fitter", fitters)
+    @pytest.mark.parametrize("fitter", fitters_bounds)
     def test_nonlinear_lsqt_Nset_1d(self, fitter):
         """1 set 1D x, 1 set 1D y, 2 param_sets, NonLinearFitter"""
         fitter = fitter()
@@ -213,7 +219,7 @@ class TestFitting:
             _ = fitter(g1, self.x1, y1)
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-    @pytest.mark.parametrize("fitter", fitters)
+    @pytest.mark.parametrize("fitter", fitters_bounds)
     def test_nonlinear_lsqt_1set_2d(self, fitter):
         """1 set 2d x, 1set 2D y, 1 pset, NonLinearFitter"""
         fitter = fitter()
@@ -226,7 +232,7 @@ class TestFitting:
         assert_allclose(model.parameters, [10, 3, 4, 0.3, 0.2, 0])
 
     @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-    @pytest.mark.parametrize("fitter", fitters)
+    @pytest.mark.parametrize("fitter", fitters_bounds)
     def test_nonlinear_lsqt_Nset_2d(self, fitter):
         """1 set 2d x, 1set 2D y, 2 param_sets, NonLinearFitter"""
         fitter = fitter()

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -23,6 +23,7 @@ from astropy.utils import NumpyRNGContext
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 fitters = [LevMarLSQFitter, TRFLSQFitter, LMLSQFitter, DogBoxLSQFitter]
+fitters_bounds = [LevMarLSQFitter, TRFLSQFitter, DogBoxLSQFitter]
 
 
 def test_swap_axes():
@@ -117,7 +118,7 @@ def test_identity():
 
 # https://github.com/astropy/astropy/pull/6018
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_fittable_compound(fitter):
     fitter = fitter()
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -292,6 +292,9 @@ class Fittable2DModelTester:
         parameters = test_parameters["parameters"]
         model = create_model(model_class, test_parameters)
 
+        if model.has_bounds and isinstance(fitter, fitting.LMLSQFitter):
+            pytest.skip("The LMLSQFitter fitter does not support models with bounds")
+
         if isinstance(parameters, dict):
             parameters = [parameters[name] for name in model.param_names]
 
@@ -372,6 +375,9 @@ class Fittable2DModelTester:
                 model_class, test_parameters, use_constraints=False
             )
             model = create_model(model_class, test_parameters, use_constraints=False)
+
+        if model_with_deriv.has_bounds and isinstance(fitter, fitting.LMLSQFitter):
+            pytest.skip("The LMLSQFitter fitter does not support models with bounds")
 
         # add 10% noise to the amplitude
         rsn = np.random.default_rng(0)
@@ -527,6 +533,9 @@ class Fittable1DModelTester:
         parameters = test_parameters["parameters"]
         model = create_model(model_class, test_parameters)
 
+        if model.has_bounds and isinstance(fitter, fitting.LMLSQFitter):
+            pytest.skip("The LMLSQFitter fitter does not support models with bounds")
+
         if isinstance(parameters, dict):
             parameters = [parameters[name] for name in model.param_names]
 
@@ -580,6 +589,9 @@ class Fittable1DModelTester:
         model_no_deriv = create_model(
             model_class, test_parameters, use_constraints=False
         )
+
+        if model_with_deriv.has_bounds and isinstance(fitter, fitting.LMLSQFitter):
+            pytest.skip("The LMLSQFitter fitter does not support models with bounds")
 
         # NOTE: PR 10644 replaced deprecated usage of RandomState but could not
         #       find a new seed that did not cause test failure, resorted to hardcoding.

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -807,6 +807,10 @@ def test_models_fitting(model, fitter):
         return
 
     m = model["class"](**model["parameters"])
+
+    if m.has_bounds and isinstance(fitter, LMLSQFitter):
+        pytest.skip("The LMLSQFitter fitter does not support models with bounds")
+
     if len(model["evaluation"][0]) == 2:
         x = np.linspace(1, 3, 100) * model["evaluation"][0][0].unit
         y = np.exp(-(x.value**2)) * model["evaluation"][0][1].unit

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -22,6 +22,7 @@ __doctest_skip__ = ["*"]
 
 
 fitters = [LevMarLSQFitter, TRFLSQFitter, LMLSQFitter, DogBoxLSQFitter]
+fitters_bounds = [LevMarLSQFitter, TRFLSQFitter, DogBoxLSQFitter]
 
 
 # BlackBody tests
@@ -79,7 +80,7 @@ def test_blackbody_return_units():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_blackbody_fit(fitter):
     fitter = fitter()
 
@@ -492,7 +493,7 @@ def test_NFW_evaluate(mass):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_NFW_fit(fitter):
     """Test linear fitting of NFW model."""
     fitter = fitter()

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -26,6 +26,12 @@ fitters = [
     fitting.DogBoxLSQFitter,
 ]
 
+fitters_bounds = [
+    fitting.LevMarLSQFitter,
+    fitting.TRFLSQFitter,
+    fitting.DogBoxLSQFitter,
+]
+
 
 def _fake_gaussian_data():
     # Generate fake data
@@ -85,7 +91,7 @@ def models_with_custom_names():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_fitting_simple(fitter):
     fitter = fitter()
 
@@ -103,7 +109,7 @@ def test_fitting_simple(fitter):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_fitting_with_initial_values(fitter):
     fitter = fitter()
 
@@ -121,7 +127,7 @@ def test_fitting_with_initial_values(fitter):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_fitting_missing_data_units(fitter):
     """
     Raise an error if the model has units but the data doesn't
@@ -152,7 +158,7 @@ def test_fitting_missing_data_units(fitter):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_fitting_missing_model_units(fitter):
     """
     Proceed if the data has units but the model doesn't
@@ -177,7 +183,7 @@ def test_fitting_missing_model_units(fitter):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_fitting_incompatible_units(fitter):
     """
     Raise an error if the data and model have incompatible units
@@ -194,7 +200,7 @@ def test_fitting_incompatible_units(fitter):
 @pytest.mark.filterwarnings(r"ignore:The fit may be unsuccessful.*")
 @pytest.mark.filterwarnings(r"ignore:divide by zero encountered.*")
 @pytest.mark.parametrize("model", compound_models_no_units)
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_compound_without_units(model, fitter):
     fitter = fitter()
 
@@ -218,7 +224,7 @@ def test_compound_without_units(model, fitter):
 # FIXME: See https://github.com/astropy/astropy/issues/10675
 # @pytest.mark.skipif(not HAS_SCIPY, reason='requires scipy')
 @pytest.mark.skip(reason="Flaky and ill-conditioned")
-@pytest.mark.parametrize("fitter", fitters)
+@pytest.mark.parametrize("fitter", fitters_bounds)
 def test_compound_fitting_with_units(fitter):
     fitter = fitter()
 

--- a/docs/changes/modeling/16994.api.rst
+++ b/docs/changes/modeling/16994.api.rst
@@ -1,0 +1,3 @@
+Using the ``LMLSQFitter`` fitter with models that have bounds is now deprecated,
+as support for bounds was very basic. Instead, non-linear fitters with more
+sophisticated support for bounds should be used instead.


### PR DESCRIPTION
Now that we have support for different non-linear fitters in astropy.modeling, including several that have proper support for bounds, we should consider starting to phase out support for the 'hacky' bounds algorithm originally introduced in ``LevMarLSQFitter``. I noticed that in fact the new ``LMLSQFitter`` uses the hacky algorithm by default, with no way to turn it off.

I think we should instead deprecate this behavior in ``LMLSQFitter`` and recommend other fitters, and once the deprecation phase is over simply change ``supported_constraints`` to exclude ``bounds`` on that fitter. There are other more suitable fitters for models with bounds, and we should be encouraging good practices. Note that at the moment most examples in the docs use ``LevMarLSQFitter`` so I think there is likely to be far more usage of that class in the wild. For that reason, I am not touching that class for now - instead, I want to make sure that the new class ``LMLSQFitter`` does 'The Right Thing' :tm:  before there is too much uptake in it.

If people are on board with this, I will update the tests, which currently fail due to the warning being emitted in several of them, and I will also add a changelog entry.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
