### PR TITLE
Backport PR #17327 on branch v6.1.x (TST: filter hypothesis healchecks on double tests)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -44,7 +44,13 @@ def pytest_report_header(config):
 # `pytest --hypothesis-profile=fuzz ...` argument.
 
 hypothesis.settings.register_profile(
-    "ci", deadline=None, print_blob=True, derandomize=True
+    "ci",
+    deadline=None,
+    print_blob=True,
+    derandomize=True,
+    # disabling HealthCheck.differing_executors to allow double test
+    # see https://github.com/astropy/astropy/issues/17299
+    suppress_health_check=[hypothesis.HealthCheck.differing_executors],
 )
 hypothesis.settings.register_profile(
     "fuzzing", deadline=None, print_blob=True, max_examples=1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
-    "hypothesis!=6.116.0", # https://github.com/astropy/astropy/issues/17299
     "pytest-doctestplus>=0.12",
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10",


### PR DESCRIPTION
### Description
Manual backport for #17327

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
