### PR TITLE
Restore 'inplace' to LMLSQFitter __call__ signature

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1714,6 +1714,7 @@ class LMLSQFitter(_NLLSQFitter):
         epsilon=DEFAULT_EPS,
         estimate_jacobian=False,
         filter_non_finite=False,
+        inplace=False,
     ):
         # Since there are several fitters with proper support for bounds, it
         # is not a good idea to keep supporting the hacky bounds algorithm

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1743,6 +1743,7 @@ class LMLSQFitter(_NLLSQFitter):
             epsilon=epsilon,
             estimate_jacobian=estimate_jacobian,
             filter_non_finite=filter_non_finite,
+            inplace=inplace,
         )
 
 


### PR DESCRIPTION
### Description

This pull request is to restore the `inplace` kwarg (implicitly) introduced in #17033 and missed in the refactoring of #17164

<!-- If the pull request closes any open issues you can add this.
Fixes https://github.com/astropy/astropy/pull/17164#issuecomment-2409068965

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
