### PR TITLE
TST: fix running array repr tests with an ellipsis on numpy 2.2 (dev)

### DIFF
--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -14,6 +14,7 @@ __all__ = [
     "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
+    "NUMPY_LT_2_2",
     "COPY_IF_NEEDED",
 ]
 
@@ -25,6 +26,7 @@ NUMPY_LT_1_25 = not minversion(np, "1.25")
 NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0")
 NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
+NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
-from astropy.utils.compat import NUMPY_LT_2_0
+from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_2
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
 
@@ -1449,8 +1449,13 @@ def test_masked_repr_explicit_structured():
 
 def test_masked_repr_summary():
     ma = Masked(np.arange(15.0), mask=[True] + [False] * 14)
+    if NUMPY_LT_2_2:
+        expected = "MaskedNDArray([———,  1.,  2., ..., 12., 13., 14.])"
+    else:
+        expected = "MaskedNDArray([———,  1.,  2., ..., 12., 13., 14.], shape=(15,))"
+
     with np.printoptions(threshold=2):
-        assert repr(ma) == "MaskedNDArray([———,  1.,  2., ..., 12., 13., 14.])"
+        assert repr(ma) == expected
 
 
 def test_masked_repr_nodata():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,7 @@ doctest_subpackage_requires = [
     "astropy/table/table.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
     "astropy/table/mixins/dask.py = dask",
     "docs/* = numpy>=2",   # not NUMPY_LT_2_0 (PR 15065)
+    "docs/timeseries/index.rst = numpy<2.2.0.dev0",  # NUMPY_LT_2_2 (PR 17364)
     "astropy/stats/info_theory.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/stats/jackknife.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/table/row.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)


### PR DESCRIPTION
### Description
[example logs](https://github.com/astropy/astropy/actions/runs/11763485911/job/32767529277)

xref: https://github.com/numpy/numpy/pull/27482

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
