### PR TITLE
Explicitly use `int | float` in type aliases

### DIFF
--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -72,8 +72,8 @@ For more examples see the :mod:`numpy.typing` definition of
 # type checking (https://github.com/python/mypy/issues/3186). For now we define
 # our own number types, but if a good definition becomes available upstream
 # then we should switch to that.
-Real: TypeAlias = float | Fraction | np.integer | np.floating
+Real: TypeAlias = int | float | Fraction | np.integer | np.floating
 Complex: TypeAlias = Real | complex | np.complexfloating
 
-UnitPower: TypeAlias = float | Fraction
-UnitScale: TypeAlias = float | Fraction | complex
+UnitPower: TypeAlias = int | float | Fraction
+UnitScale: TypeAlias = int | float | Fraction | complex


### PR DESCRIPTION
### Description

Although it is true that `int` is a subtype of `float` for typing purposes, `int` is still not a subclass of `float`. Replacing `int | float` with `float` in type aliases can therefore cause errors if the aliases are used in `isinstance()` checks at runtime. Even if we ourselves avoid such checks, we cannot really prevent downstream users from doing that.

I would have pointed this out in #17392 but that pull request was merged before I had a chance to.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
