### PR TITLE
Convert unit formatter `format_power()` utility to a class method

### DIFF
--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from . import console, utils
+from . import console
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
@@ -53,7 +53,7 @@ class Latex(console.Console):
             # `u.deg**2` returns `deg^{2}` instead of `{}^{\circ}^{2}`.
             if re.match(r".*\^{[^}]*}$", name):  # ends w/ superscript?
                 name = unit.short_names[0]
-            name += cls._format_superscript(utils.format_power(power))
+            name += cls._format_power(power)
         return name
 
     @classmethod

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import console, utils
+from . import console
 
 if TYPE_CHECKING:
     from typing import ClassVar
@@ -49,7 +49,7 @@ class Unicode(console.Console):
         if power != 1:
             if name in ("°", "e⁻", "″", "′", "ʰ"):
                 name = unit.short_names[0]
-            name += cls._format_superscript(utils.format_power(power))
+            name += cls._format_power(power)
         return name
 
     @classmethod

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -9,26 +9,8 @@ from __future__ import annotations
 from keyword import iskeyword
 from typing import TYPE_CHECKING
 
-from astropy.units.utils import maybe_simple_fraction
-
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Sequence
-
-    from astropy.units.typing import Real
-
-
-def format_power(power: Real) -> str:
-    """
-    Converts a value for a power (which may be floating point or a
-    `fractions.Fraction` object), into a string looking like either
-    an integer or a fraction, if the power is close to that.
-    """
-    if not hasattr(power, "denominator"):
-        power = maybe_simple_fraction(power)
-        if getattr(power, "denonimator", None) == 1:
-            power = power.numerator
-
-    return str(power)
 
 
 def get_non_keyword_units(


### PR DESCRIPTION
### Description

`format_power()` is needlessly complicated (and dynamic), so it should be simplified, and it is always called together with a unit formatter `_format_superscript()` method, so it is a good idea to rewrite the utility function as a class method instead.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
