### PR TITLE
Fix a typo in values_to_high_level_objects docstring

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -5,7 +5,12 @@ import numpy as np
 
 from .utils import deserialize_class
 
-__all__ = ["BaseHighLevelWCS", "HighLevelWCSMixin"]
+__all__ = [
+    "values_to_high_level_objects",
+    "high_level_objects_to_values",
+    "BaseHighLevelWCS",
+    "HighLevelWCSMixin",
+]
 
 
 def rec_getattr(obj, att):
@@ -249,7 +254,7 @@ def values_to_high_level_objects(*world_values, low_level_wcs):
 
     This function uses the information in ``wcs.world_axis_object_classes`` and
     ``wcs.world_axis_object_components`` to convert low level "values"
-    `~.Quantity` objects, to high level objects (such as `~.SkyCoord).
+    `~.Quantity` objects, to high level objects (such as `~.SkyCoord`).
 
     This is used in `.HighLevelWCSMixin.pixel_to_world`, but provided as a
     separate function for use in other places where needed.


### PR DESCRIPTION
Also add to `__all__` as these are definitely public API, they are used in ndcube and gwcs.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.