### PR TITLE
Improve some docstrings in `units`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -646,11 +646,9 @@ class UnitBase:
         return unit_format.Latex.to_string(self)
 
     def __bytes__(self) -> bytes:
-        """Return string representation for unit."""
         return unit_format.Generic.to_string(self).encode("unicode_escape")
 
     def __str__(self) -> str:
-        """Return string representation for unit."""
         return unit_format.Generic.to_string(self)
 
     def __repr__(self) -> str:
@@ -767,7 +765,6 @@ class UnitBase:
         return f.to_string(self, **kwargs)
 
     def __format__(self, format_spec: str) -> str:
-        """Try to format units using a formatter."""
         try:
             return self.to_string(format=format_spec)
         except ValueError:
@@ -2457,9 +2454,6 @@ class CompositeUnit(UnitBase):
         self._scale = sanitize_scale_value(scale)
 
     def __copy__(self) -> CompositeUnit:
-        """
-        For compatibility with python copy module.
-        """
         return CompositeUnit(self._scale, self._bases[:], self._powers[:])
 
     def decompose(self, bases=set()):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -669,50 +669,38 @@ class UnitBase:
 
     @property
     def names(self) -> list[str]:
-        """
-        Returns all of the names associated with this unit.
-        """
+        """All the names associated with the unit."""
         raise AttributeError(
             "Can not get names from unnamed units. Perhaps you meant to_string()?"
         )
 
     @property
     def name(self) -> str:
-        """
-        Returns the canonical (short) name associated with this unit.
-        """
+        """The canonical (short) name associated with the unit."""
         raise AttributeError(
             "Can not get names from unnamed units. Perhaps you meant to_string()?"
         )
 
     @property
     def aliases(self) -> list[str]:
-        """
-        Returns the alias (long) names for this unit.
-        """
+        """The aliases (long) names for the unit."""
         raise AttributeError(
             "Can not get aliases from unnamed units. Perhaps you meant to_string()?"
         )
 
     @property
     def scale(self) -> UnitScale:
-        """
-        Return the scale of the unit.
-        """
+        """The scale of the unit."""
         return 1.0
 
     @property
     def bases(self) -> list[UnitBase]:
-        """
-        Return the bases of the unit.
-        """
+        """The bases of the unit."""
         return [self]
 
     @property
     def powers(self) -> list[UnitPower]:
