### PR TITLE
BUG: make `TimeSeries.from_pandas` and `BinnedTimeSeries.read` more robust to subclassing

### DIFF
--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -394,7 +394,7 @@ class BinnedTimeSeries(BaseTimeSeries):
                 time_bin_end = None
 
             if time_bin_start.isscalar and time_bin_size.isscalar:
-                return BinnedTimeSeries(
+                return cls(
                     data=table,
                     time_bin_start=time_bin_start,
                     time_bin_end=time_bin_end,
@@ -402,7 +402,7 @@ class BinnedTimeSeries(BaseTimeSeries):
                     n_bins=len(table),
                 )
             else:
-                return BinnedTimeSeries(
+                return cls(
                     data=table,
                     time_bin_start=time_bin_start,
                     time_bin_end=time_bin_end,

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -338,7 +338,7 @@ class TimeSeries(BaseTimeSeries):
         time = Time(df.index, scale=time_scale)
         table = Table.from_pandas(df)
 
-        return TimeSeries(time=time, data=table)
+        return cls(time=time, data=table)
 
     def to_pandas(self):
         """
@@ -431,4 +431,4 @@ class TimeSeries(BaseTimeSeries):
                     f"Time column '{time_column}' not found in the input data."
                 )
 
-            return TimeSeries(time=time, data=table)
+            return cls(time=time, data=table)

--- a/docs/changes/timeseries/17351.bugfix.rst
+++ b/docs/changes/timeseries/17351.bugfix.rst
@@ -1,0 +1,2 @@
+Made ``TimeSeries.from_pandas`` and ``BinnedTimeSeries.read`` more robust to
+subclassing.


### PR DESCRIPTION
### Description
Extracted from #17314


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
