### PR TITLE
Remove an unused plotting function from tests

### DIFF
--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -11,7 +11,6 @@ from astropy.coordinates import (
     CartesianRepresentation,
     DynamicMatrixTransform,
     FunctionTransformWithFiniteDifference,
-    SphericalDifferential,
     SphericalRepresentation,
     TimeAttribute,
     get_sun,
@@ -284,35 +283,3 @@ def test_numerical_limits(distance):
     # the direction above with a small allowance for noise - finite-difference
     # rounding errors have ruined the calculation
     assert np.ptp(gcrs_coord.radial_velocity) < 65 * u.km / u.s
-
-
-def diff_info_plot(frame, time):
-    """
-    Useful for plotting a frame with multiple times. *Not* used in the testing
-    suite per se, but extremely useful for interactive plotting of results from
-    tests in this module.
-    """
-    from matplotlib import pyplot as plt
-
-    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(20, 12))
-    ax1.plot_date(
-        time.plot_date, frame.data.differentials["s"].d_xyz.to(u.km / u.s).T, fmt="-"
-    )
-    ax1.legend(["x", "y", "z"])
-
-    ax2.plot_date(
-        time.plot_date,
-        np.sum(frame.data.differentials["s"].d_xyz.to(u.km / u.s) ** 2, axis=0) ** 0.5,
-        fmt="-",
-    )
-    ax2.set_title("total")
-
-    sd = frame.data.differentials["s"].represent_as(SphericalDifferential, frame.data)
-
-    ax3.plot_date(time.plot_date, sd.d_distance.to(u.km / u.s), fmt="-")
-    ax3.set_title("radial")
-
-    ax4.plot_date(time.plot_date, sd.d_lat.to(u.marcsec / u.yr), fmt="-", label="lat")
-    ax4.plot_date(time.plot_date, sd.d_lon.to(u.marcsec / u.yr), fmt="-", label="lon")
-
-    return fig


### PR DESCRIPTION
### Description

`diff_info_plot()` came up in #17339 because it is using a deprecated `matplotlib` function. The problem with such obscure functions is that even just knowing that they exist takes more effort than implementing their functionality from scratch, should it be ever needed. Keeping the function is not worth the maintenance effort.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
