### PR TITLE
Remove deprecated  `get_moon()` function

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -17,7 +17,7 @@ from astropy.constants import c as speed_of_light
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_JPLEPHEM
 from astropy.utils.data import download_file
-from astropy.utils.decorators import classproperty, deprecated
+from astropy.utils.decorators import classproperty
 from astropy.utils.state import ScienceState
 
 from .builtin_frames import GCRS, ICRS
@@ -27,7 +27,6 @@ from .sky_coordinate import SkyCoord
 
 __all__ = [
     "get_body",
-    "get_moon",
     "get_body_barycentric",
     "get_body_barycentric_posvel",
     "solar_system_ephemeris",
@@ -498,41 +497,6 @@ def get_body(body, time, location=None, ephemeris=None):
     )
 
     return SkyCoord(gcrs)
-
-
-@deprecated("5.3", alternative='get_body("moon")')
-def get_moon(time, location=None, ephemeris=None):
-    """
-    Get a `~astropy.coordinates.SkyCoord` for the Earth's Moon as observed
-    from a location on Earth in the `~astropy.coordinates.GCRS` reference
-    system.
-
-    Parameters
-    ----------
-    time : `~astropy.time.Time`
-        Time of observation
-    location : `~astropy.coordinates.EarthLocation`
-        Location of observer on the Earth. If none is supplied, taken from
-        ``time`` (if not present, a geocentric observer will be assumed).
-    ephemeris : str, optional
-        Ephemeris to use.  If not given, use the one set with
-        ``astropy.coordinates.solar_system_ephemeris.set`` (which is
-        set to 'builtin' by default).
-
-    Returns
-    -------
-    skycoord : `~astropy.coordinates.SkyCoord`
-        GCRS Coordinate for the Moon
-
-    Notes
-    -----
-    The coordinate returned is the apparent position, which is the position of
-    the moon at time *t* minus the light travel time from the moon to the
-    observing *location*.
-
-    {_EPHEMERIS_NOTE}
-    """
-    return get_body("moon", time, location=location, ephemeris=ephemeris)
 
 
 # Add note about the ephemeris choices to the docstrings of relevant functions.

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -19,7 +19,6 @@ from astropy.coordinates.solar_system import (
     get_body,
     get_body_barycentric,
     get_body_barycentric_posvel,
-    get_moon,
     solar_system_ephemeris,
 )
 from astropy.tests.helper import CI, assert_quantity_allclose
@@ -27,7 +26,6 @@ from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
 from astropy.utils.compat.optional_deps import HAS_JPLEPHEM, HAS_SKYFIELD
 from astropy.utils.data import download_file, get_pkg_data_filename
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 if HAS_SKYFIELD:
     from skyfield.api import Loader
@@ -421,15 +419,6 @@ def test_get_body_accounts_for_location_on_Earth():
 
     difference = (icrs_sun_from_alma - icrs_sun_from_geocentre).norm()
     assert_quantity_allclose(difference, 0.13046941 * u.m, atol=1 * u.mm)
-
-
-def test_get_moon_deprecation():
-    time_now = Time.now()
-    with pytest.warns(
-        AstropyDeprecationWarning, match=r'Use get_body\("moon"\) instead\.$'
-    ):
-        moon = get_moon(time_now)
-    assert moon == get_body("moon", time_now)
 
 
 @pytest.mark.remote_data

--- a/docs/changes/coordinates/17046.api.rst
+++ b/docs/changes/coordinates/17046.api.rst
@@ -1,0 +1,2 @@
+The deprecated ``coordinates.get_moon()`` function has been removed. Use
+``coordinates.get_body("moon")`` instead.


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to remove the `get_moon()` function that was deprecated in #14354.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
