### PR TITLE
Update CompoundModel to support unit change with pipe operator

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1672,25 +1672,18 @@ class Model(metaclass=_ModelMeta):
         """
         model = self.copy()
 
-        inputs_unit = {
-            inp: getattr(kwargs[inp], "unit", dimensionless_unscaled)
-            for inp in self.inputs
-            if kwargs[inp] is not None
-        }
+        for i, comp in enumerate(model):
+            inputs_unit = comp.input_units
+            outputs_unit = comp.output_units
 
-        outputs_unit = {
-            out: getattr(kwargs[out], "unit", dimensionless_unscaled)
-            for out in self.outputs
-            if kwargs[out] is not None
-        }
-        parameter_units = self._parameter_units_for_data_units(
-            inputs_unit, outputs_unit
-        )
-        for name, unit in parameter_units.items():
-            parameter = getattr(model, name)
-            if parameter.unit is not None:
-                parameter.value = parameter.quantity.to(unit).value
-                parameter._set_unit(None, force=True)
+            parameter_units = comp._parameter_units_for_data_units(
+                inputs_unit, outputs_unit
+            )
+            for name, unit in parameter_units.items():
+                parameter = getattr(model, f"{name}_{i}")
+                if parameter.unit is not None:
+                    parameter.value = parameter.quantity.to(unit).value
+                    parameter._set_unit(None, force=True)
 
         if isinstance(model, CompoundModel):
             model.strip_units_from_tree()
@@ -1761,30 +1754,28 @@ class Model(metaclass=_ModelMeta):
         units for each parameter.
         """
         model = self.copy()
-        inputs_unit = {
-            inp: getattr(kwargs[inp], "unit", dimensionless_unscaled)
-            for inp in self.inputs
-            if kwargs[inp] is not None
-        }
+        for i, comp in enumerate(model):
+            inputs_unit = {
+                inp: kwargs[inp].unit if i == 0 else comp.input_units
+                for inp in comp.inputs
+            }
+            outputs_unit = {
+                out: kwargs[out].unit if kwargs[out] is None else comp.output_units[out]
+                for out in comp.outputs
+            }
 
-        outputs_unit = {
-            out: getattr(kwargs[out], "unit", dimensionless_unscaled)
-            for out in self.outputs
-            if kwargs[out] is not None
-        }
+            parameter_units = comp._parameter_units_for_data_units(
+                inputs_unit, outputs_unit
+            )
 
-        parameter_units = self._parameter_units_for_data_units(
-            inputs_unit, outputs_unit
-        )
+            # We are adding units to parameters that already have a value, but we
+            # don't want to convert the parameter, just add the unit directly,
+            # hence the call to ``_set_unit``.
+            for name, unit in parameter_units.items():
+                parameter = getattr(model, f"{name}_{i}")
+                parameter._set_unit(unit, force=True)
 
-        # We are adding units to parameters that already have a value, but we
-        # don't want to convert the parameter, just add the unit directly,
-        # hence the call to ``_set_unit``.
-        for name, unit in parameter_units.items():
-            parameter = getattr(model, name)
-            parameter._set_unit(unit, force=True)
-
-        return model
+            return model
 
     @property
     def _has_units(self):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -4091,7 +4091,7 @@ class CompoundModel(Model):
             raise ValueError(f"No submodels found named {name}")
 
     def without_units_for_data(self, **kwargs):
-        """
+        r"""
         See `~astropy.modeling.Model.without_units_for_data` for overview
         of this method.
 
@@ -4099,7 +4099,7 @@ class CompoundModel(Model):
         -----
         This modifies the behavior of the base method to account for the
         case where the sub-models of a compound model have different output
-        units. This is only valid for compound *, / and | compound models as
+        units. This is only valid for compound \*, / and | compound models as
         in that case it is reasonable to mix the output units. It does this
         by modifying the output units of each sub model by using the output
         units of the other sub model so that we can apply the original function

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3798,6 +3798,8 @@ class CompoundModel(Model):
             self._map_parameters()
         units_for_data = {}
         for imodel, model in enumerate(self._leaflist):
