### PR TITLE
API: mark most arguments from simple_norm as future keyword-only

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -711,7 +711,7 @@ def future_keyword_only(names: list[str], *, since=list[str]) -> FunctionType:
                     "Pass them as keywords to suppress this warning. "
                     f"(deprecated since {since_details})"
                 )
-                warnings.warn(msg, FutureWarning, stacklevel=2)
+                warnings.warn(msg, AstropyDeprecationWarning, stacklevel=2)
             return raw_function(*args, **kwargs)
 
         return decorated_function

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -7,7 +7,9 @@ import textwrap
 import threading
 import types
 import warnings
+from functools import wraps
 from inspect import signature
+from types import FunctionType
 
 from .exceptions import (
     AstropyDeprecationWarning,
@@ -619,6 +621,102 @@ def deprecated_renamed_argument(
         return wrapper
 
     return decorator
+
+
+def future_keyword_only(names: list[str], *, since=list[str]) -> FunctionType:
+    """Decorator to mark one or more function parameter(s) as future keyword-only.
+
+    Parameters
+    ----------
+    names: list[str]
+        names of parameters to be marked as future keyword-only
+    since: list[str]
+        versions in which each parameter was marked
+
+    Examples
+    --------
+    >>> @future_keyword_only(['spam', 'eggs'], since=['7.1', '7.1'])
+    ... def bacon(spam, eggs):
+    ...     ...
+    """
+
+    def decorate(raw_function):
+        # validate the conditions in which the decorator is used
+        # this adds a small overhead on startup time but not on function call
+
+        future_kwo_names = names
+        if len(future_kwo_names) != len(since):
+            raise ValueError(
+                "Expected names and since values with "
+                "identical length. "
+                f"Got {len(names)=} and {len(since)=}"
+            )
+        params = signature(raw_function).parameters
+        params_names: list[str] = list(params)
+        future_kwo_to_since = dict(zip(future_kwo_names, since))
+
+        # check that all names exist in the current signature
+        if any(n not in params for n in future_kwo_names):
+            unknown = sorted(set(future_kwo_names) - set(params_names))
+            raise ValueError(
+                "The following arguments cannot be marked as future keyword-only "
+                "because they were not found in the decorated function's signature: "
+                f"{', '.join(unknown)}"
+            )
+
+        # check that every future kwo is currently allowed as positional-or-keyword
+        # (otherwise something's wrong with the decorator call itself)
+        pos_or_kw_names = {
+            n for (n, p) in params.items() if p.kind is p.POSITIONAL_OR_KEYWORD
+        }
+        if not pos_or_kw_names.issuperset(future_kwo_names):
+            diff = sorted(set(future_kwo_names) - pos_or_kw_names)
+            raise ValueError(
+                "The following arguments cannot be marked as future keyword-only "
+                "because they are not currently positional-or-keyword: "
+                f"{', '.join(diff)}"
+            )
+
+        # check that there are no other positionally allowed arguments beyond
+        # any future kwo (otherwise these arguments could still break)
+        future_kwo_positions = [params_names.index(n) for n in future_kwo_names]
+        idx_min = min(future_kwo_positions)
+        idx_max = max(future_kwo_positions) + 1
+        while idx_max < len(params):
+            p = params[params_names[idx_max]]
+            if p.kind in (p.KEYWORD_ONLY, p.VAR_KEYWORD):
+                break
+            idx_max += 1
+        if any(n not in future_kwo_names for n in list(params)[idx_min:idx_max]):
+            broken = params_names[max(future_kwo_positions) + 1 : idx_max]
+            raise ValueError(
+                "The following positionally-allowed arguments were not marked as "
+                "future keyword-only and would be broken under future keyword-only "
+                f"requirements: {', '.join(broken)}"
+            )
+
+        @wraps(raw_function)
+        def decorated_function(*args, **kwargs):
+            if len(args) > idx_min:
+                flagged_positions = range(idx_min, len(args))
+                flagged_names = [params_names[pos] for pos in flagged_positions]
+                depr_versions = [future_kwo_to_since[n] for n in flagged_names]
+                if len(set(depr_versions)) == 1:
+                    since_details = depr_versions[0]
+                else:
+                    since_details = ", ".join(depr_versions) + ", respectively"
+                msg = (
+                    "The following arguments were received positionally, which "
+                    f"will be disallowed in a future release: {', '.join(flagged_names)}\n"
+                    "Pass them as keywords to suppress this warning. "
+                    f"(deprecated since {since_details})"
+                )
+                warnings.warn(msg, FutureWarning, stacklevel=2)
+            return raw_function(*args, **kwargs)
+
+        return decorated_function
+
+    return decorate
 
 
 # TODO: This can still be made to work for setters by implementing an

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -14,6 +14,7 @@ from astropy.utils.decorators import (
     deprecated_attribute,
     deprecated_renamed_argument,
     format_doc,
+    future_keyword_only,
     lazyproperty,
     sharedmethod,
 )
@@ -556,6 +557,94 @@ def test_deprecated_argument_remove():
     assert test() == (11, 3)
     assert test(121) == (121, 3)
     assert test(dummy=121) == (121, 3)
+
+
+def test_future_kwo_invalid_since():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Expected names and since values with "
+            r"identical length. Got len\(names\)=3 "
+            r"and len\(since\)=2"
+        ),
+    ):
+        future_keyword_only(["a", "b", "c"], since=["7.1", "7.1"])(lambda a, b, c: ...)
+
+
+def test_future_kwo_invalid_names():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The following arguments cannot be marked as future keyword-only "
+            "because they were not found in the decorated function's signature: a"
+        ),
+    ):
+        future_keyword_only(["a"], since=["7.1"])(lambda b: ...)
+
+
+@pytest.mark.parametrize(
+    "input_func",
+    [
+        pytest.param(lambda a, /: ..., id="arg-is-positional-only"),
+        pytest.param(lambda *, a: ..., id="arg-is-keyword-only"),
+        pytest.param(lambda *a: ..., id="arg-is-var-positional"),
+        pytest.param(lambda **a: ..., id="arg-is-var-keyword"),
+    ],
+)
+def test_future_kwo_not_pos_or_kw(input_func):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The following arguments cannot be marked as future keyword-only "
+            "because they are not currently positional-or-keyword: a"
+        ),
+    ):
+        future_keyword_only(["a"], since=["7.1"])(input_func)
+
+
+def test_future_kwo_broken_pos_allowed():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "The following positionally-allowed arguments were not marked as "
+            "future keyword-only and would be broken under future keyword-only "
+            r"requirements: c, d"
+        ),
+    ):
+        future_keyword_only(["b"], since=["7.1"])(lambda a, b, c, d=None: ...)
+
+
+def test_future_kwo_warn_if_and_only_if_needed():
+    func = future_keyword_only(["b", "c", "d"], since=["7.1", "7.1", "7.2"])(
+        lambda a, b, c=None, d=None: ...
+    )
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            "The following arguments were received positionally, which "
+            "will be disallowed in a future release: b, c, d\n"
+            "Pass them as keywords to suppress this warning. "
+            r"\(deprecated since 7\.1, 7\.1, 7\.2, respectively\)"
+        ),
+    ):
+        func(1, 2, 3, 4)
+
+    # also check the warning if all arguments were marked at the same time
+    with pytest.warns(
+        FutureWarning,
+        match=(
+            "The following arguments were received positionally, which "
+            "will be disallowed in a future release: b, c\n"
+            "Pass them as keywords to suppress this warning. "
+            r"\(deprecated since 7\.1\)"
+        ),
+    ):
+        func(1, 2, 3, d=4)
+
+    # check no warning is emitted if future constraints are already honored
+    func(1, b=2, c=3, d=4)
+    func(1, b=2, c=3)
+    func(1, b=2)
 
 
 def test_sharedmethod_reuse_on_subclasses():

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -619,7 +619,7 @@ def test_future_kwo_warn_if_and_only_if_needed():
         lambda a, b, c=None, d=None: ...
     )
     with pytest.warns(
-        FutureWarning,
+        AstropyDeprecationWarning,
         match=(
             "The following arguments were received positionally, which "
             "will be disallowed in a future release: b, c, d\n"
@@ -631,7 +631,7 @@ def test_future_kwo_warn_if_and_only_if_needed():
 
     # also check the warning if all arguments were marked at the same time
     with pytest.warns(
-        FutureWarning,
+        AstropyDeprecationWarning,
         match=(
             "The following arguments were received positionally, which "
             "will be disallowed in a future release: b, c\n"

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
-from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated_renamed_argument, future_keyword_only
 
 from .interval import (
     AsymmetricPercentileInterval,
@@ -435,6 +435,22 @@ class SimpleNorm:
         return axim
 
 
+@future_keyword_only(
+    [
+        "power",
+        "asinh_a",
+        "vmin",
+        "vmax",
+        "min_percent",
+        "max_percent",
+        "percent",
+        "clip",
+        "log_a",
+        "invalid",
+        "sinh_a",
+    ],
+    since=["7.1"] * 11,
+)
 @deprecated_renamed_argument(["min_cut", "max_cut"], ["vmin", "vmax"], ["6.1", "6.1"])
 def simple_norm(
     data,

--- a/docs/changes/utils/17489.feature.rst
+++ b/docs/changes/utils/17489.feature.rst
@@ -1,2 +1,0 @@
-Add a ``@future_keyword_only`` decorator to indicate positional-or-keyword
-function arguments will become keyword-only in a future version.

--- a/docs/changes/utils/17489.feature.rst
+++ b/docs/changes/utils/17489.feature.rst
@@ -1,0 +1,2 @@
+Add a ``@future_keyword_only`` decorator to indicate positional-or-keyword
+function arguments will become keyword-only in a future version.

--- a/docs/changes/visualization/17489.api.rst
+++ b/docs/changes/visualization/17489.api.rst
@@ -1,0 +1,3 @@
+All arguments from ``simple_norm`` are marked as future keyword-only, with the
+exception of the first two (``data`` and ``stretch``).
+A warning is now displayed if any other arguments are passed positionally.


### PR DESCRIPTION
### Description
Fixes #17235

about the decorator itself:
 - having to specify `since` as a separate list is less than ideal in my opinion, and there would be much more convenient designs, but I chose it to match the API of pre-existing similar decorators.
 - even though this is in the spirit of #16597, I'm not trying to rewrite *this* decorator in C for now as it seems much less likely to have a noticeable impact.

about the deprecation:
even when this deprecation is concluded (which would be in astropy 9.0 as the earliest), `simple_norm`'s signature would *still* not perfectly align with that of `SimpleNorm`: `SimpleNorm` still supports passing `percent` positionally, while `simple_norm` supports passing `stretch` positionally (which is done here for convenience as it is the one argument that's actually exercised as positional in tests beyond `data`).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
