### PR TITLE
Implement `BaseCoordinateFrame.to_table()`

### DIFF
--- a/docs/changes/coordinates/17009.feature.rst
+++ b/docs/changes/coordinates/17009.feature.rst
@@ -1,0 +1,2 @@
+``BaseCoordinateFrame`` now has a ``to_table()`` method, which converts the
+frame to a ``QTable``, analogously to the ``SkyCoord.to_table()`` method.

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1245,8 +1245,8 @@ means that attributes such as ``obstime`` can become columns or metadata::
       0.0    20.0
      20.0     0.0
   >>> t.meta
-  {'obstime': <Time object: scale='tt' format='jyear' value=2000.0>,
-   'representation_type': 'spherical', 'frame': 'galactic'}
+  {'representation_type': 'spherical', 'frame': 'galactic',
+   'obstime': <Time object: scale='tt' format='jyear' value=2000.0>}
 
 Convenience Methods
 ===================


### PR DESCRIPTION
### Description

Currently `SkyCoord` has a `to_table()` method, which can convert it to a `QTable`, but there is no such method for `BaseCoordinateFrame`. This has been acceptable until #16831 because before that there was no interoperability between `BaseCoordinateFrame` and `Table`/`QTable` at all. But now, on one hand `BaseCoordinateFrame` knows enough about `Table`/`QTable` to be used as a mixin column so it is quite surprising that it cannot be converted to a `QTable`, and on the other hand the machinery introduced in #16831 makes implementing `BaseCoordinateFrame.to_table()` quite simple.

Another justification for the `to_table()` method comes from #16999 , which is fixing some bugs that affect both `BaseCoordinateFrame` and `SkyCoord`. Turns out there isn't a very good way for implementing regression tests for both classes. Implementing `BaseCoordinateFrame.to_table()` would allow writing regression tests that don't have to bring in machinery from `io` (which is not related to the bugs in question), nor explicitly use private API (which should be avoided because it would needlessly leak implementation details). Note that this does not mean that this pull request should block the bugfix.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