+            input_units = model.input_units or input_units
+            output_units = model.output_units or output_units
             units_for_data_leaf = model._parameter_units_for_data_units(
                 input_units, output_units
             )

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1672,18 +1672,49 @@ class Model(metaclass=_ModelMeta):
         """
         model = self.copy()
 
-        for i, comp in enumerate(model):
-            inputs_unit = comp.input_units
-            outputs_unit = comp.output_units
+        if not isinstance(model, CompoundModel):
+            inputs_unit = {
+                inp: getattr(kwargs[inp], "unit", dimensionless_unscaled)
+                for inp in self.inputs
+                if kwargs[inp] is not None
+            }
 
-            parameter_units = comp._parameter_units_for_data_units(
+            outputs_unit = {
+                out: getattr(kwargs[out], "unit", dimensionless_unscaled)
+                for out in self.outputs
+                if kwargs[out] is not None
+            }
+            parameter_units = self._parameter_units_for_data_units(
                 inputs_unit, outputs_unit
             )
             for name, unit in parameter_units.items():
-                parameter = getattr(model, f"{name}_{i}")
+                parameter = getattr(model, name)
                 if parameter.unit is not None:
                     parameter.value = parameter.quantity.to(unit).value
                     parameter._set_unit(None, force=True)
+        else:
+            for i, comp in enumerate(model):
+                inputs_unit = {
+                    inp: kwargs[inp].unit
+                    if comp.input_units is None
+                    else comp.input_units[inp]
+                    for inp in comp.inputs
+                }
+                outputs_unit = {
+                    out: kwargs[out].unit
+                    if comp.output_units is None
+                    else comp.output_units[out]
+                    for out in comp.outputs
+                }
+
+                parameter_units = comp._parameter_units_for_data_units(
+                    inputs_unit, outputs_unit
+                )
+                for name, unit in parameter_units.items():
+                    parameter = getattr(model, f"{name}_{i}")
+                    if parameter.unit is not None:
+                        parameter.value = parameter.quantity.to(unit).value
+                        parameter._set_unit(None, force=True)
 
         if isinstance(model, CompoundModel):
             model.strip_units_from_tree()
@@ -1754,17 +1785,20 @@ class Model(metaclass=_ModelMeta):
         units for each parameter.
         """
         model = self.copy()
-        for i, comp in enumerate(model):
+        if not isinstance(model, CompoundModel):
             inputs_unit = {
-                inp: kwargs[inp].unit if i == 0 else comp.input_units
-                for inp in comp.inputs
-            }
-            outputs_unit = {
-                out: kwargs[out].unit if kwargs[out] is None else comp.output_units[out]
-                for out in comp.outputs
+                inp: getattr(kwargs[inp], "unit", dimensionless_unscaled)
+                for inp in self.inputs
+                if kwargs[inp] is not None
             }
 
-            parameter_units = comp._parameter_units_for_data_units(
+            outputs_unit = {
+                out: getattr(kwargs[out], "unit", dimensionless_unscaled)
+                for out in self.outputs
+                if kwargs[out] is not None
+            }
+
+            parameter_units = model._parameter_units_for_data_units(
                 inputs_unit, outputs_unit
             )
 
@@ -1772,10 +1806,33 @@ class Model(metaclass=_ModelMeta):
             # don't want to convert the parameter, just add the unit directly,
             # hence the call to ``_set_unit``.
             for name, unit in parameter_units.items():
-                parameter = getattr(model, f"{name}_{i}")
+                parameter = getattr(model, name)
                 parameter._set_unit(unit, force=True)
+        else:
+            for i, comp in enumerate(model):
+                inputs_unit = {
+                    inp: kwargs[inp].unit if i == 0 else comp.input_units[inp]
+                    for inp in comp.inputs
+                }
+                outputs_unit = {
+                    out: kwargs[out].unit
+                    if kwargs[out] is None
+                    else comp.output_units[out]
+                    for out in comp.outputs
+                }
 
-            return model
+                parameter_units = comp._parameter_units_for_data_units(
+                    inputs_unit, outputs_unit
+                )
+
+                # We are adding units to parameters that already have a value, but we
+                # don't want to convert the parameter, just add the unit directly,
+                # hence the call to ``_set_unit``.
+                for name, unit in parameter_units.items():
+                    parameter = getattr(model, f"{name}_{i}")
+                    parameter._set_unit(unit, force=True)
+
+        return model
 
     @property
     def _has_units(self):

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1651,3 +1651,16 @@ def test_reset_parameters_compound():
         ),
     ):
         c._reset_parameters(amplitude_0=np.ones((2, 3, 4)), stddev_0=np.ones((8,)))
