### PR TITLE
Speed up parallel_fit_dask by avoiding unecessary model copies

### DIFF
--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -121,6 +121,8 @@ def _fit_models_to_chunk(
 
     iterating_shape_chunk = data.shape[: len(iterating_axes)]
 
+    model_i = model.copy()
+
     for index in np.ndindex(iterating_shape_chunk):
         # If all data values are NaN, just set parameters to NaN and move on
         if np.all(np.isnan(data[index])):
@@ -128,10 +130,9 @@ def _fit_models_to_chunk(
                 parameters[(ipar,) + index] = np.nan
             continue
 
-        # Make a copy of the reference model and inject parameters
-        model_i = _copy_with_new_parameters(
-            model,
-            {
+        # Inject parameters into model
+        model_i._reset_parameters(
+            **{
                 name: parameters[(ipar,) + index]
                 for ipar, name in enumerate(model.param_names)
             },


### PR DESCRIPTION
This speeds up the fitting using parallel_fit_dask by avoiding copying the model inside each inner loop iteration, instead re-using the model and resetting the parameters.

In a real life example, this reduced the fitting time from 34.7 to 26.1s. I'm trying to add a benchmark to asv but having trouble getting deterministic enough timings for the benchmark - but I think we shouldn't hold up this PR.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
