### PR TITLE
Remove CompImageHeader subclass

### DIFF
--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -16,13 +16,13 @@ from astropy.io.fits.hdu.compressed._tiled_compression import (
 )
 from astropy.io.fits.hdu.compressed.utils import _tile_shape, _validate_tile_shape
 from astropy.io.fits.hdu.image import ImageHDU
+from astropy.io.fits.header import Header
 from astropy.io.fits.util import _is_int
 from astropy.io.fits.verify import _ErrList
 from astropy.utils.decorators import deprecated_renamed_argument, lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .header import (
-    CompImageHeader,
     _bintable_header_to_image_header,
     _image_header_to_empty_bintable,
 )
@@ -351,7 +351,7 @@ class CompImageHDU(ImageHDU):
 
             super().__init__(
                 data=data,
-                header=CompImageHeader(header or []),
+                header=header or Header(),
                 name=name,
                 do_not_scale_image_data=do_not_scale_image_data,
                 uint=uint,

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -6,7 +6,9 @@ import warnings
 from astropy.io.fits.column import KEYWORD_NAMES as TABLE_KEYWORD_NAMES
 from astropy.io.fits.column import TDEF_RE, ColDefs, Column
 from astropy.io.fits.hdu.compressed.compbintable import _CompBinTableHDU
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.io.fits.header import Header
+from astropy.io.fits.verify import VerifyWarning
+from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
 from .settings import (
     CMTYPE_ALIASES,
@@ -24,6 +26,7 @@ from .settings import (
 from .utils import _validate_tile_shape
 
 __all__ = [
+    "CompImageHeader",
     "_bintable_header_to_image_header",
     "_image_header_to_empty_bintable",
 ]
@@ -45,6 +48,12 @@ REMAPPED_KEYWORDS = {
 COMPRESSION_KEYWORDS = set(REMAPPED_KEYWORDS.values()).union(
     {"ZIMAGE", "ZCMPTYPE", "ZMASKCMP", "ZQUANTIZ", "ZDITHER0"}
 )
+
+class CompImageHeader(Header):
+    def __init__(self, *args, **kwargs):
+        warnings.warn("The CompImageHeader class is deprecated and will be "
+                      "removed in future", AstropyDeprecationWarning)
+        return super().__init__(*args, **kwargs)
 
 
 def _is_reserved_table_keyword(keyword):
@@ -651,7 +660,8 @@ def _image_header_to_empty_bintable(
             warnings.warn(
                 f"Keyword {card.keyword!r} is reserved "
                 "for use by the FITS Tiled Image "
-                "Convention so will be ignored"
+                "Convention so will be ignored",
+                VerifyWarning
             )
         elif (
             card.keyword not in ("", "COMMENT", "HISTORY")

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -3,11 +3,9 @@
 import re
 import warnings
 
-from astropy.io.fits.card import Card
 from astropy.io.fits.column import KEYWORD_NAMES as TABLE_KEYWORD_NAMES
 from astropy.io.fits.column import TDEF_RE, ColDefs, Column
 from astropy.io.fits.hdu.compressed.compbintable import _CompBinTableHDU
-from astropy.io.fits.header import Header
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .settings import (
@@ -26,158 +24,47 @@ from .settings import (
 from .utils import _validate_tile_shape
 
 __all__ = [
-    "CompImageHeader",
     "_bintable_header_to_image_header",
     "_image_header_to_empty_bintable",
 ]
 
+ZDEF_RE = re.compile(r"(?P<label>^[Zz][a-zA-Z]*)(?P<num>[1-9][0-9 ]*$)?")
+INDEXED_COMPRESSION_KEYWORDS = {"ZNAXIS", "ZTILE", "ZNAME", "ZVAL"}
+REMAPPED_KEYWORDS = {
+    "SIMPLE": "ZSIMPLE",
+    "XTENSION": "ZTENSION",
+    "BITPIX": "ZBITPIX",
+    "NAXIS": "ZNAXIS",
+    "EXTEND": "ZEXTEND",
+    "BLOCKED": "ZBLOCKED",
+    "PCOUNT": "ZPCOUNT",
+    "GCOUNT": "ZGCOUNT",
+    "CHECKSUM": "ZHECKSUM",
+    "DATASUM": "ZDATASUM",
+}
+COMPRESSION_KEYWORDS = set(REMAPPED_KEYWORDS.values()).union(
+    {"ZIMAGE", "ZCMPTYPE", "ZMASKCMP", "ZQUANTIZ", "ZDITHER0"}
+)
 
-class CompImageHeader(Header):
-    """
-    Header object for compressed image HDUs designed to keep the compression
-    header and the underlying image header properly synchronized.
 
-    This essentially wraps the image header, so that all values are read from
-    and written to the image header.  However, updates to the image header will
-    also update the table header where appropriate.
-
-    Note that if no image header is passed in, the code will instantiate a
-    regular `~astropy.io.fits.Header`.
-    """
-
-    _keyword_remaps = {
-        "SIMPLE": "ZSIMPLE",
-        "XTENSION": "ZTENSION",
-        "BITPIX": "ZBITPIX",
-        "NAXIS": "ZNAXIS",
-        "EXTEND": "ZEXTEND",
-        "BLOCKED": "ZBLOCKED",
-        "PCOUNT": "ZPCOUNT",
-        "GCOUNT": "ZGCOUNT",
-        "CHECKSUM": "ZHECKSUM",
-        "DATASUM": "ZDATASUM",
-    }
-
-    _zdef_re = re.compile(r"(?P<label>^[Zz][a-zA-Z]*)(?P<num>[1-9][0-9 ]*$)?")
-    _compression_keywords = set(_keyword_remaps.values()).union(
-        ["ZIMAGE", "ZCMPTYPE", "ZMASKCMP", "ZQUANTIZ", "ZDITHER0"]
+def _is_reserved_table_keyword(keyword):
+    m = TDEF_RE.match(keyword)
+    return keyword == "TFIELDS" or (
+        m and m.group("label").upper() in TABLE_KEYWORD_NAMES
     )
-    _indexed_compression_keywords = {"ZNAXIS", "ZTILE", "ZNAME", "ZVAL"}
 
-    def __setitem__(self, key, value):
-        # This isn't pretty, but if the `key` is either an int or a tuple we
-        # need to figure out what keyword name that maps to before doing
-        # anything else; these checks will be repeated later in the
-        # super().__setitem__ call but I don't see another way around it
-        # without some major refactoring
-        if self._set_slice(key, value, self):
-            return
 
-        if isinstance(key, int):
-            keyword, index = self._keyword_from_index(key)
-        elif isinstance(key, tuple):
-            keyword, index = key
-        else:
-            # We don't want to specify and index otherwise, because that will
-            # break the behavior for new keywords and for commentary keywords
-            keyword, index = key, None
+def _is_reserved_compression_keyword(keyword):
+    m = ZDEF_RE.match(keyword)
+    return keyword in COMPRESSION_KEYWORDS or (
+        m and m.group("label").upper() in INDEXED_COMPRESSION_KEYWORDS
+    )
 
-        if self._is_reserved_keyword(keyword):
-            return
 
-        super().__setitem__(key, value)
-
-    def append(self, card=None, useblanks=True, bottom=False, end=False):
-        # This logic unfortunately needs to be duplicated from the base class
-        # in order to determine the keyword
-        if isinstance(card, str):
-            card = Card(card)
-        elif isinstance(card, tuple):
-            card = Card(*card)
-        elif card is None:
-            card = Card()
-        elif not isinstance(card, Card):
-            raise ValueError(
-                "The value appended to a Header must be either a keyword or "
-                f"(keyword, value, [comment]) tuple; got: {card!r}"
-            )
-
-        if self._is_reserved_keyword(card.keyword):
-            return
-
-        super().append(card=card, useblanks=useblanks, bottom=bottom, end=end)
-
-    def insert(self, key, card, useblanks=True, after=False):
-        if isinstance(key, int):
-            # Determine condition to pass through to append
-            if after:
-                if key == -1:
-                    key = len(self._cards)
-                else:
-                    key += 1
-
-            if key >= len(self._cards):
-                self.append(card, end=True)
-                return
-
-        if isinstance(card, str):
-            card = Card(card)
-        elif isinstance(card, tuple):
-            card = Card(*card)
-        elif not isinstance(card, Card):
-            raise ValueError(
-                "The value inserted into a Header must be either a keyword or "
-                f"(keyword, value, [comment]) tuple; got: {card!r}"
-            )
-
-        if self._is_reserved_keyword(card.keyword):
-            return
-
-        super().insert(key, card, useblanks=useblanks, after=after)
-
-    def _update(self, card):
-        keyword = card[0]
-
-        if self._is_reserved_keyword(keyword):
-            return
-
-        super()._update(card)
-
-    @classmethod
-    def _is_reserved_keyword(cls, keyword, warn=True):
-        msg = (
-            f"Keyword {keyword!r} is reserved for use by the FITS Tiled Image "
-            "Convention and will not be stored in the header for the "
-            "image being compressed."
-        )
-
-        if keyword == "TFIELDS":
-            if warn:
-                warnings.warn(msg)
-            return True
-
-        m = TDEF_RE.match(keyword)
-
-        if m and m.group("label").upper() in TABLE_KEYWORD_NAMES:
-            if warn:
-                warnings.warn(msg)
-            return True
-
-        m = cls._zdef_re.match(keyword)
-
-        if m:
-            label = m.group("label").upper()
-            num = m.group("num")
-            if num is not None and label in cls._indexed_compression_keywords:
-                if warn:
-                    warnings.warn(msg)
-                return True
-            elif label in cls._compression_keywords:
-                if warn:
-                    warnings.warn(msg)
-                return True
-
-        return False
+def _is_reserved_keyword(keyword):
+    return _is_reserved_table_keyword(keyword) or _is_reserved_compression_keyword(
+        keyword
+    )
 
 
 def _bintable_header_to_image_header(bintable_header):
@@ -198,10 +85,7 @@ def _bintable_header_to_image_header(bintable_header):
     # keywords, which there may be in some pathological cases:
     # https://github.com/astropy/astropy/issues/2750
     for keyword in set(image_header):
-        if CompImageHeader._is_reserved_keyword(keyword, warn=False) or keyword in (
-            "CHECKSUM",
-            "DATASUM",
-        ):
+        if _is_reserved_keyword(keyword) or keyword in ("CHECKSUM", "DATASUM"):
             del image_header[keyword]
 
     if bscale:
@@ -324,8 +208,7 @@ def _bintable_header_to_image_header(bintable_header):
     for _ in range(table_blanks - image_blanks):
         image_header.append()
 
-    # Create the CompImageHeader that syncs with the table header
-    return CompImageHeader(image_header)
+    return image_header
 
 
 def _image_header_to_empty_bintable(
@@ -764,9 +647,15 @@ def _image_header_to_empty_bintable(
 
         if card.keyword == "":
             bintable.header.add_blank()
+        elif _is_reserved_keyword(card.keyword):
+            warnings.warn(
+                f"Keyword {card.keyword!r} is reserved "
+                "for use by the FITS Tiled Image "
+                "Convention so will be ignored"
+            )
         elif (
             card.keyword not in ("", "COMMENT", "HISTORY")
-            and card.keyword not in CompImageHeader._keyword_remaps
+            and card.keyword not in REMAPPED_KEYWORDS
             and card.keyword not in bintable.header
             and not card.keyword.startswith("NAXIS")
         ):

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -8,7 +8,7 @@ from astropy.io.fits.column import TDEF_RE, ColDefs, Column
 from astropy.io.fits.hdu.compressed.compbintable import _CompBinTableHDU
 from astropy.io.fits.header import Header
 from astropy.io.fits.verify import VerifyWarning
-from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from .settings import (
     CMTYPE_ALIASES,
@@ -49,10 +49,13 @@ COMPRESSION_KEYWORDS = set(REMAPPED_KEYWORDS.values()).union(
     {"ZIMAGE", "ZCMPTYPE", "ZMASKCMP", "ZQUANTIZ", "ZDITHER0"}
 )
 
+
 class CompImageHeader(Header):
     def __init__(self, *args, **kwargs):
-        warnings.warn("The CompImageHeader class is deprecated and will be "
-                      "removed in future", AstropyDeprecationWarning)
+        warnings.warn(
+            "The CompImageHeader class is deprecated and will be " "removed in future",
+            AstropyDeprecationWarning,
+        )
         return super().__init__(*args, **kwargs)
 
 
@@ -661,7 +664,7 @@ def _image_header_to_empty_bintable(
                 f"Keyword {card.keyword!r} is reserved "
                 "for use by the FITS Tiled Image "
                 "Convention so will be ignored",
-                VerifyWarning
+                VerifyWarning,
             )
         elif (
             card.keyword not in ("", "COMMENT", "HISTORY")

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -26,6 +26,7 @@ from astropy.io.fits.tests.test_table import comparerecords
 from astropy.utils.data import download_file
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import NumpyRNGContext
+from astropy.io.fits.verify import VerifyWarning
 
 
 class TestCompressedImage(FitsTestCase):
@@ -526,7 +527,7 @@ class TestCompressedImage(FitsTestCase):
             assert "CHECKSUM" in imghdr
             assert imghdr["CHECKSUM"] == "abcd1234"
 
-            with pytest.warns(UserWarning, match="Keyword 'TFIELDS' is reserved") as w:
+            with pytest.warns(VerifyWarning, match="Keyword 'TFIELDS' is reserved") as w:
                 hdul.writeto(tmp_path / "updated.fits")
 
         with fits.open(
@@ -574,7 +575,7 @@ class TestCompressedImage(FitsTestCase):
             assert "FOO" in imghdr
             assert imghdr.index("FOO") == idx
 
-            with pytest.warns(UserWarning, match="Keyword 'TFIELDS' is reserved") as w:
+            with pytest.warns(VerifyWarning, match="Keyword 'TFIELDS' is reserved") as w:
                 hdul.writeto(tmp_path / "updated.fits")
 
         with fits.open(

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -23,10 +23,10 @@ from astropy.io.fits.hdu.compressed import (
 )
 from astropy.io.fits.tests.conftest import FitsTestCase
 from astropy.io.fits.tests.test_table import comparerecords
+from astropy.io.fits.verify import VerifyWarning
 from astropy.utils.data import download_file
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import NumpyRNGContext
-from astropy.io.fits.verify import VerifyWarning
 
 
 class TestCompressedImage(FitsTestCase):
@@ -527,7 +527,9 @@ class TestCompressedImage(FitsTestCase):
             assert "CHECKSUM" in imghdr
             assert imghdr["CHECKSUM"] == "abcd1234"
 
-            with pytest.warns(VerifyWarning, match="Keyword 'TFIELDS' is reserved") as w:
+            with pytest.warns(
+                VerifyWarning, match="Keyword 'TFIELDS' is reserved"
+            ) as w:
                 hdul.writeto(tmp_path / "updated.fits")
 
         with fits.open(
@@ -575,7 +577,9 @@ class TestCompressedImage(FitsTestCase):
             assert "FOO" in imghdr
             assert imghdr.index("FOO") == idx
 
-            with pytest.warns(VerifyWarning, match="Keyword 'TFIELDS' is reserved") as w:
+            with pytest.warns(
+                VerifyWarning, match="Keyword 'TFIELDS' is reserved"
+            ) as w:
                 hdul.writeto(tmp_path / "updated.fits")
 
         with fits.open(

--- a/docs/changes/io.fits/17100.api.rst
+++ b/docs/changes/io.fits/17100.api.rst
@@ -1,0 +1,4 @@
+The ``CompImageHeader`` class is now deprecated, and headers on ``CompImageHDU``
+instances are now plain ``Header`` instances. If a reserved keyword is set on
+``CompImageHDU.header``, a warning will now be emitted at the point where the
+file is written rather than at the point where the keyword is set.


### PR DESCRIPTION
The ``CompImageHeader`` class re-implements parts of ``Header`` just to be able to detect when reserved keywords are set/added. This is unecessarily complicated, and there are ways of avoiding this:

1. Make the ability to validate cards on-the-fly part of the ``Header`` class and use in a minimal ``CompImageHeader`` subclass - this was done in https://github.com/astropy/astropy/pull/15293 but closed without merging as likely not desirable
2. Remove ``CompImageHeader`` and check for reserved keywords at the point where we convert the image header to a compressed table header
3. Remove ``CompImageHeader`` and check in ``CompImageHDU._verify`` whether such keywords are present. I considered this but wasn't sure if it would be quite right, because we don't ever want to ignore these reserved keywords, we always want to remove them (so we couldn't support the ``ignore`` mode of ``_verify``) for instance.

In options 2 and 3, the warnings will change from being emitted when set to when the file is written out, so this is somewhat a change in API, but this seems worthwhile and it is unlikely many people would be relying on exactly when a warning is emitted?

In any case, this does save quite a few lines of code and some complexity IMHO.

What do you think @saimn?

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
