### PR TITLE
Update model references in docstrings

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -195,8 +195,8 @@ class _ModelMeta(abc.ABCMeta):
         """
         The name of this model class--equivalent to ``cls.__name__``.
 
-        This attribute is provided for symmetry with the `Model.name` attribute
-        of model instances.
+        This attribute is provided for symmetry with the
+        `~astropy.modeling.Model.name` attribute of model instances.
         """
         return cls.__name__
 
@@ -1431,9 +1431,9 @@ class Model(metaclass=_ModelMeta):
     def inverse(self, value):
         if not isinstance(value, (Model, type(None))):
             raise ValueError(
-                "The ``inverse`` attribute may be assigned a `Model` "
-                "instance or `None` (where `None` explicitly forces the "
-                "model to have no inverse."
+                "The inverse attribute may be assigned a Model instance "
+                "or None (where None explicitly forces the model to have "
+                "no inverse."
             )
 
         self._user_inverse = value
@@ -1819,8 +1819,8 @@ class Model(metaclass=_ModelMeta):
         Evaluate a model at fixed positions, respecting the ``bounding_box``.
 
         The key difference relative to evaluating the model directly is that
-        this method is limited to a bounding box if the `Model.bounding_box`
-        attribute is set.
+        this method is limited to a bounding box if the
+        `~astropy.modeling.Model.bounding_box` attribute is set.
 
         Parameters
         ----------
@@ -1833,23 +1833,26 @@ class Model(metaclass=_ModelMeta):
             ``self(coords)`` yields the same shape as ``out``.  If ``out`` is
             not specified, ``coords`` will be used to determine the shape of
             the returned array. If this is not provided (or None), the model
-            will be evaluated on a grid determined by `Model.bounding_box`.
+            will be evaluated on a grid determined by
+            `~astropy.modeling.Model.bounding_box`.
 
         Returns
         -------
         out : `numpy.ndarray`
-            The model added to ``out`` if  ``out`` is not ``None``, or else a
-            new array from evaluating the model over ``coords``.
-            If ``out`` and ``coords`` are both `None`, the returned array is
-            limited to the `Model.bounding_box` limits. If
-            `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be
-            passed.
+            The model added to ``out`` if ``out`` is not ``None``,
+            or else a new array from evaluating the model
+            over ``coords``. If ``out`` and ``coords`` are
+            both `None`, the returned array is limited to the
+            `~astropy.modeling.Model.bounding_box` limits. If
+            `~astropy.modeling.Model.bounding_box` is `None`, ``arr`` or
+            ``coords`` must be passed.
 
         Raises
         ------
         ValueError
-            If ``coords`` are not given and the `Model.bounding_box` of
-            this model is not set.
+            If ``coords`` are not given and the
+            `~astropy.modeling.Model.bounding_box` of this model is not
+            set.
 
         Examples
         --------
@@ -2366,11 +2369,11 @@ class Model(metaclass=_ModelMeta):
         input_units : dict or tuple, optional
             Input units to attach.  If dict, each key is the name of a model input,
             and the value is the unit to attach.  If tuple, the elements are units
-            to attach in order corresponding to `Model.inputs`.
+            to attach in order corresponding to `~astropy.modeling.Model.inputs`.
         return_units : dict or tuple, optional
             Output units to attach.  If dict, each key is the name of a model output,
             and the value is the unit to attach.  If tuple, the elements are units
-            to attach in order corresponding to `Model.outputs`.
+            to attach in order corresponding to `~astropy.modeling.Model.outputs`.
         input_units_equivalencies : dict, optional
             Default equivalencies to apply to input values.  If set, this should be a
             dictionary where each key is a string that corresponds to one of the
@@ -2512,8 +2515,9 @@ class Model(metaclass=_ModelMeta):
 
     def _initialize_constraints(self, kwargs):
         """
-        Pop parameter constraint values off the keyword arguments passed to
-        `Model.__init__` and store them in private instance attributes.
+        Pop parameter constraint values off the keyword arguments passed
+        to `~astropy.modeling.Model.__init__` and store them in private
+        instance attributes.
         """
         # Pop any constraints off the keyword arguments
         for constraint in self.parameter_constraints:
@@ -2969,10 +2973,10 @@ class FittableModel(Model):
     # derivative with respect to parameters
     fit_deriv = None
     """
-    Function (similar to the model's `~Model.evaluate`) to compute the
-    derivatives of the model with respect to its parameters, for use by fitting
-    algorithms.  In other words, this computes the Jacobian matrix with respect
-    to the model's parameters.
+    Function (similar to the model's `~astropy.modeling.Model.evaluate`)
+    to compute the derivatives of the model with respect to its
+    parameters, for use by fitting algorithms. In other words, this
+    computes the Jacobian matrix with respect to the model's parameters.
     """
     # Flag that indicates if the model derivatives with respect to parameters
     # are given in columns or rows
@@ -3914,9 +3918,9 @@ class CompoundModel(Model):
         """
         Evaluate a model at fixed positions, respecting the ``bounding_box``.
 
-        The key difference relative to evaluating the model directly is that
-        this method is limited to a bounding box if the `Model.bounding_box`
-        attribute is set.
+        The key difference relative to evaluating the model directly
+        is that this method is limited to a bounding box if the
+        `~astropy.modeling.Model.bounding_box` attribute is set.
 
         Parameters
         ----------
@@ -3929,7 +3933,8 @@ class CompoundModel(Model):
             ``self(coords)`` yields the same shape as ``out``.  If ``out`` is
             not specified, ``coords`` will be used to determine the shape of
             the returned array. If this is not provided (or None), the model
-            will be evaluated on a grid determined by `Model.bounding_box`.
+            will be evaluated on a grid determined by
+            `~astropy.modeling.Model.bounding_box`.
 
         Returns
         -------
@@ -3937,15 +3942,16 @@ class CompoundModel(Model):
             The model added to ``out`` if  ``out`` is not ``None``, or else a
             new array from evaluating the model over ``coords``.
             If ``out`` and ``coords`` are both `None`, the returned array is
-            limited to the `Model.bounding_box` limits. If
-            `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be
-            passed.
+            limited to the `~astropy.modeling.Model.bounding_box`
+            limits. If `~astropy.modeling.Model.bounding_box` is `None`,
+            ``arr`` or ``coords`` must be passed.
 
         Raises
         ------
         ValueError
