### PR TITLE
TST: fixup test from pr-17464

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -390,7 +390,7 @@ class TestQuantityMathFuncs:
     @pytest.mark.skipif(
         NUMPY_LT_2_3, reason="np.matvec and np.vecmat are new in NumPy 2.3"
     )
-    def test_matvec():
+    def test_matvec(self):
         vec = np.arange(3) << u.s
         mat = (
             np.array(


### PR DESCRIPTION
This pull request is to address a small problem with a test added in #17464 that I failed to notice, and that was merged because the failure only occurred in with devdeps -- silly me to be in a hurry and think I could just enable auto-merge on a devdeps fix.

Only merge this is devdeps now passes!