-        """
-        Return the powers of the unit.
-        """
+        """The powers of the bases of the unit."""
         return [1]
 
     def to_string(
@@ -724,9 +712,9 @@ class UnitBase:
 
         Parameters
         ----------
-        format : `astropy.units.format.Base` subclass or str
+        format : `astropy.units.format.Base` subclass or str or None
             The name of a format or a formatter class.  If not
-            provided, defaults to the generic format.
+            provided (or `None`), defaults to the generic format.
 
         **kwargs
             Further options forwarded to the formatter. Currently
@@ -963,8 +951,7 @@ class UnitBase:
         return self * -1.0
 
     def is_equivalent(self, other, equivalencies=[]):
-        """
-        Returns `True` if this unit is equivalent to ``other``.
+        """Check whether this unit is equivalent to ``other``.
 
         Parameters
         ----------
@@ -1736,9 +1723,7 @@ class UnitBase:
         return self.EquivalentUnitsList(results)
 
     def is_unity(self) -> bool:
-        """
-        Returns `True` if the unit is unscaled and dimensionless.
-        """
+        """Check whether the unit is unscaled and dimensionless."""
         return False
 
 
@@ -1856,37 +1841,27 @@ class NamedUnit(UnitBase):
 
     @property
     def names(self) -> list[str]:
-        """
-        Returns all of the names associated with this unit.
-        """
+        """All the names associated with the unit."""
         return self._names
 
     @property
     def name(self) -> str:
-        """
-        Returns the canonical (short) name associated with this unit.
-        """
+        """The canonical (short) name associated with the unit."""
         return self._names[0]
 
     @property
     def aliases(self) -> list[str]:
-        """
-        Returns the alias (long) names for this unit.
-        """
+        """The aliases (long) names for the unit."""
         return self._names[1:]
 
     @property
     def short_names(self) -> list[str]:
-        """
-        Returns all of the short names associated with this unit.
-        """
+        """All the short names associated with the unit."""
         return self._short_names
 
     @property
     def long_names(self) -> list[str]:
-        """
-        Returns all of the long names associated with this unit.
-        """
+        """All the long names associated with the unit."""
         return self._long_names
 
     def _inject(self, namespace=None):
@@ -2393,23 +2368,17 @@ class CompositeUnit(UnitBase):
 
     @property
     def scale(self) -> UnitScale:
-        """
-        Return the scale of the composite unit.
-        """
+        """The scale of the composite unit."""
         return self._scale
 
     @property
     def bases(self) -> list[UnitBase]:
-        """
-        Return the bases of the composite unit.
-        """
+        """The bases of the composite unit."""
         return self._bases
 
     @property
     def powers(self) -> list[UnitPower]:
-        """
-        Return the powers of the composite unit.
-        """
+        """The powers of the bases of the composite unit."""
         return self._powers
 
     def _expand_and_gather(self, decompose=False, bases=set()):
@@ -2590,8 +2559,11 @@ def def_unit(
     exclude_prefixes=[],
     namespace=None,
 ):
-    """
-    Factory function for defining new units.
+    """Define a new unit.
+
+    This function differs from creating units directly with `Unit` or
+    `IrreducibleUnit` because it can also automatically generate prefixed
+    units in the given namespace.
 
     Parameters
     ----------

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -118,9 +118,6 @@ class QuantityIterator:
         self._dataiter[index] = self._quantity._to_own_unit(value)
 
     def __next__(self):
-        """
-        Return the next value, or raise StopIteration.
-        """
         out = next(self._dataiter)
         # ndarray.flat._dataiter returns scalars, so need a view as a Quantity.
         return self._quantity._new_view(out)
@@ -1200,7 +1197,6 @@ class Quantity(np.ndarray):
 
     # Arithmetic operations
     def __mul__(self, other):
-        """Multiplication between `Quantity` objects and other objects."""
         if isinstance(other, (UnitBase, str)):
             try:
                 return self._new_view(
@@ -1212,7 +1208,6 @@ class Quantity(np.ndarray):
         return super().__mul__(other)
 
     def __imul__(self, other):
-        """In-place multiplication between `Quantity` objects and others."""
         if isinstance(other, (UnitBase, str)):
             self._set_unit(other * self.unit)
             return self
@@ -1220,13 +1215,9 @@ class Quantity(np.ndarray):
         return super().__imul__(other)
 
     def __rmul__(self, other):
-        """
-        Right Multiplication between `Quantity` objects and other objects.
-        """
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        """Division between `Quantity` objects and other objects."""
         if isinstance(other, (UnitBase, str)):
             try:
                 return self._new_view(
@@ -1238,7 +1229,6 @@ class Quantity(np.ndarray):
         return super().__truediv__(other)
 
     def __itruediv__(self, other):
-        """Inplace division between `Quantity` objects and other objects."""
         if isinstance(other, (UnitBase, str)):
             self._set_unit(self.unit / other)
             return self
@@ -1246,7 +1236,6 @@ class Quantity(np.ndarray):
         return super().__itruediv__(other)
 
     def __rtruediv__(self, other):
-        """Right Division between `Quantity` objects and other objects."""
         if isinstance(other, (UnitBase, str)):
             return self._new_view(
                 1.0 / self.value, other / self.unit, propagate_info=False
@@ -1358,7 +1347,6 @@ class Quantity(np.ndarray):
             )
 
     def __round__(self, ndigits=0):
-        """Called by built-in function round()"""
         return self.round(decimals=ndigits)
 
     def __index__(self):


### PR DESCRIPTION
### Description

The first commit removes trivial dunder method docstrings from two files in `units`. These methods are not meant to be called directly by users and what they do is defined well enough in the [Python data model](https://docs.python.org/3/reference/datamodel.html#special-method-names), so these docstrings were needless clutter. There are still a few dunder methods with non-trivial docstrings that I left alone, although perhaps those docstrings should be rewritten as comments.

The second commit changes the docstrings of some properties in `astropy/units/core.py`. Although a property is implemented as a method, it is accessed as an attribute, so the user-facing docstring should be written accordingly. It also makes a few additional small changes to some of the method docstrings in `astropy/units/core.py`. Most of those changes improve compliance with [PEP 257 - Docstring Conventions](https://peps.python.org/pep-0257/) (in particular that a function docstring should start with a verb in the imperative mood), but the updates to the `UnitBase.to_string()` docstring improve the description of the behavior of the method.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.