### PR TITLE
Update docs  to reflect default `Table.meta` is now `dict`

### DIFF
--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -178,7 +178,7 @@ Accessing Properties
 
 The code below shows accessing the table columns as a |TableColumns| object,
 getting the column names, table metadata, and number of table rows. The table
-metadata is an `~collections.OrderedDict` by default.
+metadata is a :class:`dict` by default.
 ::
 
   >>> t.columns

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -720,10 +720,10 @@ meta
 ----
 
 The ``meta`` argument is an object that contains metadata associated with the
-table. It is recommended that this object be a :class:`dict` or
-:class:`~collections.OrderedDict`, but the only firm requirement is that it can
+table. It is recommended that this object be a :class:`dict`, but the
+only firm requirement is that it *must be a dict-like mapping* and can
 be copied with the standard library :func:`copy.deepcopy` routine. By
-default, ``meta`` is an empty :class:`~collections.OrderedDict`.
+default, ``meta`` is an empty :class:`dict`.
 
 copy
 ----


### PR DESCRIPTION
### Description
Catching up with the default initialisation that was changed from `OrderedDict` in #16250

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.