### PR TITLE
Emit warning when decoding bad ascii character

### DIFF
--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2899,7 +2899,9 @@ class TableElement(
                                         buf = io.BytesIO(rawdata)
                                         buf.seek(0)
                                         try:
-                                            value, mask_value = binparsers[i](buf.read)
+                                            value, mask_value = binparsers[i](
+                                                buf.read, config=config
+                                            )
                                         except Exception as e:
                                             vo_reraise(
                                                 e,
@@ -3075,7 +3077,7 @@ class TableElement(
 
                 for i, binparse in enumerate(binparsers):
                     try:
-                        value, value_mask = binparse(careful_read)
+                        value, value_mask = binparse(careful_read, config)
                     except EOFError:
                         raise
                     except Exception as e:

--- a/docs/changes/io.votable/17119.api.rst
+++ b/docs/changes/io.votable/17119.api.rst
@@ -1,0 +1,3 @@
+Trying to decode bad ascii values when parsing VOTable data in binary was not possible.
+Now it will emit a W55 warning, which also means that it's possible to ignore that warning and
+still get a VOTable as result.


### PR DESCRIPTION
The idea is to ignore such warnings when parsing VOTable data in pyvo. Some background:

Some non standard characters have entered the VORegistry. For example, running the following script:
```python
from pyvo import registry
registry.search(waveband="infrared", servicetype="ssap")[15]['res_description']
```
there's the code point \x81 which isn't displayed properly (in the description for the 'HST STIS Spectra' row). I think that comes from typing the letter for Angstrom on a Mac computer (I can't even type that letter here in my terminal) (see https://www.barcodefaq.com/knowledge-base/mac-extended-ascii-character-chart/). That letter has code point 129, which is 81 in hexadecimal.

The GAVO Registry encodes their strings as Unicode Characters, which means that the Angstrom letter will be displayed as "\x81". If you try querying the Euro-VO Registry instead (start python with: IVOA_REGISTRY=https://registry.euro-vo.org/regtap/tap/ python and run the same script as above) and astropy won't be able to parse that same description for the STIS spectra. Euro-VO provides the same data as GAVO, but encoded as Characters instead of Unicode Characters.

Using the proposed solution in this PR, astropy won't throw an exception when encountering bad ascii characters (if ignoring such errors), but will instead let them pass through. It won't be pretty though, the Angstrom unit for example will be displayed as "\ucd81".

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
