### PR TITLE
STY: manual fixes for `dict-index-missing-items` (`PLC0206`) (`io.fits`)

### DIFF
--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -50,8 +50,8 @@ def test_init_with_header():
 def test_init_with_dict():
     dict1 = {"a": 11, "b": 12, "c": 13, "d": 14, "e": 15}
     h1 = fits.Header(dict1)
-    for i in dict1:
-        assert dict1[i] == h1[i]
+    for i, expected in dict1.items():
+        assert h1[i] == expected
 
 
 def test_init_with_ordereddict():


### PR DESCRIPTION
### Description
ref #17430

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
