### PR TITLE
Convert int input to float32 if necessary

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -349,10 +349,14 @@ class SigmaClip:
         if masked:
             result = np.ma.array(data, mask=mask, copy=copy)
         else:
-            if copy:
-                result = data.astype(float, copy=True)
+            if data.dtype.kind != "f":
+                # float array type is needed to insert nans into the array
+                result = data.astype(np.float32)  # also makes a copy
             else:
-                result = data
+                if copy:
+                    result = data.copy()
+                else:
+                    result = data
             result[mask] = np.nan
 
         if unit is not None:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -609,11 +609,12 @@ class SigmaClip:
             If ``masked=False`` and ``axis`` is specified, then the
             output `~numpy.ndarray` will have the same shape as the
             input ``data`` and contain ``np.nan`` where values were
-            clipped. If the input ``data`` was a masked array, then the
-            output `~numpy.ndarray` will also contain ``np.nan`` where
-            the input mask was `True`. If ``return_bounds=True`` then
-            the returned minimum and maximum clipping thresholds will be
-            be `~numpy.ndarray`\\s.
+            clipped. In this case, integer-type ``data`` arrays will
+            be converted to `~numpy.float32`. If the input ``data``
+            was a masked array, then the output `~numpy.ndarray` will
+            also contain ``np.nan`` where the input mask was `True`. If
+            ``return_bounds=True`` then the returned minimum and maximum
+            clipping thresholds will be be `~numpy.ndarray`\\s.
         """
         data = np.asanyarray(data)
 
@@ -803,13 +804,15 @@ def sigma_clip(
         have been removed. If ``return_bounds=True`` then the returned
         minimum and maximum thresholds are scalars.
 
-        If ``masked=False`` and ``axis`` is specified, then the output
-        `~numpy.ndarray` will have the same shape as the input ``data``
-        and contain ``np.nan`` where values were clipped. If the input
-        ``data`` was a masked array, then the output `~numpy.ndarray`
-        will also contain ``np.nan`` where the input mask was `True`.
-        If ``return_bounds=True`` then the returned minimum and maximum
-        clipping thresholds will be `~numpy.ndarray`\\s.
+        If ``masked=False`` and ``axis`` is specified, then the
+        output `~numpy.ndarray` will have the same shape as the input
+        ``data`` and contain ``np.nan`` where values were clipped. In
+        this case, integer-type ``data`` arrays will be converted to
+        `~numpy.float32`. If the input ``data`` was a masked array,
+        then the output `~numpy.ndarray` will also contain ``np.nan``
+        where the input mask was `True`. If ``return_bounds=True`` then
+        the returned minimum and maximum clipping thresholds will be
+        `~numpy.ndarray`\\s.
 
     See Also
     --------

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -515,6 +515,11 @@ def test_sigma_clip_dtypes(dtype):
     arr2 = sigma_clip(arr, cenfunc=np.mean, axis=0, masked=False)
     assert arr2.dtype == arr.dtype
 
+    # Check that int dtype is converted to float32, not float
+    arr = np.ones((10, 10), dtype=int)
+    arr2 = sigma_clip(arr, axis=0, masked=False)
+    assert arr2.dtype == np.float32
+
 
 def test_mad_std():
     # Check with a small array where we know how the result should differ from std

--- a/docs/changes/stats/17116.api.rst
+++ b/docs/changes/stats/17116.api.rst
@@ -1,0 +1,2 @@
+Integer inputs to ``sigma_clip`` and ``SigmaClip`` are not converted to
+``np.float32`` instead of ``float`` if necessary.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR is a followup to https://github.com/astropy/astropy/pull/17086. That PR was a bugfix, but this PR is an API change where integer dtype arrays are converted to np.float32 instead of float to reduce the memory requirements.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
