### PR TITLE
EXP: drop `bottleneck` as an optional dependency

### DIFF
--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from astropy.stats.funcs import median_absolute_deviation
-from astropy.stats.nanfunctions import nanmedian, nansum
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -38,8 +37,8 @@ def _stat_functions(
         median_func = np.ma.median
         sum_func = np.ma.sum
     elif ignore_nan:
-        median_func = nanmedian
-        sum_func = nansum
+        median_func = np.nanmedian
+        sum_func = np.nansum
     else:
         median_func = np.median
         sum_func = np.sum

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_SCIPY
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 from . import _stats
 
@@ -853,11 +853,8 @@ def median_absolute_deviation(
             if ignore_nan:
                 data = np.ma.masked_where(np.isnan(data), data, copy=True)
         elif ignore_nan:
-            # prevent circular import
-            from astropy.stats.nanfunctions import nanmedian
-
             is_masked = False
-            func = nanmedian
+            func = np.nanmedian
         else:
             is_masked = False
             func = np.median  # drops units if result is NaN
@@ -873,10 +870,7 @@ def median_absolute_deviation(
     if axis is not None:
         data_median = np.expand_dims(data_median, axis=axis)
 
-    if HAS_BOTTLENECK:
-        result = func(np.abs(data - data_median), axis=axis)
-    else:
-        result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
+    result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
 
     if axis is None and np.ma.isMaskedArray(result):
         # return scalar version

--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -7,96 +7,42 @@ bottleneck is not installed, then the np.nan* functions are used.
 
 from __future__ import annotations
 
-import functools
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from astropy.stats.funcs import mad_std
-from astropy.units import Quantity
-from astropy.utils.compat.optional_deps import HAS_BOTTLENECK
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from numpy.typing import ArrayLike, NDArray
 
-
-if HAS_BOTTLENECK:
-    import bottleneck
-
-    def _move_tuple_axes_last(
-        array: ArrayLike,
-        axis: tuple[int, ...] | None = None,
-    ) -> ArrayLike:
-        """
-        Move the specified axes of a NumPy array to the last positions
-        and combine them.
-
-        Bottleneck can only take integer axis, not tuple, so this
-        function takes all the axes to be operated on and combines them
-        into the last dimension of the array so that we can then use
-        axis=-1.
-
-        Parameters
-        ----------
-        array : `~numpy.ndarray`
-            The input array.
-
-        axis : tuple of int
-            The axes on which to move and combine.
-
-        Returns
-        -------
-        array_new : `~numpy.ndarray`
-            Array with the axes being operated on moved into the last
-            dimension.
-        """
-        other_axes = tuple(i for i in range(array.ndim) if i not in axis)
-
-        # Move the specified axes to the last positions
-        array_new = np.transpose(array, other_axes + axis)
-
-        # Reshape the array by combining the moved axes
-        return array_new.reshape(array_new.shape[: len(other_axes)] + (-1,))
-
-    def _apply_bottleneck(
-        function: Callable,
-        array: ArrayLike,
-        axis: int | tuple[int, ...] | None = None,
-        **kwargs,
-    ) -> float | NDArray | Quantity:
-        """Wrap bottleneck function to handle tuple axis.
-
-        Also takes care to ensure the output is of the expected type,
-        i.e., a quantity, numpy array, or numpy scalar.
-        """
-        if isinstance(axis, tuple):
-            array = _move_tuple_axes_last(array, axis=axis)
-            axis = -1
-
-        result = function(array, axis=axis, **kwargs)
-        if isinstance(array, Quantity):
-            return array.__array_wrap__(result)
-        elif isinstance(result, float):
-            # For compatibility with numpy, always return a numpy scalar.
-            return np.float64(result)
-        else:
-            return result
-
-    nansum = functools.partial(_apply_bottleneck, bottleneck.nansum)
-    nanmean = functools.partial(_apply_bottleneck, bottleneck.nanmean)
-    nanmedian = functools.partial(_apply_bottleneck, bottleneck.nanmedian)
-    nanstd = functools.partial(_apply_bottleneck, bottleneck.nanstd)
-
-else:
-    nansum = np.nansum
-    nanmean = np.nanmean
-    nanmedian = np.nanmedian
-    nanstd = np.nanstd
+__all__ = [
+    "nansum",  # noqa: F822
+    "nanmean",  # noqa: F822
+    "nanmedian",  # noqa: F822
+    "nanstd",  # noqa: F822
+    "nanmadstd",  # noqa: F822
+]
 
 
-def nanmadstd(
+def __getattr__(item):
+    if item not in __all__:
+        raise AttributeError(f"Module {__name__!r} has no attribute {item!r}.")
+
+    if item == "nanmadstd":
+        return _nanmadstd
+
+    warnings.warn(
+        f"Importing {item} from {__name__} is deprecated, please use numpy directly",
+        category=AstropyDeprecationWarning,
+        stacklevel=2,
+    )
+    return getattr(np, item)
+
+
+def _nanmadstd(
     array: ArrayLike,
     axis: int | tuple[int, ...] | None = None,
 ) -> float | NDArray:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from astropy.stats._fast_sigma_clip import _sigma_clip_fast
-from astropy.stats.nanfunctions import nanmadstd, nanmean, nanmedian, nanstd
+from astropy.stats.nanfunctions import nanmadstd
 from astropy.units import Quantity
 from astropy.utils import isiterable
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
@@ -219,10 +219,10 @@ class SigmaClip:
     ) -> Callable | None:
         if isinstance(cenfunc, str):
             if cenfunc == "median":
-                cenfunc = nanmedian
+                cenfunc = np.nanmedian
 
             elif cenfunc == "mean":
-                cenfunc = nanmean
+                cenfunc = np.nanmean
 
             else:
                 raise ValueError(f"{cenfunc} is an invalid cenfunc.")
@@ -235,7 +235,7 @@ class SigmaClip:
     ) -> Callable | None:
         if isinstance(stdfunc, str):
             if stdfunc == "std":
-                stdfunc = nanstd
+                stdfunc = np.nanstd
             elif stdfunc == "mad_std":
                 stdfunc = nanmadstd
             else:
@@ -1007,8 +1007,8 @@ def sigma_clipped_stats(
         data, axis=axis, masked=False, return_bounds=False, copy=True
     )
 
-    mean = nanmean(data_clipped, axis=axis)
-    median = nanmedian(data_clipped, axis=axis)
-    std = nanstd(data_clipped, ddof=std_ddof, axis=axis)
+    mean = np.nanmean(data_clipped, axis=axis)
+    median = np.nanmedian(data_clipped, axis=axis)
+    std = np.nanstd(data_clipped, ddof=std_ddof, axis=axis)
 
     return mean, median, std

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 from astropy import units as u
 from astropy.stats import funcs
-from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_MPMATH, HAS_SCIPY
+from astropy.utils.compat.optional_deps import HAS_MPMATH, HAS_SCIPY
 from astropy.utils.misc import NumpyRNGContext
 
 
@@ -397,24 +397,17 @@ def test_mad_std_with_axis_and_nan():
     result_axis0 = np.array([2.22390333, 0.74130111, 0.74130111, 2.22390333, np.nan])
     result_axis1 = np.array([1.48260222, 1.48260222])
 
-    if HAS_BOTTLENECK:
+    with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
         assert_allclose(funcs.mad_std(data, axis=0, ignore_nan=True), result_axis0)
         assert_allclose(funcs.mad_std(data, axis=1, ignore_nan=True), result_axis1)
-    else:
-        with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
-            assert_allclose(funcs.mad_std(data, axis=0, ignore_nan=True), result_axis0)
-            assert_allclose(funcs.mad_std(data, axis=1, ignore_nan=True), result_axis1)
 
 
 def test_mad_std_with_axis_and_nan_array_type():
     # mad_std should return a masked array if given one, and not otherwise
     data = np.array([[1, 2, 3, 4, np.nan], [4, 3, 2, 1, np.nan]])
 
-    if HAS_BOTTLENECK:
+    with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
         result = funcs.mad_std(data, axis=0, ignore_nan=True)
-    else:
-        with pytest.warns(RuntimeWarning, match=r"All-NaN slice encountered"):
-            result = funcs.mad_std(data, axis=0, ignore_nan=True)
     assert not np.ma.isMaskedArray(result)
 
     data = np.ma.masked_where(np.isnan(data), data)

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -14,7 +14,6 @@ from importlib.util import find_spec
 _optional_deps = [
     "asdf_astropy",
     "bleach",
-    "bottleneck",
     "bs4",
     "bz2",  # stdlib
     "certifi",

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -110,7 +110,7 @@ Install the optional dependencies with::
 
   conda install --channel conda-forge ipython jupyter dask h5py pyarrow \
      beautifulsoup4 html5lib bleach pandas sortedcontainers pytz jplephem mpmath \
-     asdf-astropy bottleneck fsspec s3fs certifi
+     asdf-astropy fsspec s3fs certifi
 
 Testing
 -------
@@ -184,10 +184,6 @@ The further dependencies provide more specific features:
 - `asdf-astropy <https://github.com/astropy/asdf-astropy>`_ |minimum_asdf_astropy_version| or later: Enables the
   serialization of various Astropy classes into a portable, hierarchical,
   human-readable representation.
-
-- `bottleneck <https://pypi.org/project/Bottleneck/>`_: Improves the performance
-  of sigma-clipping and other functionality that may require computing
-  statistics on arrays with NaN values.
 
 - `certifi <https://pypi.org/project/certifi/>`_: Useful when downloading
   files from HTTPS or FTP+TLS sites in case Python is not able to locate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ all = [
     "mpmath>=1.2.1",
     "asdf>=2.8.3", # via asdf-astropy==0.3.*
     "asdf-astropy>=0.3",
-    "bottleneck>=1.3.3",
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
 ]


### PR DESCRIPTION
### Description
This is an experiment in response to the on-going discussion in #17185 where it is proposed that we remove the automatic selection of bottleneck nan functions for sigma clipping (and supposedly elsewhere too) because they are not as reliable as numpy (as phrased by @saimn  "slower and correct is better than faster and incorrect" !) and [not actually that much faster anymore](https://github.com/astropy/astropy/issues/17185#issuecomment-2417575712).
Unfortunately our benchmarks do not use bottleneck so I can't easily prove or disprove the performance impact of this change, but I think it's still useful to have it around for discussion.

If we decide to go this route however, note that the patch is incomplete: I'll need to update docstrings and docs.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
