### PR TITLE
Fix Ruff rule PT022 violations

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -122,7 +122,6 @@ lint.ignore = [
     "PT012",   # pytest-raises-with-multiple-statements
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion
-    "PT022",   # pytest-useless-yield-fixture
 
     # flake8-return (RET)
     "RET501",  # unnecessary-return-none

--- a/astropy/cosmology/_io/tests/test_yaml.py
+++ b/astropy/cosmology/_io/tests/test_yaml.py
@@ -174,7 +174,7 @@ class TestToFromYAML(ToFromDirectTestBase, ToFromYAMLTestMixin):
         This overrides from super because `ToFromDirectTestBase` adds a custom
         Cosmology ``CosmologyWithKwargs`` that is not registered with YAML.
         """
-        yield  # run tests
+        return  # run tests
 
     def test_from_yaml_autoidentify(self, cosmo, to_format, from_format):
         """

--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -84,7 +84,7 @@ def fmtcls2():
 
 @pytest.fixture(params=["test1", "test2"])
 def fmtcls(request):
-    yield (request.param, EmptyData)
+    return (request.param, EmptyData)
 
 
 @pytest.fixture
@@ -1095,7 +1095,7 @@ class TestSubclass:
     @pytest.fixture(autouse=True)
     def registry(self):
         """I/O registry. Not cleaned."""
-        yield
+        return
 
     def test_read_table_subclass(self):
         class MyTable(Table):

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -277,7 +277,7 @@ def a_binary_file(tmp_path):
     b_contents = b"\xde\xad\xbe\xef"
     with open(fn, "wb") as f:
         f.write(b_contents)
-    yield fn, b_contents
+    return fn, b_contents
 
 
 @pytest.fixture
@@ -286,7 +286,7 @@ def a_file(tmp_path):
     contents = "contents\n"
     with open(fn, "w") as f:
         f.write(contents)
-    yield fn, contents
+    return fn, contents
 
 
 def test_temp_cache(tmp_path):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request addresses `Ruff` rule [PT022](https://docs.astral.sh/ruff/rules/pytest-useless-yield-fixture/) violations globally.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

- Partially fixes #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
