### PR TITLE
Deprecate use_min_max_bounds= in TRFLSQFitter and DogBoxLSQFitter

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -31,8 +31,8 @@ from importlib.metadata import entry_points
 import numpy as np
 
 from astropy.units import Quantity
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from ._fitting_parallel import parallel_fit_dask
 from .optimizers import DEFAULT_ACC, DEFAULT_EPS, DEFAULT_MAXITER, SLSQP, Simplex

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -32,6 +32,7 @@ import numpy as np
 
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from ._fitting_parallel import parallel_fit_dask
 from .optimizers import DEFAULT_ACC, DEFAULT_EPS, DEFAULT_MAXITER, SLSQP, Simplex
@@ -1601,11 +1602,6 @@ class TRFLSQFitter(_NLLSQFitter):
     calc_uncertainties : bool
         If the covariance matrix should be computed and set in the fit_info.
         Default: False
-    use_min_max_bounds: bool
-        If the set parameter bounds for a model will be enforced each given
-        parameter while fitting via a simple min/max condition. A True setting
-        will replicate how LevMarLSQFitter enforces bounds.
-        Default: False
 
     Attributes
     ----------
@@ -1614,6 +1610,7 @@ class TRFLSQFitter(_NLLSQFitter):
         the most recent fit information
     """
 
+    @deprecated_renamed_argument("use_min_max_bounds", None, "7.0")
     def __init__(self, calc_uncertainties=False, use_min_max_bounds=False):
         super().__init__("trf", calc_uncertainties, use_min_max_bounds)
 
@@ -1627,11 +1624,6 @@ class DogBoxLSQFitter(_NLLSQFitter):
     calc_uncertainties : bool
         If the covariance matrix should be computed and set in the fit_info.
         Default: False
-    use_min_max_bounds: bool
-        If the set parameter bounds for a model will be enforced each given
-        parameter while fitting via a simple min/max condition. A True setting
-        will replicate how LevMarLSQFitter enforces bounds.
-        Default: False
 
     Attributes
     ----------
@@ -1640,6 +1632,7 @@ class DogBoxLSQFitter(_NLLSQFitter):
         the most recent fit information
     """
 
+    @deprecated_renamed_argument("use_min_max_bounds", None, "7.0")
     def __init__(self, calc_uncertainties=False, use_min_max_bounds=False):
         super().__init__("dogbox", calc_uncertainties, use_min_max_bounds)
 

--- a/docs/changes/modeling/16995.api.rst
+++ b/docs/changes/modeling/16995.api.rst
@@ -1,0 +1,4 @@
+The optional ``use_min_max_bounds`` keyword argument in ``TRFLSQFitter`` and
+``DogBoxLSQFitter`` has now been deprecated and should not be used. These
+fitters handle bounds correctly by default and this keyword argument was only
+provided to opt-in to a more basic form of bounds handling.


### PR DESCRIPTION
The optional ``use_min_max_bounds=`` option which is disabled by default in ``TRFLSQFitter`` and ``DogBoxLSQFitter`` should in my view be deprecated for several reasons:

* All it does is replaces proper bound-handling algorithms in these fitters by an inferior hacky approach
* The name of the keyword argument doesn't make it sound like a bad thing and users may enable it without realising (it would be different if it was called ``use_inferior_bounds_approach`` :wink:)
* It is not currently tested in our test suite (for these fitters) so we don't actually know that they work properly
* It is likely not used much, as it should basically never be needed

I am proposing deprecating these in v7.0 and removing in v8.0.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
