### PR TITLE
Enforce Ruff formatting where it was accidentally turned off

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -138,18 +138,8 @@ Coding Style/Conventions
     `ruff format <https://docs.astral.sh/ruff/formatter/>`_ code formatter, which closely follows the
     `The Black Code Style <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html>`_.
 
-  * We recognize that sometimes ruff_ will autoformat things in undesirable
-    ways, e.g., matrices.  In the cases that ruff_ produces undesirable code
-    formatting:
-
-      * one can wrap code the code in ``# fmt: off`` and ``# fmt: on`` to disable
-        ruff_ formatting over multiple lines.
-
-      * or one can add a single ``# fmt: skip`` comment to the end of a line to
-        disable ruff_ formatting for that line.
-
-    This should be done sparingly, and only
-    when ruff_ produces undesirable formatting.
+  * In the rare cases that ruff_ formatting is undesirable, it is possible to
+    `disable formatting locally <https://docs.astral.sh/ruff/formatter/#format-suppression>`_.
 
       .. note::
         When a list or array should be formatted as one item per line then this is best


### PR DESCRIPTION
### Description

[Ruff formatter is somewhat picky about the placement of format suppression instructions](https://docs.astral.sh/ruff/formatter/#format-suppression), which can cause the formatter to be accidentally turned off. The Ruff rule [RUF028 (invalid-formatter-suppression-comment)](https://docs.astral.sh/ruff/rules/invalid-formatter-suppression-comment/#invalid-formatter-suppression-comment-ruf028) guards against misplaced instructions, but it is not turned on in our configuration because it is still in [preview](https://docs.astral.sh/ruff/preview/). It is possible to look for misplaced instructions by running `ruff check --select RUF028 --preview` locally, which revealed problems in one file in `units`.

I also checked what our developer documentation had to say about suppressing the formatter and found that the description is factually wrong. Instead of updating the description it is better to link to Ruff documentation and let it provide the explanation.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
