### PR TITLE
Backport PR #17305 on branch 6.1.x (TST: Pin hypothesis to avoid double tests job failure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
+    "hypothesis!=6.116.0", # https://github.com/astropy/astropy/issues/17299
     "pytest-doctestplus>=0.12",
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10",


### PR DESCRIPTION
### Description
Manual backport for #17305

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
