### PR TITLE
Make several argument defaults immutable (and annotate them)

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -177,7 +177,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
         return [(self, self.physical_unit, self.to_physical, self.from_physical)]
 
     # ↓↓↓ properties/methods required to behave like a unit
-    def decompose(self, bases: Collection[UnitBase] = set()) -> Self:
+    def decompose(self, bases: Collection[UnitBase] = ()) -> Self:
         """Copy the current unit with the physical unit decomposed.
 
         For details, see `~astropy.units.UnitBase.decompose`.
@@ -630,7 +630,7 @@ class FunctionQuantity(Quantity):
         """Return a copy with the physical unit in CGS units."""
         return self.__class__(self.physical.cgs)
 
-    def decompose(self, bases: Collection[UnitBase] = []) -> Self:
+    def decompose(self, bases: Collection[UnitBase] = ()) -> Self:
         """Generate a new instance with the physical unit decomposed.
 
         For details, see `~astropy.units.Quantity.decompose`.

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -26,6 +26,9 @@ else:
     from numpy._core import umath as np_umath
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+    from typing import Self
+
     from astropy.units.typing import UnitPower
 
 __all__ = ["FunctionQuantity", "FunctionUnitBase"]
@@ -174,7 +177,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
         return [(self, self.physical_unit, self.to_physical, self.from_physical)]
 
     # ↓↓↓ properties/methods required to behave like a unit
-    def decompose(self, bases=set()):
+    def decompose(self, bases: Collection[UnitBase] = set()) -> Self:
         """Copy the current unit with the physical unit decomposed.
 
         For details, see `~astropy.units.UnitBase.decompose`.
@@ -627,7 +630,7 @@ class FunctionQuantity(Quantity):
         """Return a copy with the physical unit in CGS units."""
         return self.__class__(self.physical.cgs)
 
-    def decompose(self, bases=[]):
+    def decompose(self, bases: Collection[UnitBase] = []) -> Self:
         """Generate a new instance with the physical unit decomposed.
 
         For details, see `~astropy.units.Quantity.decompose`.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -37,6 +37,7 @@ from .structured import StructuredUnit, _structured_unit_like_dtype
 from .utils import is_effectively_unity
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
     from typing import Self
 
     from .typing import QuantityLike
@@ -1593,7 +1594,7 @@ class Quantity(np.ndarray):
                 # Format the whole thing as a single string.
                 return format(f"{self.value}{self._unitstr:s}", format_spec)
 
-    def decompose(self, bases=[]):
+    def decompose(self, bases: Collection[UnitBase] = []) -> Self:
         """
         Generates a new `Quantity` with the units
         decomposed. Decomposed units have only irreducible units in
@@ -1615,7 +1616,9 @@ class Quantity(np.ndarray):
         """
         return self._decompose(False, bases=bases)
 
-    def _decompose(self, allowscaledunits=False, bases=[]):
+    def _decompose(
+        self, allowscaledunits: bool = False, bases: Collection[UnitBase] = []
+    ) -> Self:
         """
         Generates a new `Quantity` with the units decomposed. Decomposed
         units have only irreducible units in them (see

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1594,7 +1594,7 @@ class Quantity(np.ndarray):
                 # Format the whole thing as a single string.
                 return format(f"{self.value}{self._unitstr:s}", format_spec)
 
-    def decompose(self, bases: Collection[UnitBase] = []) -> Self:
+    def decompose(self, bases: Collection[UnitBase] = ()) -> Self:
         """
         Generates a new `Quantity` with the units
         decomposed. Decomposed units have only irreducible units in
@@ -1617,7 +1617,7 @@ class Quantity(np.ndarray):
         return self._decompose(False, bases=bases)
 
     def _decompose(
-        self, allowscaledunits: bool = False, bases: Collection[UnitBase] = []
+        self, allowscaledunits: bool = False, bases: Collection[UnitBase] = ()
     ) -> Self:
         """
         Generates a new `Quantity` with the units decomposed. Decomposed

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -318,7 +318,7 @@ class StructuredUnit:
             operator.attrgetter("physical_type"), cls=Structure
         )
 
-    def decompose(self, bases: Collection[UnitBase] = set()) -> Self:
+    def decompose(self, bases: Collection[UnitBase] = ()) -> Self:
         """The `StructuredUnit` composed of only irreducible units.
 
         Parameters

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -3,15 +3,22 @@
 This module defines structured units and quantities.
 """
 
+from __future__ import annotations
+
 # Standard library
 import operator
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from astropy.utils.compat.numpycompat import NUMPY_LT_1_24
 
 from .core import UNITY, Unit, UnitBase
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+    from typing import Self
 
 __all__ = ["StructuredUnit"]
 
@@ -311,7 +318,7 @@ class StructuredUnit:
             operator.attrgetter("physical_type"), cls=Structure
         )
 
-    def decompose(self, bases=set()):
+    def decompose(self, bases: Collection[UnitBase] = set()) -> Self:
         """The `StructuredUnit` composed of only irreducible units.
 
         Parameters

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -93,6 +93,9 @@ py:class np.ma.MaskedArray
 # locally defined type variable for ndarray dtype
 py:class DT
 # type aliases
+py:class Complex
+py:class Real
+py:class UnitPower
 py:class UnitScale
 
 # Classes from `astropy.extern` that are nonetheless exposed in documentation


### PR DESCRIPTION
### Description

The first commit adds annotations to a few functions in `units`, all of which have a parameter with the type `Collection[UnitBase]`[^1]. In several functions with such a parameter its default value is an empty `set` or an empty `list`, both of which are mutable. In Python it is possible to permanently modify mutable function parameter defaults, which can cause bugs (see also Ruff rule [B006 (mutable-argument-default)](https://docs.astral.sh/ruff/rules/mutable-argument-default/)). It is better to use an immutable default such as an empty `tuple` because then it is obvious just from reading the function signature that calling the function does not modify the default argument.

Usually I prefer to avoid changing code in type annotation pull requests, but in this case the annotations make it obvious that the sets and lists can be replaced with tuples without changing code behavior, so adding the annotations and changing the code are conceptually related.

[^1]: I find it somewhat difficult to understand why the type is `Collection[UnitBase]` instead of `Collection[NamedUnit]`, but there is a test that asserts that `NamedUnit` is too restrictive: https://github.com/astropy/astropy/blob/24d3dd96015839ecf87899b02d403a9002bd3ef6/astropy/units/tests/test_units.py#L749-L755

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
