### PR TITLE
Improve unit formatter type annotations

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import numpy as np
 
     from astropy.units import NamedUnit, UnitBase
-    from astropy.units.typing import Real, UnitPower
+    from astropy.units.typing import UnitPower
 
 
 class Base:
@@ -110,7 +110,7 @@ class Base:
         )
 
     @classmethod
-    def _format_unit_list(cls, units: Iterable[tuple[NamedUnit, Real]]) -> str:
+    def _format_unit_list(cls, units: Iterable[tuple[NamedUnit, UnitPower]]) -> str:
         return cls._space.join(
             cls._format_unit_power(base_, power) for base_, power in units
         )

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import numpy as np
 
     from astropy.units import NamedUnit, UnitBase
-    from astropy.units.typing import UnitPower
+    from astropy.units.typing import UnitPower, UnitScale
 
 
 class Base:
@@ -52,7 +52,7 @@ class Base:
 
     @classmethod
     def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = ".8g"
+        cls, val: UnitScale | np.number, format_spec: str = ".8g"
     ) -> str:
         """
         Formats a value in exponential notation.

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
     from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
+    from astropy.units.typing import UnitScale
     from astropy.utils.parsing import ThreadSafeParser
 
 
@@ -277,7 +278,7 @@ class CDS(FITS):
 
     @classmethod
     def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = ".8g"
+        cls, val: UnitScale | np.number, format_spec: str = ".8g"
     ) -> str:
         return super(Generic, cls).format_exponential_notation(val, format_spec)
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
     from astropy.extern.ply.lex import Lexer, LexToken
     from astropy.units import CompositeUnit, NamedUnit, UnitBase
+    from astropy.units.typing import UnitScale
     from astropy.utils.parsing import ThreadSafeParser
 
 
@@ -655,6 +656,6 @@ class Generic(Base):
 
     @classmethod
     def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = "g"
+        cls, val: UnitScale | np.number, format_spec: str = "g"
     ) -> str:
         return format(val, format_spec)

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
     from astropy.units import NamedUnit, UnitBase
-    from astropy.units.typing import Real
+    from astropy.units.typing import UnitPower
 
 
 class Latex(console.Console):
@@ -39,7 +39,7 @@ class Latex(console.Console):
         return f"^{{{number}}}"
 
     @classmethod
-    def _format_unit_power(cls, unit: NamedUnit, power: Real = 1) -> str:
+    def _format_unit_power(cls, unit: NamedUnit, power: UnitPower = 1) -> str:
         name = unit._get_format_name("latex")
         if name == unit.name:
             # This doesn't escape arbitrary LaTeX strings, but it should

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from typing import ClassVar
 
     from astropy.units import NamedUnit
-    from astropy.units.typing import Real
+    from astropy.units.typing import UnitPower
 
 
 class Unicode(console.Console):
@@ -43,7 +43,7 @@ class Unicode(console.Console):
         return m.replace("-", "−")
 
     @classmethod
-    def _format_unit_power(cls, unit: NamedUnit, power: Real = 1) -> str:
+    def _format_unit_power(cls, unit: NamedUnit, power: UnitPower = 1) -> str:
         name = unit._get_format_name(cls.name)
         # Check for superscript units
         if power != 1:

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     from astropy.extern.ply.lex import LexToken
     from astropy.units import NamedUnit, UnitBase
+    from astropy.units.typing import UnitScale
 
 
 class VOUnit(FITS):
@@ -186,7 +187,7 @@ class VOUnit(FITS):
 
     @classmethod
     def format_exponential_notation(
-        cls, val: float | np.number, format_spec: str = ".8g"
+        cls, val: UnitScale | np.number, format_spec: str = ".8g"
     ) -> str:
         return super().format_exponential_notation(val, format_spec)
 

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -92,6 +92,8 @@ py:class ArrayLike
 py:class np.ma.MaskedArray
 # locally defined type variable for ndarray dtype
 py:class DT
+# type aliases
+py:class UnitScale
 
 # Classes from `astropy.extern` that are nonetheless exposed in documentation
 py:class Lexer


### PR DESCRIPTION
### Description

I've made a few small improvements that make the unit formatter code friendlier towards type checkers without complicating anything for human readers. Most of the updates only affect annotations, ~but there are a couple of simple code changes too.~

EDIT: It is better to discuss how `to_string()` methods handle the `fraction` parameter in a separate pull request.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
