### PR TITLE
Allow scalars to be used in setting empty columns

### DIFF
--- a/astropy/table/mixins/tests/test_registry.py
+++ b/astropy/table/mixins/tests/test_registry.py
@@ -3,7 +3,7 @@ from copy import copy
 import pytest
 from numpy.testing import assert_equal
 
-from astropy.table import Table
+from astropy.table import Column, Table
 from astropy.table.mixins.registry import (
     MixinRegistryError,
     _handlers,
@@ -74,10 +74,29 @@ def test_get_mixin_handler_str():
     assert get_mixin_handler(FULL_QUALNAME) is handle_spam
 
 
-def test_add_column():
+def test_add_column_to_empty_table():
     t = Table()
-    with pytest.raises(TypeError):
-        t["a"] = SpamData()
+    t["a"] = SpamData()
+    # By default, we get an object column.
+    assert isinstance(t["a"], Column)
+    assert t["a"].dtype == object
+    # But after registration, we can get the intended mixin.
+    register_mixin_handler(FULL_QUALNAME, handle_spam)
+    t = Table()
+    t["a"] = SpamData()
+
+    assert len(t) == 5
+    assert isinstance(t["a"], SpamWrapper)
+    assert_equal(t["a"].data, [0, 1, 3, 4, 5])
+
+
+def test_add_column_to_existing_table():
+    # As above, but for a table that already has a column
+    # (addition used to depend on whether or a table was empty; gh-17102).
+    t = Table([[5, 6, 7, 8, 9]], names=["x"])
+    t["a"] = SpamData()
+    assert isinstance(t["a"], Column)
+    assert t["a"].dtype == object
 
     register_mixin_handler(FULL_QUALNAME, handle_spam)
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -282,6 +282,19 @@ class TestEmptyData:
         with pytest.raises(ValueError, match="data column length"):
             t["d"] = [1.0, 2.0]
 
+    def test_scalar_double_assignment(self, table_types):
+        # Following example given by @taldcroft in
+        # https://github.com/astropy/astropy/pull/17102#issuecomment-2386767337
+        t = table_types.Table()
+        t["a"] = 1.5
+        assert len(t) == 0
+        assert isinstance(t["a"], Column)
+        assert t["a"].shape == (0,)
+        t["a"] = 1.5
+        assert len(t) == 0
+        assert isinstance(t["a"], Column)
+        assert t["a"].shape == (0,)
+
     def test_add_via_setitem_and_slice(self, table_types):
         """Test related to #3023 where a MaskedColumn is created with name=None
         and then gets changed to name='a'.  After PR #2790 this test fails

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -262,14 +262,25 @@ class TestEmptyData:
         assert len(t["a"]) == 0
 
     def test_scalar(self, table_types):
-        """Test related to #3811 where setting empty tables to scalar values
-        should raise an error instead of having an error raised when accessing
-        the table."""
+        """Test related to #3811 and #17078: we used to have setting
+        empty tables succeed, but raise on access. Then, we ensured they
+        raised on setting. But now we let setting and accessing succeed:
+        the table stays empty."""
         t = table_types.Table()
-        with pytest.raises(
-            TypeError, match="Empty table cannot have column set to scalar value"
-        ):
-            t.add_column(0)
+        t.add_column(0, name="a")
+        assert len(t) == 0
+        assert isinstance(t["a"], Column)
+        assert len(t["a"]) == 0
+        assert t["a"].dtype == int
+        t["b"] = SkyCoord(1.0, 2.0, unit="hourangle,deg")
+        assert isinstance(t["b"], SkyCoord)
+        assert len(t["b"]) == 0
+        assert t["b"].data.lon.unit == u.hourangle
+        # For this case, broadcasting still works.
+        t["c"] = [1.0]
+        # But not here.
+        with pytest.raises(ValueError, match="data column length"):
+            t["d"] = [1.0, 2.0]
 
     def test_add_via_setitem_and_slice(self, table_types):
         """Test related to #3023 where a MaskedColumn is created with name=None
@@ -2618,10 +2629,11 @@ def test_empty_table_setdefault(value):
 
 def test_empty_table_setdefault_scalar():
     t = Table()
-    with pytest.raises(
-        TypeError, match="^Empty table cannot have column set to scalar value$"
-    ):
-        t.setdefault("a", 9)
+    t.setdefault("a", 9)
+    assert len(t) == 0
+    assert t.colnames == ["a"]
+    assert type(t["a"]) is Column
+    assert t["a"].dtype == int
 
 
 def test_table_meta_copy():

--- a/docs/changes/table/17102.api.rst
+++ b/docs/changes/table/17102.api.rst
@@ -1,0 +1,3 @@
+Setting an empty table to a scalar no longer raises an exception, but
+creates an empty column. This is to support cases where the number of
+elements in a table is not known in advance, and could be zero.

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -361,17 +361,27 @@ that is not numpy-like and stores the data in a private attribute::
     ...     def __init__(self):
     ...         self._data = np.array([0, 1, 3, 4], dtype=float)
 
-By default, this cannot be used as a table column::
+By default, the outcome of setting a column using this class is not helpful::
 
-    >>> t = Table()
+    >>> t = Table([np.arange(4)], names=["index"])
     >>> t['data'] = ExampleDataClass()
-    Traceback (most recent call last):
-    ...
-    TypeError: Empty table cannot have column set to scalar value
+    >>> t
+    <Table length=4>
+    index                         data
+    int64                        object
+    ----- -------------------------------------...-
+        0 <__main__.ExampleDataClass object at ...>
+        1 <__main__.ExampleDataClass object at ...>
+        2 <__main__.ExampleDataClass object at ...>
+        3 <__main__.ExampleDataClass object at ...>
+
+What happened is that the instance is seen as a scalar object, and a
+|Column| with ``dtype=object`` is created, which has the same entry for
+each row. The same would happen if, e.g., you set ``t['data'] = None``.
 
 However, you can create a function (or 'handler') which takes
 an instance of the data class you want to have automatically
-handled and returns a mixin column::
+handled and turns it into a mixin column::
 
     >>> from astropy.table.table_helpers import ArrayWrapper
     >>> def handle_example_data_class(obj):
@@ -385,13 +395,13 @@ of the class and the handler function::
     >>> t['data'] = ExampleDataClass()
     >>> t
     <Table length=4>
-      data
-    float64
-    -------
-        0.0
-        1.0
-        3.0
-        4.0
+    index   data
+    int64 float64
+    ----- -------
+        0     0.0
+        1     1.0
+        2     3.0
+        3     4.0
 
 Because we defined the data class as part of the example
 above, the fully qualified name starts with ``__main__``,


### PR DESCRIPTION
In #17078, it was noted that one should really be able to set a column with a scalar also when the size of the table is 0: just broadcast it to zero. This PR implements it. As a result, a number of tests had to be adjusted, and the one for the registry are arguably not great. So, opening as draft -- will add changelog entries later, once we decided what is best.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17078

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
