### PR TITLE
Restore LMLSQFitter __call__ signature

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1657,7 +1657,20 @@ class LMLSQFitter(_NLLSQFitter):
     def __init__(self, calc_uncertainties=False):
         super().__init__("lm", calc_uncertainties, True)
 
-    def __call__(self, model, *args, **kwargs):
+    @fitter_unit_support
+    def __call__(
+        self,
+        model,
+        x,
+        y,
+        z=None,
+        weights=None,
+        maxiter=DEFAULT_MAXITER,
+        acc=DEFAULT_ACC,
+        epsilon=DEFAULT_EPS,
+        estimate_jacobian=False,
+        filter_non_finite=False,
+    ):
         # Since there are several fitters with proper support for bounds, it
         # is not a good idea to keep supporting the hacky bounds algorithm
         # from LevMarLSQFitter here, and better to communicate with users
@@ -1674,7 +1687,18 @@ class LMLSQFitter(_NLLSQFitter):
                 AstropyDeprecationWarning,
                 stacklevel=2,
             )
-        return super().__call__(model, *args, **kwargs)
+        return super().__call__(
+            model,
+            x,
+            y,
+            z=z,
+            weights=weights,
+            maxiter=maxiter,
+            acc=acc,
+            epsilon=epsilon,
+            estimate_jacobian=estimate_jacobian,
+            filter_non_finite=filter_non_finite,
+        )
 
 
 class SLSQPLSQFitter(Fitter):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR restores the `LMLSQFitter.__call__` signature that was changed in https://github.com/astropy/astropy/pull/16994.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
