### PR TITLE
TST: Localize ignores for ResourceWarning for socket and SSL

### DIFF
--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -40,6 +40,7 @@ def samp_hub():
     my_hub.stop()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed <socket:ResourceWarning")
 def test_SAMPIntegratedClient_notify_all(samp_hub):
     """Test that SAMP returns a warning if no receiver got the message."""
     client = SAMPIntegratedClient()

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1188,6 +1188,7 @@ def test_compressed_stream():
         assert f.read().rstrip() == b"CONTENT"
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_invalid_location_download_raises_urlerror():
     """
@@ -1199,6 +1200,7 @@ def test_invalid_location_download_raises_urlerror():
         download_file("http://www.astropy.org/nonexistentfile")
 
 
+@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
 def test_invalid_location_download_noconnect():
     """
     checks that download_file gives an OSError if the socket is blocked
@@ -1326,6 +1328,7 @@ def test_export_import_roundtrip_stream(temp_cache, valid_urls):
     assert set(get_cached_urls()) == initial_urls_in_cache
 
 
+@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
 def test_export_overwrite_flag_works(temp_cache, valid_urls, tmp_path):
     fn = tmp_path / "f.zip"
     c = b"Some contents\nto check later"
@@ -1342,6 +1345,7 @@ def test_export_overwrite_flag_works(temp_cache, valid_urls, tmp_path):
     assert get_file_contents(fn, encoding="binary") != c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
 def test_export_import_roundtrip_different_location(tmp_path, valid_urls):
     original_cache = tmp_path / "original"
     original_cache.mkdir()
@@ -1382,6 +1386,7 @@ def test_cache_size_changes_correctly_when_files_are_added_and_removed(
     assert cache_total_size() == s_i
 
 
+@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
 def test_cache_contents_agrees_with_get_urls(temp_cache, valid_urls):
     r = []
     for a, a_c in islice(valid_urls, FEW):
@@ -1501,6 +1506,7 @@ def test_check_download_cache_cleanup(temp_cache, valid_urls):
     # download cache will be checked on exit
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_cache_update_doesnt_damage_cache(temp_cache, valid_urls):
     u, _ = next(valid_urls)
     download_file(u, cache=True)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1,4 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# NOTE: All the tests here might non-deterministically emit
+#       ResourceWarning about unclosed socket or SSLSocket,
+#       which we tell pytest to ignore. See GH Issue 9619.
 
 import base64
 import contextlib
@@ -206,6 +209,7 @@ def fake_readonly_cache(tmp_path, valid_urls, monkeypatch):
             check_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_basic(valid_urls, temp_cache):
     u, c = next(valid_urls)
     assert get_file_contents(download_file(u, cache=False)) == c
@@ -216,6 +220,7 @@ def test_download_file_basic(valid_urls, temp_cache):
     assert get_file_contents(download_file(u, cache=True, sources=[])) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_absolute_path(valid_urls, temp_cache):
     def is_abs(p):
         return p == os.path.abspath(p)
@@ -228,6 +233,7 @@ def test_download_file_absolute_path(valid_urls, temp_cache):
         assert is_abs(v)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_unicode_url(valid_urls, temp_cache):
     u, c = next(valid_urls)
     unicode_url = "http://é—☃—è.com"
@@ -238,6 +244,7 @@ def test_unicode_url(valid_urls, temp_cache):
     assert unicode_url in cache_contents()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_too_long_url(valid_urls, temp_cache):
     u, c = next(valid_urls)
     long_url = "http://" + "a" * 256 + ".com"
@@ -246,6 +253,7 @@ def test_too_long_url(valid_urls, temp_cache):
     download_file(long_url, cache=True, sources=[])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_case_collision(valid_urls, temp_cache):
     u, c = next(valid_urls)
     u2, c2 = next(valid_urls)
@@ -255,6 +263,7 @@ def test_case_collision(valid_urls, temp_cache):
     assert get_file_contents(f1) != get_file_contents(f2)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_domain_name_case(valid_urls, temp_cache):
     u, c = next(valid_urls)
     download_file("http://Example.com/thing", cache=True, sources=[u])
@@ -264,6 +273,7 @@ def test_domain_name_case(valid_urls, temp_cache):
     download_file("Http://example.com/thing", cache=True, sources=[])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_download_nocache_from_internet():
     fnout = download_file(TESTURL, cache=False)
@@ -288,6 +298,7 @@ def a_file(tmp_path):
     return fn, contents
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_temp_cache(tmp_path):
     dldir0 = _get_download_cache_loc()
     check_download_cache()
@@ -321,6 +332,7 @@ def test_temp_cache(tmp_path):
     assert dldir4 == dldir0
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("parallel", [False, True])
 def test_download_with_sources_and_bogus_original(
     valid_urls, invalid_urls, temp_cache, parallel
@@ -364,6 +376,7 @@ def test_download_with_sources_and_bogus_original(
         assert is_url_in_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     (sys.platform.startswith("win") and CI), reason="flaky cache error on Windows CI"
 )
@@ -383,6 +396,7 @@ def test_download_file_threaded_many(temp_cache, valid_urls):
         assert get_file_contents(r_) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     (sys.platform.startswith("win") and CI), reason="flaky cache error on Windows CI"
 )
@@ -400,6 +414,7 @@ def test_threaded_segfault(valid_urls):
         list(P.map(lambda u: slurp_url(u), [u for (u, c) in urls]))
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     (sys.platform.startswith("win") and CI), reason="flaky cache error on Windows CI"
 )
