### PR TITLE
MAINT: Simplify class hierarchy of the parsing unit formats

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -158,13 +158,6 @@ class Base:
         ValueError
             If ``fraction`` is not recognized.
         """
-        # A separate `_to_string()` method allows subclasses (e.g. `FITS`) to implement
-        # `to_string()` without needlessly interfering with the `to_string()`
-        # implementations of their subclasses.
-        return cls._to_string(unit, fraction=fraction)
-
-    @classmethod
-    def _to_string(cls, unit: UnitBase, *, fraction: bool | str) -> str:
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions
         # like u.Ry.decompose(), which gives "2.17987e-18 kg m2 / s2".

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -299,4 +299,4 @@ class CDS(Generic):
             elif is_effectively_unity(unit.scale * 100.0):
                 return "%"
 
-        return cls._to_string(unit, fraction=fraction)
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -20,20 +20,17 @@ from typing import TYPE_CHECKING
 from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 
-from .generic import Generic
+from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
-    import numpy as np
-
     from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
-    from astropy.units.typing import UnitScale
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class CDS(Generic):
+class CDS(Base, _ParsingFormatMixin):
     """
     Support the `Centre de Données astronomiques de Strasbourg
     <https://cds.unistra.fr/>`_ `Standards for Astronomical
@@ -260,16 +257,12 @@ class CDS(Generic):
         return parsing.yacc(tabmodule="cds_parsetab", package="astropy/units")
 
     @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        cls._validate_unit(unit, detailed_exception=detailed_exception)
-        return cls._units[unit]
-
-    @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
         if " " in s:
             raise ValueError("CDS unit must not contain whitespace")
         if not isinstance(s, str):
             s = s.decode("ascii")
+
         return cls._do_parse(s, debug)
 
     @classmethod
@@ -279,12 +272,6 @@ class CDS(Generic):
     @classmethod
     def _format_superscript(cls, number: str) -> str:
         return number if number.startswith("-") else "+" + number
-
-    @classmethod
-    def format_exponential_notation(
-        cls, val: UnitScale | np.number, format_spec: str = ".8g"
-    ) -> str:
-        return super(Generic, cls).format_exponential_notation(val, format_spec)
 
     @classmethod
     def to_string(

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 
-from .fits import FITS
 from .generic import Generic
 
 if TYPE_CHECKING:
@@ -34,7 +33,7 @@ if TYPE_CHECKING:
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class CDS(FITS):
+class CDS(Generic):
     """
     Support the `Centre de Données astronomiques de Strasbourg
     <https://cds.unistra.fr/>`_ `Standards for Astronomical
@@ -259,6 +258,11 @@ class CDS(FITS):
             raise ValueError()
 
         return parsing.yacc(tabmodule="cds_parsetab", package="astropy/units")
+
+    @classmethod
+    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
+        cls._validate_unit(unit, detailed_exception=detailed_exception)
+        return cls._units[unit]
 
     @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -13,7 +13,8 @@ import numpy as np
 from astropy.units.errors import UnitScaleError
 from astropy.utils import classproperty
 
