### PR TITLE
TST: re-introduce conditional trigger for amr64 weekly cron tests

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -107,6 +107,7 @@ jobs:
 
     runs-on: ubuntu-latest
     name: Python 3.12
+    # keep condition in sync with test_arm64
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
     env:
       ARCH_ON_CI: ${{ matrix.arch }}
@@ -178,6 +179,8 @@ jobs:
 
     runs-on: linux-arm64
     name: Python 3.12 (arm64)
+    # keep condition in sync with test_more_architectures
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description
A quick follow up to #17024 after I notices that this job was running on a PR were the rest of exotic archs weren't.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
