### PR TITLE
Report maximum relative and absolute tolerance in FITS diff

### DIFF
--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -51,6 +51,12 @@ _COL_ATTRS = [
 ]
 
 
+def _get_differences(a, b):
+    relative = abs(b - a) / abs(b)
+    absolute = abs(b - 1)
+    return relative, absolute
+
+
 class _BaseDiff:
     """
     Base class for all FITS diff objects.
@@ -1109,6 +1115,9 @@ class ImageDataDiff(_BaseDiff):
         if not self.diff_pixels:
             return
 
+        max_relative = 0
+        max_absolute = 0
+
         for index, values in self.diff_pixels:
             # Convert to int to avoid np.int64 in list repr.
             index = [int(x + 1) for x in reversed(index)]
@@ -1121,6 +1130,9 @@ class ImageDataDiff(_BaseDiff):
                 rtol=self.rtol,
                 atol=self.atol,
             )
+            rdiff, adiff = _get_differences(values[0], values[1])
+            max_relative = max(max_relative, rdiff)
+            max_absolute = max(max_absolute, adiff)
 
         if self.diff_total > self.numdiffs:
             self._writeln(" ...")
@@ -1128,6 +1140,8 @@ class ImageDataDiff(_BaseDiff):
             f" {self.diff_total} different pixels found "
             f"({self.diff_ratio:.2%} different)."
         )
+        self._writeln(f" Maximum relative difference: {max_relative}.")
+        self._writeln(f" Maximum absolute difference: {max_absolute}.")
 
 
 class RawDataDiff(ImageDataDiff):

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -53,7 +53,7 @@ _COL_ATTRS = [
 
 def _get_differences(a, b):
     relative = abs(b - a) / abs(b)
-    absolute = abs(b - 1)
+    absolute = float(abs(b - a))
     return relative, absolute
 
 
@@ -1140,8 +1140,8 @@ class ImageDataDiff(_BaseDiff):
             f" {self.diff_total} different pixels found "
             f"({self.diff_ratio:.2%} different)."
         )
-        self._writeln(f" Maximum relative difference: {max_relative}.")
-        self._writeln(f" Maximum absolute difference: {max_absolute}.")
+        self._writeln(f" Maximum relative difference: {max_relative}")
+        self._writeln(f" Maximum absolute difference: {max_absolute}")
 
 
 class RawDataDiff(ImageDataDiff):

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -77,28 +77,32 @@ class TestFITSDiff_script(FitsTestCase):
         numdiff = fitsdiff.main([tmp_a, tmp_b])
         out, err = capsys.readouterr()
         assert numdiff == 1
-        assert out.splitlines()[-4:] == [
+        assert out.splitlines()[-6:] == [
             "        a> 9",
             "        b> 10",
             "     ...",
             "     100 different pixels found (100.00% different).",
+            "     Maximum relative difference: 1.0",
+            "     Maximum absolute difference: 1.0",
         ]
 
         numdiff = fitsdiff.main(["-n", "1", tmp_a, tmp_b])
         out, err = capsys.readouterr()
         assert numdiff == 1
-        assert out.splitlines()[-4:] == [
+        assert out.splitlines()[-6:] == [
             "        a> 0",
             "        b> 1",
             "     ...",
             "     100 different pixels found (100.00% different).",
+            "     Maximum relative difference: 1.0",
+            "     Maximum absolute difference: 1.0",
         ]
 
     def test_outputfile(self):
         a = np.arange(100).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)
         b = a.copy()
-        b[1, 0] = 12
+        b[1, 0] = 20
         hdu_b = PrimaryHDU(data=b)
         tmp_a = self.temp("testa.fits")
         tmp_b = self.temp("testb.fits")
@@ -109,11 +113,13 @@ class TestFITSDiff_script(FitsTestCase):
         assert numdiff == 1
         with open(self.temp("diff.txt")) as f:
             out = f.read()
-        assert out.splitlines()[-4:] == [
+        assert out.splitlines()[-6:] == [
             "     Data differs at [1, 2]:",
             "        a> 10",
-            "        b> 12",
+            "        b> 20",
             "     1 different pixels found (1.00% different).",
+            "     Maximum relative difference: 0.5",
+            "     Maximum absolute difference: 10.0",
         ]
 
     def test_atol(self):
@@ -150,7 +156,7 @@ class TestFITSDiff_script(FitsTestCase):
         a = np.arange(100, dtype=float).reshape(10, 10)
         hdu_a = PrimaryHDU(data=a)
         b = a.copy()
-        b[1, 0] = 11
+        b[1, 0] = 20
         hdu_b = PrimaryHDU(data=b)
         tmp_a = self.temp("testa.fits")
         tmp_b = self.temp("testb.fits")
@@ -173,10 +179,12 @@ Primary HDU:
    Data contains differences:
      Data differs at [1, 2]:
         a> 10.0
-         ?  ^
-        b> 11.0
-         ?  ^
+         ? ^
+        b> 20.0
+         ? ^
      1 different pixels found (1.00% different).
+     Maximum relative difference: 0.5
+     Maximum absolute difference: 10.0
 """
         )
         assert err == ""

--- a/docs/changes/io.fits/17097.feature.rst
+++ b/docs/changes/io.fits/17097.feature.rst
@@ -1,0 +1,2 @@
+Expanded ``FITSDiff`` output for ``PrimaryHDU`` and ``ImageHDU`` to include the 
+maximum relative and absolute differences in the data.

--- a/docs/changes/io.fits/17097.feature.rst
+++ b/docs/changes/io.fits/17097.feature.rst
@@ -1,2 +1,2 @@
-Expanded ``FITSDiff`` output for ``PrimaryHDU`` and ``ImageHDU`` to include the 
+Expanded ``FITSDiff`` output for ``PrimaryHDU`` and ``ImageHDU`` to include the
 maximum relative and absolute differences in the data.


### PR DESCRIPTION
With this PR, the FITS diff infrastructure now reports the maximum relative and absolute differences, as otherwise it's hard to know how different the data really are (this is similar to what ``assert_allclose`` reports):

```
E               b> 185.3959962497532
E            Data differs at [53, 11]:
E               a> 221.78221524621446
E               b> 221.78228090660704
E            ...
E            6104 different pixels found (37.26% different).
E            Maximum relative difference: 4.891022444723928e-07.
E            Maximum absolute difference: 278.7475541463714.
```

@saimn - are you on board with this? If so I can extend to the other HDU types, add a changelog entry and tests.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
