### PR TITLE
TST: avoid pyplot in most visualization tests

### DIFF
--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from astropy.utils.compat.optional_deps import HAS_PLT, HAS_SCIPY
 
 if HAS_PLT:
-    import matplotlib.pyplot as plt
+    from matplotlib.figure import Figure
 
 import numpy as np
 import pytest
@@ -15,25 +15,29 @@ from astropy.stats import histogram
 from astropy.visualization import hist
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_hist_basic(rseed=0):
     rng = np.random.default_rng(rseed)
     x = rng.standard_normal(100)
 
+    fig = Figure()
+    ax = fig.add_subplot()
     for range in [None, (-2, 2)]:
-        n1, bins1, patches1 = plt.hist(x, 10, range=range)
-        n2, bins2, patches2 = hist(x, 10, range=range)
+        n1, bins1, patches1 = ax.hist(x, 10, range=range)
+        n2, bins2, patches2 = hist(x, 10, range=range, ax=ax)
 
         assert_allclose(n1, n2)
         assert_allclose(bins1, bins2)
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_hist_specify_ax(rseed=0):
     rng = np.random.default_rng(rseed)
     x = rng.standard_normal(100)
 
-    fig, ax = plt.subplots(2)
+    fig = Figure()
+    ax = fig.subplots(2)
+
     n1, bins1, patches1 = hist(x, 10, ax=ax[0])
     assert patches1[0].axes is ax[0]
 
