### PR TITLE
Allow `Unit` to create dimensionless units with complex or rational scale factors

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -10,6 +10,7 @@ import inspect
 import operator
 import textwrap
 import warnings
+from fractions import Fraction
 from functools import cached_property
 from threading import RLock
 from typing import TYPE_CHECKING
@@ -2132,7 +2133,8 @@ class _UnitMetaClass(type):
                     warnings.warn(msg, UnitsWarning)
                 return UnrecognizedUnit(s)
 
-        elif isinstance(s, (int, float, np.floating, np.integer)):
+        # can't use units.typing.Complex because of an import loop
+        elif isinstance(s, (int, float, complex, Fraction, np.number)):
             return CompositeUnit(s, [], [])
 
         elif isinstance(s, tuple):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -36,7 +36,6 @@ def test_initialisation():
     assert u.Unit("") == u.dimensionless_unscaled
     assert u.one == u.dimensionless_unscaled
     assert u.Unit("10 m") == ten_meter
-    assert u.Unit(10.0) == u.CompositeUnit(10.0, [], [])
 
     assert u.Unit() == u.dimensionless_unscaled
 
@@ -1120,3 +1119,22 @@ def test_error_on_conversion_of_zero_to_unit():
 )
 def test_scale_sanitization(unsanitized, sanitized):
     assert u.CompositeUnit(unsanitized, [u.m], [1]).scale == sanitized
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        5,
+        10.0,
+        7 + 3j,
+        Fraction(1, 3),
+        np.int32(100),
+        np.float32(0.01),
+        np.complex128(1 - 4j),
+    ],
+    ids=type,
+)
+def test_dimensionless_scale_factor_types(scale):
+    # Regression test for #17355 - Unit did not accept all scale factor
+    # types that CompositeUnit accepted
+    assert u.Unit(scale) == u.CompositeUnit(scale, [], [])

--- a/docs/changes/units/17355.bugfix.rst
+++ b/docs/changes/units/17355.bugfix.rst
@@ -1,0 +1,3 @@
+It is now possible to use ``Unit`` to create dimensionless units with a scale
+factor that is a complex number or a ``fractions.Fraction`` instance.
+It was already possible to create such units directly with ``CompositeUnit``.


### PR DESCRIPTION
### Description

It is possible to create dimensionless units with scale factors that are complex numbers or `fractions.Fraction` instances by creating `CompositeUnit` instances directly:
```python
>>> from fractions import Fraction
>>> import numpy as np
>>> from astropy import units as u
>>> u.CompositeUnit(Fraction(1, 3), [], [])
Unit(dimensionless with a scale of 1/3)
>>> u.CompositeUnit(np.complex128(1j), [], [])
Unit(dimensionless with a scale of 1j)
>>> u.CompositeUnit(1j, [], [])
Unit(dimensionless with a scale of 1j)
```
But it is not possible to create such units through `Unit`:
```python
>>> Unit(Fraction(1, 3))
Traceback (most recent call last):
  ...
TypeError: 1/3 can not be converted to a Unit
>>> u.Unit(np.complex128(1j))
Traceback (most recent call last):
  ...
TypeError: 1j can not be converted to a Unit
>>> u.Unit(1j)
Traceback (most recent call last):
  ...
TypeError: 1j can not be converted to a Unit
```
The cause of this inconsistency is a needlessly restrictive `isinstance()` check.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
