### PR TITLE
SEC: fix security breaches in GHA workflows detected with zizmor

### DIFF
--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -70,6 +70,8 @@ jobs:
           OMP_NUM_THREADS: 1
           ASV_FACTOR: 1.3
           ASV_SKIP_SLOW: 1
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_LABEL: ${{ github.event.pull_request.base.label }}
         run: |
           set -x
           python -m pip install asv virtualenv packaging
@@ -79,12 +81,12 @@ jobs:
           # ID this runner
           python -m asv machine --yes --conf asv.ci.conf.json
 
-          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
-          echo "Contender: ${GITHUB_SHA} (${{ github.event.pull_request.head.label }})"
+          echo "Baseline:  ${BASE_SHA} (${BASE_LABEL})"
+          echo "Contender: ${GITHUB_SHA} (${BASE_LABEL})"
 
           # Run benchmarks for current commit against base
           ASV_OPTIONS="--split --show-stderr --factor $ASV_FACTOR --conf asv.ci.conf.json"
-          python -m asv continuous $ASV_OPTIONS ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA}
+          python -m asv continuous $ASV_OPTIONS ${BASE_SHA} ${GITHUB_SHA}
 
       - name: "Check ccache performance"
         shell: bash -l {0}

--- a/.github/workflows/ci_benchmark.yml
+++ b/.github/workflows/ci_benchmark.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -75,6 +75,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
+        persist-credentials: false
         fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
@@ -118,6 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: uraimo/run-on-arch-action@5397f9e30a9b62422f302092631c99ae1effcd9e # v2.8.1
         name: Run tests
@@ -182,6 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
     - opened
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
     - opened
 

--- a/.github/workflows/update_astropy_iers_data_pin.yml
+++ b/.github/workflows/update_astropy_iers_data_pin.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:


### PR DESCRIPTION
### Description
This fixes a couple security issues I found using [`zizmor`](https://github.com/woodruffw/zizmor).

One more issue remains unadressed because I do not understand what the problem is or how to address it. Here's the current output:

```
❯ zizmor .github/workflows
🌈 completed ci_cron_daily.yml
🌈 completed check_milestone.yml
🌈 completed publish.yml
🌈 completed ci_benchmark.yml
🌈 completed codeql-analysis.yml
🌈 completed update_astropy_iers_data_pin.yml
🌈 completed stalebot.yml
🌈 completed ci_cron_weekly.yml
🌈 completed open_actions.yml
🌈 completed CFF-test.yml
🌈 completed check_changelog.yml
🌈 completed ci_workflows.yml
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> /Users/clm/dev/astropy-project/coordinated/astropy/.github/workflows/open_actions.yml:3:1
  |
3 | / on:
4 | |   issues:
... |
8 | |     types:
9 | |     - opened
  | |____________^ pull_request_target is almost always used insecurely
  |

1 findings (0 unknown, 0 informational, 0 low, 0 medium, 1 high)
```



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
