### PR TITLE
API: let `Time.ptp` emit a deprecation warning against any version of numpy

### DIFF
--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -3,7 +3,6 @@
 import copy
 import itertools
 import warnings
-from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -13,7 +12,6 @@ from astropy.time import Time
 from astropy.time.utils import day_frac
 from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 from astropy.utils import iers
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 needs_array_function = pytest.mark.xfail(
@@ -641,11 +639,7 @@ class TestArithmetic:
         assert np.ptp(self.t0, axis=0).shape == (5, 5)
         assert np.ptp(self.t0, 0, keepdims=True).shape == (1, 5, 5)
 
-        if NUMPY_LT_2_0:
-            ctx = nullcontext()
-        else:
-            ctx = pytest.warns(AstropyDeprecationWarning)
-        with ctx:
+        with pytest.warns(AstropyDeprecationWarning):
             assert self.t0.ptp() == self.t0.max() - self.t0.min()
 
     def test_sort(self, use_mask):

--- a/docs/changes/time/17212.api.rst
+++ b/docs/changes/time/17212.api.rst
@@ -1,0 +1,5 @@
+``Time.ptp`` now properly emits a deprecation warning independently of NumPy's
+version. This method was previously deprecated in astropy 6.1, but the warning
+was not visible for users that had NumPy 1.x installed. Because of this, the
+warning message was updated to state that ``Time.ptp`` is deprecated since
+version 7.0 instead.


### PR DESCRIPTION
### Description
Follow up to https://github.com/astropy/astropy/pull/16212, as [requested by @eerovaher](https://github.com/astropy/astropy/pull/16212#issuecomment-2423279876)

At the time #16212, I aknowledged making the warning condition was a mistake (https://github.com/astropy/astropy/pull/16212#discussion_r1643864256) so I'm considering this a bugfix.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