@@ -41,7 +45,7 @@ def test_hist_specify_ax(rseed=0):
     assert patches2[0].axes is ax[1]
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_hist_autobin(rseed=0):
     rng = np.random.default_rng(rseed)
     x = rng.standard_normal(100)

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -5,7 +5,7 @@ import pytest
 from numpy import ma
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 
-from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB, HAS_PLT
+from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.visualization.interval import ManualInterval, PercentileInterval
 from astropy.visualization.mpl_normalize import (
     ImageNormalize,
@@ -23,7 +23,7 @@ STRETCHES = (SqrtStretch(), PowerStretch(0.5), LogStretch())
 INVALID = (None, -np.inf, -1)
 
 
-@pytest.mark.skipif(HAS_MATPLOTLIB, reason="matplotlib is installed")
+@pytest.mark.skipif(HAS_PLT, reason="matplotlib is installed")
 def test_normalize_error_message():
     with pytest.raises(
         ImportError, match=r"matplotlib is required in order to use this class."
@@ -31,7 +31,7 @@ def test_normalize_error_message():
         ImageNormalize()
 
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason="requires matplotlib")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 class TestNormalize:
     def test_invalid_interval(self):
         with pytest.raises(TypeError):
@@ -203,7 +203,7 @@ class TestNormalize:
         assert_equal(result2, result3)
 
 
-@pytest.mark.skipif(not HAS_MATPLOTLIB, reason="requires matplotlib")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 class TestImageScaling:
     def test_linear(self):
         """Test linear scaling."""
@@ -286,7 +286,7 @@ class TestImageScaling:
             simple_norm(DATA2, stretch="invalid")
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 @pytest.mark.parametrize("stretch", ["linear", "sqrt", "power", "log", "asinh", "sinh"])
 def test_simplenorm(stretch):
     data = np.arange(25).reshape((5, 5))
@@ -296,13 +296,14 @@ def test_simplenorm(stretch):
     assert_allclose(norm(data), simple_norm(data, stretch, percent=99)(data))
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_simplenorm_imshow():
-    import matplotlib.pyplot as plt
+    from matplotlib.figure import Figure
     from matplotlib.image import AxesImage
 
     data = np.arange(25).reshape((5, 5))
-    fig, ax = plt.subplots()
+    fig = Figure()
+    ax = fig.add_subplot()
     snorm = SimpleNorm("sqrt", percent=99)
     axim = snorm.imshow(data, ax=ax)
     assert isinstance(axim, AxesImage)
@@ -317,13 +318,14 @@ def test_simplenorm_imshow():
         snorm.imshow(data, ax=ax, norm=ImageNormalize())
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_imshow_norm():
-    import matplotlib.pyplot as plt
+    from matplotlib.figure import Figure
 
     image = np.random.randn(10, 10)
 
-    fig, ax = plt.subplots(label="test_imshow_norm")
+    fig = Figure()
+    ax = fig.add_subplot(label="test_imshow_norm")
     imshow_norm(image, ax=ax)
 
     with pytest.raises(ValueError):
@@ -333,7 +335,7 @@ def test_imshow_norm():
     fig.clear()
     imshow_norm(image, ax=ax, vmin=0, vmax=1)
 
-    # make sure the pyplot version works
+    # make sure the matplotlib version works
     fig.clear()
     imres, norm = imshow_norm(image, ax=None)
 

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -8,7 +8,8 @@ from erfa import ErfaWarning
 from astropy.time import Time
 from astropy.visualization.time import time_support
 
-plt = pytest.importorskip("matplotlib.pyplot")
+pytest.importorskip("matplotlib.pyplot")
+from matplotlib.figure import Figure
 
 # Since some of the examples below use times/dates in the future, we use the
 # TAI time scale to avoid ERFA warnings about dubious years.
@@ -18,10 +19,6 @@ DEFAULT_SCALE = "tai"
 def get_ticklabels(axis):
     axis.figure.canvas.draw()
     return [x.get_text() for x in axis.get_ticklabels()]
-
-
-def teardown_function(function):
-    plt.close("all")
 
 
 # We first check that we get the expected labels for different time intervals
@@ -111,7 +108,7 @@ def test_formatter_locator(interval, expected):
     # Check that the ticks and labels returned for the above cases are correct.
 
     with time_support():
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(
             Time(interval[0], scale=DEFAULT_SCALE),
@@ -167,7 +164,7 @@ FORMAT_CASES = [
 def test_formats(format, expected):
     # Check that the locators/formatters work fine for all time formats
     with time_support(format=format, simplify=False):
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         # Getting unix time and plot_date requires going through a scale for
         # which ERFA emits a warning about the date being dubious
@@ -188,7 +185,7 @@ def test_formats(format, expected):
 def test_auto_formats(format, expected):
     # Check that the format/scale is taken from the first time used.
     with time_support(simplify=False):
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         # Getting unix time and plot_date requires going through a scale for
         # which ERFA emits a warning about the date being dubious
@@ -217,7 +214,7 @@ FORMAT_CASES_SIMPLIFY = [
 def test_formats_simplify(format, expected):
     # Check the use of the simplify= option
     with time_support(format=format, simplify=True):
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(
             Time("2014-03-22T12:30:30.9", scale=DEFAULT_SCALE),
@@ -229,7 +226,7 @@ def test_formats_simplify(format, expected):
 def test_plot():
     # Make sure that plot() works properly
     with time_support():
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(
             Time("2014-03-22T12:30:30.9", scale=DEFAULT_SCALE),
@@ -250,7 +247,7 @@ def test_plot():
 def test_nested():
     with time_support(format="iso", simplify=False):
         with time_support(format="yday", simplify=True):
-            fig = plt.figure()
+            fig = Figure()
             ax = fig.add_subplot(1, 1, 1)
             ax.set_xlim(
                 Time("2014-03-22T12:30:30.9", scale=DEFAULT_SCALE),
@@ -258,7 +255,7 @@ def test_nested():
             )
             assert get_ticklabels(ax.xaxis) == ["2020", "2040", "2060"]
 
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(
             Time("2014-03-22T12:30:30.9", scale=DEFAULT_SCALE),

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -7,7 +7,7 @@ import pytest
 from astropy.utils.compat.optional_deps import HAS_PLT
 
 if HAS_PLT:
-    import matplotlib.pyplot as plt
+    from matplotlib.figure import Figure
     from matplotlib.units import ConversionError
 
 import numpy as np
@@ -17,105 +17,103 @@ from astropy.coordinates import Angle
 from astropy.visualization.units import quantity_support
 
 
-def teardown_function(function):
-    plt.close("all")
-
-
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_units():
-    plt.figure()
+    fig = Figure()
+    ax = fig.add_subplot()
 
     with quantity_support():
         buff = io.BytesIO()
 
-        plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
-        plt.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
-        plt.legend()
+        ax.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
+        ax.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
+        ax.legend()
         # Also test fill_between, which requires actual conversion to ndarray.
-        plt.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
-        plt.savefig(buff, format="svg")
+        ax.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
+        fig.savefig(buff, format="svg")
 
-        assert plt.gca().xaxis.get_units() == u.m
-        assert plt.gca().yaxis.get_units() == u.kg
+        assert ax.xaxis.get_units() == u.m
+        assert ax.yaxis.get_units() == u.kg
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_units_decorator():
     @quantity_support()
     def run_test():
-        plt.figure()
+        fig = Figure()
+        ax = fig.add_subplot()
 
         buff = io.BytesIO()
 
-        plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
-        plt.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
-        plt.legend()
+        ax.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label="label")
+        ax.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
+        ax.legend()
         # Also test fill_between, which requires actual conversion to ndarray.
-        plt.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
-        plt.savefig(buff, format="svg")
+        ax.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)
+        fig.savefig(buff, format="svg")
 
-        assert plt.gca().xaxis.get_units() == u.m
-        assert plt.gca().yaxis.get_units() == u.kg
+        assert ax.xaxis.get_units() == u.m
+        assert ax.yaxis.get_units() == u.kg
 
     run_test()
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_units_errbarr():
-    pytest.importorskip("matplotlib")
-    plt.figure()
-
     with quantity_support():
         x = [1, 2, 3] * u.s
         y = [1, 2, 3] * u.m
         yerr = [3, 2, 1] * u.cm
 
-        fig, ax = plt.subplots()
+        fig = Figure()
+        ax = fig.add_subplot()
         ax.errorbar(x, y, yerr=yerr)
 
         assert ax.xaxis.get_units() == u.s
         assert ax.yaxis.get_units() == u.m
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_incompatible_units():
-    plt.figure()
+    fig = Figure()
+    ax = fig.add_subplot()
 
     with quantity_support():
-        plt.plot([1, 2, 3] * u.m)
+        ax.plot([1, 2, 3] * u.m)
         with pytest.raises(ConversionError):
-            plt.plot([105, 210, 315] * u.kg)
+            ax.plot([105, 210, 315] * u.kg)
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_quantity_subclass():
     """Check that subclasses are recognized.
 
     Also see https://github.com/matplotlib/matplotlib/pull/13536
     """
-    plt.figure()
+    fig = Figure()
+    ax = fig.add_subplot()
 
     with quantity_support():
-        plt.scatter(Angle([1, 2, 3], u.deg), [3, 4, 5] * u.kg)
-        plt.scatter([105, 210, 315] * u.arcsec, [3050, 3025, 3010] * u.g)
-        plt.plot(Angle([105, 210, 315], u.arcsec), [3050, 3025, 3010] * u.g)
+        ax.scatter(Angle([1, 2, 3], u.deg), [3, 4, 5] * u.kg)
+        ax.scatter([105, 210, 315] * u.arcsec, [3050, 3025, 3010] * u.g)
+        ax.plot(Angle([105, 210, 315], u.arcsec), [3050, 3025, 3010] * u.g)
 
-        assert plt.gca().xaxis.get_units() == u.deg
-        assert plt.gca().yaxis.get_units() == u.kg
+        assert ax.xaxis.get_units() == u.deg
+        assert ax.yaxis.get_units() == u.kg
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_nested():
     with quantity_support():
         with quantity_support():
-            fig = plt.figure()
+            fig = Figure()
             ax = fig.add_subplot(1, 1, 1)
             ax.scatter(Angle([1, 2, 3], u.deg), [3, 4, 5] * u.kg)
 
             assert ax.xaxis.get_units() == u.deg
             assert ax.yaxis.get_units() == u.kg
 
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.scatter(Angle([1, 2, 3], u.arcsec), [3, 4, 5] * u.pc)
 
@@ -123,10 +121,10 @@ def test_nested():
         assert ax.yaxis.get_units() == u.pc
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_empty_hist():
     with quantity_support():
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.hist([1, 2, 3, 4] * u.mmag, bins=100)
         # The second call results in an empty list being passed to the
@@ -134,22 +132,25 @@ def test_empty_hist():
         ax.hist([] * u.mmag, bins=100)
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_radian_formatter():
     with quantity_support():
-        fig, ax = plt.subplots()
+        fig = Figure()
+        ax = fig.add_subplot()
         ax.plot([1, 2, 3], [1, 2, 3] * u.rad * np.pi)
         fig.canvas.draw()
         labels = [tl.get_text() for tl in ax.yaxis.get_ticklabels()]
         assert labels == ["π/2", "π", "3π/2", "2π", "5π/2", "3π", "7π/2"]
 
 
-@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
 def test_small_range():
     # see https://github.com/astropy/astropy/issues/13211
     y = [10.0, 10.25, 10.5, 10.75, 11.0, 11.25, 11.5, 11.75] * u.degree
 
-    fig, ax = plt.subplots()
+    fig = Figure()
+    ax = fig.add_subplot()
+
     with quantity_support():
         ax.plot(y)
         fig.canvas.draw()

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backend_bases import KeyEvent
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 
 import astropy.units as u
 from astropy.coordinates import FK5, SkyCoord, galactocentric_frame_defaults
@@ -14,15 +15,12 @@ from .test_images import BaseImageTests
 
 
 class TestDisplayWorldCoordinate(BaseImageTests):
-    def teardown_method(self, method):
-        plt.close("all")
-
     def test_overlay_coords(self, ignore_matplotlibrc, tmp_path):
         minus_sign = "\N{MINUS SIGN}" if mpl.rcParams["axes.unicode_minus"] else "-"
         wcs = WCS(self.msx_header)
 
-        fig = plt.figure(figsize=(4, 4))
-        canvas = fig.canvas
+        fig = Figure(figsize=(4, 4))
+        canvas = FigureCanvasAgg(fig)
 
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs)
         fig.add_axes(ax)
@@ -107,8 +105,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
     def test_cube_coords(self, ignore_matplotlibrc, tmp_path):
         wcs = WCS(self.cube_header)
 
-        fig = plt.figure(figsize=(4, 4))
-        canvas = fig.canvas
+        fig = Figure(figsize=(4, 4))
+        canvas = FigureCanvasAgg(fig)
 
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs, slices=("y", 50, "x"))
         fig.add_axes(ax)
@@ -133,8 +131,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         wcs = WCS(self.cube_header)
 
-        fig = plt.figure(figsize=(4, 4))
-        canvas = fig.canvas
+        fig = Figure(figsize=(4, 4))
+        canvas = FigureCanvasAgg(fig)
 
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs, slices=("x", "y", 2))
         fig.add_axes(ax)
@@ -159,7 +157,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         with galactocentric_frame_defaults.set("latest"):
             coord = SkyCoord(0 * u.kpc, 0 * u.kpc, 0 * u.kpc, frame="galactocentric")
 
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(1, 1, 1, projection=wcs)
         (point,) = ax.plot_coord(coord, "ro")
 

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.figure import Figure
 
 from astropy.tests.figures import figure_test
 from astropy.visualization.wcsaxes import WCSAxes
@@ -35,8 +34,7 @@ class TestFrame(BaseImageTests):
     def test_custom_frame(self):
         wcs = WCS(self.msx_header)
 
-        fig = plt.figure(figsize=(4, 4))
-
+        fig = Figure(figsize=(4, 4))
         ax = WCSAxes(fig, [0.15, 0.15, 0.7, 0.7], wcs=wcs, frame_class=HexagonalFrame)
         fig.add_axes(ax)
 
@@ -47,7 +45,7 @@ class TestFrame(BaseImageTests):
             vmin=0.0,
             vmax=2.0,
             origin="lower",
-            cmap=plt.cm.gist_heat,
+            cmap="gist_heat",
         )
 
         minpad = {}
@@ -74,7 +72,7 @@ class TestFrame(BaseImageTests):
 
     @figure_test
     def test_update_clip_path_rectangular(self, tmp_path):
-        fig = plt.figure()
+        fig = Figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
 
         fig.add_axes(ax)
@@ -97,7 +95,7 @@ class TestFrame(BaseImageTests):
 
     @figure_test
     def test_update_clip_path_nonrectangular(self, tmp_path):
-        fig = plt.figure()
+        fig = Figure()
         ax = WCSAxes(
             fig, [0.1, 0.1, 0.8, 0.8], aspect="equal", frame_class=HexagonalFrame
         )
@@ -122,7 +120,7 @@ class TestFrame(BaseImageTests):
         # When WCS is changed, a new frame is created, so we need to make sure
         # that the path is carried over to the new frame.
 
-        fig = plt.figure()
+        fig = Figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
 
         fig.add_axes(ax)
@@ -149,7 +147,7 @@ class TestFrame(BaseImageTests):
         # When WCS is changed, a new frame is created, so we need to make sure
         # that the color and linewidth are transferred over
 
-        fig = plt.figure()
+        fig = Figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
         fig.add_axes(ax)
         ax.coords.frame.set_linewidth(5)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import matplotlib.lines
-import matplotlib.pyplot as plt
 import matplotlib.text
 import numpy as np
 import pytest
 from matplotlib import rc_context
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 from matplotlib.patches import Circle, Rectangle
 
@@ -46,39 +46,42 @@ class BaseImageTests:
         slice_header = get_pkg_data_filename("data/slice_header")
         cls.slice_header = fits.Header.fromtextfile(slice_header)
 
-    def teardown_method(self, method):
-        plt.close("all")
-
 
 class TestBasic(BaseImageTests):
     @figure_test
     def test_tight_layout(self):
         # Check that tight_layout works on a WCSAxes.
-        fig = plt.figure(figsize=(8, 6))
+        fig = Figure(figsize=(8, 6))
+        canvas = FigureCanvasAgg(fig)
         for i in (1, 2):
             fig.add_subplot(2, 1, i, projection=WCS(self.msx_header))
         fig.tight_layout()
+        canvas.draw()
         return fig
 
     @figure_test
     def test_image_plot(self):
         # Test for plotting image and also setting values of ticks
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8], projection=WCS(self.msx_header), aspect="equal"
         )
         ax.set_xlim(-0.5, 148.5)
         ax.set_ylim(-0.5, 148.5)
         ax.coords[0].set_ticks([-0.30, 0.0, 0.20] * u.degree, size=5, width=1)
+        canvas.draw()
         return fig
 
     @figure_test
     def test_axes_off(self):
         # Test for turning the axes off
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=WCS(self.msx_header))
         ax.imshow(np.arange(12).reshape((3, 4)))
         ax.set_axis_off()
+        canvas.draw()
         return fig
 
     @figure_test
@@ -86,7 +89,8 @@ class TestBasic(BaseImageTests):
     def test_axisbelow(self, axisbelow):
         # Test that tick marks, labels, and gridlines are drawn with the
         # correct zorder controlled by the axisbelow property.
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8], projection=WCS(self.msx_header), aspect="equal"
         )
