### PR TITLE
Add sigma_clip tests for MaskedArray masks

### DIFF
--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -98,6 +98,24 @@ def test_sigma_clip_scalar_mask():
     assert result.mask.shape != ()
 
 
+def test_sigma_clip_masked_array():
+    """
+    Regression test to check that MaskedArray masks are propagated
+    correctly if cenfunc/stdfunc is not the default, axis is not None,
+    and masked=False.
+    """
+    arr = np.ones(10).astype(float)
+    arr[-2:] = 5
+    arr = np.ma.masked_where(arr > 1, arr)
+    out = sigma_clip(arr, cenfunc=np.mean, axis=0, masked=False)
+    assert np.all(np.isnan(out[-2:]))
+    assert_allclose(np.nanmean(out), 1.0)
+
+    out = sigma_clip(arr, stdfunc=np.std, axis=0, masked=False)
+    assert np.all(np.isnan(out[-2:]))
+    assert_allclose(np.nanmean(out), 1.0)
+
+
 def test_sigma_clip_class():
     with NumpyRNGContext(12345):
         data = np.random.randn(100)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Followup test for #17402.

Hopefully this can also go in 7.0.

@saimn 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
