### PR TITLE
MNT: update `uraimo/run-on-arch-action`

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4.2.1
         with:
           fetch-depth: 0
-      - uses: uraimo/run-on-arch-action@b0ffb25eb00af00468375982384441f063da1741  # v2.7.2
+      - uses: uraimo/run-on-arch-action@5397f9e30a9b62422f302092631c99ae1effcd9e # v2.8.1
         name: Run tests
         id: build
         with:


### PR DESCRIPTION
### Description
Fixes #17214 as suggested by @uraimo


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
