### PR TITLE
Fix creating CompImageHDU from header with bscale/bzero

### DIFF
--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -325,12 +325,6 @@ class CompImageHDU(ImageHDU):
         else:
             # Create at least a skeleton HDU that matches the input
             # header and data (if any were input)
-
-            if header is not None:
-                bscale = header.get("BSCALE")
-                bzero = header.get("BZERO")
-                simple = header.get("SIMPLE")
-
             super().__init__(
                 data=data,
                 header=header or Header(),
@@ -340,15 +334,8 @@ class CompImageHDU(ImageHDU):
                 scale_back=scale_back,
             )
 
-            if header is not None:
-                if bscale is not None:
-                    self.header["BSCALE"] = bscale
-
-                if bzero is not None:
-                    self.header["BZERO"] = bzero
-
-                if simple is not None:
-                    self.header["SIMPLE"] = simple
+            if header is not None and "SIMPLE" in header:
+                self.header["SIMPLE"] = header["SIMPLE"]
 
             self.compression_type = compression_type
             self.tile_shape = _validate_tile_shape(

--- a/docs/changes/io.fits/17237.bugfix.rst
+++ b/docs/changes/io.fits/17237.bugfix.rst
@@ -1,0 +1,2 @@
+Fix creating CompImageHDU from header with BSCALE/BZERO: keywords are now
+ignored, as done in ImageHDU.


### PR DESCRIPTION
Fix #5999

See also discussion in https://github.com/astropy/astropy/pull/15474#issuecomment-1991790330.

When creating CompImageHDU from a header with BSCALE/BZERO these keywords should be ignored, as done in ImageHDU.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
