### PR TITLE
BUG: fix setting a table column with a `np.str_` name

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -442,7 +442,7 @@ class ColumnInfo(BaseColumnInfo):
         # length to include the table length, we pick off a possible last bit.
         dtype = np.dtype(
             [
-                (name, part.dtype, part.shape[len(shape) + 1 :])
+                (str(name), part.dtype, part.shape[len(shape) + 1 :])
                 for name, part in data.items()
             ]
         )
@@ -482,6 +482,8 @@ class ColumnInfo(BaseColumnInfo):
             New instance of this class consistent with ``cols``
 
         """
+        if name is not None:
+            name = str(name)
         attrs = self.merge_cols_attributes(
             cols, metadata_conflicts, name, ("meta", "unit", "format", "description")
         )

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2097,6 +2097,12 @@ class Table:
             raise ValueError(f"Illegal type {type(item)} for table item access")
 
     def __setitem__(self, item, value):
+        # np.str_ is an example of a string subtype that may cause issues
+        # down the line because its repr differs from that of a builtin str
+        # in numpy>2 . See https://github.com/astropy/astropy/issues/17418
+        if isinstance(item, str) and type(item) is not str:
+            item = str(item)
+
         # If the item is a string then it must be the name of a column.
         # If that column doesn't already exist then create it now.
         if isinstance(item, str) and item not in self.colnames:
@@ -2388,6 +2394,9 @@ class Table:
               1 0.1    a   x
               2 0.2    b   y
         """
+        if name is not None:
+            name = str(name)
+
         if default_name is None:
             default_name = f"col{len(self.columns)}"
 

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -665,13 +665,7 @@ def test_init_QTable_and_set_units():
     assert np.all(t["col1"].value == [1, 2])
 
 
-@pytest.mark.parametrize(
-    "table_cls",
-    [
-        pytest.param(Table),
-        pytest.param(QTable, marks=pytest.mark.xfail),
-    ],
-)
+@pytest.mark.parametrize("table_cls", [Table, QTable])
 def test_table_from_columns_with_mixed_str_type_name(table_cls):
     # see https://github.com/astropy/astropy/issues/17418
     t = table_cls()

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -663,3 +663,23 @@ def test_init_QTable_and_set_units():
     assert np.all(t["col0"].value == [1000, 2000])
     assert t["col1"].unit == u.s
     assert np.all(t["col1"].value == [1, 2])
+
+
+@pytest.mark.parametrize(
+    "table_cls",
+    [
+        pytest.param(Table),
+        pytest.param(QTable, marks=pytest.mark.xfail),
+    ],
+)
+def test_table_from_columns_with_mixed_str_type_name(table_cls):
+    # see https://github.com/astropy/astropy/issues/17418
+    t = table_cls()
+    t["col0"] = [0]
+    t[np.str_("col1")] = [1]
+    t["col2"] = [2]
+    t[np.str_("col3")] = [3] * u.m
+    t.add_column([4], name="col4")
+    t.add_column([5], name=np.str_("col5"))
+    t.add_column([6] * u.m, name=np.str_("col6"))
+    assert [type(n) for n in t.colnames] == [str] * len(t.colnames)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -317,6 +317,17 @@ class DataInfo(metaclass=DataInfoMeta):
             self._attrs = {}
 
     @property
+    def name(self) -> str | None:
+        return self._attrs.get("name")
+
+    @name.setter
+    def name(self, name: str | None):
+        # make sure that the type of self.name is *exactly* NoneType or str;
+        # subtypes of str might cause issues due to differences in reprs
+        # see https://github.com/astropy/astropy/issues/17418
+        self._attrs["name"] = None if name is None else str(name)
+
+    @property
     def _parent(self):
         try:
             parent = self._parent_ref()
@@ -748,7 +759,7 @@ class BaseColumnInfo(DataInfo):
 
         # "Merged" output name is the supplied name
         if name is not None:
-            out["name"] = name
+            out["name"] = str(name)
 
         return out
 
@@ -768,19 +779,19 @@ class BaseColumnInfo(DataInfo):
 
 class MixinInfo(BaseColumnInfo):
     @property
-    def name(self):
+    def name(self) -> str | None:
         return self._attrs.get("name")
 
     @name.setter
-    def name(self, name):
+    def name(self, name: str | None):
         # For mixin columns that live within a table, rename the column in the
         # table when setting the name attribute.  This mirrors the same
         # functionality in the BaseColumn class.
+        new_name = None if name is None else str(name)
         if self.parent_table is not None:
-            new_name = None if name is None else str(name)
             self.parent_table.columns._rename_column(self.name, new_name)
 
-        self._attrs["name"] = name
+        self._attrs["name"] = new_name
 
     @property
     def groups(self):

--- a/docs/changes/table/17419.bugfix.rst
+++ b/docs/changes/table/17419.bugfix.rst
@@ -1,0 +1,3 @@
+Fix an issue where setting a table column with a ``np.str_`` name would result
+in inconsistent representations of ``t.columns`` under NumPy 2, causing
+serialization issues.


### PR DESCRIPTION
### Description
Fixes #17418

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
