### PR TITLE
Masked frames and SkyCoord

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 __all__ = [
     "BaseCoordinateFrame",
     "CoordinateFrameInfo",
-    "CoordinateSharedMethods",
     "frame_transform_graph",
     "GenericFrame",
     "RepresentationMapping",
@@ -361,66 +360,6 @@ class CoordinateFrameInfo(MixinInfo):
         return out
 
 
-class CoordinateSharedMethods:
-    @property
-    def masked(self):
-        """Whether the underlying data is masked.
-
-        Raises
-        ------
-        ValueError
-            If the frame has no associated data.
-        """
-        return self.data.masked
-
-    def get_mask(self, *attrs):
-        """Get the mask associated with these coordinates.
-
-        Parameters
-        ----------
-        *attrs : str
-            Attributes from which to get the masks to combine. Items can be
-            dotted, like ``"data.lon", "data.lat"``. By default, get the
-            combined mask of all components (including from differentials),
-            ignoring possible masks of attributes.
-
-        Returns
-        -------
-        mask : ~numpy.ndarray of bool
-            The combined, read-only mask. If the instance is not masked, it
-            is an array of `False` with the correct shape.
-
-        Raises
-        ------
-        ValueError
-            If the coordinate frame has no associated data.
-
-        """
-        if attrs:
-            values = operator.attrgetter(*attrs)(self)
-            if not isinstance(values, tuple):
-                values = (values,)
-            masks = [getattr(v, "mask", None) for v in values]
-        elif self.data.masked:
-            masks = [diff.mask for diff in self.data.differentials.values()]
-            masks.append(self.data.mask)
-        else:
-            # Short-cut if the data is not masked.
-            masks = []
-
-        # Broadcast makes it readonly too.
-        return np.broadcast_to(combine_masks(masks), self.shape)
-
-    mask = property(
-        get_mask,
-        doc="""The mask associated with these coordinates.
-
-    Combines the masks of all components of the underlying representation,
-    including possible differentials.
-    """,
-    )
-
-
 base_doc = """{__doc__}
     Parameters
     ----------
@@ -458,7 +397,7 @@ _components = """
 
 
 @format_doc(base_doc, components=_components, footer="")
-class BaseCoordinateFrame(CoordinateSharedMethods, MaskableShapedLikeNDArray):
+class BaseCoordinateFrame(MaskableShapedLikeNDArray):
     """
     The base class for coordinate frames.
 
@@ -1002,6 +941,64 @@ class BaseCoordinateFrame(CoordinateSharedMethods, MaskableShapedLikeNDArray):
     @property
     def size(self):
         return self.data.size
+
+    @property
+    def masked(self):
+        """Whether the underlying data is masked.
+
+        Raises
+        ------
+        ValueError
+            If the frame has no associated data.
+        """
+        return self.data.masked
+
+    def get_mask(self, *attrs):
+        """Get the mask associated with these coordinates.
+
+        Parameters
+        ----------
+        *attrs : str
+            Attributes from which to get the masks to combine. Items can be
+            dotted, like ``"data.lon", "data.lat"``. By default, get the
+            combined mask of all components (including from differentials),
+            ignoring possible masks of attributes.
+
+        Returns
+        -------
+        mask : ~numpy.ndarray of bool
+            The combined, read-only mask. If the instance is not masked, it
+            is an array of `False` with the correct shape.
+
+        Raises
+        ------
+        ValueError
+            If the coordinate frame has no associated data.
+
+        """
+        if attrs:
+            values = operator.attrgetter(*attrs)(self)
+            if not isinstance(values, tuple):
+                values = (values,)
+            masks = [getattr(v, "mask", None) for v in values]
+        elif self.data.masked:
+            masks = [diff.mask for diff in self.data.differentials.values()]
+            masks.append(self.data.mask)
+        else:
+            # Short-cut if the data is not masked.
+            masks = []
+
+        # Broadcast makes it readonly too.
+        return np.broadcast_to(combine_masks(masks), self.shape)
+
+    mask = property(
+        get_mask,
+        doc="""The mask associated with these coordinates.
+
+    Combines the masks of all components of the underlying representation,
+    including possible differentials.
+    """,
+    )
 
     @classmethod
     def get_frame_attr_defaults(cls):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -148,6 +148,7 @@ class CoordinateFrameInfo(MixinInfo):
 
     attrs_from_parent = {"unit"}  # Unit is read-only
     _supports_indexing = False
+    mask_val = np.ma.masked
 
     @staticmethod
     def default_format(val):

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -398,7 +398,12 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
                 return
 
             # Ensure our components are masked if a mask needs to be set.
-            if set_mask or value.masked:
+            # NOTE: we could also make ourselves masked if value.masked.
+            # But then we have to be sure that Time does the same, and live
+            # with the inconsistency that things like ndarray and Quantity cannot
+            # become masked when setting an item with a masked value.  See
+            # https://github.com/astropy/astropy/pull/17016#issuecomment-2439607869
+            if set_mask:
                 self._ensure_masked()
 
         if set_mask or clear_mask:

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -532,7 +532,9 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
         The record array fields will have the component names.
         """
         coo_items = [(c, getattr(self, c)) for c in self.components]
-        result = np.empty(self.shape, [(c, coo.dtype) for c, coo in coo_items])
+        result = np.empty_like(
+            coo_items[0][1].value, dtype=[(c, coo.dtype) for c, coo in coo_items]
+        )
         for c, coo in coo_items:
             result[c] = coo.value
         return result

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -540,6 +540,16 @@ class SphericalRepresentation(BaseRepresentation):
                     lon=self.lon, lat=self.lat, differentials=diffs, copy=False
                 )
 
