### PR TITLE
DEPR: add a pending deprecation to `Table.pformat`'s default values on arguments `max_lines` and `max_width`

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -682,7 +682,7 @@ def test_default_missing(fast_reader):
     )
     dat = ascii.read(table, fast_reader=fast_reader)
     assert dat.masked is False
-    assert dat.pformat() == [
+    assert dat.pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d ",
         "--- --- --- ---",
         "  1   3  --  --",
@@ -692,7 +692,7 @@ def test_default_missing(fast_reader):
     # Single row table with a single missing element
     table = """ a \n "" """
     dat = ascii.read(table, fast_reader=fast_reader)
-    assert dat.pformat() == [" a ", "---", " --"]
+    assert dat.pformat(max_lines=-1, max_width=-1) == [" a ", "---", " --"]
     assert dat["a"].dtype.kind == "i"
 
     # Same test with a fixed width reader
@@ -706,7 +706,7 @@ def test_default_missing(fast_reader):
     )
     dat = ascii.read(table, format="fixed_width_two_line")
     assert dat.masked is False
-    assert dat.pformat() == [
+    assert dat.pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d ",
         "--- --- --- ---",
         "  1   3  --  --",
@@ -715,7 +715,7 @@ def test_default_missing(fast_reader):
 
     dat = ascii.read(table, format="fixed_width_two_line", fill_values=None)
     assert dat.masked is False
-    assert dat.pformat() == [
+    assert dat.pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d ",
         "--- --- --- ---",
         "  1   3        ",
@@ -724,7 +724,7 @@ def test_default_missing(fast_reader):
 
     dat = ascii.read(table, format="fixed_width_two_line", fill_values=[])
     assert dat.masked is False
-    assert dat.pformat() == [
+    assert dat.pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d ",
         "--- --- --- ---",
         "  1   3        ",
@@ -1371,7 +1371,7 @@ def test_pformat_roundtrip():
         ]
     )
     dat = ascii.read(table)
-    out = ascii.read(dat.pformat())
+    out = ascii.read(dat.pformat(max_lines=-1, max_width=-1))
     assert len(dat) == len(out)
     assert dat.colnames == out.colnames
     for c in dat.colnames:
@@ -1729,14 +1729,18 @@ def test_read_with_encoding(tmp_path, encoding):
             f.write(content)
 
         table = ascii.read(testfile, encoding=encoding)
-        assert table.pformat() == [" à   b    è  ", "--- --- -----", "  1   2 héllo"]
+        assert table.pformat(max_lines=-1, max_width=-1) == [
+            " à   b    è  ",
+            "--- --- -----",
+            "  1   2 héllo",
+        ]
 
         for guess in (True, False):
             table = ascii.read(
                 testfile, format=fmt, fast_reader=False, encoding=encoding, guess=guess
             )
             assert table["è"].dtype.kind == "U"
-            assert table.pformat() == [
+            assert table.pformat(max_lines=-1, max_width=-1) == [
                 " à   b    è  ",
                 "--- --- -----",
                 "  1   2 héllo",
@@ -2051,7 +2055,7 @@ def test_read_converters_simplified():
 
     converters = {"a": str, "e": np.float32}
     t2 = Table.read(out.getvalue(), format="ascii.basic", converters=converters)
-    assert t2.pformat(show_dtype=True) == [
+    assert t2.pformat(show_dtype=True, max_lines=-1, max_width=-1) == [
         " a      b      c     d      e   ",
         "str1 float64  str5  str5 float32",
         "---- ------- ----- ----- -------",
@@ -2061,7 +2065,7 @@ def test_read_converters_simplified():
 
     converters = {"a": float, "*": [np.int64, float, bool, str]}
     t2 = Table.read(out.getvalue(), format="ascii.basic", converters=converters)
-    assert t2.pformat_all(show_dtype=True) == [
+    assert t2.pformat_all(show_dtype=True, max_lines=-1, max_width=-1) == [
         "   a       b      c     d     e  ",
         "float64 float64  bool  str5 int64",
         "------- ------- ----- ----- -----",

--- a/astropy/io/registry/base.py
+++ b/astropy/io/registry/base.py
@@ -323,7 +323,7 @@ class _UnifiedIORegistryBase:
         """``get_formats()``, without column "Data class", as a str."""
         format_table = self.get_formats(data_class, filter_on)
         format_table.remove_column("Data class")
-        format_table_str = "\n".join(format_table.pformat(max_lines=-1))
+        format_table_str = "\n".join(format_table.pformat(max_lines=-1, max_width=-1))
         return format_table_str
 
     def _is_best_match(self, class1, class2, format_classes):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -12,6 +12,7 @@ from astropy.units import Quantity, StructuredUnit, Unit
 from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
+from astropy.utils.exceptions import AstropyPendingDeprecationWarning
 from astropy.utils.metadata import MetaData
 from astropy.utils.misc import dtype_bytes_or_chars
 
@@ -38,6 +39,9 @@ class StringTruncateWarning(UserWarning):
 
 # Always emit this warning, not just the first instance
 warnings.simplefilter("always", StringTruncateWarning)
+
+# sentinel default value
+_NoValue = object()
 
 
 def _auto_names(n_cols):
@@ -852,7 +856,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     def pformat(
         self,
-        max_lines=None,
+        max_lines=_NoValue,
         show_name=True,
         show_unit=False,
         show_dtype=False,
@@ -890,6 +894,18 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             List of lines with header and formatted column values
 
         """
+        if max_lines is _NoValue:
+            warnings.warn(
+                "The default value for the max_lines argument in "
+                f"{self.__class__.__name__}.pformat is planned to change "
+                "from None to -1 in a future version of astropy. "
+                "This warning is emitted since version 7.0 ."
+                "Pass an explicit value to avoid this warning.",
+                category=AstropyPendingDeprecationWarning,
+                stacklevel=2,
+            )
+            max_lines = None
+
         _pformat_col = self._formatter._pformat_col
         lines, outs = _pformat_col(
             self,

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -217,7 +217,9 @@ class Row:
 
     def __str__(self):
         index = self.index if (self.index >= 0) else self.index + len(self._table)
-        return "\n".join(self.table[index : index + 1].pformat(max_width=-1))
+        return "\n".join(
+            self.table[index : index + 1].pformat(max_lines=None, max_width=-1)
+        )
 
     def __bytes__(self):
         return str(self).encode("utf-8")

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -24,7 +24,10 @@ from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_25
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, DataInfo, MixinInfo
 from astropy.utils.decorators import format_doc
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import (
+    AstropyPendingDeprecationWarning,
+    AstropyUserWarning,
+)
 from astropy.utils.masked import Masked
 from astropy.utils.metadata import MetaAttribute, MetaData
 
@@ -576,6 +579,9 @@ class PprintIncludeExclude(TableAttribute):
         self.__set__(instance, names)
 
         return ctx
+
+
+_NoValue = object()
 
 
 class Table:
@@ -1659,7 +1665,7 @@ class Table:
         return self._base_repr_(html=False, max_width=None)
 
     def __str__(self):
-        return "\n".join(self.pformat())
+        return "\n".join(self.pformat(max_lines=None, max_width=None))
 
     def __bytes__(self):
         return str(self).encode("utf-8")
@@ -1963,8 +1969,8 @@ class Table:
     @format_doc(_pformat_docs, id="{id}")
     def pformat(
         self,
-        max_lines=None,
-        max_width=None,
+        max_lines=_NoValue,
+        max_width=_NoValue,
         show_name=True,
         show_unit=None,
         show_dtype=False,
@@ -1987,6 +1993,29 @@ class Table:
         ``astropy.conf.max_width``.
 
         """
+        if max_lines is _NoValue:
+            warnings.warn(
+                "The default value for the max_lines argument in "
+                f"{self.__class__.__name__}.pformat is planned to change "
+                "from None to -1 in a future version of astropy. "
+                "This warning is emitted since version 7.0 ."
+                "Pass an explicit value to avoid this warning.",
+                category=AstropyPendingDeprecationWarning,
+                stacklevel=2,
+            )
+            max_lines = None
+        if max_width is _NoValue:
+            warnings.warn(
+                "The default value for the max_width argument in "
+                f"{self.__class__.__name__}.pformat is planned to change "
+                "from None to -1 in a future version of astropy. "
+                "This warning is emitted since version 7.0 ."
+                "Pass an explicit value to avoid this warning.",
+                category=AstropyPendingDeprecationWarning,
+                stacklevel=2,
+            )
+            max_width = None
+
         lines, outs = self.formatter._pformat_table(
             self,
             max_lines,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -39,6 +39,7 @@ from .column import (
     MaskedColumn,
     _auto_names,
     _convert_sequence_data_to_array,
+    _NoValue,
     col_copy,
 )
 from .connect import TableRead, TableWrite
@@ -579,9 +580,6 @@ class PprintIncludeExclude(TableAttribute):
         self.__set__(instance, names)
 
         return ctx
-
-
-_NoValue = object()
 
 
 class Table:

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -168,7 +168,13 @@ class TestColumn:
         assert c.description == "an example"
         assert c.meta == q.info.meta
         assert c.meta is not q.info.meta
-        assert c.pformat() == " q \n---\n0.0\n1.0\n2.0".splitlines()
+        assert c.pformat(max_lines=-1) == [
+            " q ",
+            "---",
+            "0.0",
+            "1.0",
+            "2.0",
+        ]
 
     def test_quantity_comparison(self, Column):
         # regression test for gh-6532
@@ -1003,7 +1009,7 @@ def test_unicode_sandwich_set(Column):
 
     c[0] = uba  # ä is a 2-byte character in utf-8, test fails with ascii encoding
     assert np.all(c == [uba, "def"])
-    assert c.pformat() == ["None", "----", "  " + uba, " def"]
+    assert c.pformat(max_lines=-1) == ["None", "----", f"  {uba}", " def"]
 
     c[:] = b"cc"
     assert np.all(c == ["cc", "cc"])

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -11,6 +11,7 @@ from hypothesis.strategies import integers
 from astropy import coordinates, time
 from astropy import units as u
 from astropy.table import Column, NdarrayMixin, QTable, Table, table_helpers, unique
+from astropy.table.tests.utils import ignore_pformat_default_pending_depr_warning
 from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.time import Time
 from astropy.utils.exceptions import AstropyUserWarning
@@ -54,6 +55,7 @@ def test_column_group_by_no_argsort(T1b):
         t1a.group_by(list(range(len(t1a))))
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_table_group_by(T1):
     """
     Test basic table group_by functionality for possible key types and for
@@ -68,7 +70,7 @@ def test_table_group_by(T1):
         assert str(tg["a"].groups) == "<ColumnGroups indices=[0 1 4 8]>"
 
         # Sorted by 'a' and in original order for rest
-        assert tg.pformat() == [
+        assert tg.pformat(max_lines=-1, max_width=-1) == [
             " a   b   c   d   q ",
             "                 m ",
             "--- --- --- --- ---",
@@ -94,7 +96,7 @@ def test_table_group_by(T1):
             tg = t1.group_by(keys)
             assert np.all(tg.groups.indices == np.array([0, 1, 3, 4, 5, 7, 8]))
             # Sorted by 'a', 'b' and in original order for rest
-            assert tg.pformat() == [
+            assert tg.pformat(max_lines=-1, max_width=-1) == [
                 " a   b   c   d   q ",
                 "                 m ",
                 "--- --- --- --- ---",
@@ -119,7 +121,7 @@ def test_table_group_by(T1):
         # Group by a simple ndarray
         tg = t1.group_by(np.array([0, 1, 0, 1, 2, 1, 0, 0]))
         assert np.all(tg.groups.indices == np.array([0, 4, 7, 8]))
-        assert tg.pformat() == [
+        assert tg.pformat(max_lines=-1, max_width=-1) == [
             " a   b   c   d   q ",
             "                 m ",
             "--- --- --- --- ---",
@@ -170,6 +172,7 @@ def test_groups_keys_time(T1b: QTable):
     assert np.all(keys["b"] == np.array(["a", "a", "b", "a", "b", "c"]))
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_groups_iterator(T1):
     tg = T1.group_by("a")
     for ii, group in enumerate(tg.groups):
@@ -221,6 +224,7 @@ def test_group_column_from_table(T1):
     assert np.all(cg.groups.indices == np.array([0, 1, 4, 8]))
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_table_groups_mask_index(T1):
     """
     Use boolean mask as item in __getitem__ for groups
@@ -235,6 +239,7 @@ def test_table_groups_mask_index(T1):
         assert np.all(t2.groups.keys["a"] == np.array([0, 2]))
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_table_groups_array_index(T1):
     """
     Use numpy array as item in __getitem__ for groups
@@ -249,6 +254,7 @@ def test_table_groups_array_index(T1):
         assert np.all(t2.groups.keys["a"] == np.array([0, 2]))
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_table_groups_slicing(T1):
     """
     Test that slicing table groups works
@@ -291,7 +297,7 @@ def test_grouped_item_access(T1):
         assert np.all(tgs.groups.keys == tg.groups.keys)
         assert np.all(tgs.groups.indices == tg.groups.indices)
         tgsa = tgs.groups.aggregate(np.sum)
-        assert tgsa.pformat() == [
+        assert tgsa.pformat(max_lines=-1, max_width=-1) == [
             " a   c    d ",
             "--- ---- ---",
             "  0  0.0   4",
@@ -303,7 +309,7 @@ def test_grouped_item_access(T1):
         assert np.all(tgs.groups.keys == tg.groups.keys)
         assert np.all(tgs.groups.indices == tg.groups.indices)
         tgsa = tgs.groups.aggregate(np.sum)
-        assert tgsa.pformat() == [
+        assert tgsa.pformat(max_lines=-1, max_width=-1) == [
             " c    d ",
             "---- ---",
             " 0.0   4",
@@ -367,7 +373,7 @@ def test_group_by_masked(T1):
     t1m = QTable(T1, masked=True)
     t1m["c"].mask[4] = True
     t1m["d"].mask[5] = True
-    assert t1m.group_by("a").pformat() == [
+    assert t1m.group_by("a").pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d   q ",
         "                 m ",
         "--- --- --- --- ---",
@@ -450,7 +456,7 @@ def test_table_aggregate(T1):
     t1 = T1["a", "c", "d"]
     tg = t1.group_by("a")
     tga = tg.groups.aggregate(np.sum)
-    assert tga.pformat() == [
+    assert tga.pformat(max_lines=-1, max_width=-1) == [
         " a   c    d ",
         "--- ---- ---",
         "  0  0.0   4",
@@ -483,7 +489,7 @@ def test_table_aggregate(T1):
     with pytest.warns(UserWarning, match="converting a masked element to nan"), ctx:
         tga = tg.groups.aggregate(np.sum)
 
-    assert tga.pformat() == [
+    assert tga.pformat(max_lines=-1, max_width=-1) == [
         " a   c    d    q  ",
         "               m  ",
         "--- ---- ---- ----",
@@ -500,7 +506,7 @@ def test_table_aggregate(T1):
     t1m["d"].mask[5] = True
     tg = t1m.group_by("a")
     tga = tg.groups.aggregate(np.sum)
-    assert tga.pformat() == [
+    assert tga.pformat(max_lines=-1, max_width=-1) == [
         " a   c    d ",
         "--- ---- ---",
         "  0  0.0   4",
@@ -513,7 +519,7 @@ def test_table_aggregate(T1):
     tg = T1.group_by("a")
     with pytest.warns(AstropyUserWarning, match="Cannot aggregate column"):
         tga = tg.groups.aggregate(np.sum)
-    assert tga.pformat() == [
+    assert tga.pformat(max_lines=-1, max_width=-1) == [
         " a   c    d   q  ",
         "              m  ",
         "--- ---- --- ----",
@@ -548,7 +554,7 @@ def test_table_aggregate_reduceat(T1):
 
     assert np.all(tga_r == tga_n)
     assert np.all(tga_a == tga_n)
-    assert tga_n.pformat() == [
+    assert tga_n.pformat(max_lines=-1, max_width=-1) == [
         " a   c    d ",
         "--- ---- ---",
         "  0  0.0   4",
@@ -559,7 +565,7 @@ def test_table_aggregate_reduceat(T1):
     tga_r = tg.groups.aggregate(np.mean)
     tga_n = tg.groups.aggregate(np_mean)
     assert np.all(tga_r == tga_n)
-    assert tga_n.pformat() == [
+    assert tga_n.pformat(max_lines=-1, max_width=-1) == [
         " a   c   d ",
         "--- --- ---",
         "  0 0.0 4.0",
@@ -573,7 +579,13 @@ def test_table_aggregate_reduceat(T1):
 
     with pytest.warns(AstropyUserWarning, match="Cannot aggregate column"):
         tga = tg.groups.aggregate(np_add)
-    assert tga.pformat() == [" a ", "---", "  0", "  1", "  2"]
+    assert tga.pformat(max_lines=-1, max_width=-1) == [
+        " a ",
+        "---",
+        "  0",
+        "  1",
+        "  2",
+    ]
 
 
 def test_column_aggregate(T1):
@@ -625,13 +637,17 @@ def test_table_filter():
     )
     tg = t.group_by("a")
     t2 = tg.groups.filter(all_positive)
-    assert t2.groups[0].pformat() == [
+    assert t2.groups[0].pformat(max_lines=-1, max_width=-1) == [
         " a   c   d ",
         "--- --- ---",
         " -2 7.0   0",
         " -2 5.0   1",
     ]
-    assert t2.groups[1].pformat() == [" a   c   d ", "--- --- ---", "  0 0.0   4"]
+    assert t2.groups[1].pformat(max_lines=-1, max_width=-1) == [
+        " a   c   d ",
+        "--- --- ---",
+        "  0 0.0   4",
+    ]
 
 
 def test_column_filter():

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -595,7 +595,13 @@ def test_column_aggregate(T1):
     for masked in (False, True):
         tg = QTable(T1, masked=masked).group_by("a")
         tga = tg["c"].groups.aggregate(np.sum)
-        assert tga.pformat() == [" c  ", "----", " 0.0", " 6.0", "22.0"]
+        assert tga.pformat(max_lines=-1) == [
+            " c  ",
+            "----",
+            " 0.0",
+            " 6.0",
+            "22.0",
+        ]
 
 
 def test_column_aggregate_f8():
@@ -604,7 +610,12 @@ def test_column_aggregate_f8():
     for masked in (False, True):
         tg = Table({"a": np.arange(2, dtype=">f8")}, masked=masked).group_by("a")
         tga = tg["a"].groups.aggregate(np.sum)
-        assert tga.pformat() == [" a ", "---", "0.0", "1.0"]
+        assert tga.pformat(max_lines=-1) == [
+            " a ",
+            "---",
+            "0.0",
+            "1.0",
+        ]
 
 
 def test_table_filter():
@@ -674,9 +685,9 @@ def test_column_filter():
     tg = t.group_by("a")
     c2 = tg["c"].groups.filter(lambda column: np.all(column >= 0))
     assert len(c2.groups) == 3
-    assert c2.groups[0].pformat() == [" c ", "---", "7.0", "5.0"]
-    assert c2.groups[1].pformat() == [" c ", "---", "0.0"]
-    assert c2.groups[2].pformat() == [" c ", "---", "3.0", "2.0", "1.0"]
+    assert c2.groups[0].pformat(max_lines=-1) == [" c ", "---", "7.0", "5.0"]
+    assert c2.groups[1].pformat(max_lines=-1) == [" c ", "---", "0.0"]
+    assert c2.groups[2].pformat(max_lines=-1) == [" c ", "---", "3.0", "2.0", "1.0"]
 
 
 def test_group_mixins():

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -32,7 +32,7 @@ class SetupData:
 
 class TestPprint(SetupData):
     def test_pformat(self):
-        assert self.t.pformat() == [
+        assert self.t.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "  1  --",

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -749,7 +749,7 @@ def test_quantity_representation():
     Test that table representation of quantities does not have unit
     """
     t = QTable([[1, 2] * u.m])
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "col0",
         " m  ",
         "----",
@@ -854,7 +854,7 @@ def test_representation_representation(c, expected_pformat):
     Test that Representations are represented correctly.
     """
     t = Table([c])
-    assert t.pformat() == expected_pformat
+    assert t.pformat(max_lines=-1, max_width=-1) == expected_pformat
 
 
 def test_skycoord_representation():
@@ -865,7 +865,7 @@ def test_skycoord_representation():
     # With no unit we get "None" in the unit row
     c = coordinates.SkyCoord([0], [1], [0], representation_type="cartesian")
     t = Table([c])
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "     col0     ",
         "None,None,None",
         "--------------",
@@ -875,7 +875,7 @@ def test_skycoord_representation():
     # Test that info works with a dynamically changed representation
     c = coordinates.SkyCoord([0], [1], [0], unit="m", representation_type="cartesian")
     t = Table([c])
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "    col0   ",
         "   m,m,m   ",
         "-----------",
@@ -883,7 +883,7 @@ def test_skycoord_representation():
     ]
 
     t["col0"].representation_type = "unitspherical"
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "  col0  ",
         "deg,deg ",
         "--------",
@@ -891,7 +891,7 @@ def test_skycoord_representation():
     ]
 
     t["col0"].representation_type = "cylindrical"
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "    col0    ",
         "  m,deg,m   ",
         "------------",
@@ -965,7 +965,7 @@ def test_ndarray_mixin(as_ndarray_mixin):
     assert t[1]["d"][0] == d[1][0]
     assert t[1]["d"][1] == d[1][1]
 
-    assert t.pformat(show_dtype=True) == (
+    assert t.pformat(show_dtype=True, max_lines=-1, max_width=-1) == (
         [
             "  a [f0, f1]     b [x, y]      c [rx, ry]      d    ",
             "(int32, str1) (int32, str2) (float64, str3) int64[2]",
@@ -997,7 +997,7 @@ def test_possible_string_format_functions():
     """
     t = QTable([[1, 2] * u.m])
     t["col0"].info.format = "%.3f"
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         " col0",
         "  m  ",
         "-----",
@@ -1006,7 +1006,7 @@ def test_possible_string_format_functions():
     ]
 
     t["col0"].info.format = "hi {:.3f}"
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "  col0  ",
         "   m    ",
         "--------",
@@ -1015,7 +1015,7 @@ def test_possible_string_format_functions():
     ]
 
     t["col0"].info.format = ".4f"
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         " col0 ",
         "  m   ",
         "------",

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -23,6 +23,7 @@ from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.coordinates.tests.test_representation import representation_equal
 from astropy.table import Column, MaskedColumn, QTable, Table, TableMergeError
 from astropy.table.operations import _get_out_class, join_distance, join_skycoord
+from astropy.table.tests.utils import ignore_pformat_default_pending_depr_warning
 from astropy.time import Time, TimeDelta
 from astropy.units.quantity import Quantity
 from astropy.utils import metadata
@@ -136,7 +137,7 @@ class TestJoin:
         assert type(t12["d"]) is type(t2["d"])
         assert t12.masked is False
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a   b   c   d ",
                 "--- --- --- ---",
@@ -163,7 +164,7 @@ class TestJoin:
             assert type(t12[name]) is Column
         assert type(t12["d"]) is MaskedColumn
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a   b   c   d ",
                 "--- --- --- ---",
@@ -180,7 +181,7 @@ class TestJoin:
         assert t12.has_masked_columns is True
         assert t12.masked is False
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a   b   c   d ",
                 "--- --- --- ---",
@@ -196,7 +197,7 @@ class TestJoin:
         assert t12.has_masked_columns is True
         assert t12.masked is False
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a   b   c   d ",
                 "--- --- --- ---",
@@ -229,7 +230,7 @@ class TestJoin:
         assert type(t12["d"]) is type(t2["d"])
         assert t12.masked is False
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  c  b_2  d ",
                 "--- --- --- --- ---",
@@ -252,7 +253,7 @@ class TestJoin:
         t12 = table.join(t1, t2, join_type="left", keys="a")
         assert t12.has_masked_columns is True
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  c  b_2  d ",
                 "--- --- --- --- ---",
@@ -269,7 +270,7 @@ class TestJoin:
         t12 = table.join(t1, t2, join_type="right", keys="a")
         assert t12.has_masked_columns is True
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  c  b_2  d ",
                 "--- --- --- --- ---",
@@ -286,7 +287,7 @@ class TestJoin:
         t12 = table.join(t1, t2, join_type="outer", keys="a")
         assert t12.has_masked_columns is True
         assert sort_eq(
-            t12.pformat(),
+            t12.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  c  b_2  d ",
                 "--- --- --- --- ---",
@@ -321,7 +322,7 @@ class TestJoin:
         t1m["c"].mask[2] = True
         t1m2 = table.join(t1m, t2, join_type="inner", keys="a")
         assert sort_eq(
-            t1m2.pformat(),
+            t1m2.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  c  b_2  d ",
                 "--- --- --- --- ---",
@@ -335,7 +336,7 @@ class TestJoin:
 
         t21m = table.join(t2, t1m, join_type="inner", keys="a")
         assert sort_eq(
-            t21m.pformat(),
+            t21m.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  d  b_2  c ",
                 "--- --- --- --- ---",
@@ -373,7 +374,7 @@ class TestJoin:
         t2m["d"].mask[2] = True
         t1m2m = table.join(t1m, t2m, join_type="inner", keys="a")
         assert sort_eq(
-            t1m2m.pformat(),
+            t1m2m.pformat(max_lines=-1, max_width=-1),
             [
                 " a  b_1  c  b_2  d ",
                 "--- --- --- --- ---",
@@ -853,7 +854,7 @@ class TestJoin:
             "     4 1.1 .. 1.0    -- .. --",
             "     5   -- .. --  0.5 .. 0.0",
         ]
-        assert t12.pformat(show_dtype=True) == exp
+        assert t12.pformat(show_dtype=True, max_lines=-1, max_width=-1) == exp
 
     def test_keys_left_right_basic(self):
         """Test using the keys_left and keys_right args to specify different
@@ -945,7 +946,7 @@ class TestJoin:
             names=["structured", "string"],
         )
         t12 = table.join(t1, t2, ["structured"], join_type="outer")
-        assert t12.pformat() == (
+        assert t12.pformat(max_lines=-1, max_width=-1) == (
             [
                 "structured [f, i] string_1 string_2",
                 "----------------- -------- --------",
@@ -984,7 +985,12 @@ class TestSetdiff:
         out = table.setdiff(self.t1, self.t2)
         assert type(out["a"]) is type(self.t1["a"])
         assert type(out["b"]) is type(self.t1["b"])
-        assert out.pformat() == [" a   b ", "--- ---", "  1 bar", "  1 foo"]
+        assert out.pformat(max_lines=-1, max_width=-1) == [
+            " a   b ",
+            "--- ---",
+            "  1 bar",
+            "  1 foo",
+        ]
 
     def test_default_same_tables(self, operation_table_type):
         self._setup(operation_table_type)
@@ -992,7 +998,7 @@ class TestSetdiff:
 
         assert type(out["a"]) is type(self.t1["a"])
         assert type(out["b"]) is type(self.t1["b"])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
         ]
@@ -1009,7 +1015,7 @@ class TestSetdiff:
 
         assert type(out["a"]) is type(self.t1["a"])
         assert type(out["b"]) is type(self.t1["b"])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "  1 foo",
@@ -1022,7 +1028,7 @@ class TestSetdiff:
 
         assert type(out["a"]) is type(self.t1["a"])
         assert type(out["b"]) is type(self.t1["b"])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             " a   b   d ",
             "--- --- ---",
             "  4 bar  R4",
@@ -1096,7 +1102,7 @@ class TestVStack:
         out = table.vstack([self.t1, t2[1]])
         assert type(out["a"]) is type(self.t1["a"])
         assert type(out["b"]) is type(self.t1["b"])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "0.0 foo",
@@ -1110,7 +1116,7 @@ class TestVStack:
         t2.meta.clear()
         out = table.vstack([self.t1, t2["a"]])
         assert out.masked is False
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "0.0 foo",
@@ -1179,7 +1185,7 @@ class TestVStack:
         assert type(t12) is operation_table_type
         assert type(t12["a"]) is type(t1["a"])
         assert type(t12["b"]) is type(t1["b"])
-        assert t12.pformat() == [
+        assert t12.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "0.0 foo",
@@ -1192,7 +1198,7 @@ class TestVStack:
         assert type(t124) is operation_table_type
         assert type(t12["a"]) is type(t1["a"])
         assert type(t12["b"]) is type(t1["b"])
-        assert t124.pformat() == [
+        assert t124.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "0.0 foo",
@@ -1212,7 +1218,7 @@ class TestVStack:
         t4 = self.t4
         t12 = table.vstack([t1, t2], join_type="outer")
         assert t12.masked is False
-        assert t12.pformat() == [
+        assert t12.pformat(max_lines=-1, max_width=-1) == [
             " a   b   c ",
             "--- --- ---",
             "0.0 foo  --",
@@ -1223,7 +1229,7 @@ class TestVStack:
 
         t124 = table.vstack([t1, t2, t4], join_type="outer")
         assert t124.masked is False
-        assert t124.pformat() == [
+        assert t124.pformat(max_lines=-1, max_width=-1) == [
             " a   b   c ",
             "--- --- ---",
             "0.0 foo  --",
@@ -1264,7 +1270,7 @@ class TestVStack:
         t4["b"].mask[1] = True
         t14 = table.vstack([t1, t4])
         assert t14.masked is False
-        assert t14.pformat() == [
+        assert t14.pformat(max_lines=-1, max_width=-1) == [
             " a   b ",
             "--- ---",
             "0.0 foo",
@@ -1330,7 +1336,7 @@ class TestVStack:
                 in str(warning_lines[1].message)
             )
             # Check units are suitably ignored for a regular Table
-            assert out.pformat() == [
+            assert out.pformat(max_lines=-1, max_width=-1) == [
                 "   a       b   ",
                 "   km          ",
                 "-------- ------",
@@ -1343,7 +1349,7 @@ class TestVStack:
             ]
         else:
             # Check QTable correctly dealt with units.
-            assert out.pformat() == [
+            assert out.pformat(max_lines=-1, max_width=-1) == [
                 "   a       b   ",
                 "   km          ",
                 "-------- ------",
@@ -1530,7 +1536,7 @@ class TestVStack:
             names=["structured", "string"],
         )
         t12 = table.vstack([t1, t2])
-        assert t12.pformat() == (
+        assert t12.pformat(max_lines=-1, max_width=-1) == (
             [
                 "structured [f, i] string",
                 "----------------- ------",
@@ -1553,7 +1559,7 @@ class TestVStack:
         # One table without the structured column.
         t3 = t2[("string",)]
         t13 = table.vstack([t1, t3])
-        assert t13.pformat() == [
+        assert t13.pformat(max_lines=-1, max_width=-1) == [
             "structured [f, i] string",
             "----------------- ------",
             "         (1.0, 1)    one",
@@ -1754,7 +1760,7 @@ class TestDStack:
             names=["structured", "string"],
         )
         t12 = table.dstack([t1, t2])
-        assert t12.pformat() == (
+        assert t12.pformat(max_lines=-1, max_width=-1) == (
             [
                 "structured [f, i]     string   ",
                 "------------------ ------------",
@@ -1773,7 +1779,7 @@ class TestDStack:
         # One table without the structured column.
         t3 = t2[("string",)]
         t13 = table.dstack([t1, t3])
-        assert t13.pformat() == [
+        assert t13.pformat(max_lines=-1, max_width=-1) == [
             "structured [f, i]    string   ",
             "----------------- ------------",
             "   (1.0, 1) .. -- one .. three",
@@ -1844,7 +1850,7 @@ class TestHStack:
         self._setup(operation_table_type)
         out = table.hstack([self.t1, self.t1])
         assert out.masked is False
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "a_1 b_1 a_2 b_2",
             "--- --- --- ---",
             "0.0 foo 0.0 foo",
@@ -1855,7 +1861,7 @@ class TestHStack:
         self._setup(operation_table_type)
         out = table.hstack([self.t1[0], self.t2[1]])
         assert out.masked is False
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "a_1 b_1 a_2 b_2  c ",
             "--- --- --- --- ---",
             "0.0 foo 3.0 sez   5",
@@ -1867,7 +1873,7 @@ class TestHStack:
         assert type(out["a"]) is type(self.t1["a"])
         assert type(out["b"]) is type(self.t1["b"])
         assert type(out["c"]) is type(self.t2["c"])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             " a   b   c ",
             "--- --- ---",
             "0.0 foo   4",
@@ -1923,6 +1929,7 @@ class TestHStack:
         with pytest.raises(ValueError):
             table.hstack([self.t1, self.t2], join_type="invalid join type")
 
+    @ignore_pformat_default_pending_depr_warning
     def test_stack_basic(self, operation_table_type):
         self._setup(operation_table_type)
         t1 = self.t1
@@ -1937,7 +1944,7 @@ class TestHStack:
         assert type(out["b_1"]) is type(t1["b"])
         assert type(out["a_2"]) is type(t2["a"])
         assert type(out["b_2"]) is type(t2["b"])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "a_1 b_1 a_2 b_2  c ",
             "--- --- --- --- ---",
             "0.0 foo 2.0 pez   4",
@@ -1953,7 +1960,7 @@ class TestHStack:
 
         out = table.hstack([t1, t2, t3, t4], join_type="outer")
         assert out.masked is False
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "a_1 b_1 a_2 b_2  c   d   e   f   g ",
             "--- --- --- --- --- --- --- --- ---",
             "0.0 foo 2.0 pez   4 4.0   7 0.0 foo",
@@ -1963,7 +1970,7 @@ class TestHStack:
 
         out = table.hstack([t1, t2, t3, t4], join_type="inner")
         assert out.masked is False
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "a_1 b_1 a_2 b_2  c   d   e   f   g ",
             "--- --- --- --- --- --- --- --- ---",
             "0.0 foo 2.0 pez   4 4.0   7 0.0 foo",
@@ -1986,7 +1993,7 @@ class TestHStack:
         t2.meta.clear()
         t2["b"].mask[1] = True
         out = table.hstack([t1, t2])
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "a_1 b_1 a_2 b_2",
             "--- --- --- ---",
             "0.0 foo 0.0 foo",
@@ -2002,7 +2009,7 @@ class TestHStack:
             table_names=("left", "right"),
         )
         assert out.masked is False
-        assert out.pformat() == [
+        assert out.pformat(max_lines=-1, max_width=-1) == [
             "left_a left_b right_a right_b  c ",
             "------ ------ ------- ------- ---",
             "   0.0    foo     2.0     pez   4",
@@ -2092,6 +2099,7 @@ class TestHStack:
             assert "hstack requires masking" in str(err.value)
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_unique(operation_table_type):
     t = operation_table_type.read(
         [
@@ -2117,7 +2125,7 @@ def test_unique(operation_table_type):
     del t_s["b", "c", "d"]
     t_all = table.unique(t_s)
     assert sort_eq(
-        t_all.pformat(),
+        t_all.pformat(max_lines=-1, max_width=-1),
         [
             " a ",
             "---",
@@ -2130,7 +2138,7 @@ def test_unique(operation_table_type):
     key1 = "a"
     t1a = table.unique(t, key1)
     assert sort_eq(
-        t1a.pformat(),
+        t1a.pformat(max_lines=-1, max_width=-1),
         [
             " a   b   c   d ",
             "--- --- --- ---",
@@ -2141,7 +2149,7 @@ def test_unique(operation_table_type):
     )
     t1b = table.unique(t, key1, keep="last")
     assert sort_eq(
-        t1b.pformat(),
+        t1b.pformat(max_lines=-1, max_width=-1),
         [
             " a   b   c   d ",
             "--- --- --- ---",
@@ -2152,7 +2160,7 @@ def test_unique(operation_table_type):
     )
     t1c = table.unique(t, key1, keep="none")
     assert sort_eq(
-        t1c.pformat(),
+        t1c.pformat(max_lines=-1, max_width=-1),
         [
             " a   b   c   d ",
             "--- --- --- ---",
@@ -2163,7 +2171,7 @@ def test_unique(operation_table_type):
     key2 = ["a", "b"]
     t2a = table.unique(t, key2)
     assert sort_eq(
-        t2a.pformat(),
+        t2a.pformat(max_lines=-1, max_width=-1),
         [
             " a   b   c   d ",
             "--- --- --- ---",
@@ -2177,7 +2185,7 @@ def test_unique(operation_table_type):
 
     t2b = table.unique(t, key2, keep="last")
     assert sort_eq(
-        t2b.pformat(),
+        t2b.pformat(max_lines=-1, max_width=-1),
         [
             " a   b   c   d ",
             "--- --- --- ---",
@@ -2190,7 +2198,7 @@ def test_unique(operation_table_type):
     )
     t2c = table.unique(t, key2, keep="none")
     assert sort_eq(
-        t2c.pformat(),
+        t2c.pformat(max_lines=-1, max_width=-1),
         [
             " a   b   c   d ",
             "--- --- --- ---",
@@ -2220,7 +2228,7 @@ def test_unique(operation_table_type):
 
     t1_mu = table.unique(t1_m, silent=True)
     assert t1_mu.masked is False
-    assert t1_mu.pformat() == [
+    assert t1_mu.pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d ",
         "--- --- --- ---",
         "  0   a 0.0   4",
@@ -2239,7 +2247,7 @@ def test_unique(operation_table_type):
     # order
     t1_mu = table.unique(t1_m, keys=["d", "a", "b"], silent=True)
     assert t1_mu.masked is False
-    assert t1_mu.pformat() == [
+    assert t1_mu.pformat(max_lines=-1, max_width=-1) == [
         " a   b   c   d ",
         "--- --- --- ---",
         "  2   a 4.0  --",

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -10,9 +10,10 @@ import pytest
 from astropy import conf, table
 from astropy import units as u
 from astropy.io import ascii
-from astropy.table import QTable, Table
+from astropy.table import Column, QTable, Table
 from astropy.table.table_helpers import simple_table
 from astropy.table.tests.utils import ignore_pformat_default_pending_depr_warning
+from astropy.utils.exceptions import AstropyPendingDeprecationWarning
 
 BIG_WIDE_ARR = np.arange(2000, dtype=np.float64).reshape(100, 20)
 SMALL_ARR = np.arange(18, dtype=np.int64).reshape(6, 3)
@@ -117,6 +118,26 @@ class TestMultiD:
             "     3 .. 30",
             "     5 .. 50",
         ]
+
+
+def test_pformat_max_size_deprecation():
+    with (
+        pytest.warns(
+            AstropyPendingDeprecationWarning,
+            match=r"The default value for the max_lines argument",
+        ),
+        pytest.warns(
+            AstropyPendingDeprecationWarning,
+            match=r"The default value for the max_width argument",
+        ),
+    ):
+        Table().pformat()
+
+    with pytest.warns(
+        AstropyPendingDeprecationWarning,
+        match=r"The default value for the max_lines argument",
+    ):
+        Column().pformat()
 
 
 def test_html_escaping():

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from astropy.io import ascii
 from astropy.table import QTable, Table
 from astropy.table.table_helpers import simple_table
+from astropy.table.tests.utils import ignore_pformat_default_pending_depr_warning
 
 BIG_WIDE_ARR = np.arange(2000, dtype=np.float64).reshape(100, 20)
 SMALL_ARR = np.arange(18, dtype=np.int64).reshape(6, 3)
@@ -27,7 +28,7 @@ class TestMultiD:
             np.array([[5, 6], [50, 60]], dtype=np.int64),
         ]
         t = table_type(arr)
-        lines = t.pformat(show_dtype=True)
+        lines = t.pformat(show_dtype=True, max_lines=-1, max_width=-1)
         assert lines == [
             "  col0     col1     col2  ",
             "int64[2] int64[2] int64[2]",
@@ -36,7 +37,7 @@ class TestMultiD:
             "10 .. 20 30 .. 40 50 .. 60",
         ]
 
-        lines = t.pformat(html=True, show_dtype=True)
+        lines = t.pformat(html=True, show_dtype=True, max_lines=-1, max_width=-1)
         assert lines == [
             f'<table id="table{id(t)}">',
             "<thead><tr><th>col0</th><th>col1</th><th>col2</th></tr></thead>",
@@ -58,7 +59,7 @@ class TestMultiD:
         ]
 
         t = table_type([arr])
-        lines = t.pformat(show_dtype=True)
+        lines = t.pformat(show_dtype=True, max_lines=-1, max_width=-1)
         assert lines == [
             "   col0   ",
             "int64[2,2]",
@@ -76,7 +77,7 @@ class TestMultiD:
             np.array([[(5,)], [(50,)]], dtype=np.int64),
         ]
         t = table_type(arr)
-        lines = t.pformat(show_dtype=True)
+        lines = t.pformat(show_dtype=True, max_lines=-1, max_width=-1)
         assert lines == [
             "   col0       col1       col2   ",
             "int64[1,1] int64[1,1] int64[1,1]",
@@ -85,7 +86,7 @@ class TestMultiD:
             "        10         30         50",
         ]
 
-        lines = t.pformat(html=True, show_dtype=True)
+        lines = t.pformat(html=True, show_dtype=True, max_lines=-1, max_width=-1)
         assert lines == [
             f'<table id="table{id(t)}">',
             "<thead><tr><th>col0</th><th>col1</th><th>col2</th></tr></thead>",
@@ -107,7 +108,7 @@ class TestMultiD:
         ]
 
         t = table_type([arr])
-        lines = t.pformat(show_dtype=True)
+        lines = t.pformat(show_dtype=True, max_lines=-1, max_width=-1)
         assert lines == [
             "    col0    ",
             "int64[2,1,1]",
@@ -146,7 +147,7 @@ class TestPprint:
 
     def test_empty_table(self, table_type):
         t = table_type()
-        lines = t.pformat()
+        lines = t.pformat(max_lines=-1, max_width=-1)
         assert lines == ["<No columns>"]
         c = repr(t)
         masked = "masked=True " if t.masked else ""
@@ -155,6 +156,7 @@ class TestPprint:
             "<No columns>",
         ]
 
+    @ignore_pformat_default_pending_depr_warning
     def test_format0(self, table_type):
         """Try getting screen size but fail to defaults because testing doesn't
         have access to screen (fcntl.ioctl fails).
@@ -297,7 +299,7 @@ class TestPprint:
         """Test a range of max_lines"""
         self._setup(table_type)
         for max_lines in (0, 1, 4, 5, 6, 7, 8, 100, 101, 102, 103, 104, 130):
-            lines = self.tb.pformat(max_lines=max_lines, show_unit=False)
+            lines = self.tb.pformat(max_lines=max_lines, show_unit=False, max_width=-1)
             assert len(lines) == max(8, min(102, max_lines))
 
     def test_pformat_all(self, table_type):
@@ -610,6 +612,7 @@ def test_pprint_py3_bytes():
     assert t["col"].pformat() == ["col ", "----", " val", "bläh"]
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_pprint_structured():
     su = table.Column(
         [
@@ -675,7 +678,7 @@ def test_html():
     dat = np.array([1.0, 2.0], dtype=np.float32)
     t = Table([dat], names=["a"])
 
-    lines = t.pformat(html=True)
+    lines = t.pformat(html=True, max_lines=-1, max_width=-1)
     assert lines == [
         f'<table id="table{id(t)}">',
         "<thead><tr><th>a</th></tr></thead>",
@@ -684,7 +687,7 @@ def test_html():
         "</table>",
     ]
 
-    lines = t.pformat(html=True, tableclass="table-striped")
+    lines = t.pformat(html=True, tableclass="table-striped", max_lines=-1, max_width=-1)
     assert lines == [
         f'<table id="table{id(t)}" class="table-striped">',
         "<thead><tr><th>a</th></tr></thead>",
@@ -693,7 +696,9 @@ def test_html():
         "</table>",
     ]
 
-    lines = t.pformat(html=True, tableclass=["table", "table-striped"])
+    lines = t.pformat(
+        html=True, tableclass=["table", "table-striped"], max_lines=-1, max_width=-1
+    )
     assert lines == [
         f'<table id="table{id(t)}" class="table table-striped">',
         "<thead><tr><th>a</th></tr></thead>",
@@ -705,7 +710,7 @@ def test_html():
 
 def test_align():
     t = simple_table(2, kinds="iS")
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "  1   b",
@@ -713,7 +718,7 @@ def test_align():
     ]
     # Use column format attribute
     t["a"].format = "<"
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "1     b",
@@ -723,22 +728,22 @@ def test_align():
     # Now override column format attribute with various combinations of align
     tpf = [" a   b ", "--- ---", " 1   b ", " 2   c "]
     for align in ("^", ["^", "^"], ("^", "^")):
-        assert tpf == t.pformat(align=align)
+        assert t.pformat(align=align, max_lines=-1, max_width=-1) == tpf
 
-    assert t.pformat(align="<") == [
+    assert t.pformat(align="<", max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "1   b  ",
         "2   c  ",
     ]
-    assert t.pformat(align="0=") == [
+    assert t.pformat(align="0=", max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "001 00b",
         "002 00c",
     ]
 
-    assert t.pformat(align=["<", "^"]) == [
+    assert t.pformat(align=["<", "^"], max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "1    b ",
@@ -749,21 +754,21 @@ def test_align():
     # character that is the same as an align character.
     t = simple_table(2, kinds="iS")
 
-    assert t.pformat(align="^^") == [
+    assert t.pformat(align="^^", max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "^1^ ^b^",
         "^2^ ^c^",
     ]
 
-    assert t.pformat(align="^>") == [
+    assert t.pformat(align="^>", max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "^^1 ^^b",
         "^^2 ^^c",
     ]
 
-    assert t.pformat(align="^<") == [
+    assert t.pformat(align="^<", max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "1^^ b^^",
@@ -774,21 +779,21 @@ def test_align():
     t1 = Table([[1.0, 2.0], [1, 2]], names=["column1", "column2"])
     t1["column1"].format = "#^.2f"
 
-    assert t1.pformat() == [
+    assert t1.pformat(max_lines=-1, max_width=-1) == [
         "column1 column2",
         "------- -------",
         "##1.00#       1",
         "##2.00#       2",
     ]
 
-    assert t1.pformat(align="!<") == [
+    assert t1.pformat(align="!<", max_lines=-1, max_width=-1) == [
         "column1 column2",
         "------- -------",
         "1.00!!! 1!!!!!!",
         "2.00!!! 2!!!!!!",
     ]
 
-    assert t1.pformat(align=[None, "!<"]) == [
+    assert t1.pformat(align=[None, "!<"], max_lines=-1, max_width=-1) == [
         "column1 column2",
         "------- -------",
         "##1.00# 1!!!!!!",
@@ -797,7 +802,7 @@ def test_align():
 
     # Zero fill
     t["a"].format = "+d"
-    assert t.pformat(align="0=") == [
+    assert t.pformat(align="0=", max_lines=-1, max_width=-1) == [
         " a   b ",
         "--- ---",
         "+01 00b",
@@ -805,13 +810,13 @@ def test_align():
     ]
 
     with pytest.raises(ValueError):
-        t.pformat(align=["fail"])
+        t.pformat(align=["fail"], max_lines=-1, max_width=-1)
 
     with pytest.raises(TypeError):
-        t.pformat(align=0)
+        t.pformat(align=0, max_lines=-1, max_width=-1)
 
     with pytest.raises(TypeError):
-        t.pprint(align=0)
+        t.pprint(align=0, max_lines=-1, max_width=-1)
 
     # Make sure pprint() does not raise an exception
     t.pprint()
@@ -823,6 +828,7 @@ def test_align():
         t.pprint(align="x=")
 
 
+@ignore_pformat_default_pending_depr_warning
 def test_auto_format_func():
     """Test for #5802 (fix for #5800 where format_func key is not unique)"""
     t = Table([[1, 2] * u.m])
@@ -840,7 +846,7 @@ def test_decode_replace():
     https://docs.python.org/3/library/codecs.html#codecs.replace_errors
     """
     t = Table([[b"Z\xf0"]])
-    assert t.pformat() == [
+    assert t.pformat(max_lines=-1, max_width=-1) == [
         "col0",
         "----",
         "  Z\ufffd",

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -609,7 +609,7 @@ def test_pprint_py3_bytes():
     blah = "bläh".encode()
     dat = np.array([val, blah], dtype=[("col", "S10")])
     t = table.Table(dat)
-    assert t["col"].pformat() == ["col ", "----", " val", "bläh"]
+    assert t["col"].pformat(max_lines=-1) == ["col ", "----", " val", "bläh"]
 
 
 @ignore_pformat_default_pending_depr_warning
@@ -625,7 +625,7 @@ def test_pprint_structured():
             ("f", [("p0", np.float64), ("p1", np.float64, (2,))]),
         ],
     )
-    assert su.pformat() == [
+    assert su.pformat(max_lines=-1) == [
         "  su [i, f[p0, p1]]   ",
         "----------------------",
         "(1, (1.5, [1.6, 1.7]))",

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -986,7 +986,7 @@ def test_inserting_quantity_row_in_empty_table(
     assert type(table["b"]) is expected_column_type
     assert type(table["c"]) is Column
 
-    assert table.pformat() == expected_pformat
+    assert table.pformat(max_lines=-1, max_width=-1) == expected_pformat
 
 
 @pytest.mark.usefixtures("table_types")

--- a/astropy/table/tests/utils.py
+++ b/astropy/table/tests/utils.py
@@ -1,0 +1,6 @@
+import pytest
+
+ignore_pformat_default_pending_depr_warning = pytest.mark.filterwarnings(
+    r"ignore:The default value for the (max_lines|max_width) argument "
+    r"in \w+\.pformat:PendingDeprecationWarning"
+)

--- a/docs/changes/table/17179.api.rst
+++ b/docs/changes/table/17179.api.rst
@@ -1,0 +1,7 @@
+``Table.pformat``'s ``max_lines`` and ``max_width`` arguments defaulting to
+``None`` is now pending deprecation. In a future version of Astropy, we plan to
+change their default values to -1, which gives more consistent outputs,
+independent of the terminal size.
+
+``Column.pformat``'s ``max_lines`` argument follows the same pending
+deprecation.


### PR DESCRIPTION
### Description
Fixes #15828

A couple keys for reviewers (I'll generally refer to `max_lines` and `max_width` as "max sizes"):
- I took the initiative to also apply this deprecation to `BaseColumn.pformat` for consistency, but this has *not* been discussed on the issue. Hopefully this is also not controversial.
- evidently, many tests needed adapting. I devised them in two categories:
  - tests that check for an exact output: I added the explicit *future* max sizes (-1) there to ensure stability. These can be cleaned up in the future, after the deprecation is terminated, but they do not *need* to be
  - tests that check for equality between two `pformat` return values: there I thought that leaving the implicit defaults made more sense, so I defined a unique decorator to ignore the associated warnings in these cases. This decorator should be removed when the deprecation period is terminated.
  - some tests fall contain a mix of both categories, and were decorated to ignore the warning but only *after* I added explicit sizes where due.

If this approach is consensual, I'll open a reminder issue to link back here for when we end the deprecation period.
Note that the branch is also written be be reviewable at a commit-by-commit level.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


TODO:
- [ ] pass CI
- [x] add test for the deprecation warnings themselves