### PR TITLE
TST: disable unwanted healthchecks in hypothesis test methods

### DIFF
--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -11,7 +11,7 @@ from itertools import product
 
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis.extra.numpy import basic_indices
 from numpy.testing import assert_allclose, assert_equal
 
@@ -1025,11 +1025,13 @@ class TestCompHDUSections:
         self.hdul = None
 
     @given(basic_indices((13, 17, 25)))
+    @settings(suppress_health_check=[HealthCheck.differing_executors])
     def test_section_slicing(self, index):
         assert_equal(self.hdul[1].section[index], self.hdul[1].data[index])
         assert_equal(self.hdul[1].section[index], self.data[index])
 
     @given(basic_indices((13, 17, 25)))
+    @settings(suppress_health_check=[HealthCheck.differing_executors])
     def test_section_slicing_scaling(self, index):
         assert_equal(self.hdul[2].section[index], self.hdul[2].data[index])
         assert_equal(self.hdul[2].section[index], self.data[index] * 2 + 100)

--- a/astropy/utils/tests/test_shapes.py
+++ b/astropy/utils/tests/test_shapes.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis.extra.numpy import basic_indices
 from numpy.testing import assert_equal
 
@@ -51,6 +51,7 @@ class TestSimplifyBasicIndex:
         self.data = np.random.random(TEST_SHAPE)
 
     @given(basic_indices(TEST_SHAPE))
+    @settings(suppress_health_check=[HealthCheck.differing_executors])
     def test_indexing(self, index):
         new_index = simplify_basic_index(index, shape=self.shape)
         assert_equal(self.data[index], self.data[new_index])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ test = [
     "coverage>=6.4.4",
     "pre-commit>=2.9.3", # lower bound is not tested beyond installation
     "pytest>=7.3.0",
-    "hypothesis!=6.116.0", # https://github.com/astropy/astropy/issues/17299
     "pytest-doctestplus>=0.12",
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10.0",


### PR DESCRIPTION
### Description
This pull request is to address the fire from #17299.
I'm not sure yet that this approach is correct (this should be discussed upstream in https://github.com/HypothesisWorks/hypothesis/issues/4154), but I'm opening this PR now so it is immediately available to others.


update: this now has an alternative solution in #17327, though, in case this one is picked: close #17327

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
