### PR TITLE
In unit.to_string(), treat fraction='multiline' as a request

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -731,7 +731,8 @@ class UnitBase:
             - `False` : display unit bases with negative powers as they are;
             - 'inline' or `True` : use a single-line fraction;
             - 'multiline' : use a multiline fraction (available for the
-              'latex', 'console' and 'unicode' formats only).
+              'latex', 'console' and 'unicode' formats only; for others,
+              an 'inline' fraction is used).
 
         Raises
         ------

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -48,6 +48,7 @@ class Base:
         return {
             True: cls._format_inline_fraction,
             "inline": cls._format_inline_fraction,
+            "multiline": cls._format_inline_fraction,
         }
 
     @classmethod
@@ -127,7 +128,7 @@ class Base:
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, *, fraction: bool | Literal["inline"] = True
+        cls, unit: UnitBase, *, fraction: bool | Literal["inline", "multiline"] = True
     ) -> str:
         """Convert a unit to its string representation.
 
@@ -143,9 +144,9 @@ class Base:
             - `False` : display unit bases with negative powers as they are
               (e.g., ``km s-1``);
             - 'inline' or `True` : use a single-line fraction (e.g., ``km / s``);
-            - 'multiline' : use a multiline fraction (available for the
-              ``latex``, ``console`` and ``unicode`` formats only; e.g.,
-              ``$\\mathrm{\\frac{km}{s}}$``).
+            - 'multiline' : use a multiline fraction if possible (available for
+              the ``latex``, ``console`` and ``unicode`` formats; e.g.,
+              ``$\\mathrm{\\frac{km}{s}}$``). If not possible, use 'inline'.
 
         Raises
         ------
@@ -191,7 +192,9 @@ class Base:
         except KeyError:
             # We accept Booleans, but don't advertise them in the error message
             *all_but_last, last = (
-                repr(key) for key in cls._fraction_formatters if isinstance(key, str)
+                repr(key)
+                for key in cls._fraction_formatters
+                if isinstance(key, str) and hasattr(cls, f"_format_{key}_fraction")
             )
             supported_formats = (
                 f"{', '.join(all_but_last)} or {last}" if all_but_last else last

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -283,7 +283,7 @@ class CDS(FITS):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline"] = False
+        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
     ) -> str:
         # Remove units that aren't known to the format
         unit = cls._decompose_to_known_units(unit)

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -8,12 +8,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from astropy.utils import classproperty
-
 from . import base
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from typing import ClassVar, Literal
 
     from astropy.units import UnitBase
@@ -39,12 +36,6 @@ class Console(base.Base):
 
     _line: ClassVar[str] = "-"
     _space: ClassVar[str] = " "
-
-    @classproperty(lazy=True)
-    def _fraction_formatters(cls) -> dict[bool | str, Callable[[str, str, str], str]]:
-        return super()._fraction_formatters | {
-            "multiline": cls._format_multiline_fraction
-        }
 
     @classmethod
     def _format_superscript(cls, number: str) -> str:

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -68,7 +68,7 @@ class FITS(generic.Generic):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline"] = False
+        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
     ) -> str:
         # Remove units that aren't known to the format
         unit = cls._decompose_to_known_units(unit)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -342,7 +342,7 @@ class OGIP(FITS):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline"] = "inline"
+        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = "inline"
     ) -> str:
         # Remove units that aren't known to the format
         unit = cls._decompose_to_known_units(unit)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -202,7 +202,7 @@ class VOUnit(FITS):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline"] = False
+        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
     ) -> str:
         # Remove units that aren't known to the format
         unit = cls._decompose_to_known_units(unit)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -583,28 +583,21 @@ def test_format_styles_non_default_fraction(format_spec, fraction, string, decom
     assert fluxunit.decompose().to_string(format_spec, fraction=fraction) == decomposed
 
 
-@pytest.mark.parametrize("format_spec", ["generic", "cds", "fits", "ogip", "vounit"])
-def test_no_multiline_fraction(format_spec):
+@pytest.mark.parametrize("format_spec", u_format.Base.registry.keys())
+def test_multiline_fraction_different_if_available(format_spec):
     fluxunit = u.W / u.m**2
     multiline_format = fluxunit.to_string(format_spec, fraction="multiline")
     inline_format = fluxunit.to_string(format_spec, fraction="inline")
-    assert multiline_format == inline_format
+    if format_spec in ["generic", "cds", "fits", "ogip", "vounit"]:
+        assert multiline_format == inline_format
+    else:
+        assert multiline_format != inline_format
 
 
 @pytest.mark.parametrize("format_spec", u_format.Base.registry.keys())
 def test_unknown_fraction_style(format_spec):
-    if hasattr(u_format.Base.registry[format_spec], "_format_multiline_fraction"):
-        available = "'inline' or 'multiline'"
-    else:
-        available = "'inline'"
     fluxunit = u.W / u.m**2
-    with pytest.raises(
-        ValueError,
-        match=(
-            f"^'{format_spec}' format only supports {available} fractions, "
-            r"not fraction='parrot'\.$"
-        ),
-    ):
+    with pytest.raises(ValueError, match="'parrot'"):
         fluxunit.to_string(format_spec, fraction="parrot")
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -586,23 +586,22 @@ def test_format_styles_non_default_fraction(format_spec, fraction, string, decom
 @pytest.mark.parametrize("format_spec", ["generic", "cds", "fits", "ogip", "vounit"])
 def test_no_multiline_fraction(format_spec):
     fluxunit = u.W / u.m**2
-    with pytest.raises(
-        ValueError,
-        match=(
-            f"^'{format_spec}' format only supports 'inline' fractions, "
-            r"not fraction='multiline'\.$"
-        ),
-    ):
-        fluxunit.to_string(format_spec, fraction="multiline")
+    multiline_format = fluxunit.to_string(format_spec, fraction="multiline")
+    inline_format = fluxunit.to_string(format_spec, fraction="inline")
+    assert multiline_format == inline_format
 
 
-@pytest.mark.parametrize("format_spec", ["latex", "console", "unicode"])
+@pytest.mark.parametrize("format_spec", u_format.Base.registry.keys())
 def test_unknown_fraction_style(format_spec):
+    if hasattr(u_format.Base.registry[format_spec], "_format_multiline_fraction"):
+        available = "'inline' or 'multiline'"
+    else:
+        available = "'inline'"
     fluxunit = u.W / u.m**2
     with pytest.raises(
         ValueError,
         match=(
-            f"^'{format_spec}' format only supports 'inline' or 'multiline' fractions, "
+            f"^'{format_spec}' format only supports {available} fractions, "
             r"not fraction='parrot'\.$"
         ),
     ):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -583,21 +583,24 @@ def test_format_styles_non_default_fraction(format_spec, fraction, string, decom
     assert fluxunit.decompose().to_string(format_spec, fraction=fraction) == decomposed
 
 
-@pytest.mark.parametrize("format_spec", u_format.Base.registry.keys())
+@pytest.mark.parametrize("format_spec", u_format.Base.registry)
 def test_multiline_fraction_different_if_available(format_spec):
     fluxunit = u.W / u.m**2
-    multiline_format = fluxunit.to_string(format_spec, fraction="multiline")
     inline_format = fluxunit.to_string(format_spec, fraction="inline")
     if format_spec in ["generic", "cds", "fits", "ogip", "vounit"]:
+        with pytest.warns(UnitsWarning, match="does not support multiline"):
+            multiline_format = fluxunit.to_string(format_spec, fraction="multiline")
         assert multiline_format == inline_format
     else:
+        multiline_format = fluxunit.to_string(format_spec, fraction="multiline")
         assert multiline_format != inline_format
 
 
-@pytest.mark.parametrize("format_spec", u_format.Base.registry.keys())
+@pytest.mark.parametrize("format_spec", u_format.Base.registry)
 def test_unknown_fraction_style(format_spec):
     fluxunit = u.W / u.m**2
-    with pytest.raises(ValueError, match="'parrot'"):
+    msg = "fraction can only be False, 'inline', or 'multiline', not 'parrot'"
+    with pytest.raises(ValueError, match=msg):
         fluxunit.to_string(format_spec, fraction="parrot")
 
 

--- a/docs/changes/units/17374.api.rst
+++ b/docs/changes/units/17374.api.rst
@@ -1,3 +1,3 @@
 Passing ``fraction='multiline'`` to ``unit.to_string()`` will no longer raise
 an exception if the given format does not support multiline fractions, but
-instead use an inline fraction.
+rather give a warning and use an inline fraction.

--- a/docs/changes/units/17374.api.rst
+++ b/docs/changes/units/17374.api.rst
@@ -1,0 +1,3 @@
+Passing ``fraction='multiline'`` to ``unit.to_string()`` will no longer raise
+an exception if the given format does not support multiline fractions, but
+instead use an inline fraction.


### PR DESCRIPTION
This pull request changes the meaning of passing `fraction="multiline"` in `unit.to_string(format, fraction=...)` to mean "use multi-line format if possible (and inline if not)", rather than raise an exception. This partially as it will make library code supporting multiple formats easier (no need to worry if a format passed in by the user supports multiline or not), and partially to make our own code simpler - e.g., we will no longer need some of the efforts to work-around typing difficulties in #17343. 

The first commit only changes the behaviour (and tests), the second simplifies our code, removing the `fraction_formatters` dict.

This is an API change, though so minor and only in the sense that some code will no longer raise an exception, that  I'm milestoning it for 7.1. Note that if we treat this as mistaken strictness, it could be considered a bug instead, that could usefully be included in 7.0.1...

Ping also @olebole, since he in previous discussions thought it was useful to have an exception be raised.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
