### PR TITLE
Make max_width and max_lines deterministic for testing

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -64,14 +64,15 @@ def fast_thread_switching():
 
 
 def pytest_configure(config):
-
     # Ensure number of columns and lines is deterministic for testing
     from astropy import conf
+
     conf.max_width = 80
     conf.max_lines = 24
 
     # Disable IERS auto download for testing
     from astropy.utils.iers import conf as iers_conf
+
     iers_conf.auto_download = False
 
     builtins._pytest_running = True
@@ -121,14 +122,15 @@ def pytest_configure(config):
 
 
 def pytest_unconfigure(config):
-
     # Undo settings related to number of lines/columns to show
     from astropy import conf
+
     conf.reset("max_width")
     conf.reset("max_lines")
 
     # Undo IERS auto download setting for testing
     from astropy.utils.iers import conf as iers_conf
+
     iers_conf.reset("auto_download")
 
     builtins._pytest_running = False

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -64,9 +64,14 @@ def fast_thread_switching():
 
 
 def pytest_configure(config):
-    from astropy.utils.iers import conf as iers_conf
+
+    # Ensure number of columns and lines is deterministic for testing
+    from astropy import conf
+    conf.max_width = 80
+    conf.max_lines = 24
 
     # Disable IERS auto download for testing
+    from astropy.utils.iers import conf as iers_conf
     iers_conf.auto_download = False
 
     builtins._pytest_running = True
@@ -116,9 +121,14 @@ def pytest_configure(config):
 
 
 def pytest_unconfigure(config):
-    from astropy.utils.iers import conf as iers_conf
+
+    # Undo settings related to number of lines/columns to show
+    from astropy import conf
+    conf.reset("max_width")
+    conf.reset("max_lines")
 
     # Undo IERS auto download setting for testing
+    from astropy.utils.iers import conf as iers_conf
     iers_conf.reset("auto_download")
 
     builtins._pytest_running = False

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -161,9 +161,8 @@ class TestPprint:
         """
         self._setup(table_type)
         arr = np.arange(4000, dtype=np.float64).reshape(100, 40)
-        with conf.set_temp("max_width", None):
-            with conf.set_temp("max_lines", None):
-                lines = table_type(arr).pformat()
+        with conf.set_temp("max_width", None), conf.set_temp("max_lines", None):
+            lines = table_type(arr).pformat()
         width, nlines = get_terminal_size()
         assert len(lines) == nlines
         for line in lines[:-1]:  # skip last "Length = .. rows" line

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -7,8 +7,7 @@ from shutil import get_terminal_size
 import numpy as np
 import pytest
 
-from astropy import table
-from astropy import conf
+from astropy import conf, table
 from astropy import units as u
 from astropy.io import ascii
 from astropy.table import QTable, Table

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from astropy import table
+from astropy import conf
 from astropy import units as u
 from astropy.io import ascii
 from astropy.table import QTable, Table
@@ -161,7 +162,9 @@ class TestPprint:
         """
         self._setup(table_type)
         arr = np.arange(4000, dtype=np.float64).reshape(100, 40)
-        lines = table_type(arr).pformat()
+        with conf.set_temp("max_width", None):
+            with conf.set_temp("max_lines", None):
+                lines = table_type(arr).pformat()
         width, nlines = get_terminal_size()
         assert len(lines) == nlines
         for line in lines[:-1]:  # skip last "Length = .. rows" line


### PR DESCRIPTION
I decided to set the values to use for testing to the common default for a terminal rather than -1, because the latter requires some tests to be updated and also generates too large output in the docs. It is easier to set the values to the common defaults (80/24).

Fixes https://github.com/astropy/astropy/issues/8691
Fixes https://github.com/astropy/astropy/issues/16307

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
