### PR TITLE
Inject version_slug manually into html_context since RTD no longer does it

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,6 +321,7 @@ def _custom_edit_url(
 # A dictionary of values to pass into the template engine's context for all pages.
 html_context = {
     "default_mode": "light",
+    "version_slug": os.environ.get('READTHEDOCS_VERSION') or '',
     "to_be_indexed": ["stable", "latest"],
     "is_development": dev,
     "github_user": "astropy",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,7 +321,7 @@ def _custom_edit_url(
 # A dictionary of values to pass into the template engine's context for all pages.
 html_context = {
     "default_mode": "light",
-    "version_slug": os.environ.get('READTHEDOCS_VERSION') or '',
+    "version_slug": os.environ.get("READTHEDOCS_VERSION") or "",
     "to_be_indexed": ["stable", "latest"],
     "is_development": dev,
     "github_user": "astropy",


### PR DESCRIPTION
Should hopefully address https://github.com/astropy/astropy/issues/17007 but we'll need to wait until there is a ``latest`` build to know for sure.

Close #17068