### PR TITLE
BUG: fix importing from `astropy.visualization.wcsaxes.patches` under Python's optimized mode

### DIFF
--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
+import sys
 import warnings
 
 import numpy as np
@@ -19,18 +20,19 @@ __all__ = ["Quadrangle", "SphericalCircle"]
 
 # Monkey-patch the docs to fix CapStyle and JoinStyle subs.
 # TODO! delete when upstream fix matplotlib/matplotlib#19839
-Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
-    "`.CapStyle`", "``matplotlib._enums.CapStyle``"
-)
-Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
-    "`.JoinStyle`", "``matplotlib._enums.JoinStyle``"
-)
-Polygon.set_capstyle.__doc__ = Polygon.set_capstyle.__doc__.replace(
-    "`.CapStyle`", "``matplotlib._enums.CapStyle``"
-)
-Polygon.set_joinstyle.__doc__ = Polygon.set_joinstyle.__doc__.replace(
-    "`.JoinStyle`", "``matplotlib._enums.JoinStyle``"
-)
+if sys.flags.optimize < 2:
+    Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
+        "`.CapStyle`", "``matplotlib._enums.CapStyle``"
+    )
+    Polygon.__init__.__doc__ = Polygon.__init__.__doc__.replace(
+        "`.JoinStyle`", "``matplotlib._enums.JoinStyle``"
+    )
+    Polygon.set_capstyle.__doc__ = Polygon.set_capstyle.__doc__.replace(
+        "`.CapStyle`", "``matplotlib._enums.CapStyle``"
+    )
+    Polygon.set_joinstyle.__doc__ = Polygon.set_joinstyle.__doc__.replace(
+        "`.JoinStyle`", "``matplotlib._enums.JoinStyle``"
+    )
 
 
 def _rotate_polygon(lon, lat, lon0, lat0):


### PR DESCRIPTION
### Description
ref #17472

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
