### PR TITLE
Remove configuration for deprecated Ruff rules

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -117,7 +117,6 @@ lint.ignore = [
 
     # flake8-pytest-style (PT)
     "PT003",   # pytest-extraneous-scope-function
-    "PT004",   # pytest-missing-fixture-name-underscore # deprecated in ruff 0.6.0
     "PT006",   # pytest-parametrize-names-wrong-type
     "PT007",   # pytest-parametrize-values-wrong-type
     "PT011",   # pytest-raises-too-broad

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,10 +326,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # New ones should be avoided and is up to maintainers to enforce.
     "A00",
 
-    # flake8-annotations (ANN)
-    "ANN101",  # No annotation for `self`.
-    "ANN102",  # No annotation for `cls`.
-
     # flake8-bugbear (B)
     "B008",  # FunctionCallArgumentDefault
 


### PR DESCRIPTION
### Description

`astropy` has chosen to maintain a list of rules Ruff should ignore rather than a list of rules Ruff should enforce: https://github.com/astropy/astropy/blob/e7d35aeebeda5917817d7aecd5e97f4bf12e6d2b/pyproject.toml#L316-L317
Among the rules that we have configured Ruff to ignore there are three that are deprecated: [ANN101 (missing-type-self)](https://docs.astral.sh/ruff/rules/missing-type-self/#missing-type-self-ann101), [ANN102 (missing-type-cls)](https://docs.astral.sh/ruff/rules/missing-type-cls/#missing-type-cls-ann102) and [PT004 (pytest-missing-fixture-name-underscore)](https://docs.astral.sh/ruff/rules/pytest-missing-fixture-name-underscore/#pytest-missing-fixture-name-underscore-pt004). Deprecated rules are not selected with `lint.select = ["ALL"]` [since Ruff 0.5.0](https://github.com/astral-sh/ruff/releases/tag/0.5.0), so there is no need to explicitly ignore them anymore. Removing configuration for such rules reduces clutter in our configuration files and prevents any problems that could arise when these rules are finally removed.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
