### PR TITLE
Backport PR #16999 on branch v6.1.x (BUG: ensure coordinate decs are always written out to  tables.)

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -640,7 +640,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
                 RepresentationMapping("d_distance", "radial_velocity", u.km / u.s),
             ],
         )
-
+        repr_info.setdefault(
+            r.RadialDifferential,
+            [RepresentationMapping("d_distance", "radial_velocity", u.km / u.s)],
+        )
         repr_info.setdefault(
             r.CartesianDifferential,
             [

--- a/docs/changes/coordinates/16999.bugfix.rst
+++ b/docs/changes/coordinates/16999.bugfix.rst
@@ -1,0 +1,5 @@
+Avoid some components not being included in table output of coordinates if
+the representation type was ``"unitspherical"``.
+
+In the process, also ensured that one can pass in the ``radial_velocity``
+keyword argument if one uses ``differential_type="radial"``.


### PR DESCRIPTION
BUG: ensure coordinate decs are always written out to tables. (cherry picked from commit 1e97f5548ef60773d2f6da822562b0f2a296e755)

This backport was a little messy, but does, I think, the right thing.

EDIT: Backport PR #16999 on branch v6.1.x