### PR TITLE
TST: unignore numpy ABI compatibility warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,6 @@ filterwarnings = [
     "error",
     "ignore:unclosed <socket:ResourceWarning",
     "ignore:unclosed <ssl.SSLSocket:ResourceWarning",
-    "ignore:numpy\\.ufunc size changed:RuntimeWarning",
-    "ignore:numpy\\.ndarray size changed:RuntimeWarning",
     "ignore:matplotlibrc text\\.usetex:UserWarning:matplotlib",
     # https://github.com/h5py/h5py/pull/2416
     "ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning",


### PR DESCRIPTION
### Description

With the introduction of `oldest-supported-numpy` and the new backward-compatibility-by-default mechanism introduced in numpy 1.25, these warnings should be much less likely to occur in CI, and we might want to know when they do (this may still happen if we have an unmaintained optional dependency).
I'm taking a bet that they are currently *not* present in our CI jobs. Let's see what happens.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
