### PR TITLE
ENH: allow quantity_support to be used as a decorator

### DIFF
--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -31,8 +31,7 @@ def test_units():
         plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
         plt.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
         plt.legend()
-        # Also test fill_between, which requires actual conversion to ndarray
-        # with numpy >=1.10 (#4654).
+        # Also test fill_between, which requires actual conversion to ndarray.
         plt.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
         plt.savefig(buff, format="svg")
 
@@ -51,8 +50,7 @@ def test_units_decorator():
         plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
         plt.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
         plt.legend()
-        # Also test fill_between, which requires actual conversion to ndarray
-        # with numpy >=1.10 (#4654).
+        # Also test fill_between, which requires actual conversion to ndarray.
         plt.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
         plt.savefig(buff, format="svg")
 

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -41,6 +41,28 @@ def test_units():
 
 
 @pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+def test_units_decorator():
+    @quantity_support()
+    def run_test():
+        plt.figure()
+
+        buff = io.BytesIO()
+
+        plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
+        plt.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
+        plt.legend()
+        # Also test fill_between, which requires actual conversion to ndarray
+        # with numpy >=1.10 (#4654).
+        plt.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
+        plt.savefig(buff, format="svg")
+
+        assert plt.gca().xaxis.get_units() == u.m
+        assert plt.gca().yaxis.get_units() == u.kg
+
+    run_test()
+
+
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
 def test_units_errbarr():
     pytest.importorskip("matplotlib")
     plt.figure()

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from contextlib import ContextDecorator
+
 import numpy as np
 
 __all__ = ["quantity_support"]
@@ -48,7 +50,7 @@ def quantity_support(format="latex_inline"):
         else:
             return f"{n}π/2"
 
-    class MplQuantityConverter(units.ConversionInterface):
+    class MplQuantityConverter(units.ConversionInterface, ContextDecorator):
         def __init__(self):
             # Keep track of original converter in case the context manager is
             # used in a nested way.

--- a/docs/changes/visualization/17006.feature.rst
+++ b/docs/changes/visualization/17006.feature.rst
@@ -1,2 +1,2 @@
-Allow ``astropy.visualization.units.quantity_support`` to be used as either
-a decorator or a context manager.
+Allow ``astropy.visualization.units.quantity_support`` to be used as a
+decorator in addition to the already supported use as a context manager.

--- a/docs/changes/visualization/17006.feature.rst
+++ b/docs/changes/visualization/17006.feature.rst
@@ -1,0 +1,2 @@
+Allow ``astropy.visualization.units.quantity_support`` to be used as either
+a decorator or a context manager.


### PR DESCRIPTION
### Description
Allow `astropy.visualization.units.quantity_support` to be used as either a decorator or a context manager.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
