### PR TITLE
BUG: (slow, steady and) correct wins the race: prefer numpy over bottleneck for nanfunctions on float32 arrays

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -121,6 +121,7 @@ class SigmaClip:
     specified as a string. If one of the options is set to a string
     while the other has a custom callable, you may in some cases see
     better performance if you have the `bottleneck`_ package installed.
+    To preserve accuracy, bottleneck is only used for float64 computations.
 
     .. _bottleneck:  https://github.com/pydata/bottleneck
 
@@ -825,6 +826,7 @@ def sigma_clip(
     specified as a string. If one of the options is set to a string
     while the other has a custom callable, you may in some cases see
     better performance if you have the `bottleneck`_ package installed.
+    To preserve accuracy, bottleneck is only used for float64 computations.
 
     .. _bottleneck:  https://github.com/pydata/bottleneck
 
@@ -973,6 +975,7 @@ def sigma_clipped_stats(
     specified as a string. If one of the options is set to a string
     while the other has a custom callable, you may in some cases see
     better performance if you have the `bottleneck`_ package installed.
+    To preserve accuracy, bottleneck is only used for float64 computations.
 
     .. _bottleneck:  https://github.com/pydata/bottleneck
 

--- a/docs/changes/stats/17204.bugfix.rst
+++ b/docs/changes/stats/17204.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed accuracy of sigma clipping for large ``float32`` arrays when
+``bottleneck`` is installed. Performance may be impacted for computations
+involving arrays with dtype other than ``float64``. This change has no impact
+for environments that do not have ``bottleneck`` installed.


### PR DESCRIPTION
### Description
Fixes #17185
Fixes #11492

maybe we could only fallback on numpy for large arrays, but I don't think we know of a good threshold yet.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
