### PR TITLE
STY: autofix invalid-first-argument-name-for-class-method (N804) (package wise)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -87,7 +87,6 @@ lint.ignore = [
     "N801",  # invalid-class-name
     "N802",  # invalid-function-name
     "N803",  # invalid-argument-name
-    "N804",  # invalid-first-argument-name-for-class-method
     "N805",  # invalid-first-argument-name-for-method
     "N807",  # dunder-function-name
     "N813",  # camelcase-imported-as-lowercase

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -31,7 +31,7 @@ class ConstantMeta(type):
     among other reasons).
     """
 
-    def __new__(mcls, name, bases, d):
+    def __new__(cls, name, bases, d):
         def wrap(meth):
             @functools.wraps(meth)
             def wrapper(self, *args, **kwargs):
@@ -86,7 +86,7 @@ class ConstantMeta(type):
             ):
                 d[attr] = wrap(value)
 
-        return super().__new__(mcls, name, bases, d)
+        return super().__new__(cls, name, bases, d)
 
 
 class Constant(Quantity, metaclass=ConstantMeta):

--- a/astropy/coordinates/tests/test_geodetic_representations.py
+++ b/astropy/coordinates/tests/test_geodetic_representations.py
@@ -24,11 +24,11 @@ from astropy.units.tests.test_quantity_erfa_ufuncs import vvd
 
 class TestCustomGeodeticRepresentations:
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         # Preserve the original REPRESENTATION_CLASSES dict so that importing
         # the test file doesn't add a persistent test subclass (CustomGeodetic, etc.)
-        self.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
-        self.DUPLICATE_REPRESENTATIONS_ORIG = deepcopy(DUPLICATE_REPRESENTATIONS)
+        cls.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
+        cls.DUPLICATE_REPRESENTATIONS_ORIG = deepcopy(DUPLICATE_REPRESENTATIONS)
 
         class CustomGeodetic(BaseGeodeticRepresentation):
             _flattening = 0.01832
@@ -50,18 +50,18 @@ class TestCustomGeodeticRepresentations:
             _equatorial_radius = 3396190.0 * u.m
             _flattening = 0.5886007555512007 * u.percent
 
-        self.CustomGeodetic = CustomGeodetic
-        self.CustomSphericGeodetic = CustomSphericGeodetic
-        self.CustomSphericBodycentric = CustomSphericBodycentric
-        self.IAUMARS2000GeodeticRepresentation = IAUMARS2000GeodeticRepresentation
-        self.IAUMARS2000BodycentricRepresentation = IAUMARS2000BodycentricRepresentation
+        cls.CustomGeodetic = CustomGeodetic
+        cls.CustomSphericGeodetic = CustomSphericGeodetic
+        cls.CustomSphericBodycentric = CustomSphericBodycentric
+        cls.IAUMARS2000GeodeticRepresentation = IAUMARS2000GeodeticRepresentation
+        cls.IAUMARS2000BodycentricRepresentation = IAUMARS2000BodycentricRepresentation
 
     @classmethod
-    def teardown_class(self):
+    def teardown_class(cls):
         REPRESENTATION_CLASSES.clear()
-        REPRESENTATION_CLASSES.update(self.REPRESENTATION_CLASSES_ORIG)
+        REPRESENTATION_CLASSES.update(cls.REPRESENTATION_CLASSES_ORIG)
         DUPLICATE_REPRESENTATIONS.clear()
-        DUPLICATE_REPRESENTATIONS.update(self.DUPLICATE_REPRESENTATIONS_ORIG)
+        DUPLICATE_REPRESENTATIONS.update(cls.DUPLICATE_REPRESENTATIONS_ORIG)
 
     def get_representation(self, representation):
         if isinstance(representation, str):

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -160,18 +160,16 @@ class FITS_rec(np.recarray):
     _character_as_bytes = False
     _load_variable_length_data = True
 
-    def __new__(subtype, input):
+    def __new__(cls, input):
         """
         Construct a FITS record array from a recarray.
         """
         # input should be a record array
         if input.dtype.subdtype is None:
-            self = np.recarray.__new__(
-                subtype, input.shape, input.dtype, buf=input.data
-            )
+            self = np.recarray.__new__(cls, input.shape, input.dtype, buf=input.data)
         else:
             self = np.recarray.__new__(
-                subtype, input.shape, input.dtype, buf=input.data, strides=input.strides
+                cls, input.shape, input.dtype, buf=input.data, strides=input.strides
             )
 
         self._init()

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -100,10 +100,10 @@ class _ModelMeta(abc.ABCMeta):
     # Default empty dict for _parameters_, which will be empty on model
     # classes that don't have any Parameters
 
-    def __new__(mcls, name, bases, members, **kwds):
+    def __new__(cls, name, bases, members, **kwds):
         # See the docstring for _is_dynamic above
         if "_is_dynamic" not in members:
-            members["_is_dynamic"] = mcls._is_dynamic
+            members["_is_dynamic"] = cls._is_dynamic
         opermethods = [
             ("__add__", _model_oper("+")),
             ("__sub__", _model_oper("-")),
@@ -121,7 +121,7 @@ class _ModelMeta(abc.ABCMeta):
 
         for opermethod, opercall in opermethods:
             members[opermethod] = opercall
-        cls = super().__new__(mcls, name, bases, members, **kwds)
+        self = super().__new__(cls, name, bases, members, **kwds)
 
         param_names = list(members["_parameters_"])
 
@@ -133,16 +133,16 @@ class _ModelMeta(abc.ABCMeta):
                     param_names = list(tbase._parameters_) + param_names
         # Remove duplicates (arising from redefinition in subclass).
         param_names = list(dict.fromkeys(param_names))
-        if cls._parameters_:
-            if hasattr(cls, "_param_names"):
+        if self._parameters_:
+            if hasattr(self, "_param_names"):
                 # Slight kludge to support compound models, where
-                # cls.param_names is a property; could be improved with a
+                # param_names is a property; could be improved with a
                 # little refactoring but fine for now
-                cls._param_names = tuple(param_names)
+                self._param_names = tuple(param_names)
             else:
-                cls.param_names = tuple(param_names)
+                self.param_names = tuple(param_names)
 
-        return cls
+        return self
 
     def __init__(cls, name, bases, members, **kwds):
         super().__init__(name, bases, members, **kwds)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -1170,7 +1170,7 @@ def test_SmoothlyBrokenPowerLaw1D_fit_deriv():
 
 class _ExtendedModelMeta(_ModelMeta):
     @classmethod
-    def __prepare__(mcls, name, bases, **kwds):
+    def __prepare__(cls, name, bases, **kwds):
         # this shows the parent class machinery still applies
         namespace = super().__prepare__(name, bases, **kwds)
         # the custom bit

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -77,7 +77,7 @@ class BitFlag(int):
 
 
 class BitFlagNameMeta(type):
-    def __new__(mcls, name, bases, members):
+    def __new__(cls, name, bases, members):
         for k, v in members.items():
             if not k.startswith("_"):
                 v = BitFlag(v)
@@ -113,7 +113,7 @@ class BitFlagNameMeta(type):
         else:
             members = {"_locked": True, "__version__": "", **members}
 
-        return super().__new__(mcls, name, bases, members)
+        return super().__new__(cls, name, bases, members)
 
     def __setattr__(cls, name, val):
         if name == "_locked":

--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -252,7 +252,7 @@ class BinnedTimeSeries(BaseTimeSeries):
 
     @classmethod
     def read(
-        self,
+        cls,
         filename,
         time_bin_start_column=None,
         time_bin_end_column=None,

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -313,7 +313,7 @@ class TimeSeries(BaseTimeSeries):
         return result
 
     @classmethod
-    def from_pandas(self, df, time_scale="utc"):
+    def from_pandas(cls, df, time_scale="utc"):
         """
         Convert a :class:`~pandas.DataFrame` to a
         :class:`astropy.timeseries.TimeSeries`.
