### PR TITLE
TST: Use Python 3.12 or later for doctest in cosmology and table

### DIFF
--- a/astropy/cosmology/_io/mapping.py
+++ b/astropy/cosmology/_io/mapping.py
@@ -38,8 +38,7 @@ identical to the |Planck18| cosmology from which it was generated.
 
     >>> cosmo = Cosmology.from_format(cm, format="mapping")
     >>> cosmo
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                  Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
 How did |Cosmology.from_format| know to return an instance of the |FlatLambdaCDM| class?
 The mapping object has a field ``cosmology`` which can be either the string name of the
@@ -57,22 +56,20 @@ argument to |Cosmology.from_format|.
     >>> del cm["cosmology"]  # remove cosmology class
 
     >>> Cosmology.from_format(cm, cosmology="FlatLambdaCDM")
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                  Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
 To the second point, we can use specific cosmology class to parse the data.
 
     >>> from astropy.cosmology import FlatLambdaCDM
     >>> FlatLambdaCDM.from_format(cm)
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                  Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
 Also, the class' default parameter values are used to fill in any information missing in
 the data. For example, if ``Tcmb0`` is missing, the default value of 0.0 K is used.
 
     >>> del cm["Tcmb0"]  # show FlatLambdaCDM provides default
     >>> FlatLambdaCDM.from_format(cm)
-    FlatLambdaCDM(name="Planck18", H0=..., Tcmb0=0.0 K, ...)
+    FlatLambdaCDM(name='Planck18', H0=..., Tcmb0=<Quantity 0. K>, ...)
 
 If instead of *missing* information, there is *extra* information, there are a few
 options. The first is to use the ``move_to_meta`` keyword argument to move fields that
@@ -81,7 +78,7 @@ are not in the Cosmology constructor to the Cosmology's metadata.
     >>> cm2 = cm | {"extra": 42, "cosmology": "FlatLambdaCDM"}
     >>> cosmo = Cosmology.from_format(cm2, move_to_meta=True)
     >>> cosmo.meta
-    OrderedDict([('extra', 42), ...])
+    {'extra': 42, ...}
 
 Alternatively, the ``rename`` keyword argument can be used to rename keys in the mapping
 to fields of the |Cosmology|. This is crucial when the mapping has keys that are not
@@ -93,8 +90,7 @@ valid arguments to the |Cosmology| constructor.
 
     >>> rename = {'cosmo_cls': 'cosmology', 'cosmo_name': 'name'}
     >>> Cosmology.from_format(cm3, rename=rename)
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                    Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 0. K>, Neff=3.046, m_nu=None, Ob0=0.04897)
 
 Let's take a closer look at |Cosmology.to_format|, because there a lot of options, to
 tailor the output to specific needs.
@@ -103,11 +99,7 @@ The dictionary type may be changed with the ``cls`` keyword argument:
 
     >>> from collections import OrderedDict
     >>> Planck18.to_format('mapping', cls=OrderedDict)
