### PR TITLE
STY: autofix `invalid-first-argument-name-for-class-method` (N804) (units)

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2033,7 +2033,7 @@ class _UnitMetaClass(type):
     """
 
     def __call__(
-        self,
+        cls,
         s="",
         represents=None,
         format=None,

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -2047,7 +2047,7 @@ def test_masked_quantity_str_repr():
 
 class TestQuantitySubclassAboveAndBelow:
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         class MyArray(np.ndarray):
             def __array_finalize__(self, obj):
                 super_array_finalize = super().__array_finalize__
@@ -2056,9 +2056,9 @@ class TestQuantitySubclassAboveAndBelow:
                 if hasattr(obj, "my_attr"):
                     self.my_attr = obj.my_attr
 
-        self.MyArray = MyArray
-        self.MyQuantity1 = type("MyQuantity1", (u.Quantity, MyArray), dict(my_attr="1"))
-        self.MyQuantity2 = type("MyQuantity2", (MyArray, u.Quantity), dict(my_attr="2"))
+        cls.MyArray = MyArray
+        cls.MyQuantity1 = type("MyQuantity1", (u.Quantity, MyArray), dict(my_attr="1"))
+        cls.MyQuantity2 = type("MyQuantity2", (MyArray, u.Quantity), dict(my_attr="2"))
 
     def test_setup(self):
         mq1 = self.MyQuantity1(10, u.m)

--- a/astropy/units/tests/test_quantity_info.py
+++ b/astropy/units/tests/test_quantity_info.py
@@ -25,10 +25,10 @@ def assert_no_info(a):
 
 class TestQuantityInfo:
     @classmethod
-    def setup_class(self):
-        self.q = u.Quantity(np.arange(1.0, 5.0), "m/s")
-        self.q.info.name = "v"
-        self.q.info.description = "air speed of a african swallow"
+    def setup_class(cls):
+        cls.q = u.Quantity(np.arange(1.0, 5.0), "m/s")
+        cls.q.info.name = "v"
+        cls.q.info.description = "air speed of a african swallow"
 
     def test_copy(self):
         q_copy1 = self.q.copy()
@@ -102,11 +102,11 @@ class TestQuantityInfo:
 
 class TestStructuredQuantity:
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         value = np.array([(1.0, 2.0), (3.0, 4.0)], dtype=[("p", "f8"), ("v", "f8")])
-        self.q = u.Quantity(value, "m, m/s")
-        self.q.info.name = "pv"
-        self.q.info.description = "Location and speed"
+        cls.q = u.Quantity(value, "m, m/s")
+        cls.q.info.name = "pv"
+        cls.q.info.description = "Location and speed"
 
     def test_keying(self):
         q_p = self.q["p"]
@@ -129,17 +129,17 @@ class TestQuantitySubclass:
     """
 
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         class MyQuantity(u.Quantity):
             def __array_finalize__(self, obj):
                 super().__array_finalize__(obj)
                 if hasattr(obj, "swallow"):
                     self.swallow = obj.swallow
 
-        self.my_q = MyQuantity([10.0, 20.0], u.m / u.s)
-        self.my_q.swallow = "African"
-        self.my_q_w_info = self.my_q.copy()
-        self.my_q_w_info.info.name = "swallow"
+        cls.my_q = MyQuantity([10.0, 20.0], u.m / u.s)
+        cls.my_q.swallow = "African"
+        cls.my_q_w_info = cls.my_q.copy()
+        cls.my_q_w_info.info.name = "swallow"
 
     def test_setup(self):
         assert_no_info(self.my_q)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2663,22 +2663,22 @@ class TestRecFunctions:
     tested_module = np.lib.recfunctions
 
     @classmethod
