### PR TITLE
fix: Ob0 is never None

### DIFF
--- a/astropy/cosmology/flrw/base.py
+++ b/astropy/cosmology/flrw/base.py
@@ -176,7 +176,7 @@ class FLRW(Cosmology, _ScaleFactor):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
         density at z=0.
 
@@ -346,9 +346,9 @@ class FLRW(Cosmology, _ScaleFactor):
         return self.Om0 + self.Ogamma0 + self.Onu0 + self.Ode0 + self.Ok0
 
     @cached_property
-    def Odm0(self) -> float | None:
+    def Odm0(self) -> float:
         """Omega dark matter; dark matter density/critical density at z=0."""
-        return None if self.Ob0 is None else (self.Om0 - self.Ob0)
+        return self.Om0 - self.Ob0
 
     @cached_property
     def Ok0(self) -> float:
@@ -506,10 +506,6 @@ class FLRW(Cosmology, _ScaleFactor):
             each redshift.
             Returns `float` if the input is scalar.
 
-        Raises
-        ------
-        ValueError
-            If ``Ob0`` is `None`.
         """
         z = aszarr(z)
         return self.Ob0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
@@ -533,21 +529,11 @@ class FLRW(Cosmology, _ScaleFactor):
             critical density at each redshift.
             Returns `float` if the input is scalar.
 
-        Raises
-        ------
-        ValueError
-            If ``Ob0`` is `None`.
-
         Notes
         -----
         This does not include neutrinos, even if non-relativistic at the
         redshift of interest.
         """
-        if self.Odm0 is None:
-            raise ValueError(
-                "Baryonic density not set for this cosmology, "
-                "unclear meaning of dark matter density"
-            )
         z = aszarr(z)
         return self.Odm0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
 

--- a/astropy/cosmology/flrw/tests/test_base.py
+++ b/astropy/cosmology/flrw/tests/test_base.py
@@ -125,11 +125,7 @@ class FLRWTest(
         assert isinstance(cosmo_cls.Odm0, cached_property)
 
         # on the instance
-        assert (
-            cosmo.Odm0 is None
-            if cosmo.Ob0 is None
-            else np.allclose(cosmo.Odm0, cosmo.Om0 - cosmo.Ob0)
-        )
+        assert np.allclose(cosmo.Odm0, cosmo.Om0 - cosmo.Ob0)
 
     def test_Ok0(self, cosmo_cls, cosmo):
         """Test ``cached_property`` ``Ok0``."""
@@ -354,10 +350,7 @@ class FLRWTest(
         assert c.H0.value == 100
         for n, v in filter_keys_from_items(c.parameters, ("H0",)):
             v_expect = getattr(cosmo, n)
-            if v is None:
-                assert v is v_expect
-            else:
-                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
+            assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
         assert not u.allclose(c.Ogamma0, cosmo.Ogamma0)
         assert not u.allclose(c.Onu0, cosmo.Onu0)
 
@@ -370,10 +363,7 @@ class FLRWTest(
         assert c.meta == {**cosmo.meta, **dict(zz="tops")}
         for n, v in filter_keys_from_items(c.parameters, ("H0", "Tcmb0")):
             v_expect = getattr(cosmo, n)
-            if v is None:
-                assert v is v_expect
-            else:
-                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
+            assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
         assert not u.allclose(c.Ogamma0, cosmo.Ogamma0)
         assert not u.allclose(c.Onu0, cosmo.Onu0)
         assert not u.allclose(c.Tcmb0.value, cosmo.Tcmb0.value)

--- a/astropy/cosmology/flrw/tests/test_w0cdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0cdm.py
@@ -81,10 +81,7 @@ class TestwCDM(FLRWTest, Parameterw0TestMixin):
         assert c.w0 == 0.1
         for n, v in filter_keys_from_items(c.parameters, ("w0",)):
             v_expect = getattr(cosmo, n)
-            if v is None:
-                assert v is v_expect
-            else:
-                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
+            assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
 
     @pytest.mark.parametrize("z", valid_zs)
     def test_w(self, cosmo, z):

--- a/astropy/cosmology/flrw/tests/test_w0wacdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wacdm.py
@@ -82,10 +82,7 @@ class Testw0waCDM(FLRWTest, Parameterw0TestMixin, ParameterwaTestMixin):
         assert c.wa == 0.2
         for n, v in filter_keys_from_items(c.parameters, ("w0", "wa")):
             v_expect = getattr(cosmo, n)
-            if v is None:
-                assert v is v_expect
-            else:
-                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
+            assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
 
     # @pytest.mark.parametrize("z", valid_zs)  # TODO! recompute comparisons below
     def test_w(self, cosmo):

--- a/astropy/cosmology/flrw/tests/test_w0wzcdm.py
+++ b/astropy/cosmology/flrw/tests/test_w0wzcdm.py
@@ -88,12 +88,7 @@ class Testw0wzCDM(FLRWTest, Parameterw0TestMixin, ParameterwzTestMixin):
         assert c.w0 == 0.1
         assert c.wz == 0.2
         for n, v in filter_keys_from_items(c.parameters, ("w0", "wz")):
-            if v is None:
-                assert v is getattr(cosmo, n)
-            else:
-                assert u.allclose(
-                    v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1)
-                )
+            assert u.allclose(v, getattr(cosmo, n), atol=1e-4 * getattr(v, "unit", 1))
 
     # @pytest.mark.parametrize("z", valid_zs)  # TODO! recompute comparisons below
     def test_w(self, cosmo):

--- a/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
+++ b/astropy/cosmology/flrw/tests/test_wpwazpcdm.py
@@ -131,10 +131,7 @@ class TestwpwaCDM(
         assert c.zp == 14
         for n, v in filter_keys_from_items(c.parameters, ("wp", "wa", "zp")):
             v_expect = getattr(cosmo, n)
-            if v is None:
-                assert v is v_expect
-            else:
-                assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
+            assert_quantity_allclose(v, v_expect, atol=1e-4 * getattr(v, "unit", 1))
 
     # @pytest.mark.parametrize("z", valid_zs)  # TODO! recompute comparisons below
     def test_w(self, cosmo):


### PR DESCRIPTION
Nothing is broken, but https://github.com/astropy/astropy/pull/16847 didn't catch everything, including dead code.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
