### PR TITLE
BUG: fix compatibility with Python's optimized mode (`cosmology`)

### DIFF
--- a/astropy/cosmology/_io/model.py
+++ b/astropy/cosmology/_io/model.py
@@ -266,9 +266,11 @@ def to_model(cosmology: _CosmoT, *_: object, method: str) -> _CosmologyModel[_Co
     CosmoModel = type(clsname, (_CosmologyModel,), {**attrs, **params})
     # override __signature__ and format the doc.
     CosmoModel.evaluate.__signature__ = msig
-    CosmoModel.evaluate.__doc__ = CosmoModel.evaluate.__doc__.format(
-        cosmo_cls=cosmo_cls.__qualname__, method=method
-    )
+    if CosmoModel.evaluate.__doc__ is not None:
+        # guard against PYTHONOPTIMIZE mode
+        CosmoModel.evaluate.__doc__ = CosmoModel.evaluate.__doc__.format(
+            cosmo_cls=cosmo_cls.__qualname__, method=method
+        )
 
     # instantiate class using default values
     model = CosmoModel(

--- a/astropy/cosmology/tests/test_connect.py
+++ b/astropy/cosmology/tests/test_connect.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import inspect
+import sys
 
 import pytest
 
@@ -156,7 +157,8 @@ class TestCosmologyReadWrite(ReadWriteTestMixin):
         assert "overwrite" in sig.parameters
 
         # also in docstring
-        assert "overwrite : bool" in writer.__doc__
+        if not sys.flags.optimize:
+            assert "overwrite : bool" in writer.__doc__
 
     @pytest.mark.parametrize("format, _, has_deps", readwrite_formats)
     def test_readwrite_reader_class_mismatch(


### PR DESCRIPTION
### Description
ref #17472

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
