### PR TITLE
Fix grammatical error in fitting docstrings

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1121,7 +1121,7 @@ class _NonLinearLSQFitter(Fitter):
         If the covariance matrix should be computed and set in the fit_info.
         Default: False
     use_min_max_bounds : bool
-        If the set parameter bounds for a model will be enforced each given
+        If set, the parameter bounds for a model will be enforced for each given
         parameter while fitting via a simple min/max condition.
         Default: True
     """
@@ -1541,7 +1541,7 @@ class _NLLSQFitter(_NonLinearLSQFitter):
         If the covariance matrix should be computed and set in the fit_info.
         Default: False
     use_min_max_bounds: bool
-        If the set parameter bounds for a model will be enforced each given
+        If set, the parameter bounds for a model will be enforced for each given
         parameter while fitting via a simple min/max condition. A True setting
         will replicate how LevMarLSQFitter enforces bounds.
         Default: False
@@ -2147,7 +2147,7 @@ def fitter_to_model_params_array(
     fps :
         The fit parameter values to be assigned
     use_min_max_bounds: bool
-        If the set parameter bounds for model will be enforced on each
+        If set, the parameter bounds for the model will be enforced on each
         parameter with bounds.
         Default: True
     """
@@ -2221,7 +2221,7 @@ def fitter_to_model_params(model, fps, use_min_max_bounds=True):
     fps :
         The fit parameter values to be assigned
     use_min_max_bounds: bool
-        If the set parameter bounds for model will be enforced on each
+        If set, the parameter bounds for the model will be enforced on each
         parameter with bounds.
         Default: True
     """


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes a basic grammatical error in the docstrings associated with the `use_min_max_bounds` parameter for the functions `fitter_to_model_params`, `fitter_to_model_params_array` and class `_NLLSQFitter`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->
