### PR TITLE
Speed up `UnitBase.compose()`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -11,7 +11,6 @@ import operator
 import textwrap
 import warnings
 from functools import cached_property
-from itertools import pairwise
 from threading import RLock
 from typing import TYPE_CHECKING
 
@@ -1445,24 +1444,19 @@ class UnitBase:
         else:
             units = filter_units(_flatten_units_collection(units))
 
-        results = self._compose(
-            equivalencies=equivalencies,
-            namespace=units,
-            max_depth=max_depth,
-            depth=0,
-            cached_results={},
-        )
-
-        if not results:
-            return []
-
         # Sort the results so the simplest ones appear first.
         # Simplest is defined as "the minimum sum of absolute
         # powers" (i.e. the fewest bases), and preference should
         # be given to results where the sum of powers is positive
         # and the scale is exactly equal to 1.0
-        results = sorted(
-            results,
+        return sorted(
+            self._compose(
+                equivalencies=equivalencies,
+                namespace=units,
+                max_depth=max_depth,
+                depth=0,
+                cached_results={},
+            ),
             key=lambda x: (
                 not is_effectively_unity(x.scale),
                 sum(x.powers) < 0.0,
@@ -1470,12 +1464,6 @@ class UnitBase:
                 abs(x.scale),
             ),
         )
-
-        return [results[0]] + [
-            x2
-            for (_, x1_str), (x2, x2_str) in pairwise((x, str(x)) for x in results)
-            if x1_str != x2_str
-        ]
 
     def to_system(self, system):
         """Convert this unit into ones belonging to the given system.

--- a/docs/changes/units/17425.perf.rst
+++ b/docs/changes/units/17425.perf.rst
@@ -1,0 +1,1 @@
+``UnitBase.compose()`` is now 20% faster.


### PR DESCRIPTION
### Description

I've simplified the function and managed to speed it up by 20% or so in the process. I've opened this pull request with two commits because I'm not sure if the simplifications in the second commit are allowed. If they are allowed then the commits should be combined into one before merging. If they are not allowed then the second commit should just be dropped.

### Performance comparison

On `main`:
```python
Python 3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from astropy import units as u

In [2]: %timeit u.kg.compose(units=u.si)
817 μs ± 2.1 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [3]: %timeit u.Pa.compose(units=u.si)
1.59 ms ± 5.72 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
With the patch here:
```python
In [1]: from astropy import units as u

In [2]: %timeit u.kg.compose(units=u.si)
647 μs ± 944 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [3]: %timeit u.Pa.compose(units=u.si)
1.21 ms ± 1.52 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
