### PR TITLE
Partially revert "Milestone workflow should only listen to milestoning events"

### DIFF
--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -2,7 +2,7 @@ name: Check PR milestone
 
 on:
   pull_request:
-    types: [opened, synchronize, milestoned, demilestoned]
+    types: [synchronize, milestoned, demilestoned]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -2,7 +2,7 @@ name: Check PR milestone
 
 on:
   pull_request:
-    types: [milestoned, demilestoned]
+    types: [opened, synchronize, milestoned, demilestoned]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Partially reverts astropy/astropy#17269

Please use "Squash and Merge".

Ugh. I misremembered how things work in Actions. I think we still need synchronize, otherwise when PR author push new commits, the milestone check is reported as skipped and Actions discards the last successful run when milestone was applied.