### PR TITLE
TST: avoid unecessary declarations when numpy 2.2 is available

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -48,6 +48,7 @@ from astropy.utils.compat import (
     NUMPY_LT_1_24,
     NUMPY_LT_2_0,
     NUMPY_LT_2_1,
+    NUMPY_LT_2_2,
 )
 
 if NUMPY_LT_2_0:
@@ -65,14 +66,22 @@ FUNCTION_HELPERS = {}
 """Functions with implementations usable with proper unit conversion."""
 DISPATCHED_FUNCTIONS = {}
 """Functions for which we provide our own implementation."""
-SUPPORTED_NEP35_FUNCTIONS = {
+
+if NUMPY_LT_2_2:
+    # in numpy 2.2 these are auto detected by numpy itself
     # xref https://github.com/numpy/numpy/issues/27451
-    np.arange,
-    np.empty, np.ones, np.zeros, np.full,
-    np.array, np.asarray, np.asanyarray, np.ascontiguousarray, np.asfortranarray,
-    np.frombuffer, np.fromfile, np.fromfunction, np.fromiter, np.fromstring,
-    np.require, np.identity, np.eye, np.tri, np.genfromtxt, np.loadtxt,
-}  # fmt: skip
+    SUPPORTED_NEP35_FUNCTIONS = {
+        np.arange,
+        np.empty, np.ones, np.zeros, np.full,
+        np.array, np.asarray, np.asanyarray, np.ascontiguousarray, np.asfortranarray,
+        np.frombuffer, np.fromfile, np.fromfunction, np.fromiter, np.fromstring,
+        np.require, np.identity, np.eye, np.tri, np.genfromtxt, np.loadtxt,
+    }  # fmt: skip
+    """Functions that support a 'like' keyword argument and dispatch on it (NEP 35)"""
+else:
+    # When our minimum becomes numpy>=2.2, this can be removed, here and in the tests
+    SUPPORTED_NEP35_FUNCTIONS = set()
+
 """Functions that support a 'like' keyword argument and dispatch on it (NEP 35)"""
 UNSUPPORTED_FUNCTIONS = set()
 """Functions that cannot sensibly be used with quantities."""

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -28,6 +28,7 @@ from astropy.utils.compat import (
     NUMPY_LT_1_25,
     NUMPY_LT_2_0,
     NUMPY_LT_2_1,
+    NUMPY_LT_2_2,
 )
 
 if TYPE_CHECKING:
@@ -2840,9 +2841,9 @@ class TestRecFunctions:
 all_wrapped_functions = get_wrapped_functions(
     np, np.fft, np.linalg, np.lib.recfunctions
 )
-all_wrapped_functions |= (
-    SUPPORTED_NEP35_FUNCTIONS  # ref https://github.com/numpy/numpy/issues/27451
-)
+if NUMPY_LT_2_2:
+    # ref https://github.com/numpy/numpy/issues/27451
+    all_wrapped_functions |= SUPPORTED_NEP35_FUNCTIONS
 tested_functions = get_covered_functions(locals())
 untested_functions = set()
 deprecated_functions = set()


### PR DESCRIPTION
### Description
This is not required, but nice-to-have: it helps signal that `SUPPORTED_NEP35_FUNCTIONS` becomes unneeded when our oldest supported numpy is 2.2 or newer.
 
xref: https://github.com/numpy/numpy/pull/27490


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
