### PR TITLE
Speed up checksum calculation in io.fits (alternative)

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -945,7 +945,7 @@ class _ImageBaseHDU(_ValidHDU):
             else:
                 byteswapped = False
 
-            cs = self._compute_checksum(d.flatten().view(np.uint8))
+            cs = self._compute_checksum(d.ravel().view(np.uint8))
 
             # If the data was byteswapped in this method then return it to
             # its original little-endian order.

--- a/docs/changes/io.fits/17209.perf.rst
+++ b/docs/changes/io.fits/17209.perf.rst
@@ -1,0 +1,1 @@
+Optimize checksum computation.


### PR DESCRIPTION
This is an alternative to #17205, which optimizes the checksum calculation within numpy itself, by realizing that the routine taken from FITS is just a very complicated way to add unsigned int 32 together, written perhaps in a time that unsigned int 64 did not exist.

Timing with this PR is essentially identical to that of #17205, but the code is much simpler (though still need a loop to ensure that also for files larger than 16GB, the sum cannot overflow).

Note that this includes the commit from #17205 with the changelog entry as well as the one that changes a `.flatten()` to `.ravel()` to avoid a copy. The latter is definitely OK, since we only read the data. Asking not to squash commits so that proper credit is given.

p.s. Not running benchmark, since for #17205, it didn't show anything, so clearly there is no relevant benchmark. Feel free to push one to this PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16372
<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
