### PR TITLE
STY: manual fixes for `dict-index-missing-items` (`PLC0206`) (`units`)

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1416,8 +1416,7 @@ class DuckQuantity3(DuckQuantity2):
         out = kwargs.get("out")
 
         kwargs_copy = {}
-        for k in kwargs:
-            kwarg = kwargs[k]
+        for k, kwarg in kwargs.items():
             if isinstance(kwarg, type(self)):
                 kwargs_copy[k] = kwarg.data
             elif isinstance(kwarg, (list, tuple)):


### PR DESCRIPTION
### Description
ref #17430

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
