### PR TITLE
Backport PR #17200 on branch v6.1.x ( Fix converting ohm to string with OGIP formatter)

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -352,7 +352,7 @@ def_unit(
     namespace=_ns,
     prefixes=True,
     doc="Ohm: electrical resistance",
-    format={"latex": r"\Omega", "unicode": "Ω"},
+    format={"latex": r"\Omega", "ogip": "ohm", "unicode": "Ω"},
 )
 def_unit(
     ["S", "Siemens", "siemens"],

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -251,6 +251,11 @@ def test_ogip_sqrt(string):
     assert u_format.OGIP.parse(string) == u.m ** Fraction(3, 2)
 
 
+def test_ogip_ohm():
+    # Regression test for #17200 - OGIP converted u.ohm to 'V / A'
+    assert u_format.OGIP.to_string(u.ohm) == "ohm"
+
+
 class RoundtripBase:
     deprecated_units = set()
 

--- a/docs/changes/units/17200.bugfix.rst
+++ b/docs/changes/units/17200.bugfix.rst
@@ -1,0 +1,3 @@
+Converting the ohm to a string with the OGIP unit formatter (e.g.
+``f"{u.ohm:ogip}"``) previously produced the string ``'V / A'``, but now
+produces ``'ohm'`` as expected.


### PR DESCRIPTION
### Description

Manual backport for #17200
(cherry picked from commit e2d4fc65219c9e0712fadea37b77d41180681598)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
