### PR TITLE
Turn `CDS`, `OGIP` and `VOUnit` unit formatters into `FITS` formatter subclasses

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -152,6 +152,13 @@ class Base:
         ValueError
             If ``fraction`` is not recognized.
         """
+        # A separate `_to_string()` method allows subclasses (e.g. `FITS`) to implement
+        # `to_string()` without needlessly interfering with the `to_string()`
+        # implementations of their subclasses.
+        return cls._to_string(unit, fraction=fraction)
+
+    @classmethod
+    def _to_string(cls, unit: UnitBase, *, fraction: bool | str) -> str:
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions
         # like u.Ry.decompose(), which gives "2.17987e-18 kg m2 / s2".

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -21,6 +21,7 @@ from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
+from .fits import FITS
 from .generic import Generic
 
 if TYPE_CHECKING:
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class CDS(Generic):
+class CDS(FITS):
     """
     Support the `Centre de Données astronomiques de Strasbourg
     <https://cds.unistra.fr/>`_ `Standards for Astronomical
@@ -307,4 +308,4 @@ class CDS(Generic):
             elif is_effectively_unity(unit.scale * 100.0):
                 return "%"
 
-        return super().to_string(unit, fraction=fraction)
+        return cls._to_string(unit, fraction=fraction)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -26,7 +26,8 @@ from typing import TYPE_CHECKING
 from astropy.units.errors import UnitParserWarning, UnitsWarning
 from astropy.utils import classproperty, parsing
 
-from . import core, generic, utils
+from . import core, utils
+from .fits import FITS
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class OGIP(generic.Generic):
+class OGIP(FITS):
     """
     Support the units in `Office of Guest Investigator Programs (OGIP)
     FITS files
@@ -332,11 +333,6 @@ class OGIP(generic.Generic):
         return parsing.yacc(tabmodule="ogip_parsetab", package="astropy/units")
 
     @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        cls._validate_unit(unit, detailed_exception=detailed_exception)
-        return cls._units[unit]
-
-    @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
         return cls._do_parse(s.strip(), debug)
 
@@ -359,4 +355,4 @@ class OGIP(generic.Generic):
                     UnitsWarning,
                 )
 
-        return super().to_string(unit, fraction=fraction)
+        return cls._to_string(unit, fraction=fraction)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING
 from astropy.units.errors import UnitScaleError, UnitsError, UnitsWarning
 from astropy.utils import classproperty
 
-from . import core, generic, utils
+from . import core, utils
+from .fits import FITS
 
 if TYPE_CHECKING:
     from re import Pattern
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
     from astropy.units import NamedUnit, UnitBase
 
 
-class VOUnit(generic.Generic):
+class VOUnit(FITS):
     """
     The IVOA standard for units used by the VO.
 
@@ -221,7 +222,7 @@ class VOUnit(generic.Generic):
                 f"Multiply your data by {unit.scale:e}."
             )
 
-        return super().to_string(unit, fraction=fraction)
+        return cls._to_string(unit, fraction=fraction)
 
     @classmethod
     def _fix_deprecated(cls, x: str) -> list[str]:

--- a/docs/changes/units/16789.api.rst
+++ b/docs/changes/units/16789.api.rst
@@ -1,1 +1,0 @@
-The ``CDS`` unit formatter is now a subclass of the ``Generic`` formatter.

--- a/docs/changes/units/17178.api.rst
+++ b/docs/changes/units/17178.api.rst
@@ -1,0 +1,2 @@
+The ``CDS``, ``OGIP`` and ``VOUnit`` unit formatters are now subclasses of the
+``FITS`` unit formatter.


### PR DESCRIPTION
### Description

Currently the `CDS`, `FITS`, `OGIP` and `VOUnit` unit formatters are all subclasses of `Generic`, which implements several methods for them that it does not use itself. In many cases the reason `Generic` does not use those methods has to do with the fact that differently from the other mentioned formatters `Generic` does not implement an external standard. Making `FITS` the common parent class of `CDS`, `OGIP` and `VOUnit` will enable decluttering `Generic` without introducing needless code duplication.

This is technically an API change, but I don't expect anyone downstream to even notice. The public API breakage is limited to something that involves ~`isinstance()` or~ `issubclass()` calls, but I cannot imagine any useful purpose for such checks. That being said, it is still a public API change so it is better to merge this before the v7.0 feature freeze. 

Considering how close the feature freeze is, this pull request is opened as small as possible. We can afford to postpone applying the simplifications this enables until after the feature freeze because they should not affect the public API at all. However, if the reviewers would like to see some non-trivial simplifications already in this pull request then they could be included.

The only (and very minor) complication is that the implementation of `Base.to_string()` should be moved to `Base._to_string()` so that `FITS.to_string()` implementation could be bypassed. However, the new `Base._to_string()` enables implementing the `to_string()` method of `Console` and its subclasses in a way that type checkers can understand, which is also useful (but actually making that change is beyond the scope here).

EDIT: Removes change log from #16789

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