+            elif issubclass(other_class, RadialRepresentation):
+                diffs = self._re_represent_differentials(
+                    other_class, differential_class
+                )
+                return other_class(
+                    distance=self.distance,
+                    differentials=diffs,
+                    copy=False,
+                )
+
         return super().represent_as(other_class, differential_class)
 
     def to_cartesian(self):
@@ -751,6 +761,16 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
                     differentials=diffs,
                     copy=False,
                 )
+            elif issubclass(other_class, RadialRepresentation):
+                diffs = self._re_represent_differentials(
+                    other_class, differential_class
+                )
+                return other_class(
+                    distance=self.r,
+                    differentials=diffs,
+                    copy=False,
+                )
+
             from .cylindrical import CylindricalRepresentation
 
             if issubclass(other_class, CylindricalRepresentation):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import operator
 import re
 import warnings
 from typing import TYPE_CHECKING
@@ -14,13 +15,12 @@ from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.masked import MaskableShapedLikeNDArray
+from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
 from .angles import Angle
 from .baseframe import (
     BaseCoordinateFrame,
     CoordinateFrameInfo,
-    CoordinateSharedMethods,
     GenericFrame,
     frame_transform_graph,
 )
@@ -52,7 +52,7 @@ class SkyCoordInfo(CoordinateFrameInfo):
         return out
 
 
-class SkyCoord(CoordinateSharedMethods, MaskableShapedLikeNDArray):
+class SkyCoord(MaskableShapedLikeNDArray):
     """High-level object providing a flexible interface for celestial coordinate
     representation, manipulation, and transformation between systems.
 
@@ -265,6 +265,36 @@ class SkyCoord(CoordinateSharedMethods, MaskableShapedLikeNDArray):
     @property
     def shape(self):
         return self.frame.shape
+
+    # The following 3 have identical implementation as in BaseCoordinateFrame,
+    # but we cannot just rely on __getattr__ to get them from the frame,
+    # because (1) get_mask has to be able to access our own attributes, and
+    # (2) masked and mask are abstract properties in MaskableSharedLikeNDArray
+    # which thus need to be explicitly defined.
+    # TODO: factor out common methods and attributes in a mixin class.
+    @property
+    def masked(self):
+        return self.data.masked
+
+    def get_mask(self, *attrs):
+        if not attrs:
+            # Just use the frame
+            return self._sky_coord_frame.get_mask()
+
+        values = operator.attrgetter(*attrs)(self)
+        if not isinstance(values, tuple):
+            values = (values,)
+        masks = [getattr(v, "mask", None) for v in values]
+        # Broadcast makes it readonly too.
+        return np.broadcast_to(combine_masks(masks), self.shape)
+
+    @property
+    def mask(self):
+        return self._sky_coord_frame.mask
+
+    masked.__doc__ = BaseCoordinateFrame.masked.__doc__
+    get_mask.__doc__ = BaseCoordinateFrame.get_mask.__doc__
+    mask.__doc__ = BaseCoordinateFrame.mask.__doc__
 
     def __eq__(self, value):
         """Equality operator for SkyCoord.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -14,11 +14,13 @@ from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.masked import MaskableShapedLikeNDArray
 
 from .angles import Angle
 from .baseframe import (
     BaseCoordinateFrame,
     CoordinateFrameInfo,
+    CoordinateSharedMethods,
     GenericFrame,
     frame_transform_graph,
 )
@@ -50,7 +52,7 @@ class SkyCoordInfo(CoordinateFrameInfo):
         return out
 
 
