### PR TITLE
TYP: simplify type annotation `int | float` to `float`

### DIFF
--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -31,10 +31,10 @@ __all__ = [
 def calculate_bin_edges(
     a: ArrayLike,
     bins: int
-    | list[int | float]
+    | list[float]
     | Literal["blocks", "knuth", "scott", "freedman"]
     | None = 10,
-    range: tuple[int | float, int | float] | None = None,
+    range: tuple[float, float] | None = None,
     weights: ArrayLike | None = None,
 ) -> NDArray[float]:
     """
@@ -114,10 +114,10 @@ def calculate_bin_edges(
 def histogram(
     a: ArrayLike,
     bins: int
-    | list[int | float]
+    | list[float]
     | Literal["blocks", "knuth", "scott", "freedman"]
     | None = 10,
-    range: tuple[int | float, int | float] | None = None,
+    range: tuple[float, float] | None = None,
     weights: ArrayLike | None = None,
     **kwargs,
 ) -> tuple[NDArray, NDArray]:

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -72,8 +72,8 @@ For more examples see the :mod:`numpy.typing` definition of
 # type checking (https://github.com/python/mypy/issues/3186). For now we define
 # our own number types, but if a good definition becomes available upstream
 # then we should switch to that.
-Real: TypeAlias = int | float | Fraction | np.integer | np.floating
+Real: TypeAlias = float | Fraction | np.integer | np.floating
 Complex: TypeAlias = Real | complex | np.complexfloating
 
-UnitPower: TypeAlias = int | float | Fraction
-UnitScale: TypeAlias = int | float | Fraction | complex
+UnitPower: TypeAlias = float | Fraction
+UnitScale: TypeAlias = float | Fraction | complex


### PR DESCRIPTION
### Description
Noticed this while working on #17391
follow up to #16562
Unfortunately I can't remember the source for this piece of advice (maybe that's actually specific to mypy), but type checkers treat `int` as a subtype of `float`, so the union `int | float` can be simplified to `float` in annotations.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
