### PR TITLE
Fix the representation of the unit angstrom with `OGIP` unit formatter

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -61,7 +61,12 @@ def_unit(
     namespace=_ns,
     doc="ångström: 10 ** -10 m",
     prefixes=[(["m", "milli"], ["milli", "m"], 1.0e-3)],
-    format={"latex": r"\mathring{A}", "unicode": "Å", "vounit": "Angstrom"},
+    format={
+        "latex": r"\mathring{A}",
+        "ogip": "angstrom",
+        "unicode": "Å",
+        "vounit": "Angstrom",
+    },
 )
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -529,7 +529,7 @@ def test_latex_inline_scale():
         ("unicode", "erg Å⁻¹ s⁻¹ cm⁻²", "10000000 kg m⁻¹ s⁻³"),
         (">25s", "   erg / (Angstrom s cm2)", "        1e+07 kg / (m s3)"),
         ("cds", "erg.Angstrom-1.s-1.cm-2", "10000000kg.m-1.s-3"),
-        ("ogip", "10 erg / (nm s cm**2)", "1e+07 kg / (m s**3)"),
+        ("ogip", "erg / (angstrom s cm**2)", "1e+07 kg / (m s**3)"),
         ("fits", "erg Angstrom-1 s-1 cm-2", "10**7 kg m-1 s-3"),
         ("vounit", "erg.Angstrom**-1.s**-1.cm**-2", "10000000kg.m**-1.s**-3"),
         # TODO: make fits and vounit less awful!

--- a/docs/changes/units/17241.bugfix.rst
+++ b/docs/changes/units/17241.bugfix.rst
@@ -1,0 +1,2 @@
+The ``"ogip"`` unit format now represents the unit angstrom as ``"angstrom"``
+instead of ``"0.1 nm"``.


### PR DESCRIPTION
### Description

Table 2 in the [OGIP standard](https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/) declares that the unit angstrom is represented by the string `"angstrom"`. Although the `astropy` `OGIP` parser can already parse `"angstrom"`, the `OGIP` writer needlessly converts it.

The first commit updates the tests to reveal the bug, the second fixes it.

I have found more similar bugs very recently, which makes me think that there is something wrong with how the unit formatter roundtrip tests are written.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
