### PR TITLE
Add a helpers for a few unit formatter error messages

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -267,25 +267,24 @@ class _ParsingFormatMixin:
         return did_you_mean(unit, cls._units, fix=cls._fix_deprecated)
 
     @classmethod
-    def _try_decomposed(cls, unit: UnitBase) -> str | None:
-        return None
-
-    @classmethod
     def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
         if unit not in cls._units:
             if detailed_exception:
-                raise ValueError(
-                    f"Unit '{unit}' not supported by the {cls.__name__} standard. "
-                    + cls._did_you_mean_units(unit)
-                )
+                raise ValueError(cls._invalid_unit_error_message(unit))
             raise ValueError()
         if unit in cls._deprecated_units:
-            message = (
-                f"The unit '{unit}' has been deprecated in the {cls.__name__} standard."
-            )
-            if (decomposed := cls._try_decomposed(cls._units[unit])) is not None:
-                message += f" Suggested: {decomposed}."
-            warnings.warn(message, UnitsWarning)
+            warnings.warn(cls._deprecated_unit_warning_message(unit), UnitsWarning)
+
+    @classmethod
+    def _invalid_unit_error_message(cls, unit: str) -> str:
+        return (
+            f"Unit '{unit}' not supported by the {cls.__name__} standard. "
+            + cls._did_you_mean_units(unit)
+        )
+
+    @classmethod
+    def _deprecated_unit_warning_message(cls, unit: str) -> str:
+        return f"The unit '{unit}' has been deprecated in the {cls.__name__} standard."
 
     @classmethod
     def _decompose_to_known_units(

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -117,12 +117,8 @@ class VOUnit(Base, _GenericParserMixin):
 
             if cls._custom_unit_regex.match(t.value):
                 warnings.warn(
-                    UnitParserWarning(
-                        f"Unit {t.value!r} not supported by the VOUnit standard. "
-                        + cls._did_you_mean_units(t.value)
-                    )
+                    cls._invalid_unit_error_message(t.value), UnitParserWarning
                 )
-
                 return cls._def_custom_unit(t.value)
 
             raise
@@ -226,5 +222,8 @@ class VOUnit(Base, _GenericParserMixin):
         )
 
     @classmethod
-    def _try_decomposed(cls, unit: UnitBase) -> str:
-        return cls.to_string(unit._represents)
+    def _deprecated_unit_warning_message(cls, unit: str) -> str:
+        return (
+            super()._deprecated_unit_warning_message(unit)
+            + f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
+        )


### PR DESCRIPTION
### Description

The new `_invalid_unit_error_message()` method reduces code duplication between `_ParsingFormatMixin._validate_unit()` and `VOUnit._get_unit()`.

`_deprecated_unit_warning_message()` replaces `_try_decomposed()`. The main problems with the latter were that it was very difficult to understand its purpose based on its name and it was very difficult to understand its purpose based on its implementations.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
