### PR TITLE
STY: manual fixes for `dict-index-missing-items` (`PLC0206`) (`nddata`)

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -237,10 +237,10 @@ class NDArithmeticMixin:
         # Find the appropriate keywords for the appropriate method (not sure
         # if data and uncertainty are ever used ...)
         kwds2 = {"mask": {}, "meta": {}, "wcs": {}, "data": {}, "uncertainty": {}}
-        for i in kwds:
+        for i, kwd in kwds.items():
             splitted = i.split("_", 1)
             try:
-                kwds2[splitted[0]][splitted[1]] = kwds[i]
+                kwds2[splitted[0]][splitted[1]] = kwd
             except KeyError:
                 raise KeyError(f"Unknown prefix {splitted[0]} for parameter {i}")
 


### PR DESCRIPTION
### Description
ref #17430

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
