### PR TITLE
BUG: avoid an assert statement in business logic (`units`)

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1353,14 +1353,16 @@ class Quantity(np.ndarray):
     def __index__(self):
         # for indices, we do not want to mess around with scaling at all,
         # so unlike for float, int, we insist here on unscaled dimensionless
-        try:
-            assert self.unit.is_unity()
-            return self.value.__index__()
-        except Exception:
-            raise TypeError(
-                "only integer dimensionless scalar quantities "
-                "can be converted to a Python index"
-            )
+        if self.unit.is_unity():
+            try:
+                return self.value.__index__()
+            except AttributeError:
+                pass
+
+        raise TypeError(
+            "only integer dimensionless scalar quantities "
+            "can be converted to a Python index"
+        )
 
     # TODO: we may want to add a hook for dimensionless quantities?
     @property

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -4,6 +4,7 @@
 import copy
 import decimal
 import numbers
+import operator
 import pickle
 from fractions import Fraction
 
@@ -717,6 +718,14 @@ class TestQuantityOperations:
         # Array quantity
         q = u.Quantity([1.0, 2.0, 3.0], u.m)
         assert np.all(np.array(q) == np.array([1.0, 2.0, 3.0]))
+
+    def test_index(self):
+        val = 123
+        out = operator.index(u.Quantity(val, u.one, dtype=int))
+        assert out == val
+
+        with pytest.raises(TypeError):
+            operator.index(u.Quantity(val, u.m, dtype=int))
 
 
 def test_quantity_conversion():


### PR DESCRIPTION
### Description
ref: #17472
Following https://github.com/astropy/astropy/issues/17471#issuecomment-2508222612

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
