### PR TITLE
Ensure tables can be created also when explicitly setting units to dimensionless

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -938,7 +938,7 @@ class Table:
                 if value.strip() == "":
                     value = None
 
-            if value not in (np.ma.masked, None):
+            if value is not None and value is not np.ma.masked:
                 col = self[name]
                 if attr == "unit" and isinstance(col, Quantity):
                     # Update the Quantity unit in-place

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3533,3 +3533,11 @@ def test_table_columns_update_deprecation():
         ),
     ):
         Table().columns.update({"a": [0]})
+
+
+def test_qtable_with_explicit_units():
+    # Regression test for gh-17047; the problem was that the dimensionless
+    # unit ended up being compared to np.ma.masked.  See also
+    # astropy/units/tests/test_units.py::test_comparison_dimensionless_with_np_ma_masked
+    tt = QTable(data=[[1.0, 2.0, 3.0]], names=["weight"], units={"weight": u.one})
+    assert tt["weight"].unit == u.dimensionless_unscaled

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -21,7 +21,7 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.misc import isiterable
 
 from . import format as unit_format
-from .errors import UnitConversionError, UnitsError, UnitsWarning
+from .errors import UnitConversionError, UnitScaleError, UnitsError, UnitsWarning
 from .utils import (
     is_effectively_unity,
     resolve_fractions,
@@ -2128,7 +2128,7 @@ class _UnitMetaClass(type):
                 return UnrecognizedUnit(s)
 
         elif isinstance(s, (int, float, np.floating, np.integer)):
-            return CompositeUnit(s, [], [], _error_check=False)
+            return CompositeUnit(s, [], [])
 
         elif isinstance(s, tuple):
             from .structured import StructuredUnit
@@ -2293,6 +2293,11 @@ class CompositeUnit(UnitBase):
     powers : sequence of numbers
         A sequence of powers (in parallel with ``bases``) for each
         of the base units.
+
+    Raises
+    ------
+    UnitScaleError
+        If the scale is zero.
     """
 
     _decomposed_cache = None
@@ -2313,6 +2318,8 @@ class CompositeUnit(UnitBase):
         # kwarg `_error_check` is False, the error checking is turned
         # off.
         if _error_check:
+            if scale == 0:
+                raise UnitScaleError("cannot create a unit with a scale of 0.")
             for base in bases:
                 if not isinstance(base, UnitBase):
                     raise TypeError("bases must be sequence of UnitBase instances")

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1022,3 +1022,23 @@ def test_dask_arrays():
 def test_get_format_name_deprecation():
     with pytest.warns(AstropyDeprecationWarning, match=r"Use to_string\(\) instead\.$"):
         assert u.m.get_format_name("fits") == "m"
+
+
+def test_comparison_dimensionless_with_np_ma_masked():
+    # Found to be a problem indirectly in gh-17047;
+    # The path np.ma.masked.__eq__(u.dimensionless_unscaled)
+    # used to give a ZeroDivisionError.
+    comparison = u.dimensionless_unscaled == np.ma.masked
+    assert comparison is np.ma.masked
+
+
+def test_error_on_conversion_of_zero_to_unit():
+    # Found to be a problem indirectly in gh-17047; we allow conversion
+    # of numbers to units, but should not allow 0.
+    with pytest.raises(u.UnitScaleError, match="cannot create.*scale of 0"):
+        u.Unit(0)
+    with pytest.raises(u.UnitScaleError, match="cannot create.*scale of 0"):
+        u.dimensionless_unscaled.to(0)
+    # Also check some that do work.
+    assert u.dimensionless_unscaled.to(0.125) == 8
+    assert u.dimensionless_unscaled.to(8) == 0.125

--- a/docs/changes/table/17048.bugfix.rst
+++ b/docs/changes/table/17048.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that initializing a ``QTable`` with explicit units` also succeeds if
+one of the units is ``u.one``.

--- a/docs/changes/units/17048.bugfix.rst
+++ b/docs/changes/units/17048.bugfix.rst
@@ -1,0 +1,4 @@
+An exception is now raised if it is attempted to create a unit with a
+scale of zero, avoiding bugs further downstream (including surprising
+ones, such as a comparison of ``np.ma.masked == u.one`` leading to
+a ``ZeroDivisionError``).


### PR DESCRIPTION
This pull request is to address the problem encountered in #17047, where a `QTable` could not be created if a `u.dimensionless_unscaled` unit was passed in. While a simple fix to `Table` fixed the problem for tables (first pair of commits), it turned out there was also a somewhat subtle bug in units, which is that it was possible to create a unit with zero scale - which is a bad unit since nothing can be converted to it (scale ratios give `ZeroDivisionError`). So, the second pair of commits adds a test and a fix for that.

Fixes #17047

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