-from . import core, generic, utils
+from . import Base, core, utils
+from .generic import _GenericParserMixin
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from astropy.units import UnitBase
 
 
-class FITS(generic.Generic):
+class FITS(Base, _GenericParserMixin):
     """
     The FITS standard unit format.
 
@@ -62,11 +63,6 @@ class FITS(generic.Generic):
         return names
 
     @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        cls._validate_unit(unit, detailed_exception=detailed_exception)
-        return cls._units[unit]
-
-    @classmethod
     def to_string(
         cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
     ) -> str:
@@ -98,7 +94,7 @@ class FITS(generic.Generic):
 
     @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
-        result = super().parse(s, debug)
+        result = cls._do_parse(s, debug)
         if hasattr(result, "function_unit"):
             raise ValueError("Function units are not yet supported for FITS units.")
         return result

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -26,17 +26,21 @@ from typing import TYPE_CHECKING
 from astropy.units.errors import UnitParserWarning, UnitsWarning
 from astropy.utils import classproperty, parsing
 
-from . import Generic, core, utils
+from . import core, utils
+from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
+    import numpy as np
+
     from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
+    from astropy.units.typing import UnitScale
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class OGIP(Generic):
+class OGIP(Base, _ParsingFormatMixin):
     """
     Support the units in `Office of Guest Investigator Programs (OGIP)
     FITS files
@@ -332,11 +336,6 @@ class OGIP(Generic):
         return parsing.yacc(tabmodule="ogip_parsetab", package="astropy/units")
 
     @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        cls._validate_unit(unit, detailed_exception=detailed_exception)
-        return cls._units[unit]
-
-    @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
         return cls._do_parse(s.strip(), debug)
 
@@ -360,3 +359,9 @@ class OGIP(Generic):
                 )
 
         return super().to_string(unit, fraction=fraction)
+
+    @classmethod
+    def format_exponential_notation(
+        cls, val: UnitScale | np.number, format_spec: str = "g"
+    ) -> str:
+        return format(val, format_spec)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -26,8 +26,7 @@ from typing import TYPE_CHECKING
 from astropy.units.errors import UnitParserWarning, UnitsWarning
 from astropy.utils import classproperty, parsing
 
-from . import core, utils
-from .fits import FITS
+from . import Generic, core, utils
 
 if TYPE_CHECKING:
     from typing import ClassVar, Literal
@@ -37,7 +36,7 @@ if TYPE_CHECKING:
     from astropy.utils.parsing import ThreadSafeParser
 
 
-class OGIP(FITS):
+class OGIP(Generic):
     """
     Support the units in `Office of Guest Investigator Programs (OGIP)
     FITS files
@@ -331,6 +330,11 @@ class OGIP(FITS):
             raise ValueError()
 
         return parsing.yacc(tabmodule="ogip_parsetab", package="astropy/units")
+
+    @classmethod
+    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
+        cls._validate_unit(unit, detailed_exception=detailed_exception)
+        return cls._units[unit]
 
     @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -359,4 +359,4 @@ class OGIP(Generic):
                     UnitsWarning,
                 )
 
-        return cls._to_string(unit, fraction=fraction)
+        return super().to_string(unit, fraction=fraction)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -219,7 +219,7 @@ class VOUnit(Generic):
                 f"Multiply your data by {unit.scale:e}."
             )
 
-        return cls._to_string(unit, fraction=fraction)
+        return super().to_string(unit, fraction=fraction)
 
     @classmethod
     def _fix_deprecated(cls, x: str) -> list[str]:

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -12,8 +12,7 @@ from typing import TYPE_CHECKING
 from astropy.units.errors import UnitParserWarning, UnitScaleError, UnitsError
 from astropy.utils import classproperty
 
-from . import core, utils
-from .fits import FITS
+from . import Generic, core, utils
 
 if TYPE_CHECKING:
     from re import Pattern
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
     from astropy.units.typing import UnitScale
 
 
-class VOUnit(FITS):
+class VOUnit(Generic):
     """
     The IVOA standard for units used by the VO.
 
@@ -89,6 +88,11 @@ class VOUnit(FITS):
     @classproperty(lazy=True)
     def _deprecated_units(cls) -> frozenset[str]:
         return cls._all_units[1]
+
+    @classmethod
+    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
+        cls._validate_unit(unit, detailed_exception=detailed_exception)
+        return cls._units[unit]
 
     @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING
 from astropy.units.errors import UnitParserWarning, UnitScaleError, UnitsError
 from astropy.utils import classproperty
 
-from . import Generic, core, utils
+from . import Base, core, utils
+from .generic import _GenericParserMixin
 
 if TYPE_CHECKING:
     from re import Pattern
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
     from astropy.units.typing import UnitScale
 
 
-class VOUnit(Generic):
+class VOUnit(Base, _GenericParserMixin):
     """
     The IVOA standard for units used by the VO.
 
@@ -90,11 +91,6 @@ class VOUnit(Generic):
         return cls._all_units[1]
 
     @classmethod
-    def _parse_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
-        cls._validate_unit(unit, detailed_exception=detailed_exception)
-        return cls._units[unit]
-
-    @classmethod
     def parse(cls, s: str, debug: bool = False) -> UnitBase:
         if s in ("unknown", "UNKNOWN"):
             return None
@@ -106,7 +102,7 @@ class VOUnit(Generic):
                 f"'{s}' contains multiple slashes, which is "
                 "disallowed by the VOUnit standard."
             )
