### PR TITLE
Enable `fit_mean=True` in `lombscargle_scipy` for Scipy 1.15+

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -85,7 +85,9 @@ def validate_method(method, dy, fit_mean, nterms, frequency, assume_regular_freq
     prefer_fast = len(frequency) > 200 and (
         assume_regular_frequency or _is_regular(frequency)
     )
-    prefer_scipy = "scipy" in methods and dy is None and not (fit_mean and SCIPY_LT_1_15)
+    prefer_scipy = (
+        "scipy" in methods and dy is None and not (fit_mean and SCIPY_LT_1_15)
+    )
 
     # automatically choose the appropriate method
     if method == "auto":

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -6,7 +6,7 @@ from .utils import SCIPY_LT_1_15
 
 
 def lombscargle_scipy(
-        t, y, frequency, normalization="standard", fit_mean=False, center_data=True
+    t, y, frequency, normalization="standard", fit_mean=False, center_data=True
 ):
     """Lomb-Scargle Periodogram.
 
@@ -63,15 +63,17 @@ def lombscargle_scipy(
         raise ValueError("frequency should be one-dimensional")
 
     if center_data:
+        kwargs = {"precenter": True}
+        # Already taken care of by 'precenter', but still needed for normalization
         y = y - y.mean()
+    else:
+        kwargs = {"precenter": False}
 
     if SCIPY_LT_1_15:
         if fit_mean:
             raise NotImplementedError("`fit_mean=True` requires Scipy 1.15+")
-        else:
-            kwargs = {}
     else:
-        kwargs = {"floating_mean": fit_mean}
+        kwargs["floating_mean"] = fit_mean
 
     # Note: scipy `freqs` input is in angular frequencies
     p = signal.lombscargle(t, y, 2 * np.pi * frequency, **kwargs)

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -2,6 +2,9 @@ from math import factorial
 
 import numpy as np
 
+from astropy.utils import minversion
+
+SCIPY_LT_1_15 = not minversion("scipy", "1.15.dev")
 
 def bitceil(N):
     """

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -6,6 +6,7 @@ from astropy.utils import minversion
 
 SCIPY_LT_1_15 = not minversion("scipy", "1.15.dev")
 
+
 def bitceil(N):
     """
     Find the bit (i.e. power of 2) immediately greater than or equal to N

--- a/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
@@ -76,7 +76,7 @@ def test_all_methods(
     if method == "scipy":
         if fit_mean and SCIPY_LT_1_15:
             pytest.skip("SciPy 1.15+ required for using `fit_mean=True`")
-        elif errors == "full" or errors == "partial" and normalization == "psd":
+        elif errors == "full" or (errors == "partial" and normalization == "psd"):
             pytest.skip("scipy method only supports uniform uncertainties dy")
 
     t, y, dy = data

--- a/docs/changes/timeseries/17170.feature.rst
+++ b/docs/changes/timeseries/17170.feature.rst
@@ -1,0 +1,3 @@
+The ``scipy`` method of ``timeseries.periodograms.lombscargle.Lombscargle`` now
+supports the ``fit_mean=True`` setting with newer Scipy versions (1.15+),
+equivalent to its ``floating_mean`` option.


### PR DESCRIPTION
### Description
Replacement of #17163, that will enable the scipy lombscargle implementation to be called with `fit_mean=True` for scipy versions supporting this as the `floating_mean` option introduced with scipy/scipy#21277.
This is also unskipping the respective tests for the `scipy` method, plus a number of others with constant uncertainties that are actually accepted by this method (though not used for anything, which however seems to only be relevant for the `psd` normalisation).

The discussion over the final behaviour, and in particular defaults, of the `floating_mean` option was still open in scipy/scipy#21696, but has been settled for reverting to the old default as of scipy/scipy#21697.
I'd still note some points:

1. This PR is not changing any defaults for `fit_mean`, as its default has always been `True` in `Lombscargle`, and the `scipy` method can currently only be used when explicitly setting `fit_mean=False`:
```python
>>> lm = LombScargle(t, y, None)
>>> lm.power(frequencies, method='scipy')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "astropy/timeseries/periodograms/lombscargle/core.py", line 381, in power
    power = lombscargle(
  File "astropy/timeseries/periodograms/lombscargle/implementations/main.py", line 209, in lombscargle
    raise ValueError("scipy method does not support fit_mean=True")
ValueError: scipy method does not support fit_mean=True
```
2. The eventual default behaviour of `floating_mean` will not matter for this implementation, since it always explicitly sets it to the value of `fit_mean`.
3. The only default that is changed at all is, that the _default method_ for `fit_mean=True` will now often become `scipy`, where it has usually been `cython` before. This could even be changed by not making this change in `prefer_scipy`, but since the results are identical, and performance per the tests on the scipy side should not be any worse than the Cython version, I would consider this an irrelevant change on the user side.
4. One more thing I noted is that all other methods seem to handle `fit_mean` and `center_data` in the same branch, i.e effectively the latter is always treated as `True` if the former is. This is obviously related to the somewhat misleading documentation described in #17038. I think this is equivalent to the old `precenter` option in `signal.lombscargle`, but anyway scipy handles both independently, and will thus return different results for `fit_mean=True`, `center_data=False`. For consistency I am therefore also forcing the latter to `True` in this case, but the wrapper function itself still accepts both combinations. I think this still needs more discussion which combinations should be supported or make sense at all.

* Fixes #17149
* Fixes #17166
* Close #17163
* Close  #17600 (added by @neutrinoceros)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
