### PR TITLE
TST: add a CI job for Python's optimized mode

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -115,6 +115,24 @@ jobs:
           cache-path: .tox
           cache-key: doubletest-${{ github.ref_name }}
 
+  test_optimized_mode:
+    # tox itself doesn't support optimized mode so we'll run pytest directly
+    # see https://github.com/tox-dev/tox/issues/3006
+    needs: [initial_checks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: 3.x
+      - name: Build
+        run: python -m pip install -e '.[test]'
+      - name: Run pytest
+        run: pytest --color=yes -ra -n4
+        env:
+          PYTHONOPTIMIZE: 2
+
   allowed_failures:
     needs: [initial_checks]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@9f1fedda61294df4c004c05519a3fbf3b8e1f32f  # v2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,7 @@ filterwarnings = [
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
     # Weird warning from the vectorized do_format in Angle.to_string. low numpy/python?
     "ignore:invalid value encountered in do_format:RuntimeWarning",
+    "ignore:assertions not in test modules or plugins will be ignored:UserWarning"
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
### Description
The end goal is to close #17471, but actual fixes will be done in small, subpackage-focused PRs that I'll link below

- https://github.com/astropy/astropy/pull/17473
- https://github.com/astropy/astropy/pull/17474
- https://github.com/astropy/astropy/pull/17475
- https://github.com/astropy/astropy/pull/17476
- https://github.com/astropy/astropy/pull/17477
- https://github.com/astropy/astropy/pull/17478
- https://github.com/astropy/astropy/pull/17481
- https://github.com/astropy/astropy/pull/17548
- https://github.com/astropy/astropy/pull/17549
- https://github.com/astropy/astropy/pull/17555
- https://github.com/astropy/astropy/pull/17556
- https://github.com/astropy/astropy/pull/17557
- https://github.com/astropy/astropy/pull/17571
- https://github.com/astropy/astropy/pull/17572
- https://github.com/astropy/astropy/pull/17573

upstream:
- https://github.com/data-apis/array-api-strict/pull/104

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