@@ -108,6 +112,7 @@ class TestBasic(BaseImageTests):
         # Add a line (default zorder=2).
         ax.plot([32, 128], [32, 128], linewidth=10)
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -119,7 +124,8 @@ class TestBasic(BaseImageTests):
 
         wcs_msx = WCS(self.msx_header)
 
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.15, 0.15, 0.8, 0.8],
             projection=WCS(self.twoMASS_k_header),
@@ -146,6 +152,7 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -157,7 +164,8 @@ class TestBasic(BaseImageTests):
 
         wcs_msx = WCS(self.msx_header)
 
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.15, 0.15, 0.8, 0.8],
             projection=WCS(self.twoMASS_k_header),
@@ -181,6 +189,7 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -188,7 +197,8 @@ class TestBasic(BaseImageTests):
         # Test for overlaying grid, changing format of ticks, setting spacing
         # and number of ticks
 
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.25, 0.25, 0.65, 0.65], projection=WCS(self.msx_header), aspect="equal"
         )
@@ -217,13 +227,15 @@ class TestBasic(BaseImageTests):
         assert ax.coords.frame.get_color() == "red"
         assert ax.coords.frame.get_linewidth() == 2
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_curvilinear_grid_patches_image(self):
         # Overlay curvilinear grid and patches on image
 
-        fig = plt.figure(figsize=(8, 8))
+        fig = Figure(figsize=(8, 8))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8], projection=WCS(self.rosat_header), aspect="equal"
         )
@@ -263,13 +275,15 @@ class TestBasic(BaseImageTests):
         )
         ax.add_patch(p)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_cube_slice_image(self):
         # Test for cube slicing
 
-        fig = plt.figure()
+        fig = Figure()
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8],
             projection=WCS(self.cube_header),
@@ -292,6 +306,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].grid(grid_type="contours", color="orange", linestyle="solid")
         ax.coords[2].grid(grid_type="contours", color="red", linestyle="solid")
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -299,7 +314,8 @@ class TestBasic(BaseImageTests):
         # Test for cube slicing. Here we test with longitude and latitude since
         # there is some longitude-specific code in _update_grid_contour.
 
-        fig = plt.figure()
+        fig = Figure()
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8],
             projection=WCS(self.cube_header),
@@ -319,11 +335,13 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_plot_coord(self):
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.15, 0.15, 0.8, 0.8],
             projection=WCS(self.twoMASS_k_header),
@@ -345,13 +363,15 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_scatter_coord(self):
         from matplotlib.collections import PathCollection
 
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.15, 0.15, 0.8, 0.8],
             projection=WCS(self.twoMASS_k_header),
@@ -372,11 +392,13 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_text_coord(self):
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.15, 0.15, 0.8, 0.8],
             projection=WCS(self.twoMASS_k_header),
@@ -397,11 +419,13 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_plot_line(self):
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.15, 0.15, 0.8, 0.8],
             projection=WCS(self.twoMASS_k_header),
@@ -419,12 +443,14 @@ class TestBasic(BaseImageTests):
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_changed_axis_units(self):
         # Test to see if changing the units of axis works
-        fig = plt.figure()
+        fig = Figure()
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8],
             projection=WCS(self.cube_header),
@@ -450,12 +476,14 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_ticklabel(exclude_overlapping=True)
         ax.coords[2].set_ticklabel(exclude_overlapping=True)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_minor_ticks(self):
         # Test for drawing minor ticks
-        fig = plt.figure()
+        fig = Figure()
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8],
             projection=WCS(self.cube_header),
@@ -480,11 +508,13 @@ class TestBasic(BaseImageTests):
         ax.coords[2].set_minor_frequency(3)
         ax.coords[1].set_minor_frequency(10)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_ticks_labels(self):
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = WCSAxes(fig, [0.1, 0.1, 0.7, 0.7], wcs=None)
         fig.add_axes(ax)
         ax.set_xlim(-0.5, 2)
@@ -518,12 +548,14 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticklabel_position("all")
         ax.coords[1].set_ticklabel_position("r")
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_no_ticks(self):
         # Check that setting no ticks works
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.1, 0.1, 0.8, 0.8], projection=WCS(self.msx_header), aspect="equal"
         )
@@ -531,6 +563,7 @@ class TestBasic(BaseImageTests):
         ax.set_ylim(-0.5, 148.5)
         ax.coords[0].set_ticks(number=0)
         ax.coords[0].grid(True)
+        canvas.draw()
         return fig
 
     @figure_test
@@ -559,7 +592,8 @@ class TestBasic(BaseImageTests):
                 "grid.alpha": 0.5,
             }
         ):
-            fig = plt.figure(figsize=(6, 6))
+            fig = Figure(figsize=(6, 6))
+            canvas = FigureCanvasAgg(fig)
             ax = WCSAxes(fig, [0.15, 0.1, 0.7, 0.7], wcs=None)
             fig.add_axes(ax)
             ax.set_xlim(-0.5, 2)
@@ -569,7 +603,8 @@ class TestBasic(BaseImageTests):
             ax.set_ylabel("Y label")
             ax.coords[0].set_ticklabel(exclude_overlapping=True)
             ax.coords[1].set_ticklabel(exclude_overlapping=True)
-            return fig
+            canvas.draw()
+        return fig
 
     @figure_test
     def test_tick_angles(self):
@@ -582,7 +617,8 @@ class TestBasic(BaseImageTests):
         w.wcs.crpix = [1, 1]
         w.wcs.radesys = "ICRS"
         w.wcs.equinox = 2000.0
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=w)
         ax.set_xlim(1, -1)
         ax.set_ylim(-1, 1)
@@ -594,6 +630,7 @@ class TestBasic(BaseImageTests):
         # for backward-compatibility with previous reference images we
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
+        canvas.draw()
         return fig
 
     @figure_test
@@ -608,7 +645,8 @@ class TestBasic(BaseImageTests):
         w.wcs.crpix = [1, 1]
         w.wcs.radesys = "ICRS"
         w.wcs.equinox = 2000.0
-        fig = plt.figure(figsize=(6, 3))
+        fig = Figure(figsize=(6, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=w)
         ax.set_xlim(1, -1)
         ax.set_ylim(-1, 1)
@@ -620,12 +658,14 @@ class TestBasic(BaseImageTests):
         # for backward-compatibility with previous reference images we
         # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
+        canvas.draw()
         return fig
 
     @figure_test
     def test_set_coord_type(self):
         # Test for setting coord_type
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.2, 0.2, 0.6, 0.6], projection=WCS(self.msx_header), aspect="equal"
         )
@@ -637,6 +677,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_major_formatter("x.xxx")
         ax.coords[0].set_ticklabel(exclude_overlapping=True)
         ax.coords[1].set_ticklabel(exclude_overlapping=True)
+        canvas.draw()
         return fig
 
     @figure_test
@@ -648,7 +689,8 @@ class TestBasic(BaseImageTests):
         # potential ticks (which causes the tick angle calculation to return
         # NaN).
         wcs = WCS(self.slice_header)
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.25, 0.25, 0.5, 0.5], projection=wcs, aspect="auto")
         limits = wcs.wcs_world2pix([0, 0], [35e3, 80e3], 0)[1]
         ax.set_ylim(*limits)
@@ -660,6 +702,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_ticklabel_position("all")
         ax.coords[0].set_axislabel_position("b")
         ax.coords[1].set_axislabel_position("l")
+        canvas.draw()
         return fig
 
     @figure_test
@@ -669,12 +712,14 @@ class TestBasic(BaseImageTests):
         # list of bounding boxes for tick labels, but with default values of 0
         # to 1, which caused issues.
         wcs = WCS(self.msx_header)
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.25, 0.25, 0.5, 0.5], projection=wcs, aspect="auto")
         ax.coords[0].set_axislabel("Label 1")
         ax.coords[1].set_axislabel("Label 2")
         ax.coords[1].set_axislabel_visibility_rule("always")
         ax.coords[1].set_ticklabel_visible(False)
+        canvas.draw()
         return fig
 
     @figure_test(savefig_kwargs={"bbox_inches": "tight"})
@@ -690,7 +735,8 @@ class TestBasic(BaseImageTests):
         wcs.wcs.ctype = ["solar-x", "solar-y"]
         wcs.wcs.cunit = ["arcsec", "arcsec"]
 
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_subplot(1, 1, 1, projection=wcs)
 
         ax.imshow(np.zeros([1024, 1024]), origin="lower")
@@ -711,6 +757,7 @@ class TestBasic(BaseImageTests):
 
         assert ax.format_coord(512, 512) == "513.0 513.0 (world)"
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -719,7 +766,8 @@ class TestBasic(BaseImageTests):
         # and SphericalCircle don't)
 
         wcs = WCS(self.msx_header)
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.25, 0.25, 0.5, 0.5], projection=wcs, aspect="equal")
 
         # Pixel coordinates
@@ -812,13 +860,15 @@ class TestBasic(BaseImageTests):
         assert np.allclose(r1.get_xy(), r3.get_xy())
         assert np.allclose(r2.get_xy()[0], [266.4, -29.25])
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_quadrangle(self, tmp_path):
         # Test that Quadrangle can have curved edges while Rectangle does not
         wcs = WCS(self.msx_header)
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.25, 0.25, 0.5, 0.5], projection=wcs, aspect="equal")
         ax.set_xlim(0, 10000)
         ax.set_ylim(-10000, 0)
@@ -851,13 +901,15 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticklabel_visible(False)
         ax.coords[1].set_ticklabel_visible(False)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_beam_shape_from_args(self, tmp_path):
         # Test for adding the beam shape with the beam parameters as arguments
         wcs = WCS(self.msx_header)