-        result = cls._do_parse(s, debug=debug)
+        result = cls._do_parse(s, debug)
         if hasattr(result, "function_unit"):
             raise ValueError("Function units are not yet supported in VOUnit.")
         return result
@@ -193,7 +189,7 @@ class VOUnit(Generic):
     def format_exponential_notation(
         cls, val: UnitScale | np.number, format_spec: str = ".8g"
     ) -> str:
-        return super().format_exponential_notation(val, format_spec)
+        return format(val, format_spec)
 
     @classmethod
     def _format_inline_fraction(

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -1031,9 +1031,22 @@ def test_parse_error_message_for_output_only_format(format_):
         u.Unit("m", format=format_)
 
 
-def test_unknown_parser():
-    with pytest.raises(ValueError, match=r"Unknown.*unicode'\] for output only"):
-        u.Unit("m", format="foo")
+class TestUnknownFormat:
+    # Check full message to ensure we correctly classify in-out and
+    # output only formats.
+    UNKNOWN_MSG = (
+        r"Unknown format {!r}.  Valid formatter names are: "
+        r"\['cds', 'generic', 'fits', 'ogip', 'vounit'\] for input and output, "
+        r"and \['console', 'latex', 'latex_inline', 'unicode'\] for output only."
+    )
+
+    def test_unknown_parser(self):
+        with pytest.raises(ValueError, match=self.UNKNOWN_MSG.format("foo")):
+            u.Unit("m", format="foo")
+
+    def test_unknown_output_format(self):
+        with pytest.raises(ValueError, match=self.UNKNOWN_MSG.format("abc")):
+            u.m.to_string("abc")
 
 
 def test_celsius_fits():


### PR DESCRIPTION
This rather large refactor was triggered by @eerovaher's [comment in #17374](
https://github.com/astropy/astropy/pull/17374#issuecomment-2473973198) that it should become possible to get of the private `_to_string()` method. This was indeed possible, with a relatively minor refactor. 

However, it seemed sensible to go a bit further, and make the whole class hierarchy a bit more logical. The rationale is below, split by commit. If helpful, I can limit this PR to commits 1 and 2. Opening as draft in part because my naming is not great, in part because some things are a bit hacky (like not registering classes ending in `Base`), and in part because I'm not sure about the inheritance structure (use mixins?). Also, one definitely needs to do something more sensible with `format_exponential_notation`... Finally, while I think all classes we use should be documented, it is not clear we really want to commit to the in-between classes - there really are a few too many little private methods to fine-tune results...

The current state is the following inheritance diagram (classes with * implement a parser):
```
   Base⭢Console⭢Unicode
       ︳       ⮡Latex⭢LatexInline
       ⮡Generic*⭢FITS⭢OGIP*
                      ⮡CDS*
                      ⮡VOUnit
```
Logically, OGIP and CDS should not inherit from Generic, since they have different parsers, while VOUnit probably should inherit directly from Generic, since it shares little with FITS.

Next are ~four~ five commits (EDIT: updated with move to mixin classes): 

1. Remove the dependence on FITS. This needs duplicating `_parse_unit` since the one from Generic is no good (but those methods get removed later). One now has:
```
   Base⭢Console⭢Unicode
       ︳       ⮡Latex⭢LatexInline
       ⮡Generic*⭢FITS
                 ⮡OGIP*
                 ⮡CDS*
                 ⮡VOUnit
```
2. Removes `_to_string()`, merging the code in `to_string()`.
3. Make all parsing units depend on a single base.
```
   Base⭢Console⭢Unicode
       ︳       ⮡Latex⭢LatexInline
       ⮡ParsingFormatBase⭢Generic*⭢FITS
                          ︳       ⮡VOUnit
                          ⮡OGIP*
                          ⮡CDS*
```
4. Factor out the generic parser, so Generic, FITS, and VOUnit can just add their own stuff around it. `_parse_unit` in the latter two can now be removed again.
```
   Base⭢Console⭢Unicode
       ︳       ⮡Latex⭢LatexInline
       ⮡ParsingFormatBase⭢GenericParserBase*⭢Generic
                          ︳                 ⮡FITS
                          ︳                 ⮡VOUnit
                          ⮡OGIP*
                          ⮡CDS*
```
5. (EDIT: added later) Move to mixin classes so that we can keep those private implementation details for now.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
