### PR TITLE
Lon lat initialization with wrong string

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -183,7 +183,7 @@ class Angle(SpecificTypeQuantity):
             elif isiterable(angle) and not (
                 isinstance(angle, np.ndarray) and angle.dtype.kind not in "SUVO"
             ):
-                angle = [Angle(x, unit, copy=COPY_IF_NEEDED) for x in angle]
+                angle = [cls(x, unit, copy=COPY_IF_NEEDED) for x in angle]
 
         return super().__new__(cls, angle, unit, dtype=dtype, copy=copy, **kwargs)
 
@@ -582,7 +582,9 @@ class Latitude(Angle):
 
     def __new__(cls, angle, unit=None, **kwargs):
         # Forbid creating a Lat from a Long.
-        if isinstance(angle, Longitude):
+        if isinstance(angle, Longitude) or (
+            isinstance(angle, str) and angle.endswith(("E", "W"))
+        ):
             raise TypeError("A Latitude angle cannot be created from a Longitude angle")
         self = super().__new__(cls, angle, unit=unit, **kwargs)
         self._validate_angles()
@@ -707,7 +709,9 @@ class Longitude(Angle):
 
     def __new__(cls, angle, unit=None, wrap_angle=None, **kwargs):
         # Forbid creating a Long from a Lat.
-        if isinstance(angle, Latitude):
+        if isinstance(angle, Latitude) or (
+            isinstance(angle, str) and angle.endswith(("N", "S"))
+        ):
             raise TypeError(
                 "A Longitude angle cannot be created from a Latitude angle."
             )

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -698,7 +698,7 @@ def test_latitude():
 
     lim_exc = r"Latitude angle\(s\) must be within -90 deg <= angle <= 90 deg, got"
     with pytest.raises(ValueError, match=rf"{lim_exc} \[91. 89.\] deg"):
-        Latitude(["91d", "89d"])
+        Latitude([91, 89] * u.deg)
     with pytest.raises(ValueError, match=f"{lim_exc} -91.0 deg"):
         Latitude("-91d")
 
@@ -777,13 +777,13 @@ def test_lon_as_lat():
     assert lat.value[0] == 10.0
 
 
-@pytest.mark.parametrize("lon", ["12.3dW", "12h13m12sE"])
+@pytest.mark.parametrize("lon", ["12.3dW", "12h13m12sE", ["1d", "1dW"]])
 def test_lon_as_lat_str(lon):
     with pytest.raises(TypeError, match="Latitude.*cannot be created from a Longitude"):
         Latitude(lon)
 
 
-@pytest.mark.parametrize("lat", ["12.3dN", "12d13m12sS"])
+@pytest.mark.parametrize("lat", ["12.3dN", "12d13m12sS", ["1d", "1dS"]])
 def test_lat_as_lon_str(lat):
     with pytest.raises(TypeError, match="Longitude.*cannot be created from a Latitude"):
         Longitude(lat)

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -777,6 +777,18 @@ def test_lon_as_lat():
     assert lat.value[0] == 10.0
 
 
+@pytest.mark.parametrize("lon", ["12.3dW", "12h13m12sE"])
+def test_lon_as_lat_str(lon):
+    with pytest.raises(TypeError, match="Latitude.*cannot be created from a Longitude"):
+        Latitude(lon)
+
+
+@pytest.mark.parametrize("lat", ["12.3dN", "12d13m12sS"])
+def test_lat_as_lon_str(lat):
+    with pytest.raises(TypeError, match="Longitude.*cannot be created from a Latitude"):
+        Longitude(lat)
+
+
 def test_longitude():
     """Test setting and manipulation operations on Longitude angles."""
 

--- a/docs/changes/coordinates/17132.bugfix.rst
+++ b/docs/changes/coordinates/17132.bugfix.rst
@@ -1,0 +1,3 @@
+``Longitude`` and ``Latitude`` can no longer be initialized with strings
+ending in "N" or "S", and "E" or "W", respectively, since those suggest
+the other type.


### PR DESCRIPTION
As noted in #17129, one currently can initialize a Longitude with a string ending in N or S, and a Latitude with one ending in E or W. This PR raises an appropriate error. Possibly this could be done more elegantly, by passing in a constraint to the parser, but that seemed overkill.

I thought it might be good not to backport, since this could be seen as an API change too.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17129

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
