### PR TITLE
Fix mistake in indentation in astropy.wcs

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -508,7 +508,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                         tmp_wcsprm = tmp_wcsprm.sub(naxis)
                     except ValueError:
                         pass
-                    est_naxis = tmp_wcsprm.naxis if tmp_wcsprm.naxis else 2
+                est_naxis = tmp_wcsprm.naxis if tmp_wcsprm.naxis else 2
 
             except _wcs.NoWcsKeywordsFoundError:
                 pass


### PR DESCRIPTION
I'm not sure if this is a bug or not but decided to open it in case it is - reading the logic of this block it seems likely that ``est_naxis`` should be estimated even if ``naxis`` is not specified explicitly. I think all the tests pass with this change so would be good to figure out if there was a use case that is affected by this.

@mcara @nden - what do you think? was this code correct before or is this PR right?

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
