### PR TITLE
Deprecate `UnitBase.in_units()`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1210,6 +1210,7 @@ class UnitBase:
         else:
             return self.get_converter(Unit(other), equivalencies)(value)
 
+    @deprecated(since="7.0", alternative="to()")
     def in_units(self, other, value=1.0, equivalencies=[]):
         """
         Alias for `to` for backward compatibility with pynbody.

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -256,9 +256,9 @@ def test_register():
     assert "foo" not in u.get_current_unit_registry().registry
 
 
-def test_in_units():
-    speed_unit = u.cm / u.s
-    _ = speed_unit.in_units(u.pc / u.hour, 1)
+def test_in_units_deprecation():
+    with pytest.warns(AstropyDeprecationWarning, match=r"Use to\(\) instead\.$"):
+        assert (u.m / u.s).in_units(u.cm / u.s) == 100
 
 
 def test_null_unit():

--- a/docs/changes/units/17121.api.rst
+++ b/docs/changes/units/17121.api.rst
@@ -1,0 +1,2 @@
+The ``UnitBase.in_units()`` method is deprecated.
+The ``to()`` method can be used as a drop-in replacement.


### PR DESCRIPTION
### Description

The method is an alias for `to()`, so `to()` can be used as a drop-in replacement.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
