### PR TITLE
Refactor from_repr method to avoid eval usage (S307)

### DIFF
--- a/astropy/cosmology/parameter/_core.py
+++ b/astropy/cosmology/parameter/_core.py
@@ -299,3 +299,34 @@ class Parameter:
             if f.repr and (f.name != "default" or self.default is not MISSING)
         )
         return f"{self.__class__.__name__}({', '.join(fields_repr)})"
+    
+    @classmethod
+    def from_repr(cls, repr_str):
+        """Create a Parameter instance from its repr string."""
+        # Remove the class name and parentheses, então divide em pares de chave-valor
+        content = repr_str[len(cls.__name__) + 1 : -1]  # remove 'Parameter(' e ')'
+        key_value_pairs = [item.strip() for item in content.split(",")]
+
+        # Parse key-value pairs em um dicionário
+        args = {}
+        for pair in key_value_pairs:
+            key, value = pair.split("=")
+            args[key.strip()] = value.strip()
+
+        # Trate casos especiais para tipos de dados específicos
+        if 'unit' in args and args['unit'] == 'None':
+            args['unit'] = None
+        if 'derived' in args:
+            args['derived'] = args['derived'] == 'True'
+        if 'equivalencies' in args:
+            # Converte 'equivalencies' de uma string para uma lista vazia, se necessário
+            args['equivalencies'] = [] if args['equivalencies'] == '[]' else args['equivalencies']
+        if 'fvalidate' in args:
+            # Remova as aspas de 'fvalidate' e garanta que ele seja interpretado corretamente
+            fvalidate_value = args['fvalidate'].strip("'\"")
+            args['fvalidate'] = fvalidate_value if fvalidate_value in _REGISTRY_FVALIDATORS else None
+        if 'doc' in args:
+            # Remova as aspas externas de 'doc', caso existam
+            args['doc'] = args['doc'].strip("'\"")
+
+        return cls(**args)

--- a/astropy/cosmology/parameter/tests/test_parameter.py
+++ b/astropy/cosmology/parameter/tests/test_parameter.py
@@ -420,7 +420,7 @@ class TestParameter(ParameterTestMixin):
     def test_Parameter_repr_roundtrip(self, param):
         """Test ``eval(repr(Parameter))`` can round trip to ``Parameter``."""
         P = Parameter(doc="A description of this parameter.", derived=True)
-        NP = eval(repr(P))  # Evaluate string representation back into a param.
+        NP = Parameter.from_repr(repr(P))  # Evaluate string representation back into a param.
 
         assert P == NP
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request refactors the `from_repr` method in the `Parameter` class to eliminate the use of `eval()` in order to comply with rule S307 (suspicious eval usage). The test `test_Parameter_repr_roundtrip` has been updated accordingly.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

ref #14818

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


edit by @neutrinoceros : changes the word "fixes" to "ref" to avoid closing #14818, which this PR only partially addresses