### PR TITLE
TST/DOC: request all optional dependencies in tox build_docs env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,9 @@ pip_pre =
 [testenv:build_docs]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
-extras = docs
+extras =
+  docs
+  all
 commands =
     {list_dependencies_command}
     sphinx-build -b html . _build/html {posargs:-j auto}


### PR DESCRIPTION
### Description
This addresses the immediate issue with #17052, but probably doesn't close it: we should probably also add a CI job to exercise `tox -e build_docs`. Happy to do it in this PR too if there's a simple consensus on that (I suggest we add it to weekly cron).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
