### PR TITLE
Simplify and speed up `_UnitMetaClass.__call__()`

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -8,7 +8,7 @@ This package defines the SI units.  They are also available in
 
 import numpy as np
 
-from .core import Unit, UnitBase, def_unit
+from .core import CompositeUnit, UnitBase, def_unit
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -20,7 +20,7 @@ _ns = globals()
 
 def_unit(
     ["percent", "pct"],
-    Unit(0.01),
+    CompositeUnit(0.01, [], []),
     namespace=_ns,
     prefixes=False,
     doc="percent: one hundredth of unity, factor 0.01",

--- a/docs/changes/units/17399.perf.rst
+++ b/docs/changes/units/17399.perf.rst
@@ -1,0 +1,1 @@
+Converting strings to units with ``Unit()`` is now up to 225% faster.


### PR DESCRIPTION
### Description

Many changes are quite trivial, but there are two that are worth highlighting with inline comments.

EDIT: Overall, there's a few code branches that aren't needed and handling `str` input can now be moved before handling `Quantity`, so the common use case of creating a unit from a `str` is now faster.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
