### PR TITLE
Backport PR #17013 on branch v6.1.x (Fix empty data coordinate transformations and empty time IERS queries)

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -783,3 +783,14 @@ def test_regression_16998(differential_type, diff_kwargs, extra_kwargs):
     if differential_type:
         expected_entries |= {"differential_type"} | set(diff_kwargs)
     assert set(coord.info._represent_as_dict()) == expected_entries
+
+
+def test_regression_17008():
+    """Test that one can transform a SkyCoord with empty data to other frames.
+
+    The underlying bug that caused the problem reported in gh-17008
+    is tested in utils/iers/tests/test_iers.py::test_empty_mjd
+    """
+    s = SkyCoord([] * u.deg, [] * u.deg, obstime=Time([], format="iso"))
+    itrs = s.itrs  # This failed before.
+    assert itrs.size == 0

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -443,9 +443,6 @@ class IERS(QTable):
         if is_scalar:
             mjd = np.array([mjd])
             utc = np.array([utc])
-        elif mjd.size == 0:
-            # Short-cut empty input.
-            return np.array([])
 
         self._refresh_table_as_needed(mjd)
 
@@ -493,7 +490,8 @@ class IERS(QTable):
             results.append(status)
             return results
         else:
-            self._check_interpolate_indices(i1, i, np.max(mjd))
+            # Pass in initial to np.max to allow things to work for empty mjd.
+            self._check_interpolate_indices(i1, i, np.max(mjd, initial=50000))
             return results[0] if len(results) == 1 else results
 
     def _refresh_table_as_needed(self, mjd):
@@ -853,7 +851,8 @@ class IERS_Auto(IERS_A):
           In other words the IERS-A table was created by IERS long enough
           ago that it can be considered stale for predictions.
         """
-        max_input_mjd = np.max(mjd)
+        # Pass in initial to np.max to allow things to work for empty mjd.
+        max_input_mjd = np.max(mjd, initial=50000)
         now_mjd = self.time_now.mjd
 
         # IERS-A table contains predictive data out for a year after

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -383,6 +383,23 @@ class TestIERS_Auto:
             assert dat["MJD"][-1] == (57539.0 + 60) * u.d
 
 
+@pytest.mark.parametrize("query", ["ut1_utc", "pm_xy"])
+@pytest.mark.parametrize("jd", [np.array([]), Time([], format="mjd")])
+@pytest.mark.parametrize("return_status", [False, True])
+def test_empty_mjd(query, jd, return_status):
+    # Regression test for gh-17008
+    with iers.conf.set_temp("auto_download", False):
+        iers_table = iers.IERS_Auto.open()
+        result = getattr(iers_table, query)(jd, return_status=return_status)
+        n_exp = (1 if query == "ut1_utc" else 2) + (1 if return_status else 0)
+        if n_exp == 1:
+            assert isinstance(result, np.ndarray)
+            assert result.size == 0
+        else:
+            assert len(result) == n_exp
+            assert all(r.size == 0 for r in result)
+
+
 @pytest.mark.remote_data
 def test_IERS_B_parameters_loading_into_IERS_Auto():
     A = iers.IERS_Auto.open()

--- a/docs/changes/coordinates/17013.bugfix.rst
+++ b/docs/changes/coordinates/17013.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that coordinates can be transformed to other coordinate frames
+also if they have size zero (i.e., hold empty data arrays).

--- a/docs/changes/utils/17013.bugfix.rst
+++ b/docs/changes/utils/17013.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that queries of ``.ut1_utc()`` and ``.pm_xy()`` return the correct
+results also when passing in an empty array of times.


### PR DESCRIPTION
Backport of #17013