+
+
+def test_without_units_for_data_compound():
+    phys = models.Linear1D(slope=-4 * u.ph / u.keV, intercept=100 * u.ph)
+    phys.output_units = {"y": u.ph}
+    response = models.Linear1D(slope=1 * u.ct / u.ph, intercept=0 * u.ct)
+    response.output_units = {"y": u.ct}
+    comb = phys | response
+    comb_without_units = comb.without_units_for_data()
+    comb_with_units = comb.with_units_from_data(x=1 * u.keV, y=1 * u.ct)
+    for name in comb.param_names:
+        assert getattr(comb, name).value == getattr(comb_with_units, name).value
+        assert getattr(comb, name).unit == getattr(comb_with_units, name).unit

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -1651,16 +1651,3 @@ def test_reset_parameters_compound():
         ),
     ):
         c._reset_parameters(amplitude_0=np.ones((2, 3, 4)), stddev_0=np.ones((8,)))
-
-
-def test_without_units_for_data_compound():
-    phys = models.Linear1D(slope=-4 * u.ph / u.keV, intercept=100 * u.ph)
-    phys.output_units = {"y": u.ph}
-    response = models.Linear1D(slope=1 * u.ct / u.ph, intercept=0 * u.ct)
-    response.output_units = {"y": u.ct}
-    comb = phys | response
-    comb_without_units = comb.without_units_for_data()
-    comb_with_units = comb.with_units_from_data(x=1 * u.keV, y=1 * u.ct)
-    for name in comb.param_names:
-        assert getattr(comb, name).value == getattr(comb_with_units, name).value
-        assert getattr(comb, name).unit == getattr(comb_with_units, name).unit

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -279,3 +279,17 @@ def test_fitting_custom_names(model, fitter):
         assert_quantity_allclose(
             getattr(new_model, param_name).quantity, getattr(model, param_name).quantity
         )
+
+
+@pytest.mark.filterwarnings(r"ignore:Model is linear in parameters*")
+def test_fitting_model_pipe_with_units():
+    e = np.linspace(0, 25, 100) * u.keV
+    phys = models.Linear1D(slope=-4 * u.ph / u.keV, intercept=100 * u.ph)
+    phys.output_units = {"y": u.ph}
+    response = models.Linear1D(slope=1 * u.ct / u.ph, intercept=0 * u.ct)
+    response.output_units = {"y": u.ct}
+    comb = phys | response
+    fake_data = comb(e)
+    fit = fitting.LevMarLSQFitter()
+    res = fit(comb, e, fake_data)
+    assert res

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -282,7 +282,8 @@ def test_fitting_custom_names(model, fitter):
 
 
 @pytest.mark.filterwarnings(r"ignore:Model is linear in parameters*")
-def test_fitting_model_pipe_with_units():
+@pytest.mark.parametrize("fitter", fitters)
+def test_fitting_model_pipe_with_units(fitter):
     e = np.linspace(0, 25, 100) * u.keV
     phys = models.Linear1D(slope=-4 * u.ph / u.keV, intercept=100 * u.ph)
     phys.output_units = {"y": u.ph}
@@ -290,6 +291,7 @@ def test_fitting_model_pipe_with_units():
     response.output_units = {"y": u.ct}
     comb = phys | response
     fake_data = comb(e)
-    fit = fitting.LevMarLSQFitter()
+    fit = fitter()
     res = fit(comb, e, fake_data)
-    assert res
+    for name in comb.param_names:
+        assert getattr(comb, name) == getattr(res, name)

--- a/docs/changes/modeling/17127.feature.rst
+++ b/docs/changes/modeling/17127.feature.rst
@@ -1,0 +1,1 @@
+Extend unit changing compound model operations to include the pipe (`|`) operator.


### PR DESCRIPTION
### Description
This pull request tries to address an issue with compound models not allowing/supporting the `|` changing units. In particular this required updating the `without_units_for_data` and `with_units_from_data` on the compound model class to allow for `|` to change the units through the models.

Fixes #17126.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