-            If ``coords`` are not given and the `Model.bounding_box` of
-            this model is not set.
+            If ``coords`` are not given and the
+            `~astropy.modeling.Model.bounding_box` of this model is not
+            set.
 
         Examples
         --------
@@ -4556,12 +4562,13 @@ def _custom_model_wrapper(func, fit_deriv=None):
 
 def render_model(model, arr=None, coords=None):
     """
-    Evaluates a model on an input array. Evaluation is limited to
-    a bounding box if the `Model.bounding_box` attribute is set.
+    Evaluates a model on an input array. Evaluation is limited to a
+    bounding box if the `~astropy.modeling.Model.bounding_box` attribute
+    is set.
 
     Parameters
     ----------
-    model : `Model`
+    model : `~astropy.modeling.Model`
         Model to be evaluated.
     arr : `numpy.ndarray`, optional
         Array on which the model is evaluated.
@@ -4575,8 +4582,9 @@ def render_model(model, arr=None, coords=None):
         The model evaluated on the input ``arr`` or a new array from
         ``coords``.
         If ``arr`` and ``coords`` are both `None`, the returned array is
-        limited to the `Model.bounding_box` limits. If
-        `Model.bounding_box` is `None`, ``arr`` or ``coords`` must be passed.
+        limited to the `~astropy.modeling.Model.bounding_box` limits.
+        If `~astropy.modeling.Model.bounding_box` is `None`, ``arr`` or
+        ``coords`` must be passed.
 
     Examples
     --------

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -769,7 +769,7 @@ class Model(metaclass=_ModelMeta):
     def _initialize_setters(self, kwargs):
         """
         This exists to inject defaults for settable properties for models
-        originating from `custom_model`.
+        originating from `~astropy.modeling.custom_model`.
         """
         if hasattr(self, "_settable_properties"):
             setters = {
@@ -1488,7 +1488,8 @@ class Model(metaclass=_ModelMeta):
         >>> model_1d.bounding_box = (-5, 5)
         >>> model_2d.bounding_box = ((-6, 6), (-5, 5))
 
-        Setting the bounding_box limits for a user-defined 3D `custom_model`:
+        Setting the bounding_box limits for a user-defined 3D
+        `~astropy.modeling.custom_model`:
 
         >>> from astropy.modeling.models import custom_model
         >>> def const3d(x, y, z, amp=1):
@@ -2386,9 +2387,10 @@ class Model(metaclass=_ModelMeta):
 
         Returns
         -------
-        `CompoundModel`
-            A `CompoundModel` composed of the current model plus
-            `~astropy.modeling.mappings.UnitsMapping` model(s) that attach the units.
+        `~astropy.modeling.CompoundModel`
+            A `~astropy.modeling.CompoundModel` composed of the current
+            model plus `~astropy.modeling.mappings.UnitsMapping`
+            model(s) that attach the units.
 
         Raises
         ------
@@ -4452,8 +4454,8 @@ def custom_model(*args, fit_deriv=None):
 
 def _custom_model_inputs(func):
     """
-    Processes the inputs to the `custom_model`'s function into the appropriate
-    categories.
+    Processes the inputs to the `~astropy.modeling.custom_model`'s
+    function into the appropriate categories.
 
     Parameters
     ----------
@@ -4468,7 +4470,8 @@ def _custom_model_inputs(func):
     settable_params : dict
         dictionary of defaults for settable model properties
     params : dict
-        dictionary of model parameters set by `custom_model`'s function
+        dictionary of model parameters set by
+        `~astropyl.modeling.custom_model`'s function
     """
     inputs, parameters = get_inputs_and_params(func)
 
@@ -4504,13 +4507,15 @@ def _custom_model_inputs(func):
 
 def _custom_model_wrapper(func, fit_deriv=None):
     """
-    Internal implementation `custom_model`.
+    Internal implementation `~astropy.modeling.custom_model`.
 
-    When `custom_model` is called as a function its arguments are passed to
-    this function, and the result of this function is returned.
+    When `~astropy.modeling.custom_model` is called as a function its
+    arguments are passed to this function, and the result of this
+    function is returned.
 
-    When `custom_model` is used as a decorator a partial evaluation of this
-    function is returned by `custom_model`.
+    When `~astropy.modeling.custom_model` is used as a decorator
+    a partial evaluation of this function is returned by
+    `~astropy.modeling.custom_model`.
     """
     if not callable(func):
         raise ModelDefinitionError(


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR updates docstrings in the `modeling.core` module to prevent Sphinx build failures due to unresolved references in external packages that define models which use `astropy.modeling.Model` (via `Fittable2DModel`) as the base class.
This occurred in `photutils`, where I had to ignore these unresolved references to prevent Sphinx warnings, but the references have no links in the docs.  See https://photutils.readthedocs.io/en/latest/api/photutils.psf.MoffatPSF.html#photutils.psf.MoffatPSF as an example.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
