### PR TITLE
TST: refactor a couple tests to avoid the use of random numbers (table)

### DIFF
--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -15,45 +15,6 @@ from astropy.utils.data_info import ParentDtypeInfo
 from .table import Column, Table
 
 
-class TimingTables:
-    """
-    Object which contains two tables and various other attributes that
-    are useful for timing and other API tests.
-    """
-
-    def __init__(self, size=1000, masked=False):
-        self.masked = masked
-
-        # Initialize table
-        self.table = Table(masked=self.masked)
-
-        # Create column with mixed types
-        np.random.seed(12345)
-        self.table["i"] = np.arange(size)
-        self.table["a"] = np.random.random(size)  # float
-        self.table["b"] = np.random.random(size) > 0.5  # bool
-        self.table["c"] = np.random.random((size, 10))  # 2d column
-        self.table["d"] = np.random.choice(np.array(list(string.ascii_letters)), size)
-
-        self.extra_row = {"a": 1.2, "b": True, "c": np.repeat(1, 10), "d": "Z"}
-        self.extra_column = np.random.randint(0, 100, size)
-        self.row_indices = np.where(self.table["a"] > 0.9)[0]
-        self.table_grouped = self.table.group_by("d")
-
-        # Another table for testing joining
-        self.other_table = Table(masked=self.masked)
-        self.other_table["i"] = np.arange(1, size, 3)
-        self.other_table["f"] = np.random.random()
-        self.other_table.sort("f")
-
-        # Another table for testing hstack
-        self.other_table_2 = Table(masked=self.masked)
-        self.other_table_2["g"] = np.random.random(size)
-        self.other_table_2["h"] = np.random.random((size, 10))
-
-        self.bool_mask = self.table["a"] > 0.6
-
-
 def simple_table(size=3, cols=None, kinds="ifS", masked=False):
     """
     Return a simple table for testing.

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -4,6 +4,9 @@ from contextlib import nullcontext
 
 import numpy as np
 import pytest
+from hypothesis import given
+from hypothesis.extra.numpy import arrays
+from hypothesis.strategies import integers
 
 from astropy import coordinates, time
 from astropy import units as u
@@ -729,7 +732,8 @@ def test_group_mixins_unsupported(col):
 
 
 @pytest.mark.parametrize("add_index", [False, True])
-def test_group_stable_sort(add_index):
+@given(arrays("int64", shape=1000, elements=integers(min_value=0, max_value=5)))
+def test_group_stable_sort(add_index, a):
     """Test that group_by preserves the order of the table.
 
     This table has 5 groups with an average of 200 rows per group, so it is not
@@ -738,7 +742,6 @@ def test_group_stable_sort(add_index):
     This tests explicitly the case where grouping is done via the index sort.
     See: https://github.com/astropy/astropy/issues/14882
     """
-    a = np.random.randint(0, 5, 1000)
     b = np.arange(len(a))
     t = Table([a, b], names=["a", "b"])
     if add_index:

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -8,6 +8,8 @@ https://github.com/astropy/astropy/wiki/Table-item-access-definition
 import numpy as np
 import pytest
 
+from astropy.table import Row
+
 
 @pytest.mark.usefixtures("table_data")
 class BaseTestItems:
@@ -248,8 +250,8 @@ class TestTableItems(BaseTestItems):
         py 3.3 failure mode
         """
         t = table_data.Table(table_data.COLS)
-        idxs = np.random.randint(len(t), size=2)
-        t[idxs[1]]
+        row = t[np.int64(0)]
+        assert type(t[np.int64(0)]) is Row
 
     def test_select_bad_column(self, table_data):
         """Select column name that does not exist"""

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -250,7 +250,6 @@ class TestTableItems(BaseTestItems):
         py 3.3 failure mode
         """
         t = table_data.Table(table_data.COLS)
-        row = t[np.int64(0)]
         assert type(t[np.int64(0)]) is Row
 
     def test_select_bad_column(self, table_data):


### PR DESCRIPTION
### Description

~Following @nstarman's suggestion from https://github.com/astropy/astropy/pull/16086/files#r1567914977
This is step 0 of #17026~

Update: the scope of this PR was changed to removing random-number generators in a couple simple test cases in the `table` test suite.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
