### PR TITLE
Implement Analytical Derivatives on `CompoundModel`

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3313,10 +3313,10 @@ class CompoundModel(Model):
 
             left_deriv = self.left.fit_deriv(*left_inputs, *left_params)
             if not self.left.col_fit_deriv:
-                left_deriv = np.asanyarray(left_deriv).T
+                left_deriv = (np.asanyarray(left_deriv).T).tolist()
             right_deriv = self.right.fit_deriv(*right_inputs, *right_params)
             if not self.right.col_fit_deriv:
-                right_deriv = np.asanyarray(right_deriv).T
+                right_deriv = (np.asanyarray(right_deriv).T).tolist()
 
             # We now have to use various differentiation rules to apply the
             # arithmetic operators to the derivatives.

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -1216,3 +1216,55 @@ def test_fit_mixed_recursive_compound_model_with_mixed_units():
     assert_quantity_allclose(fit.intercept_2, 10 * u.m)
     assert_quantity_allclose(fit.slope_3, 0 * u.kg / u.s)
     assert_quantity_allclose(fit.intercept_3, 5 * u.kg)
+
+
+def numerical_partial_deriv(model, *inputs, param_idx, delta=1e-5):
+    """
+    Evaluate the central difference approximation of the derivative for param_idx.
+
+    Parameters
+    ----------
+    model
+        The model to evaluate
+    inputs
+        The inputs to the model
+    param_idx
+        The index of the parameter to compute the partial derivative for.
+    delta
+        The step size with which to compute the central difference.
+    """
+    param = model.parameters
+
+    param_down = param.copy()
+    param_down[param_idx] = param[param_idx] - delta
+    param_up = param.copy()
+    param_up[param_idx] = param[param_idx] + delta
+
+    up = model.evaluate(*inputs, *param_up)
+    down = model.evaluate(*inputs, *param_down)
+
+    return (up - down) / (2 * delta)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        Gaussian1D(5, 2, 3) + Linear1D(2, 3),
+        Gaussian1D(5, 2, 3) - Linear1D(2, 3),
+        Polynomial1D(2) * Gaussian1D(),
+        Polynomial1D(2) / Gaussian1D(),
+    ],
+)
+def test_compound_fit_deriv(model):
+    """
+    Given some compound models compare the numerical derivatives to analytical ones.
+    """
+    x = np.linspace(1, 5, num=10)
+    numerical = [
+        numerical_partial_deriv(model, x, param_idx=i)
+        for i in range(len(model.parameters))
+    ]
+    analytical = model.fit_deriv(x, *model.parameters)
+
+    for n, a in zip(numerical, analytical):
+        assert np.allclose(n, a)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -1249,10 +1249,16 @@ def numerical_partial_deriv(model, *inputs, param_idx, delta=1e-5):
 @pytest.mark.parametrize(
     "model",
     [
-        Gaussian1D(5, 2, 3) + Linear1D(2, 3),
-        Gaussian1D(5, 2, 3) - Linear1D(2, 3),
-        Polynomial1D(2) * Gaussian1D(),
-        Polynomial1D(2) / Gaussian1D(),
+        pytest.param(
+            m, id=m._format_expression(format_leaf=lambda i, l: type(l).__name__)
+        )
+        for m in [
+            Gaussian1D(5, 2, 3) + Linear1D(2, 3),
+            Gaussian1D(5, 2, 3) - Linear1D(2, 3),
+            Polynomial1D(2) * Gaussian1D(),
+            Polynomial1D(2) / Gaussian1D(),
+            Polynomial1D(2) + Gaussian1D(),
+        ]
     ],
 )
 def test_compound_fit_deriv(model):

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -637,10 +637,10 @@ def test_compound_model():
         scheduler="synchronous",
     )
 
-    assert_allclose(model_fit.amplitude_0.value, [2, 1.63349282])
-    assert_allclose(model_fit.mean_0.value, [1.1, 1.145231])
-    assert_allclose(model_fit.stddev_0.value, [0.1, 0.73632987])
-    assert_allclose(model_fit.amplitude_1.value, [2, 2])
+    assert_allclose(model_fit.amplitude_0.value, [2, 1.633], atol=0.001)
+    assert_allclose(model_fit.mean_0.value, [1.1, 1.145], atol=0.001)
+    assert_allclose(model_fit.stddev_0.value, [0.1, 0.736], atol=0.001)
+    assert_allclose(model_fit.amplitude_1.value, [2, 2], atol=0.001)
 
 
 def test_model_dimension_mismatch():

--- a/docs/changes/modeling/17034.perf.rst
+++ b/docs/changes/modeling/17034.perf.rst
@@ -1,0 +1,1 @@
+``CompoundModel`` now implements numerical derivatives of parameters when using the +, -, * or / operators. This improves the speed of fitting these models because numerical derivatives of the parameters are not calculated.


### PR DESCRIPTION
### Description

This pull request adds support for computing analytical derivatives on `CompoundModel` for the +, -, * and / operators.
Others are possible, but haven't been attempted yet.

The main motivation for this PR is to *substantially* improve the performance of fitting these models. The [profiling script](https://github.com/aperiosoftware/SPICE-Model-Fitting-Reports) we are using which fits a `Const + Gaussian1D` model in parallel went from 28.1s to 19.8s so a 1.4x speedup.

Probably Fixes #3783, but that might have a slightly larger scope

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.