### PR TITLE
ENH: implement `np.arange` dispatch for `Quantity`

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -470,12 +470,14 @@ def arange_impl(*args, start=None, stop=None, step=None, dtype=None, device=None
             elif start is None:
                 start = pos1
         case start, stop, *rest:
-            match rest:
-                # rebind step if possible
-                case step, *_:
-                    pass # nothing to do
             if start is not None and stop is None:
                 start, stop = stop, start
+            match rest:
+                # rebind step and dtype if possible
+                case step,:
+                    pass
+                case step, dtype:
+                    pass
 
     has_out_unit = False
     for arg in (start, stop, step):

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -34,8 +34,6 @@ return a Quantity directly using ``quantity_result, None, None``.
 
 """
 
-from __future__ import annotations
-
 import functools
 import operator
 
@@ -490,7 +488,7 @@ def arange_impl(*args, start=None, stop=None, step=None, dtype=None, device=None
         if v is not None
     }
 
-    new_values, out_unit = _quantities2arrays(*list(qty_kwargs.values()), unit_from_first=True)
+    new_values, out_unit = _quantities2arrays(*qty_kwargs.values(), unit_from_first=True)
     kwargs = dict(zip(qty_kwargs.keys(), new_values))
     kwargs["dtype"] = dtype
     if not NUMPY_LT_2_0:

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -493,10 +493,8 @@ def arange_impl(*args, start=None, stop=None, step=None, dtype=None, device=None
     new_values, out_unit = _quantities2arrays(*list(qty_kwargs.values()), unit_from_first=True)
     kwargs = dict(zip(qty_kwargs.keys(), new_values))
     kwargs["dtype"] = dtype
-
     if not NUMPY_LT_2_0:
         kwargs["device"] = device
-
 
     return np.arange(**kwargs), out_unit, None
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -39,6 +39,7 @@ KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
 POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
 
 ARCSEC_PER_DEGREE = 60 * 60
+ARCSEC_PER_RADIAN = ARCSEC_PER_DEGREE * np.rad2deg(1)
 
 needs_array_function = pytest.mark.xfail(
     not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
@@ -374,21 +375,21 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
                 id="pos: stop",
             ),
             pytest.param(
-                (0 * u.radian, 1 * u.degree),
+                (0 * u.degree, 1 * u.radian),
                 {},
                 np.arange(1, dtype=float),
                 id="pos: start, stop",
             ),
             pytest.param(
-                (0 * u.radian, 1 * u.degree, 1 * u.arcsec),
+                (0 * u.degree, 1 * u.radian, 1 * u.arcsec),
                 {},
-                np.arange(ARCSEC_PER_DEGREE, dtype=float),
+                np.arange(ARCSEC_PER_RADIAN, dtype=float),
                 id="pos: start, stop, step",
             ),
             pytest.param(
-                (0 * u.radian, 1 * u.degree),
+                (0 * u.degree, 1 * u.radian),
                 {"step": 1 * u.arcsec},
-                np.arange(ARCSEC_PER_DEGREE, dtype=float),
+                np.arange(ARCSEC_PER_RADIAN, dtype=float),
                 id="pos: start, stop; kw: step",
             ),
             pytest.param(
@@ -445,11 +446,7 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
 
     def test_arange_incorrect_input_type(self):
         with pytest.raises(
-            TypeError,
-            match=(
-                r"Expected every explicit argument \(start, stop and step\) "
-                r"to be Quantity or None\."
-            ),
+            TypeError, match="Expected stop to be a Quantity, got stop="
         ):
             np.arange(10, like=u.Quantity([], u.s))
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -372,49 +372,49 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
             pytest.param(
                 (1 * u.radian,),
                 {},
-                np.arange(1),
+                np.arange(1, dtype=float),
                 id="pos: stop",
             ),
             pytest.param(
                 (0 * u.radian, 1 * u.degree),
                 {},
-                np.arange(1),
+                np.arange(1, dtype=float),
                 id="pos: start, stop",
             ),
             pytest.param(
                 (0 * u.radian, 1 * u.degree, 1 * u.arcsec),
                 {},
-                np.arange(ARCSEC_PER_DEGREE),
+                np.arange(ARCSEC_PER_DEGREE, dtype=float),
                 id="pos: start, stop, step",
             ),
             pytest.param(
                 (0 * u.radian, 1 * u.degree),
                 {"step": 1 * u.arcsec},
-                np.arange(ARCSEC_PER_DEGREE),
+                np.arange(ARCSEC_PER_DEGREE, dtype=float),
                 id="pos: start, stop; kw: step",
             ),
             pytest.param(
                 (0 * u.radian,),
                 {"stop": 5 * u.radian},
-                np.rad2deg(np.arange(5) * ARCSEC_PER_DEGREE),
+                np.rad2deg(np.arange(5, dtype=float) * ARCSEC_PER_DEGREE),
                 id="pos: start; kw: stop",
             ),
             pytest.param(
                 (10 * u.radian, None),
                 {},
-                np.rad2deg(np.arange(10) * ARCSEC_PER_DEGREE),
+                np.rad2deg(np.arange(10, dtype=float) * ARCSEC_PER_DEGREE),
                 id="pos: stop, followed by 1 None",
             ),
             pytest.param(
                 (10 * u.radian, None, None),
                 {},
-                np.rad2deg(np.arange(10) * ARCSEC_PER_DEGREE),
+                np.rad2deg(np.arange(10, dtype=float) * ARCSEC_PER_DEGREE),
                 id="pos: stop, followed by 2 None",
             ),
             pytest.param(
                 (10 * u.radian, None, None, None),
                 {},
-                np.rad2deg(np.arange(10) * ARCSEC_PER_DEGREE),
+                np.rad2deg(np.arange(10, dtype=float) * ARCSEC_PER_DEGREE),
                 id="pos: stop, followed by 3 None",
             ),
         ],
@@ -427,7 +427,15 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         )
         assert type(arr) is angle_cls
         assert arr.unit == u.radian
+        assert arr.dtype == expected.dtype
         np.testing.assert_array_almost_equal(arr.to_value(u.arcsec), expected)
+
+    def test_arange_pos_dtype(self):
+        arr = np.arange(0 * u.s, 10 * u.s, 1 * u.s, int, like=u.Quantity([], u.radian))
+        assert type(arr) is u.Quantity
+        assert arr.unit == u.s
+        assert arr.dtype == np.dtype(int)
+        np.testing.assert_array_equal(arr.value, np.arange(10))
 
     def test_arange_incorrect_input_type(self):
         with pytest.raises(

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -450,6 +450,14 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         ):
             np.arange(10, like=u.Quantity([], u.s))
 
+    def test_arange_unit_from_stop(self):
+        Q = 1 * u.km
+        a = np.arange(start=1 * u.s, stop=10 * u.min, like=Q)
+        b = np.arange(stop=10 * u.min, start=1 * u.s, like=Q)
+        assert a.unit == u.min
+        assert b.unit == u.min
+        np.testing.assert_array_equal(a.value, b.value)
+
 
 class TestAccessingParts(InvariantUnitTestSetup):
     def test_diag(self):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -423,7 +423,7 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         assert type(arr) is u.Quantity
         assert arr.unit == u.radian
         assert arr.dtype == expected.dtype
-        np.testing.assert_array_almost_equal(arr.to_value(u.arcsec), expected)
+        assert_allclose(arr.to_value(u.arcsec), expected)
 
     def test_arange_like_quantity_subclass(self):
         class AngularUnits(u.SpecificTypeQuantity):
@@ -435,14 +435,14 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         assert type(arr) is AngularUnits
         assert arr.unit == u.radian
         assert arr.dtype == np.dtype(float)
-        np.testing.assert_array_equal(arr.value, np.arange(10))
+        assert_array_equal(arr.value, np.arange(10))
 
     def test_arange_pos_dtype(self):
         arr = np.arange(0 * u.s, 10 * u.s, 1 * u.s, int, like=u.Quantity([], u.radian))
         assert type(arr) is u.Quantity
         assert arr.unit == u.s
         assert arr.dtype == np.dtype(int)
-        np.testing.assert_array_equal(arr.value, np.arange(10))
+        assert_array_equal(arr.value, np.arange(10))
 
     def test_arange_incorrect_input_type(self):
         with pytest.raises(
@@ -456,7 +456,7 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         b = np.arange(stop=10 * u.min, start=1 * u.s, like=Q)
         assert a.unit == u.min
         assert b.unit == u.min
-        np.testing.assert_array_equal(a.value, b.value)
+        assert_array_equal(a.value, b.value)
 
 
 class TestAccessingParts(InvariantUnitTestSetup):

--- a/docs/changes/units/17059.feature.rst
+++ b/docs/changes/units/17059.feature.rst
@@ -1,1 +1,2 @@
-Added a ``np.arange`` dispatch for ``Quantity``.
+Added a ``np.arange`` dispatch for ``Quantity`` (requires one to use
+``like=<some_quantity>``).

--- a/docs/changes/units/17059.feature.rst
+++ b/docs/changes/units/17059.feature.rst
@@ -1,0 +1,1 @@
+Added a ``np.arange`` dispatch for ``Quantity``.

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -139,14 +139,10 @@ Beware that `~numpy.arange` works, but requires an additional ``like`` argument
     <Quantity [0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] cm>
 
 Also note that the unit of the output array is dictated by that of the ``stop``
-argument, and the data has a floating-point dtype. If an integer dtype is
-desired, it can be achieved as
+argument, and that, like for quantities generally, the data has a floating-point
+dtype.
 
-    >>> np.arange(0 * u.cm, 10 * u.mm, 1 * u.mm, like=u.Quantity([], u.m), dtype=int)
-    <Quantity [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] mm>
-
-Alternatively, one may move the units outside of the call as
-`~numpy.arange`::
+Alternatively, one may move the units outside of the call to `~numpy.arange`::
 
     >>> np.arange(0, 10, 1) << u.mm
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] mm>

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -133,23 +133,28 @@ A workaround for this at the moment would be to do::
 
 As well as with `~numpy.full` one cannot do `~numpy.zeros`, `~numpy.ones`, and `~numpy.empty`.
 
-The `~numpy.arange` function does not work either::
+Beware that `~numpy.arange` works, but requires an additional ``like`` argument
 
-    >>> np.arange(0 * u.m, 10 * u.m, 1 * u.m)
-    Traceback (most recent call last):
-    ...
-    TypeError: only dimensionless scalar quantities can be converted to Python scalars
+    >>> np.arange(0 * u.cm, 1 * u.cm, 1 * u.mm, like=u.Quantity([], u.cm))
+    <Quantity [0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] cm>
 
-Workarounds include moving the units outside of the call to
+Also note that the unit of the output array is dictated by that of the first
+argument, and the data has a floating-point dtype. If an integer dtype is
+desired, it can be achieved as
+
+    >>> np.arange(0 * u.mm, 1 * u.cm, 1 * u.mm, like=u.Quantity([], u.m), dtype=int)
+    <Quantity [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] mm>
+
+Alternatively, one may move the units outside of the call as
 `~numpy.arange`::
 
-    >>> np.arange(0, 10, 1) * u.m
-    <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>
+    >>> np.arange(0, 10, 1) << u.mm
+    <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] mm>
 
-Additionally, `~numpy.linspace` _does_ work:
+Or use `~numpy.linspace`:
 
-    >>> np.linspace(0 * u.m, 9 * u.m, 10)
-    <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] m>
+    >>> np.linspace(0 * u.cm, 9 * u.mm, 10)
+    <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] mm>
 
 
 Quantities Lose Their Units When Broadcasted

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -138,11 +138,11 @@ Beware that `~numpy.arange` works, but requires an additional ``like`` argument
     >>> np.arange(0 * u.cm, 1 * u.cm, 1 * u.mm, like=u.Quantity([], u.cm))
     <Quantity [0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] cm>
 
-Also note that the unit of the output array is dictated by that of the first
+Also note that the unit of the output array is dictated by that of the ``stop``
 argument, and the data has a floating-point dtype. If an integer dtype is
 desired, it can be achieved as
 
-    >>> np.arange(0 * u.mm, 1 * u.cm, 1 * u.mm, like=u.Quantity([], u.m), dtype=int)
+    >>> np.arange(0 * u.cm, 10 * u.mm, 1 * u.mm, like=u.Quantity([], u.m), dtype=int)
     <Quantity [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] mm>
 
 Alternatively, one may move the units outside of the call as


### PR DESCRIPTION
### Description
Implement a helper function for `np.arange` with `like=Quantity(...)`.
Since the implementation turned out to be complex with many overrides to take into account, I'm opening this PR at an early stage for visibility.
Ref #17001

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

TODO:
- [x] handle completion tests (xref https://github.com/numpy/numpy/issues/27451)
- [x] flesh out all `raise` statements (write actual error messages)
- [x] improve test coverage
- [x] add a test case for `like=Angle(...)`
- [x] changelog

