### PR TITLE
API: move eV and Ry units definition from to `misc`

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -114,18 +114,6 @@ def_unit(
 ##########################################################################
 # ENERGY
 
-# Here, explicitly convert the planck constant to 'eV s' since the constant
-# can override that to give a more precise value that takes into account
-# covariances between e and h.  Eventually, this may also be replaced with
-# just `_si.Ryd.to(eV)`.
-def_unit(
-    ["Ry", "rydberg"],
-    (_si.Ryd * _si.c * _si.h.to(si.eV * si.s)).to(si.eV),
-    namespace=_ns,
-    prefixes=True,
-    doc="Rydberg: Energy of a photon whose wavenumber is the Rydberg constant",
-    format={"latex": r"R_{\infty}", "unicode": "R∞"},
-)
 def_unit(
     ["foe", "Bethe", "bethe"],
     1e51 * si.g * si.cm**2 / si.s**2,

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -386,11 +386,11 @@ def doppler_radio(rest):
         return restwav * ckms / (ckms - x)
 
     def to_vel_en(x):
-        resten = rest.to_value(si.eV, equivalencies=spectral())
+        resten = rest.to_value(misc.eV, equivalencies=spectral())
         return (resten - x) / (resten) * ckms
 
     def from_vel_en(x):
-        resten = rest.to_value(si.eV, equivalencies=spectral())
+        resten = rest.to_value(misc.eV, equivalencies=spectral())
         voverc = x / ckms
         return resten * (1 - voverc)
 
@@ -398,7 +398,7 @@ def doppler_radio(rest):
         [
             (si.Hz, si.km / si.s, to_vel_freq, from_vel_freq),
             (si.AA, si.km / si.s, to_vel_wav, from_vel_wav),
-            (si.eV, si.km / si.s, to_vel_en, from_vel_en),
+            (misc.eV, si.km / si.s, to_vel_en, from_vel_en),
         ],
         "doppler_radio",
         {"rest": rest},
@@ -456,11 +456,11 @@ def doppler_optical(rest):
         return restwav * (1 + voverc)
 
     def to_vel_en(x):
-        resten = rest.to_value(si.eV, equivalencies=spectral())
+        resten = rest.to_value(misc.eV, equivalencies=spectral())
         return ckms * (resten - x) / x
 
     def from_vel_en(x):
-        resten = rest.to_value(si.eV, equivalencies=spectral())
+        resten = rest.to_value(misc.eV, equivalencies=spectral())
         voverc = x / ckms
         return resten / (1 + voverc)
 
@@ -468,7 +468,7 @@ def doppler_optical(rest):
         [
             (si.Hz, si.km / si.s, to_vel_freq, from_vel_freq),
             (si.AA, si.km / si.s, to_vel_wav, from_vel_wav),
-            (si.eV, si.km / si.s, to_vel_en, from_vel_en),
+            (misc.eV, si.km / si.s, to_vel_en, from_vel_en),
         ],
         "doppler_optical",
         {"rest": rest},
@@ -533,11 +533,11 @@ def doppler_relativistic(rest):
         return restwav * ((1 + voverc) / (1 - voverc)) ** 0.5
 
     def to_vel_en(x):
-        resten = rest.to_value(si.eV, spectral())
+        resten = rest.to_value(misc.eV, spectral())
         return (resten**2 - x**2) / (resten**2 + x**2) * ckms
 
     def from_vel_en(x):
-        resten = rest.to_value(si.eV, spectral())
+        resten = rest.to_value(misc.eV, spectral())
         voverc = x / ckms
         return resten * ((1 - voverc) / (1 + (voverc))) ** 0.5
 
@@ -545,7 +545,7 @@ def doppler_relativistic(rest):
         [
             (si.Hz, si.km / si.s, to_vel_freq, from_vel_freq),
             (si.AA, si.km / si.s, to_vel_wav, from_vel_wav),
-            (si.eV, si.km / si.s, to_vel_en, from_vel_en),
+            (misc.eV, si.km / si.s, to_vel_en, from_vel_en),
         ],
         "doppler_relativistic",
         {"rest": rest},
@@ -817,7 +817,7 @@ def temperature_energy():
     e = _si.e.value
     k_B = _si.k_B.value
     return Equivalency(
-        [(si.K, si.eV, lambda x: x / (e / k_B), lambda x: x * (e / k_B))],
+        [(si.K, misc.eV, lambda x: x / (e / k_B), lambda x: x * (e / k_B))],
         "temperature_energy",
     )
 

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -104,6 +104,30 @@ def_unit(
     doc="Unified atomic mass unit",
 )
 
+##########################################################################
+# ENERGY
+
+def_unit(
+    ["eV", "electronvolt"],
+    _si.e.value * si.J,
+    namespace=_ns,
+    prefixes=True,
+    doc="Electron Volt",
+)
+
+# Here, explicitly convert the planck constant to 'eV s' since the constant
+# can override that to give a more precise value that takes into account
+# covariances between e and h.  Eventually, this may also be replaced with
+# just `_si.Ryd.to(eV)`.
+def_unit(
+    ["Ry", "rydberg"],
+    (_si.Ryd * _si.c * _si.h.to(eV * si.s)).to(eV),
+    namespace=_ns,
+    prefixes=True,
+    doc="Rydberg: Energy of a photon whose wavenumber is the Rydberg constant",
+    format={"latex": r"R_{\infty}", "unicode": "R∞"},
+)
+
 
 ###########################################################################
 # COMPUTER

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -8,8 +8,6 @@ This package defines the SI units.  They are also available in
 
 import numpy as np
 
-from astropy.constants import si as _si
-
 from .core import Unit, UnitBase, def_unit
 
 __all__: list[str] = []  #  Units are added at the end
@@ -314,13 +312,6 @@ def_unit(
     namespace=_ns,
     prefixes=True,
     doc="Joule: energy",
-)
-def_unit(
-    ["eV", "electronvolt"],
-    _si.e.value * J,
-    namespace=_ns,
-    prefixes=True,
-    doc="Electron Volt",
 )
 
 

--- a/docs/changes/units/17246.api.rst
+++ b/docs/changes/units/17246.api.rst
@@ -1,0 +1,4 @@
+The ``eV`` and ``rydberg`` units were moved to ``astropy.units.misc`` (from
+``astropy.units.si`` and ``astropy.units.astrophys``, respectively). They remain
+available under the root namespace ``astropy.units`` as ``astropy.units.eV``
+and ``astropy.units.rydberg``.


### PR DESCRIPTION
### Description
This was [suggested in reviews for #17122](https://github.com/astropy/astropy/pull/17122/files#r1788151608)
I agree with Eero that having `eV` in the SI system is surprising, and I agree with Marten that it makes more sense as part of the "astrophys" unit system. Hopefully this helps getting #17122 moving forward.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