-        fig = plt.figure(figsize=(4, 3))
+        fig = Figure(figsize=(4, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, aspect="equal")
         ax.set_xlim(-10, 10)
         ax.set_ylim(-10, 10)
@@ -874,6 +926,7 @@ class TestBasic(BaseImageTests):
             color="black",
         )
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -885,20 +938,23 @@ class TestBasic(BaseImageTests):
         hdr["BPA"] = 30.0
 
         wcs = WCS(hdr)
-        fig = plt.figure(figsize=(4, 3))
+        fig = Figure(figsize=(4, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, aspect="equal")
         ax.set_xlim(-10, 10)
         ax.set_ylim(-10, 10)
 
         add_beam(ax, header=hdr)
 
+        canvas.draw()
         return fig
 
     @figure_test
     def test_scalebar(self, tmp_path):
         # Test for adding a scale bar
         wcs = WCS(self.msx_header)
-        fig = plt.figure(figsize=(4, 3))
+        fig = Figure(figsize=(4, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, aspect="equal")
         ax.set_xlim(-10, 10)
         ax.set_ylim(-10, 10)
@@ -912,6 +968,7 @@ class TestBasic(BaseImageTests):
             label_top=True,
         )
 
+        canvas.draw()
         return fig
 
     @figure_test
@@ -920,31 +977,37 @@ class TestBasic(BaseImageTests):
         # be incorrectly simplified.
 
         wcs = WCS(self.msx_header)
-        fig = plt.figure(figsize=(5, 3))
+        fig = Figure(figsize=(5, 3))
+        canvas = FigureCanvasAgg(fig)
         fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, frame_class=EllipticalFrame)
+        canvas.draw()
         return fig
 
     @figure_test
     def test_hms_labels(self):
         # This tests the appearance of the hms superscripts in tick labels
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.3, 0.2, 0.65, 0.6], projection=WCS(self.twoMASS_k_header), aspect="equal"
         )
         ax.set_xlim(-0.5, 0.5)
         ax.set_ylim(-0.5, 0.5)
         ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
+        canvas.draw()
         return fig
 
     @figure_test(style={"text.usetex": True})
     def test_latex_labels(self):
-        fig = plt.figure(figsize=(3, 3))
+        fig = Figure(figsize=(3, 3))
+        canvas = FigureCanvasAgg(fig)
         ax = fig.add_axes(
             [0.3, 0.2, 0.65, 0.6], projection=WCS(self.twoMASS_k_header), aspect="equal"
         )
         ax.set_xlim(-0.5, 0.5)
         ax.set_ylim(-0.5, 0.5)
         ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
+        canvas.draw()
         return fig
 
     @figure_test
@@ -955,14 +1018,15 @@ class TestBasic(BaseImageTests):
         wcs = WCS()
         wcs.wcs.ctype = ["lon", "lat"]
 
-        fig = plt.figure(figsize=(6, 6))
+        fig = Figure(figsize=(6, 6))
+        canvas = FigureCanvasAgg(fig)
 
         # The first subplot tests:
         # - that plt.tick_params works
         # - that by default both axes are changed
         # - changing the tick direction and appearance, the label appearance and padding
         ax = fig.add_subplot(2, 2, 1, projection=wcs)
-        plt.tick_params(
+        ax.tick_params(
             direction="in",
             length=20,
             width=5,
@@ -982,7 +1046,7 @@ class TestBasic(BaseImageTests):
         # - that the tick positioning works (bottom/left/top/right)
         # Make sure that we can pass things that can index coords
         ax = fig.add_subplot(2, 2, 2, projection=wcs)
-        plt.tick_params(
+        ax.tick_params(
             axis=0,
             direction="in",
             length=20,
@@ -994,7 +1058,7 @@ class TestBasic(BaseImageTests):
             bottom=True,
             grid_color="purple",
         )
-        plt.tick_params(
+        ax.tick_params(
             axis="lat",
             direction="out",
             labelsize=8,
@@ -1035,7 +1099,7 @@ class TestBasic(BaseImageTests):
             right=True,
             grid_color="red",
         )
-        plt.grid()
+        ax.grid()
 
         ax.coords[0].set_auto_axislabel(False)
         ax.coords[1].set_auto_axislabel(False)
@@ -1060,6 +1124,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_auto_axislabel(False)
         ax.coords[1].set_auto_axislabel(False)
 
+        canvas.draw()
         return fig
 
 
@@ -1077,13 +1142,15 @@ def wave_wcs_1d():
 
 @figure_test
 def test_1d_plot_1d_wcs(wave_wcs_1d):
-    fig = plt.figure()
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(1, 1, 1, projection=wave_wcs_1d)
     (lines,) = ax.plot([10, 12, 14, 12, 10])
 
     ax.set_xlabel("this is the x-axis")
     ax.set_ylabel("this is the y-axis")
 
+    canvas.draw()
     return fig
 
 
@@ -1093,12 +1160,14 @@ def test_1d_plot_1d_wcs_format_unit(wave_wcs_1d):
     This test ensures that the format unit is updated and displayed for both
     the axis ticks and default axis labels.
     """
-    fig = plt.figure()
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(1, 1, 1, projection=wave_wcs_1d)
     (lines,) = ax.plot([10, 12, 14, 12, 10])
 
     ax.coords[0].set_format_unit("nm")
 
+    canvas.draw()
     return fig
 
 
@@ -1115,7 +1184,8 @@ def spatial_wcs_2d():
 
 @figure_test
 def test_1d_plot_2d_wcs_correlated(spatial_wcs_2d):
-    fig = plt.figure()
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(1, 1, 1, projection=spatial_wcs_2d, slices=("x", 0))
     (lines,) = ax.plot([10, 12, 14, 12, 10], "-o", color="orange")
 
@@ -1127,6 +1197,7 @@ def test_1d_plot_2d_wcs_correlated(spatial_wcs_2d):
     ax.coords["glat"].set_ticklabel(color="blue")
     ax.coords["glat"].grid(color="blue")
 
+    canvas.draw()
     return fig
 
 
@@ -1160,6 +1231,8 @@ def test_1d_plot_1d_sliced_low_level_wcs(
     """
     Test that a SLLWCS through a coupled 2D WCS plots as line OK.
     """
+    import matplotlib.pyplot as plt
+
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=spatial_wcs_2d_small_angle[slices])
     (lines,) = ax.plot([10, 12, 14, 12, 10], "-o", color="orange")
@@ -1188,6 +1261,8 @@ def test_1d_plot_put_varying_axis_on_bottom_lon(
     change, and a set of lat ticks on the top because it does but it's the
     correlated axis not the actual one you are plotting against.
     """
+    import matplotlib.pyplot as plt
+
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection=spatial_wcs_2d_small_angle, slices=slices)
     (lines,) = ax.plot([10, 12, 14, 12, 10], "-o", color="orange")
@@ -1205,7 +1280,8 @@ def test_allsky_labels_wrap():
     # Regression test for a bug that caused some tick labels to not be shown
     # when looking at all-sky maps in the case where coord_wrap < 360
 
-    fig = plt.figure(figsize=(4, 4))
+    fig = Figure(figsize=(4, 4))
+    canvas = FigureCanvasAgg(fig)
 
     icen = 0
 
@@ -1230,6 +1306,7 @@ def test_allsky_labels_wrap():
 
     fig.subplots_adjust(hspace=2, left=0.05, right=0.95, bottom=0.1, top=0.95)
 
+    canvas.draw()
     return fig
 
 
@@ -1250,6 +1327,7 @@ def test_tickable_gridlines():
     )
 
     fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(projection=wcs)
     ax.set_xlim(-0.5, 360 - 0.5)
     ax.set_ylim(-0.5, 150 - 0.5)
@@ -1276,6 +1354,7 @@ def test_tickable_gridlines():
     overlay[1].set_ticklabel(color="blue")
     overlay[1].set_axislabel("Galactic latitude", color="blue")
 
+    canvas.draw()
     return fig
 
 
@@ -1321,6 +1400,7 @@ def test_overlay_nondegree_unit(nondegree_frame):
     )
 
     fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(projection=wcs)
 
     ax.set_xlim(-0.5, 20 - 0.5)
@@ -1341,6 +1421,7 @@ def test_overlay_nondegree_unit(nondegree_frame):
     overlay[1].set_ticklabel(color="r")
     overlay[1].grid(color="r", linestyle="dashed")
 
+    canvas.draw()
     return fig
 
 
@@ -1360,6 +1441,7 @@ def test_nosimplify():
     )
 
     fig = Figure(figsize=(7, 8))
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(projection=wcs)
 
     ax.coords[0].set_ticks(spacing=0.25 * u.hourangle)
@@ -1375,6 +1457,7 @@ def test_nosimplify():
     ax.set_aspect(15)
     ax.grid()
 
+    canvas.draw()
     return fig
 
 
@@ -1393,8 +1476,10 @@ def test_custom_formatter(spatial_wcs_2d_small_angle):
         else:
             return "apple"
 
-    fig = plt.figure()
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(1, 1, 1, projection=spatial_wcs_2d_small_angle)
     ax.coords[0].set_major_formatter(double_format)
     ax.coords[1].set_major_formatter(fruit_format)
+    canvas.draw()
     return fig

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -3,10 +3,11 @@ import warnings
 from contextlib import nullcontext
 
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.contour import QuadContourSet
+from matplotlib.figure import Figure
 from packaging.version import Version
 
 from astropy import units as u
