### PR TITLE
Remove unecessary step from release docs

### DIFF
--- a/docs/development/maintainers/releasing.rst
+++ b/docs/development/maintainers/releasing.rst
@@ -429,12 +429,11 @@ clean-up tasks to finalize the process.
 Post-Release procedures
 -----------------------
 
-#. Update Readthedocs so that it builds docs for the version you just released.
-   You'll find this in the "Admin" tab, in the "Edit Versions" section --
-   click on "Activate" for the tag of the release you have just done.
-   Also verify that the ``stable`` Readthedocs version builds correctly for
-   the new version (it should trigger automatically once you've done the
-   previous step).
+#. Make sure that Readthedocs is building the documentation for the version you just released.
+   You'll find this in the "Versions" tab -- click on "Edit" for the tag you
+   just released, and make sure that "Active" is checked. Also verify that the
+   ``stable`` Readthedocs version builds correctly for the new version (it
+   should trigger automatically once you've done the previous step).
 
 #. When releasing a patch release, also set the previous RTD version in the
    release history to "Hidden".  For example when releasing v6.0.2, set

--- a/docs/development/maintainers/releasing.rst
+++ b/docs/development/maintainers/releasing.rst
@@ -429,10 +429,10 @@ clean-up tasks to finalize the process.
 Post-Release procedures
 -----------------------
 
-#. Make sure that Readthedocs is building the documentation for the version you just released.
+#. Make sure that ReadTheDocs is building the documentation for the version you just released.
    You'll find this in the "Versions" tab -- click on "Edit" for the tag you
    just released, and make sure that "Active" is checked. Also verify that the
-   ``stable`` Readthedocs version builds correctly for the new version (it
+   ``stable`` ReadTheDocs version builds correctly for the new version (it
    should trigger automatically once you've done the previous step).
 
 #. When releasing a patch release, also set the previous RTD version in the


### PR DESCRIPTION
This paragraph is out of date - new version tags are activated automatically.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
