### PR TITLE
Speed up parsing simple unit strings with `Unit`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2095,12 +2095,16 @@ class _UnitMetaClass(type):
                 # Return the NULL unit
                 return dimensionless_unscaled
 
-            if format is None:
-                format = unit_format.Generic
-
             f = unit_format.get_format(format)
             if isinstance(s, bytes):
                 s = s.decode("ascii")
+
+            try:
+                return f._parse_unit(s, detailed_exception=False)  # Try a shortcut
+            except (AttributeError, ValueError):
+                # No `f._parse_unit()` (AttributeError)
+                # or `s` was a composite unit (ValueError).
+                pass
 
             try:
                 return f.parse(s)

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -572,17 +572,12 @@ class Generic(Base):
     @classmethod
     def _do_parse(cls, s: str, debug: bool = False) -> UnitBase:
         try:
-            # This is a short circuit for the case where the string
-            # is just a single unit name
-            return cls._parse_unit(s, detailed_exception=False)
+            return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
         except ValueError as e:
-            try:
-                return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
-            except ValueError as e:
-                if str(e):
-                    raise
-                else:
-                    raise ValueError(f"Syntax error parsing unit '{s}'")
+            if str(e):
+                raise
+            else:
+                raise ValueError(f"Syntax error parsing unit '{s}'")
 
     @classmethod
     def _get_unit_name(cls, unit: NamedUnit) -> str:

--- a/docs/changes/units/17004.perf.rst
+++ b/docs/changes/units/17004.perf.rst
@@ -1,0 +1,2 @@
+Parsing strings representing non-composite units with ``Unit`` is now up to 25%
+faster.


### PR DESCRIPTION
### Description

The updates do not slow down parsing strings representing composite units. The tradeoff is that they do slow down parsing simple strings with the unit parser `parse()` methods, but those are not meant to be called by users. They are public mostly to define our API for downstream developers.

Setup: `$ ipython -i -c 'from astropy import units as u; from astropy.units.format import Generic, CDS, FITS, OGIP, VOUnit'`

On `main`:
```
Python 3.12.3 (main, Jul 31 2024, 17:43:48) [GCC 13.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: for formatter in (None, Generic, CDS, FITS, OGIP, VOUnit):
   ...:     print(formatter)
   ...:     %timeit u.Unit("m", format=formatter)
   ...:     print()
   ...: 
None
1.24 μs ± 15.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.generic.Generic'>
1.22 μs ± 12.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.cds.CDS'>
1.26 μs ± 19.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.fits.FITS'>
1.6 μs ± 19.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.ogip.OGIP'>
1.34 μs ± 6.97 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.vounit.VOUnit'>
1.6 μs ± 6.92 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

In this pull request:
```
...
None
959 ns ± 8.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.generic.Generic'>
976 ns ± 1.83 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.cds.CDS'>
1.12 μs ± 4.52 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.fits.FITS'>
1.21 μs ± 1.78 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.ogip.OGIP'>
1.21 μs ± 0.884 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

<class 'astropy.units.format.vounit.VOUnit'>
1.33 μs ± 5.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
