### PR TITLE
Backport PR #17175 on branch v6.1.x (WCSAxes: fix get_axislabel() to return the default label if no label has been explicitly provided)

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -102,6 +102,8 @@ class CoordinateHelper:
         self.frame = frame
         self.default_label = default_label or ""
         self._auto_axislabel = True
+        self._axislabel_set = False
+
         # Disable auto label for elliptical frames as it puts labels in
         # annoying places.
         if issubclass(self.parent_axes.frame_class, EllipticalFrame):
@@ -502,6 +504,8 @@ class CoordinateHelper:
         if minpad is None:
             minpad = 1
 
+        self._axislabel_set = True
+
         self.axislabels.set_text(text)
         self.axislabels.set_minpad(minpad)
         self.axislabels.set(**kwargs)
@@ -518,7 +522,10 @@ class CoordinateHelper:
         label : str
             The axis label
         """
-        return self.axislabels.get_text()
+        if self._auto_axislabel and not self._axislabel_set:
+            return self._get_default_axislabel()
+        else:
+            return self.axislabels.get_text()
 
     def set_auto_axislabel(self, auto_label):
         """
@@ -646,7 +653,7 @@ class CoordinateHelper:
 
     def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, visible_ticks):
         # Render the default axis label if no axis label is set.
-        if self._auto_axislabel and not self.get_axislabel():
+        if self._auto_axislabel and not self._axislabel_set:
             self.set_axislabel(self._get_default_axislabel())
 
         renderer.open_group("axis labels")

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -676,3 +676,20 @@ def test_invisible_bbox():
     assert ax.get_tightbbox(fig.canvas.get_renderer()) is not None
     ax.set_visible(False)
     assert ax.get_tightbbox(fig.canvas.get_renderer()) is None
+
+
+def test_get_axislabel_default():
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = "RA---TAN", "DEC--TAN"
+
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs)
+    assert ax.coords[0].get_axislabel() == "pos.eq.ra"
+    assert ax.coords[1].get_axislabel() == "pos.eq.dec"
+
+    # Make sure that setting axis labels explicitly works, including to an
+    # empty string
+    ax.coords[0].set_axislabel("Right Ascension")
+    ax.coords[1].set_axislabel("")
+    assert ax.coords[0].get_axislabel() == "Right Ascension"
+    assert ax.coords[1].get_axislabel() == ""

--- a/docs/changes/visualization/17175.bugfix.rst
+++ b/docs/changes/visualization/17175.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that caused ``CoordinateHelper.get_axislabel()`` to return an
+empty string instead of the default label if no label has been explicitly
+provided.


### PR DESCRIPTION
### Description

(cherry picked from commit 1294aed972a47eef358c06aa3d279e9ecf6056f9)
Manual backport for #17175

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
