### PR TITLE
Speed up converting composite units to strings (with some formatters)

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -644,10 +644,12 @@ class Generic(Base):
         are "known" to a given format.
         """
         if isinstance(unit, core.CompositeUnit):
-            new_unit = core.Unit(unit.scale)
-            for base, power in zip(unit.bases, unit.powers):
-                new_unit = new_unit * cls._decompose_to_known_units(base) ** power
-            return new_unit
+            return core.CompositeUnit(
+                unit.scale,
+                [cls._decompose_to_known_units(base) for base in unit.bases],
+                unit.powers,
+                _error_check=False,
+            )
         if isinstance(unit, core.NamedUnit):
             try:
                 cls._get_unit_name(unit)

--- a/docs/changes/units/17043.perf.rst
+++ b/docs/changes/units/17043.perf.rst
@@ -1,0 +1,2 @@
+Converting composite units to strings with the ``"cds"``, ``"fits"``,
+``"ogip"`` and ``"vounit"`` formatters is now at least twice as fast.


### PR DESCRIPTION
### Description

The `Generic._decompose_to_known_units()` method is now much faster if its argument is a `CompositeUnit` instance, which greatly speeds up converting composite units to strings using the `"cds"`. `"fits"`, `"ogip"` and `"vounit"` formatters (but not `"generic"` itself). The more components the composite unit has, the bigger the speedup, but even with very simple units the speedup is at least a factor of two or so.

Our benchmarks only use the `"generic"` formatter, which is not affected, so there is no point in running them.

#### Timing comparison

Setup
```
$ ipython -i -c "from astropy import units as u; unit = u.m / u.s"
Python 3.12.3 (main, Sep 11 2024, 14:17:37) [GCC 13.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: for formatter in ("cds", "fits", "ogip", "vounit"):
   ...:     print(formatter)
   ...:     %timeit unit.to_string(formatter)
   ...:     print()
```

On current `main`

```
cds
11.5 μs ± 53.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

fits
12.9 μs ± 46.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

ogip
12.8 μs ± 23.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

vounit
18 μs ± 80.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

With the patch here
```
cds
4.91 μs ± 22.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

fits
6.35 μs ± 11.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

ogip
6.02 μs ± 70 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

vounit
9.41 μs ± 23 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```



- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
