### PR TITLE
TST: unignore `__array__` protocol warning from numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,8 +220,6 @@ filterwarnings = [
     "ignore:unclosed <socket:ResourceWarning",
     "ignore:unclosed <ssl.SSLSocket:ResourceWarning",
     "ignore:matplotlibrc text\\.usetex:UserWarning:matplotlib",
-    # https://github.com/h5py/h5py/pull/2416
-    "ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
### Description
Fixes #16815 now that h5py 3.12 is available


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
