### PR TITLE
BUG: fix calling `np.nanvar` and `np.nanstd` with `Quantity` inputs + an `out` argument

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -218,7 +218,6 @@ dispatched_function = FunctionAssigner(DISPATCHED_FUNCTIONS)
         np.fft.fft2, np.fft.ifft2, np.fft.rfft2, np.fft.irfft2,
         np.fft.fftn, np.fft.ifftn, np.fft.rfftn, np.fft.irfftn,
         np.fft.hfft, np.fft.ihfft,
-        np.nanstd,  # See comment on nanvar helper.
         np.linalg.eigvals, np.linalg.eigvalsh,
     } | ({np.asfarray} if NUMPY_LT_2_0 else set())  # noqa: NPY201
 )  # fmt: skip
@@ -252,15 +251,45 @@ def like_helper(a, *args, **kwargs):
     return (a.view(np.ndarray),) + args, kwargs, unit, None
 
 
+def _quantity_out_as_array(out):
+    from astropy.units import Quantity
+
+    if isinstance(out, Quantity):
+        return out.view(np.ndarray)
+    else:
+        # TODO: for an ndarray output, one could in principle
+        # try converting the input to dimensionless.
+        raise NotImplementedError
+
+
 # nanvar is safe for Quantity and was previously in SUBCLASS_FUNCTIONS, but it
 # is not safe for Angle, since the resulting unit is inconsistent with being
 # an Angle. By using FUNCTION_HELPERS, the unit gets passed through
 # _result_as_quantity, which will correctly drop to Quantity.
 # A side effect would be that np.nanstd then also produces Quantity; this
-# is avoided by it being helped by invariant_a_helpers above.
+# is avoided by it being helped below.
 @function_helper
-def nanvar(a, *args, **kwargs):
-    return (a.view(np.ndarray),) + args, kwargs, a.unit**2, None
+def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, **kwargs):
+    a = _as_quantity(a)
+    out_array = None if out is None else _quantity_out_as_array(out)
+    return (
+        (a.view(np.ndarray), axis, dtype, out_array, ddof, keepdims),
+        kwargs,
+        a.unit**2,
+        out,
+    )
+
+
+@function_helper
+def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, **kwargs):
+    a = _as_quantity(a)
+    out_array = None if out is None else _quantity_out_as_array(out)
+    return (
+        (a.view(np.ndarray), axis, dtype, out_array, ddof, keepdims),
+        kwargs,
+        a.unit,
+        out,
+    )
 
 
 @function_helper
@@ -424,15 +453,8 @@ def _quantities2arrays(*args, unit_from_first=False):
 
 def _iterable_helper(*args, out=None, **kwargs):
     """Convert arguments to Quantity, and treat possible 'out'."""
-    from astropy.units import Quantity
-
     if out is not None:
-        if isinstance(out, Quantity):
-            kwargs["out"] = out.view(np.ndarray)
-        else:
-            # TODO: for an ndarray output, we could in principle
-            # try converting all Quantity to dimensionless.
-            raise NotImplementedError
+        kwargs["out"] = _quantity_out_as_array(out)  # raises if not Quantity.
 
     arrays, unit = _quantities2arrays(*args)
     return arrays, kwargs, unit, out
@@ -867,19 +889,13 @@ def cross_like_a_v(a, v, *args, **kwargs):
 
 @function_helper
 def einsum(*operands, out=None, **kwargs):
-    from astropy.units import Quantity
-
     subscripts, *operands = operands
 
     if not isinstance(subscripts, str):
         raise ValueError('only "subscripts" string mode supported for einsum.')
 
     if out is not None:
-        if not isinstance(out, Quantity):
-            raise NotImplementedError
-
-        else:
-            kwargs["out"] = out.view(np.ndarray)
+        kwargs["out"] = _quantity_out_as_array(out)
 
     qs = _as_quantities(*operands)
     unit = functools.reduce(operator.mul, (q.unit for q in qs), dimensionless_unscaled)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1280,10 +1280,52 @@ class TestNanFunctions(InvariantUnitTestSetup):
     def test_nanstd(self):
         self.check(np.nanstd)
 
+    @pytest.mark.parametrize(
+        "out_init",
+        [
+            pytest.param(u.Quantity(-1, "m"), id="out with coorect unit"),
+            # this should work too: out.unit will be overridden
+            pytest.param(u.Quantity(-1), id="out with a different unit"),
+        ],
+    )
+    def test_nanstd_out(self, out_init):
+        out = out_init.copy()
+        o = np.nanstd(self.q, out=out)
+        assert o is out
+        assert o == np.nanstd(self.q)
+
+        # Also check array input, Quantity output.
+        out = out_init.copy()
+        o2 = np.nanstd(self.q.value, out=out)
+        assert o2 is out
+        assert o2.unit == u.dimensionless_unscaled
+        assert o2 == np.nanstd(self.q.value)
+
     def test_nanvar(self):
         out = np.nanvar(self.q)
         expected = np.nanvar(self.q.value) * self.q.unit**2
         assert np.all(out == expected)
+
+    @pytest.mark.parametrize(
+        "out_init",
+        [
+            pytest.param(u.Quantity(-1, "m"), id="out with coorect unit"),
+            # this should work too: out.unit will be overridden
+            pytest.param(u.Quantity(-1), id="out with a different unit"),
+        ],
+    )
+    def test_nanvar_out(self, out_init):
+        out = out_init.copy()
+        o = np.nanvar(self.q, out=out)
+        assert o is out
+        assert o == np.nanvar(self.q)
+
+        # Also check array input, Quantity output.
+        out = out_init.copy()
+        o2 = np.nanvar(self.q.value, out=out)
+        assert o2 is out
+        assert o2.unit == u.dimensionless_unscaled
+        assert o2 == np.nanvar(self.q.value)
 
     def test_nanprod(self):
         with pytest.raises(u.UnitsError):

--- a/docs/changes/units/17354.bugfix.rst
+++ b/docs/changes/units/17354.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed calling ``np.nanvar`` and ``np.nanstd`` with ``Quantity`` ``out`` argument.


### PR DESCRIPTION
### Description
Fixes #17353

Given this was a *regression* in astropy 6.1.5, I would be tempted to propose a hotfix 6.1.6 release, so I'm requesting a review from the release team.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