@@ -35,22 +36,18 @@ TEX_UNAVAILABLE = True
 MATPLOTLIB_LT_3_7 = Version(mpl.__version__) < Version("3.7")
 
 
-def teardown_function(function):
-    plt.close("all")
-
-
 def test_grid_regression(ignore_matplotlibrc):
     # Regression test for a bug that meant that if the rc parameter
     # axes.grid was set to True, WCSAxes would crash upon initialization.
-    plt.rc("axes", grid=True)
-    fig = plt.figure(figsize=(3, 3))
+    mpl.rc("axes", grid=True)
+    fig = Figure(figsize=(3, 3))
     WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
 
 
 def test_format_coord_regression(ignore_matplotlibrc, tmp_path):
     # Regression test for a bug that meant that if format_coord was called by
     # Matplotlib before the axes were drawn, an error occurred.
-    fig = plt.figure(figsize=(3, 3))
+    fig = Figure(figsize=(3, 3))
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
     assert ax.format_coord(10, 10) == ""
@@ -85,7 +82,7 @@ COORDSYS= 'icrs    '
 
 @pytest.mark.parametrize("grid_type", ["lines", "contours"])
 def test_no_numpy_warnings(ignore_matplotlibrc, tmp_path, grid_type):
-    fig = plt.figure()
+    fig = Figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
     ax.imshow(np.zeros((100, 200)))
     ax.coords.grid(color="white", grid_type=grid_type)
@@ -114,7 +111,8 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmp_path, grid_type):
 
 def test_invalid_frame_overlay(ignore_matplotlibrc):
     # Make sure a nice error is returned if a frame doesn't exist
-    ax = plt.subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
+    fig = Figure()
+    ax = fig.add_subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
     with pytest.raises(ValueError, match=r"Frame banana not found"):
         ax.get_coords_overlay("banana")
 
@@ -125,7 +123,7 @@ def test_invalid_frame_overlay(ignore_matplotlibrc):
 def test_plot_coord_transform(ignore_matplotlibrc):
     twoMASS_k_header = get_pkg_data_filename("data/2MASS_k_header")
     twoMASS_k_header = fits.Header.fromtextfile(twoMASS_k_header)
-    fig = plt.figure(figsize=(6, 6))
+    fig = Figure(figsize=(6, 6))
     ax = fig.add_axes(
         [0.15, 0.15, 0.8, 0.8], projection=WCS(twoMASS_k_header), aspect="equal"
     )
@@ -140,7 +138,7 @@ def test_plot_coord_transform(ignore_matplotlibrc):
 def test_scatter_coord_transform(ignore_matplotlibrc):
     twoMASS_k_header = get_pkg_data_filename("data/2MASS_k_header")
     twoMASS_k_header = fits.Header.fromtextfile(twoMASS_k_header)
-    fig = plt.figure(figsize=(6, 6))
+    fig = Figure(figsize=(6, 6))
     ax = fig.add_axes(
         [0.15, 0.15, 0.8, 0.8], projection=WCS(twoMASS_k_header), aspect="equal"
     )
@@ -156,7 +154,8 @@ def test_set_label_properties(ignore_matplotlibrc):
     # Regression test to make sure that arguments passed to
     # set_xlabel/set_ylabel are passed to the underlying coordinate helpers
 
-    ax = plt.subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
+    fig = Figure()
+    ax = fig.add_subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
 
     ax.set_xlabel("Test x label", labelpad=2, color="red")
     ax.set_ylabel("Test y label", labelpad=3, color="green")
@@ -212,11 +211,12 @@ def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
     wcs3d.wcs.cdelt = [6.25, 6.25, 23]
     wcs3d.wcs.crval = [0.0, 0.0, 1.0]
 
+    fig = Figure()
     with warnings.catch_warnings():
         # https://github.com/astropy/astropy/issues/9690
         warnings.filterwarnings("ignore", message=r".*PY_SSIZE_T_CLEAN.*")
-        plt.subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
-        plt.savefig(tmp_path / "test.png")
+        fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
+        fig.savefig(tmp_path / "test.png")
 
     # Angle case
 
@@ -225,14 +225,25 @@ def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
     with warnings.catch_warnings():
         # https://github.com/astropy/astropy/issues/9690
         warnings.filterwarnings("ignore", message=r".*PY_SSIZE_T_CLEAN.*")
-        plt.clf()
-        plt.subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 2))
-        plt.savefig(tmp_path / "test.png")
+        fig.clear()
+        fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 2))
+        fig.savefig(tmp_path / "test.png")
 
 
+@pytest.fixture
+def tmp_plt_figure():
+    import matplotlib.pyplot as plt
+
+    figure = plt.figure()
+    yield figure
+    plt.close(figure)
+
+
+@pytest.mark.usefixtures("tmp_plt_figure")
 def test_plt_xlabel_ylabel(tmp_path):
     # Regression test for a bug that happened when using plt.xlabel
     # and plt.ylabel with Matplotlib 3.0
+    import matplotlib.pyplot as plt
 
     plt.subplot(projection=WCS())
     plt.xlabel("Galactic Longitude")
@@ -259,16 +270,18 @@ def test_grid_type_contours_transform(tmp_path):
         "name": ("x", "y"),
     }
 
-    fig = plt.figure()
+    fig = Figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], transform=transform, coord_meta=coord_meta)
     fig.add_axes(ax)
     ax.grid(grid_type="contours")
     fig.savefig(tmp_path / "test.png")
 
 
+@pytest.mark.usefixtures("tmp_plt_figure")
 def test_plt_imshow_origin():
     # Regression test for a bug that caused origin to be set to upper when
     # plt.imshow was called.
+    import matplotlib.pyplot as plt
 
     ax = plt.subplot(projection=WCS())
     plt.imshow(np.ones((2, 2)))
@@ -279,8 +292,8 @@ def test_plt_imshow_origin():
 def test_ax_imshow_origin():
     # Regression test for a bug that caused origin to be set to upper when
     # ax.imshow was called with no origin
-
-    ax = plt.subplot(projection=WCS())
+    fig = Figure()
+    ax = fig.add_subplot(projection=WCS())
     ax.imshow(np.ones((2, 2)))
     assert ax.get_xlim() == (-0.5, 1.5)
     assert ax.get_ylim() == (-0.5, 1.5)
@@ -293,23 +306,24 @@ def test_grid_contour_large_spacing(tmp_path):
 
     filename = tmp_path / "test.png"
 
-    ax = plt.subplot(projection=WCS())
+    fig = Figure()
+    ax = fig.add_subplot(projection=WCS())
     ax.set_xlim(-0.5, 1.5)
     ax.set_ylim(-0.5, 1.5)
     ax.coords[0].set_ticks(values=[] * u.one)
 
     ax.coords[0].grid(grid_type="contours")
-    plt.savefig(filename)
+    fig.savefig(filename)
 
     ax.coords[0].grid(grid_type="contours")
-    plt.savefig(filename)
+    fig.savefig(filename)
 
 
 def test_contour_return():
     # Regression test for a bug that caused contour and contourf to return None
     # instead of the contour object.
 
-    fig = plt.figure()
+    fig = Figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
 
@@ -324,7 +338,7 @@ def test_contour_empty():
     # Regression test for a bug that caused contour to crash if no contours
     # were present.
 
-    fig = plt.figure()
+    fig = Figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
 
@@ -349,7 +363,8 @@ def test_iterate_coords(ignore_matplotlibrc):
     wcs3d.wcs.cdelt = [6.25, 6.25, 23]
     wcs3d.wcs.crval = [0.0, 0.0, 1.0]
 
-    ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
+    fig = Figure()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
 
     x, y, z = ax.coords
 
@@ -358,17 +373,17 @@ def test_invalid_slices_errors(ignore_matplotlibrc):
     # Make sure that users get a clear message when specifying a WCS with
     # >2 dimensions without giving the 'slices' argument, or if the 'slices'
     # argument has too many/few elements.
-
+    fig = Figure()
     wcs3d = WCS(naxis=3)
     wcs3d.wcs.ctype = ["x", "y", "z"]
 
-    plt.subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
+    fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
 
     with pytest.raises(
         ValueError,
         match=r"WCS has more than 2 pixel dimensions, so 'slices' should be set",
     ):
-        plt.subplot(1, 1, 1, projection=wcs3d)
+        fig.add_subplot(1, 1, 1, projection=wcs3d)
 
     with pytest.raises(
         ValueError,
@@ -377,36 +392,36 @@ def test_invalid_slices_errors(ignore_matplotlibrc):
             r" be 3."
         ),
     ):
-        plt.subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1, 2))
+        fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1, 2))
 
     wcs2d = WCS(naxis=2)
     wcs2d.wcs.ctype = ["x", "y"]
 
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs2d)
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs2d)
     assert ax.frame_class is RectangularFrame
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=("x", "y"))
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs2d, slices=("x", "y"))
     assert ax.frame_class is RectangularFrame
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=("y", "x"))
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs2d, slices=("y", "x"))
     assert ax.frame_class is RectangularFrame
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=["x", "y"])
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs2d, slices=["x", "y"])
     assert ax.frame_class is RectangularFrame
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs2d, slices=(1, "x"))
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs2d, slices=(1, "x"))
     assert ax.frame_class is RectangularFrame1D
 
     wcs1d = WCS(naxis=1)
     wcs1d.wcs.ctype = ["x"]
 
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs1d)
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs1d)
     assert ax.frame_class is RectangularFrame1D
 
     with pytest.raises(ValueError):
