### PR TITLE
TST: fix a couple broken test cases

### DIFF
--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -965,9 +965,8 @@ def test_ndarray_mixin(as_ndarray_mixin):
     assert t[1]["d"][0] == d[1][0]
     assert t[1]["d"][1] == d[1][1]
 
-    assert (
-        t.pformat(show_dtype=True)
-        == [
+    assert t.pformat(show_dtype=True) == (
+        [
             "  a [f0, f1]     b [x, y]      c [rx, ry]      d    ",
             "(int32, str1) (int32, str2) (float64, str3) int64[2]",
             "------------- ------------- --------------- --------",

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -945,9 +945,8 @@ class TestJoin:
             names=["structured", "string"],
         )
         t12 = table.join(t1, t2, ["structured"], join_type="outer")
-        assert (
-            t12.pformat()
-            == [
+        assert t12.pformat() == (
+            [
                 "structured [f, i] string_1 string_2",
                 "----------------- -------- --------",
                 "          (1., 1)      one       --",
@@ -1531,9 +1530,8 @@ class TestVStack:
             names=["structured", "string"],
         )
         t12 = table.vstack([t1, t2])
-        assert (
-            t12.pformat()
-            == [
+        assert t12.pformat() == (
+            [
                 "structured [f, i] string",
                 "----------------- ------",
                 "          (1., 1)    one",
@@ -1756,9 +1754,8 @@ class TestDStack:
             names=["structured", "string"],
         )
         t12 = table.dstack([t1, t2])
-        assert (
-            t12.pformat()
-            == [
+        assert t12.pformat() == (
+            [
                 "structured [f, i]     string   ",
                 "------------------ ------------",
                 "(1., 1) .. (3., 3) one .. three",


### PR DESCRIPTION
### Description
I discovered while working on #17179 that a couple test cases were silently broken since #16433 when run against numpy>=2.0

This is admittedly confusing (which explains why I did this mistake and why it passed review), so let me try to explain what's going on:
Because of missing parens, these assert statements are currently equivalent to
```python
assert (1 == 2 if condition else 1)
```

though the way the Python intepreter reads the expression `(1 == 2 if False else True)`, it will *first* evaluate the condition (`if condition`) and then, with `condition==False`, jump to the `else` branch as the result of the expression: `1`, which is "truthy", resulting in a successful assertion, never actually evaluating the (here, broken) comparison (`1 == 2`).
In short, the current form reads as
```python
assert ((1 == 2) if condition else (1))
```

The correct, intended form is
```python
assert 1 == (2 if condition else 1)
```

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
