### PR TITLE
STY: autofix `redundant-final-literal` (`PYI064`)

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -634,7 +634,7 @@ class UnitBase:
 
     # Make sure that __rmul__ of units gets called over the __mul__ of Numpy
     # arrays to avoid element-wise multiplication.
-    __array_priority__: Final[Literal[1000]] = 1000
+    __array_priority__: Final = 1000
 
     def __deepcopy__(self, memo: dict[int, Any] | None) -> Self:
         # This may look odd, but the units conversion will be very


### PR DESCRIPTION
### Description
ref #17430

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
