### PR TITLE
ENH: add support for NEP 35 array constructors (`empty`, `ones`, `zeros` and `full`) with `like=Quantity(...)`)

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -30,6 +30,7 @@ from .quantity_helper.function_helpers import (
     DISPATCHED_FUNCTIONS,
     FUNCTION_HELPERS,
     SUBCLASS_SAFE_FUNCTIONS,
+    UNIT_FROM_LIKE_ARG,
     UNSUPPORTED_FUNCTIONS,
 )
 from .structured import StructuredUnit, _structured_unit_like_dtype
@@ -1932,6 +1933,12 @@ class Quantity(np.ndarray):
                 AstropyWarning,
             )
             return super().__array_function__(function, types, args, kwargs)
+
+        if unit is UNIT_FROM_LIKE_ARG:
+            # fallback mechanism for NEP 35 functions that dispatch on the 'like'
+            # argument (i.e. self, in this context), in cases where no other
+            # argument provides a unit
+            unit = self.unit
 
         # If unit is None, a plain array is expected (e.g., boolean), which
         # means we're done.

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -94,6 +94,12 @@ For most, masked input simply makes no sense, but for others it may have
 been lack of time.  Issues or PRs for support for functions are welcome.
 """
 
+
+SUPPORTED_NEP35_FUNCTIONS = set()
+"""Set of supported numpy functions with a 'like' keyword argument that dispatch
+on it (NEP 35).
+"""
+
 # Almost all from np.core.fromnumeric defer to methods so are OK.
 MASKED_SAFE_FUNCTIONS |= {
     getattr(np, name)

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -35,6 +35,7 @@ from astropy.utils.masked.function_helpers import (
     DISPATCHED_FUNCTIONS,
     IGNORED_FUNCTIONS,
     MASKED_SAFE_FUNCTIONS,
+    SUPPORTED_NEP35_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
 
@@ -1754,7 +1755,10 @@ untested_functions |= poly_functions
 
 def test_basic_testing_completeness():
     assert all_wrapped_functions == (
-        tested_functions | IGNORED_FUNCTIONS | UNSUPPORTED_FUNCTIONS
+        tested_functions
+        | IGNORED_FUNCTIONS
+        | UNSUPPORTED_FUNCTIONS
+        | SUPPORTED_NEP35_FUNCTIONS
     )
 
 

--- a/docs/changes/units/17120.feature.rst
+++ b/docs/changes/units/17120.feature.rst
@@ -1,0 +1,2 @@
+Added support for calling numpy array constructors (``np.empty``, ``np.ones``,
+``np.zeros`` and ``np.full``) with ``like=Quantity(...)`` .

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -119,30 +119,37 @@ pandas if they decide to override the dunder methods.
 
 See: https://github.com/astropy/astropy/issues/11247
 
-Numpy array creation functions cannot be used to initialize Quantity
---------------------------------------------------------------------
+Using Numpy array creation functions to initialize Quantity
+------------------------------------------------------------
 Trying the following example will ignore the unit:
 
     >>> np.full(10, 1 * u.m)
     array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])
 
-A workaround for this at the moment would be to do::
+However, the following works as one would expect
+
+    >>> np.full(10, 1.0, like=u.Quantity([], u.m))
+    <Quantity [1., 1., 1., 1., 1., 1., 1., 1., 1., 1.] m>
+
+and is equivalent to::
 
     >>> np.full(10, 1) << u.m
     <Quantity [1., 1., 1., 1., 1., 1., 1., 1., 1., 1.] m>
 
-As well as with `~numpy.full` one cannot do `~numpy.zeros`, `~numpy.ones`, and `~numpy.empty`.
+`~numpy.zeros`, `~numpy.ones`, and `~numpy.empty` behave similarly.
 
-Beware that `~numpy.arange` works, but requires an additional ``like`` argument
+`~numpy.arange` also supports the ``like`` keyword argument
 
     >>> np.arange(0 * u.cm, 1 * u.cm, 1 * u.mm, like=u.Quantity([], u.cm))
     <Quantity [0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9] cm>
 
 Also note that the unit of the output array is dictated by that of the ``stop``
 argument, and that, like for quantities generally, the data has a floating-point
-dtype.
+dtype. If ``stop`` is a pure number, the unit of the output will default to that
+of the ``like`` argument.
 
-Alternatively, one may move the units outside of the call to `~numpy.arange`::
+As with ``~numpy.full`` and similar functions, one may alternatively move the
+units outside of the call to `~numpy.arange`::
 
     >>> np.arange(0, 10, 1) << u.mm
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.] mm>


### PR DESCRIPTION
### Description
Follow up to #17059, fixes #17001
Note that this is not a complete implementation of NEP 35 functions, but it does cover everything that was listed on #17001. I plan to open another issue to track what's left to do.
While working on these functions, I found that the mechanism suggested by @mhvk in #17059 for defaulting the output unit to that of the `like` argument made most sense for functions that don't take other arguments for which a quantity is meaningful, so I implemented it here and retro-fitted it in my implementation for `np.arange` too, with the particularity that I'm passing it under a different, private name (`_like`) to better signal that this argument is internal and not passed down by numpy itself.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
