### PR TITLE
Refactoring of the parsing of simple units, moving short-circuit up

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2090,17 +2090,20 @@ class _UnitMetaClass(type):
         if isinstance(s, UnitBase):
             return s
 
-        elif isinstance(s, (bytes, str)):
+        elif isinstance(s, (str, bytes)):
             if len(s.strip()) == 0:
                 # Return the NULL unit
                 return dimensionless_unscaled
 
-            if format is None:
-                format = unit_format.Generic
-
             f = unit_format.get_format(format)
             if isinstance(s, bytes):
                 s = s.decode("ascii")
+
+            # Short-circuit for simple units for the default case of Generic.
+            if f is unit_format.Generic and (
+                unit := get_current_unit_registry().registry.get(s)
+            ):
+                return unit
 
             try:
                 return f.parse(s)

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -98,6 +98,10 @@ class FITS(generic.Generic):
 
     @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
+        # Short-circuit, and also the only way to get "deg C" to be recognized
+        # it would be a composite unit otherwise.
+        if unit := cls._units.get(s.strip()):
+            return unit
         result = super().parse(s, debug)
         if hasattr(result, "function_unit"):
             raise ValueError("Function units are not yet supported for FITS units.")

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -572,17 +572,12 @@ class Generic(Base):
     @classmethod
     def _do_parse(cls, s: str, debug: bool = False) -> UnitBase:
         try:
-            # This is a short circuit for the case where the string
-            # is just a single unit name
-            return cls._parse_unit(s, detailed_exception=False)
+            return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
         except ValueError as e:
-            try:
-                return cls._parser.parse(s, lexer=cls._lexer, debug=debug)
-            except ValueError as e:
-                if str(e):
-                    raise
-                else:
-                    raise ValueError(f"Syntax error parsing unit '{s}'")
+            if str(e):
+                raise
+            else:
+                raise ValueError(f"Syntax error parsing unit '{s}'") from e
 
     @classmethod
     def _get_unit_name(cls, unit: NamedUnit) -> str:

--- a/docs/changes/units/17012.perf.rst
+++ b/docs/changes/units/17012.perf.rst
@@ -1,0 +1,1 @@
+Sped up the parsing of simple units by about 25%.


### PR DESCRIPTION
This is an alternative to #17004 that does not rely on private methods, and removes the short-circuiting from the unit parser. It builds on #17011, since removing the short-circuit from the unit parser brought out quite a few bugs. (EDIT: #17011 is merged, so only 3 commits left.) But it turns out that for FITS at least, some short-circuiting has to be done, since it weirdly defines a unit "deg C", which would in normal parsing become "degrees Coulomb" (and which we really do *not* want in a composite unit!).

Note that while the last commit is labelled performance, this is only relative to the case where the short circuit is not present at all. Relative to main, performance benefits are modest.

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
