### PR TITLE
BUG: avoid assert statement in business logic (`table`)

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3118,7 +3118,8 @@ class Table:
 
     def _set_row(self, idx, colnames, vals):
         try:
-            assert len(vals) == len(colnames)
+            if not len(vals) == len(colnames):
+                raise Exception
         except Exception:
             raise ValueError(
                 "right hand side must be a sequence of values with "


### PR DESCRIPTION
### Description
ref #17472

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
