### PR TITLE
Improve performance for WCSAxes imshow

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -27,13 +27,12 @@ __all__ = ["WCSAxes", "WCSAxesSubplot"]
 VISUAL_PROPERTIES = ["facecolor", "edgecolor", "linewidth", "alpha", "linestyle"]
 
 if HAS_PIL:
-    import PIL.Image
-    if hasattr(PIL.Image, "FLIP_TOP_BOTTOM"):
-        # PIL version < 9.1
-        from PIL.Image import FLIP_TOP_BOTTOM
-    else:
+    if minversion("PIL", "9.1"):
         from PIL.Image import Transpose
         FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
+    else:
+        from PIL.Image import FLIP_TOP_BOTTOM
+        
 
 class _WCSAxesArtist(Artist):
     """This is a dummy artist to enforce the correct z-order of axis ticks,

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -27,12 +27,15 @@ __all__ = ["WCSAxes", "WCSAxesSubplot"]
 VISUAL_PROPERTIES = ["facecolor", "edgecolor", "linewidth", "alpha", "linestyle"]
 
 if HAS_PIL:
+    from PIL.Image import Image
+
     if minversion("PIL", "9.1"):
         from PIL.Image import Transpose
+
         FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
     else:
         from PIL.Image import FLIP_TOP_BOTTOM
-        
+
 
 class _WCSAxesArtist(Artist):
     """This is a dummy artist to enforce the correct z-order of axis ticks,
@@ -227,9 +230,8 @@ class WCSAxes(Axes):
         elif origin == "upper":
             raise ValueError("Cannot use images with origin='upper' in WCSAxes.")
 
-        if HAS_PIL:
-            if isinstance(X, PIL.Image.Image) or hasattr(X, "getpixel"):
-                X = X.transpose(FLIP_TOP_BOTTOM)
+        if HAS_PIL and (isinstance(X, Image) or hasattr(X, "getpixel")):
+            X = X.transpose(FLIP_TOP_BOTTOM)
 
         return super().imshow(X, *args, origin=origin, **kwargs)
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -221,16 +221,16 @@ class WCSAxes(Axes):
             raise ValueError("Cannot use images with origin='upper' in WCSAxes.")
 
         if HAS_PIL:
-            from PIL.Image import Image
+            import PIL.Image
 
-            if minversion("PIL", "9.1"):
-                from PIL.Image import Transpose
-
-                FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
-            else:
+            if hasattr(PIL.Image, "FLIP_TOP_BOTTOM"):
+                # PIL version < 9.1
                 from PIL.Image import FLIP_TOP_BOTTOM
+            else:
+                from PIL.Image import Transpose
+                FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
 
-            if isinstance(X, Image) or hasattr(X, "getpixel"):
+            if isinstance(X, PIL.Image.Image) or hasattr(X, "getpixel"):
                 X = X.transpose(FLIP_TOP_BOTTOM)
 
         return super().imshow(X, *args, origin=origin, **kwargs)

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -26,6 +26,14 @@ __all__ = ["WCSAxes", "WCSAxesSubplot"]
 
 VISUAL_PROPERTIES = ["facecolor", "edgecolor", "linewidth", "alpha", "linestyle"]
 
+if HAS_PIL:
+    import PIL.Image
+    if hasattr(PIL.Image, "FLIP_TOP_BOTTOM"):
+        # PIL version < 9.1
+        from PIL.Image import FLIP_TOP_BOTTOM
+    else:
+        from PIL.Image import Transpose
+        FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
 
 class _WCSAxesArtist(Artist):
     """This is a dummy artist to enforce the correct z-order of axis ticks,
@@ -221,15 +229,6 @@ class WCSAxes(Axes):
             raise ValueError("Cannot use images with origin='upper' in WCSAxes.")
 
         if HAS_PIL:
-            import PIL.Image
-
-            if hasattr(PIL.Image, "FLIP_TOP_BOTTOM"):
-                # PIL version < 9.1
-                from PIL.Image import FLIP_TOP_BOTTOM
-            else:
-                from PIL.Image import Transpose
-                FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
-
             if isinstance(X, PIL.Image.Image) or hasattr(X, "getpixel"):
                 X = X.transpose(FLIP_TOP_BOTTOM)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request aims to remove a performance issue when using the `imshow` of a `WCSAxes` instance. The issue is that this uses `minversion` to check the PIL version, which in the case of PIL uses the `packages_distributions` function which is extremely slow (in my case representing the vast majority of the time spent in the function). This PR avoids this by using `hasattr` on the module to assess which import should be used.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
