### PR TITLE
Remove `CDS._get_unit_name()`

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     import numpy as np
 
     from astropy.extern.ply.lex import Lexer
-    from astropy.units import NamedUnit, UnitBase
+    from astropy.units import UnitBase
     from astropy.utils.parsing import ThreadSafeParser
 
 
@@ -277,10 +277,6 @@ class CDS(Generic):
         if not isinstance(s, str):
             s = s.decode("ascii")
         return cls._do_parse(s, debug)
-
-    @classmethod
-    def _get_unit_name(cls, unit: NamedUnit) -> str:
-        return unit._get_format_name(cls.name)
 
     @classmethod
     def _format_mantissa(cls, m: str) -> str:


### PR DESCRIPTION
### Description

If `CDS` does not implement its own `_get_unit_name()` method then it will just inherit the implementation from `Generic`: https://github.com/astropy/astropy/blob/65eb172d2ac1872ef0c08d7f269adb2b77d4918e/astropy/units/format/generic.py#L591-L595

I can't think of a good reason why `CDS` should not inherit this. I think the reason it did implement the method on its own was just that `CDS` couldn't inherit anything from `Generic` before 01d713dd4327a7136aa118fd85ae3b9ddaae50e5. `CDS` therefore had to implement machinery that was similar to the one in `Generic`, but apparently there were small differences, the most likely reason being that in practice it is difficult to keep parallel implementations of code in sync with each other.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
