### PR TITLE
Fix writing COOSYS elements from votable to xml

### DIFF
--- a/astropy/io/votable/tests/data/coosys.xml
+++ b/astropy/io/votable/tests/data/coosys.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" version="1.5">
+  <COOSYS ID="coosys0" system="ICRS" equinox="J2000" epoch="J2014.5"  refposition="BARYCENTER"/>
   <RESOURCE>
   <!-- "equinox", "epoch", "system", "refposition" -->
     <COOSYS ID="coosys1" system="ICRS" equinox="J2000" epoch="J2015.5"  refposition="BARYCENTER"/>
     <COOSYS ID="coosys2" system="FK4" equinox="B1950" epoch="B1950.0"  refposition="UNKNOWN"/>
     <TABLE name="sources">
-      <FIELD name="RA" ID="ra" ucd="pos.eq.ra;meta.main" datatype="double" unit="deg" ref="my_coosys"/>
-      <FIELD name="Dec" ID="dec" ucd="pos.eq.dec;meta.main" datatype="double" unit="deg" ref="my_coosys"/>
+      <FIELD name="RA" ID="ra" ucd="pos.eq.ra;meta.main" datatype="double" unit="deg" ref="coosys0"/>
+      <FIELD name="Dec" ID="dec" ucd="pos.eq.dec;meta.main" datatype="double" unit="deg" ref="coosys1"/>
+      <FIELD name="OtherDec" ID="other_dec" ucd="pos.eq.dec" datatype="double" unit="deg" ref="coosys2"/>
       <FIELD name="Name" ID="name" ucd="meta.id;meta.main" datatype="char" arraysize="8*"/>
       <DATA>
         <TABLEDATA>
           <TR>
             <TD>010.68</TD>
             <TD>+41.27</TD>
+            <TD>+12.34</TD>
             <TD>N 224</TD>
           </TR>
         </TABLEDATA>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -12,6 +12,7 @@
   itself modeled on the FITS Table format [2]; VOTable was designed to
   be closer to the FITS Binary Table format.
  </DESCRIPTION>
+ <COOSYS ID="J2000" equinox="J2000" system="eq_FK5"/>
  <PARAM ID="wrong_arraysize" arraysize="0" datatype="float" name="wrong_arraysize" value=""/>
  <PARAM ID="INPUT" arraysize="*" datatype="float" name="INPUT" ucd="phys.size;instr.tel" unit="km.h-1" value="0 0">
   <DESCRIPTION>

--- a/astropy/io/votable/tests/test_coosys.py
+++ b/astropy/io/votable/tests/test_coosys.py
@@ -77,7 +77,12 @@ def test_coosys_system():
 
 
 def _coosys_tests(votable):
-    assert len(list(votable.iter_coosys())) == 2
+    assert len(list(votable.iter_coosys())) == 3
+    coosys = votable.get_coosys_by_id("coosys0")
+    assert coosys.system == "ICRS"
+    assert coosys.equinox == "J2000"
+    assert coosys.epoch == "J2014.5"
+    assert coosys.refposition == "BARYCENTER"
 
     coosys = votable.get_coosys_by_id("coosys1")
     assert coosys.system == "ICRS"

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3978,6 +3978,7 @@ class Resource(
             ]
             if kwargs["version_1_2_or_later"]:
                 element_sets.append(self.groups)
+
             for element_set in element_sets:
                 for element in element_set:
                     element.to_xml(w, **kwargs)
@@ -4379,9 +4380,6 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                 ]
                 if kwargs["version_1_2_or_later"]:
                     element_sets.append(self.groups)
-                    if not kwargs["version_1_4_or_later"]:
-                        # COOSYS was deprecated in v1.2, and undeprecated in v1.4
-                        del element_sets[0]
 
                 for element_set in element_sets:
                     for element in element_set:

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -4378,7 +4378,11 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                     self.resources,
                 ]
                 if kwargs["version_1_2_or_later"]:
-                    element_sets[0] = self.groups
+                    element_sets.append(self.groups)
+                    if not kwargs["version_1_4_or_later"]:
+                        # COOSYS was deprecated in v1.2, and undeprecated in v1.4
+                        del element_sets[0]
+
                 for element_set in element_sets:
                     for element in element_set:
                         element.to_xml(w, **kwargs)

--- a/docs/changes/io.votable/17356.bugfix.rst
+++ b/docs/changes/io.votable/17356.bugfix.rst
@@ -1,1 +1,1 @@
-Updated XML writer for ``VOTableFile`` and ``Resource`` elements to include or drop ``coordinate_systems`` depending on VOTable version.
+Updated XML writer for ``VOTableFile`` element to include or drop ``coordinate_systems`` regardless of version.

--- a/docs/changes/io.votable/17356.bugfix.rst
+++ b/docs/changes/io.votable/17356.bugfix.rst
@@ -1,0 +1,1 @@
+Updated XML writer for ``VOTableFile`` and ``Resource`` elements to include or drop ``coordinate_systems`` depending on VOTable version.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address inconsistent handling of COOSYS elements in writing to xml. COOSYS elements were deprecated in v1.2 and undeprecated in v1.4. However, COOSYS elements were being written in RESOURCE elements regardless of version, and base level COOSYS elements were removed from VOTableFile for every version greater than 1.2. <del>This PR implements a version check and removes COOSYS from VOTableFile and RESOURCE elements on writing to xml if the version is 1.2 or 1.3.</del>
Upon further review we've decided that the original removal of the COOSYS from VOTableFile was a mistake, so this PR implements the expected behavior of preserving COOSYS on both VOTableFile and RESOURCE elements regardless of VOTable version.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17348

<!-- Optional opt-out -->