-class SkyCoord(ShapedLikeNDArray):
+class SkyCoord(CoordinateSharedMethods, MaskableShapedLikeNDArray):
     """High-level object providing a flexible interface for celestial coordinate
     representation, manipulation, and transformation between systems.
 
@@ -369,6 +371,11 @@ class SkyCoord(ShapedLikeNDArray):
 
           self.frame.data[item] = value.frame.data
         """
+        if value is np.ma.masked or value is np.ma.nomask:
+            self.data.__setitem__(item, value)
+            self.cache.clear()
+            return
+
         if self.__class__ is not value.__class__:
             raise TypeError(
                 "can only set from object of same class: "

--- a/astropy/coordinates/tests/helper.py
+++ b/astropy/coordinates/tests/helper.py
@@ -11,7 +11,7 @@ def skycoord_equal(sc1, sc2):
         return False
     if sc1.shape != sc2.shape:
         return False  # Maybe raise ValueError corresponding to future numpy behavior
-    eq = np.ones(shape=sc1.shape, dtype=bool)
+    eq = True
     for comp in sc1.data.components:
-        eq &= getattr(sc1.data, comp) == getattr(sc2.data, comp)
-    return np.all(eq)
+        eq &= np.all(getattr(sc1.data, comp) == getattr(sc2.data, comp))
+    return eq

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -1,0 +1,120 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import astropy.coordinates.representation as r
+import astropy.units as u
+from astropy.coordinates.tests.test_representation import representation_equal
+from astropy.utils.masked import Masked
+
+
+class TestSphericalRepresentationSeparateMasks:
+    """Tests for mask propagation for Spherical with separate masks."""
+
+    def setup_class(self):
+        self.lon = np.array([0.0, 3.0, 6.0, 12.0, 15.0, 18.0]) << u.hourangle
+        self.lat = np.array([-15.0, 30.0, 60.0, -60.0, 89.0, -80.0]) << u.deg
+        self.dis = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]) << u.pc
+        self.mask_lon = np.array([False, True, False, False, True, True])
+        self.mask_lat = np.array([False, False, True, False, True, True])
+        self.mask_dis = np.array([False, False, False, True, False, True])
+        self.mlon = Masked(self.lon, self.mask_lon)
+        self.mlat = Masked(self.lat, self.mask_lat)
+        self.mdis = Masked(self.dis, self.mask_dis)
+        self.msph = r.SphericalRepresentation(self.mlon, self.mlat, self.mdis)
+        self.mask_ang = self.mask_lon | self.mask_lat
+        self.mask = self.mask_ang | self.mask_dis
+
+    def test_initialization(self):
+        assert_array_equal(self.msph.lon.mask, self.mask_lon)
+        assert_array_equal(self.msph.lat.mask, self.mask_lat)
+        assert_array_equal(self.msph.distance.mask, self.mask_dis)
+        assert_array_equal(self.msph.unmasked.lon, self.lon)
+        assert_array_equal(self.msph.unmasked.lat, self.lat)
+        assert_array_equal(self.msph.unmasked.distance, self.dis)
+
+        assert_array_equal(self.msph.mask, self.mask)
+        assert_array_equal(self.msph.get_mask(), self.mask)
+        assert_array_equal(self.msph.get_mask("lon", "lat"), self.mask_ang)
+
+    def test_convert_to_cartesian(self):
+        mcart = self.msph.represent_as(r.CartesianRepresentation)
+        assert_array_equal(mcart.mask, self.mask)
+
+    def test_convert_to_unit_spherical(self):
+        musph = self.msph.represent_as(r.UnitSphericalRepresentation)
+        assert_array_equal(musph.lon.mask, self.mask_lon)
+        assert_array_equal(musph.lat.mask, self.mask_lat)
+        assert_array_equal(musph.mask, self.mask_ang)
+
+    def test_convert_to_radial(self):
+        mrad = r.RadialRepresentation.from_representation(self.msph)
+        assert_array_equal(mrad.mask, self.mask_dis)
+
+    def test_convert_to_physics_spherical(self):
+        mpsph = self.msph.represent_as(r.PhysicsSphericalRepresentation)
+        assert_array_equal(mpsph.phi.mask, self.mask_lon)
+        assert_array_equal(mpsph.theta.mask, self.mask_lat)
+        assert_array_equal(mpsph.r.mask, self.mask_dis)
+        assert_array_equal(mpsph.mask, self.mask)
+        assert_array_equal(mpsph.get_mask("phi", "theta"), self.mask_ang)
+
+    def test_set_mask(self):
+        msph = self.msph.copy()
+        msph[0] = np.ma.masked
+        assert_array_equal(msph.mask, np.concatenate(([True], self.mask[1:])))
+        msph[0] = np.ma.nomask
+        assert_array_equal(msph.mask, self.mask)
+
+    def test_setitem(self):
+        msph = self.msph.copy()
+        msph[0] = self.msph[1]
+        assert_array_equal(msph.mask, np.concatenate(([True], self.mask[1:])))
+        assert_array_equal(
+            msph.unmasked.lon, np.concatenate((msph.lon[1:2], self.lon[1:]))
+        )
+        msph[0] = self.msph[0]
+        assert_array_equal(msph.mask, self.mask)
+        assert_array_equal(msph.unmasked.lon, self.lon)
+
+    def test_set_masked_item_on_unmasked_instance(self):
+        sph = self.msph.copy().unmasked
+        sph[0] = self.msph[1]
+        assert sph.masked
+        assert_array_equal(
+            sph.mask, np.concatenate(([True], np.zeros_like(self.mask[1:])))
+        )
+        assert_array_equal(
+            sph.unmasked.lon, np.concatenate((sph.lon[1:2], self.lon[1:]))
+        )
+        sph[0] = self.msph[0].unmasked
+        assert sph.masked  # Does not get reset
+        assert_array_equal(sph.mask, np.zeros_like(self.mask))
+        assert_array_equal(sph.unmasked.lon, self.lon)
+
+    def test_set_np_ma_masked_on_unmasked_instance(self):
+        sph = self.msph.copy().unmasked
+        sph[0] = np.ma.masked
+        assert sph.masked
+        assert_array_equal(
+            sph.mask, np.concatenate(([True], np.zeros_like(self.mask[1:])))
+        )
+        assert_array_equal(sph.unmasked.lon, self.lon)
+        sph[0] = np.ma.nomask
+        assert sph.masked  # Does not get reset
+        assert_array_equal(sph.mask, np.zeros_like(self.mask))
+        assert_array_equal(sph.unmasked.lon, self.lon)
+
+    def test_set_np_ma_nomasked_on_unmasked_instance(self):
+        sph = self.msph.copy().unmasked
+        sph[0] = np.ma.nomask
+        assert not sph.masked
+        assert_array_equal(sph.unmasked.lon, self.lon)
+
+    def test_filled(self):
+        unmasked = self.msph.unmasked
+        sph = self.msph.filled(unmasked[1])
+        expected = unmasked.copy()
+        expected[self.mask] = unmasked[1]
+        assert np.all(representation_equal(sph, expected))

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -8,6 +8,7 @@ import astropy.coordinates.representation as r
 import astropy.units as u
 from astropy.coordinates import FK5, SkyCoord
 from astropy.coordinates.matrix_utilities import rotation_matrix
