### PR TITLE
fix overflow with VLA columns and numpy 2

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -2271,6 +2271,16 @@ def _makep(array, descr_output, format, nrows=None):
         nelem = data_output[idx].shape
         descr_output[idx, 0] = np.prod(nelem)
         descr_output[idx, 1] = _offset
+
+        # detect overflow when using P format
+        if (
+            descr_output.dtype == np.int32
+            and int(descr_output[idx, 0]) * _nbytes >= 2**31
+        ):
+            raise ValueError(
+                "The heapsize limit for 'P' format has been reached. "
+                "Please consider using the 'Q' format for your file."
+            )
         _offset += descr_output[idx, 0] * _nbytes
 
     return data_output

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1123,11 +1123,7 @@ class FITS_rec(np.recarray):
                 # Even if this VLA has not been read or updated, we need to
                 # include the size of its constituent arrays in the heap size
                 # total
-                if type(recformat) == _FormatP and heapsize >= 2**31:
-                    raise ValueError(
-                        "The heapsize limit for 'P' format has been reached. "
-                        "Please consider using the 'Q' format for your file."
-                    )
+
             if isinstance(recformat, _FormatX) and name in self._converted:
                 _wrapx(self._converted[name], raw_field, recformat.repeat)
                 continue

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3234,13 +3234,10 @@ class TestVLATables(FitsTestCase):
 
         col = fits.Column(name="MATRIX", format=f"PD({nelem})", unit="", array=matrix)
 
-        t = fits.BinTableHDU.from_columns([col])
-        t.name = "MATRIX"
-
         with pytest.raises(
             ValueError, match="Please consider using the 'Q' format for your file."
         ):
-            t.writeto(self.temp("matrix.fits"))
+            fits.BinTableHDU.from_columns([col])
 
     @pytest.mark.skipif(sys.maxsize < 2**32, reason="requires 64-bit system")
     @pytest.mark.skipif(sys.platform == "win32", reason="Cannot test on Windows")

--- a/docs/changes/io.fits/17328.bugfix.rst
+++ b/docs/changes/io.fits/17328.bugfix.rst
@@ -1,0 +1,1 @@
+Fix overflow error with Numpy 2 and VLA columns using P format.


### PR DESCRIPTION
Encountered this error while running huge mem tests:
```
❯ pytest astropy/io/fits/tests/test_table.py -k test_heapsize_P_limit --run-hugemem
...

            nelem = data_output[idx].shape
            descr_output[idx, 0] = np.prod(nelem)
            descr_output[idx, 1] = _offset
>           _offset += descr_output[idx, 0] * _nbytes
E           RuntimeWarning: overflow encountered in scalar multiply

astropy/io/fits/column.py:2274: RuntimeWarning
=================================== short test summary info ====================================
FAILED astropy/io/fits/tests/test_table.py::TestVLATables::test_heapsize_P_limit - RuntimeWarning: overflow encountered in scalar multiply
```

This happens with the test added in #13429 when the VLA column is too big to fit with the P format (int32). #13429 added a check for this but it happens later when writing the file. Numpy 2 now prevents overflows and so raises an error while building the FITS_rec.

Current fix is just a dirty way to make the test pass but adding another row to the VLA column would raise another error (OverflowError from Numpy) so we need a better fix. I think we can just detect the overflow and raise an error here instead of where it's done in #13429. 
This is not critical for the release since a user doing that would just get an error in any case, just opening the PR so this is not forgotten. 