-        plt.subplot(1, 1, 1, projection=wcs2d, slices=(1, "y"))
+        fig.add_subplot(1, 1, 1, projection=wcs2d, slices=(1, "y"))
 
 
 EXPECTED_REPR_1 = """
@@ -436,19 +451,19 @@ EXPECTED_REPR_2 = """
 
 def test_repr(ignore_matplotlibrc):
     # Unit test to make sure __repr__ looks as expected
-
+    fig = Figure()
     wcs3d = WCS(GAL_HEADER)
 
     # Cube header has world coordinates as distance, lon, lat, so start off
     # by slicing in a way that we select just lon,lat:
 
-    ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=(1, "x", "y"))
+    ax = fig.add_subplot(1, 1, 1, projection=wcs3d, slices=(1, "x", "y"))
     assert repr(ax.coords) == EXPECTED_REPR_1
 
     # Now slice in a way that all world coordinates are still present:
 
-    plt.clf()
-    ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
+    fig.clear()
+    ax = fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
     assert repr(ax.coords) == EXPECTED_REPR_2
 
 
@@ -463,14 +478,14 @@ def time_spectral_wcs_2d():
 def test_time_wcs(time_spectral_wcs_2d):
     # Regression test for a bug that caused WCSAxes to error when using a WCS
     # with a time axis.
-
-    plt.subplot(projection=time_spectral_wcs_2d)
+    fig = Figure()
+    fig.add_subplot(projection=time_spectral_wcs_2d)
 
 
 @pytest.mark.skipif(TEX_UNAVAILABLE, reason="TeX is unavailable")
 def test_simplify_labels_usetex(ignore_matplotlibrc, tmp_path):
     """Regression test for https://github.com/astropy/astropy/issues/8004."""
-    plt.rc("text", usetex=True)
+    mpl.rc("text", usetex=True)
 
     header = {
         "NAXIS": 2,
@@ -488,7 +503,8 @@ def test_simplify_labels_usetex(ignore_matplotlibrc, tmp_path):
     }
 
     wcs = WCS(header)
-    fig, ax = plt.subplots(subplot_kw=dict(frame_class=EllipticalFrame, projection=wcs))
+    fig = Figure()
+    ax = fig.add_subplot(frame_class=EllipticalFrame, projection=wcs)
     ax.set_xlim(-0.5, header["NAXIS1"] - 0.5)
     ax.set_ylim(-0.5, header["NAXIS2"] - 0.5)
     ax.coords[0].set_ticklabel(exclude_overlapping=True)
@@ -542,7 +558,6 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
     """Test if ``axis.set_xlabel()`` calls the correct ``coords[i]_set_axislabel()`` in a
     WCS plot. Regression test for https://github.com/astropy/astropy/issues/10435.
     """
-
     labels = ["RA", "Declination"]
     header = {
         "NAXIS": 2,
@@ -559,7 +574,8 @@ def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
     }
 
     wcs = WCS(header)
-    fig, ax = plt.subplots(subplot_kw=dict(frame_class=frame_class, projection=wcs))
+    fig = Figure()
+    ax = fig.add_subplot(frame_class=frame_class, projection=wcs)
     ax.set_xlabel(labels[0])
     ax.set_ylabel(labels[1])
 
@@ -574,10 +590,11 @@ def test_bbox_size(atol):
     # Test for the size of a WCSAxes bbox (only have Matplotlib >= 3.0 now)
     extents = [11.38888888888889, 3.5, 576.0, 432.0]
 
-    fig = plt.figure()
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
-    fig.add_axes(ax)
-    fig.canvas.draw()
+    canvas.figure.add_axes(ax)
+    canvas.draw()
     renderer = fig.canvas.renderer
     ax_bbox = ax.get_tightbbox(renderer)
 
@@ -590,9 +607,10 @@ def test_bbox_size(atol):
 
 
 def test_wcs_type_transform_regression():
+    fig = Figure()
     wcs = WCS(TARGET_HEADER)
     sliced_wcs = SlicedLowLevelWCS(wcs, np.s_[1:-1, 1:-1])
-    ax = plt.subplot(1, 1, 1, projection=wcs)
+    ax = fig.add_subplot(1, 1, 1, projection=wcs)
     ax.get_transform(sliced_wcs)
 
     high_wcs = HighLevelWCSWrapper(sliced_wcs)
@@ -600,7 +618,7 @@ def test_wcs_type_transform_regression():
 
 
 def test_multiple_draws_grid_contours(tmp_path):
-    fig = plt.figure()
+    fig = Figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS())
     ax.grid(color="black", grid_type="contours")
     fig.savefig(tmp_path / "plot.png")
@@ -611,9 +629,10 @@ def test_get_coord_range_nan_regression():
     # Test to make sure there is no internal casting of NaN to integers
     # NumPy 1.24 raises a RuntimeWarning if a NaN is cast to an integer
 
+    fig = Figure()
     wcs = WCS(TARGET_HEADER)
     wcs.wcs.crval[0] = 0  # Re-position the longitude wrap to the middle
-    ax = plt.subplot(1, 1, 1, projection=wcs)
+    ax = fig.add_subplot(1, 1, 1, projection=wcs)
 
     # Set the Y limits within valid latitudes/declinations
     ax.set_ylim(300, 500)
@@ -641,14 +660,14 @@ def test_get_coord_range_nan_regression():
 
 
 def test_imshow_error():
-    fig = plt.figure()
+    fig = Figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS())
     with pytest.raises(ValueError, match="Cannot use images with origin='upper"):
         ax.imshow(np.ones(100).reshape(10, 10), origin="upper")
 
 
 def test_label_setting():
-    fig = plt.figure()
+    fig = Figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS())
     # Check both xlabel and label kwargs work
     ax.set_xlabel(xlabel="label")
@@ -670,7 +689,8 @@ def test_label_setting():
 
 
 def test_invisible_bbox():
-    fig = plt.figure()
+    fig = Figure()
+    _canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(1, 1, 1, projection=WCS())
 
     assert ax.get_tightbbox(fig.canvas.get_renderer()) is not None
@@ -682,7 +702,8 @@ def test_get_axislabel_default():
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = "RA---TAN", "DEC--TAN"
 
-    fig = plt.figure()
+    fig = Figure()
+    _canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(1, 1, 1, projection=wcs)
     assert ax.coords[0].get_axislabel() == "pos.eq.ra"
     assert ax.coords[1].get_axislabel() == "pos.eq.dec"

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.figure import Figure
 
 from astropy import units as u
 from astropy.tests.figures import figure_test
@@ -63,7 +63,7 @@ class TestTransformCoordMeta(BaseImageTests):
         wcs.wcs.cdelt = [6.25, 6.25]
         wcs.wcs.crval = [0.0, 0.0]
 
-        fig = plt.figure(figsize=(4, 4))
+        fig = Figure(figsize=(4, 4))
 
         ax = WCSAxes(fig, [0.15, 0.15, 0.7, 0.7], wcs=wcs)
         fig.add_axes(ax)
@@ -101,7 +101,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
     @figure_test
     def test_coords_overlay_auto_coord_meta(self):
-        fig = plt.figure(figsize=(4, 4))
+        fig = Figure(figsize=(4, 4))
 
         ax = WCSAxes(fig, [0.15, 0.15, 0.7, 0.7], wcs=WCS(self.msx_header))
         fig.add_axes(ax)
@@ -129,7 +129,7 @@ class TestTransformCoordMeta(BaseImageTests):
         coord_meta["wrap"] = (360.0 * u.deg, None)
         coord_meta["unit"] = (u.deg, u.deg)
         coord_meta["name"] = "lon", "lat"
-        fig = plt.figure(figsize=(4, 4))
+        fig = Figure(figsize=(4, 4))
 
         ax = WCSAxes(fig, [0.15, 0.15, 0.7, 0.7], transform=s, coord_meta=coord_meta)
         fig.add_axes(ax)

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -4,9 +4,10 @@ import warnings
 from copy import deepcopy
 from textwrap import dedent
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
 from matplotlib.transforms import Affine2D, IdentityTransform
 
 from astropy import units as u
@@ -27,13 +28,6 @@ from astropy.visualization.wcsaxes.wcsapi import (
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseLowLevelWCS, SlicedLowLevelWCS
 from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping
-
-
-@pytest.fixture
-def plt_close():
-    yield
-    plt.close("all")
-
 
 WCS2D = WCS(naxis=2)
 WCS2D.wcs.ctype = ["x", "y"]
@@ -312,7 +306,7 @@ def test_custom_coord_type_from_ctype():
         "eggs": "custom:pos.eggs",
     }
     with custom_ctype_to_ucd_mapping(custom_mapping):
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(111, projection=wcs)
         assert ax.coords["eggs"].coord_type == "scalar"
         assert ax.coords["eggs"].coord_wrap == None
@@ -332,7 +326,7 @@ def test_custom_coord_type_from_ctype():
             assert ax.coords["eggs"].coord_wrap == 360 * u.deg
             assert ax.coords["eggs"].get_format_unit() == u.arcsec
 
-        fig = plt.figure()
+        fig = Figure()
         ax = fig.add_subplot(111, projection=wcs)
         assert ax.coords["eggs"].coord_type == "scalar"
         assert ax.coords["eggs"].coord_wrap == None
@@ -356,7 +350,7 @@ def test_custom_coord_type_from_ctype_nested():
     }
 
     with custom_ctype_to_ucd_mapping(custom_mapping):
