### PR TITLE
Cosmo: simplify Quantity in docs, adding auto xref

### DIFF
--- a/astropy/cosmology/_io/row.py
+++ b/astropy/cosmology/_io/row.py
@@ -220,8 +220,8 @@ def to_row(cosmology, *args, cosmology_in_meta=False, table_cls=QTable, rename=N
         Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
     In Astropy, Row objects are always part of a Table. :class:`~astropy.table.QTable`
-    is recommended for tables with `~astropy.units.Quantity` columns. However the
-    returned type may be overridden using the ``cls`` argument:
+    is recommended for tables with |Quantity| columns. However the returned type may be
+    overridden using the ``cls`` argument:
 
         >>> from astropy.table import Table
         >>> Planck18.to_format("astropy.table", cls=Table)

--- a/astropy/cosmology/_io/table.py
+++ b/astropy/cosmology/_io/table.py
@@ -52,8 +52,8 @@ To move the cosmology class from the metadata to a Table row, set the
     ------------- -------- ------------ ------- ------- ------- ----------- -------
     FlatLambdaCDM Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
-Astropy recommends `~astropy.table.QTable` for tables with `~astropy.units.Quantity`
-columns. However the returned type may be overridden using the ``cls`` argument:
+Astropy recommends `~astropy.table.QTable` for tables with |Quantity| columns. However
+the returned type may be overridden using the ``cls`` argument:
 
     >>> from astropy.table import Table
     >>> Planck18.to_format("astropy.table", cls=Table)
@@ -392,9 +392,8 @@ def to_table(cosmology, *args, cls=QTable, cosmology_in_meta=True, rename=None):
         ------------- -------- ------------ ------- ------- ------- ----------- -------
         FlatLambdaCDM Planck18        67.66 0.30966  2.7255   3.046 0.0 .. 0.06 0.04897
 
-    Astropy recommends `~astropy.table.QTable` for tables with
-    `~astropy.units.Quantity` columns. However the returned type may be
-    overridden using the ``cls`` argument:
+    Astropy recommends `~astropy.table.QTable` for tables with |Quantity| columns.
+    However the returned type may be overridden using the ``cls`` argument:
 
         >>> from astropy.table import Table
         >>> Planck18.to_format("astropy.table", cls=Table)

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -178,7 +178,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     """
 
     H0: Parameter = Parameter(
-        doc="Hubble constant as an |Quantity| at z=0.",
+        doc="Hubble constant at z=0.",
         unit="km/(s Mpc)",
         fvalidate="scalar",
     )
@@ -189,7 +189,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     Ode0: Parameter = ParameterOde0.clone()
     Tcmb0: Parameter = Parameter(
         default=0.0 * u.K,
-        doc="Temperature of the CMB as |Quantity| at z=0.",
+        doc="Temperature of the CMB at z=0.",
         unit="Kelvin",
         fvalidate="scalar",
     )
@@ -1162,8 +1162,8 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        rho : Quantity
-            Critical density in g/cm^3 at each input redshift.
+        rho : Quantity ['mass density']
+            Critical density at each input redshift.
         """
         return self.critical_density0 * (self.efunc(z)) ** 2
 
@@ -1395,7 +1395,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : Quantity
+        d : Quantity ['length']
             The angular diameter distance between each input redshift pair.
             Returns scalar if input is scalar, array else-wise.
         """
@@ -1482,7 +1482,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        V : Quantity
+        V : Quantity ['volume']
             Comoving volume in :math:`Mpc^3` at each input redshift.
         """
         Ok0 = self.Ok0

--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -178,7 +178,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     """
 
     H0: Parameter = Parameter(
-        doc="Hubble constant as an `~astropy.units.Quantity` at z=0.",
+        doc="Hubble constant as an |Quantity| at z=0.",
         unit="km/(s Mpc)",
         fvalidate="scalar",
     )
@@ -189,7 +189,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
     Ode0: Parameter = ParameterOde0.clone()
     Tcmb0: Parameter = Parameter(
         default=0.0 * u.K,
-        doc="Temperature of the CMB as `~astropy.units.Quantity` at z=0.",
+        doc="Temperature of the CMB as |Quantity| at z=0.",
         unit="Kelvin",
         fvalidate="scalar",
     )
@@ -352,17 +352,17 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
     @cached_property
     def hubble_time(self) -> u.Quantity:
-        """Hubble time as `~astropy.units.Quantity`."""
+        """Hubble time."""
         return (_sec_to_Gyr / (self.H0.value * _H0units_to_invs)) << u.Gyr
 
     @cached_property
     def hubble_distance(self) -> u.Quantity:
-        """Hubble distance as `~astropy.units.Quantity`."""
+        """Hubble distance."""
         return (const.c / self.H0).to(u.Mpc)
 
     @cached_property
     def critical_density0(self) -> u.Quantity:
-        """Critical density as `~astropy.units.Quantity` at z=0."""
+        """Critical density at z=0."""
         return (
             _critdens_const * (self.H0.value * _H0units_to_invs) ** 2
         ) << u.g / u.cm**3
@@ -639,7 +639,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        Tcmb : `~astropy.units.Quantity` ['temperature']
+        Tcmb : Quantity ['temperature']
             The temperature of the CMB in K.
         """
         return self.Tcmb0 * (aszarr(z) + 1.0)
@@ -658,7 +658,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        Tnu : `~astropy.units.Quantity` ['temperature']
+        Tnu : Quantity ['temperature']
             The temperature of the cosmic neutrino background in K.
         """
         return self.Tnu0 * (aszarr(z) + 1.0)
@@ -984,7 +984,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        H : `~astropy.units.Quantity` ['frequency']
+        H : Quantity ['frequency']
             Hubble parameter at each input redshift.
         """
         return self.H0 * self.efunc(z)
@@ -1006,7 +1006,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             Lookback time in Gyr to each input redshift.
 
         See Also
@@ -1031,7 +1031,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             Lookback time in Gyr to each input redshift.
         """
         return self.hubble_time * self._integral_lookback_time(z)
@@ -1077,7 +1077,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Lookback distance in Mpc
         """
         return (self.lookback_time(z) * const.c).to(u.Mpc)
@@ -1096,7 +1096,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             The age of the universe in Gyr at each input redshift.
 
         See Also
@@ -1120,7 +1120,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             The age of the universe in Gyr at each input redshift.
         """
         return self.hubble_time * self._integral_age(z)
@@ -1162,7 +1162,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        rho : `~astropy.units.Quantity`
+        rho : Quantity
             Critical density in g/cm^3 at each input redshift.
         """
         return self.critical_density0 * (self.efunc(z)) ** 2
@@ -1184,7 +1184,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc to each input redshift.
         """
         return self._comoving_distance_z1z2(0, z)
@@ -1205,7 +1205,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc between each input redshift.
         """
         return self._integral_comoving_distance_z1z2(z1, z2)
@@ -1249,7 +1249,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc between each input redshift.
         """
         return self.hubble_distance * self._integral_comoving_distance_z1z2_scalar(z1, z2)  # fmt: skip
@@ -1273,7 +1273,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving transverse distance in Mpc at each input redshift.
 
         Notes
@@ -1300,7 +1300,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving transverse distance in Mpc between input redshift.
 
         Notes
@@ -1336,7 +1336,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Angular diameter distance in Mpc at each input redshift.
 
         References
@@ -1365,7 +1365,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Luminosity distance in Mpc at each input redshift.
 
         See Also
@@ -1395,7 +1395,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity`
+        d : Quantity
             The angular diameter distance between each input redshift pair.
             Returns scalar if input is scalar, array else-wise.
         """
@@ -1450,7 +1450,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        distmod : `~astropy.units.Quantity` ['length']
+        distmod : Quantity ['length']
             Distance modulus at each input redshift, in magnitudes.
 
         See Also
@@ -1482,7 +1482,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        V : `~astropy.units.Quantity`
+        V : Quantity
             Comoving volume in :math:`Mpc^3` at each input redshift.
         """
         Ok0 = self.Ok0
@@ -1520,7 +1520,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        dV : `~astropy.units.Quantity`
+        dV : Quantity
             Differential comoving volume per redshift per steradian at each
             input redshift.
         """
@@ -1541,7 +1541,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             The distance in comoving kpc corresponding to an arcmin at each
             input redshift.
         """
@@ -1561,7 +1561,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             The distance in proper kpc corresponding to an arcmin at each input
             redshift.
         """
@@ -1581,7 +1581,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        theta : `~astropy.units.Quantity` ['angle']
+        theta : Quantity ['angle']
             The angular separation in arcsec corresponding to a comoving kpc at
             each input redshift.
         """
@@ -1601,7 +1601,7 @@ class FLRW(Cosmology, _ScaleFactorMixin):
 
         Returns
         -------
-        theta : `~astropy.units.Quantity` ['angle']
+        theta : Quantity ['angle']
             The angular separation in arcsec corresponding to a proper kpc at
             each input redshift.
         """

--- a/astropy/cosmology/flrw/lambdacdm.py
+++ b/astropy/cosmology/flrw/lambdacdm.py
@@ -226,7 +226,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc between each input redshift.
 
         References
@@ -306,7 +306,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc between each input redshift.
         """
         try:
@@ -339,7 +339,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc between each input redshift.
         """
         try:
@@ -372,7 +372,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        d : `~astropy.units.Quantity` ['length']
+        d : Quantity ['length']
             Comoving distance in Mpc between each input redshift.
 
         References
@@ -431,7 +431,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             The age of the universe in Gyr at each input redshift.
         """
         t = inf if isinstance(z, Number) else np.full_like(z, inf, dtype=float)
@@ -453,7 +453,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             The age of the universe in Gyr at each input redshift.
 
         References
@@ -479,7 +479,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             The age of the universe in Gyr at each input redshift.
 
         References
@@ -515,7 +515,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             Lookback time in Gyr to each input redshift.
         """
         return self._EdS_age(0) - self._EdS_age(z)
@@ -545,7 +545,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             Lookback time in Gyr to each input redshift.
         """
         return self.hubble_time * log(aszarr(z) + 1.0)
@@ -570,7 +570,7 @@ class LambdaCDM(FLRW):
 
         Returns
         -------
-        t : `~astropy.units.Quantity` ['time']
+        t : Quantity ['time']
             Lookback time in Gyr to each input redshift.
         """
         return self._flat_age(0) - self._flat_age(z)

--- a/astropy/cosmology/funcs/optimize.py
+++ b/astropy/cosmology/funcs/optimize.py
@@ -152,7 +152,7 @@ def z_at_value(
     func : function or method
         A function that takes a redshift as input.
 
-    fval : `~astropy.units.Quantity`
+    fval : Quantity
         The (scalar or array) value of ``func(z)`` to recover.
 
     zmin : float or array-like['dimensionless'] or quantity-like, optional
@@ -202,7 +202,7 @@ def z_at_value(
 
     Returns
     -------
-    z : `~astropy.units.Quantity` ['redshift']
+    z : Quantity ['redshift']
         The redshift ``z`` satisfying ``zmin < z < zmax`` and ``func(z) =
         fval`` within ``ztol``. Has units of cosmological redshift.
 

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -386,7 +386,7 @@ def with_H0(H0: Quantity | None = None) -> Equivalency:
 
     Parameters
     ----------
-    H0 : None or Quantity['frequency']
+    H0 : None or Quantity ['frequency']
         The value of the Hubble constant to assume. If a |Quantity|, will assume the
         quantity *is* ``H0``. If `None` (default), use the ``H0`` attribute from
         :mod:`~astropy.cosmology.default_cosmology`.

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -386,10 +386,9 @@ def with_H0(H0: Quantity | None = None) -> Equivalency:
 
     Parameters
     ----------
-    H0 : None or `~astropy.units.Quantity` ['frequency']
-        The value of the Hubble constant to assume. If a
-        `~astropy.units.Quantity`, will assume the quantity *is* ``H0``. If
-        `None` (default), use the ``H0`` attribute from
+    H0 : None or Quantity['frequency']
+        The value of the Hubble constant to assume. If a |Quantity|, will assume the
+        quantity *is* ``H0``. If `None` (default), use the ``H0`` attribute from
         :mod:`~astropy.cosmology.default_cosmology`.
 
     References

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,6 +193,7 @@ numpydoc_xref_aliases.update(
         "ints": ":class:`python:int`",
         # for astropy
         "number": ":term:`number`",
+        "Quantity": ":class:`~astropy.units.Quantity`",
         "Representation": ":class:`~astropy.coordinates.BaseRepresentation`",
         "writable": ":term:`writable file-like object`",
         "readable": ":term:`readable file-like object`",


### PR DESCRIPTION
I enable auto-xref to Quantity, then apply this simplification to Cosmology, searching for ``` `.Quantity` ``` to simplify.

This should also enable a lot of simplifications in other sub-packages.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
