### PR TITLE
Added what's new entry for modeling speedups

### DIFF
--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -279,7 +279,7 @@ Note that it is not yet possible to use ``Quantity`` with dask arrays directly.
 Performance improvements in astropy.modeling
 ============================================
 
-There have been significant improvements to the performance of fitting in
+There have been significant improvements to the performance of non-linear fitters in
 :mod:`astropy.modeling`, with typical speedups of 2x for simple models and 4x or
 more for compound models.
 

--- a/docs/whatsnew/7.0.rst
+++ b/docs/whatsnew/7.0.rst
@@ -23,6 +23,7 @@ In particular, this release includes:
 * :ref:`whatsnew_7_0_contributor_doc_improvement`
 * :ref:`whatsnew_7_0_typing_stats`
 * :ref:`whatsnew_7_0_unit_conversion_array_like`
+* :ref:`whatsnew_7_0_modeling_speedup`
 * :ref:`whatsnew_7_0_parallel_fitting`
 * :ref:`whatsnew_7_0_rgb_image_visualization_enhancement`
 * :ref:`whatsnew_7_0_lorentz2d_model`
@@ -272,6 +273,15 @@ value in ``Unit.to`` and have those arrays not be converted to Numpy arrays:
     dask.array<mul, shape=(10,), dtype=float64, chunksize=(10,), chunktype=numpy.ndarray>
 
 Note that it is not yet possible to use ``Quantity`` with dask arrays directly.
+
+.. _whatsnew_7_0_modeling_speedup:
+
+Performance improvements in astropy.modeling
+============================================
+
+There have been significant improvements to the performance of fitting in
+:mod:`astropy.modeling`, with typical speedups of 2x for simple models and 4x or
+more for compound models.
 
 .. _whatsnew_7_0_parallel_fitting:
 


### PR DESCRIPTION
Realised today that despite all the improvements we did not actually advertise this! Keeping it simple and values are hard to generalize too much but these values do seem to match what is seen for typical models and gives a good idea of what to expect (so not just say 10% improvements)

This is a combination of the following PRs:

* https://github.com/astropy/astropy/pull/17034
* https://github.com/astropy/astropy/pull/16673

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