-        fig = plt.figure()
+        fig = Figure()
         custom_meta_1 = {
             "pos.eggs": {
                 "coord_wrap": 360.0 * u.deg,
@@ -381,8 +375,8 @@ def test_custom_coord_type_from_ctype_nested():
                 assert ax.coords["spam"].get_format_unit() == u.deg
 
         # Now test the mappings have been removed
-        fig2 = plt.figure()
-        ax = fig.add_subplot(111, projection=wcs)
+        fig2 = Figure()
+        ax = fig2.add_subplot(111, projection=wcs)
         assert ax.coords["eggs"].coord_type == "scalar"
         assert ax.coords["eggs"].coord_wrap == None
         assert ax.coords["eggs"].get_format_unit() == u.deg
@@ -540,8 +534,9 @@ def test_apply_slices(sub_wcs, wcs_slice, wcsaxes_slices, world_map, ndim):
 
 # parametrize here to pass to the fixture
 @pytest.mark.parametrize("wcs_slice", [np.s_[:, :, 0, :]])
-def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice, plt_close):
+def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice):
     slices_wcsaxes = [0, "x", "y"]
+    fig = Figure()
 
     for sub_wcs_ in (sub_wcs, SlicedLowLevelWCS(wcs_4d, wcs_slice)):
         with warnings.catch_warnings():
@@ -571,8 +566,8 @@ def test_sliced_ND_input(wcs_4d, sub_wcs, wcs_slice, plt_close):
         assert coord_meta["default_ticks_position"] == ["", "brtl", "brtl"]
 
         # Validate the axes initialize correctly
-        plt.clf()
-        plt.subplot(projection=sub_wcs_, slices=slices_wcsaxes)
+        fig.clear()
+        fig.add_subplot(projection=sub_wcs_, slices=slices_wcsaxes)
 
 
 class LowLevelWCS5D(BaseLowLevelWCS):
@@ -658,13 +653,14 @@ def test_edge_axes():
         "latpole": 90.0,
     }
     wcs = WCS(header)
-    fig = plt.figure()
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
     ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=wcs)
     ax.imshow(data, origin="lower")
     # By default the x- and y- axes should be drawn
     lon = ax.coords[0]
     lat = ax.coords[1]
-    fig.canvas.draw()
+    canvas.draw()
     np.testing.assert_equal(
         lon._ticks.world["b"], np.array([90.0, 180.0, 180.0, 270.0, 0.0])
     )
@@ -717,9 +713,9 @@ def test_coord_meta_wcsapi():
 
 
 @figure_test
-def test_wcsapi_5d_with_names(plt_close):
+def test_wcsapi_5d_with_names():
     # Test for plotting image and also setting values of ticks
-    fig = plt.figure(figsize=(6, 6))
+    fig = Figure(figsize=(6, 6))
     ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=LowLevelWCS5D())
     ax.set_xlim(-0.5, 148.5)
     ax.set_ylim(-0.5, 148.5)
@@ -776,9 +772,9 @@ class LowLevelWCSCelestial2D(BaseLowLevelWCS):
 
 
 @figure_test
-def test_wcsapi_2d_celestial_arcsec(plt_close):
+def test_wcsapi_2d_celestial_arcsec():
     # Regression test for plot_coord/scatter_coord/text_coord with celestial WCS that is not in degrees
-    fig = plt.figure(figsize=(6, 6))
+    fig = Figure(figsize=(6, 6))
     ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=LowLevelWCSCelestial2D())
     ax.set_xlim(-0.5, 200.5)
     ax.set_ylim(-0.5, 200.5)

--- a/docs/visualization/matplotlib_integration.rst
+++ b/docs/visualization/matplotlib_integration.rst
@@ -27,8 +27,8 @@ the quantity:
     from astropy.visualization import quantity_support
     quantity_support()
     from matplotlib import pyplot as plt
-    plt.figure(figsize=(5,3))
-    plt.plot([1, 2, 3] * u.m)
+    fig, ax = plt.subplots(figsize=(5, 3))
+    ax.plot([1, 2, 3] * u.m)
 
 Quantities are automatically converted to the first unit set on a
 particular axis, so in the following, the y-axis remains in ``m`` even
@@ -38,17 +38,17 @@ though the second line is given in ``cm``:
    :include-source:
    :context:
 
-    plt.plot([1, 2, 3] * u.cm)
+    ax.plot([1, 2, 3] * u.cm)
 
 Plotting a quantity with an incompatible unit will raise an exception.
-For example, calling ``plt.plot([1, 2, 3] * u.kg)`` (mass unit) to overplot
+For example, calling ``ax.plot([1, 2, 3] * u.kg)`` (mass unit) to overplot
 on the plot above that is displaying length units.
 
 To make sure unit support is turned off afterward, you can use
 `~astropy.visualization.quantity_support` with a ``with`` statement::
 
     with quantity_support():
-        plt.plot([1, 2, 3] * u.m)
+        ax.plot([1, 2, 3] * u.m)
 
 .. _plotting-times:
 
@@ -86,8 +86,8 @@ using the |Time| class:
 
     time_support()
 
-    plt.figure(figsize=(5,3))
-    plt.plot(Time([58000, 59000, 62000], format='mjd'), [1.2, 3.3, 2.3])
+    fig, ax = plt.subplots(figsize=(5, 3))
+    ax.plot(Time([58000, 59000, 62000], format='mjd'), [1.2, 3.3, 2.3])
 
 By default, the format and scale used for the plots is taken from the first time
 that Matplotlib encounters for a particular Axes instance. The format and scale
@@ -106,12 +106,12 @@ can also be explicitly controlled by passing arguments to ``time_support``:
    :context:
 
     time_support(format='mjd', scale='tai')
-    plt.figure(figsize=(5,3))
-    plt.plot(Time([50000, 52000, 54000], format='mjd'), [1.2, 3.3, 2.3])
+    fig, ax = plt.subplots(figsize=(5, 3))
+    ax.plot(Time([50000, 52000, 54000], format='mjd'), [1.2, 3.3, 2.3])
 
 To make sure support for plotting times is turned off afterward, you can use
 `~astropy.visualization.time_support` as a context manager::
 
     with time_support(format='mjd', scale='tai'):
-        plt.figure(figsize=(5,3))
-        plt.plot(Time([50000, 52000, 54000], format='mjd'))
+        fig, ax = plt.subplots(figsize=(5, 3))
+        ax.plot(Time([50000, 52000, 54000], format='mjd'))

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -64,8 +64,7 @@ Here's an example using the
     norm = simple_norm(image, 'sqrt')
 
     # Display the image
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    fig, ax = plt.subplots()
     im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
 
@@ -230,8 +229,7 @@ the data and the interval and stretch objects:
     # norm = ImageNormalize(image, MinMaxInterval(), SqrtStretch())
 
     # Display the image
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    fig, ax = plt.subplots()
     im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
 
@@ -265,8 +263,7 @@ use case:
     image = np.arange(65536).reshape((256, 256))
 
     # Display the exact same thing as the above plot
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    fig, ax = plt.subplots()
     im, norm = imshow_norm(image, ax, origin='lower',
                            interval=MinMaxInterval(), stretch=SqrtStretch())
     fig.colorbar(im)
@@ -301,8 +298,7 @@ also be the vmin and vmax limits, which you can determine from the
     norm = ImageNormalize(vmin=vmin, vmax=vmax, stretch=SqrtStretch())
 
     # Display the image
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    fig, ax = plt.subplots()
     im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
 
@@ -331,8 +327,7 @@ composite stretch can stretch residual images with negative values:
     # Image of random Gaussian noise
     rng = np.random.default_rng()
     image = rng.normal(size=(64, 64))
-    fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    fig, ax = plt.subplots()
     # ImageNormalize normalizes values to [0,1] before applying the stretch
     norm = ImageNormalize(stretch=stretch, vmin=-5, vmax=5)
     im = ax.imshow(image, origin='lower', norm=norm, cmap='gray')

--- a/docs/visualization/rgb.rst
+++ b/docs/visualization/rgb.rst
@@ -43,7 +43,8 @@ To generate a color PNG file with the default (arcsinh) scaling:
     image_g = rng.random((100,100))
     image_b = rng.random((100,100))
     image = make_lupton_rgb(image_r, image_g, image_b, stretch=0.5)
-    plt.imshow(image)
+    fig, ax = plt.subplots()
+    ax.imshow(image)
 
 This method requires that the three images be aligned and have the same pixel
 scale and size. Changing the ``interval`` from the default of an instance of
@@ -76,7 +77,8 @@ it with Figure 1 of `Lupton et al. (2004)`_:
     i = fits.getdata(i_name)
 
     rgb_default = make_lupton_rgb(i, r, g, filename="ngc6976-default.jpeg")
-    plt.imshow(rgb_default, origin='lower')
+    fig, ax = plt.subplots()
+    ax.imshow(rgb_default, origin='lower')
 
 The image above was generated with the default parameters. However using a
 different scaling, e.g Q=10, stretch=0.5, faint features
@@ -89,7 +91,8 @@ of the galaxies show up. Compare with Fig. 1 of `Lupton et al. (2004)`_ or the
    :align: center
 
    rgb = make_lupton_rgb(i, r, g, Q=10, stretch=0.5, filename="ngc6976.jpeg")
-   plt.imshow(rgb, origin='lower')
+   fig, ax = plt.subplots()
+   ax.imshow(rgb, origin='lower')
 
 
 .. _SDSS Skyserver image: https://skyserver.sdss.org/dr13/en/tools/chart/navi.aspx?ra=313.12381&dec=-5.74611
@@ -155,7 +158,9 @@ now using a linear scaling.
             maximum = val
     rgb = make_rgb(i, r, g, interval=ManualInterval(vmin=0, vmax=maximum),
                    filename="ngc6976-linear.jpeg")
