### PR TITLE
Reduce the number of unit formatter `_parse_unit()` implementations

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING
 
 from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
-from astropy.utils.misc import did_you_mean
 
 from .fits import FITS
 from .generic import Generic
@@ -259,19 +258,6 @@ class CDS(FITS):
             raise ValueError()
 
         return parsing.yacc(tabmodule="cds_parsetab", package="astropy/units")
-
-    @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        if unit not in cls._units:
-            if detailed_exception:
-                raise ValueError(
-                    f"Unit '{unit}' not supported by the CDS SAC standard. "
-                    f"{did_you_mean(unit, cls._units)}"
-                )
-            else:
-                raise ValueError()
-
-        return cls._units[unit]
 
     @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -127,16 +127,6 @@ class VOUnit(FITS):
             raise
 
     @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        super()._validate_unit(unit, detailed_exception=False)
-        return cls._units[unit]
-
-    @classmethod
-    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
-        if unit not in cls._custom_units:
-            super()._validate_unit(unit, detailed_exception)
-
-    @classmethod
     def _get_unit_name(cls, unit: NamedUnit) -> str:
         # The da- and d- prefixes are discouraged.  This has the
         # effect of adding a scale to value in the result.
@@ -151,7 +141,10 @@ class VOUnit(FITS):
                     f"In '{unit}': VOUnit can not represent units with the 'd' "
                     "(deci) prefix"
                 )
-        return super()._get_unit_name(unit)
+        name = unit._get_format_name(cls.name)
+        if name not in cls._custom_units:
+            cls._validate_unit(name, detailed_exception=True)
+        return name
 
     @classmethod
     def _def_custom_unit(cls, unit: str) -> UnitBase:


### PR DESCRIPTION
### Description

The first commit removes `CDS._parse_unit()`. This changes an error message a little bit (it now mentions the "CDS standard" instead of the "CDS SAC standard"), but that shouldn't be a problem.

The second commit manages to remove `_parse_unit()` and `_validate_unit()` implementations from `VOUnit` at the cost of making `VOUnit._get_unit_name()` just a little bit more complicated. Additionally, the implementation of `_parse_unit()` that `VOUnit` now inherits from `FITS` obeys its `detailed_exception` parameter. Although this is a change in how the code behaves, it was very strange that previously the `detailed_exception` value did not matter and it was also very strange that this was the case only in `VOUnit` and not with the other unit formatters.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
