### PR TITLE
Add types to ImageNormalize __init__ parameters

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -84,13 +84,13 @@ class ImageNormalize(Normalize):
 
     def __init__(
         self,
-        data=None,
-        interval=None,
-        vmin=None,
-        vmax=None,
-        stretch=LinearStretch(),
-        clip=False,
-        invalid=-1.0,
+        data: np.ndarray | None = None,
+        interval: BaseInterval | None = None,
+        vmin: float | None = None,
+        vmax: float | None = None,
+        stretch: BaseStretch = LinearStretch(),
+        clip: bool = False,
+        invalid: float | None = -1.0,
     ):
         # this super call checks for matplotlib
         super().__init__(vmin=vmin, vmax=vmax, clip=clip)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address an argument type incompatibility when evaluating the `stretch` parameter in the `ImageNormalize` class and providing any stretch type other than `LinearStretch`.

When attempting to build a normalization instance, e.g.:

```
import numpy as np

from astropy.visualization import ImageNormalize, MinMaxInterval
from astropy.visualization.stretch import LogStretch

image_data = np.random.randint(0, 100, size=(10, 10))  # A 10x10 test image

norm = ImageNormalize(image_data, interval=MinMaxInterval(), stretch=LogStretch())
```

the `stretch` parameter will warn:

```
Argument of type "LogStretch" cannot be assigned to parameter "stretch" of type "LinearStretch" in function "__init__"
  "LogStretch" is not assignable to "LinearStretch" Pylance (reportArgumentType)
``` 

This is caused by type checkers assuming the type of `stretch` from the default value (`LinearStretch()`) in lieu of any being explicitly provided.

This PR adds an explicit type to `stretch` of `BaseStretch`, which resolves this typing issue. This is in keeping with the code below, which raises a `TypeError` if `stretch` is not an instance of a `BaseStretch` class.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
