### PR TITLE
Fixed a bug that caused WCS.slice to ignore numpy_order= if dimensions were dropped

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -292,6 +292,21 @@ def test_slice_wcs():
         mywcs[0, ::2]
 
 
+def test_slice_drop_dimensions_order():
+
+    # Regression test for a bug that caused WCS.slice to ignore
+    # ``numpy_order=False`` if dimensions were dropped.
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
+
+    wcs_sliced_1 = wcs.slice([0, slice(None), slice(None)], numpy_order=True)
+    assert wcs_sliced_1.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
+
+    wcs_sliced_2 = wcs.slice([slice(None), slice(None), 0], numpy_order=False)
+    assert wcs_sliced_2.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
+
+
 def test_axis_names():
     mywcs = WCS(naxis=4)
     mywcs.wcs.ctype = ["RA---TAN", "DEC--TAN", "VOPT-LSR", "STOKES"]

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -293,18 +293,17 @@ def test_slice_wcs():
 
 
 def test_slice_drop_dimensions_order():
-
     # Regression test for a bug that caused WCS.slice to ignore
     # ``numpy_order=False`` if dimensions were dropped.
 
     wcs = WCS(naxis=3)
-    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
+    wcs.wcs.ctype = "RA---TAN", "DEC--TAN", "FREQ"
 
     wcs_sliced_1 = wcs.slice([0, slice(None), slice(None)], numpy_order=True)
-    assert wcs_sliced_1.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
+    assert wcs_sliced_1.world_axis_physical_types == ["pos.eq.ra", "pos.eq.dec"]
 
     wcs_sliced_2 = wcs.slice([slice(None), slice(None), 0], numpy_order=False)
-    assert wcs_sliced_2.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
+    assert wcs_sliced_2.world_axis_physical_types == ["pos.eq.ra", "pos.eq.dec"]
 
 
 def test_axis_names():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3316,7 +3316,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             A tuple containing the same number of slices as the WCS system.
             The ``step`` method, the third argument to a slice, is not
             presently supported.
-        numpy_order : bool
+        numpy_order : bool, default: True
             Use numpy order, i.e. slice the WCS so that an identical slice
             applied to a numpy array will slice the array and WCS in the same
             way. If set to `False`, the WCS will be sliced in FITS order,

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3333,6 +3333,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         elif not hasattr(view, "__len__"):  # view MUST be an iterable
             view = [view]
 
+        if len(view) < self.wcs.naxis:
+            view = list(view) + [slice(None) for i in range(self.wcs.naxis - len(view))]
+
+        if not numpy_order:
+            view = view[::-1]
+
         if not all(isinstance(x, slice) for x in view):
             # We need to drop some dimensions, but this may not always be
             # possible with .sub due to correlated axes, so instead we use the
@@ -3357,10 +3363,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             if iview.step is not None and iview.step < 0:
                 raise NotImplementedError("Reversing an axis is not implemented.")
 
-            if numpy_order:
-                wcs_index = self.wcs.naxis - 1 - i
-            else:
-                wcs_index = i
+            wcs_index = self.wcs.naxis - 1 - i
 
             if wcs_index < 2:
                 itables = [x_tables, y_tables][wcs_index]

--- a/docs/changes/wcs/17147.bugfix.rst
+++ b/docs/changes/wcs/17147.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that caused ``WCS.slice`` to ignore ``numpy_order=`` and always
+interpret the slices as if ``numpy_order`` was ``True``, in the specific case
+where the slices were such that dimensions in the WCS would be dropped.

--- a/docs/changes/wcs/17147.bugfix.rst
+++ b/docs/changes/wcs/17147.bugfix.rst
@@ -1,3 +1,3 @@
-Fixed a bug that caused ``WCS.slice`` to ignore ``numpy_order=`` and always
+Fixed a bug that caused ``WCS.slice`` to ignore ``numpy_order`` and always
 interpret the slices as if ``numpy_order`` was ``True``, in the specific case
 where the slices were such that dimensions in the WCS would be dropped.


### PR DESCRIPTION
This is a bug that I came across while working on some other improvements. Basically examples like ``WCS.slice([0, slice(None), slice(None)], numpy_order=False)`` returned the wrong result, as if ``numpy_order=True``.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
