### PR TITLE
Declare wildcard imports in `__init__.py` files as permanently allowed

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -193,7 +193,7 @@ lint.unfixable = [
 ]
 
 [lint.extend-per-file-ignores]
-"__init__.py" = ["E402", "F401", "F403"]
+"__init__.py" = ["E402", "F401"]
 "test_*.py" = [
     "PTH", # all flake8-use-pathlib
     "RUF015",  # Prefer next({iterable}) over single element slice

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -184,14 +184,6 @@ Coding Style/Conventions
 
       # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-* Star-imports, e.g.,
-
-    from packagename import *
-
-  should never be used, except as a tool to flatten the namespace of a module.
-  An example of the allowed usage is given in the :ref:`import-star-example`
-  example.
-
 * Classes should either use direct variable access, or Python’s property
   mechanism for setting object instance variables. ``get_value``/``set_value``
   style methods should be used only when getting and setting the values
@@ -489,50 +481,6 @@ the hierarchy.
 
 .. note:: For more information on the benefits of `super`, see
           https://rhettinger.wordpress.com/2011/05/26/super-considered-super/
-
-.. _import-star-example:
-
-Acceptable use of ``from module import *``
-------------------------------------------
-
-``from module import *`` is discouraged in a module that contains
-implementation code, as it impedes clarity and often imports unused variables.
-It can, however, be used for a package that is laid out in the following
-manner::
-
-    packagename
-    packagename/__init__.py
-    packagename/submodule1.py
-    packagename/submodule2.py
-
-In this case, ``packagename/__init__.py`` may be::
-
-    """
-    A docstring describing the package goes here
-    """
-    from submodule1 import *
-    from submodule2 import *
-
-This allows functions or classes in the submodules to be used directly as
-``packagename.foo`` rather than ``packagename.submodule1.foo``. If this is
-used, it is strongly recommended that the submodules make use of the ``__all__``
-variable to specify which modules should be imported. Thus, ``submodule2.py``
-might read::
-
-    from numpy import array, linspace
-
-    __all__ = ['foo', 'AClass']
-
-    def foo(bar):
-        # the function would be defined here
-        pass
-
-    class AClass:
-        # the class is defined here
-        pass
-
-This ensures that ``from submodule import *`` only imports ``foo`` and
-``AClass``, but not `numpy.array` or `numpy.linspace`.
 
 .. _Numpy: https://numpy.org/
 .. _Scipy: https://www.scipy.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -411,6 +411,7 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "INP001", # implicit-namespace-package. The examples are not a package.
     "T203"    # pprint found
 ]
+"__init__.py" = ["F403"]  # Wildcard imports
 
 [tool.ruff.lint.flake8-annotations]
 ignore-fully-untyped = true


### PR DESCRIPTION
### Description

Wildcard imports (`from ... import *`) are guarded against by Ruff rule [F403 (undefined-local-with-import-star)](https://docs.astral.sh/ruff/rules/undefined-local-with-import-star/#undefined-local-with-import-star-f403), but we do make an exception for `__init__.py` files. This is consistent with [PEP 8](https://peps.python.org/pep-0008/): 

> There is one defensible use case for a wildcard import, which is to republish an internal interface as part of a public API...

Currently the exception is written down in `.ruff.toml`, but that file is supposed to be temporary. The end goal is to remove everything from that file either by removing rule violations or by declaring the exceptions permanent. In the case of F403 in `__init__.py` files the exception should indeed be permanent, so the first commit moves it to `pyproject.toml`, which is where our permanent Ruff configuration is.

The second commit removes developer documentation about wildcard imports. There isn't much need to provide thorough documentation about them anymore because Ruff guards against them automatically. Removing clutter from the developer documentation makes it easier for us to maintain it and lowers the barrier of entry for potential new contributors.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
