### PR TITLE
Add an inplace=False/True keyword argument to ``__call__`` on fitters to allow in-place modification of models

### DIFF
--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -150,7 +150,9 @@ def _fit_models_to_chunk(
         else:
             weights_kwargs = dict(weights=weights[index])
 
-        # Do the actual fitting
+        # Do the actual fitting - note that we can use inplace=True here to
+        # speed things up by avoiding an unecessary copy, since we don't need
+        # to retain the original parameter values.
         try:
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
@@ -158,6 +160,7 @@ def _fit_models_to_chunk(
                     model_i,
                     *world_values,
                     data[index],
+                    inplace=True,
                     **weights_kwargs,
                     **fitter_kwargs,
                 )

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -151,7 +151,7 @@ def _fit_models_to_chunk(
             weights_kwargs = dict(weights=weights[index])
 
         # Do the actual fitting - note that we can use inplace=True here to
-        # speed things up by avoiding an unecessary copy, since we don't need
+        # speed things up by avoiding an unnecessary copy, since we don't need
         # to retain the original parameter values.
         try:
             with warnings.catch_warnings(record=True) as w:

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -531,7 +531,17 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             return xnew, ynew
 
     @fitter_unit_support
-    def __call__(self, model, x, y, z=None, weights=None, rcond=None, inplace=False):
+    def __call__(
+        self,
+        model,
+        x,
+        y,
+        z=None,
+        weights=None,
+        rcond=None,
+        *,
+        inplace=False,
+    ):
         """
         Fit data to this model.
 
@@ -1330,6 +1340,7 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
         epsilon=DEFAULT_EPS,
         estimate_jacobian=False,
         filter_non_finite=False,
+        *,
         inplace=False,
     ):
         """
@@ -1715,7 +1726,17 @@ class SLSQPLSQFitter(Fitter):
         self.fit_info = {}
 
     @fitter_unit_support
-    def __call__(self, model, x, y, z=None, weights=None, inplace=False, **kwargs):
+    def __call__(
+        self,
+        model,
+        x,
+        y,
+        z=None,
+        weights=None,
+        *,
+        inplace=False,
+        **kwargs,
+    ):
         """
         Fit data to this model.
 
@@ -1799,7 +1820,17 @@ class SimplexLSQFitter(Fitter):
         self.fit_info = {}
 
     @fitter_unit_support
-    def __call__(self, model, x, y, z=None, weights=None, inplace=False, **kwargs):
+    def __call__(
+        self,
+        model,
+        x,
+        y,
+        z=None,
+        weights=None,
+        *,
+        inplace=False,
+        **kwargs,
+    ):
         """
         Fit data to this model.
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1385,7 +1385,11 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
             a copy of the input model with parameters set by the fitter
 
         """
-        model_copy = _validate_model(model, self.supported_constraints, copy=not inplace)
+        model_copy = _validate_model(
+            model,
+            self.supported_constraints,
+            copy=not inplace,
+        )
         model_copy.sync_constraints = False
         _, fit_param_indices, _ = model_to_fit_params(model_copy)
 
@@ -1756,7 +1760,11 @@ class SLSQPLSQFitter(Fitter):
             a copy of the input model with parameters set by the fitter
 
         """
-        model_copy = _validate_model(model, self._opt_method.supported_constraints, copy=not inplace)
+        model_copy = _validate_model(
+            model,
+            self._opt_method.supported_constraints,
+            copy=not inplace,
+        )
         model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
         farg = (
@@ -1830,7 +1838,11 @@ class SimplexLSQFitter(Fitter):
             a copy of the input model with parameters set by the fitter
 
         """
-        model_copy = _validate_model(model, self._opt_method.supported_constraints, copy=not inplace)
+        model_copy = _validate_model(
+            model,
+            self._opt_method.supported_constraints,
+            copy=not inplace,
+        )
         model_copy.sync_constraints = False
         farg = _convert_input(x, y, z)
         farg = (

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -580,8 +580,11 @@ class LinearLSQFitter(metaclass=_FitterMeta):
 
         Returns
         -------
-        model_copy : `~astropy.modeling.FittableModel`
-            a copy of the input model with parameters set by the fitter
+        fitted_model : `~astropy.modeling.FittableModel`
+            If ``inplace`` is `False` (the default), this is a copy of the
+            input model with parameters set by the fitter. If ``inplace`` is
+            `True`, this is the same model as the input model, with parameters
+            updated to be those set by the fitter.
 
         """
         if not model.fittable:
@@ -927,7 +930,7 @@ class FittingWithOutlierRemoval:
             f" niter: {self.niter}, outlier_kwargs: {self.outlier_kwargs})"
         )
 
-    def __call__(self, model, x, y, z=None, weights=None, **kwargs):
+    def __call__(self, model, x, y, z=None, weights=None, *, inplace=False, **kwargs):
         """
         Parameters
         ----------
@@ -945,11 +948,19 @@ class FittingWithOutlierRemoval:
             Weights to be passed to the fitter.
         kwargs : dict, optional
             Keyword arguments to be passed to the fitter.
+        inplace : bool, optional
+            If `False` (the default), a copy of the model with the fitted
+            parameters set will be returned. If `True`, the returned model will
+            be the same instance as the model passed in, and the parameter
+            values will be changed inplace.
 
         Returns
         -------
         fitted_model : `~astropy.modeling.FittableModel`
-            Fitted model after outlier removal.
+            If ``inplace`` is `False` (the default), this is a copy of the
+            input model with parameters set by the fitter. If ``inplace`` is
+            `True`, this is the same model as the input model, with parameters
+            updated to be those set by the fitter.
         mask : `numpy.ndarray`
             Boolean mask array, identifying which points were used in the final
             fitting iteration (False) and which were found to be outliers or
@@ -1004,7 +1015,7 @@ class FittingWithOutlierRemoval:
         loop = False
 
         # Starting fit, prior to any iteration and masking:
-        fitted_model = self.fitter(model, x, y, z, weights=weights, **kwargs)
+        fitted_model = self.fitter(model, x, y, z, weights=weights, inplace=inplace, **kwargs)
         filtered_data = np.ma.masked_array(data)
         if filtered_data.mask is np.ma.nomask:
             filtered_data.mask = False
@@ -1085,6 +1096,7 @@ class FittingWithOutlierRemoval:
                     *(c[good] for c in coords),
                     filtered_data.data[good],
                     weights=filtered_weights,
+                    inplace=inplace,
                     **kwargs,
                 )
             else:
@@ -1093,6 +1105,7 @@ class FittingWithOutlierRemoval:
                     *coords,
                     filtered_data,
                     weights=filtered_weights,
+                    inplace=inplace,
                     **kwargs,
                 )
 
@@ -1392,8 +1405,11 @@ class _NonLinearLSQFitter(metaclass=_FitterMeta):
 
         Returns
         -------
-        model_copy : `~astropy.modeling.FittableModel`
-            a copy of the input model with parameters set by the fitter
+        fitted_model : `~astropy.modeling.FittableModel`
+            If ``inplace`` is `False` (the default), this is a copy of the
+            input model with parameters set by the fitter. If ``inplace`` is
+            `True`, this is the same model as the input model, with parameters
+            updated to be those set by the fitter.
 
         """
         model_copy = _validate_model(
@@ -1777,8 +1793,11 @@ class SLSQPLSQFitter(Fitter):
 
         Returns
         -------
-        model_copy : `~astropy.modeling.FittableModel`
-            a copy of the input model with parameters set by the fitter
+        fitted_model : `~astropy.modeling.FittableModel`
+            If ``inplace`` is `False` (the default), this is a copy of the
+            input model with parameters set by the fitter. If ``inplace`` is
+            `True`, this is the same model as the input model, with parameters
+            updated to be those set by the fitter.
 
         """
         model_copy = _validate_model(
@@ -1865,8 +1884,11 @@ class SimplexLSQFitter(Fitter):
 
         Returns
         -------
-        model_copy : `~astropy.modeling.FittableModel`
-            a copy of the input model with parameters set by the fitter
+        fitted_model : `~astropy.modeling.FittableModel`
+            If ``inplace`` is `False` (the default), this is a copy of the
+            input model with parameters set by the fitter. If ``inplace`` is
+            `True`, this is the same model as the input model, with parameters
+            updated to be those set by the fitter.
 
         """
         model_copy = _validate_model(

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1015,7 +1015,9 @@ class FittingWithOutlierRemoval:
         loop = False
 
         # Starting fit, prior to any iteration and masking:
-        fitted_model = self.fitter(model, x, y, z, weights=weights, inplace=inplace, **kwargs)
+        fitted_model = self.fitter(
+            model, x, y, z, weights=weights, inplace=inplace, **kwargs
+        )
         filtered_data = np.ma.masked_array(data)
         if filtered_data.mask is np.ma.nomask:
             filtered_data.mask = False

--- a/docs/changes/modeling/17033.feature.rst
+++ b/docs/changes/modeling/17033.feature.rst
@@ -1,0 +1,4 @@
+Added ``inplace=False/True`` keyword argument to the ``__call__`` method of most fitters,
+to optionally allow the original model passed to the fitter to be modified with the fitted
+values of the parameters, rather than return a copy. This can improve performance if users
+don't need to keep hold of the initial parameter values.

--- a/docs/changes/modeling/17033.perf.rst
+++ b/docs/changes/modeling/17033.perf.rst
@@ -1,0 +1,2 @@
+Improved the performance of ``parallel_fit_dask`` by avoiding unecessary copies of the
+model inside the fitter.

--- a/docs/changes/modeling/17033.perf.rst
+++ b/docs/changes/modeling/17033.perf.rst
@@ -1,2 +1,2 @@
-Improved the performance of ``parallel_fit_dask`` by avoiding unecessary copies of the
+Improved the performance of ``parallel_fit_dask`` by avoiding unnecessary copies of the
 model inside the fitter.

--- a/docs/modeling/performance.rst
+++ b/docs/modeling/performance.rst
@@ -10,3 +10,10 @@ once and reusing the model.
 
 Consider the :ref:`performance tips <astropy-units-performance>` that apply to
 quantities when initializing and evaluating models with quantities.
+
+When fitting models with one of the fitter classes, by default a copy of the
+model is returned, with parameters set to those determined by the fitting. If
+you do not need to preserve the initial model used in the fitting, you can
+optionally pass ``inplace=True`` when calling the fitter, and the parameters
+will be updated on the model you supply rather than returning a copy of the
+model - this can improve performance in some cases.


### PR DESCRIPTION
This then uses this keyword argument to speed up the fitting in ``parallel_fit_dask`` since we can modify the parameters in-place without any risk.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
