### PR TITLE
Allow more tests to run without latest IERS data

### DIFF
--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -180,7 +180,6 @@ def test_fiducial_roudtrip(fullstack_icrs, fullstack_fiducial_altaz):
     npt.assert_allclose(fullstack_icrs.dec.deg, icrs2.dec.deg)
 
 
-@pytest.mark.remote_data
 def test_future_altaz():
     """
     While this does test the full stack, it is mostly meant to check that a
@@ -209,5 +208,6 @@ def test_future_altaz():
             AstropyWarning,
             match="Tried to get polar motions for times after IERS data is valid.*",
         ),
+        iers.conf.set_temp("auto_max_age", None),
     ):
         SkyCoord(1 * u.deg, 2 * u.deg).transform_to(AltAz(location=location, obstime=t))

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -222,7 +222,6 @@ def test_regression_4210():
         eclobj.distance
 
 
-@pytest.mark.remote_data
 def test_regression_futuretimes_4302():
     """
     Checks that an error is not raised for future times not covered by IERS
@@ -263,7 +262,8 @@ def test_regression_futuretimes_4302():
     with ctx1, ctx2, ctx3:
         future_time = Time("2511-5-1")
         c = CIRS(1 * u.deg, 2 * u.deg, obstime=future_time)
-        c.transform_to(ITRS(obstime=future_time))
+        with iers.conf.set_temp("auto_max_age", None):
+            c.transform_to(ITRS(obstime=future_time))
 
 
 def test_regression_4996():

--- a/astropy/coordinates/tests/test_utils.py
+++ b/astropy/coordinates/tests/test_utils.py
@@ -10,10 +10,10 @@ from astropy.coordinates.builtin_frames.utils import (
 from astropy.coordinates.solar_system import get_body_barycentric_posvel
 from astropy.tests.helper import PYTEST_LT_8_0, assert_quantity_allclose
 from astropy.time import Time
+from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
 
 
-@pytest.mark.remote_data
 def test_polar_motion_unsupported_dates():
     msg = r"Tried to get polar motions for times {} IERS.*"
 
@@ -25,7 +25,11 @@ def test_polar_motion_unsupported_dates():
     with pytest.warns(AstropyWarning, match=msg.format("before")), ctx:
         get_polar_motion(Time("1900-01-01"))
 
-    with pytest.warns(AstropyWarning, match=msg.format("after")), ctx:
+    with (
+        pytest.warns(AstropyWarning, match=msg.format("after")),
+        ctx,
+        iers.conf.set_temp("auto_max_age", None),
+    ):
         get_polar_motion(Time("2100-01-01"))
 
 


### PR DESCRIPTION
### Description

In #17359 a few tests were marked as remote data tests because they tried to fetch IERS data over the Internet if the bundled data was too old. However, that change disables the tests in question entirely in normal test runs. The allowed age of the IERS data is configurable and the `astropy` configuration system has simple ways of modifying the configuration temporarily only for some block of code. It is therefore very simple to allow the tests to run even without Internet access.

To verify that the patch here works you must have an older version of `astropy-iers-data` installed so that the tests fail with some commit that predates #17359 (e.g. 59f1adaecb239535e8e2a10a7245de267e8d5010). You can then see that 382bb84b82e32f8b9b65bef51d3a98bfd3ee4ed1 does indeed prevent test failures, but at the cost of skipping the tests entirely, and that this patch allows the tests to run successfully.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
