### PR TITLE
TST: Fine tune PR label driven events

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   benchmark:
-    if: github.repository == 'astropy/astropy' && contains(github.event.pull_request.labels.*.name, 'benchmark')
+    if: (github.repository == 'astropy/astropy' && ((github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'benchmark')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'benchmark')))
     name: "Compare asv with astropy main"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'Extra CI')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Extra CI')))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'Extra CI')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Extra CI')))
     env:
       ARCH_ON_CI: "normal"
     strategy:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Python 3.12
     # keep condition in sync with test_arm64
-    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'Extra CI')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Extra CI')))
     env:
       ARCH_ON_CI: ${{ matrix.arch }}
 
@@ -180,7 +180,9 @@ jobs:
     runs-on: linux-arm64
     name: Python 3.12 (arm64)
     # keep condition in sync with test_more_architectures
-    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'Extra CI')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Extra CI')))
+    env:
+      ARCH_ON_CI: "arm64"
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
@@ -191,6 +193,5 @@ jobs:
           python-version: '3.12'
       - name: Set up dependencies
         run: pip install tox
-
       - name: Run tests
         run: tox -e py312-test -- -n=2

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -110,3 +110,17 @@ jobs:
         - name: (Allowed Failure) Python 3.12 with remote data and dev version of key dependencies
           linux: py312-test-devdeps
           posargs: --remote-data=any --verbose
+
+  test_wheel_building:
+    needs: [initial_checks]
+    # This ensures that a couple of wheel targets work fine in pull requests and pushes
+    permissions:
+      contents: none
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
+    with:
+      upload_to_pypi: false
+      upload_to_anaconda: false
+      test_extras: test
+      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --pyargs astropy
+      targets: |
+        - cp311-manylinux_x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,6 @@ on:
     # We also want this workflow triggered if the 'Build all wheels' label is added
     # or present when PR is updated
     types:
-      - opened
-      - reopened
       - synchronize
       - labeled
 
@@ -23,21 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  test_wheel_building:
-    # This ensures that a couple of targets work fine in pull requests and pushes
-    permissions:
-      contents: none
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
-    if: (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'labeled'))
-    with:
-      upload_to_pypi: false
-      upload_to_anaconda: false
-      test_extras: test
-      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --pyargs astropy
-      targets: |
-        - cp311-manylinux_x86_64
-
   build_and_publish:
     # This does the actual wheel building and publishing as part of the cron job
     # or if triggered manually via the workflow dispatch, or for a tag.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
     # We also want this workflow triggered if the 'Build all wheels' label is added
     # or present when PR is updated
     types:
+      - opened
+      - reopened
       - synchronize
       - labeled
 
@@ -27,7 +29,7 @@ jobs:
     permissions:
       contents: none
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
-    if: (github.event_name == 'push' || github.event_name == 'pull_request')
+    if: (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'labeled'))
     with:
       upload_to_pypi: false
       upload_to_anaconda: false
@@ -42,7 +44,7 @@ jobs:
     permissions:
       contents: none
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
-    if: (github.repository == 'astropy/astropy' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
+    if: (github.repository == 'astropy/astropy' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'Build all wheels')) || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'Build all wheels')))
     with:
 
       # We upload to PyPI for all tags starting with v but not ones ending in .dev


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fine-tune event handling for workflows listening to PR `'labeled'` events so that a workflow only runs when its label is applied (not other labels) and when non-`'labeled'` events come in, it only runs when its label exists. Hopefully.

Feel free to apply and un-apply labels to test this. Or let me know how you want me to test this otherwise.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17111

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
