### PR TITLE
Remove `BaseCoordinateFrame.get_frame_attr_names()`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -26,7 +26,7 @@ from astropy import units as u
 from astropy.table import QTable
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.data_info import MixinInfo
-from astropy.utils.decorators import deprecated, format_doc, lazyproperty
+from astropy.utils.decorators import format_doc, lazyproperty
 from astropy.utils.exceptions import AstropyWarning
 
 from . import representation as r
@@ -945,21 +945,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     def get_frame_attr_defaults(cls):
         """Return a dict with the defaults for each frame attribute."""
         return {name: getattr(cls, name).default for name in cls.frame_attributes}
-
-    @deprecated(
-        "5.2",
-        alternative="get_frame_attr_defaults",
-        message=(
-            "The {func}() {obj_type} is deprecated and may be removed in a future"
-            " version. Use {alternative}() to obtain a dict of frame attribute names"
-            " and default values."
-            " The fastest way to obtain the names is frame_attributes.keys()"
-        ),
-    )
-    @classmethod
-    def get_frame_attr_names(cls):
-        """Return a dict with the defaults for each frame attribute."""
-        return cls.get_frame_attr_defaults()
 
     def get_representation_cls(self, which="base"):
         """The class used for part of this frame's data.

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -43,7 +43,6 @@ from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from astropy.units import allclose
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .test_representation import unitphysics  # this fixture is used below  # noqa: F401
 
@@ -110,9 +109,7 @@ def test_frame_subclass_attribute_descriptor():
     assert mfk4.equinox.value == "B1950.000"
     assert mfk4.obstime.value == "B1980.000"
     assert mfk4.newattr == "newattr"
-
-    with pytest.warns(AstropyDeprecationWarning):
-        assert set(mfk4.get_frame_attr_names()) == {"equinox", "obstime", "newattr"}
+    assert set(mfk4.get_frame_attr_defaults()) == {"equinox", "obstime", "newattr"}
 
     mfk4 = MyFK4(equinox="J1980.0", obstime="J1990.0", newattr="world")
     assert mfk4.equinox.value == "J1980.000"

--- a/docs/changes/coordinates/17252.api.rst
+++ b/docs/changes/coordinates/17252.api.rst
@@ -1,0 +1,2 @@
+The deprecated ``BaseCoordinateFrame.get_frame_attr_names()`` is removed.
+Use ``get_frame_attr_defaults()`` instead.

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -487,7 +487,6 @@ documentation::
   sc.gcrs                                sc.separation_3d
   sc.geocentrictrueecliptic              sc.shape
   sc.get_constellation                   sc.size
-  sc.get_frame_attr_names                sc.skyoffset_frame
   sc.guess_from_table                    sc.spherical
   sc.has_data                            sc.spherical_offsets_to
   sc.hcrs                                sc.squeeze
@@ -586,7 +585,6 @@ class), and |SkyCoord| (a.k.a. high-level class; see
   sc.frame.flatten                             sc.frame.reshape
   sc.frame.frame_attributes                    sc.frame.separation
   sc.frame.frame_specific_representation_info  sc.frame.separation_3d
-  sc.frame.get_frame_attr_names                sc.frame.shape
   sc.frame.has_data                            sc.frame.size
   sc.frame.is_equivalent_frame                 sc.frame.spherical
   sc.frame.is_frame_attr_default               sc.frame.squeeze


### PR DESCRIPTION
### Description

The method was deprecated in eea7b8eedacae3e5a589d3500fbc068fe26cce2e.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