+from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.coordinates.tests.test_representation import representation_equal
 from astropy.utils.masked import Masked
 
@@ -351,6 +352,8 @@ class TestSkyCoordWithDifferentials:
         # All parts of the coordinate influence the final positions.
         expected_mask = self.sc.get_mask() | getattr(dt, "mask", False)
         assert_array_equal(sc.mask, expected_mask)
+        expected_unmasked = self.sc.unmasked.apply_space_motion(dt=dt)
+        assert skycoord_equal(sc.unmasked, expected_unmasked)
 
 
 class TestSkyCoordWithOnlyDifferentialsMasked(TestSkyCoordWithDifferentials):

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -340,6 +340,13 @@ class TestSkyCoordWithDifferentials:
         assert_array_equal(self.sc.get_mask(), self.mask)
         assert_array_equal(self.sc.get_mask("ra", "dec"), False)
 
+    def test_filled(self):
+        unmasked = self.sc.unmasked
+        filled = self.sc.filled(unmasked[1])
+        expected = unmasked.copy()
+        expected[self.mask] = unmasked[1]
+        assert skycoord_equal(filled, expected)
+
     @pytest.mark.parametrize(
         "dt",
         [

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -15,19 +15,19 @@ from astropy.utils.masked import Masked
 
 class MaskedSphericalSetup:
     @classmethod
-    def setup_class(self):
-        self.lon = np.array([0.0, 3.0, 6.0, 12.0, 15.0, 18.0]) << u.hourangle
-        self.lat = np.array([-15.0, 30.0, 60.0, -60.0, 89.0, -80.0]) << u.deg
-        self.dis = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]) << u.pc
-        self.mask_lon = np.array([False, True, False, False, True, True])
-        self.mask_lat = np.array([False, False, True, False, True, True])
-        self.mask_dis = np.array([False, False, False, True, False, True])
-        self.mlon = Masked(self.lon, self.mask_lon)
-        self.mlat = Masked(self.lat, self.mask_lat)
-        self.mdis = Masked(self.dis, self.mask_dis)
-        self.msph = r.SphericalRepresentation(self.mlon, self.mlat, self.mdis)
-        self.mask_ang = self.mask_lon | self.mask_lat
-        self.mask = self.mask_ang | self.mask_dis
+    def setup_class(cls):
+        cls.lon = np.array([0.0, 3.0, 6.0, 12.0, 15.0, 18.0]) << u.hourangle
+        cls.lat = np.array([-15.0, 30.0, 60.0, -60.0, 89.0, -80.0]) << u.deg
+        cls.dis = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0]) << u.pc
+        cls.mask_lon = np.array([False, True, False, False, True, True])
+        cls.mask_lat = np.array([False, False, True, False, True, True])
+        cls.mask_dis = np.array([False, False, False, True, False, True])
+        cls.mlon = Masked(cls.lon, cls.mask_lon)
+        cls.mlat = Masked(cls.lat, cls.mask_lat)
+        cls.mdis = Masked(cls.dis, cls.mask_dis)
+        cls.msph = r.SphericalRepresentation(cls.mlon, cls.mlat, cls.mdis)
+        cls.mask_ang = cls.mask_lon | cls.mask_lat
+        cls.mask = cls.mask_ang | cls.mask_dis
 
 
 class TestSphericalRepresentationSeparateMasks(MaskedSphericalSetup):
