### PR TITLE
BUG: add missing ufunc helpers for `np.matvec` and `np.vecmat`

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from astropy.units.core import dimensionless_unscaled, unit_scale_converter
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_3
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
@@ -544,8 +544,11 @@ for ufunc in twoarg_invtrig_ufuncs:
 # ufuncs handled as special cases
 UFUNC_HELPERS[np.multiply] = helper_multiplication
 UFUNC_HELPERS[np.matmul] = helper_multiplication
-if isinstance(getattr(np, "vecdot", None), np.ufunc):
+if not NUMPY_LT_2_0:
     UFUNC_HELPERS[np.vecdot] = helper_multiplication
+if not NUMPY_LT_2_3:
+    UFUNC_HELPERS[np.vecmat] = helper_multiplication
+    UFUNC_HELPERS[np.matvec] = helper_multiplication
 UFUNC_HELPERS[np.divide] = helper_division
 UFUNC_HELPERS[np.true_divide] = helper_division
 UFUNC_HELPERS[np.power] = helper_power

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -18,7 +18,7 @@ from astropy.tests.helper import PYTEST_LT_8_0
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_25, NUMPY_LT_2_0
+from astropy.utils.compat.numpycompat import NUMPY_LT_1_25, NUMPY_LT_2_0, NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 if TYPE_CHECKING:
@@ -386,6 +386,29 @@ class TestQuantityMathFuncs:
         q2 = np.array([4j, 5j, 6j]) / u.s
         o = np.vecdot(q1, q2)
         assert o == (32.0 + 0j) * u.m / u.s
+
+    @pytest.mark.skipif(
+        NUMPY_LT_2_3, reason="np.matvec and np.vecmat are new in NumPy 2.3"
+    )
+    def test_matvec():
+        vec = np.arange(3) << u.s
+        mat = (
+            np.array(
+                [
+                    [1.0, -1.0, 2.0],
+                    [0.0, 3.0, -1.0],
+                    [-1.0, -1.0, 1.0],
+                ]
+            )
+            << u.m
+        )
+        ref_matvec = (vec * mat).sum(-1)
+        res_matvec = np.matvec(mat, vec)
+        assert_array_equal(res_matvec, ref_matvec)
+
+        ref_vecmat = (vec * mat.T).sum(-1)
+        res_vecmat = np.vecmat(vec, mat)
+        assert_array_equal(res_vecmat, ref_vecmat)
 
     @pytest.mark.parametrize("function", (np.divide, np.true_divide))
     def test_divide_scalar(self, function):

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -15,6 +15,7 @@ __all__ = [
     "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
     "NUMPY_LT_2_2",
+    "NUMPY_LT_2_3",
     "COPY_IF_NEEDED",
 ]
 
@@ -27,6 +28,7 @@ NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0")
 NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
+NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None


### PR DESCRIPTION
### Description
[example logs](https://github.com/astropy/astropy/actions/runs/12045745339/job/33584893498)
xref: https://github.com/numpy/numpy/pull/25675

given how small the change, I think we should backport to 7.0.1

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
