### PR TITLE
Add groups to VOTables.Resource.to_xml()

### DIFF
--- a/astropy/io/votable/tests/test_resource.py
+++ b/astropy/io/votable/tests/test_resource.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # LOCAL
+import io
+
 from astropy.io.votable import parse
 from astropy.utils.data import get_pkg_data_filename
 
@@ -7,6 +9,31 @@ from astropy.utils.data import get_pkg_data_filename
 def test_resource_groups():
     # Read the VOTABLE
     votable = parse(get_pkg_data_filename("data/resource_groups.xml"))
+
+    resource = votable.resources[0]
+    groups = resource.groups
+    params = resource.params
+
+    # Test that params inside groups are not outside
+
+    assert len(groups[0].entries) == 1
+    assert groups[0].entries[0].name == "ID"
+
+    assert len(params) == 2
+    assert params[0].name == "standardID"
+    assert params[1].name == "accessURL"
+
+
+def test_roundtrip():
+    # Issue #16511 VOTable writer does not write out GROUPs within RESOURCEs
+
+    # Read the VOTABLE
+    votable = parse(get_pkg_data_filename("data/resource_groups.xml"))
+
+    bio = io.BytesIO()
+    votable.to_xml(bio)
+    bio.seek(0)
+    votable = parse(bio)
 
     resource = votable.resources[0]
     groups = resource.groups

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3969,13 +3969,16 @@ class Resource(
                 w.element("DESCRIPTION", self.description, wrap=True)
             if self.mivot_block is not None and self.type == "meta":
                 self.mivot_block.to_xml(w)
-            for element_set in (
+            element_sets = [
                 self.coordinate_systems,
                 self.time_systems,
                 self.params,
                 self.infos,
                 self.links,
-            ):
+            ]
+            if kwargs["version_1_2_or_later"]:
+                element_sets.append(self.groups)
+            for element_set in element_sets:
                 for element in element_set:
                     element.to_xml(w, **kwargs)
 

--- a/docs/changes/io.votable/17344.bugfix.rst
+++ b/docs/changes/io.votable/17344.bugfix.rst
@@ -1,0 +1,1 @@
+Updated xml writer for VOTable Resource elements to include groups.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address VOTable failing to write GROUPs contained within RESOURCEs when writing to xml. This mimics the behavior of `VOTableFile.to_xml()` by adding `self.groups` to `element_sets`. 

A related issue, in the VOTable Format Definition document the Version History (Section 9.1) suggests that COOSYS was deprecated in VOTable v1.2, but it remains defined in Section 3.4 without note of deprecation, and in the Element Hierarchy in section 7.1 without the deprecation symbol. The current COOSYS tests place all COOSYS elements in RESOURCE elements, and any COOSYS elements placed outside of a RESOURCE element would be dropped as written as `VOTableFile.to_xml()` replaces `self.coordinate_systems` with `self.groups` if the version is 1.2 or later. Should this PR update Resource writer to have the same behavior and remove/rewrite the COOSYS tests, or leave `coordinate_systems` in place to be replaced later by another PR?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16511
