### PR TITLE
Introducing Astropy Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 ----
 
-|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo| |Gurubase|
 ----
 The Astropy Project is a community effort to develop a
 single core package for astronomy in Python and foster interoperability between
@@ -131,3 +131,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |Codespaces| image:: https://github.com/codespaces/badge.svg
     :target: https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=2081289
     :alt: Open in GitHub Codespaces
+
+.. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Astropy%20Guru-006BFF
+    :target: https://gurubase.io/g/astropy
+    :alt: Astropy Guru


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Astropy Guru](https://gurubase.io/g/astropy) to Gurubase. Astropy Guru uses the data from this repo and data from the [docs](https://docs.astropy.org/en/stable/index.html) to answer questions by leveraging the LLM.

In this PR, I showcased the "Astropy Guru" badge, which highlights that Astropy now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Astropy Guru in Gurubase, just let me know that's totally fine.