### PR TITLE
Define unit formatter protocols

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -17,13 +17,15 @@ if TYPE_CHECKING:
     from astropy.units import NamedUnit, UnitBase
     from astropy.units.typing import UnitPower, UnitScale
 
+    from . import UnitFormatter
+
 
 class Base:
     """
     The abstract base class of all unit formats.
     """
 
-    registry: ClassVar[dict[str, type[Base]]] = {}
+    registry: ClassVar[dict[str, UnitFormatter]] = {}
     _space: ClassVar[str] = " "
     _scale_unit_separator: ClassVar[str] = " "
     _times: ClassVar[str] = "*"
@@ -201,10 +203,3 @@ class Base:
         return formatter(
             s, cls._format_unit_list(positive) or "1", cls._format_unit_list(negative)
         )
-
-    @classmethod
-    def parse(cls, s: str) -> UnitBase:
-        """
-        Convert a string to a unit object.
-        """
-        raise NotImplementedError(f"Can not parse with {cls.__name__} format")


### PR DESCRIPTION
### Description

Currently the `Base` unit formatter implements some common functionality for the unit formatters, but it also defines the public API for them. The latter is needlessly complicating refactoring in #17397. For example, it necessitates the presence of a skeleton `Base.parse()` method which cannot be changed because public API should be stable. A simple solution (available since [PEP 544 - Protocols: Structural subtyping (static duck typing)](https://peps.python.org/pep-0544/), i.e. Python 3.8) is to define the public API using protocols so that `Base` would provide an implementation of the API instead of its definition. Note that the introduction of the protocols does not really change what the definition of the unit formatter API is, it only changes _where_ the definition is.

I am opening this as a draft because surely there is documentation that will have to be updated too. Also, I'm not sure if `format_exponential_notation()` should be part of the `UnitFormatter` protocol or not.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
