### PR TITLE
DOC: Edit on generated API doc no longer 404

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -260,6 +260,29 @@ htmlhelp_basename = project + "doc"
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
+
+def _custom_edit_url(
+    github_user,
+    github_repo,
+    github_version,
+    doc_path,
+    file_name,
+    default_edit_page_url_template,
+):
+    """Create custom 'edit' URLs for API modules since they are dynamically generated."""
+    if file_name.startswith("api/"):
+        # this is a dynamically generated API page
+        doc_path = "astropy"
+        file_name = ""
+    return default_edit_page_url_template.format(
+        github_user=github_user,
+        github_repo=github_repo,
+        github_version=github_version,
+        doc_path=doc_path,
+        file_name=file_name,
+    )
+
+
 # A dictionary of values to pass into the template engine's context for all pages.
 html_context = {
     "default_mode": "light",
@@ -269,6 +292,9 @@ html_context = {
     "github_repo": "astropy",
     "github_version": "main",
     "doc_path": "docs",
+    "edit_page_url_template": "{{ astropy_custom_edit_url(github_user, github_repo, github_version, doc_path, file_name, default_edit_page_url_template) }}",
+    "default_edit_page_url_template": "https://github.com/{github_user}/{github_repo}/edit/{github_version}/{doc_path}{file_name}",
+    "astropy_custom_edit_url": _custom_edit_url,
     # Tell Jinja2 templates the build is running on Read the Docs
     "READTHEDOCS": os.environ.get("READTHEDOCS", "") == "True",
 }


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to prevent ugly 404 when someone clicks "Edit on GitHub" on a generated API doc page (e.g, https://docs.astropy.org/en/latest/api/astropy.units.Quantity.html) modeled after https://github.com/vispy/vispy/pull/2220 . However, because how we like to import things to the upper level to have pretty "public API", it is hard for me to find out where the actual source code file is, so I just applied a hack-fix to point user to the generic astropy upper level source tree (https://github.com/astropy/astropy/tree/main/astropy) when that option is clicked instead. Non-generated RST files are not affected.

Fix #17044

Rendered page: https://astropy--17049.org.readthedocs.build/en/17049/api/astropy.units.Quantity.html#astropy.units.Quantity

Related issues:

* https://github.com/pydata/pydata-sphinx-theme/issues/1269
* https://github.com/pydata/pydata-sphinx-theme/issues/477

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
