### PR TITLE
BUG: ensure setting a column to a scalar always works.

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2694,6 +2694,9 @@ class Table:
             raise ValueError("cannot replace a table index column")
 
         col = self._convert_data_to_col(col, name=name, copy=copy)
+        if col.shape == ():
+            raise ValueError("cannot replace a column with a scalar.")
+
         self._set_col_parent_table_and_mask(col)
 
         # Ensure that new column is the right length, unless it is the only column

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3541,3 +3541,18 @@ def test_qtable_with_explicit_units():
     # astropy/units/tests/test_units.py::test_comparison_dimensionless_with_np_ma_masked
     tt = QTable(data=[[1.0, 2.0, 3.0]], names=["weight"], units={"weight": u.one})
     assert tt["weight"].unit == u.dimensionless_unscaled
+
+
+@pytest.mark.parametrize("empty_table", [True, False])
+def test_table_replace_column_with_scalar(empty_table):
+    # Regression test for bug mentioned in
+    # https://github.com/astropy/astropy/pull/17102#issuecomment-2386963846
+    t = QTable() if empty_table else QTable([[5, 6, 7]], names=["0"])
+    t["a"] = np.arange(3.0)
+    t["a"] = 5.0
+    assert len(t) == 3
+    assert t["a"].shape == (3,)
+    assert np.all(t["a"] == 5.0)
+    # Direct replacement should never work.
+    with pytest.raises(ValueError, match="cannot replace.*with a scalar"):
+        t.replace_column("a", 2)

--- a/docs/changes/table/17105.bugfix.rst
+++ b/docs/changes/table/17105.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that setting an existing column to a scalar always properly fills it
+(rather than breaking the table if there was only one column in it).


### PR DESCRIPTION
Previously, it broke the table by replacing the column with the scalar, as I noted in https://github.com/astropy/astropy/pull/17102#issuecomment-2386963846.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
