### PR TITLE
Simplify parsing utilities

### DIFF
--- a/astropy/utils/parsing.py
+++ b/astropy/utils/parsing.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import os
 import re
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -36,23 +36,18 @@ _TAB_HEADER = """# Licensed under a 3-clause BSD style license - see LICENSE.rst
 _LOCK = threading.RLock()
 
 
-def _add_tab_header(filename: str, package: str) -> None:
-    with open(filename) as f:
-        contents = f.read()
-
-    with open(filename, "w") as f:
-        f.write(_TAB_HEADER.format(package=package))
-        f.write(contents)
-
-
 @contextlib.contextmanager
-def _patch_get_caller_module_dict(module: ModuleType) -> Generator[None, None, None]:
+def _patch_ply_module(
+    module: ModuleType, file: Path, package: str
+) -> Generator[None, None, None]:
     """Temporarily replace the module's get_caller_module_dict.
 
     This is a function inside ``ply.lex`` and ``ply.yacc`` (each has a copy)
     that is used to retrieve the caller's local symbols. Here, we patch the
     function to instead retrieve the grandparent's local symbols to account
     for a wrapper layer.
+
+    Additionally, a custom header is inserted into any files ``ply`` writes.
     """
     original = module.get_caller_module_dict
 
@@ -61,9 +56,12 @@ def _patch_get_caller_module_dict(module: ModuleType) -> Generator[None, None, N
         # Add 2, not 1, because the wrapper itself adds another level
         return original(levels + 2)
 
+    file_exists = file.exists() or file.with_suffix(".pyc").exists()
     module.get_caller_module_dict = wrapper
     yield
     module.get_caller_module_dict = original
+    if not file_exists:
+        file.write_text(_TAB_HEADER.format(package=package) + file.read_text())
 
 
 def lex(lextab: str, package: str, reflags: int = int(re.VERBOSE)) -> Lexer:
@@ -93,24 +91,11 @@ def lex(lextab: str, package: str, reflags: int = int(re.VERBOSE)) -> Lexer:
     """
     from astropy.extern.ply import lex
 
-    caller_file = lex.get_caller_module_dict(2)["__file__"]
-    caller_dir = os.path.dirname(caller_file)
-    lextab_filename_py = os.path.join(caller_dir, lextab + ".py")
-    lextab_filename_pyc = os.path.join(caller_dir, lextab + ".pyc")
-    with _LOCK:
-        lextab_exists = os.path.exists(lextab_filename_py) or os.path.exists(
-            lextab_filename_pyc
+    caller_dir = Path(lex.get_caller_module_dict(2)["__file__"]).parent
+    with _LOCK, _patch_ply_module(lex, caller_dir / (lextab + ".py"), package):
+        return lex.lex(
+            optimize=True, lextab=lextab, outputdir=caller_dir, reflags=reflags
         )
-        with _patch_get_caller_module_dict(lex):
-            lexer = lex.lex(
-                optimize=True,
-                lextab=lextab,
-                outputdir=caller_dir,
-                reflags=reflags,
-            )
-        if not lextab_exists:
-            _add_tab_header(lextab_filename_py, package)
-        return lexer
 
 
 class ThreadSafeParser:
@@ -153,21 +138,13 @@ def yacc(tabmodule: str, package: str) -> ThreadSafeParser:
     """
     from astropy.extern.ply import yacc
 
-    caller_file = yacc.get_caller_module_dict(2)["__file__"]
-    caller_dir = os.path.dirname(caller_file)
-    tab_filename_py = os.path.join(caller_dir, tabmodule + ".py")
-    tab_filename_pyc = os.path.join(caller_dir, tabmodule + ".pyc")
-    with _LOCK:
-        tab_exists = os.path.exists(tab_filename_py) or os.path.exists(tab_filename_pyc)
-        with _patch_get_caller_module_dict(yacc):
-            parser = yacc.yacc(
-                tabmodule=tabmodule,
-                outputdir=caller_dir,
-                debug=False,
-                optimize=True,
-                write_tables=True,
-            )
-        if not tab_exists:
-            _add_tab_header(tab_filename_py, package)
-
+    caller_dir = Path(yacc.get_caller_module_dict(2)["__file__"]).parent
+    with _LOCK, _patch_ply_module(yacc, caller_dir / (tabmodule + ".py"), package):
+        parser = yacc.yacc(
+            tabmodule=tabmodule,
+            outputdir=caller_dir,
+            debug=False,
+            optimize=True,
+            write_tables=True,
+        )
     return ThreadSafeParser(parser)


### PR DESCRIPTION
### Description

It is possible to simplify our parsing utilities by making use of `pathlib.Path` and the convenience methods it provides. Moving some common code that inserts a custom header to the files `ply` writes out from `lex()` and `yacc()` avoids code duplication, which simplifies the code even more. I'm not entirely convinced that moving that code to the same context manager that patches the `get_caller_module_dict()` functions is the best thing to do. An alternative would be to introduce a second context manager just for inserting the custom headers, but then we would end up with two context managers that are always called together, and that doesn't sound like a very good solution either.

The updated code is used by the unit parsers, so `units` maintainers might be interested in this.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
