### PR TITLE
BUG: Fix ticklabels getter in `CoordinateHelper`

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -311,7 +311,7 @@ class CoordinateHelper:
             "CoordinateHelper.ticklabels should not be accessed directly and is deprecated",
             AstropyDeprecationWarning,
         )
-        return self._ticks
+        return self._ticklabels
 
     @ticklabels.setter
     def ticklabels(self, value):

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -167,23 +167,13 @@ def test_get_position():
     assert ax.coords[1].get_axislabel_position() == ["r"]
 
 
-def test_getters():
+def test_deprecated_getters():
     fig = plt.figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     helper = CoordinateHelper(parent_axes=ax)
 
-    assert helper.parent_axes == helper._parent_axes
-    assert helper.parent_map == helper._parent_map
-    assert helper.transform == helper._transform
-    assert helper.coord_index == helper._coord_index
-    assert helper.coord_type == helper._coord_type
-    assert helper.coord_unit == helper._coord_unit
-    assert helper.coord_wrap == helper._coord_wrap
-    assert helper.frame == helper._frame
-    assert helper.default_label == helper._default_label
-
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
-        assert helper.ticks == helper._ticks
-        assert helper.ticklabels == helper._ticklabels
-        assert helper.axislabels == helper._axislabels
+        assert not helper.ticks.get_display_minor_ticks()
+        assert helper.ticklabels.text == {}
+        assert helper.axislabels.get_visibility_rule() == "labels"

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt
@@ -168,12 +167,13 @@ def test_get_position():
 
 
 def test_deprecated_getters():
-    fig = plt.figure()
+    fig, _ = plt.subplots()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     helper = CoordinateHelper(parent_axes=ax)
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+    with pytest.warns(AstropyDeprecationWarning):
         assert not helper.ticks.get_display_minor_ticks()
+    with pytest.warns(AstropyDeprecationWarning):
         assert helper.ticklabels.text == {}
+    with pytest.warns(AstropyDeprecationWarning):
         assert helper.axislabels.get_visibility_rule() == "labels"

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt
@@ -9,6 +10,7 @@ import pytest
 from astropy import units as u
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.wcsaxes.coordinate_helpers import CoordinateHelper
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.wcs import WCS
@@ -163,3 +165,25 @@ def test_get_position():
     assert ax.coords[1].get_ticklabel_position() == ["r", "l"]
     assert ax.coords[0].get_axislabel_position() == ["t"]
     assert ax.coords[1].get_axislabel_position() == ["r"]
+
+
+def test_getters():
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
+    helper = CoordinateHelper(parent_axes=ax)
+
+    assert helper.parent_axes == helper._parent_axes
+    assert helper.parent_map == helper._parent_map
+    assert helper.transform == helper._transform
+    assert helper.coord_index == helper._coord_index
+    assert helper.coord_type == helper._coord_type
+    assert helper.coord_unit == helper._coord_unit
+    assert helper.coord_wrap == helper._coord_wrap
+    assert helper.frame == helper._frame
+    assert helper.default_label == helper._default_label
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=AstropyDeprecationWarning)
+        assert helper.ticks == helper._ticks
+        assert helper.ticklabels == helper._ticklabels
+        assert helper.axislabels == helper._axislabels

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -172,8 +172,11 @@ def test_deprecated_getters():
     helper = CoordinateHelper(parent_axes=ax)
 
     with pytest.warns(AstropyDeprecationWarning):
-        assert not helper.ticks.get_display_minor_ticks()
+        ticks = helper.ticks
+    assert not ticks.get_display_minor_ticks()
     with pytest.warns(AstropyDeprecationWarning):
-        assert helper.ticklabels.text == {}
+        ticklabels = helper.ticklabels
+    assert ticklabels.text == {}
     with pytest.warns(AstropyDeprecationWarning):
-        assert helper.axislabels.get_visibility_rule() == "labels"
+        axislabels = helper.axislabels
+    assert axislabels.get_visibility_rule() == "labels"

--- a/docs/changes/visualization/17444.bugfix.rst
+++ b/docs/changes/visualization/17444.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broken `ticklabels` getter in `CoordinateHelper`. The getter was incorrectly returning the helper's ticks rather than the labels; this PR corrects that.

--- a/docs/changes/visualization/17444.bugfix.rst
+++ b/docs/changes/visualization/17444.bugfix.rst
@@ -1,1 +1,2 @@
-Fix broken `ticklabels` getter in `CoordinateHelper`. The getter was incorrectly returning the helper's ticks rather than the labels; this PR corrects that.
+Fix ``CoordinateHelper.ticklabels``. The getter was incorrectly returning
+the helper's ticks rather than the labels.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

While working with some code that references  the `ticklabels` attribute of `CoordinateHelper` (which I realize needs to be updated as these properties are deprecated), I noticed that the `ticklabels` getter returns the ticks rather than the labels. This is a small PR to fix that. This previously worked but looks to have been broken in astropy 7 (in particular in https://github.com/astropy/astropy/commit/1425e1c72ee679c8088759fa639355fd4dab8c70).

I'm happy to add a test for these setters (something that checks the type of the returned value?) if that's desired.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