-    OrderedDict([('cosmology', <class 'astropy.cosmology...FlatLambdaCDM'>),
-        ('name', 'Planck18'), ('H0', <Quantity 67.66 km / (Mpc s)>),
-        ('Om0', 0.30966), ('Tcmb0', <Quantity 2.7255 K>), ('Neff', 3.046),
-        ('m_nu', <Quantity [0.  , 0.  , 0.06] eV>), ('Ob0', 0.04897),
-        ('meta', ...
+    OrderedDict({'cosmology': <class 'astropy.cosmology.flrw.lambdacdm.FlatLambdaCDM'>, 'name': 'Planck18', 'H0': <Quantity 67.66 km / (Mpc s)>, 'Om0': 0.30966, 'Tcmb0': <Quantity 2.7255 K>, 'Neff': 3.046, 'm_nu': <Quantity [0.  , 0.  , 0.06] eV>, 'Ob0': 0.04897, 'meta': ...
 
 Sometimes it is more useful to have the name of the cosmology class, not the type
 itself. The keyword argument ``cosmology_as_str`` may be used:
@@ -235,31 +227,27 @@ def from_mapping(
 
         >>> cosmo = Cosmology.from_format(cm, format="mapping")
         >>> cosmo
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     The ``cosmology`` field can be omitted if the cosmology class (or its string name)
     is passed as the ``cosmology`` keyword argument to |Cosmology.from_format|.
 
         >>> del cm["cosmology"]  # remove cosmology class
         >>> Cosmology.from_format(cm, cosmology="FlatLambdaCDM")
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     Alternatively, specific cosmology classes can be used to parse the data.
 
         >>> from astropy.cosmology import FlatLambdaCDM
         >>> FlatLambdaCDM.from_format(cm)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     When using a specific cosmology class, the class' default parameter values are used
     to fill in any missing information.
 
         >>> del cm["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(cm)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 0. K>, Neff=3.046, m_nu=None, Ob0=0.04897)
 
     The ``move_to_meta`` keyword argument can be used to move fields that are not in the
     Cosmology constructor to the Cosmology's metadata. This is useful when the
@@ -268,7 +256,7 @@ def from_mapping(
         >>> cm2 = cm | {"extra": 42, "cosmology": "FlatLambdaCDM"}
         >>> cosmo = Cosmology.from_format(cm2, move_to_meta=True)
         >>> cosmo.meta
-        OrderedDict([('extra', 42), ...])
+        {'extra': 42, ...}
 
     The ``rename`` keyword argument can be used to rename keys in the mapping to fields
     of the |Cosmology|. This is crucial when the mapping has keys that are not valid
@@ -280,8 +268,7 @@ def from_mapping(
 
         >>> rename = {'cosmo_cls': 'cosmology', 'cosmo_name': 'name'}
         >>> Cosmology.from_format(cm3, rename=rename)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 0. K>, Neff=3.046, m_nu=None, Ob0=0.04897)
     """
     # Rename keys, if given a ``renames`` dict.
     # Also, make a copy of the mapping, so we can pop from it.
@@ -371,11 +358,7 @@ def to_mapping(
 
         >>> from collections import OrderedDict
         >>> Planck18.to_format('mapping', cls=OrderedDict)
-        OrderedDict([('cosmology', <class 'astropy.cosmology...FlatLambdaCDM'>),
-          ('name', 'Planck18'), ('H0', <Quantity 67.66 km / (Mpc s)>),
-          ('Om0', 0.30966), ('Tcmb0', <Quantity 2.7255 K>), ('Neff', 3.046),
-          ('m_nu', <Quantity [0.  , 0.  , 0.06] eV>), ('Ob0', 0.04897),
-          ('meta', ...
+        OrderedDict({'cosmology': <class 'astropy.cosmology.flrw.lambdacdm.FlatLambdaCDM'>, 'name': 'Planck18', 'H0': <Quantity 67.66 km / (Mpc s)>, 'Om0': 0.30966, 'Tcmb0': <Quantity 2.7255 K>, 'Neff': 3.046, 'm_nu': <Quantity [0.  , 0.  , 0.06] eV>, 'Ob0': 0.04897, 'meta': {'Oc0': 0.2607, 'n': 0.9665, 'sigma8': 0.8102, 'tau': 0.0561, 'z_reion': <Quantity 7.82 redshift>, 't0': <Quantity 13.787 Gyr>, 'reference': 'Planck Collaboration 2018, 2020, A&A, 641, A6  (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)'}})
 
     Sometimes it is more useful to have the name of the cosmology class, not
     the type itself. The keyword argument ``cosmology_as_str`` may be used:

--- a/astropy/cosmology/_io/row.py
+++ b/astropy/cosmology/_io/row.py
@@ -18,15 +18,14 @@ The cosmological class and other metadata, e.g. a paper reference, are in
 the Table's metadata.
 
     >>> cr.meta
-    OrderedDict([('Oc0', 0.2607), ('n', 0.9665), ...])
+    {'Oc0': 0.2607, 'n': 0.9665, ...}
 
 Now this row can be used to load a new cosmological instance identical
 to the ``Planck18`` cosmology from which it was generated.
 
     >>> cosmo = Cosmology.from_format(cr, format="astropy.row")
     >>> cosmo
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                    Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
 For more information on the argument options, see :ref:`cosmology_io_builtin-table`.
 """
@@ -105,8 +104,7 @@ def from_row(
 
         >>> cosmo = Cosmology.from_format(cr, format="astropy.row")
         >>> cosmo
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     The ``cosmology`` information (column or metadata) may be omitted if the cosmology
     class (or its string name) is passed as the ``cosmology`` keyword argument to
@@ -114,23 +112,20 @@ def from_row(
 
         >>> del cr.columns["cosmology"]  # remove cosmology from metadata
         >>> Cosmology.from_format(cr, cosmology="FlatLambdaCDM")
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     Alternatively, specific cosmology classes can be used to parse the data.
 
         >>> from astropy.cosmology import FlatLambdaCDM
         >>> FlatLambdaCDM.from_format(cr)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     When using a specific cosmology class, the class' default parameter values are used
     to fill in any missing information.
 
         >>> del cr.columns["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(cr)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 0. K>, Neff=3.046, m_nu=None, Ob0=0.04897)
 
     If a `~astropy.table.Row` object has columns that do not match the fields of the
     `~astropy.cosmology.Cosmology` class, they can be mapped using the ``rename``
@@ -229,7 +224,7 @@ def to_row(
     Table's metadata.
 
         >>> cr.meta
-        OrderedDict([('Oc0', 0.2607), ('n', 0.9665), ...])
+        {'Oc0': 0.2607, 'n': 0.9665, ...}
 
     To move the cosmology class from a column to the Table's metadata, set the
     ``cosmology_in_meta`` argument to `True`:

--- a/astropy/cosmology/_io/table.py
+++ b/astropy/cosmology/_io/table.py
@@ -23,7 +23,7 @@ The cosmological class and other metadata, e.g. a paper reference, are in the Ta
 metadata.
 
     >>> ct.meta
-    OrderedDict([..., ('cosmology', 'FlatLambdaCDM')])
+    {..., 'cosmology': 'FlatLambdaCDM'}
 
 
 Cosmology supports the astropy Table-like protocol (see :ref:`Table-like Objects`) to
@@ -79,8 +79,7 @@ it was generated.
 
     >>> cosmo = Cosmology.from_format(ct, format="astropy.table")
     >>> cosmo
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                    Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
     >>> cosmo == Planck18
     True
 
@@ -90,23 +89,20 @@ The ``cosmology`` information (row or metadata) may be omitted if the cosmology 
 
     >>> del ct.meta["cosmology"]  # remove cosmology from metadata
     >>> Cosmology.from_format(ct, cosmology="FlatLambdaCDM")
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                    Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+    FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
 Alternatively, specific cosmology classes can be used to parse the data.
 
     >>> from astropy.cosmology import FlatLambdaCDM
     >>> FlatLambdaCDM.from_format(ct)
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                    Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+     FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
 When using a specific cosmology class, the class' default parameter values are used to
 fill in any missing information.
 
     >>> del ct["Tcmb0"]  # show FlatLambdaCDM provides default
     >>> FlatLambdaCDM.from_format(ct)
-    FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                    Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+     FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 0. K>, Neff=3.046, m_nu=None, Ob0=0.04897)
 
 For tables with multiple rows of cosmological parameters, the ``index`` argument is
 needed to select the correct row. The index can be an integer for the row number or, if
@@ -237,8 +233,7 @@ def from_table(
 
         >>> cosmo = Cosmology.from_format(ct, format="astropy.table")
         >>> cosmo
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     The ``cosmology`` information (column or metadata) may be omitted if the cosmology
     class (or its string name) is passed as the ``cosmology`` keyword argument to
@@ -246,23 +241,20 @@ def from_table(
 
         >>> del ct.meta["cosmology"]  # remove cosmology from metadata
         >>> Cosmology.from_format(ct, cosmology="FlatLambdaCDM")
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+        FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     Alternatively, specific cosmology classes can be used to parse the data.
 
         >>> from astropy.cosmology import FlatLambdaCDM
         >>> FlatLambdaCDM.from_format(ct)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
+         FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 2.7255 K>, Neff=3.046, m_nu=<Quantity [0.  , 0.  , 0.06] eV>, Ob0=0.04897)
 
     When using a specific cosmology class, the class' default parameter values are used
     to fill in any missing information.
 
         >>> del ct["Tcmb0"]  # show FlatLambdaCDM provides default
         >>> FlatLambdaCDM.from_format(ct)
-        FlatLambdaCDM(name="Planck18", H0=67.66 km / (Mpc s), Om0=0.30966,
-                      Tcmb0=0.0 K, Neff=3.046, m_nu=None, Ob0=0.04897)
+         FlatLambdaCDM(name='Planck18', H0=<Quantity 67.66 km / (Mpc s)>, Om0=0.30966, Tcmb0=<Quantity 0. K>, Neff=3.046, m_nu=None, Ob0=0.04897)
 
     For tables with multiple rows of cosmological parameters, the ``index`` argument is
     needed to select the correct row. The index can be an integer for the row number or,
@@ -406,7 +398,7 @@ def to_table(
     the Table's metadata.
 
         >>> ct.meta
-        OrderedDict([..., ('cosmology', 'FlatLambdaCDM')])
+        {..., 'cosmology': 'FlatLambdaCDM'}
 
     To move the cosmology class from the metadata to a Table column, set the
     ``cosmology_in_meta`` argument to `False`:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -93,6 +93,8 @@ __doctest_skip__ = [
     "Table.convert_unicode_to_bytestring",
 ]
 
+__doctest_requires__ = {("Table.from_pandas", "Table.to_pandas"): ["pandas"]}
+
 _pprint_docs = """
     {__doc__}
 
@@ -406,7 +408,7 @@ class TableAttribute(MetaAttribute):
       >>> t.identifier
       10
       >>> t.meta
-      OrderedDict([('__attributes__', {'identifier': 10})])
+      {'__attributes__': {'identifier': 10}}
     """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,10 +228,10 @@ doctest_norecursedirs = [
     "*/tests/command.py",
 ]
 doctest_subpackage_requires = [
-    "astropy/cosmology/_io/mapping.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
-    "astropy/cosmology/_io/row.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
-    "astropy/cosmology/_io/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
-    "astropy/table/table.py = python<3.12",  # PYTHON_LT_3_12 (PR 14784)
+    "astropy/cosmology/_io/mapping.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
+    "astropy/cosmology/_io/row.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
+    "astropy/cosmology/_io/table.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
+    "astropy/table/table.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
     "astropy/table/mixins/dask.py = dask",
     "docs/* = numpy>=2",   # not NUMPY_LT_2_0 (PR 15065)
     "astropy/stats/info_theory.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

As we move to use newer Python and have more jobs also using them, it makes sense to switch the doctest to a more modern Python. Looks like the old pins were from #14784

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
