### PR TITLE
BUG: ensure zero length tables with coordinates or representations can be stacked.

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -270,19 +270,17 @@ class CoordinateFrameInfo(MixinInfo):
         attrs = self.merge_cols_attributes(
             coords, metadata_conflicts, name, ("meta", "description")
         )
+
+        # Make a new coordinate with the desired length.
         coord0 = coords[0]
+        out = coord0._apply(np.zeros_like, shape=(length,) + coord0.shape[1:])
 
-        # Make a new coord object with the desired length and attributes
-        # by using the _apply / __getitem__ machinery to effectively return
-        # coord0[[0, 0, ..., 0, 0]]. This will have the all the right frame
-        # attributes with the right shape.
-        indexes = np.zeros(length, dtype=np.int64)
-        out = coord0[indexes]
-
-        # Use __setitem__ machinery to check for consistency of all coords
+        # Use __setitem__ machinery to check for consistency of all coords.
+        # We use :0 to ensure we do not break on empty coordinates (with the
+        # side benefit that we do not actually set anything).
         for coord in coords[1:]:
             try:
-                out[0] = coord[0]
+                out[:0] = coord[:0]
             except Exception as err:
                 raise ValueError("Input coords are inconsistent.") from err
 

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -104,18 +104,18 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
         attrs = self.merge_cols_attributes(
             reps, metadata_conflicts, name, ("meta", "description")
         )
-        # Make a new representation or differential with the desired length
-        # using the _apply / __getitem__ machinery to effectively return
-        # rep0[[0, 0, ..., 0, 0]]. This will have the right shape, and
-        # include possible differentials.
-        indexes = np.zeros(length, dtype=np.int64)
-        out = reps[0][indexes]
+
+        # Make a new representation or differential with the desired length.
+        rep0 = reps[0]
+        out = rep0._apply(np.zeros_like, shape=(length,) + rep0.shape[1:])
 
         # Use __setitem__ machinery to check whether all representations
         # can represent themselves as this one without loss of information.
+        # We use :0 to ensure we do not break on empty coordinates (with the
+        # side benefit that we do not actually set anything).
         for rep in reps[1:]:
             try:
-                out[0] = rep[0]
+                out[:0] = rep[:0]
             except Exception as err:
                 raise ValueError("input representations are inconsistent.") from err
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1523,6 +1523,15 @@ class TestVStack:
         with pytest.raises(ValueError, match="representations are inconsistent"):
             table.vstack([t1, t3])
 
+    def test_vstack_different_sky_coordinates(self):
+        """Test that SkyCoord can generally not be mixed together."""
+        sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        sc2 = SkyCoord([5, 6] * u.deg, [7, 8] * u.deg, frame="fk5")
+        t1 = Table([sc1])
+        t2 = Table([sc2])
+        with pytest.raises(ValueError, match="coords are inconsistent"):
+            table.vstack([t1, t2])
+
     def test_vstack_structured_column(self):
         """Regression tests for gh-13271."""
         # Two tables with matching names, including a structured column.

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -2597,3 +2597,11 @@ def test_table_comp(t1, t2):
         assert not any(t2 == t1)
         assert all(t1 != t2)
         assert all(t2 != t1)
+
+
+def test_empty_skycoord_vstack():
+    # Explicit regression test for gh-17378
+    table1 = Table({"foo": SkyCoord([], [], unit="deg")})
+    table2 = table.vstack([table1, table1])  # Used to fail.
+    assert len(table2) == 0
+    assert isinstance(table2["foo"], SkyCoord)

--- a/docs/changes/table/17380.bugfix.rst
+++ b/docs/changes/table/17380.bugfix.rst
@@ -1,0 +1,3 @@
+Ensure that tables holding coordinates or representations can also be stacked
+if they have zero length. This fix also ensures that the ``insert`` method
+works correctly with a zero-length table holding a coordinate object.


### PR DESCRIPTION
This pull request is to ensure that `SkyCoord`, base frames, and representations can create new versions of themselves with `.info.new_like` also if they have zero length, thus enabling `vstack` operations on zero-length tables holding them.

First commit is a simple test, second one a fix, not just for `SkyCoord`, but also for representations. Also adds more complete tests that include an outer join of empty with not empty, which led to a bigger rewrite of `new_like`.

Note that the new `check_cols_equal` function could be used elsewhere in `test_operations` too. I can add this to this PR if it is OK to backport it, otherwise I can open a new one.

I also realized masked representations still are claimed to fail, but that is just because we forgot to define `info.mask_val` - but that probably really is better done as a new PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17378

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
