### PR TITLE
BUG: avoid assert statements in business logic (`io.ascii`)

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1073,12 +1073,12 @@ class BaseOutputter:
         """
         # Allow specifying a single converter instead of a list of converters.
         # The input `converters` must be a ``type`` value that can init np.dtype.
-        try:
-            # Don't allow list-like things that dtype accepts
-            assert type(converters) is type
-            converters = [np.dtype(converters)]
-        except (AssertionError, TypeError):
-            pass
+        if type(converters) is type:
+            try:
+                # Don't allow list-like things that dtype accepts
+                converters = [np.dtype(converters)]
+            except TypeError:
+                pass
 
         converters_out = []
         try:

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -289,11 +289,10 @@ def _validate_read_write_kwargs(read_write, **kwargs):
                 # See if ``val`` walks and quacks like a ``cls```.
                 try:
                     new_val = cls(val)
-                    assert new_val == val
                 except Exception:
                     ok = False
                 else:
-                    ok = True
+                    ok = new_val == val
         return ok
 
     kwarg_types = READ_KWARG_TYPES if read_write == "read" else WRITE_KWARG_TYPES


### PR DESCRIPTION
### Description
ref #17472 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
