### PR TITLE
Fix WCS world axis selection in `fit_parallel_dask`

### DIFF
--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -19,7 +19,7 @@ def _pixel_to_world_values_block(*pixel, wcs=None):
     Convert a block of pixel values to world values using a WCS. This is for
     use in map_blocks.
     """
-    world = wcs.pixel_to_world_values(*pixel[::-1])[::-1]
+    world = wcs.array_index_to_world_values(*pixel)
     world = np.array(world)
     return world
 
@@ -457,11 +457,18 @@ def parallel_fit_dask(
 
         # Construct dask arrays of world coordinates for every pixel in the cube.
         # We will then iterate over this in map_blocks.
-        world = _wcs_to_world_dask(world, data.shape, chunks=data.chunksize)
+        # NOTE: This returns in world (cartesian) order
+        world_dask_arrays = _wcs_to_world_dask(world, data.shape, chunks=data.chunksize)
 
         # Extract world arrays for just fitting dimensions
-        world = [world[idx] for idx in fitting_axes]
+        fitting_pixel_axes = np.arange(data.ndim)[::-1][np.array(fitting_axes)]
+        world_idx = [
+            np.argwhere(world.axis_correlation_matrix[:, fpa])[:, 0][0]
+            for fpa in fitting_pixel_axes
+        ]
+        world = [world_dask_arrays[idx] for idx in world_idx]
         world_arrays = True
+
     elif isinstance(world, tuple):
         # If world is a tuple then we allow N inputs where N is the number of fitting_axes
         # Each array in the tuple should with be broadcastable to the shape of the fitting_axes

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -988,3 +988,51 @@ def test_skip_empty_data(tmp_path):
     assert_allclose(model_fit.amplitude.value, [2, np.nan])
     assert_allclose(model_fit.mean.value, [5, np.nan])
     assert_allclose(model_fit.stddev.value, [1.0, np.nan])
+
+
+def test_world_wcs_axis_correlation():
+    # Regression test for a bug that caused the world coordinates to not be
+    # properly extracted from a WCS object if the axis correlation matrix
+    # resulted in a difference in order between pixel and world coordinates.
+
+    model = Gaussian1D()
+    fitter = TRFLSQFitter()
+    data = gaussian(
+        np.arange(1, 6)[:, None],
+        np.array([5, 5]),
+        np.array([3, 2]),
+        np.array([1, 1]),
+    ).T
+
+    common_kwargs = dict(data=data, model=model, fitter=fitter, scheduler="synchronous")
+
+    # First case: a simple WCS - as the fitting axis is 1 in Numpy order, this
+    # means we should use the world coordinates for the first WCS dimension. In
+    # this case, the Gaussian means should be 3 and 2.
+
+    wcs1 = WCS(naxis=2)
+    wcs1.wcs.cdelt = 1, 2
+
+    model_fit = parallel_fit_dask(fitting_axes=1, world=wcs1, **common_kwargs)
+    assert_allclose(model_fit.mean, [3, 2])
+
+    # Second case: as above, but WCS axes swapped. In this case, the means
+    # should be 6 and 4.
+
+    wcs1 = WCS(naxis=2)
+    wcs1.wcs.cdelt = 2, 1
+
+    model_fit = parallel_fit_dask(fitting_axes=1, world=wcs1, **common_kwargs)
+    assert_allclose(model_fit.mean, [6, 4])
+
+    # Third case: as in first case, but this time we set the PC matrix such
+    # that the world axes are in a different order to their corresponding pixel
+    # axis. In this case, the means should be 6 and 4 because fitting_axes=1
+    # should correspond to the second WCS dimension.
+
+    wcs3 = WCS(naxis=2)
+    wcs3.wcs.cdelt = 1, 2
+    wcs3.wcs.pc = [[0, 1], [1, 0]]
+
+    model_fit = parallel_fit_dask(fitting_axes=1, world=wcs1, **common_kwargs)
+    assert_allclose(model_fit.mean, [6, 4])


### PR DESCRIPTION
### Description

This fix uses the axis correlation matrix to select which world axes corresponding to the fitting axes supplied as array indicies.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.