### PR TITLE
BUG: fix instanciating Angle from a pandas Series

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -184,7 +184,9 @@ class Angle(SpecificTypeQuantity):
                 if angle.dtype.kind in "SUVO":
                     angle = [cls(x, unit, copy=COPY_IF_NEEDED) for x in angle]
 
-            elif hasattr(angle, "__array__"):
+            elif hasattr(angle, "__array__") and (
+                not hasattr(angle, "dtype") or angle.dtype.kind not in "SUVO"
+            ):
                 angle = np.asarray(angle)
 
             elif isiterable(angle):

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -67,6 +67,17 @@ def test_angle_from_pyarrow():
     npt.assert_array_equal(angle.value, input_data)
 
 
+def test_angle_from_pandas():
+    # see https://github.com/astropy/astropy/issues/17357
+    pd = pytest.importorskip("pandas")
+
+    input_data = ["10 0 0", "12 0 0"]
+    df = pd.DataFrame({"angle": input_data})
+    angle = Angle(df["angle"], unit=u.hourangle)
+    expected = Angle(input_data, u.hourangle)
+    npt.assert_array_equal(angle.value, expected.value)
+
+
 def test_dms():
     a1 = Angle([0, 45.5, -45.5], unit=u.degree)
     d, m, s = a1.dms

--- a/docs/changes/coordinates/17358.bugfix.rst
+++ b/docs/changes/coordinates/17358.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed instantiating ``Angle`` from a ``pandas`` ``Series`` object.


### PR DESCRIPTION
### Description

Fixes #17357
(EDIT: updated above number to refer to correct issue that is closed by this PR)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
