### PR TITLE
DOC: add a missing doctest-requires directive

### DIFF
--- a/docs/modeling/parallel-fitting.rst
+++ b/docs/modeling/parallel-fitting.rst
@@ -171,6 +171,8 @@ to fit all spectra in the cube:
    :include-source:
    :nofigs:
 
+.. doctest-requires:: dask
+
     >>> from astropy.modeling.fitting import parallel_fit_dask
     >>> model_fit = parallel_fit_dask(model=model,
     ...                               fitter=fitter,


### PR DESCRIPTION
### Description
Extracted from #17053 as suggested by @pllim

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
