### PR TITLE
BUG: avoid a `RuntimeWarning` in `WCS.world_to_array_index` by converting NaN inputs to int

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -46,7 +46,15 @@ def _toindex(value):
     >>> _toindex(np.array([1.5, 2.49999]))
     array([2, 2])
     """
-    indx = np.asarray(np.floor(np.asarray(value) + 0.5), dtype=int)
+    arr = np.floor(np.asarray(value) + 0.5)
+
+    fill_value = np.iinfo(int).min
+    if np.isscalar(arr):
+        if np.isnan(arr):
+            arr = fill_value
+    else:
+        arr[np.isnan(arr)] = fill_value
+    indx = np.asarray(arr, dtype=int)
     return indx
 
 

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -282,3 +282,27 @@ def test_minimal_mixin_subclass():
     pixel = high_level_wcs.world_to_array_index(*coord)
 
     assert_allclose(pixel, (1, 2))
+
+
+def test_world_to_array_index_nan():
+    # see https://github.com/astropy/astropy/issues/17227
+    wcs1 = WCS(naxis=1)
+    wcs1.wcs.crpix = (1,)
+    wcs1.wcs.set()
+    wcs1.pixel_bounds = [None]
+
+    res1 = wcs1.world_to_array_index(*wcs1.pixel_to_world((5,)))
+    assert not np.any(np.isnan(res1))
+    assert res1.ndim == 0
+    assert res1.item() == 5
+
+    wcs2 = WCS(naxis=2)
+    wcs2.wcs.crpix = (1, 1)
+    wcs2.wcs.set()
+    wcs2.pixel_bounds = [None, (-0.5, 3.5)]
+
+    res2 = wcs2.world_to_array_index(*wcs2.pixel_to_world(5, 5))
+    assert not np.any(np.isnan(res2))
+    assert isinstance(res2, tuple)
+    assert len(res2) == 2
+    assert res2 == (np.iinfo(int).min, 5)

--- a/docs/changes/wcs/17236.bugfix.rst
+++ b/docs/changes/wcs/17236.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid a ``RuntimeWarning`` in ``WCS.world_to_array_index`` by converting
+NaN inputs to int.


### PR DESCRIPTION
### Description
Fixes #17227 as [suggested by @astrofrog](https://github.com/astropy/astropy/issues/17227#issuecomment-2429136064)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
