### PR TITLE
BUG: fix lazy string interpolation in AstropyLogger

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -582,7 +582,7 @@ class StreamHandler(logging.StreamHandler):
                 color_print(record.levelname, "brown", end="", file=stream)
             else:
                 color_print(record.levelname, "red", end="", file=stream)
-        record.message = f"{record.msg} [{record.origin:s}]"
+        record.message = f"{record.msg % record.args} [{record.origin:s}]"
         print(": " + record.message, file=stream)
 
 

--- a/docs/changes/utils/17196.bugfix.rst
+++ b/docs/changes/utils/17196.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where astropy's logger wouldn't perform lazy string interpolation.


### PR DESCRIPTION
### Description
Fixes #17191

Notes to reviewers:
- [as I explained in the issue](https://github.com/astropy/astropy/issues/17191#issuecomment-2419045580), this is difficult to test systematically, and my only test doesn't fail on main (most likely because pytest is changing logging behavior to make it testable, but hides the bug in the process)
- I put the changelog fragment into `changes/utils`, which seems inappropriate, but there isn't any appropriate directory yet. Should I create `changes/logger` instead ?

for posterity here's my (useless) test:
```python
def test_string_interpolation(caplog):
    # see https://github.com/astropy/astropy/issues/17191
    msg_args = [
        ("Example 0: ", ()),
        ("Example 1: %s", ("spam",)),
        ("Example 2: %s %s", ("eggs", "bacon")),
    ]
    for msg, args in msg_args:
        log.info(msg, *args)

    output = [(rec.msg, rec.args) for rec in caplog.records]
    assert output == msg_args
    assert caplog.messages == [rec.msg % rec.args for rec in caplog.records]
```
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
