### PR TITLE
TYP: fix incorrect type annotations for optional parameters in stats

### DIFF
--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -516,7 +516,7 @@ class RegularEvents(FitnessFunc):
     def __init__(
         self,
         dt: float,
-        p0: float | None = 0.05,
+        p0: float = 0.05,
         gamma: float | None = None,
         ncp_prior: float | None = None,
     ) -> None:
@@ -575,7 +575,7 @@ class PointMeasures(FitnessFunc):
 
     def __init__(
         self,
-        p0: float | None = 0.05,
+        p0: float = 0.05,
         gamma: float | None = None,
         ncp_prior: float | None = None,
     ) -> None:

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -49,7 +49,7 @@ def _stat_functions(
 
 def biweight_location(
     data: ArrayLike,
-    c: float | None = 6.0,
+    c: float = 6.0,
     M: float | ArrayLike | None = None,
     axis: int | tuple[int, ...] | None = None,
     *,
@@ -187,7 +187,7 @@ def biweight_location(
 
 def biweight_scale(
     data: ArrayLike,
-    c: float | None = 9.0,
+    c: float = 9.0,
     M: float | ArrayLike | None = None,
     axis: int | tuple[int, ...] | None = None,
     modify_sample_size: bool | None = False,
@@ -313,7 +313,7 @@ def biweight_scale(
 
 def biweight_midvariance(
     data: ArrayLike,
-    c: float | None = 9.0,
+    c: float = 9.0,
     M: float | ArrayLike | None = None,
     axis: int | tuple[int, ...] | None = None,
     modify_sample_size: bool | None = False,
@@ -497,7 +497,7 @@ def biweight_midvariance(
 
 def biweight_midcovariance(
     data: ArrayLike,
-    c: float | None = 9.0,
+    c: float = 9.0,
     M: float | ArrayLike | None = None,
     modify_sample_size: bool | None = False,
 ) -> NDArray[float]:
@@ -714,7 +714,7 @@ def biweight_midcovariance(
 def biweight_midcorrelation(
     x: ArrayLike,
     y: ArrayLike,
-    c: float | None = 9.0,
+    c: float = 9.0,
     M: float | ArrayLike | None = None,
     modify_sample_size: bool | None = False,
 ) -> float:

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -36,7 +36,7 @@ __doctest_requires__ = {"vtest": ["scipy"]}
 
 def _components(
     data: NDArray | Quantity,
-    p: float | None = 1.0,
+    p: float = 1.0,
     phi: float | NDArray | Quantity = 0.0,
     axis: int | None = None,
     weights: NDArray | None = None,
@@ -58,7 +58,7 @@ def _components(
 
 def _angle(
     data: NDArray | Quantity,
-    p: float | None = 1.0,
+    p: float = 1.0,
     phi: float | NDArray | Quantity = 0.0,
     axis: int | None = None,
     weights: NDArray | None = None,
@@ -78,7 +78,7 @@ def _angle(
 
 def _length(
     data: NDArray | Quantity,
-    p: float | None = 1.0,
+    p: float = 1.0,
     phi: float | NDArray | Quantity = 0.0,
     axis: int | None = None,
     weights: NDArray | None = None,
@@ -278,7 +278,7 @@ def circstd(
 
 def circmoment(
     data: NDArray | Quantity,
-    p: float | None = 1.0,
+    p: float = 1.0,
     centered: bool | None = False,
     axis: int | None = None,
     weights: NDArray | None = None,

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -71,7 +71,7 @@ to convert it to 1-sigma standard deviation.
 def binom_conf_interval(
     k: int | NDArray,
     n: int | NDArray,
-    confidence_level: float | None = 0.68269,
+    confidence_level: float = 0.68269,
     interval: Literal["wilson", "jeffreys", "flat", "wald"] = "wilson",
 ) -> NDArray:
     r"""Binomial proportion confidence interval given k successes,
@@ -307,7 +307,7 @@ def binned_binom_proportion(
     success: ArrayLike,
     bins: int | ArrayLike = 10,
     range: tuple[float, float] | None = None,
-    confidence_level: float | None = 0.68269,
+    confidence_level: float = 0.68269,
     interval: Literal["wilson", "jeffreys", "flat", "wald"] = "wilson",
 ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
     """Binomial proportion and confidence interval in bins of a continuous
@@ -521,8 +521,8 @@ def poisson_conf_interval(
         "frequentist-confidence",
         "kraft-burrows-nousek",
     ] = "root-n",
-    sigma: float | None = 1.0,
-    background: float | None = 0.0,
+    sigma: float = 1.0,
+    background: float = 0.0,
     confidence_level: float | None = None,
 ) -> NDArray:
     r"""Poisson parameter confidence interval given observed counts.
@@ -959,7 +959,7 @@ def signal_to_noise_oir_ccd(
     dark_eps: float,
     rd: float,
     npix: float,
-    gain: float | None = 1.0,
+    gain: float = 1.0,
 ) -> float | NDArray:
     """Computes the signal to noise ratio for source being observed in the
     optical/IR using a CCD.
@@ -1005,7 +1005,7 @@ def signal_to_noise_oir_ccd(
 
 def bootstrap(
     data: NDArray,
-    bootnum: int | None = 100,
+    bootnum: int = 100,
     samples: int | None = None,
     bootfunc: Callable | None = None,
 ) -> NDArray:

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -66,7 +66,7 @@ def jackknife_resampling(data: NDArray[DT]) -> NDArray[DT]:
 def jackknife_stats(
     data: NDArray,
     statistic: Callable,
-    confidence_level: float | None = 0.95,
+    confidence_level: float = 0.95,
 ) -> tuple[float | NDArray, float | NDArray, float | NDArray, NDArray]:
     """Performs jackknife estimation on the basis of jackknife resamples.
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -164,12 +164,12 @@ class SigmaClip:
 
     def __init__(
         self,
-        sigma: float | None = 3.0,
+        sigma: float = 3.0,
         sigma_lower: float | None = None,
         sigma_upper: float | None = None,
         maxiters: int | None = 5,
-        cenfunc: Literal["median", "mean"] | Callable | None = "median",
-        stdfunc: Literal["std", "mad_std"] | Callable | None = "std",
+        cenfunc: Literal["median", "mean"] | Callable = "median",
+        stdfunc: Literal["std", "mad_std"] | Callable = "std",
         grow: float | Literal[False] | None = False,
     ) -> None:
         self.sigma = sigma
@@ -669,12 +669,12 @@ class SigmaClip:
 
 def sigma_clip(
     data: ArrayLike,
-    sigma: float | None = 3.0,
+    sigma: float = 3.0,
     sigma_lower: float | None = None,
     sigma_upper: float | None = None,
     maxiters: int | None = 5,
-    cenfunc: Literal["median", "mean"] | Callable | None = "median",
-    stdfunc: Literal["std", "mad_std"] | Callable | None = "std",
+    cenfunc: Literal["median", "mean"] | Callable = "median",
+    stdfunc: Literal["std", "mad_std"] | Callable = "std",
     axis: int | tuple[int, ...] | None = None,
     masked: bool | None = True,
     return_bounds: bool | None = False,
@@ -883,13 +883,13 @@ def sigma_clipped_stats(
     data: ArrayLike,
     mask: NDArray | None = None,
     mask_value: float | None = None,
-    sigma: float | None = 3.0,
+    sigma: float = 3.0,
     sigma_lower: float | None = None,
     sigma_upper: float | None = None,
     maxiters: int | None = 5,
-    cenfunc: Literal["median", "mean"] | Callable | None = "median",
-    stdfunc: Literal["std", "mad_std"] | Callable | None = "std",
-    std_ddof: int | None = 0,
+    cenfunc: Literal["median", "mean"] | Callable = "median",
+    stdfunc: Literal["std", "mad_std"] | Callable = "std",
+    std_ddof: int = 0,
     axis: int | tuple[int, ...] | None = None,
     grow: float | Literal[False] | None = False,
 ) -> tuple[float, float, float]:


### PR DESCRIPTION
### Description
This is a direct follow up to #16562 were some confusion around optional parameters and the meaning of `| None` as a type hint crept in. I initially explained the issue in [a comment](https://github.com/astropy/astropy/pull/17221#discussion_r1810203049) that I'll reproduce here for convenience:

> what does it mean to pass `sigma=None` ? This looks like it could be a misunderstanding of the meaning of this type-annotation: `| None` is not synonymous with "has a default value" (though the name of typing.Optional may be the source of confusion), but really means "this parameter can be None".


I grepped for the regular expression `(float|int) \| None = [\d\.]` to discover incorrect cases (also a couple correct ones !). Inspecting the code for where these parameters were used quickly revealed that in 22 cases, passing `None` wouldn't make sense and would immediately trigger an exception. In some cases, the docstrings also provided clear indications that the annotations were not correct: some parameters were documented as `int, or None (optional)` next to others documented as `int (optional)`.

Discovered while reviewing #17221

cc @jeffjennings

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
