### PR TITLE
MNT: add a trailing newline to `pyproject.toml` in `update_astropy_iers_data_pin.py`

### DIFF
--- a/.github/workflows/update_astropy_iers_data_pin.py
+++ b/.github/workflows/update_astropy_iers_data_pin.py
@@ -26,4 +26,4 @@ elif changed_lines > 1:
     print(f"More than one line found containing astropy-iers-data in {project_file}")
     sys.exit(1)
 
-project_file.write_text("\n".join(lines))
+project_file.write_text("\n".join(lines) + "\n")


### PR DESCRIPTION
### Description
This removes a little friction I saw in #17486 where pre-commit.ci would flag the other bot's work.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
