### PR TITLE
Fix converting ohm to string with OGIP formatter

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -372,7 +372,7 @@ def_unit(
     namespace=_ns,
     prefixes=True,
     doc="Ohm: electrical resistance",
-    format={"latex": r"\Omega", "unicode": "Ω"},
+    format={"latex": r"\Omega", "ogip": "ohm", "unicode": "Ω"},
 )
 def_unit(
     ["S", "Siemens", "siemens"],

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -335,6 +335,11 @@ def test_ogip_negative_exponent_parenthesis(string, unit, power):
         assert u_format.OGIP.parse(string) == unit
 
 
+def test_ogip_ohm():
+    # Regression test for #17200 - OGIP converted u.ohm to 'V / A'
+    assert u_format.OGIP.to_string(u.ohm) == "ohm"
+
+
 class RoundtripBase:
     def check_roundtrip(self, unit, output_format=None):
         if output_format is None:

--- a/docs/changes/units/17200.bugfix.rst
+++ b/docs/changes/units/17200.bugfix.rst
@@ -1,0 +1,3 @@
+Converting the ohm to a string with the OGIP unit formatter (e.g.
+``f"{u.ohm:ogip}"``) previously produced the string ``'V / A'``, but now
+produces ``'ohm'`` as expected.


### PR DESCRIPTION
### Description

According to the [OGIP standard](https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/), the unit ohm should be represented with the string 'ohm'. This is correctly enforced by the `astropy` OGIP parser:
```python
>>> from astropy import units as u
>>> u.Unit("Ohm", format="ogip")
Traceback (most recent call last):
 ...
ValueError: 'Ohm' did not parse as ogip unit: At col 0, Unit 'Ohm' not supported by the OGIP standard. Did you mean Yohm, Zohm, ohm, yohm or zohm? ...
>>> u.Unit("ohm", format="ogip")
Unit("Ohm")
```
In contrast, converting the unit back to a string produces unexpected output:
```python
>>> f"{u.ohm:ogip}"
'V / A'
```
This is not caught by our roundtripping tests because they start with units, convert them to strings and then back to units, meaning that our tests assert `u.ohm == u.V / u.A`, which succeeds.

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
