### PR TITLE
Even if IERS_Auto predictive values are stale, do not download IERS-A if downloading is disabled

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -883,6 +883,11 @@ class IERS_Auto(IERS_A):
           In other words the IERS-A table was created by IERS long enough
           ago that it can be considered stale for predictions.
         """
+        # If downloading is disabled, bail out silently.
+        # _check_interpolate_indices() will error later if appropriate.
+        if not conf.auto_download:
+            return
+
         # Pass in initial to np.max to allow things to work for empty mjd.
         max_input_mjd = np.max(mjd, initial=50000)
         now_mjd = self.time_now.mjd

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -341,12 +341,22 @@ class TestIERS_Auto:
                 dat.ut1_utc(Time(60000, format="mjd").jd)
             assert len(warns) == 1
 
-            # Warning only if we are getting return status
+            # Confirm that disabling the download means no warning because there is no
+            # refresh to even fail, but there will still be the interpolation error
+            with (
+                iers.conf.set_temp("auto_download", False),
+                pytest.raises(
+                    ValueError,
+                    match="interpolating from IERS_Auto using predictive values that are more",
+                ),
+            ):
+                dat.ut1_utc(Time(60000, format="mjd").jd)
+
+            # Warning only (i.e., no exception) if we are getting return status
             with pytest.warns(
                 iers.IERSStaleWarning, match="IERS_Auto predictive values are older"
-            ) as warns:
+            ):
                 dat.ut1_utc(Time(60000, format="mjd").jd, return_status=True)
-            assert len(warns) == 1
 
             # Now set auto_max_age = None which says that we don't care how old the
             # available IERS-A file is.  There should be no warnings or exceptions.

--- a/docs/changes/utils/17387.bugfix.rst
+++ b/docs/changes/utils/17387.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where an old IERS-A table with stale predictive values could trigger
+the download of a new IERS-A table even if automatic downloading was disabled.


### PR DESCRIPTION
This PR fixes the root bug revealed by #17359: the code that identifies stale IERS_Auto predictive values would always try to download a more up-to-date IERS-A even if downloading was disabled (`auto_download=False`).

This bug was essentially introduced by #16187, because previously `auto_download=False` would ignore the bundled IERS-A entirely, stale or not.