### PR TITLE
ENH: add support for NEP 35 array constructors (`frombuffer`, `fromfile`, `fromiter`, `fromstring` and `fromfunction`) with `like=Quantity(...))`

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -579,7 +579,7 @@ def fromrawdata_helper(*args, **kwargs):
 
 @function_helper
 def fromfunction(function, shape, *, dtype=float, **kwargs):
-    zero_arg = (0,) * len(shape)
+    zero_arg = np.zeros(len(shape), dtype)
     try:
         out_unit = function(*zero_arg).unit
     except Exception:

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -70,6 +70,7 @@ SUPPORTED_NEP35_FUNCTIONS = {
     np.arange,
     np.empty, np.ones, np.zeros, np.full,
     np.array, np.asarray, np.asanyarray, np.ascontiguousarray, np.asfortranarray,
+    np.frombuffer, np.fromfile, np.fromfunction, np.fromiter, np.fromstring,
 }  # fmt: skip
 """Functions that support a 'like' keyword argument and dispatch on it (NEP 35)"""
 UNSUPPORTED_FUNCTIONS = set()
@@ -571,6 +572,20 @@ def aslayoutarray_helper(a, dtype=None):
     if out_unit is not UNIT_FROM_LIKE_ARG:
         a = _as_quantity(a).value
     return (a, dtype), {}, out_unit, None
+
+@function_helper(helps={np.frombuffer, np.fromfile, np.fromiter, np.fromstring})
+def fromrawdata_helper(*args, **kwargs):
+    return args, kwargs, UNIT_FROM_LIKE_ARG, None
+
+@function_helper
+def fromfunction(function, shape, *, dtype=float, **kwargs):
+    zero_arg = (0,) * len(shape)
+    try:
+        out_unit = function(*zero_arg).unit
+    except Exception:
+        out_unit = UNIT_FROM_LIKE_ARG
+    return (function, shape), {"dtype": dtype, **kwargs}, out_unit, None
+
 
 @dispatched_function
 def block(arrays):

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -563,7 +563,7 @@ def asarray_impl_2(a, dtype=None, order=None, *, device=None, copy=None):
     out_unit = getattr(a, "unit", UNIT_FROM_LIKE_ARG)
     if out_unit is not UNIT_FROM_LIKE_ARG:
         a = _as_quantity(a).value
-    return (a, dtype, order), {"device": device, "copy":copy}, out_unit, None
+    return (a, dtype, order), {"device": device, "copy": copy}, out_unit, None
 
 
 @function_helper(helps={np.ascontiguousarray, np.asfortranarray})

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -519,6 +519,37 @@ class TestArrayCreation(BasicTestSetup):
     def test_asfortranarray(self):
         self.check(np.asfortranarray, np.arange(10))
 
+    def test_frombuffer(self):
+        self.check(np.frombuffer, b"\x01\x02\x03", dtype=np.uint8)
+
+    def test_fromfile(self, tmp_path):
+        arr = np.arange(10)
+        test_file = tmp_path / "arr.npy"
+        arr.tofile(test_file)
+        self.check(np.fromfile, test_file)
+
+    def test_fromfunction(self):
+        self.check(np.fromfunction, lambda i, j: i * j, (3, 3))
+
+    def test_fromfunction_unit_from_retv(self):
+        Q = [1, 2, 3] << u.cm
+        arr = np.fromfunction(lambda i, j: (i * j) << u.s, (3, 3), like=Q)
+        assert type(arr) is u.Quantity
+        assert arr.unit == u.s
+
+    def test_fromiter(self):
+        it = (i * j for i, j in zip(range(3), range(3), strict=True))
+        self.check(
+            np.fromiter,
+            it,
+            dtype=np.dtype((int, 3)),
+            # cannot generate another array after consuming the iterator
+            skip_equality_check=True,
+        )
+
+    def test_fromstring(self):
+        self.check(np.fromstring, "1 2 3", sep=" ")
+
 
 class TestAccessingParts(InvariantUnitTestSetup):
     def test_diag(self):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -538,7 +538,7 @@ class TestArrayCreation(BasicTestSetup):
         assert arr.unit == u.s
 
     def test_fromiter(self):
-        it = (i * j for i, j in zip(range(3), range(3), strict=True))
+        it = (i * i for i in range(3))
         self.check(
             np.fromiter,
             it,

--- a/docs/changes/units/17128.feature.rst
+++ b/docs/changes/units/17128.feature.rst
@@ -1,0 +1,3 @@
+Added support for calling numpy array constructors (``np.frombuffer``,
+``np.fromfile``, ``np.fromiter``, ``np.fromstring`` and ``np.fromfunction``)
+with ``like=Quantity(...))`` .


### PR DESCRIPTION
### Description
Ref #17124

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
