### PR TITLE
Make parsing implicit custom units with `"vounit"` format obey `parse_strict`

### DIFF
--- a/astropy/units/errors.py
+++ b/astropy/units/errors.py
@@ -49,5 +49,5 @@ class UnitsWarning(AstropyWarning):
     """
 
 
-class UnitParserWarning(AstropyWarning):
+class UnitParserWarning(UnitsWarning):
     """Unit parser warnings"""

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -9,7 +9,7 @@ import re
 import warnings
 from typing import TYPE_CHECKING
 
-from astropy.units.errors import UnitScaleError, UnitsError, UnitsWarning
+from astropy.units.errors import UnitParserWarning, UnitScaleError, UnitsError
 from astropy.utils import classproperty
 
 from . import core, utils
@@ -116,11 +116,10 @@ class VOUnit(FITS):
 
             if cls._custom_unit_regex.match(t.value):
                 warnings.warn(
-                    (
+                    UnitParserWarning(
                         f"Unit {t.value!r} not supported by the VOUnit standard. "
                         + cls._did_you_mean_units(t.value)
-                    ),
-                    UnitsWarning,
+                    )
                 )
 
                 return cls._def_custom_unit(t.value)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -720,14 +720,13 @@ def test_deprecated_did_you_mean_units():
     assert "Crab (deprecated)" in str(exc_info.value)
     assert "mCrab (deprecated)" in str(exc_info.value)
 
-    with pytest.warns(
-        UnitsWarning,
-        match=r".* Did you mean 0\.1nm, Angstrom "
-        r"\(deprecated\) or angstrom \(deprecated\)\?",
-    ) as w:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Did you mean 0\.1nm, Angstrom \(deprecated\) or angstrom \(deprecated\)\?"
+        ),
+    ):
         u.Unit("ANGSTROM", format="vounit")
-    assert len(w) == 1
-    assert str(w[0].message).count("0.1nm") == 1
 
     with pytest.warns(UnitsWarning, match=r".* 0\.1nm\.") as w:
         u.Unit("angstrom", format="vounit")
@@ -754,9 +753,8 @@ def test_vounit_binary_prefix():
     assert u.Unit("KiB", format="vounit") == u.Unit("1024 B")
     assert u.Unit("Kibyte", format="vounit") == u.Unit("1024 B")
     assert u.Unit("Kibit", format="vounit") == u.Unit("128 B")
-    with pytest.warns(UnitsWarning) as w:
+    with pytest.raises(ValueError, match="not supported by the VOUnit standard"):
         u.Unit("kibibyte", format="vounit")
-    assert len(w) == 1
 
 
 def test_vounit_unknown():
@@ -777,7 +775,7 @@ def test_vounit_details():
     with pytest.warns(
         UnitsWarning, match="Unit 'kdB' not supported by the VOUnit standard.*"
     ):
-        u.Unit("kdB", format="vounit")
+        u.Unit("kdB", format="vounit", parse_strict="warn")
 
     # The da- prefix is not allowed, and the d- prefix is discouraged
     assert u.dam.to_string("vounit") == "10m"
@@ -859,7 +857,7 @@ def test_vounit_custom():
 def test_vounit_implicit_custom():
     # Yikes, this becomes "femto-urlong"...  But at least there's a warning.
     with pytest.warns(UnitsWarning) as w:
-        x = u.Unit("furlong/week", format="vounit")
+        x = u.Unit("furlong/week", format="vounit", parse_strict="warn")
     assert x.bases[0]._represents.scale == 1e-15
     assert x.bases[0]._represents.bases[0].name == "urlong"
     assert len(w) == 2

--- a/docs/changes/units/17232.bugfix.rst
+++ b/docs/changes/units/17232.bugfix.rst
@@ -1,0 +1,6 @@
+Parsing custom units with ``u.Unit()`` using the ``"vounit"`` format now obeys
+the ``parse_strict`` parameter, unless the custom units are made explicit with
+quotation marks.
+For example, ``u.Unit("custom_unit", format="vounit")`` now raises an error,
+but ``u.Unit("custom_unit", format="vounit", parse_strict="silent")`` or
+``u.Unit("'custom_unit'", format="vounit")`` do not.


### PR DESCRIPTION
### Description

The VOUnit standard allows defining custom units, so when the `astropy` `VOUnit` formatter encounters a non-standard unit it emits a warning instead of raising an error. However, the way this is currently implemented means that something like `u.Unit("custom_unit", format="vounit", parse_strict=...)` does not obey the `parse_strict` parameter. This has made needlessly difficult for users to use `astropy` for validating unit strings (#16199) and at the same time it has also made it needlessly complicated for users to suppress the warning (#13017).

Previously this has been too complicated to address, but the machinery introduced recently in 8b124d3ed448dd4a5de096fb95d6725a7d432bd2 makes it quite simple. The new behavior is:
```python
>>> from astropy import units as u
>>> u.Unit("custom_unit", format="vounit")  # by default parse_strict="raise"
Traceback (most recent call last):
  ...
ValueError: Unit 'custom_unit' not supported by the VOUnit standard. 
If you cannot change the unit string then try specifying the 'parse_strict' argument.
>>> u.Unit("custom_unit", format="vounit", parse_strict="warn")
WARNING: UnitParserWarning: Unit 'custom_unit' not supported by the VOUnit standard.  [astropy.units.format.vounit]
Unit("custom_unit")
>>> u.Unit("custom_unit", format="vounit", parse_strict="silent")
Unit("custom_unit")
```
The above behavior should be enough to close #16199, but it would be good if @JeremyMcCormick and @gpdf could confirm this.

The `astropy` `votable` machinery is meant to emit its own warnings for non-standard units: https://github.com/astropy/astropy/blob/86fda91f2784ed2971916c110e09939539cded7d/astropy/io/votable/tree.py#L899-L901
Because the `parse_strict="silent"` argument now behaves as expected then this should also close #13017, but it would be good if downstream developers could confirm this. This has affected `astroquery`, so I'm asking @bsipocz and @keflavich to review.

This might also help address #8978 but it might not go far enough to close it.

There is no change in how explicit custom units (i.e. quoted) are parsed, so even with this patch
```python
>>> from astropy import units as u
>>> u.Unit("'custom_unit'", format="vounit", parse_strict="raise")
Unit("custom_unit")
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
