### PR TITLE
BUG: ensure scalar quantity indices work

### DIFF
--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -848,7 +848,8 @@ class TableLoc:
             stop = MaxValue() if item.stop is None else item.stop
             rows = index.range((start,), (stop,))
         else:
-            if not isinstance(item, (list, np.ndarray)):  # single element
+            if not (isinstance(item, list) or getattr(item, "shape", ())):
+                # single element
                 item = [item]
             # item should be a list or ndarray of values
             rows = []

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -623,3 +623,12 @@ def test_nd_columun_as_index(masked):
         ValueError, match="Multi-dimensional column 'arr' cannot be used as an index."
     ):
         t.add_index("arr")
+
+
+def test_quantity_column_as_index():
+    # Regression test for https://github.com/astropy/astropy/issues/16036
+    t = QTable({"a": u.Quantity([0, 1], unit="m"), "b": [1, 2]})
+    t.add_index(["a"])
+    sel = t.loc[t["a"][0]]
+    assert sel.index == 0
+    assert sel["b"] == 1

--- a/docs/changes/table/17329.bugfix.rst
+++ b/docs/changes/table/17329.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that for a ``QTable`` with a ``Quantity`` column as an index,
+a scalar quantity index works as expected.


### PR DESCRIPTION
This pull request ensures that if one has a `QTable` with an quantity as an index, one can use scalar `Quantity` as needed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16036

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
