### PR TITLE
TST: Change changelog and milestone checks from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,8 +1,7 @@
 name: Check PR change log
 
 on:
-  # So it cannot be skipped.
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, labeled, unlabeled]
 
 concurrency:

--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -1,8 +1,7 @@
 name: Check PR milestone
 
 on:
-  # So it cannot be skipped.
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, milestoned, demilestoned]
 
 concurrency:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to change changelog and milestone checks from `pull_request_target` to `pull_request` to hopefully lessen the chance of them being MIA in PRs during high traffic season.

![Screenshot 2024-10-21 182032](https://github.com/user-attachments/assets/3c0adeb9-fec6-45c1-9b59-5c9550ec4aff)

I am actually not 100% sure if this is the cause but we won't know until we see them stop behaving this way after merge. Also, there is really no good reason anymore to avoid them from being skipped with our now complex test matrix and branch protection rules. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