@@ -194,9 +194,9 @@ class TestFrame(MaskedSphericalSetup):
     """Tests that mask is calculated properly for frames, using FK5."""
 
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.fk5 = FK5(self.msph)
+        cls.fk5 = FK5(cls.msph)
 
     def test_initialization_directly(self):
         d = Masked([50, 1.0] * u.kpc, mask=[False, True])
@@ -282,13 +282,13 @@ class TestSkyCoord(TestFrame):
     """
 
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.p = np.linspace(900, 1000, self.msph.size) << u.hPa
-        self.mask_p = np.array([True, False, False, False, False, False])
-        self.mp = Masked(self.p, self.mask_p)
+        cls.p = np.linspace(900, 1000, cls.msph.size) << u.hPa
+        cls.mask_p = np.array([True, False, False, False, False, False])
+        cls.mp = Masked(cls.p, cls.mask_p)
         # Ensure we have an attribute not associated with the frame.
-        self.fk5 = SkyCoord(self.msph, frame="fk5", pressure=self.mp)
+        cls.fk5 = SkyCoord(cls.msph, frame="fk5", pressure=cls.mp)
 
     def test_non_frame_attribute(self):
         assert_array_equal(self.fk5.get_mask("pressure"), self.mask_p)
@@ -299,32 +299,30 @@ class TestSkyCoord(TestFrame):
 
 class TestSkyCoordWithDifferentials:
     @classmethod
-    def setup_class(self):
-        self.ra = [0.0, 3.0, 6.0, 12.0, 15.0, 18.0] << u.hourangle
-        self.dec = [-15.0, 30.0, 60.0, -60.0, 89.0, -80.0] << u.deg
-        self.dis = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0] << u.pc
-        self.mask_dis = np.array([False, True, False, True, False, True])
-        self.pm_ra_cosdec = [1.0, 2.0, 3.0, -4.0, -5.0, -6.0] << (u.mas / u.yr)
-        self.mask_pm_ra_cosdec = np.array([False, False, True, False, False, True])
-        self.pm_dec = [-9.0, -7.0, 5.0, 3.0, 1.0, 0.0] << (u.mas / u.yr)
-        self.mask_pm_dec = np.array([False, False, True, True, False, True])
-        self.rv = [40.0, 50.0, 0.0, 0.0, -30.0, -10.0] << (u.km / u.s)
-        self.mask_rv = np.array([False, False, False, False, True, True])
-        self.mdis = Masked(self.dis, self.mask_dis)
-        self.mpm_ra_cosdec = Masked(self.pm_ra_cosdec, self.mask_pm_ra_cosdec)
-        self.mpm_dec = Masked(self.pm_dec, self.mask_pm_dec)
-        self.mrv = Masked(self.rv, self.mask_rv)
-        self.sc = SkyCoord(
-            ra=self.ra,
-            dec=self.dec,
-            distance=self.mdis,
-            pm_ra_cosdec=self.mpm_ra_cosdec,
-            pm_dec=self.mpm_dec,
-            radial_velocity=self.mrv,
+    def setup_class(cls):
+        cls.ra = [0.0, 3.0, 6.0, 12.0, 15.0, 18.0] << u.hourangle
+        cls.dec = [-15.0, 30.0, 60.0, -60.0, 89.0, -80.0] << u.deg
+        cls.dis = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0] << u.pc
+        cls.mask_dis = np.array([False, True, False, True, False, True])
+        cls.pm_ra_cosdec = [1.0, 2.0, 3.0, -4.0, -5.0, -6.0] << (u.mas / u.yr)
+        cls.mask_pm_ra_cosdec = np.array([False, False, True, False, False, True])
+        cls.pm_dec = [-9.0, -7.0, 5.0, 3.0, 1.0, 0.0] << (u.mas / u.yr)
+        cls.mask_pm_dec = np.array([False, False, True, True, False, True])
+        cls.rv = [40.0, 50.0, 0.0, 0.0, -30.0, -10.0] << (u.km / u.s)
+        cls.mask_rv = np.array([False, False, False, False, True, True])
+        cls.mdis = Masked(cls.dis, cls.mask_dis)
+        cls.mpm_ra_cosdec = Masked(cls.pm_ra_cosdec, cls.mask_pm_ra_cosdec)
+        cls.mpm_dec = Masked(cls.pm_dec, cls.mask_pm_dec)
+        cls.mrv = Masked(cls.rv, cls.mask_rv)
+        cls.sc = SkyCoord(
+            ra=cls.ra,
+            dec=cls.dec,
+            distance=cls.mdis,
+            pm_ra_cosdec=cls.mpm_ra_cosdec,
+            pm_dec=cls.mpm_dec,
+            radial_velocity=cls.mrv,
         )
-        self.mask = (
-            self.mask_dis | self.mask_pm_ra_cosdec | self.mask_pm_dec | self.mask_rv
-        )
+        cls.mask = cls.mask_dis | cls.mask_pm_ra_cosdec | cls.mask_pm_dec | cls.mask_rv
 
     def test_setup(self):
         assert self.sc.masked
@@ -365,18 +363,16 @@ class TestSkyCoordWithDifferentials:
 
 class TestSkyCoordWithOnlyDifferentialsMasked(TestSkyCoordWithDifferentials):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
         # Overwrite SkyCoord using unmasked distance.
-        self.mask_dis = False
-        self.sc = SkyCoord(
-            ra=self.ra,
-            dec=self.dec,
-            distance=self.dis,
-            pm_ra_cosdec=self.mpm_ra_cosdec,
-            pm_dec=self.mpm_dec,
-            radial_velocity=self.mrv,
+        cls.mask_dis = False
+        cls.sc = SkyCoord(
+            ra=cls.ra,
+            dec=cls.dec,
+            distance=cls.dis,
+            pm_ra_cosdec=cls.mpm_ra_cosdec,
+            pm_dec=cls.mpm_dec,
+            radial_velocity=cls.mrv,
         )
-        self.mask = (
-            self.mask_dis | self.mask_pm_ra_cosdec | self.mask_pm_dec | self.mask_rv
-        )
+        cls.mask = cls.mask_dis | cls.mask_pm_ra_cosdec | cls.mask_pm_dec | cls.mask_rv

--- a/astropy/coordinates/tests/test_masked.py
+++ b/astropy/coordinates/tests/test_masked.py
@@ -37,6 +37,15 @@ class TestSphericalRepresentationSeparateMasks:
         assert_array_equal(self.msph.mask, self.mask)
         assert_array_equal(self.msph.get_mask(), self.mask)
         assert_array_equal(self.msph.get_mask("lon", "lat"), self.mask_ang)
+        assert repr(self.msph) == (
+            "<SphericalRepresentation (lon, lat, distance) in (hourangle, deg, pc)\n"
+            "    [( 0., -15., 10.), (———,  30., 20.), ( 6.,  ———, 30.),\n"
+            "     (12., -60., ———), (———,  ———, 50.), (———,  ———, ———)]>"
+        )
+        assert str(self.msph) == (
+            "[( 0., -15., 10.), (———,  30., 20.), ( 6.,  ———, 30.), (12., -60., ———),\n"
+            " (———,  ———, 50.), (———,  ———, ———)] (hourangle, deg, pc)"
+        )
 
     def test_convert_to_cartesian(self):
         mcart = self.msph.represent_as(r.CartesianRepresentation)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -394,6 +394,13 @@ class TestSphericalRepresentation:
         )
         assert representation_equal_up_to_angular_type(got, expected)
 
+        got = sph.represent_as(RadialRepresentation, RadialDifferential)
+        assert np.may_share_memory(sph.distance, got.distance)
+        expected = BaseRepresentation.represent_as(
+            sph, RadialRepresentation, RadialDifferential
+        )
+        assert representation_equal_up_to_angular_type(got, expected)
+
     def test_transform(self):
         """Test ``.transform()`` on rotation and general matrices."""
         # set up representation
@@ -850,6 +857,13 @@ class TestPhysicsSphericalRepresentation:
         assert_allclose_quantity(got.rho, expected.rho, atol=5e-17 * u.kpc)
         assert_allclose_quantity(got.phi, expected.phi, atol=3e-16 * u.deg)
         assert_array_equal(got.z, expected.z)
+
+        got = sph.represent_as(RadialRepresentation, RadialDifferential)
+        assert np.may_share_memory(sph.r, got.distance)
+        expected = BaseRepresentation.represent_as(
+            sph, RadialRepresentation, RadialDifferential
+        )
+        assert representation_equal_up_to_angular_type(got, expected)
 
     def test_to_cylindrical_at_the_origin(self):
         """Test that the transformation to cylindrical at the origin preserves phi."""

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -661,7 +661,7 @@ class TestJoin:
 
         # Check for left, right, outer join which requires masking. Works for
         # the listed mixins classes.
-        if isinstance(col, (Quantity, Time, TimeDelta)):
+        if isinstance(col, (Quantity, Time, TimeDelta, SkyCoord)):
             out = table.join(t1, t2, join_type="left")
             assert len(out) == 3
             assert np.all(out["idx"] == [0, 1, 3])
@@ -1474,10 +1474,10 @@ class TestVStack:
             with pytest.raises(NotImplementedError, match=re.escape(msg)):
                 table.vstack([t, t])
 
-        # Check for outer stack which requires masking.  Only Time supports
-        # this currently.
+        # Check for outer stack which requires masking.  Works for
+        # the listed mixins classes.
         t2 = table.QTable([col], names=["b"])  # different from col name for t
-        if isinstance(col, (Time, TimeDelta, Quantity)):
+        if isinstance(col, (Time, TimeDelta, Quantity, SkyCoord)):
             out = table.vstack([t, t2], join_type="outer")
             assert len(out) == len_col * 2
             assert np.all(out["a"][:len_col] == col)
@@ -2074,8 +2074,9 @@ class TestHStack:
             assert np.all(out["col0_1"] == col1[: len(col2)])
             assert np.all(out["col0_2"] == col2)
 
-        # Time class supports masking, all other mixins do not
-        if isinstance(col1, (Time, TimeDelta, Quantity)):
+        # Check mixin classes that support masking (and that we raise for
+        # those that do not).
+        if isinstance(col1, (Time, TimeDelta, Quantity, SkyCoord)):
             out = table.hstack([t1, t2], join_type="outer")
             assert len(out) == len(t1)
             assert np.all(out["col0_1"] == col1)

--- a/docs/changes/coordinates/17016.feature.rst
+++ b/docs/changes/coordinates/17016.feature.rst
@@ -1,0 +1,5 @@
+``SkyCoord``, coordinate frames, and representations have all have gained the
+ability to deal with ``Masked`` data. In general, the procedure is similar to
+that of ``Time``, except that different representation components do not share
+the mask, to enable holding, e.g., a catalogue of objects in which only some
+have associated distances.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -425,6 +425,60 @@ and transforming velocities. These are available both via the lower-level
 For more details on velocity support (and limitations), see the
 :doc:`velocities` page.
 
+.. _astropy-coordinates-masks:
+
+Masks
+-----
+
+Sometimes you may have incomplete information about objects, e.g., some have
+distances while others have not. `~astropy.coordinates` supports using masks
+for such purposes, using the |Masked| class::
+
+    >>> from astropy.utils.masked import Masked
+    >>> distance = Masked([0.1, np.nan]*u.kpc, mask=[False, True])
+    >>> sc = SkyCoord([1., 2.]*u.hourangle, [3., 4.]*u.deg, distance=distance)
+    >>> sc
+    <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
+        [(15., 3., 0.1), (30., 4., ———)]>
+
+The masks propagates as you would expect::
+
+    >>> sc.separation(sc[0])  # doctest: +FLOAT_CMP
+    <MaskedAngle [ 0.        , 15.00502838] deg>
+    >>> sc.separation_3d(sc[0])  # doctest: +FLOAT_CMP
+    <MaskedDistance [ 0., ———] kpc>
+    >>> gcrs = sc.gcrs  # doctest: +SHOW_WARNINGS
+    RuntimeWarning: invalid value encountered in ld...
+    RuntimeWarning: invalid value encountered in anp...
+    >>> gcrs  # doctest: +FLOAT_CMP
+    <SkyCoord (GCRS: obstime=J2000.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, kpc)
+        [(15.00054403, 2.99988395, 0.1), (        ———,        ———, ———)]>
+
+In the last example, you will notice that the angles of the second item have
+become masked too. This is because the distance is required in the conversion.
+Indeed, because we put in ``NaN``, we get not only the warnings during
+the conversion, but also ``NaN`` in the unmasked converted angles::
+
+    >>> gcrs.unmasked  # doctest: +FLOAT_CMP
+    <SkyCoord (GCRS: obstime=J2000.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, kpc)
+        [(15.00054403, 2.99988395, 0.1), (        nan,        nan, nan)]>
+
+In principle, by using a "good guess" for the distance, this can be avoided::
+
+    >>> distance2 = Masked([0.1, 1.]*u.kpc, mask=[False, True])
+    >>> sc2 = SkyCoord([1., 2.]*u.hourangle, [3., 4.]*u.deg, distance=distance2)
+    >>> gcrs2 = sc2.gcrs
+    >>> gcrs2  # doctest: +FLOAT_CMP
+    <SkyCoord (GCRS: obstime=J2000.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, kpc)
+        [(15.00054403, 2.99988395, 0.1), (        ———,        ———, ———)]>
+    >>> gcrs2.unmasked  # doctest: +FLOAT_CMP
+    <SkyCoord (GCRS: obstime=J2000.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, kpc)
+        [(15.00054403, 2.99988395, 0.1), (30.00201927, 3.99996188, 1. )]>
+
+.. warning::
+    Support for masks is new in astropy 7.0, and likely incomplete.
+    Please report any problems you find.
+
 .. _astropy-coordinates-overview:
 
 Overview of `astropy.coordinates` Concepts

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -447,7 +447,7 @@ The masks propagates as you would expect::
     <MaskedAngle [ 0.        , 15.00502838] deg>
     >>> sc.separation_3d(sc[0])  # doctest: +FLOAT_CMP
     <MaskedDistance [ 0., ———] kpc>
-    >>> gcrs = sc.gcrs  # doctest: +SHOW_WARNINGS
+    >>> gcrs = sc.gcrs  # doctest: +SHOW_WARNINGS +IGNORE_OUTPUT
     RuntimeWarning: invalid value encountered in ld...
     RuntimeWarning: invalid value encountered in anp...
     >>> gcrs  # doctest: +FLOAT_CMP

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -31,6 +31,7 @@ In particular, this release includes:
 * :ref:`whatsnew_7_0_simplenorm`
 * :ref:`whatsnew_7_0_sigmaclippedstats`
 * :ref:`whatsnew_7_0_wcsaxes_default_axes`
+* :ref:`whatsnew-7.0-masked-coordinates`
 
 In addition to these major changes, Astropy v7.0 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -516,6 +517,32 @@ This default can be overridden by manually setting the axes to use with
 `~.CoordinateHelper.set_axislabel_position`. In practice, you should be able
 to just call `~.CoordinateHelper.set_ticklabel_position` because axis labels
 and ticks will default to being shown on the same axes as tick labels.
+
+.. _whatsnew-7.0-masked-coordinates:
+
+Support for masks in ``coordinates``
+====================================
+
+Initial support for masks has been implemented for |SkyCoord|, as well as for
+coordinate frames and coordinate representations.
+
+Like more generally for |Masked| instances, one can access the mask using
+`~astropy.coordinates.SkyCoord.mask` and check whether the underlying data are
+masked using `~astropy.coordinates.SkyCoord.masked`. Like for all masked
+classes, one can access underlying unmasked data using
+`~astropy.utils.masked.MaskableShapedLikeNDArray.unmasked` and one can get a
+new instance with masked data replaced with a fill value using
+:meth:`~astropy.utils.masked.MaskableShapedLikeNDArray.filled`.
+
+By default, the mask combines all masks of the underlying representation
+components, including those on possible differentials like radial velocity and
+proper motion. It is possible to make other choices using the new
+`~astropy.coordinates.SkyCoord.get_mask()` method. For instance,
+``sc.get_mask("ra", "dec")`` would get the combined masks of just the angular
+components, which may be useful if dealing with, e.g., a catalogue of stars
+where distances are available only for some of the objects.
+
+For concrete examples, see :ref:`astropy-coordinates-masks`.
 
 Full change log
 ===============


### PR DESCRIPTION
This pull request is the follow-up to #16845, using the mask on representations in `SkyCoord` and coordinate frames. It also includes brief docs and a what's-new entry.

Notes:
- Based on #16845 ~(hence opened as draft for now)~, but feel free to just look at the whole here;
- Because the coordinates API is shown without inherited members, I cannot link to the new `.mask` property and other features in the what's-new. I tried just adding  `:inherited-members:` to `ref_api.py`, but that leads to large numbers of failures that seem out of scope of this PR.
- So far, I've stuck to the standard `Masked` approach, that masks just get propagated. For some methods, like `apply_space_motion`, as well as for coordinate transformations, it might make more sense to treat masked values truly as missing ones, so that, e.g., a masked distance is taken to be the same as if the coordinate had `UnitSpherical` representation. The question then is whether that is in fact what the user wants, i.e., to what extent one should refuse the temptation to guess...

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
