### PR TITLE
CLN: remove unneeded compatibility layer for Pillow<9.1

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -10,7 +10,6 @@ from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
 
 from astropy.coordinates import BaseCoordinateFrame, SkyCoord
-from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_PIL
 from astropy.wcs import WCS
 from astropy.wcs.wcsapi import BaseHighLevelWCS, BaseLowLevelWCS
@@ -27,14 +26,7 @@ __all__ = ["WCSAxes", "WCSAxesSubplot"]
 VISUAL_PROPERTIES = ["facecolor", "edgecolor", "linewidth", "alpha", "linestyle"]
 
 if HAS_PIL:
-    from PIL.Image import Image
-
-    if minversion("PIL", "9.1"):
-        from PIL.Image import Transpose
-
-        FLIP_TOP_BOTTOM = Transpose.FLIP_TOP_BOTTOM
-    else:
-        from PIL.Image import FLIP_TOP_BOTTOM
+    from PIL.Image import Image, Transpose
 
 
 class _WCSAxesArtist(Artist):
@@ -231,7 +223,7 @@ class WCSAxes(Axes):
             raise ValueError("Cannot use images with origin='upper' in WCSAxes.")
 
         if HAS_PIL and (isinstance(X, Image) or hasattr(X, "getpixel")):
-            X = X.transpose(FLIP_TOP_BOTTOM)
+            X = X.transpose(Transpose.FLIP_TOP_BOTTOM)
 
         return super().imshow(X, *args, origin=origin, **kwargs)
 


### PR DESCRIPTION
### Description
Follow up to #17404 
Rationale: while I'm still unconvinced by the argument that SPEC 0 merely allows us to drop support for Pillow 9.1, I had a look at https://pypi.org/simple/pillow/ and found that the oldest version with support for CPython 3.11 was actually 9.2, so we're already not supporting 9.1, de facto. Hence this clean up is safe to perform now.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
