### PR TITLE
ENH: add support for NEP 35 array constructors (`require`, `identiy`, `eye`, `tri`, `genfromtxt` and `loadtxt`) with `like=Quantity(...))`

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import itertools
+from io import StringIO
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -496,6 +497,9 @@ class TestArrayCreation(BasicTestSetup):
         assert arr2.unit == u.s
         assert_array_equal(arr2.value, arr1.value)
 
+    def test_require(self):
+        self.check(np.require, np.arange(10))
+
     def test_array(self):
         self.check(np.array, np.arange(10))
 
@@ -519,14 +523,22 @@ class TestArrayCreation(BasicTestSetup):
     def test_asfortranarray(self):
         self.check(np.asfortranarray, np.arange(10))
 
-    def test_frombuffer(self):
-        self.check(np.frombuffer, b"\x01\x02\x03", dtype=np.uint8)
+    def test_genfromtxt(self):
+        s = StringIO("1.0,2.0,3.0")
+        self.check(np.genfromtxt, s, delimiter=",", skip_equality_check=True)
+
+    def test_loadtxt(self):
+        s = StringIO("0 1\n2 3")
+        self.check(np.loadtxt, s, skip_equality_check=True)
 
     def test_fromfile(self, tmp_path):
         arr = np.arange(10)
         test_file = tmp_path / "arr.npy"
         arr.tofile(test_file)
         self.check(np.fromfile, test_file)
+
+    def test_frombuffer(self):
+        self.check(np.frombuffer, b"\x01\x02\x03", dtype=np.uint8)
 
     def test_fromfunction(self):
         self.check(np.fromfunction, lambda i, j: i * j, (3, 3))
@@ -549,6 +561,15 @@ class TestArrayCreation(BasicTestSetup):
 
     def test_fromstring(self):
         self.check(np.fromstring, "1 2 3", sep=" ")
+
+    def test_identity(self):
+        self.check(np.identity, 3)
+
+    def test_eye(self):
+        self.check(np.eye, 3)
+
+    def test_tri(self):
+        self.check(np.eye, 3)
 
 
 class TestAccessingParts(InvariantUnitTestSetup):

--- a/docs/changes/units/17130.feature.rst
+++ b/docs/changes/units/17130.feature.rst
@@ -1,0 +1,3 @@
+Added support for calling numpy array constructors (``np.require``,
+``np.identity``, ``np.eye``, ``np.tri``, ``np.genfromtxt`` and ``np.loadtxt``)
+with ``like=Quantity(...))`` .

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -15,6 +15,7 @@ In particular, this release includes:
 * :ref:`whatsnew-7.0-table-masked-quantity`
 * :ref:`whatsnew-7.0-table-frames`
 * :ref:`whatsnew_7_0_quantity_to_string_formatter`
+* :ref:`whatsnew_7_0_numpy_constructors_like_quantity`
 * :ref:`whatsnew_7_0_ecsv_meta_default_dict`
 * :ref:`whatsnew_7_0_contributor_doc_improvement`
 * :ref:`whatsnew_7_0_typing_stats`
@@ -85,6 +86,61 @@ Example:
     '$1.235 \\times 10^{2} \\; \\mathrm{m}$'
     >>> q.to_string(precision=3, format='latex')
     '$123 \\; \\mathrm{m}$'
+
+.. _whatsnew_7_0_numpy_constructors_like_quantity:
+
+NumPy constructor functions with a ``like`` argument are now supported with ``Quantity``
+========================================================================================
+
+We added support for constructing ``Quantity`` arrays from 21 NumPy functions
+via the ``like`` keyword argument.
+
+Example:
+
+.. code-block:: python
+
+    >>> import numpy as np
+    >>> from astropy import units as u
+    >>> q = u.Quantity(1.0, u.m)
+    >>> np.arange(0, 10, 1, like=q)
+    <Quantity [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] m>
+    >>> np.eye(3, like=q)
+    <Quantity [[1., 0., 0.],
+               [0., 1., 0.],
+               [0., 0., 1.]] m>
+    >>> np.full((3, 3), 1*u.s, like=q)
+    <Quantity [[1., 1., 1.],
+               [1., 1., 1.],
+               [1., 1., 1.]] s>
+
+
+The unit of the output ``Quantity`` is defined from the first quantity argument
+where it is meaningful. Otherwise, and by default, the output unit will be that
+of the ``like`` argument itself.
+
+Here's the entire list of functions affected
+
+* `~numpy.arange`
+* `~numpy.empty`
+* `~numpy.ones`
+* `~numpy.zeros`
+* `~numpy.full`
+* `~numpy.array`
+* `~numpy.asarray`
+* `~numpy.asanyarray`
+* `~numpy.ascontiguousarray`
+* `~numpy.asfortranarray`
+* `~numpy.require`
+* `~numpy.fromfunction`
+* `~numpy.fromstring`
+* `~numpy.fromiter`
+* `~numpy.fromfile`
+* `~numpy.frombuffer`
+* `~numpy.identity`
+* `~numpy.loadtxt`
+* `~numpy.genfromtxt`
+* `~numpy.eye`
+* `~numpy.tri`
 
 .. _whatsnew_7_0_ecsv_meta_default_dict:
 


### PR DESCRIPTION
### Description
Concludes the first half of #17124 (`units`)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
