### PR TITLE
Add a warning class for invalid OGIP multiplications

### DIFF
--- a/astropy/units/errors.py
+++ b/astropy/units/errors.py
@@ -9,6 +9,8 @@ __all__ = [
     "UnitTypeError",
     "UnitsWarning",
     "UnitParserWarning",
+    "OGIPParserWarning",
+    "OGIPInvalidMultiplicationWarning",
 ]
 
 from astropy.utils.exceptions import AstropyWarning
@@ -51,3 +53,20 @@ class UnitsWarning(AstropyWarning):
 
 class UnitParserWarning(AstropyWarning):
     """Unit parser warnings"""
+
+
+class OGIPParserWarning(UnitParserWarning):
+    """Base class for OGIP parser warnings."""
+
+
+class OGIPInvalidMultiplicationWarning(OGIPParserWarning):
+    """Warning for OGIP multiplications missing a space between the factors."""
+
+    def __init__(self, left: str, right: str) -> None:
+        self.message = (
+            f"if '{left}{right}' was meant to be a multiplication, "
+            f"it should have been written as '{left} {right}'."
+        )
+
+    def __str__(self) -> str:
+        return self.message

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -23,7 +23,7 @@ import warnings
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
-from astropy.units.errors import UnitParserWarning, UnitsWarning
+from astropy.units.errors import OGIPInvalidMultiplicationWarning, UnitsWarning
 from astropy.utils import classproperty, parsing
 
 from . import core, generic, utils
@@ -210,24 +210,15 @@ class OGIP(generic.Generic):
                             | UNIT OPEN_PAREN complete_expression CLOSE_PAREN power numeric_power
                             | OPEN_PAREN complete_expression CLOSE_PAREN power numeric_power
             """
-            bad_multiplication_message = (
-                "if '{0}{1}' was meant to be a multiplication, "
-                "it should have been written as '{0} {1}'."
-            )
-
             if len(p) == 7:
                 warnings.warn(
-                    bad_multiplication_message.format(p[1], f"({p[3]})**{p[6]}"),
-                    UnitParserWarning,
+                    OGIPInvalidMultiplicationWarning(str(p[1]), f"({p[3]})**{p[6]}")
                 )
                 p[0] = p[1] * p[3] ** p[6]
             elif len(p) == 6:
                 p[0] = p[2] ** p[5]
             elif len(p) == 5:
-                warnings.warn(
-                    bad_multiplication_message.format(p[1], f"({p[3]})"),
-                    UnitParserWarning,
-                )
+                warnings.warn(OGIPInvalidMultiplicationWarning(str(p[1]), f"({p[3]})"))
                 p[0] = p[1] * p[3]
             elif len(p) == 4:
                 p[0] = p[2]

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -291,19 +291,13 @@ def test_ogip_sqrt(string):
     [
         pytest.param(
             "m(s)**2",
-            (
-                r"^if 'm\(s\)\*\*2' was meant to be a multiplication, "
-                r"it should have been written as 'm \(s\)\*\*2'.$"
-            ),
+            r"'m\(s\)\*\*2' .* should have been written as 'm \(s\)\*\*2'\.$",
             u.m * u.s**2,
             id="m(s)**2",
         ),
         pytest.param(
             "m(s)",
-            (
-                r"^if 'm\(s\)' was meant to be a multiplication, "
-                r"it should have been written as 'm \(s\)'.$"
-            ),
+            r"'m\(s\)' .* should have been written as 'm \(s\)'\.$",
             u.m * u.s,
             id="m(s)",
         ),

--- a/astropy/units/tests/test_parser_warnings.py
+++ b/astropy/units/tests/test_parser_warnings.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Tests for detailed unit parser warning messages."""
+
+from astropy.units import OGIPInvalidMultiplicationWarning
+
+
+def test_OGIPInvalidMultiplicationWarning() -> None:
+    assert str(OGIPInvalidMultiplicationWarning("m", "(s)")) == (
+        "if 'm(s)' was meant to be a multiplication, it should have "
+        "been written as 'm (s)'."
+    )


### PR DESCRIPTION
### Description

[The `astropy` parsing formatters implement a few different standards for converting strings to units.](https://docs.astropy.org/en/stable/units/format.html#built-in-formats) What the parsers should do in case a string does not comply with the specified standard can be controlled with the [`parse_strict` parameter](https://docs.astropy.org/en/stable/units/format.html#dealing-with-unrecognized-units). The parsers can raise a `ValueError`, which means that even with `parse_strict="warn"` or `"silent"` `Unit` still returns an `UnrecognizedUnit`. The recently merged #16892 allows the parsers to emit a `UnitParserWarning` instead, in which case `Unit` can return a proper unit, but the parsers still need to be updated to make use of that mechanism. Additionally, we might want to put some effort into making the messages more user-friendly so that they would suggest (if possible) what a correct string might look like. This raises the question where should the error messages be constructed. There are two obvious options: the parsers themselves or dedicated warning classes.

#### Benefits of dedicated warning classes

- Separating parsing from constructing error messages allows simplifying the parser code and adheres to the principle of separation of concerns.
- Because the error messages should be informative, not trivial, they should be tested. Separate warning classes make it simple to test the error messages in detail without having to invoke the entirety of the unit parsing machinery. The tests checking that the parser warnings are actually emitted can be shortened if they don't have to test the full error messages.
- The `parse_strict` parameter for `Unit()` applies to any and all warnings the parsers might emit. Separate warning classes make it simple for users to implement more specific warning filtering by using `parse_strict="warn"` together with a custom filter for [`warnings.catch_warnings()`](https://docs.python.org/3/library/warnings.html#warnings.catch_warnings). Note that it is possible to filter warnings based on their message, but filtering based on warning category is more reliable because [in APE 2 we make promises about the stability of warning types but not about the stability of the messages](https://github.com/astropy/astropy-APEs/blob/main/APE2.rst#releases-and-backwards-compatibility).
- The warning classes can be given informative names, which might (in some cases) allow shortening the warning messages without making them less informative.

#### Benefits of parsers constructing the error messages

- If every unit standard violation has a corresponding warning class then the number of warning classes can be very large.
- It is simple to see what the error messages are when reading the parser code, they do not have to be looked up from a separate file.
- Because the `Generic`, `FITS` and `VOUnit` parsers share a lot of code then it would not be very simple to ensure that the relevant unit standard is always reflected in the warning class name. This is not a problem if we don't want to include the standard name in the warning class name.

In this pull request I have implemented `OGIPInvalidMultiplicationWarning` as an example. The `units` maintainers should either merge this pull request, in which case we should implement `UnitParserWarning` subclasses for all minor standard violations, or they should reject it, in which case we should avoid subclassing `UnitParserWarning` entirely. Having dedicated warning classes for some but not all parser warnings sounds like a bad idea.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
