### PR TITLE
BUG: ensure coordinate decs are always written out to tables.

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -751,3 +751,39 @@ def test_regression_10291():
     assert_quantity_allclose(
         venus.separation(sun), 554.427 * u.arcsecond, atol=0.001 * u.arcsecond
     )
+
+
+@pytest.mark.parametrize("coord_cls", [ICRS, SkyCoord])
+@pytest.mark.parametrize(
+    "differential_type, diff_kwargs",
+    [
+        (None, {}),
+        (
+            "unitsphericalcoslat",
+            {
+                "pm_ra_cosdec": [40, 50] * u.mas / u.yr,
+                "pm_dec": [60, 70] * u.mas / u.yr,
+            },
+        ),
+        ("radial", {"radial_velocity": [80, 90] * u.km / u.s}),
+    ],
+)
+@pytest.mark.parametrize("extra_kwargs", [{}, {"representation_type": "unitspherical"}])
+def test_regression_16998(coord_cls, differential_type, diff_kwargs, extra_kwargs):
+    """Direct tests of the underlying problem causing gh-16998.
+
+    Note that the issue itself was of columns missing in data written to a file.
+    That is now tested directly by the "icrs" column in
+    astropy/io/tests/mixin_columns.py.
+    Here, we test the underlying problem, that .info._represent_as_dict()
+    did not return a full set of columns in some cases.
+    """
+    if extra_kwargs and differential_type:
+        extra_kwargs["differential_type"] = differential_type
+    coord = coord_cls([0, 10] * u.deg, [20, 30] * u.deg, **diff_kwargs, **extra_kwargs)
+    expected_entries = {"ra", "dec", "representation_type"}
+    if differential_type:
+        expected_entries |= {"differential_type"} | set(diff_kwargs)
+    if coord_cls is SkyCoord:
+        expected_entries.add("frame")
+    assert set(coord.info._represent_as_dict()) == expected_entries

--- a/astropy/io/tests/mixin_columns.py
+++ b/astropy/io/tests/mixin_columns.py
@@ -46,7 +46,14 @@ scpmrv = coordinates.SkyCoord(
 scrv = coordinates.SkyCoord(
     [1, 2], [3, 4], [5, 6], unit="deg,deg,pc", radial_velocity=[11, 12] * u.km / u.s
 )
-icrs = coordinates.ICRS([1, 2] * u.deg, [3, 4] * u.deg)
+# Use UnitSpherical and Radial for a regression test for gh-16998.
+icrs = coordinates.ICRS(
+    [1, 2] * u.deg,
+    [3, 4] * u.deg,
+    radial_velocity=[5, 6] * u.km / u.s,
+    representation_type="unitspherical",
+    differential_type="radial",
+)
 altaz = coordinates.AltAz(
     [1, 2] * u.deg,
     [3, 4] * u.deg,
@@ -163,7 +170,13 @@ compare_attrs = {
         "representation_type",
         "frame.name",
     ],
-    "icrs": ["ra", "dec", "representation_type"],
+    "icrs": [
+        "ra",
+        "dec",
+        "radial_velocity",
+        "representation_type",
+        "differential_type",
+    ],
     "altaz": ["alt", "az", "obstime", "location", "representation_type"],
     "so": ["lon", "lat", "rotation", "origin"],
     "sond": ["rotation", "origin"],
@@ -216,7 +229,7 @@ non_trivial_names = {
         "scpmrv.radial_velocity",
     ],
     "scrv": ["scrv.ra", "scrv.dec", "scrv.distance", "scrv.radial_velocity"],
-    "icrs": ["icrs.ra", "icrs.dec"],
+    "icrs": ["icrs.ra", "icrs.dec", "icrs.radial_velocity"],
     "altaz": [
         "altaz.az",
         "altaz.alt",
@@ -234,7 +247,12 @@ non_trivial_names = {
         "so.origin.location.y",
         "so.origin.location.z",
     ],
-    "sond": ["sond.rotation", "sond.origin.ra", "sond.origin.dec"],
+    "sond": [
+        "sond.rotation",
+        "sond.origin.ra",
+        "sond.origin.dec",
+        "sond.origin.radial_velocity",
+    ],
     "sd": ["sd.d_lon_coslat", "sd.d_lat", "sd.d_distance"],
     "sr": ["sr.lon", "sr.lat", "sr.distance"],
     "srd": [

--- a/docs/changes/coordinates/16999.bugfix.rst
+++ b/docs/changes/coordinates/16999.bugfix.rst
@@ -1,0 +1,5 @@
+Avoid some components not being included in table output of coordinates if
+the representation type was ``"unitspherical"``.
+
+In the process, also ensured that one can pass in the ``radial_velocity``
+keyword argument if one uses ``differential_type="radial"``.


### PR DESCRIPTION
This pull request is to address a bug in how coordinates in tables are written out: if the data are unitspherical, the last representation name was removed, which only is OK for the (default) case in which the representation class is spherical. The corrects that, as well as similar problems for proper motion and radial-velocity.

In the process, also allows things like `ICRS(ra, dec, radial_velocity=..., differential_type="radial")` (which raised on `radial_velocity` before, since the default name was not set).

p.s. All this is a lot of hassle just because the frames insist on hiding the actual data inside different representations -- and then wish to write those for-show ones to files instead of using the true underlying data. But that's for another time... 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16998

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
