### PR TITLE
Fix a bug in local_partial_pixel_derivative

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -932,6 +932,38 @@ def test_local_pixel_derivatives(spatial_wcs_2d_small_angle):
     np.testing.assert_allclose(derivs[not_diag].flat, [0, 0], atol=1e-8)
 
 
+def test_local_pixel_derivatives_cube():
+    cube_wcs = WCS(naxis=3)
+    cube_wcs.wcs.ctype = "RA---TAN", "DEC--TAN", "FREQ"
+    cube_wcs.wcs.crval = 10, 20, 30
+    cube_wcs.wcs.cdelt = 0.0001, 0.0001, 0.01
+    cube_wcs.wcs.cunit = "deg", "deg", "GHz"
+    cube_wcs.wcs.set()
+
+    derivs = local_partial_pixel_derivatives(cube_wcs, 0, 0, 0)
+    np.testing.assert_allclose(
+        derivs, [[0.0001, 0, 0], [0, 0.0001, 0], [0, 0, 1e7]], rtol=0.1, atol=1e-5
+    )
+
+    derivs = local_partial_pixel_derivatives(cube_wcs, 0, 0, 0, normalize_by_world=True)
+    np.testing.assert_allclose(
+        derivs, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], rtol=0.1, atol=1e-5
+    )
+
+    # Slice WCS so that there are two pixel and three world coordinates
+    sliced_wcs = cube_wcs[:, 0, :]
+
+    derivs = local_partial_pixel_derivatives(sliced_wcs, 0, 0, 0)
+    np.testing.assert_allclose(
+        derivs, [[0.0001, 0], [0, 0], [0, 1e7]], rtol=0.1, atol=1e-5
+    )
+
+    derivs = local_partial_pixel_derivatives(
+        sliced_wcs, 0, 0, 0, normalize_by_world=True
+    )
+    np.testing.assert_allclose(derivs, [[1, 0], [1, 0], [0, 1]], rtol=0.1, atol=1e-5)
+
+
 def test_pixel_to_world_correlation_matrix_celestial():
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = "RA---TAN", "DEC--TAN"

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -976,7 +976,7 @@ def local_partial_pixel_derivatives(wcs, *pixel, normalize_by_world=False):
         derivatives[:, i] = world_off - world_ref
 
     if normalize_by_world:
-        derivatives /= derivatives.sum(axis=0)[:, np.newaxis]
+        derivatives /= derivatives.sum(axis=1)[:, np.newaxis]
 
     return derivatives
 

--- a/docs/changes/wcs/17003.bugfix.rst
+++ b/docs/changes/wcs/17003.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that caused the results from local_partial_pixel_derivative to be incorrect when using normalize_by_world=True (the matrix was previously normalized along the wrong axis)


### PR DESCRIPTION
Fix a bug that caused the results from local_partial_pixel_derivative to be incorrect when using normalize_by_world=True. I found this issue by using that function with a WCS that had different number of world and pixel coordinates.

@Cadair can you take a careful look at this to check that you agree? 

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
