### PR TITLE
STY: ignore rule `UP031` in a specific case where an fstring would be less readable

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -43,7 +43,7 @@ class Card(_Verify):
     """The length of a Card image; should always be 80 for valid FITS files."""
 
     # String for a FITS standard compliant (FSC) keyword.
-    _keywd_FSC_RE = re.compile(r"^[A-Z0-9_-]{0,%d}$" % KEYWORD_LENGTH)
+    _keywd_FSC_RE = re.compile(r"^[A-Z0-9_-]{0,%d}$" % KEYWORD_LENGTH)  # noqa: UP031, RUF100
     # This will match any printable ASCII character excluding '='
     _keywd_hierarch_RE = re.compile(
         r"^(?:HIERARCH +)?(?:^[ -<>-~]+ ?)+$", re.IGNORECASE


### PR DESCRIPTION
### Description
ref #17430

seeing that upstream issue doesn't seem like it'll converge quickly, this seems like the easiest way to go.
note that needed to add a noqa for `RUF100` too so ruff<0.8 doesn't clean up the first noqa
xref: https://github.com/astral-sh/ruff/issues/14555 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
