### PR TITLE
Remove `nsamples` parameter of `ZScaleInterval`

### DIFF
--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -9,8 +9,6 @@ import abc
 
 import numpy as np
 
-from astropy.utils.decorators import deprecated_attribute, deprecated_renamed_argument
-
 from .transform import BaseTransform
 
 __all__ = [
@@ -219,9 +217,8 @@ class ZScaleInterval(BaseInterval):
         The number of points in the array to sample for determining
         scaling factors.  Defaults to 1000.
 
-        .. versionchanged:: 5.2
-            ``n_samples`` replaces the deprecated ``nsamples`` argument,
-            which will be removed in the future.
+        .. versionchanged:: 7.0
+            ``nsamples`` parameter is removed.
 
     contrast : float, optional
         The scaling factor (between 0 and 1) for determining the minimum
@@ -243,7 +240,6 @@ class ZScaleInterval(BaseInterval):
         5.
     """
 
-    @deprecated_renamed_argument("nsamples", "n_samples", "5.2")
     def __init__(
         self,
         n_samples=1000,
@@ -259,9 +255,6 @@ class ZScaleInterval(BaseInterval):
         self.min_npixels = min_npixels
         self.krej = krej
         self.max_iterations = max_iterations
-
-    # Mark `nsamples` as deprecated
-    nsamples = deprecated_attribute("nsamples", "5.2", alternative="n_samples")
 
     def get_limits(self, values):
         # Sample the image

--- a/docs/changes/visualization/17186.api.rst
+++ b/docs/changes/visualization/17186.api.rst
@@ -1,0 +1,1 @@
+The deprecated ``nsamples`` parameter of ``ZScaleInterval`` is removed.


### PR DESCRIPTION
### Description

The parameter was deprecated in 5f55486ba6df26b95dba3fbe9132135341b00dad.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
