### PR TITLE
Split the `sanitize_scale()` unit utility

### DIFF
--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -830,11 +830,7 @@ def test_quantity_conversion_equivalency_passed_on():
     assert_allclose(q4.value, q5.value)
 
 
-# Regression test for issue #2315, divide-by-zero error when examining 0*unit
-
-
 def test_self_equivalency():
-    assert u.deg.is_equivalent(0 * u.radian)
     assert u.deg.is_equivalent(1 * u.radian)
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -15,6 +15,8 @@ from astropy.units import utils
 from astropy.utils.compat.optional_deps import HAS_DASK
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
+FLOAT_EPS = np.finfo(float).eps
+
 
 def test_initialisation():
     assert u.Unit(u.m) is u.m
@@ -1042,3 +1044,14 @@ def test_error_on_conversion_of_zero_to_unit():
     # Also check some that do work.
     assert u.dimensionless_unscaled.to(0.125) == 8
     assert u.dimensionless_unscaled.to(8) == 0.125
+
+
+@pytest.mark.parametrize(
+    "unsanitized,sanitized",
+    [
+        pytest.param(complex(2, FLOAT_EPS), 2, id="almost_real_complex"),
+        pytest.param(complex(FLOAT_EPS, 2), 2j, id="almost_imaginary_complex"),
+    ],
+)
+def test_scale_sanitization(unsanitized, sanitized):
+    assert u.CompositeUnit(unsanitized, [u.m], [1]).scale == sanitized

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -4,12 +4,9 @@ Test utilities for `astropy.units`.
 """
 
 import numpy as np
-from numpy import finfo
 
 from astropy.units.quantity import Quantity
-from astropy.units.utils import quantity_asanyarray, sanitize_scale
-
-_float_finfo = finfo(float)
+from astropy.units.utils import quantity_asanyarray
 
 
 def test_quantity_asanyarray():
@@ -25,8 +22,3 @@ def test_quantity_asanyarray():
 
     np_array = quantity_asanyarray(array_of_integers, dtype=np.inexact)
     assert np.issubdtype(np_array.dtype, np.inexact)
-
-
-def test_sanitize_scale():
-    assert sanitize_scale(complex(2, _float_finfo.eps)) == 2
-    assert sanitize_scale(complex(_float_finfo.eps, 2)) == 2j

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -76,3 +76,4 @@ Real: TypeAlias = int | float | Fraction | np.integer | np.floating
 Complex: TypeAlias = Real | complex | np.complexfloating
 
 UnitPower: TypeAlias = int | float | Fraction
+UnitScale: TypeAlias = int | float | Fraction | complex

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, overload
 import numpy as np
 from numpy import finfo
 
+from .errors import UnitScaleError
+
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
     from typing import Literal, SupportsFloat, TypeVar
@@ -191,9 +193,9 @@ def is_effectively_unity(value: Complex) -> bool:
         )
 
 
-def sanitize_scale(scale: Complex) -> UnitScale:
-    if is_effectively_unity(scale):
-        return 1.0
+def sanitize_scale_type(scale: Complex) -> UnitScale:
+    if not scale:
+        raise UnitScaleError("cannot create a unit with a scale of 0.")
 
     # Maximum speed for regular case where scale is a float.
     if scale.__class__ is float:
@@ -201,8 +203,12 @@ def sanitize_scale(scale: Complex) -> UnitScale:
 
     # We cannot have numpy scalars, since they don't autoconvert to
     # complex if necessary.  They are also slower.
-    if hasattr(scale, "dtype"):
-        scale = scale.item()
+    return scale.item() if isinstance(scale, np.number) else scale
+
+
+def sanitize_scale_value(scale: UnitScale) -> UnitScale:
+    if is_effectively_unity(scale):
+        return 1.0
 
     # All classes that scale can be (int, float, complex, Fraction)
     # have an "imag" attribute.

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -22,10 +22,9 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from astropy.units.typing import Complex, Real, UnitPower
-
     from .core import UnitBase
     from .quantity import Quantity
+    from .typing import Complex, Real, UnitPower, UnitScale
 
     DType = TypeVar("DType", bound=np.generic)
     FloatLike = TypeVar("FloatLike", bound=SupportsFloat)
@@ -192,7 +191,7 @@ def is_effectively_unity(value: Complex) -> bool:
         )
 
 
-def sanitize_scale(scale: Complex) -> Complex:
+def sanitize_scale(scale: Complex) -> UnitScale:
     if is_effectively_unity(scale):
         return 1.0
 


### PR DESCRIPTION
### Description

The first commit defines a type alias for the scale of a unit.

The second commit rewrites a test involving explicit calls of `sanitize_scale()`. The rewritten test performs the same checks, but does so using only public API.

The third commit splits `sanitize_scale()` into `sanitize_scale_type()` and `sanitize_scale_value()`. The former includes checks that should be performed before computations involving the scale, which includes checking that the value is not zero (previously done by `CompositeUnit.__init__()`). The latter includes checks the outcome of which can change as a result of computations, so they need to be performed after the computations are complete. The separate functions allow avoiding redundant checks at runtime.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
