### PR TITLE
DOC: fix a misleading use of 'subclass' in docs

### DIFF
--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -231,7 +231,7 @@ array with the following properties:
   single item, slicing, or index array access.
 - Has a ``shape`` attribute.
 - Has a ``__len__()`` method for length.
-- Has an ``info`` class descriptor which is a subclass of the
+- Has an ``info`` class descriptor which is an instance of a subclass of the
   :class:`astropy.utils.data_info.MixinInfo` class.
 
 The `Example: ArrayWrapper`_ section shows a minimal working example of a class


### PR DESCRIPTION
### Description

In https://github.com/astropy/astropy/pull/17189#discussion_r1805181428, we found this sentence to be a bit misleading. This fixes it as suggested by @taldcroft.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