@@ -438,6 +453,7 @@ def test_download_file_threaded_many_partial_success(
             assert r_ is None
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_cache(valid_urls):
     u1, c1 = next(valid_urls)
     download_file(u1, cache=True)
@@ -467,6 +483,7 @@ def test_clear_download_cache(valid_urls):
     assert is_url_in_cache(u1)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_multiple_references_doesnt_corrupt_storage(
     temp_cache, tmp_path
 ):
@@ -505,6 +522,7 @@ def test_clear_download_multiple_references_doesnt_corrupt_storage(
     ), "No reference exists any more, file should be deleted"
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("use_cache", [False, True])
 def test_download_file_local_cache_survives(tmp_path, temp_cache, use_cache):
     """Confirm that downloading a local file does not delete it.
@@ -526,6 +544,7 @@ def test_download_file_local_cache_survives(tmp_path, temp_cache, use_cache):
     assert get_file_contents(f) == contents
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_sources_normal(temp_cache, valid_urls, invalid_urls):
     primary, contents = next(valid_urls)
     fallback1 = next(invalid_urls)
@@ -535,6 +554,7 @@ def test_sources_normal(temp_cache, valid_urls, invalid_urls):
     assert not is_url_in_cache(fallback1)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_sources_fallback(temp_cache, valid_urls, invalid_urls):
     primary = next(invalid_urls)
     fallback1, contents = next(valid_urls)
@@ -544,6 +564,7 @@ def test_sources_fallback(temp_cache, valid_urls, invalid_urls):
     assert not is_url_in_cache(fallback1)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_sources_ignore_primary(temp_cache, valid_urls, invalid_urls):
     primary, bogus = next(valid_urls)
     fallback1, contents = next(valid_urls)
@@ -553,6 +574,7 @@ def test_sources_ignore_primary(temp_cache, valid_urls, invalid_urls):
     assert not is_url_in_cache(fallback1)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_sources_multiple(temp_cache, valid_urls, invalid_urls):
     primary = next(invalid_urls)
     fallback1 = next(invalid_urls)
@@ -564,6 +586,7 @@ def test_sources_multiple(temp_cache, valid_urls, invalid_urls):
     assert not is_url_in_cache(fallback2)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_sources_multiple_missing(temp_cache, valid_urls, invalid_urls):
     primary = next(invalid_urls)
     fallback1 = next(invalid_urls)
@@ -575,6 +598,7 @@ def test_sources_multiple_missing(temp_cache, valid_urls, invalid_urls):
     assert not is_url_in_cache(fallback2)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_update_url(tmp_path, temp_cache):
     with TemporaryDirectory(dir=tmp_path) as d:
         f_name = os.path.join(d, "f")
@@ -602,12 +626,14 @@ def test_update_url(tmp_path, temp_cache):
     ), "Failed update should not remove the current version"
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_download_noprogress():
     fnout = download_file(TESTURL, cache=False, show_progress=False)
     assert os.path.isfile(fnout)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_download_cache():
     download_dir = _get_download_cache_loc()
@@ -628,6 +654,7 @@ def test_download_cache():
     assert not os.path.isdir(lockdir), "Cache dir lock was not released!"
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_download_certificate_verification_failed():
     """Tests for https://github.com/astropy/astropy/pull/10434"""
@@ -649,6 +676,7 @@ def test_download_certificate_verification_failed():
     assert os.path.isfile(fnout)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_cache_after_clear(tmp_path, temp_cache, valid_urls):
     testurl, contents = next(valid_urls)
     # Test issues raised in #4427 with clear_download_cache() without a URL,
@@ -666,6 +694,7 @@ def test_download_cache_after_clear(tmp_path, temp_cache, valid_urls):
     assert os.path.isfile(fnout)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_download_parallel_from_internet_works(temp_cache):
     main_url = conf.dataurl
@@ -680,6 +709,7 @@ def test_download_parallel_from_internet_works(temp_cache):
     assert all(os.path.isfile(f) for f in fnout), fnout
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("method", [None, "spawn"])
 def test_download_parallel_fills_cache(tmp_path, valid_urls, method):
     urls = []
@@ -702,6 +732,7 @@ def test_download_parallel_fills_cache(tmp_path, valid_urls, method):
     check_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_parallel_with_empty_sources(valid_urls, temp_cache):
     urls = []
     sources = {}
@@ -717,6 +748,7 @@ def test_download_parallel_with_empty_sources(valid_urls, temp_cache):
         assert get_file_contents(r) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_parallel_with_sources_and_bogus_original(
     valid_urls, invalid_urls, temp_cache
 ):
@@ -738,6 +770,7 @@ def test_download_parallel_with_sources_and_bogus_original(
         assert get_file_contents(r) != c_bad
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_parallel_many(temp_cache, valid_urls):
     td = list(islice(valid_urls, N_PARALLEL_HAMMER))
 
@@ -747,6 +780,7 @@ def test_download_parallel_many(temp_cache, valid_urls):
         assert get_file_contents(r_) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_parallel_partial_success(temp_cache, valid_urls, invalid_urls):
     """Check that a partially successful download works.
 
@@ -766,6 +800,7 @@ def test_download_parallel_partial_success(temp_cache, valid_urls, invalid_urls)
     # assert not any([is_url_in_cache(u) for (u, c) in td])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.slow
 def test_download_parallel_partial_success_lock_safe(
     temp_cache, valid_urls, invalid_urls
@@ -792,6 +827,7 @@ def test_download_parallel_partial_success_lock_safe(
         random.setstate(s)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_parallel_update(temp_cache, tmp_path):
     td = []
     for i in range(N_PARALLEL_HAMMER):
@@ -829,6 +865,7 @@ def test_download_parallel_update(temp_cache, tmp_path):
         assert get_file_contents(r_3) == c_plus
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     (sys.platform.startswith("win") and CI), reason="flaky cache error on Windows CI"
 )
@@ -850,6 +887,7 @@ def test_update_parallel(temp_cache, valid_urls):
         assert get_file_contents(f) == c2
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     (sys.platform.startswith("win") and CI), reason="flaky cache error on Windows CI"
 )
@@ -871,12 +909,14 @@ def test_update_parallel_multi(temp_cache, valid_urls):
     assert any(get_file_contents(f) == c for (f, c) in r)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_url_nocache():
     with get_readable_fileobj(TESTURL, cache=False, encoding="utf-8") as page:
         assert page.read().find("Astropy") > -1
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_find_by_hash(valid_urls, temp_cache):
     testurl, contents = next(valid_urls)
     p = download_file(testurl, cache=True)
@@ -890,6 +930,7 @@ def test_find_by_hash(valid_urls, temp_cache):
     assert not os.path.isfile(fnout)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_find_invalid():
     # this is of course not a real data file and not on any remote server, but
@@ -900,6 +941,7 @@ def test_find_invalid():
         )
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("package", [None, "astropy", "numpy"])
 def test_get_invalid(package):
     """Test can create a file path to an invalid file."""
@@ -909,6 +951,7 @@ def test_get_invalid(package):
 
 
 # Package data functions
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize(
     "filename", ["local.dat", "local.dat.gz", "local.dat.bz2", "local.dat.xz"]
 )
@@ -950,6 +993,7 @@ def bad_compressed(request, tmp_path):
     return filename
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_local_data_obj_invalid(bad_compressed):
     is_bz2 = bad_compressed.endswith(".bz2")
     is_xz = bad_compressed.endswith(".xz")
@@ -972,6 +1016,7 @@ def test_local_data_obj_invalid(bad_compressed):
             assert f.read().rstrip().endswith(b"invalid")
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_local_data_name():
     assert os.path.isfile(TESTLOCAL) and TESTLOCAL.endswith("local.dat")
 
@@ -984,6 +1029,7 @@ def test_local_data_name():
     # assert os.path.isfile(fnout2) and fnout2.endswith('README.rst')
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_data_name_third_party_package():
     """Regression test for issue #1256
 
@@ -1008,12 +1054,14 @@ def test_data_name_third_party_package():
         sys.path.pop(0)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_local_data_nonlocalfail():
     # this would go *outside* the astropy tree
     with pytest.raises(RuntimeError):
         get_pkg_data_filename("../../../data/README.rst")
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_compute_hash(tmp_path):
     rands = b"1234567890abcdefghijklmnopqrstuvwxyz"
 
@@ -1029,6 +1077,7 @@ def test_compute_hash(tmp_path):
     assert chhash == shash
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_pkg_data_contents():
     with get_pkg_data_fileobj("data/local.dat") as f:
         contents1 = f.read()
@@ -1038,6 +1087,7 @@ def test_get_pkg_data_contents():
     assert contents1 == contents2
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_data_noastropy_fallback(monkeypatch):
     """
@@ -1119,6 +1169,7 @@ def test_data_noastropy_fallback(monkeypatch):
     # no warnings should be raise in fileobj because cache is unnecessary
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize(
     "encoding, expected_type, expected_lines",
     [
@@ -1157,6 +1208,7 @@ def test_read_unicode(filename, encoding, expected_type, expected_lines):
     assert contents.splitlines() == expected_lines
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_compressed_stream():
     gzipped_data = (
         b"H4sICIxwG1AAA2xvY2FsLmRhdAALycgsVkjLzElVANKlxakpCpl5CiUZqQ"
@@ -1200,7 +1252,7 @@ def test_invalid_location_download_raises_urlerror():
         download_file("http://www.astropy.org/nonexistentfile")
 
 
-@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_invalid_location_download_noconnect():
     """
     checks that download_file gives an OSError if the socket is blocked
@@ -1211,6 +1263,7 @@ def test_invalid_location_download_noconnect():
         download_file("http://astropy.org/nonexistentfile")
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data(source="astropy")
 def test_is_url_in_cache_remote():
     assert not is_url_in_cache("http://astropy.org/nonexistentfile")
@@ -1219,6 +1272,7 @@ def test_is_url_in_cache_remote():
     assert is_url_in_cache(TESTURL)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_is_url_in_cache_local(temp_cache, valid_urls, invalid_urls):
     testurl, contents = next(valid_urls)
     nonexistent = next(invalid_urls)
@@ -1233,6 +1287,7 @@ def test_is_url_in_cache_local(temp_cache, valid_urls, invalid_urls):
 
 # If non-deterministic failure happens see
 # https://github.com/astropy/astropy/issues/9765
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache(tmp_path, temp_cache, valid_urls, invalid_urls):
     testurl, testurl_contents = next(valid_urls)
     testurl2, testurl2_contents = next(valid_urls)
@@ -1256,6 +1311,7 @@ def test_check_download_cache(tmp_path, temp_cache, valid_urls, invalid_urls):
     check_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_import_roundtrip_one(tmp_path, temp_cache, valid_urls):
     testurl, contents = next(valid_urls)
     f = download_file(testurl, cache=True, show_progress=False)
@@ -1275,6 +1331,7 @@ def test_export_import_roundtrip_one(tmp_path, temp_cache, valid_urls):
     )
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_url_not_present(temp_cache, valid_urls):
     testurl, contents = next(valid_urls)
     with NamedTemporaryFile("wb") as zip_file:
@@ -1283,6 +1340,7 @@ def test_export_url_not_present(temp_cache, valid_urls):
             export_download_cache(zip_file, [testurl])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_import_one(tmp_path, temp_cache, valid_urls):
     testurl, testurl_contents = next(valid_urls)
     testurl2, testurl2_contents = next(valid_urls)
@@ -1299,6 +1357,7 @@ def test_import_one(tmp_path, temp_cache, valid_urls):
     assert not is_url_in_cache(testurl2)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_import_roundtrip(tmp_path, temp_cache, valid_urls):
     zip_file_name = tmp_path / "the.zip"
     for u, c in islice(valid_urls, FEW):
@@ -1313,6 +1372,7 @@ def test_export_import_roundtrip(tmp_path, temp_cache, valid_urls):
     assert set(get_cached_urls()) == initial_urls_in_cache
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_import_roundtrip_stream(temp_cache, valid_urls):
     for u, c in islice(valid_urls, FEW):
         download_file(u, cache=True)
@@ -1328,7 +1388,7 @@ def test_export_import_roundtrip_stream(temp_cache, valid_urls):
     assert set(get_cached_urls()) == initial_urls_in_cache
 
 
-@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_overwrite_flag_works(temp_cache, valid_urls, tmp_path):
     fn = tmp_path / "f.zip"
     c = b"Some contents\nto check later"
@@ -1345,7 +1405,7 @@ def test_export_overwrite_flag_works(temp_cache, valid_urls, tmp_path):
     assert get_file_contents(fn, encoding="binary") != c
 
 
-@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_import_roundtrip_different_location(tmp_path, valid_urls):
     original_cache = tmp_path / "original"
     original_cache.mkdir()
@@ -1369,11 +1429,13 @@ def test_export_import_roundtrip_different_location(tmp_path, valid_urls):
             assert get_file_contents(download_file(u, cache=True)) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_cache_size_is_zero_when_empty(temp_cache):
     assert not get_cached_urls()
     assert cache_total_size() == 0
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_cache_size_changes_correctly_when_files_are_added_and_removed(
     temp_cache, valid_urls
 ):
@@ -1386,7 +1448,7 @@ def test_cache_size_changes_correctly_when_files_are_added_and_removed(
     assert cache_total_size() == s_i
 
 
-@pytest.mark.filterwarnings("ignore:unclosed <ssl.SSLSocket:ResourceWarning")
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_cache_contents_agrees_with_get_urls(temp_cache, valid_urls):
     r = []
     for a, a_c in islice(valid_urls, FEW):
@@ -1397,12 +1459,14 @@ def test_cache_contents_agrees_with_get_urls(temp_cache, valid_urls):
         assert cache_contents()[u] == h
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("desired_size", [1_000_000_000_000_000_000, 1 * _u.Ebyte])
 def test_free_space_checker_huge(tmp_path, desired_size):
     with pytest.raises(OSError):
         check_free_space_in_dir(tmp_path, desired_size)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_free_space_file_directory(tmp_path):
     fn = tmp_path / "file"
     with open(fn, "w"):
@@ -1421,12 +1485,14 @@ def test_get_free_space_file_directory(tmp_path):
     assert free_space > 0 and free_space.unit == _u.Mbit
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_bogus_settings(invalid_urls, temp_cache):
     u = next(invalid_urls)
     with pytest.raises(KeyError):
         download_file(u, sources=[])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_local_directory(tmp_path):
     """Make sure we get a URLError rather than OSError even if it's a
     local directory."""
@@ -1434,6 +1500,7 @@ def test_download_file_local_directory(tmp_path):
         download_file(url_to(tmp_path))
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_schedules_deletion(valid_urls):
     u, c = next(valid_urls)
     f = download_file(u)
@@ -1441,6 +1508,7 @@ def test_download_file_schedules_deletion(valid_urls):
     # how to test deletion actually occurs?
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_cache_refuses_to_delete_outside_the_cache(tmp_path):
     fn = str(tmp_path / "file")
     with open(fn, "w") as f:
@@ -1451,6 +1519,7 @@ def test_clear_download_cache_refuses_to_delete_outside_the_cache(tmp_path):
     assert os.path.exists(fn)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache_finds_bogus_entries(temp_cache, valid_urls):
     u, c = next(valid_urls)
     download_file(u, cache=True)
@@ -1464,6 +1533,7 @@ def test_check_download_cache_finds_bogus_entries(temp_cache, valid_urls):
     clear_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache_finds_bogus_subentries(temp_cache, valid_urls):
     u, c = next(valid_urls)
     f = download_file(u, cache=True)
@@ -1476,6 +1546,7 @@ def test_check_download_cache_finds_bogus_subentries(temp_cache, valid_urls):
     clear_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache_cleanup(temp_cache, valid_urls):
     u, c = next(valid_urls)
     fn = download_file(u, cache=True)
@@ -1513,6 +1584,7 @@ def test_download_cache_update_doesnt_damage_cache(temp_cache, valid_urls):
     download_file(u, cache="update")
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_cache_dir_is_actually_a_file(tmp_path, valid_urls):
     """Ensure that bogus cache settings are handled sensibly.
 
@@ -1606,24 +1678,28 @@ def test_cache_dir_is_actually_a_file(tmp_path, valid_urls):
     os.remove(cd)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_fileobj_str(a_file):
     fn, c = a_file
     with get_readable_fileobj(str(fn)) as rf:
         assert rf.read() == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_fileobj_pathlib(a_file):
     fn, c = a_file
     with get_readable_fileobj(pathlib.Path(fn)) as rf:
         assert rf.read() == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_fileobj_binary(a_binary_file):
     fn, c = a_binary_file
     with get_readable_fileobj(fn, encoding="binary") as rf:
         assert rf.read() == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_fileobj_already_open_text(a_file):
     fn, c = a_file
     with open(fn) as f:
@@ -1632,6 +1708,7 @@ def test_get_fileobj_already_open_text(a_file):
                 rf.read()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_fileobj_already_open_binary(a_file):
     fn, c = a_file
     with open(fn, "rb") as f:
@@ -1639,6 +1716,7 @@ def test_get_fileobj_already_open_binary(a_file):
             assert rf.read() == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_fileobj_binary_already_open_binary(a_binary_file):
     fn, c = a_binary_file
     with open(fn, "rb") as f:
@@ -1646,6 +1724,7 @@ def test_get_fileobj_binary_already_open_binary(a_binary_file):
             assert rf.read() == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_cache_contents_not_writable(temp_cache, valid_urls):
     c = cache_contents()
     with pytest.raises(TypeError):
@@ -1658,6 +1737,7 @@ def test_cache_contents_not_writable(temp_cache, valid_urls):
         c["foo"] = 7
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_cache_relocatable(tmp_path, valid_urls):
     u, c = next(valid_urls)
     d1 = tmp_path / "1"
@@ -1678,6 +1758,7 @@ def test_cache_relocatable(tmp_path, valid_urls):
         check_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_get_readable_fileobj_cleans_up_temporary_files(tmp_path, monkeypatch):
     """checks that get_readable_fileobj leaves no temporary files behind"""
     # Create a 'file://' URL pointing to a path on the local filesystem
@@ -1698,6 +1779,7 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmp_path, monkeypatch):
     assert len(tempdir_listing) == 0
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_path_objects_get_readable_fileobj():
     fpath = pathlib.Path(TESTLOCAL)
     with get_readable_fileobj(fpath) as f:
@@ -1707,6 +1789,7 @@ def test_path_objects_get_readable_fileobj():
         )
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_nested_get_readable_fileobj():
     """Ensure fileobj state is as expected when get_readable_fileobj()
     is called inside another get_readable_fileobj().
@@ -1724,6 +1807,7 @@ def test_nested_get_readable_fileobj():
     assert fileobj.closed and fileobj2.closed
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_wrong_size(monkeypatch):
     @contextlib.contextmanager
     def mockurl(remote_url, timeout=None):
@@ -1769,6 +1853,7 @@ def test_download_file_wrong_size(monkeypatch):
         assert f.read() == b"a" * real_length
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_can_make_directories_readonly(tmp_path):
     try:
         with readonly_dir(tmp_path):
@@ -1787,6 +1872,7 @@ def test_can_make_directories_readonly(tmp_path):
             raise
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_can_make_files_readonly(tmp_path):
     fn = tmp_path / "test"
     c = "contents\n"
@@ -1804,16 +1890,19 @@ def test_can_make_files_readonly(tmp_path):
     assert get_file_contents(fn) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_read_cache_readonly(readonly_cache):
     assert cache_contents() == readonly_cache
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_cache_readonly(readonly_cache):
     for u in readonly_cache:
         f = download_file(u, cache=True)
         assert f == readonly_cache[u]
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_import_file_cache_readonly(readonly_cache, tmp_path):
     filename = tmp_path / "test-file"
     content = "Some text or other"
@@ -1826,6 +1915,7 @@ def test_import_file_cache_readonly(readonly_cache, tmp_path):
     assert not is_url_in_cache(url)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_import_file_cache_invalid_cross_device_link(tmp_path, monkeypatch):
     def no_rename(path, mode=None):
         if os.path.exists(path):
@@ -1846,6 +1936,7 @@ def test_import_file_cache_invalid_cross_device_link(tmp_path, monkeypatch):
     assert is_url_in_cache(url)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_cache_readonly_cache_miss(readonly_cache, valid_urls):
     u, c = next(valid_urls)
     with pytest.warns(CacheMissingWarning):
@@ -1854,6 +1945,7 @@ def test_download_file_cache_readonly_cache_miss(readonly_cache, valid_urls):
     assert not is_url_in_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_cache_readonly_update(readonly_cache):
     for u in readonly_cache:
         with pytest.warns(CacheMissingWarning):
@@ -1862,6 +1954,7 @@ def test_download_file_cache_readonly_update(readonly_cache):
         assert compute_hash(f) == compute_hash(readonly_cache[u])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache_works_if_readonly(readonly_cache):
     check_download_cache()
 
@@ -1875,27 +1968,32 @@ def test_check_download_cache_works_if_readonly(readonly_cache):
 # tests.
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_read_cache_fake_readonly(fake_readonly_cache):
     assert cache_contents() == fake_readonly_cache
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_cache_fake_readonly(fake_readonly_cache):
     for u in fake_readonly_cache:
         f = download_file(u, cache=True)
         assert f == fake_readonly_cache[u]
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_mkdtemp_cache_fake_readonly(fake_readonly_cache):
     with pytest.raises(OSError):
         tempfile.mkdtemp()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_TD_cache_fake_readonly(fake_readonly_cache):
     with pytest.raises(OSError):
         with TemporaryDirectory():
             pass
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_import_file_cache_fake_readonly(fake_readonly_cache, tmp_path):
     filename = tmp_path / "test-file"
     content = "Some text or other"
@@ -1908,6 +2006,7 @@ def test_import_file_cache_fake_readonly(fake_readonly_cache, tmp_path):
     assert not is_url_in_cache(url)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_cache_fake_readonly_cache_miss(fake_readonly_cache, valid_urls):
     u, c = next(valid_urls)
     with pytest.warns(CacheMissingWarning):
@@ -1916,6 +2015,7 @@ def test_download_file_cache_fake_readonly_cache_miss(fake_readonly_cache, valid
     assert get_file_contents(f) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_file_cache_fake_readonly_update(fake_readonly_cache):
     for u in fake_readonly_cache:
         with pytest.warns(CacheMissingWarning):
@@ -1924,10 +2024,12 @@ def test_download_file_cache_fake_readonly_update(fake_readonly_cache):
         assert compute_hash(f) == compute_hash(fake_readonly_cache[u])
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache_works_if_fake_readonly(fake_readonly_cache):
     check_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_pkgname_isolation(temp_cache, valid_urls):
     a = "bogus_cache_name"
 
@@ -1997,6 +2099,7 @@ def test_pkgname_isolation(temp_cache, valid_urls):
     assert not get_cached_urls(pkgname=a)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_transport_cache_via_zip(temp_cache, valid_urls):
     a = "bogus_cache_name"
 
@@ -2031,6 +2134,7 @@ def test_transport_cache_via_zip(temp_cache, valid_urls):
     assert set(get_cached_urls()) == set(get_cached_urls(pkgname=a))
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_download_parallel_respects_pkgname(temp_cache, valid_urls):
     a = "bogus_cache_name"
 
@@ -2042,6 +2146,7 @@ def test_download_parallel_respects_pkgname(temp_cache, valid_urls):
     assert len(get_cached_urls(pkgname=a)) == FEW
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     not CAN_RENAME_DIRECTORY_IN_USE,
     reason="This platform is unable to rename directories that are in use.",
@@ -2054,6 +2159,7 @@ def test_removal_of_open_files(temp_cache, valid_urls):
         check_download_cache()
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     not CAN_RENAME_DIRECTORY_IN_USE,
     reason="This platform is unable to rename directories that are in use.",
@@ -2069,6 +2175,7 @@ def test_update_of_open_files(temp_cache, valid_urls):
     assert is_url_in_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_removal_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     def no_rmtree(*args, **kwargs):
         warnings.warn(CacheMissingWarning("in use"))
@@ -2087,6 +2194,7 @@ def test_removal_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
             clear_download_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     def no_rmtree(*args, **kwargs):
         warnings.warn(CacheMissingWarning("in use"))
@@ -2110,6 +2218,7 @@ def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     assert get_file_contents(download_file(u, cache=True, sources=[])) == c
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_no_allow_internet(temp_cache, valid_urls):
     u, c = next(valid_urls)
     with conf.set_temp("allow_internet", False):
@@ -2121,6 +2230,7 @@ def test_no_allow_internet(temp_cache, valid_urls):
             download_file(TESTURL)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_cache_not_too_aggressive(temp_cache, valid_urls):
     u, c = next(valid_urls)
     download_file(u, cache=True)
@@ -2132,6 +2242,7 @@ def test_clear_download_cache_not_too_aggressive(temp_cache, valid_urls):
     assert is_url_in_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_cache_variants(temp_cache, valid_urls):
     # deletion by contents filename
     u, c = next(valid_urls)
@@ -2165,6 +2276,7 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
     assert not is_url_in_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_cache_invalid_cross_device_link(
     temp_cache, valid_urls, monkeypatch
 ):
@@ -2182,6 +2294,7 @@ def test_clear_download_cache_invalid_cross_device_link(
     assert not is_url_in_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_clear_download_cache_raises_os_error(temp_cache, valid_urls, monkeypatch):
     def no_rename(path, mode=None):
         raise OSError(errno.EBUSY, "os.rename monkeypatched out")
@@ -2196,6 +2309,7 @@ def test_clear_download_cache_raises_os_error(temp_cache, valid_urls, monkeypatc
         clear_download_cache(u)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.skipif(
     CI and not IS_CRON,
     reason="Flaky/too much external traffic for regular CI",
@@ -2208,6 +2322,7 @@ def test_ftp_tls_auto(temp_cache):
     download_file(url)
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("base", ["http://example.com", "https://example.com"])
 def test_url_trailing_slash(temp_cache, valid_urls, base):
     slash = base + "/"
@@ -2227,12 +2342,14 @@ def test_url_trailing_slash(temp_cache, valid_urls, base):
     # see if implicit check_download_cache squawks
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_empty_url(temp_cache, valid_urls):
     u, c = next(valid_urls)
     download_file("file://", cache=True, sources=[u])
     assert not is_url_in_cache("file:///")
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.remote_data
 def test_download_ftp_file_properly_handles_socket_error():
     faulty_url = "ftp://anonymous:mail%40astropy.org@nonexisting/pub/products/iers/finals2000A.all"
@@ -2254,6 +2371,7 @@ def test_download_ftp_file_properly_handles_socket_error():
     assert found_msg, f'Got {errmsg}, expected one of these: {",".join(possible_msgs)}'
 
 
+@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize(
     ("s", "ans"),
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,8 +222,6 @@ log_cli_level = "info"
 xfail_strict = true
 filterwarnings = [
     "error",
-    "ignore:unclosed <socket:ResourceWarning",
-    "ignore:unclosed <ssl.SSLSocket:ResourceWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to localize ignores for ResourceWarning.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Related to #9619 and https://github.com/astropy/astropy/issues/11120

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
