### PR TITLE
Fix handling the unit day in the `OGIP` unit formatter

### DIFF
--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -82,7 +82,7 @@ class OGIP(FITS):
         }
         simple_units = [
             "angstrom", "arcmin", "arcsec", "AU", "barn", "bin",
-            "byte", "chan", "count", "day", "deg", "erg", "G",
+            "byte", "chan", "count", "d", "deg", "erg", "G",
             "h", "lyr", "mag", "min", "photon", "pixel",
             "voxel", "yr",
         ]  # fmt: skip

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -447,9 +447,9 @@ class TestRoundtripOGIP(RoundtripBase):
         ids=str,
     )
     def test_roundtrip(self, unit):
-        if str(unit) in ("d", "0.001 Crab"):
-            # Special-case day, which gets auto-converted to hours, and mCrab,
-            # which the default check does not recognize as a deprecated unit.
+        if str(unit) == "0.001 Crab":
+            # Special-case mCrab, which the default check does not recognize
+            # as a deprecated unit.
             with pytest.warns(UnitsWarning):
                 s = unit.to_string(self.format_)
                 a = Unit(s, format=self.format_)

--- a/docs/changes/units/17216.bugfix.rst
+++ b/docs/changes/units/17216.bugfix.rst
@@ -1,0 +1,2 @@
+The ``OGIP`` unit formatter now handles the unit ``day`` and the corresponding
+string ``"d"`` in full compliance with the standard.


### PR DESCRIPTION
### Description

Table 2 in the [OGIP unit standard](https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/) makes it explicitly clear that the unit day is a valid unit and that the string that represents it is `"d"`. Despite that, the `astropy` `OGIP` formatter neither recognizes `"d"`:
```python
>>> from astropy import units as u
>>> u.Unit("d", format="ogip")
Traceback (most recent call last):
  ...
ValueError: 'd' did not parse as ogip unit: ...
```
nor can it convert the day to a string as expected:
```python
>>> f"{u.day:ogip}"
WARNING: UnitsWarning: '24.0' scale should be a power of 10 in OGIP format [astropy.units.format.ogip]
'24 h'
```
Our tests could have caught the problem, but a special case hardcoded into the logic of a test actively suppressed the failure, allowing the bug to remain undetected. This pull request removes the special case from the test, which reveals the bug, and then fixes the `OGIP` formatter to comply with the standard.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
