### PR TITLE
BUG: fix histogram binning's consistency with numpy for outer edges

### DIFF
--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -28,6 +28,38 @@ __all__ = [
 ]
 
 
+# this function is adapted from numpy 2.1.2
+def _get_outer_edges(a: ArrayLike, range: tuple[float, float] | None):
+    """
+    Determine the outer bin edges to use, from either the data or the range
+    argument
+    """
+    if range is not None:
+        first_edge, last_edge = range
+        if first_edge > last_edge:
+            raise ValueError("max must be larger than min in range parameter.")
+        if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
+            raise ValueError(
+                f"supplied range of [{first_edge}, {last_edge}] is not finite"
+            )
+    elif a.size == 0:
+        # handle empty arrays. Can't determine range, so use 0-1.
+        first_edge, last_edge = 0, 1
+    else:
+        first_edge, last_edge = a.min(), a.max()
+        if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
+            raise ValueError(
+                f"autodetected range of [{first_edge}, {last_edge}] is not finite"
+            )
+
+    # expand empty range to avoid divide by zero
+    if first_edge == last_edge:
+        first_edge = first_edge - 0.5
+        last_edge = last_edge + 0.5
+
+    return first_edge, last_edge
+
+
 def calculate_bin_edges(
     a: ArrayLike,
     bins: int
@@ -94,15 +126,11 @@ def calculate_bin_edges(
         else:
             raise ValueError(f"unrecognized bin code: '{bins}'")
 
-        if range:
-            # Check that the upper and lower edges are what was requested.
-            # The current implementation of the bin width estimators does not
-            # guarantee this, it only ensures that data outside the range is
-            # excluded from calculation of the bin widths.
-            if bins[0] != range[0]:
-                bins[0] = range[0]
-            if bins[-1] != range[1]:
-                bins[-1] = range[1]
+        # The current implementation of the bin width estimators does not
+        # guarantee that outer edges are consistent with numpy's approach,
+        # it only ensures that data outside the range is excluded from
+        # calculation of the bin widths.
+        bins[0], bins[-1] = _get_outer_edges(a, range)
 
     elif np.ndim(bins) == 0:
         # Number of bins was given

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.stats import (
     calculate_bin_edges,
@@ -138,35 +138,42 @@ def test_histogram_output_knuth():
 def test_histogram_output():
     rng = np.random.default_rng(0)
     X = rng.standard_normal(100)
+    X_range = X_min, X_max = X.min(), X.max()
 
     counts, bins = histogram(X, bins=10)
     assert_allclose(counts, [2, 0, 12, 14, 14, 17, 16, 8, 9, 8])
 
     # fmt: off
-    assert_allclose(bins, [-2.32503077, -1.89228844, -1.4595461, -1.02680377, -0.59406143,
+    assert_allclose(bins, [X_min, -1.89228844, -1.4595461, -1.02680377, -0.59406143,
                            -0.1613191, 0.27142324, 0.70416558, 1.13690791, 1.56965025,
-                           2.00239258])
+                           X_max])
     # fmt: on
 
     counts, bins = histogram(X, bins="scott")
     assert_allclose(counts, [2, 14, 27, 25, 16, 16])
 
     # fmt: off
-    assert_allclose(bins, [-2.32503077, -1.59953424, -0.87403771, -0.14854117, 0.57695536,
-                           1.3024519, 2.02794843])
+    assert_allclose(bins, [X_min, -1.59953424, -0.87403771, -0.14854117, 0.57695536,
+                           1.3024519, X_max])
     # fmt: on
 
     counts, bins = histogram(X, bins="freedman")
     assert_allclose(counts, [2, 11, 16, 18, 22, 14, 13, 4])
 
     # fmt: off
-    assert_allclose(bins, [-2.32503077, -1.74087192, -1.15671306, -0.5725542,  0.01160465,
-                           0.59576351, 1.17992237, 1.76408122, 2.34824008], rtol=2e-7)
+    assert_allclose(bins, [X_min, -1.74087192, -1.15671306, -0.5725542,  0.01160465,
+                           0.59576351, 1.17992237, 1.76408122, X_max], rtol=2e-7)
     # fmt: on
 
     counts, bins = histogram(X, bins="blocks")
     assert_allclose(counts, [3, 97])
-    assert_allclose(bins, [-2.32503077, -1.37136996, 2.00239258])
+    assert_allclose(bins, [X_min, -1.37136996, X_max])
+
+
+def test_histogram_empty_data():
+    counts, bins = histogram([], bins=2)
+    assert_allclose(counts, [0, 0])
+    assert_array_equal(bins, [0, 0.5, 1.0])
 
 
 def test_histogram_badargs(N=1000, rseed=0):

--- a/docs/changes/stats/17391.bugfix.rst
+++ b/docs/changes/stats/17391.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``histogram`` binning's consistency with numpy for outer edges.


### PR DESCRIPTION
### Description
This addresses the bug part from #8011
Since the functionality we need to imitate from numpy already exists as a function, and it's not public, it seemed to me that the most robust option would be to vendor it from there. Maybe we want to import it instead, though that would require a fallback mechanism too so I'm keeping it simple for the first round of review at least.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
