### PR TITLE
Optimize getting config item values 

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -64,17 +64,7 @@ class ConfigurationChangedWarning(AstropyWarning):
     """
 
 
-class _ConfigNamespaceMeta(type):
-    def __init__(cls, name, bases, dict):
-        if cls.__bases__[0] is object:
-            return
-
-        for key, val in dict.items():
-            if isinstance(val, ConfigItem):
-                val.name = key
-
-
-class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
+class ConfigNamespace:
     """
     A namespace of configuration items.  Each subpackage with
     configuration items should define a subclass of this class,
@@ -326,6 +316,9 @@ class ConfigItem:
             self.aliases = [aliases]
         else:
             self.aliases = aliases
+
+    def __set_name__(self, owner, name):
+        self.name = name
 
     def __set__(self, obj, value):
         return self.set(value)

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -21,8 +21,7 @@ from textwrap import TextWrapper
 from warnings import warn
 
 from astropy.extern.configobj import configobj, validate
-from astropy.utils import find_current_module, silence
-from astropy.utils import isiterable
+from astropy.utils import find_current_module, isiterable, silence
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .paths import get_config_dir_path
@@ -329,10 +328,10 @@ class ConfigItem:
         # cache value on the descriptor itself, to avoid repeated accesses
         # to the ConfigObj object which is much slower
         try:
-            val = self.value
+            return self.value
         except AttributeError:
             val = self.value = self()
-        return val
+            return val
 
     def set(self, value):
         """
@@ -387,8 +386,8 @@ class ConfigItem:
 
         """
         initval = self()
-        self.set(value)
         try:
+            self.set(value)
             yield
         finally:
             self.set(initval)

--- a/docs/changes/config/17461.perf.rst
+++ b/docs/changes/config/17461.perf.rst
@@ -1,0 +1,1 @@
+Optimize getting config item values.


### PR DESCRIPTION
Fix #12504 (I think, doing better might be possible but not sure without breaking some feature of our complicated configuration system):

As explained there, getting a config item is quite slow, values being stored within the ConfigObj object . And io.fits accesses config items when e.g. accessing the value of a card, this means a lot of config item calls for tables especially with many columns. 

So here I'm adding a cache on the ConfigItem descriptor, allowing to get the key much faster while still storing its value on the ConfigObj object.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