-    plt.imshow(rgb, origin='lower')
+
+    fig, ax = plt.subplots()
+    ax.imshow(rgb, origin='lower')
 
 
 
@@ -187,7 +192,9 @@ can be beneficial. In this case, the a stretch instance of
 
     rgb_log = make_rgb(i, r, g, interval=ManualInterval(vmin=0, vmax=maximum),
                        stretch=LogStretch(a=1000), filename="ngc6976-log.jpeg")
-    plt.imshow(rgb_log, origin='lower')
+
+    fig, ax = plt.subplots()
+    ax.imshow(rgb_log, origin='lower')
 
 By specifying per-filter maximum values, it is possible to emphasize
 certain objects, such as the very reddest sources:
@@ -202,7 +209,9 @@ certain objects, such as the very reddest sources:
     intervals[0] = ManualInterval(vmin=0, vmax=30.)
     rgb_log = make_rgb(i, r, g, interval=intervals, stretch=LogStretch(a=1000),
                        filename="ngc6976-log-alt.jpeg")
-    plt.imshow(rgb_log, origin='lower')
+
+    fig, ax = plt.subplots()
+    ax.imshow(rgb_log, origin='lower')
 
 
 Other stretches, such as square root, can also be used:
@@ -225,4 +234,6 @@ Other stretches, such as square root, can also be used:
 
     rgb_sqrt = make_rgb(i, r, g, interval=ManualInterval(vmin=0, vmax=maximum),
                         stretch=SqrtStretch(), filename="ngc6976-sqrt.jpeg")
-    plt.imshow(rgb_sqrt, origin='lower')
+
+    fig, ax = plt.subplots()
+    ax.imshow(rgb_sqrt, origin='lower')

--- a/docs/visualization/wcsaxes/controlling_axes.rst
+++ b/docs/visualization/wcsaxes/controlling_axes.rst
@@ -46,7 +46,7 @@ you want to disable this behavior you can either set an explicit label for that
 axis with `~astropy.visualization.wcsaxes.CoordinateHelper.set_axislabel` or you
 can disable the feature per coordinate with::
 
-  ax = plt.subplot(projection=wcs)  # doctest: +SKIP
+  fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))  # doctest: +SKIP
   ax.coords[0].set_auto_axislabel(False)  # doctest: +SKIP
 
 

--- a/docs/visualization/wcsaxes/custom_frames.rst
+++ b/docs/visualization/wcsaxes/custom_frames.rst
@@ -22,7 +22,7 @@ following example shows how to use the built-in
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs, frame_class=EllipticalFrame)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, frame_class=EllipticalFrame))
 
     ax.coords.grid(color='white')
 
@@ -50,7 +50,7 @@ all-sky plots such as Aitoff projections:
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs, frame_class=EllipticalFrame)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, frame_class=EllipticalFrame))
 
     path_effects=[patheffects.withStroke(linewidth=3, foreground='black')]
     ax.coords.grid(color='white')
@@ -112,7 +112,7 @@ which we can then use:
      hdu = fits.open(filename)[0]
      wcs = WCS(hdu.header)
 
-     ax = plt.subplot(projection=wcs, frame_class=HexagonalFrame)
+     fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, frame_class=HexagonalFrame))
 
      ax.coords.grid(color='white')
 

--- a/docs/visualization/wcsaxes/images_contours.rst
+++ b/docs/visualization/wcsaxes/images_contours.rst
@@ -20,7 +20,7 @@ For the example in the following page we start from the example introduced in
 
     import matplotlib.pyplot as plt
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
 Plotting images as bitmaps or contours should be done via the usual matplotlib

--- a/docs/visualization/wcsaxes/index.rst
+++ b/docs/visualization/wcsaxes/index.rst
@@ -32,24 +32,14 @@ package:
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    plt.subplot(projection=wcs)
-    plt.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
-    plt.grid(color='white', ls='solid')
-    plt.xlabel('Galactic Longitude')
-    plt.ylabel('Galactic Latitude')
-
-This example uses the :mod:`matplotlib.pyplot` interface to Matplotlib, but WCSAxes
-can be used with any of the other ways of using Matplotlib (some examples of which
-are given in :ref:`initialization`). For example, using the partially object-oriented
-interface, you can do::
-
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
     ax.grid(color='white', ls='solid')
-    ax.set_xlabel('Galactic Longitude')
-    ax.set_ylabel('Galactic Latitude')
+    ax.set(xlabel='Galactic Longitude', ylabel='Galactic Latitude')
 
-However, the axes object is needed to access some of the more advanced functionality
+The above example uses the partially-object oriented matplotlib interface (keeping
+explicit references to figure and axes objects), as opposed to the pyplot interface.
+Note that this needed to access some of the more advanced functionality
 of WCSAxes.  An example of this usage is:
 
 .. plot::
@@ -57,7 +47,7 @@ of WCSAxes.  An example of this usage is:
    :include-source:
    :align: center
 
-    ax = plt.subplot(projection=wcs, label='overlays')
+    ax = fig.add_subplot(projection=wcs, label='overlays')
 
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 

--- a/docs/visualization/wcsaxes/initializing_axes.rst
+++ b/docs/visualization/wcsaxes/initializing_axes.rst
@@ -41,7 +41,7 @@ axes object:
    :align: center
 
     import matplotlib.pyplot as plt
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
 
 The ``ax`` object created is an instance of the
 :class:`~astropy.visualization.wcsaxes.WCSAxes` class. Note that if no WCS

--- a/docs/visualization/wcsaxes/overlaying_coordinate_systems.rst
+++ b/docs/visualization/wcsaxes/overlaying_coordinate_systems.rst
@@ -20,7 +20,7 @@ For the example in the following page we start from the example introduced in
 
     import matplotlib.pyplot as plt
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
 The coordinates shown by default in a plot will be those derived from the WCS

--- a/docs/visualization/wcsaxes/overlays.rst
+++ b/docs/visualization/wcsaxes/overlays.rst
@@ -25,7 +25,7 @@ For the example in the following page we start from the example introduced in
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
 
@@ -124,7 +124,7 @@ For example, you can add markers with positions defined in the FK5 system using:
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
     ax.set_autoscale_on(False)
@@ -159,7 +159,7 @@ in FK5 equatorial coordinates:
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
     ax.set_autoscale_on(False)
@@ -244,7 +244,7 @@ Here's a comparison of the two types of patches for plotting a quadrangle in `~a
     from matplotlib.patches import Rectangle
 
     # Set the Galactic axes such that the plot includes the ICRS south pole
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.set_xlim(0, 10000)
     ax.set_ylim(-10000, 0)
 
@@ -264,7 +264,7 @@ Here's a comparison of the two types of patches for plotting a quadrangle in `~a
                   transform=ax.get_transform('icrs'))
     ax.add_patch(r)
 
-    plt.legend(loc='upper right')
+    ax.legend(loc='upper right')
 
 Contours
 ********
@@ -288,7 +288,7 @@ image to plot the contours for:
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
     ax.set_autoscale_on(False)
@@ -324,7 +324,7 @@ and a |Quantity| as the radius:
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
     ax.set_autoscale_on(False)
@@ -373,7 +373,7 @@ image can be done with the
     hdu = fits.open(filename)[0]
     wcs = WCS(hdu.header)
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
     ax.set_autoscale_on(False)

--- a/docs/visualization/wcsaxes/slicing_datacubes.rst
+++ b/docs/visualization/wcsaxes/slicing_datacubes.rst
@@ -54,7 +54,7 @@ We then instantiate the `~astropy.visualization.wcsaxes.WCSAxes` using the
    :nofigs:
 
     import matplotlib.pyplot as plt
-    ax = plt.subplot(projection=wcs, slices=(50, 'y', 'x'))
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, slices=(50, 'y', 'x')))
 
 By setting ``slices=(50, 'y', 'x')``, we have chosen to plot the second
 dimension on the y-axis and the third dimension on the x-axis. Even though we
@@ -108,7 +108,7 @@ If we don't want to reverse the dimensions plotted, we can simply do:
    :align: center
 
     import matplotlib.pyplot as plt
-    ax = plt.subplot(projection=wcs, slices=(50, 'x', 'y'))
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, slices=(50, 'x', 'y')))
     ax.imshow(image_data[:, :, 50])
 
 
@@ -125,7 +125,7 @@ down to one dimension.
    :nofigs:
 
     import matplotlib.pyplot as plt
-    ax = plt.subplot(projection=wcs, slices=(50, 50, 'x'))
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, slices=(50, 50, 'x')))
 
 
 Here we have selected the 50 pixel in the first and second dimensions and will
@@ -165,8 +165,8 @@ for each of the spatial axes.
    :align: center
    :nofigs:
 
-    import matplotlib.pyplot as plt
-    ax = plt.subplot(projection=wcs, slices=(50, 'x', 0))
+    import matplotlib.pyplot as plot
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs, slices=(50, 'x', 0)))
 
 .. plot::
    :context:

--- a/docs/visualization/wcsaxes/ticks_labels_grid.rst
+++ b/docs/visualization/wcsaxes/ticks_labels_grid.rst
@@ -20,7 +20,7 @@ For the example in the following page we start from the example introduced in
 
     import matplotlib.pyplot as plt
 
-    ax = plt.subplot(projection=wcs)
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 
 .. _coordinateobjects:


### PR DESCRIPTION
### Description

This is a first stab at ridding ourselves of the `pyplot` interface in the test suite.
I haven't run image tests locally yet so let's see how this does in CI.

ref: #16916


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
