### PR TITLE
Do not change dtype of float32 input

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -442,8 +442,11 @@ class SigmaClip:
         In this case, we replace clipped values with NaNs as placeholder
         values.
         """
-        # float array type is needed to insert nans into the array
-        filtered_data = data.astype(float)  # also makes a copy
+        if data.dtype.kind != "f":
+            # float array type is needed to insert nans into the array
+            filtered_data = data.astype(np.float32)  # also makes a copy
+        else:
+            filtered_data = np.copy(data)
 
         # remove invalid values
         bad_mask = ~np.isfinite(filtered_data)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -502,17 +502,18 @@ def test_sigma_clip_axis_shapes(axis, bounds_shape):
     "dtype", [">f2", "<f2", ">f4", "<f4", ">f8", "<f8", "<i4", ">i8"]
 )
 def test_sigma_clip_dtypes(dtype):
-    # Check the shapes of the output for different use cases
-
+    # Compare the outputs for various dtypes
     with NumpyRNGContext(12345):
         array = np.random.randint(-5, 5, 1000).astype(float)
     array[30] = 100
-
     reference = sigma_clip(array, copy=True, masked=False)
-
     actual = sigma_clip(array.astype(dtype), copy=True, masked=False)
-
     assert_equal(reference, actual)
+
+    # Check that the output dtype is the same as the input dtype
+    arr = np.ones((10, 10), dtype=np.float32)
+    arr2 = sigma_clip(arr, cenfunc=np.mean, axis=0, masked=False)
+    assert arr2.dtype == arr.dtype
 
 
 def test_mad_std():

--- a/docs/changes/stats/17086.bugfix.rst
+++ b/docs/changes/stats/17086.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where float32 inputs to sigma_clip and SigmaClip were
+changed to float.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes a bug reported by a user where `float32` arrays were converted to `float` (causing a memory error in their example).  The bug is triggered only when a non-default `cenfunc` or `stdfunc` is used along with `axis=0` and `masked=False`, causing the `_sigmaclip_withaxis` method to be called instead of `_sigmaclip_fast`.

With this PR, float dtypes are preserved, but integer dtypes are changed to `np.float32` (needed to insert NaNs).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
