### PR TITLE
BUG: ensure representation masks are used in table joins

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -50,6 +50,7 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
 
     attrs_from_parent = {"unit"}  # Indicates unit is read-only
     _supports_indexing = False
+    mask_val = np.ma.masked
 
     @staticmethod
     def default_format(val):

--- a/docs/changes/table/17381.bugfix.rst
+++ b/docs/changes/table/17381.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that representations and differentials, like SkyCoord, can be used in
+table join operations, by making use of the fact that they can now be masked.


### PR DESCRIPTION
This corrects an omission in #17016 which introduced masks for representations and sky coordinates, but forgot to ensure that representations can now be fully used in table joins by defining `info.mask_val` (this was noted for `SkyCoord`). Calling this a bugfix so that we can backport to 7.0.1, since it seems sad not to have it.

Note: this will have a merge conflict with #17380, but happy to rebase either one.

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
