### PR TITLE
RFC: replace deprecated `matplotlib.pyplot.plot_date` function in docs and tests

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -943,18 +943,19 @@ class TimeGPS(TimeFromEpoch):
 
 class TimePlotDate(TimeFromEpoch):
     """
-    Matplotlib `~matplotlib.pyplot.plot_date` input:
+    Input for a `~matplotlib.axes.Axes` object with ax.xaxis.axis_date():
     1 + number of days from 0001-01-01 00:00:00 UTC.
 
-    This can be used directly in the matplotlib `~matplotlib.pyplot.plot_date`
-    function::
+    This can be used as follow::
 
       >>> import matplotlib.pyplot as plt
       >>> jyear = np.linspace(2000, 2001, 20)
       >>> t = Time(jyear, format='jyear', scale='utc')
-      >>> plt.plot_date(t.plot_date, jyear)
-      >>> plt.gcf().autofmt_xdate()  # orient date labels at a slant
-      >>> plt.draw()
+      >>> fig, ax = plt.subplots()
+      >>> ax.xaxis.axis_date()
+      >>> ax.scatter(t.plot_date, jyear)
+      >>> fig.autofmt_xdate()  # orient date labels at a slant
+      >>> fig.show()
 
     For example, 730120.0003703703 is midnight on January 1, 2000.
     """

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -417,8 +417,10 @@ radial velocity of 10 km/s:
                radial_velocity=[10]*1000*u.km/u.s,
                location=location, obstime=time)
     gcrs = aa.transform_to(GCRS(obstime=time))
-    plt.plot_date(time.plot_date, gcrs.radial_velocity.to(u.km/u.s))
-    plt.ylabel('RV [km/s]')
+
+    fig, ax = plt.subplots()
+    ax.scatter(time.datetime, gcrs.radial_velocity.to(u.km / u.s))
+    ax.set_ylabel("RV [km/s]")
 
 This seems plausible: the radial velocity should indeed be very close to 10 km/s
 because the frame does not involve a velocity shift.
@@ -436,8 +438,9 @@ the same: the radial velocity should be essentially the same in both frames:
                radial_velocity=[10]*1000*u.km/u.s,
                location=location, obstime=time)
     gcrs = aa.transform_to(GCRS(obstime=time))
-    plt.plot_date(time.plot_date, gcrs.radial_velocity.to(u.km/u.s))
-    plt.ylabel('RV [km/s]')
+
+    ax.scatter(time.datetime, gcrs.radial_velocity.to(u.km / u.s))
+    ax.set_ylabel("RV [km/s]")
 
 But this result is nonsense, with values from -1000 to 1000 km/s instead of the
 ~10 km/s we expected. The root of the problem here is that the machine

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1013,9 +1013,10 @@ To get the representation of a |Time| object::
   >>> import matplotlib.pyplot as plt  # doctest: +SKIP
   >>> jyear = np.linspace(2000, 2001, 20)  # doctest: +SKIP
   >>> t = Time(jyear, format='jyear')  # doctest: +SKIP
-  >>> plt.plot_date(t.plot_date, jyear)  # doctest: +SKIP
-  >>> plt.gcf().autofmt_xdate()  # orient date labels at a slant  # doctest: +SKIP
-  >>> plt.draw()  # doctest: +SKIP
+  >>> fig, ax = plt.subplots()  # doctest: +SKIP
+  >>> ax.scatter(t.datetime, jyear)  # doctest: +SKIP
+  >>> fig.autofmt_xdate()  # orient date labels at a slant  # doctest: +SKIP
+  >>> fig.show()  # doctest: +SKIP
 
 .. EXAMPLE END
 


### PR DESCRIPTION
### Description
Fixes #17317

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
