### PR TITLE
Bound Gaussian2D x/y stddev to be strictly positive

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -335,11 +335,17 @@ class Gaussian2D(Fittable2DModel):
     y_mean = Parameter(
         default=0, description="Peak position (along y axis) of Gaussian"
     )
+    # Ensure stddev makes sense if its bounds are not explicitly set.
+    # stddev must be non-zero and positive.
     x_stddev = Parameter(
-        default=1, description="Standard deviation of the Gaussian (along x axis)"
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        description="Standard deviation of the Gaussian (along x axis)",
     )
     y_stddev = Parameter(
-        default=1, description="Standard deviation of the Gaussian (along y axis)"
+        default=1,
+        bounds=(FLOAT_EPSILON, None),
+        description="Standard deviation of the Gaussian (along y axis)",
     )
     theta = Parameter(
         default=0.0,

--- a/docs/changes/modeling/17137.api.rst
+++ b/docs/changes/modeling/17137.api.rst
@@ -1,0 +1,2 @@
+By default, the ``Gaussian2D`` ``x_stddev`` and ``y_stddev`` parameters
+are bounded to be greater than zero.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

`Gaussian1D` `stddev` is currently bounded to be strictly positive:
https://github.com/astropy/astropy/blob/b6d9f704451adeee2e23a64a3222c5061cce7163/astropy/modeling/functional_models.py#L162

This PR adds these same bounds to `Gaussian2D` x/y `stddev`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
