### PR TITLE
BUG: fix how np.put, putmask, place, copyto deal with masked, nomask

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -439,8 +439,10 @@ def put(a, ind, v, mode="raise"):
     if isinstance(ind, Masked) or not isinstance(a, Masked):
         raise NotImplementedError
 
-    v_data, v_mask = get_data_and_mask(v)
-    if v_data is not None:
+    if v is np.ma.masked or v is np.ma.nomask:
+        v_mask = v is np.ma.masked
+    else:
+        v_data, v_mask = get_data_and_mask(v)
         np.put(a.unmasked, ind, v_data, mode=mode)
     # v_mask of None will be correctly interpreted as False.
     np.put(a.mask, ind, v_mask, mode=mode)
@@ -458,8 +460,10 @@ def putmask(a, mask, values):
     if isinstance(mask, Masked) or not isinstance(a, Masked):
         raise NotImplementedError
 
-    values_data, values_mask = get_data_and_mask(values)
-    if values_data is not None:
+    if values is np.ma.masked or values is np.ma.nomask:
+        values_mask = values is np.ma.masked
+    else:
+        values_data, values_mask = get_data_and_mask(values)
         np.putmask(a.unmasked, mask, values_data)
     np.putmask(a.mask, mask, values_mask)
 
@@ -476,8 +480,10 @@ def place(arr, mask, vals):
     if isinstance(mask, Masked) or not isinstance(arr, Masked):
         raise NotImplementedError
 
-    vals_data, vals_mask = get_data_and_mask(vals)
-    if vals_data is not None:
+    if vals is np.ma.masked or vals is np.ma.nomask:
+        vals_mask = vals is np.ma.masked
+    else:
+        vals_data, vals_mask = get_data_and_mask(vals)
         np.place(arr.unmasked, mask, vals_data)
     np.place(arr.mask, mask, vals_mask)
 
@@ -494,12 +500,12 @@ def copyto(dst, src, casting="same_kind", where=True):
     if not isinstance(dst, Masked) or isinstance(where, Masked):
         raise NotImplementedError
 
-    src_data, src_mask = get_data_and_mask(src)
-
-    if src_data is not None:
+    if src is np.ma.masked or src is np.ma.nomask:
+        src_mask = src is np.ma.masked
+    else:
+        src_data, src_mask = get_data_and_mask(src)
         np.copyto(dst.unmasked, src_data, casting=casting, where=where)
-    if src_mask is not None:
-        np.copyto(dst.mask, src_mask, where=where)
+    np.copyto(dst.mask, src_mask, where=where)
 
 
 @dispatched_function

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -415,6 +415,14 @@ class TestSettingParts(MaskedArraySetup):
         np.put(expected_mask, [0, 2], [False, True])
         assert_array_equal(ma.unmasked, expected)
         assert_array_equal(ma.mask, expected_mask)
+        np.put(ma, [1, 2], np.ma.masked)
+        np.put(expected_mask, [1, 2], True)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
+        np.put(ma, [0, 1], np.ma.nomask)
+        np.put(expected_mask, [0, 1], False)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
 
         with pytest.raises(TypeError):
             # Indices cannot be masked.
@@ -426,7 +434,7 @@ class TestSettingParts(MaskedArraySetup):
 
     def test_putmask(self):
         ma = self.ma.flatten()
-        mask = [True, False, False, False, True, False]
+        mask = np.array([True, False, False, False, True, False])
         values = Masked(
             np.arange(100, 650, 100), mask=[False, True, True, True, False, False]
         )
@@ -437,13 +445,21 @@ class TestSettingParts(MaskedArraySetup):
         np.putmask(expected_mask, mask, values.mask)
         assert_array_equal(ma.unmasked, expected)
         assert_array_equal(ma.mask, expected_mask)
+        np.putmask(ma, ~mask, np.ma.masked)
+        np.putmask(expected_mask, ~mask, True)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
+        np.putmask(ma, mask, np.ma.nomask)
+        np.putmask(expected_mask, mask, False)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
 
         with pytest.raises(TypeError):
             np.putmask(self.a.flatten(), mask, values)
 
     def test_place(self):
         ma = self.ma.flatten()
-        mask = [True, False, False, False, True, False]
+        mask = np.array([True, False, False, False, True, False])
         values = Masked([100, 200], mask=[False, True])
         np.place(ma, mask, values)
         expected = self.a.flatten()
@@ -452,13 +468,21 @@ class TestSettingParts(MaskedArraySetup):
         np.place(expected_mask, mask, values.mask)
         assert_array_equal(ma.unmasked, expected)
         assert_array_equal(ma.mask, expected_mask)
+        np.place(ma, ~mask, np.ma.masked)
+        np.place(expected_mask, ~mask, True)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
+        np.place(ma, mask, np.ma.nomask)
+        np.place(expected_mask, mask, False)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
 
         with pytest.raises(TypeError):
             np.place(self.a.flatten(), mask, values)
 
     def test_copyto(self):
         ma = self.ma.flatten()
-        mask = [True, False, False, False, True, False]
+        mask = np.array([True, False, False, False, True, False])
         values = Masked(
             np.arange(100, 650, 100), mask=[False, True, True, True, False, False]
         )
@@ -467,6 +491,14 @@ class TestSettingParts(MaskedArraySetup):
         np.copyto(expected, values.unmasked, where=mask)
         expected_mask = self.mask_a.flatten()
         np.copyto(expected_mask, values.mask, where=mask)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
+        np.copyto(ma, np.ma.masked, where=~mask)
+        np.copyto(expected_mask, True, where=~mask)
+        assert_array_equal(ma.unmasked, expected)
+        assert_array_equal(ma.mask, expected_mask)
+        np.copyto(ma, np.ma.nomask, where=mask)
+        np.copyto(expected_mask, False, where=mask)
         assert_array_equal(ma.unmasked, expected)
         assert_array_equal(ma.mask, expected_mask)
 

--- a/docs/changes/utils/17014.bugfix.rst
+++ b/docs/changes/utils/17014.bugfix.rst
@@ -1,0 +1,4 @@
+For ``Masked`` instances, ``np.put``, ``np.putmask``, ``np.place`` and
+``np.copyto`` can now handle putting/copying not just ``np.ma.masked`` but
+also ``np.ma.nomask``; for both cases, only the mask of the relevant entries
+will be set.


### PR DESCRIPTION
For ``Masked`` instances, ``np.put``, ``np.putmask``, ``np.place`` and ``np.copyto`` can now handle putting/copying not only ``np.ma.masked`` but also ``np.ma.nomask``; for both cases, only the mask of the relevant entries will be set.

It is not being backported since it relies on new utility functions introduced in #16844 (given these functions are very rarely, if ever, used, that should be fine; indeed, I only found by inspection that the new treatment was not quite right, and the old treatment incomplete).

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
