### PR TITLE
BUG: fix an incoming incompatibility with matplotlib 3.10 (`AnchoredEllipse` is removed)

### DIFF
--- a/astropy/visualization/wcsaxes/helpers.py
+++ b/astropy/visualization/wcsaxes/helpers.py
@@ -5,7 +5,9 @@ Helpers functions for different kinds of WCSAxes instances.
 """
 
 import numpy as np
-from mpl_toolkits.axes_grid1.anchored_artists import AnchoredEllipse, AnchoredSizeBar
+from matplotlib.offsetbox import AnchoredOffsetbox, AuxTransformBox
+from matplotlib.patches import Ellipse
+from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 
 import astropy.units as u
 from astropy.wcs.utils import proj_plane_pixel_scales
@@ -109,21 +111,17 @@ def add_beam(
     minor /= degrees_per_pixel
     major /= degrees_per_pixel
 
-    corner = CORNERS[corner]
-
-    beam = AnchoredEllipse(
-        ax.transData,
-        width=minor,
-        height=major,
-        angle=angle,
-        loc=corner,
+    aux_tr_box = AuxTransformBox(ax.transData)
+    ellipse = Ellipse((0, 0), width=minor, height=major, angle=angle, **kwargs)
+    aux_tr_box.add_artist(ellipse)
+    box = AnchoredOffsetbox(
+        child=aux_tr_box,
         pad=pad,
         borderpad=borderpad,
+        loc=CORNERS[corner],
         frameon=frame,
     )
-    beam.ellipse.set(**kwargs)
-
-    ax.add_artist(beam)
+    ax.add_artist(box)
 
 
 def add_scalebar(


### PR DESCRIPTION
### Description
[example logs](https://github.com/astropy/astropy/actions/runs/11249012073/job/31275145019)

xref https://github.com/matplotlib/matplotlib/pull/28874

the goal is to remove usage of mpl_toolkits
- [x] `AnchoredEllipse`
- [ ] ~`AnchoredSizeBar` (not removed yet, but the migration guid for `AnchoredEllispe` also shows how to avoid it so might as well be consistent)~ update: actually, it's much harder to migrate properly because we're re-exposing `AnchoredSizeBar`'s keyword arguments, so, since it's not broken, I won't fix it :)

I'll open for review when I'm done fixing both and after I checked that the patch also works on matplotib 3.6


for reference, here's the old doc's example our code is likely based on:
https://matplotlib.org/3.7.5/gallery/axes_grid1/simple_anchored_artists.html
together with the corresponding modern/lower level example I'm using as a reference for this migration: https://matplotlib.org/stable/gallery/misc/anchored_artists.html
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
