### PR TITLE
Add `support_nddata` to `parallel_fit_dask`

### DIFF
--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -300,7 +300,7 @@ def parallel_fit_dask(
         fitters for more information about the meaning of weights.
         If passed as a `.NDUncertainty` object it will be converted to a
         `.StdDevUncertainty` and then passed to the fitter as 1 over that.
-    mask : `numpy.nddata`
+    mask : `numpy.ndarray`
         A boolean mask to be applied to the data.
     fitting_axes : int or tuple
         The axes to keep for the fitting (other axes will be sliced/iterated over)

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -295,9 +295,11 @@ def parallel_fit_dask(
     data_units : `astropy.units.Unit`
         Units for the data array, for when the data array is not a ``Quantity``
         instance.
-    weights : `numpy.ndarray` or `dask.array.core.Array`
+    weights : `numpy.ndarray`, `dask.array.core.Array` or `astropy.nddata.NDUncertainty`
         The weights to use in the fitting. See the documentation for specific
         fitters for more information about the meaning of weights.
+        If passed as a `.NDUncertainty` object it will be converted to a
+        `.StdDevUncertainty` and then passed to the fitter as 1 over that.
     mask : `numpy.nddata`
         A boolean mask to be applied to the data.
     fitting_axes : int or tuple

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import astropy.units as u
 from astropy.modeling.utils import _combine_equivalency_dict
+from astropy.nddata import NDUncertainty, StdDevUncertainty, support_nddata
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 
@@ -252,13 +253,15 @@ class ParameterContainer:
         return values[item]
 
 
+@support_nddata(wcs="world", weights="uncertainty", unit="data_unit", mask="mask")
 def parallel_fit_dask(
+    data,
     *,
     model,
     fitter,
-    data,
     data_unit=None,
     weights=None,
+    mask=None,
     fitting_axes=None,
     world=None,
     chunk_n_max=None,
@@ -295,6 +298,8 @@ def parallel_fit_dask(
     weights : `numpy.ndarray` or `dask.array.core.Array`
         The weights to use in the fitting. See the documentation for specific
         fitters for more information about the meaning of weights.
+    mask : `numpy.nddata`
+        A boolean mask to be applied to the data.
     fitting_axes : int or tuple
         The axes to keep for the fitting (other axes will be sliced/iterated over)
     world : `None` or tuple or APE-14-WCS
@@ -380,6 +385,17 @@ def parallel_fit_dask(
             raise TypeError(
                 "Can only set preserve_native_chunks=True if input weights is a dask array (if specified)"
             )
+
+    if isinstance(weights, NDUncertainty):
+        weights = weights.represent_as(StdDevUncertainty)
+        weights = 1 / weights.array
+
+    if mask is not None:
+        imask = np.logical_not(mask).astype(float)
+        if weights is None:
+            weights = imask
+        else:
+            weights *= imask
 
     # Sanitize fitting_axes and determine iterating_axes
     ndim = data.ndim

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -253,7 +253,7 @@ class ParameterContainer:
         return values[item]
 
 
-@support_nddata(wcs="world", weights="uncertainty", unit="data_unit", mask="mask")
+@support_nddata(wcs="world", uncertainty="weights", unit="data_unit")
 def parallel_fit_dask(
     data,
     *,

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -255,10 +255,10 @@ class ParameterContainer:
 
 @support_nddata(wcs="world", uncertainty="weights", unit="data_unit")
 def parallel_fit_dask(
-    data,
     *,
     model,
     fitter,
+    data,
     data_unit=None,
     weights=None,
     mask=None,

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -22,6 +22,7 @@ from astropy.modeling.models import (  # noqa: E402
     Linear1D,
     Planar2D,
 )
+from astropy.nddata import NDData  # noqa: E402
 from astropy.tests.helper import assert_quantity_allclose  # noqa: E402
 from astropy.utils.compat.optional_deps import HAS_PLT  # noqa: E402
 from astropy.wcs import WCS  # noqa: E402
@@ -1036,3 +1037,40 @@ def test_world_wcs_axis_correlation():
 
     model_fit = parallel_fit_dask(fitting_axes=1, world=wcs1, **common_kwargs)
     assert_allclose(model_fit.mean, [6, 4])
+
+
+def test_support_nddata():
+    data = gaussian(np.arange(20), 2, 10, 1).reshape((20, 1)) * u.Jy
+
+    # Introduce outliers
+    data[10, 0] = 1000.0 * u.Jy
+    # Mask the outliers (invalid is True)
+    mask = data > 100.0 * u.Jy
+
+    model = Gaussian1D(amplitude=1.5 * u.Jy, mean=7 * u.um, stddev=0.002 * u.mm)
+    fitter = LevMarLSQFitter()
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = "OFFSET", "WAVE"
+    wcs.wcs.crval = 10, 0.1
+    wcs.wcs.crpix = 1, 1
+    wcs.wcs.cdelt = 10, 0.1
+    wcs.wcs.cunit = "deg", "um"
+
+    nd_data = NDData(
+        data=data,
+        wcs=wcs,
+        mask=mask,
+    )
+
+    model_fit = parallel_fit_dask(
+        data=nd_data,
+        model=model,
+        fitter=fitter,
+        fitting_axes=0,
+        scheduler="synchronous",
+    )
+
+    assert_allclose(model_fit.amplitude.quantity, 2 * u.Jy)
+    assert_allclose(model_fit.mean.quantity, 1.1 * u.um)
+    assert_allclose(model_fit.stddev.quantity, 0.1 * u.um)

--- a/docs/changes/modeling/17273.feature.rst
+++ b/docs/changes/modeling/17273.feature.rst
@@ -1,0 +1,1 @@
+``parallel_fit_dask`` now supports ``NDData`` objects as the ``data=`` argument using the ``data``, ``wcs``, ``uncertainty``, ``mask`` and ``unit`` attributes of the ``NDData`` object.

--- a/docs/changes/modeling/17273.feature.rst
+++ b/docs/changes/modeling/17273.feature.rst
@@ -1,1 +1,0 @@
-``parallel_fit_dask`` now supports ``NDData`` objects as the ``data=`` argument using the ``data``, ``wcs``, ``uncertainty``, ``mask`` and ``unit`` attributes of the ``NDData`` object.


### PR DESCRIPTION
This was an oversight for our previous parallel fitting work, we wanted to be able to support passing in an `NDData` object to `parallel_fit_dask` as it will be very useful for both solar data and `specutils.Spectrum1D` objects.

I would very much like to sneak this into the 7.0 release, as it's a subtle API change to `parallel_fit_dask` and doing it after the release will mean our users will have to wait another 6 months. I can buy @saimn or whoever else I need to suitable beverages as penance.