@@ -354,7 +354,7 @@ class TimeSeries(BaseTimeSeries):
 
     @classmethod
     def read(
-        self,
+        cls,
         filename,
         time_column=None,
         time_format=None,

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -21,10 +21,10 @@ if HAS_SCIPY:
 
 class TestInit:
     @classmethod
-    def setup_class(self):
-        self.rates = np.array([1, 5, 30, 400])[:, np.newaxis]
-        self.parr = np.random.poisson(self.rates, (4, 1000))
-        self.parr_t = np.random.poisson(self.rates.squeeze(), (1000, 4))
+    def setup_class(cls):
+        cls.rates = np.array([1, 5, 30, 400])[:, np.newaxis]
+        cls.parr = np.random.poisson(cls.rates, (4, 1000))
+        cls.parr_t = np.random.poisson(cls.rates.squeeze(), (1000, 4))
 
     def test_numpy_init(self):
         # Test that we can initialize directly from a Numpy array
@@ -559,9 +559,9 @@ ADVANCED_INDICES = [
 
 class TestGetSetItemAdvancedIndex:
     @classmethod
-    def setup_class(self):
-        self.distribution = np.arange(60.0).reshape(3, 4, 5)
-        self.d = Distribution(self.distribution)
+    def setup_class(cls):
+        cls.distribution = np.arange(60.0).reshape(3, 4, 5)
+        cls.d = Distribution(cls.distribution)
 
     def test_setup(self):
         ai1, ai2 = ADVANCED_INDICES[:2]
@@ -592,26 +592,26 @@ class TestGetSetItemAdvancedIndex:
 
 class TestQuantityDistributionGetSetItemAdvancedIndex(TestGetSetItemAdvancedIndex):
     @classmethod
-    def setup_class(self):
-        self.distribution = np.arange(60.0).reshape(3, 4, 5) << u.m
-        self.d = Distribution(self.distribution)
+    def setup_class(cls):
+        cls.distribution = np.arange(60.0).reshape(3, 4, 5) << u.m
+        cls.d = Distribution(cls.distribution)
 
 
 class StructuredDtypeBase:
     @classmethod
-    def setup_class(self):
-        self.dtype = np.dtype([("a", "f8"), ("b", "(2,2)f8")])
+    def setup_class(cls):
+        cls.dtype = np.dtype([("a", "f8"), ("b", "(2,2)f8")])
         data = np.arange(5.0) + (np.arange(60.0) * 10).reshape(3, 4, 5, 1)
-        self.distribution = data.view(self.dtype).reshape(3, 4, 5)
-        self.d = Distribution(self.distribution)
+        cls.distribution = data.view(cls.dtype).reshape(3, 4, 5)
+        cls.d = Distribution(cls.distribution)
 
 
 class TestStructuredQuantityDistributionInit(StructuredDtypeBase):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.unit = u.Unit("km, m")
-        self.d_unit = self.unit
+        cls.unit = u.Unit("km, m")
+        cls.d_unit = cls.unit
 
     def test_init_via_structured_samples(self):
         distribution = self.distribution << self.unit
@@ -634,10 +634,10 @@ class TestStructuredAdvancedIndex(StructuredDtypeBase, TestGetSetItemAdvancedInd
 
 class TestStructuredDistribution(StructuredDtypeBase):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.item = (0.0, [[-1.0, -2.0], [-3.0, -4.0]])
-        self.b_item = [[-1.0, -2.0], [-3.0, -4.0]]
+        cls.item = (0.0, [[-1.0, -2.0], [-3.0, -4.0]])
+        cls.b_item = [[-1.0, -2.0], [-3.0, -4.0]]
 
     @pytest.mark.parametrize("item", [-2, slice(1, 3), "a", "b"])
     def test_getitem(self, item):
@@ -682,9 +682,9 @@ class TestStructuredDistribution(StructuredDtypeBase):
 
 class TestStructuredQuantityDistribution(TestStructuredDistribution):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.distribution = self.distribution * u.Unit("km,m")
-        self.d = self.d * u.Unit("km,m")
-        self.item = self.item * u.Unit("Mm,km")
-        self.b_item = self.b_item * u.km
+        cls.distribution = cls.distribution * u.Unit("km,m")
+        cls.d = cls.d * u.Unit("km,m")
+        cls.item = cls.item * u.Unit("Mm,km")
+        cls.b_item = cls.b_item * u.km

--- a/astropy/uncertainty/tests/test_functions.py
+++ b/astropy/uncertainty/tests/test_functions.py
@@ -17,27 +17,27 @@ from astropy.uncertainty import Distribution
 
 class ArraySetup:
     @classmethod
-    def setup_class(self):
-        self.a = (
+    def setup_class(cls):
+        cls.a = (
             np.array([[[0.0]], [[10.0]]])
             + np.array([[0.0], [1.0], [2.0]])
             + np.arange(4.0) / 10.0
         )
-        self.b = -(np.arange(3.0, 6.0)[:, np.newaxis] + np.arange(4.0) / 10.0)
-        self.da = Distribution(self.a)
-        self.db = Distribution(self.b)
-        self.c = np.array([[200.0], [300.0]])
+        cls.b = -(np.arange(3.0, 6.0)[:, np.newaxis] + np.arange(4.0) / 10.0)
+        cls.da = Distribution(cls.a)
+        cls.db = Distribution(cls.b)
+        cls.c = np.array([[200.0], [300.0]])
 
 
 class QuantitySetup(ArraySetup):
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         super().setup_class()
-        self.a <<= u.m
-        self.b <<= u.km
-        self.da <<= u.m
-        self.db <<= u.km
-        self.c <<= u.Mm
+        cls.a <<= u.m
+        cls.b <<= u.km
+        cls.da <<= u.m
+        cls.db <<= u.km
+        cls.c <<= u.Mm
 
 
 class TestConcatenation(ArraySetup):

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -228,11 +228,11 @@ class ParentAttribute:
 
 
 class DataInfoMeta(type):
-    def __new__(mcls, name, bases, dct):
+    def __new__(cls, name, bases, dct):
         # Ensure that we do not gain a __dict__, which would mean
         # arbitrary attributes could be set.
         dct.setdefault("__slots__", [])
-        return super().__new__(mcls, name, bases, dct)
+        return super().__new__(cls, name, bases, dct)
 
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -121,7 +121,7 @@ def test_IERS_B_old_style_excerpt(path_transform):
 
 class TestIERS_AExcerpt:
     @classmethod
-    def teardown_class(self):
+    def teardown_class(cls):
         iers.IERS_A.close()
 
     def test_simple(self):
@@ -201,7 +201,7 @@ class TestIERS_AExcerpt:
 
 class TestIERS_A:
     @classmethod
-    def teardown_class(self):
+    def teardown_class(cls):
         iers.IERS_A.close()
 
     def test_simple(self):


### PR DESCRIPTION
### Description
Follow up to #17291 and #17292, ref https://github.com/astropy/astropy/pull/17016#discussion_r1807002358

This one finishes the job at the package level. I'm hoping the footprint is small enough that it can be merged quickly still.
Happy to split this PR to the sub package level otherwise.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
