### PR TITLE
API: ensure that to_system uses the simplest unit

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -420,6 +420,7 @@ def test_compose_cgs_to_si(unit):
     si = unit.to_system(u.si)
     assert [x.is_equivalent(unit) for x in si]
     assert si[0] == unit.si
+    assert np.isclose(si[0].scale, unit.decompose(bases=u.si.bases).scale)
 
 
 # We use a set to make sure we don't have any duplicates.
@@ -447,6 +448,7 @@ def test_compose_si_to_cgs(unit):
     else:
         assert [x.is_equivalent(unit) for x in cgs]
         assert cgs[0] == unit.cgs
+        assert np.isclose(cgs[0].scale, unit.decompose(bases=u.cgs.bases).scale)
 
 
 def test_to_si():
@@ -464,8 +466,22 @@ def test_to_si():
 
 
 def test_to_cgs():
-    assert u.Pa.to_system(u.cgs)[1]._bases[0] is u.Ba
-    assert u.Pa.to_system(u.cgs)[1]._scale == 10.0
+    assert u.Pa.to_system(u.cgs)[0].bases[0] is u.Ba
+    assert u.Pa.to_system(u.cgs)[0].scale == 10.0
+
+
+@pytest.mark.parametrize(
+    "unit, system, expected_bases",
+    [
+        (u.Pa, "si", [u.Pa]),
+        (u.sr, "si", [u.rad]),
+        (u.Gal, "si", [u.m, u.s]),
+        (u.Gal, "cgs", [u.cm, u.s]),
+    ],
+)
+def test_to_system_best_unit(unit, system, expected_bases):
+    in_system = getattr(unit, system)
+    assert in_system.bases == expected_bases
 
 
 def test_decompose_to_cgs():

--- a/docs/changes/units/17122.api.rst
+++ b/docs/changes/units/17122.api.rst
@@ -1,0 +1,7 @@
+Unit conversions to a given system with ``unit.to_system()``,
+``unit.si``, and ``unit.cgs``, will now prefer the simplest unit if it
+is in the given system, rather than prioritizing more complicated
+units if those had a base unit component.  E.g., ``u.Pa.si`` will now
+simply return ``Unit("Pa")`` rather than ``Unit("N / m2")``.  However,
+the case where a unit can be simply described in base units remains
+unchanged: ``u.Gal.cgs`` will still give ``Unit("cm / s2")``.

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -123,22 +123,26 @@ Examples
 To convert between unit systems::
 
    >>> u.Pa.to_system(u.cgs)
-   [Unit("10 P / s"), Unit("10 Ba")]
+   [Unit("10 Ba"), Unit("10 P / s")]
 
 There is also a shorthand for this which only returns the first of
 many possible matches::
 
    >>> u.Pa.cgs
-   Unit("10 P / s")
+   Unit("10 Ba")
 
 This is equivalent to decomposing into the new system and then
-composing into the most complex units possible, though
+composing into the simplest units possible in that system, though
 :meth:`~astropy.units.core.UnitBase.to_system` adds some extra logic to
-return the results sorted in the most useful order::
+return the results sorted such that if a simple combination of base
+units exists, it will be put sorted to the front::
 
-   >>> u.Pa.decompose(bases=u.cgs.bases)
-   Unit("10 g / (cm s2)")
+   >>> unit = u.m**2 / u.s
+   >>> unit.decompose(bases=u.cgs.bases)
+   Unit("10000 cm2 / s")
    >>> _.compose(units=u.cgs)
-   [Unit("10 Ba"), Unit("10 P / s")]
+   [Unit("10000 St"), Unit("10000 cm2 / s")]
+   >>> unit.to_system(u.cgs)
+   [Unit("10000 cm2 / s"), Unit("10000 St")]
 
 .. EXAMPLE END

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -114,7 +114,7 @@ And it can convert between unit systems, such as `SI
 <https://en.wikipedia.org/wiki/Centimetre-gram-second_system_of_units>`_::
 
     >>> (1.0 * u.Pa).cgs
-    <Quantity 10. P / s>
+    <Quantity 10. Ba>
 
 The units ``mag``, ``dex``, and ``dB`` are special, being :ref:`logarithmic
 units <logarithmic_units>`, for which a value is the logarithm of a physical


### PR DESCRIPTION
Currently, if one gets the `.si` equivalent of a unit that is already in the SI system, one somewhat surprising does not get the unit back:
```
u.Pa.si
# Unit("N / m2")
u.N.si
# Unit("J / m")
u.J.si
# Unit("s W")
Unit("J / s")
```
One gets the same unit back only when the input is a base unit.

This does not seem to make much sense, and is related to scoring possible composite units by the number of bases units divided by the total number of units, presumably as a measure of the unit's simplicity.

It would seem to make more sense to weight rather by the number of units that are *not* bases, and pick the one with the minimum number of those. This PR does that: unit conversions to a given system with ``unit.to_system()`` will now prefer the simplest unit if it is in the given system, rather than prioritizing more complicated units if those had a base unit component.  E.g., ``u.Pa.si`` will now simply return ``Unit("Pa")`` rather than ``Unit("N / m2")``.  However, the case where a unit can be simply described in base units remains unchanged: ``u.Gal.cgs`` will still give ``Unit("cm / s2")``.

Labeling this an API change, since I guess it is. Though the behaviour was weird enough that bugfix might have been reasonable...

@eerovaher -- does this help https://github.com/astropy/astropy/issues/10585 and close https://github.com/astropy/astropy/issues/11532? EDITED: @mhvk - not quite, sadly, though it goes in the right direction.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
