### PR TITLE
BUG: fix lazy logging bug

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -582,7 +582,12 @@ class StreamHandler(logging.StreamHandler):
                 color_print(record.levelname, "brown", end="", file=stream)
             else:
                 color_print(record.levelname, "red", end="", file=stream)
-        record.message = f"{record.msg % record.args} [{record.origin:s}]"
+        # Make lazy interpretation intentional to leave the option to use
+        # special characters without escaping in log messages.
+        if record.args:
+            record.message = f"{record.msg % record.args} [{record.origin:s}]"
+        else:
+            record.message = f"{record.msg} [{record.origin:s}]"
         print(": " + record.message, file=stream)
 
 


### PR DESCRIPTION
This is to fix the bug in https://github.com/astropy/astropy/pull/17196 that caused astroquery test to break (as queries can have legit special characters and we don't want to force escaping on those just print them as is)