-    def setup_class(self):
-        self.pv_dtype = np.dtype([("p", "f8"), ("v", "f8")])
-        self.pv_t_dtype = np.dtype(
+    def setup_class(cls):
+        cls.pv_dtype = np.dtype([("p", "f8"), ("v", "f8")])
+        cls.pv_t_dtype = np.dtype(
             [("pv", np.dtype([("pp", "f8"), ("vv", "f8")])), ("t", "f8")]
         )
 
-        self.pv = np.array([(1.0, 0.25), (2.0, 0.5), (3.0, 0.75)], self.pv_dtype)
-        self.pv_t = np.array(
-            [((4.0, 2.5), 0.0), ((5.0, 5.0), 1.0), ((6.0, 7.5), 2.0)], self.pv_t_dtype
+        cls.pv = np.array([(1.0, 0.25), (2.0, 0.5), (3.0, 0.75)], cls.pv_dtype)
+        cls.pv_t = np.array(
+            [((4.0, 2.5), 0.0), ((5.0, 5.0), 1.0), ((6.0, 7.5), 2.0)], cls.pv_t_dtype
         )
 
-        self.pv_unit = u.StructuredUnit((u.km, u.km / u.s), ("p", "v"))
-        self.pv_t_unit = u.StructuredUnit((self.pv_unit, u.s), ("pv", "t"))
+        cls.pv_unit = u.StructuredUnit((u.km, u.km / u.s), ("p", "v"))
+        cls.pv_t_unit = u.StructuredUnit((cls.pv_unit, u.s), ("pv", "t"))
 
-        self.q_pv = self.pv << self.pv_unit
-        self.q_pv_t = self.pv_t << self.pv_t_unit
+        cls.q_pv = cls.pv << cls.pv_unit
+        cls.q_pv_t = cls.pv_t << cls.pv_t_unit
 
     def test_structured_to_unstructured(self):
         # can't unstructure something with incompatible units

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -19,31 +19,31 @@ from astropy.utils.masked import Masked
 
 class StructuredTestBase:
     @classmethod
-    def setup_class(self):
-        self.pv_dtype = np.dtype([("p", "f8"), ("v", "f8")])
-        self.pv_t_dtype = np.dtype([("pv", self.pv_dtype), ("t", "f8")])
-        self.p_unit = u.km
-        self.v_unit = u.km / u.s
-        self.t_unit = u.s
-        self.pv_dtype = np.dtype([("p", "f8"), ("v", "f8")])
-        self.pv_t_dtype = np.dtype([("pv", self.pv_dtype), ("t", "f8")])
-        self.pv = np.array([(1.0, 0.25), (2.0, 0.5), (3.0, 0.75)], self.pv_dtype)
-        self.pv_t = np.array(
+    def setup_class(cls):
+        cls.pv_dtype = np.dtype([("p", "f8"), ("v", "f8")])
+        cls.pv_t_dtype = np.dtype([("pv", cls.pv_dtype), ("t", "f8")])
+        cls.p_unit = u.km
+        cls.v_unit = u.km / u.s
+        cls.t_unit = u.s
+        cls.pv_dtype = np.dtype([("p", "f8"), ("v", "f8")])
+        cls.pv_t_dtype = np.dtype([("pv", cls.pv_dtype), ("t", "f8")])
+        cls.pv = np.array([(1.0, 0.25), (2.0, 0.5), (3.0, 0.75)], cls.pv_dtype)
+        cls.pv_t = np.array(
             [
                 ((4.0, 2.5), 0.0),
                 ((5.0, 5.0), 1.0),
                 ((6.0, 7.5), 2.0),
             ],
-            self.pv_t_dtype,
+            cls.pv_t_dtype,
         )
 
 
 class StructuredTestBaseWithUnits(StructuredTestBase):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.pv_unit = StructuredUnit((self.p_unit, self.v_unit), ("p", "v"))
-        self.pv_t_unit = StructuredUnit((self.pv_unit, self.t_unit), ("pv", "t"))
+        cls.pv_unit = StructuredUnit((cls.p_unit, cls.v_unit), ("p", "v"))
+        cls.pv_t_unit = StructuredUnit((cls.pv_unit, cls.t_unit), ("pv", "t"))
 
 
 class TestStructuredUnitBasics(StructuredTestBase):
@@ -628,10 +628,10 @@ class TestStructuredQuantity(StructuredTestBaseWithUnits):
 
 class TestStructuredQuantityFunctions(StructuredTestBaseWithUnits):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.q_pv = self.pv << self.pv_unit
-        self.q_pv_t = self.pv_t << self.pv_t_unit
+        cls.q_pv = cls.pv << cls.pv_unit
+        cls.q_pv_t = cls.pv_t << cls.pv_t_unit
 
     def test_empty_like(self):
         z = np.empty_like(self.q_pv)


### PR DESCRIPTION
### Description
ref https://github.com/astropy/astropy/pull/17016#discussion_r1807002358


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
