### PR TITLE
BUG: respect VOUnit standard when converting a dimensionless unit to a string

### DIFF
--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -215,12 +215,16 @@ class VOUnit(FITS):
         # Remove units that aren't known to the format
         unit = cls._decompose_to_known_units(unit)
 
-        if unit.physical_type == "dimensionless" and unit.scale != 1:
-            raise UnitScaleError(
-                "The VOUnit format is not able to "
-                "represent scale for dimensionless units. "
-                f"Multiply your data by {unit.scale:e}."
-            )
+        if unit.physical_type == "dimensionless":
+            if unit.scale != 1:
+                raise UnitScaleError(
+                    "The VOUnit format is not able to "
+                    "represent scale for dimensionless units. "
+                    f"Multiply your data by {unit.scale:e}."
+                )
+            # the VO standard explicitly forbids representing a dimensionless
+            # unit with an empty string, and instead recommends '1'
+            return "1"
 
         return cls._to_string(unit, fraction=fraction)
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -715,6 +715,11 @@ def test_repr_latex():
     assert u.m._repr_latex_() == u.m.to_string("latex")
 
 
+def test_repr_one_vounit():
+    # see https://github.com/astropy/astropy/issues/17228
+    assert u.one.to_string("vounit") == "1"
+
+
 def test_operations_with_strings():
     assert u.m / "5s" == (u.m / (5.0 * u.s))
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -290,7 +290,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
     def world_axis_units(self):
         units = []
         for unit in self.wcs.cunit:
-            if unit is None:
+            if unit is None or unit == "":
+                # Use an empty string for missing units. We include
+                # dimensionless_unscaled here because using VO format
+                # it would be converted to '1'.
                 unit = ""
             elif isinstance(unit, u.Unit):
                 unit = unit.to_string(format="vounit")

--- a/docs/changes/units/17230.bugfix.rst
+++ b/docs/changes/units/17230.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where ``one.to_string(format='vounit')`` would return an empty
+string, in violation of the VOUnit standard 1.1, which recommends ``'1'``.


### PR DESCRIPTION
### Description
Fixes #17228

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
