### PR TITLE
Respect WCSAXES if present when determining the number of dimensions in a WCS

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1951,3 +1951,26 @@ def test_DistortionLookupTable():
             img_world_wcs.pixel_to_world_values(12 + dx * 3, 22 + dy * 3),
             [12 + dx * 3, 22 + dy * 3],
         )
+
+
+def test_ignore_rogue_dimensions_if_wcsaxes_explicit():
+
+    # Regression test for an issue that caused WCS to fail to parse a header
+    # which had a well defined WCSAXES, and extra dimensions not within
+    # WCSAXES.
+
+
+    header = fits.Header()
+    header['WCSAXES'] = 2
+    header['CTYPE3'] = 'TEST'
+    assert wcs.WCS(header).naxis == 2
+
+    # Example with SIP which errors if there are more than two dimensions in
+    # the WCS - previously the header below would have been identified as 3D
+    # based on the CDELT3 value despite WCSAXES being set.
+
+    filename = get_pkg_data_filename("data/sip.fits")
+    header = fits.getheader(filename)
+    assert header['WCSAXES'] == 2
+    header['CDELT3'] = 2
+    wcs.WCS(header)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1971,4 +1971,4 @@ def test_ignore_rogue_dimensions_if_wcsaxes_explicit():
     header = fits.getheader(filename)
     assert header["WCSAXES"] == 2
     header["CDELT3"] = 2
-    wcs.WCS(header)
+    assert wcs.WCS(header).naxis == 2

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1971,4 +1971,6 @@ def test_ignore_rogue_dimensions_if_wcsaxes_explicit():
     header = fits.getheader(filename)
     assert header["WCSAXES"] == 2
     header["CDELT3"] = 2
-    assert wcs.WCS(header).naxis == 2
+    # Ignore a warning that relates to NAXIS being 0
+    with pytest.warns(wcs.FITSFixedWarning):
+        assert wcs.WCS(header).naxis == 2

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1954,15 +1954,13 @@ def test_DistortionLookupTable():
 
 
 def test_ignore_rogue_dimensions_if_wcsaxes_explicit():
-
     # Regression test for an issue that caused WCS to fail to parse a header
     # which had a well defined WCSAXES, and extra dimensions not within
     # WCSAXES.
 
-
     header = fits.Header()
-    header['WCSAXES'] = 2
-    header['CTYPE3'] = 'TEST'
+    header["WCSAXES"] = 2
+    header["CTYPE3"] = "TEST"
     assert wcs.WCS(header).naxis == 2
 
     # Example with SIP which errors if there are more than two dimensions in
@@ -1971,6 +1969,6 @@ def test_ignore_rogue_dimensions_if_wcsaxes_explicit():
 
     filename = get_pkg_data_filename("data/sip.fits")
     header = fits.getheader(filename)
-    assert header['WCSAXES'] == 2
-    header['CDELT3'] = 2
+    assert header["WCSAXES"] == 2
+    header["CDELT3"] = 2
     wcs.WCS(header)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -493,7 +493,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
             # e.g. CDELT3 to infer that the WCS has three dimensions even if
             # WCSAXES is 2.
             if naxis is None:
-                naxis = header.get('WCSAXES' + key.strip())
+                naxis = header.get("WCSAXES" + key.strip())
 
             est_naxis = 2
             try:

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -473,6 +473,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                 header_string = header.tostring().rstrip()
             else:
                 header_string = header
+                header = fits.Header.fromstring(header_string)
 
             # Importantly, header is a *copy* of the passed-in header
             # because we will be modifying it
@@ -486,6 +487,13 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                 raise AssertionError(
                     "'fobj' must be either None or an astropy.io.fits.HDUList object."
                 )
+
+            # If WCSAXES is present, we respect it and use it to set naxis,
+            # because otherwise WCSLIB may ignore it and use the presence of
+            # e.g. CDELT3 to infer that the WCS has three dimensions even if
+            # WCSAXES is 2.
+            if naxis is None:
+                naxis = header.get('WCSAXES' + key.strip())
 
             est_naxis = 2
             try:
@@ -558,7 +566,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                 else:
                     raise
 
-            if naxis is not None:
+            if naxis is not None and wcsprm.naxis != naxis:
                 wcsprm = wcsprm.sub(naxis)
             self.naxis = wcsprm.naxis
 

--- a/docs/changes/wcs/17076.api.rst
+++ b/docs/changes/wcs/17076.api.rst
@@ -1,0 +1,2 @@
+The ``WCS`` class will now respect ``WCSAXESa`` to determine the number of
+dimensions in a WCS, if present in a header.

--- a/docs/changes/wcs/17076.api.rst
+++ b/docs/changes/wcs/17076.api.rst
@@ -1,2 +1,3 @@
 The ``WCS`` class will now respect ``WCSAXESa`` to determine the number of
-dimensions in a WCS, if present in a header.
+dimensions in a WCS by default, if present in a header. This default value
+can be overridden using the already-existing ``naxis`` keyword argument.


### PR DESCRIPTION
[WCS Paper I](https://www.atnf.csiro.au/people/mcalabre/WCS/wcs.pdf) specifies that the WCSAXES keyword determines the number of dimensions in the WCS. For some reason, WCSLIB does not always respect this - for instance if a file has WCSAXES=2 but has a CTYPE3 present (which is the case in some astrometry.net files), the final WCS will have three dimensions. The WCSLIB source code mentions:

```
* Hence the definition of WCSAXESa forces the scanner to be implemented in two
* passes.  The first pass is used to determine the number of coordinate
* representations (up to 27) and the number of coordinate axes in each.
* Effectively WCSAXESa is ignored unless it exceeds the "largest index" in
* which case the keywords for the extra axes assume their default values.  The
* number of PVi_ma and PSi_ma keywords in each representation is also counted
* in the first pass.
```

Essentially I think this behavior is a technical limitation of how WCSLIB works, but strictly speaking the standard suggests that WCSAXES should be respected if provided. It is actually quite easy to support this properly in ``astropy.wcs`` as demonstrated in this PR.

I am not labelling this as a bug even though it is one because as it has the potential to break things for users in a few corner cases, it is probably best introduced in a major version.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
