### PR TITLE
Add support for kwarg only and positional only arguments in support_nddata

### DIFF
--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -145,7 +145,8 @@ def support_nddata(
     all_returns = returns + keeps
 
     def support_nddata_decorator(func):
-        func_parameters = signature(func).parameters
+        func_sig = signature(func)
+        func_parameters = func_sig.parameters
         for param in func_parameters.values():
             if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
                 raise ValueError("func may not have *args or **kwargs.")
@@ -158,7 +159,6 @@ def support_nddata(
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            func_sig = signature(func)
             bound_args = func_sig.bind_partial(*args, **kwargs)
             data = bound_args.arguments[data_arg_name]
             unpack = isinstance(data, accepts)

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -145,39 +145,21 @@ def support_nddata(
     all_returns = returns + keeps
 
     def support_nddata_decorator(func):
-        # Find out args and kwargs
-        func_args, func_kwargs = [], []
-        sig = signature(func).parameters
-        for param_name, param in sig.items():
+        func_parameters = signature(func).parameters
+        for param in func_parameters.values():
             if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
                 raise ValueError("func may not have *args or **kwargs.")
-            try:
-                if param.kind == param.KEYWORD_ONLY or param.default != param.empty:
-                    func_kwargs.append(param_name)
-                else:
-                    func_args.append(param_name)
-            # The comparison to param.empty may fail if the default is a
-            # numpy array or something similar. So if the comparison fails then
-            # it's quite obvious that there was a default and it should be
-            # appended to the "func_kwargs".
-            except ValueError as exc:
-                if (
-                    "The truth value of an array with more than one element "
-                    "is ambiguous." in str(exc)
-                ):
-                    func_kwargs.append(param_name)
-                else:
-                    raise
 
         data_arg_name = attr_arg_map.get("data", "data")
-        if data_arg_name not in sig.keys():
+        if data_arg_name not in func_parameters.keys():
             raise ValueError(
                 f"Can only wrap a function with a {data_arg_name} argument."
             )
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            bound_args = signature(func).bind_partial(*args, **kwargs)
+            func_sig = signature(func)
+            bound_args = func_sig.bind_partial(*args, **kwargs)
             data = bound_args.arguments[data_arg_name]
             unpack = isinstance(data, accepts)
             input_data = data
@@ -206,7 +188,7 @@ def support_nddata(
                         continue
                     # Warn if the property is set but not used by the function.
                     propmatch = attr_arg_map.get(prop, prop)
-                    if propmatch not in func_kwargs:
+                    if propmatch not in func_parameters:
                         ignored.append(prop)
                         continue
 
@@ -226,13 +208,23 @@ def support_nddata(
                         # indistinguishable from an explicitly passed kwarg
                         # and it won't notice that and use the attribute of the
                         # NDData.
-                        if propmatch in func_args or (
-                            propmatch in func_kwargs
-                            and (
+                        warn_conflict = False
+                        try:
+                            if (
                                 bound_args.arguments[propmatch]
-                                is not sig[propmatch].default
-                            )
-                        ):
+                                is not func_parameters[propmatch].default
+                            ):
+                                warn_conflict = True
+                        except ValueError as exc:
+                            if (
+                                "The truth value of an array with more than one element "
+                                "is ambiguous." in str(exc)
+                            ):
+                                warn_conflict = False
+                            else:
+                                raise
+
+                        if warn_conflict:
                             warnings.warn(
                                 "Property {} has been passed explicitly and "
                                 "as an NDData property{}, using explicitly "
@@ -256,6 +248,9 @@ def support_nddata(
                         AstropyUserWarning,
                     )
 
+            # Need to apply defaults so that any positional only arguments are
+            # passed as positional properly
+            bound_args.apply_defaults()
             result = func(*bound_args.args, **bound_args.kwargs)
 
             if unpack and repack:

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -86,7 +86,7 @@ def test_pass_nddata_kwarg_only(func):
     (
         lambda data, wcs=None, mask=None, /, *, unit=None: (data, wcs, unit, mask),
         lambda data, wcs=None, /, mask=None, *, unit: (data, wcs, unit, mask),
-        lambda wcs=None, /, data, mask=None, *, unit: (data, wcs, unit, mask),
+        lambda wcs=None, /, data=None, mask=None, *, unit: (data, wcs, unit, mask),
         lambda wcs=None, /, mask=None, *, data, unit: (data, wcs, unit, mask),
     ),
 )

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -86,6 +86,8 @@ def test_pass_nddata_kwarg_only(func):
     (
         lambda data, wcs=None, mask=None, /, *, unit=None: (data, wcs, unit, mask),
         lambda data, wcs=None, /, mask=None, *, unit: (data, wcs, unit, mask),
+        lambda wcs=None, /, data, mask=None, *, unit: (data, wcs, unit, mask),
+        lambda wcs=None, /, mask=None, *, data, unit: (data, wcs, unit, mask),
     ),
 )
 def test_pass_nddata_positional_only(func):

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -81,6 +81,61 @@ def test_pass_nddata_kwarg_only(func):
     assert unit_out is unit_in
 
 
+@pytest.mark.parametrize(
+    "func",
+    (
+        lambda data, wcs=None, mask=None, /, *, unit=None: (data, wcs, unit, mask),
+        lambda data, wcs=None, /, mask=None, *, unit: (data, wcs, unit, mask),
+    ),
+)
+def test_pass_nddata_positional_only(func):
+    wrapped_function = support_nddata(func)
+
+    data_in = np.array([1, 2, 3])
+    wcs_in = WCS(naxis=1)
+    unit_in = u.Jy
+    mask_in = np.array([True, False, False])
+
+    nddata_in = NDData(data_in, wcs=wcs_in, unit=unit_in, mask=mask_in)
+
+    data_out, wcs_out, unit_out, mask_out = wrapped_function(nddata_in)
+
+    assert data_out is data_in
+    assert wcs_out is wcs_in
+    assert unit_out is unit_in
+    assert mask_out is mask_in
+
+    nddata2 = NDData(data_in, unit=unit_in, mask=mask_in)
+
+    data_out, wcs_out, unit_out, mask_out = wrapped_function(nddata2)
+
+    assert data_out is data_in
+    assert wcs_out is None
+    assert unit_out is unit_in
+    assert mask_out is mask_in
+
+    data_out, wcs_out, unit_out, mask_out = wrapped_function(nddata2, wcs_in)
+
+    assert data_out is data_in
+    assert wcs_out is wcs_in
+    assert unit_out is unit_in
+    assert mask_out is mask_in
+
+    with pytest.warns(
+        AstropyUserWarning,
+        match=(
+            "Property wcs has been passed explicitly and as "
+            "an NDData property, using explicitly specified value"
+        ),
+    ) as w:
+        data_out, wcs_out, unit_out, mask_out = wrapped_function(nddata_in, wcs_in)
+
+    assert data_out is data_in
+    assert wcs_out is wcs_in
+    assert unit_out is unit_in
+    assert mask_out is mask_in
+
+
 def test_pass_nddata_and_explicit():
     data_in = np.array([1, 2, 3])
     wcs_in = WCS(naxis=1)

--- a/docs/changes/nddata/17281.bugfix.rst
+++ b/docs/changes/nddata/17281.bugfix.rst
@@ -1,0 +1,1 @@
+Add support for positional only and keyword only arguments when using the ``support_nddata`` decorator.


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17280

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.