### PR TITLE
API: change default behavior in `Table.pformat` and `Column.pformat` and add (pending) deprecation to `Table.pformat_all`

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -2061,7 +2061,7 @@ def test_read_converters_simplified():
 
     converters = {"a": float, "*": [np.int64, float, bool, str]}
     t2 = Table.read(out.getvalue(), format="ascii.basic", converters=converters)
-    assert t2.pformat_all(show_dtype=True) == [
+    assert t2.pformat(show_dtype=True) == [
         "   a       b      c     d     e  ",
         "float64 float64  bool  str5 int64",
         "------- ------- ----- ----- -----",

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -852,7 +852,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     def pformat(
         self,
-        max_lines=None,
+        max_lines=-1,
         show_name=True,
         show_unit=False,
         show_dtype=False,
@@ -860,17 +860,19 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
     ):
         """Return a list of formatted string representation of column values.
 
-        If no value of ``max_lines`` is supplied then the height of the
+        If ``max_lines=None`` is supplied then the height of the
         screen terminal is used to set ``max_lines``.  If the terminal
         height cannot be determined then the default will be
         determined using the ``astropy.conf.max_lines`` configuration
         item. If a negative value of ``max_lines`` is supplied then
-        there is no line limit applied.
+        there is no line limit applied (default).
 
         Parameters
         ----------
-        max_lines : int
-            Maximum lines of output (header + data rows)
+        max_lines : int or None
+            Maximum lines of output (header + data rows).
+            -1 (default) implies no limit, ``None`` implies using the
+            height of the current terminal.
 
         show_name : bool
             Include column name. Default is True.
@@ -904,7 +906,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
     def pprint(self, max_lines=None, show_name=True, show_unit=False, show_dtype=False):
         """Print a formatted string representation of column values.
 
-        If no value of ``max_lines`` is supplied then the height of the
+        If ``max_lines=None`` (default) then the height of the
         screen terminal is used to set ``max_lines``.  If the terminal
         height cannot be determined then the default will be
         determined using the ``astropy.conf.max_lines`` configuration

--- a/astropy/table/mixins/tests/test_dask.py
+++ b/astropy/table/mixins/tests/test_dask.py
@@ -39,7 +39,7 @@ class TestDaskHandler:
         assert_equal(sub["a"].compute(), np.arange(10))
 
     def test_pformat(self):
-        assert self.t.pformat_all() == [
+        assert self.t.pformat() == [
             " a ",
             "---",
             "  0",

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -557,8 +557,8 @@ class TableFormatter:
     def _pformat_table(
         self,
         table,
-        max_lines=None,
-        max_width=None,
+        max_lines=-1,
+        max_width=-1,
         show_name=True,
         show_unit=None,
         show_dtype=False,
@@ -574,9 +574,13 @@ class TableFormatter:
         ----------
         max_lines : int or None
             Maximum number of rows to output
+            -1 (default) implies no limit, ``None`` implies using the
+            height of the current terminal.
 
         max_width : int or None
             Maximum character width of output
+            -1 (default) implies no limit, ``None`` implies using the
+            width of the current terminal.
 
         show_name : bool
             Include a header row for column names. Default is True.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1649,7 +1649,7 @@ class Table:
         return self._base_repr_(html=False, max_width=None)
 
     def __str__(self):
-        return "\n".join(self.pformat())
+        return "\n".join(self.pformat(max_lines=None, max_width=None))
 
     def __bytes__(self):
         return str(self).encode("utf-8")
@@ -1919,8 +1919,8 @@ class Table:
     @format_doc(_pformat_docs, id="{id}")
     def pformat(
         self,
-        max_lines=None,
-        max_width=None,
+        max_lines=-1,
+        max_width=-1,
         show_name=True,
         show_unit=None,
         show_dtype=False,
@@ -1932,12 +1932,12 @@ class Table:
         """Return a list of lines for the formatted string representation of
         the table.
 
-        If no value of ``max_lines`` is supplied then the height of the
+        If ``max_lines=None`` is supplied then the height of the
         screen terminal is used to set ``max_lines``.  If the terminal
-        height cannot be determined then the default is taken from the
-        configuration item ``astropy.conf.max_lines``.  If a negative
-        value of ``max_lines`` is supplied then there is no line limit
-        applied.
+        height cannot be determined then the default will be
+        determined using the ``astropy.conf.max_lines`` configuration
+        item. If a negative value of ``max_lines`` is supplied then
+        there is no line limit applied (default).
 
         The same applies for ``max_width`` except the configuration item  is
         ``astropy.conf.max_width``.
@@ -1961,6 +1961,7 @@ class Table:
 
         return lines
 
+    @deprecated(since="7.0", alternative="Table.pformat")
     @format_doc(_pformat_docs, id="{id}")
     def pformat_all(
         self,
@@ -1977,12 +1978,12 @@ class Table:
         """Return a list of lines for the formatted string representation of
         the entire table.
 
-        If no value of ``max_lines`` is supplied then the height of the
+        If ``max_lines=None`` is supplied then the height of the
         screen terminal is used to set ``max_lines``.  If the terminal
-        height cannot be determined then the default is taken from the
-        configuration item ``astropy.conf.max_lines``.  If a negative
-        value of ``max_lines`` is supplied then there is no line limit
-        applied.
+        height cannot be determined then the default will be
+        determined using the ``astropy.conf.max_lines`` configuration
+        item. If a negative value of ``max_lines`` is supplied then
+        there is no line limit applied (default).
 
         The same applies for ``max_width`` except the configuration item  is
         ``astropy.conf.max_width``.

--- a/docs/changes/table/17184.api.rst
+++ b/docs/changes/table/17184.api.rst
@@ -1,0 +1,6 @@
+The default behavior of ``Table.pformat`` was changed to include all rows and columns
+instead of truncating the outputs to fit the current terminal.  The new default
+keyword arguments ``max_width=-1`` and ``max_lines=-1`` now match those in
+``Table.pformat_all``. Since the ``Table.pformat_all`` method is now redundant, it is
+pending deprecation. Similarly, the default behavior of ``Column.pformat`` was changed
+to include all rows instead of truncating the outputs to fit the current terminal.

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -16,6 +16,7 @@ In particular, this release includes:
 * :ref:`whatsnew-7.0-table-frames`
 * :ref:`whatsnew-7.0-table-notebook-backends`
 * :ref:`whatsnew-7.0-table-init-columns-order`
+* :ref:`whatsnew_7_0_table_pformat_default_changes`
 * :ref:`whatsnew_7_0_quantity_to_string_formatter`
 * :ref:`whatsnew_7_0_numpy_constructors_like_quantity`
 * :ref:`whatsnew_7_0_ecsv_meta_default_dict`
@@ -114,6 +115,21 @@ Starting with ``7.0`` the table would instead look like this::
     --- --- ---
      10   7  --
      20  35  15
+
+.. _whatsnew_7_0_table_pformat_default_changes:
+
+``Table.pformat`` is now independent of terminal dimensions
+===========================================================
+
+``Table.pformat`` and ``Column.pformat`` do not truncate their outputs according
+to terminal height and width by default any more. The new default behavior is
+intended to be less surprising.
+
+Truncating representations to fit the current terminal is still supported but
+now requires explicitly passing ``max_lines=None`` and/or ``max_width=None``.
+
+``Table.pformat_all`` is deprecated as it is now fully redundant.
+
 
 .. _whatsnew_7_0_quantity_to_string_formatter:
 


### PR DESCRIPTION
### Description
Fixes #15828, replaces #17179

EDIT: Closes #17179

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
