### PR TITLE
Allow major formatter to be a callable in WCSAxes

### DIFF
--- a/astropy/tests/figures/py311-test-image-mpl360-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpl360-cov.json
@@ -50,6 +50,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "9d91bcf571af6dcc1425b6dfd76fb92e3e0180fb9fd0c852f9eba3fb06e079fc",
   "astropy.visualization.wcsaxes.tests.test_images.test_overlay_nondegree_unit": "aa9b85520da54dc61d4db2988883ff184fb59cd27c52a04899cb33599fcab4b7",
   "astropy.visualization.wcsaxes.tests.test_images.test_nosimplify": "a00b1ccd640c53a92ca0856b9577b9408d0332cb0985db0662a4621e0c002e16",
+  "astropy.visualization.wcsaxes.tests.test_images.test_custom_formatter": "e04eb07365c6bbc4774a20150c13dadcf72b9c5a664805aff2fffd106fdecd87",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/tests/figures/py311-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpldev-cov.json
@@ -50,6 +50,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.test_tickable_gridlines": "9d91bcf571af6dcc1425b6dfd76fb92e3e0180fb9fd0c852f9eba3fb06e079fc",
   "astropy.visualization.wcsaxes.tests.test_images.test_overlay_nondegree_unit": "aa9b85520da54dc61d4db2988883ff184fb59cd27c52a04899cb33599fcab4b7",
   "astropy.visualization.wcsaxes.tests.test_images.test_nosimplify": "a00b1ccd640c53a92ca0856b9577b9408d0332cb0985db0662a4621e0c002e16",
+  "astropy.visualization.wcsaxes.tests.test_images.test_custom_formatter": "e04eb07365c6bbc4774a20150c13dadcf72b9c5a664805aff2fffd106fdecd87",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay": "0a87473ff8e5b5610f4adac1518c608afcd2178b25584fb42f77bcc594c4f47a",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_coords_overlay_auto_coord_meta": "2f737bb70fb1a5452cb0efa79010376614dc559e9aff607f638f044ac6b04448",
   "astropy.visualization.wcsaxes.tests.test_transform_coord_meta.TestTransformCoordMeta.test_direct_init": "1f24c5243bfdf0f30e88afc4f2f5d66db85954cea50a2910af94975ff8765b45",

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -433,11 +433,13 @@ class CoordinateHelper:
         Parameters
         ----------
         formatter : str or callable
-            The format string to use, or a callable which takes a
+            The format string to use, or a callable (for advanced use cases).
+            If specified as a callable, this should take a
             `~astropy.units.Quantity` (which could be scalar or array) of tick
-            world coordinates as well as a ``spacing`` keyword argument, which
-            gives (also as a `~astropy.units.Quantity`) the spacing between
-            ticks, and returns an iterable of strings containing the labels.
+            world coordinates as well as an optional ``spacing`` keyword
+            argument, which gives (also as a `~astropy.units.Quantity`) the
+            spacing between ticks, and returns an iterable of strings
+            containing the labels.
         """
         if callable(formatter):
             self._custom_formatter = formatter

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -105,6 +105,7 @@ class CoordinateHelper:
         self._default_label = default_label or ""
         self._auto_axislabel = True
         self._axislabel_set = False
+        self._custom_formatter = None
 
         # Disable auto label for elliptical frames as it puts labels in
         # annoying places.

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -19,6 +19,7 @@ from astropy.coordinates import (
 )
 from astropy.io import fits
 from astropy.tests.figures import figure_test
+from astropy.utils import isiterable
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.visualization.wcsaxes import WCSAxes, add_beam, add_scalebar
@@ -1372,4 +1373,26 @@ def test_nosimplify():
     ax.set_aspect(15)
     ax.grid()
 
+    return fig
+
+
+@figure_test
+def test_custom_formatter(spatial_wcs_2d_small_angle):
+    def double_format(value, **kwargs):
+        if isiterable(value):
+            return [f"{(v * 2):.4f}" for v in value]
+        else:
+            return f"{(value * 2):.2f}"
+
+    def fruit_format(value, **kwargs):
+        fruits = ["apple", "pear", "banana", "orange", "kiwi", "grape"]
+        if isiterable(value):
+            return (fruits * 10)[: len(value)]
+        else:
+            return "apple"
+
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=spatial_wcs_2d_small_angle)
+    ax.coords[0].set_major_formatter(double_format)
+    ax.coords[1].set_major_formatter(fruit_format)
     return fig

--- a/docs/changes/visualization/17020.feature.rst
+++ b/docs/changes/visualization/17020.feature.rst
@@ -1,0 +1,1 @@
+Added the ability to specify a callable function in ``CoordinateHelper.set_major_formatter``


### PR DESCRIPTION
This makes it possible to override completely the formatter to use in WCSAxes, using public API.

cc @Cadair @ayshih

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
