### PR TITLE
feat(coords): deprecate `.get_name()` for `.name`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -106,7 +106,7 @@ def _get_repr_classes(base, **differentials):
     for name, differential_type in differentials.items():
         if differential_type == "base":
             # We don't want to fail for this case.
-            differential_type = r.DIFFERENTIAL_CLASSES.get(base.get_name(), None)
+            differential_type = r.DIFFERENTIAL_CLASSES.get(base.name, None)
 
         elif differential_type in r.DIFFERENTIAL_CLASSES:
             differential_type = r.DIFFERENTIAL_CLASSES[differential_type]
@@ -223,9 +223,9 @@ class CoordinateFrameInfo(MixinInfo):
 
         out = super()._represent_as_dict(attrs)
 
-        out["representation_type"] = representation_type.get_name()
+        out["representation_type"] = representation_type.name
         if differential_type is not None:
-            out["differential_type"] = differential_type.get_name()
+            out["differential_type"] = differential_type.name
 
         # Note that coord.info.unit is a fake composite unit (e.g. 'deg,deg,None'
         # or None,None,m) and is not stored. The individual attributes have

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -34,7 +34,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
     astrom = erfa_astrom.get().apco(cirs_frame)
 
     if (
-        icrs_coo.data.get_name() == "unitspherical"
+        icrs_coo.data.name == "unitspherical"
         or icrs_coo.data.to_cartesian().x.unit == u.one
     ):
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -77,7 +77,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     if (
-        cirs_coo.data.get_name() == "unitspherical"
+        cirs_coo.data.name == "unitspherical"
         or cirs_coo.data.to_cartesian().x.unit == u.one
     ):
         # if no distance, just use the coordinate direction to yield the
@@ -117,7 +117,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
     astrom = erfa_astrom.get().apcs(gcrs_frame)
 
     if (
-        icrs_coo.data.get_name() == "unitspherical"
+        icrs_coo.data.name == "unitspherical"
         or icrs_coo.data.to_cartesian().x.unit == u.one
     ):
         # if no distance, just do the infinite-distance/no parallax calculation
@@ -162,7 +162,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     if (
-        gcrs_coo.data.get_name() == "unitspherical"
+        gcrs_coo.data.name == "unitspherical"
         or gcrs_coo.data.to_cartesian().x.unit == u.one
     ):
         # if no distance, just use the coordinate direction to yield the
@@ -212,7 +212,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     i_ra = u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED)
     i_dec = u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED)
     if (
-        gcrs_coo.data.get_name() == "unitspherical"
+        gcrs_coo.data.name == "unitspherical"
         or gcrs_coo.data.to_cartesian().x.unit == u.one
     ):
         # if no distance, just use the coordinate direction to yield the

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -264,12 +264,12 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
 
     # -----------------------------------------------------------------
 
-    @deprecated("v6.1", alternative="name")
+    @deprecated("v7.1", alternative="name")
     @classmethod
     def get_name(cls):
         """Name of the representation or differential.
 
-        See `name` for details.
+        Returns the ``.name`` attribute.
         """
         return cls.name
 

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -5,7 +5,7 @@ import abc
 import functools
 import operator
 import warnings
-from typing import ClassVar
+from typing import ClassVar, Final
 
 import numpy as np
 
@@ -145,13 +145,14 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
 
     # Ensure multiplication/division with ndarray or Quantity doesn't lead to
     # object arrays.
-    __array_priority__: ClassVar[int] = 50000
+    __array_priority__: Final = 50000
 
     name: ClassVar[str]
     """Name of the representation or differential.
 
-    In lower case, with any trailing 'representation' or 'differential' removed. (E.g.,
-    'spherical' for `~astropy.coordinates.SphericalRepresentation` or
+    By default, the lower-cased name of the class with with any trailing
+    'representation' or 'differential' removed. (E.g., 'spherical' for
+    `~astropy.coordinates.SphericalRepresentation` or
     `~astropy.coordinates.SphericalDifferential`.)
     """
 
@@ -262,8 +263,6 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
         if any(hasattr(attr, "mask") for attr in attrs):
             self._ensure_masked()
 
-    # -----------------------------------------------------------------
-
     @deprecated("v7.1", alternative="name")
     @classmethod
     def get_name(cls):
@@ -272,8 +271,6 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
         Returns the ``.name`` attribute.
         """
         return cls.name
-
-    # -----------------------------------------------------------------
 
     # The two methods that any subclass has to define.
     @classmethod

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -12,6 +12,7 @@ import astropy.units as u
 from astropy.coordinates.angles import Angle
 from astropy.utils import classproperty
 from astropy.utils.data_info import MixinInfo
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, Masked, combine_masks
 
@@ -244,8 +245,10 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
         if any(hasattr(attr, "mask") for attr in attrs):
             self._ensure_masked()
 
-    @classmethod
-    def get_name(cls):
+    # -----------------------------------------------------------------
+
+    @classproperty
+    def name(cls) -> str:
         """Name of the representation or differential.
 
         In lower case, with any trailing 'representation' or 'differential'
@@ -261,6 +264,17 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
             name = name[:-12]
 
         return name
+
+    @deprecated("v6.1", alternative="name")
+    @classmethod
+    def get_name(cls):
+        """Name of the representation or differential.
+
+        See `name` for details.
+        """
+        return cls.name
+
+    # -----------------------------------------------------------------
 
     # The two methods that any subclass has to define.
     @classmethod
@@ -653,7 +667,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 'Representations must have an "attr_classes" class attribute.'
             )
 
-        repr_name = cls.get_name()
+        repr_name = cls.name
         # first time a duplicate is added
         # remove first entry and add both using their qualnames
         if repr_name in REPRESENTATION_CLASSES:
@@ -801,7 +815,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
     @classproperty
     def _compatible_differentials(cls):
-        return [DIFFERENTIAL_CLASSES[cls.get_name()]]
+        return [DIFFERENTIAL_CLASSES[cls.name]]
 
     @property
     def differentials(self):
@@ -1342,7 +1356,7 @@ class BaseDifferential(BaseRepresentationOrDifferential):
             base_attr_classes = cls.base_representation.attr_classes
             cls.attr_classes = {"d_" + c: u.Quantity for c in base_attr_classes}
 
-        repr_name = cls.get_name()
+        repr_name = cls.name
         if repr_name in DIFFERENTIAL_CLASSES:
             raise ValueError(f"Differential class {repr_name} already defined")
 

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -147,24 +147,28 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
     # object arrays.
     __array_priority__: Final = 50000
 
-    name: ClassVar[str]
+    # Have to define this default b/c init_subclass is not called for the base class.
+    name: ClassVar[str] = "base"
     """Name of the representation or differential.
 
-    By default, the lower-cased name of the class with with any trailing
-    'representation' or 'differential' removed. (E.g., 'spherical' for
-    `~astropy.coordinates.SphericalRepresentation` or
+    When a subclass is defined, by default, the name is the lower-cased name of the
+    class with with any trailing 'representation' or 'differential' removed. (E.g.,
+    'spherical' for `~astropy.coordinates.SphericalRepresentation` or
     `~astropy.coordinates.SphericalDifferential`.)
+
+    This can be customized when defining a subclass by setting the class attribute.
     """
 
     info = BaseRepresentationOrDifferentialInfo()
 
     def __init_subclass__(cls) -> None:
-        # Name of the representation or differential.
-        cls.name = (
-            cls.__name__.lower()
-            .removesuffix("representation")
-            .removesuffix("differential")
-        )
+        # Name of the representation or differential
+        if "name" not in cls.__dict__:
+            cls.name = (
+                cls.__name__.lower()
+                .removesuffix("representation")
+                .removesuffix("differential")
+            )
 
     def __init__(self, *args, **kwargs):
         # make argument a list, so we can pop them off.

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -398,7 +398,7 @@ def _parse_coordinate_arg(coords, frame, units):
                 if (
                     reprname == "d_distance"
                     and not hasattr(orig_vel, reprname)
-                    and "unit" in orig_vel.get_name()
+                    and "unit" in orig_vel.name
                 ):
                     continue
                 values.append(getattr(vel, reprname))
@@ -507,7 +507,7 @@ def _parse_coordinate_arg(coords, frame, units):
             if n_coords > n_attr_names:
                 raise ValueError(
                     f"Input coordinates have {n_coords} values but representation"
-                    f" {frame.representation_type.get_name()} only accepts"
+                    f" {frame.representation_type.name} only accepts"
                     f" {n_attr_names}"
                 )
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -130,8 +130,8 @@ class TestRadialRepresentation:
 
 class TestSphericalRepresentation:
     def test_name(self):
-        assert SphericalRepresentation.get_name() == "spherical"
-        assert SphericalRepresentation.get_name() in REPRESENTATION_CLASSES
+        assert SphericalRepresentation.name == "spherical"
+        assert SphericalRepresentation.name in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -527,8 +527,8 @@ class TestSphericalRepresentation:
 
 class TestUnitSphericalRepresentation:
     def test_name(self):
-        assert UnitSphericalRepresentation.get_name() == "unitspherical"
-        assert UnitSphericalRepresentation.get_name() in REPRESENTATION_CLASSES
+        assert UnitSphericalRepresentation.name == "unitspherical"
+        assert UnitSphericalRepresentation.name in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -702,8 +702,8 @@ class TestUnitSphericalRepresentation:
 
 class TestPhysicsSphericalRepresentation:
     def test_name(self):
-        assert PhysicsSphericalRepresentation.get_name() == "physicsspherical"
-        assert PhysicsSphericalRepresentation.get_name() in REPRESENTATION_CLASSES
+        assert PhysicsSphericalRepresentation.name == "physicsspherical"
+        assert PhysicsSphericalRepresentation.name in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -1000,8 +1000,8 @@ class TestPhysicsSphericalRepresentation:
 
 class TestCartesianRepresentation:
     def test_name(self):
-        assert CartesianRepresentation.get_name() == "cartesian"
-        assert CartesianRepresentation.get_name() in REPRESENTATION_CLASSES
+        assert CartesianRepresentation.name == "cartesian"
+        assert CartesianRepresentation.name in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -1267,8 +1267,8 @@ class TestCartesianRepresentation:
 
 class TestCylindricalRepresentation:
     def test_name(self):
-        assert CylindricalRepresentation.get_name() == "cylindrical"
-        assert CylindricalRepresentation.get_name() in REPRESENTATION_CLASSES
+        assert CylindricalRepresentation.name == "cylindrical"
+        assert CylindricalRepresentation.name in REPRESENTATION_CLASSES
 
     def test_empty_init(self):
         with pytest.raises(TypeError) as exc:
@@ -1898,7 +1898,7 @@ class TestCartesianRepresentationWithDifferential:
         )
 
         r2 = CartesianRepresentation.from_representation(r1)
-        assert r2.get_name() == "cartesian"
+        assert r2.name == "cartesian"
         assert not r2.differentials
 
         r3 = SphericalRepresentation(r1)
@@ -1921,22 +1921,22 @@ class TestCartesianRepresentationWithDifferential:
 
         # Only change the representation, drop the differential
         new_rep = rep1.represent_as(SphericalRepresentation)
-        assert new_rep.get_name() == "spherical"
+        assert new_rep.name == "spherical"
         assert not new_rep.differentials  # dropped
 
         # Pass in separate classes for representation, differential
         new_rep = rep1.represent_as(
             SphericalRepresentation, SphericalCosLatDifferential
         )
-        assert new_rep.get_name() == "spherical"
-        assert new_rep.differentials["s"].get_name() == "sphericalcoslat"
+        assert new_rep.name == "spherical"
+        assert new_rep.differentials["s"].name == "sphericalcoslat"
 
         # Pass in a dictionary for the differential classes
         new_rep = rep1.represent_as(
             SphericalRepresentation, {"s": SphericalCosLatDifferential}
         )
-        assert new_rep.get_name() == "spherical"
-        assert new_rep.differentials["s"].get_name() == "sphericalcoslat"
+        assert new_rep.name == "spherical"
+        assert new_rep.differentials["s"].name == "sphericalcoslat"
 
         # make sure represent_as() passes through the differentials
         for name in REPRESENTATION_CLASSES:
@@ -1951,9 +1951,9 @@ class TestCartesianRepresentationWithDifferential:
             new_rep = rep1.represent_as(
                 REPRESENTATION_CLASSES[name], DIFFERENTIAL_CLASSES[name]
             )
-            assert new_rep.get_name() == name
+            assert new_rep.name == name
             assert len(new_rep.differentials) == 1
-            assert new_rep.differentials["s"].get_name() == name
+            assert new_rep.differentials["s"].name == name
 
         with pytest.raises(ValueError) as excinfo:
             rep1.represent_as("name")
@@ -2117,7 +2117,7 @@ def test_to_cartesian():
     )
 
     cart = sr.to_cartesian()
-    assert cart.get_name() == "cartesian"
+    assert cart.name == "cartesian"
     assert not cart.differentials
 
 
@@ -2207,7 +2207,7 @@ def unitphysics():
         del PhysicsSphericalRepresentation._unit_representation
 
     # remove from the module-level representations, if present
-    REPRESENTATION_CLASSES.pop(UnitPhysicsSphericalRepresentation.get_name(), None)
+    REPRESENTATION_CLASSES.pop(UnitPhysicsSphericalRepresentation.name, None)
 
 
 def test_unitphysics(unitphysics):

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -630,11 +630,11 @@ class TestSphericalDifferential:
         self._setup(omit_coslat)
         if omit_coslat:
             assert self.SD_cls is SphericalCosLatDifferential
-            assert self.SD_cls.get_name() == "sphericalcoslat"
+            assert self.SD_cls.name == "sphericalcoslat"
         else:
             assert self.SD_cls is SphericalDifferential
-            assert self.SD_cls.get_name() == "spherical"
-        assert self.SD_cls.get_name() in DIFFERENTIAL_CLASSES
+            assert self.SD_cls.name == "spherical"
+        assert self.SD_cls.name in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self, omit_coslat):
         self._setup(omit_coslat)
@@ -802,11 +802,11 @@ class TestUnitSphericalDifferential:
         self._setup(omit_coslat)
         if omit_coslat:
             assert self.USD_cls is UnitSphericalCosLatDifferential
-            assert self.USD_cls.get_name() == "unitsphericalcoslat"
+            assert self.USD_cls.name == "unitsphericalcoslat"
         else:
             assert self.USD_cls is UnitSphericalDifferential
-            assert self.USD_cls.get_name() == "unitspherical"
-        assert self.USD_cls.get_name() in DIFFERENTIAL_CLASSES
+            assert self.USD_cls.name == "unitspherical"
+        assert self.USD_cls.name in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self, omit_coslat):
         self._setup(omit_coslat)
@@ -921,8 +921,8 @@ class TestRadialDifferential:
         self.sf = s.scale_factors()
 
     def test_name(self):
-        assert RadialDifferential.get_name() == "radial"
-        assert RadialDifferential.get_name() in DIFFERENTIAL_CLASSES
+        assert RadialDifferential.name == "radial"
+        assert RadialDifferential.name in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         r, s, e, sf = self.r, self.s, self.e, self.sf
@@ -965,8 +965,8 @@ class TestPhysicsSphericalDifferential:
         self.sf = s.scale_factors()
 
     def test_name(self):
-        assert PhysicsSphericalDifferential.get_name() == "physicsspherical"
-        assert PhysicsSphericalDifferential.get_name() in DIFFERENTIAL_CLASSES
+        assert PhysicsSphericalDifferential.name == "physicsspherical"
+        assert PhysicsSphericalDifferential.name in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -1024,8 +1024,8 @@ class TestCylindricalDifferential:
         self.sf = s.scale_factors()
 
     def test_name(self):
-        assert CylindricalDifferential.get_name() == "cylindrical"
-        assert CylindricalDifferential.get_name() in DIFFERENTIAL_CLASSES
+        assert CylindricalDifferential.name == "cylindrical"
+        assert CylindricalDifferential.name in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf
@@ -1077,8 +1077,8 @@ class TestCartesianDifferential:
         self.sf = s.scale_factors()
 
     def test_name(self):
-        assert CartesianDifferential.get_name() == "cartesian"
-        assert CartesianDifferential.get_name() in DIFFERENTIAL_CLASSES
+        assert CartesianDifferential.name == "cartesian"
+        assert CartesianDifferential.name in DIFFERENTIAL_CLASSES
 
     def test_simple_differentials(self):
         s, e, sf = self.s, self.e, self.sf

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -183,9 +183,9 @@ def test_accessors(sc, scmany):
     sph = sc.spherical
     gal = sc.galactic
 
-    if sc.data.get_name().startswith("unit") and not sc.data.differentials[
+    if sc.data.name.startswith("unit") and not sc.data.differentials[
         "s"
-    ].get_name().startswith("unit"):
+    ].name.startswith("unit"):
         # this xfail can be eliminated when issue #7028 is resolved
         pytest.xfail(".velocity fails if there is an RV but not distance")
     sc.velocity

--- a/docs/changes/coordinates/17503.api.rst
+++ b/docs/changes/coordinates/17503.api.rst
@@ -1,0 +1,2 @@
+On representations the method `get_name` has been deprecated in favor of the class-level
+attribute `name`. The method will be removed in a future release.


### PR DESCRIPTION
Using `classproperty` we can simplify `.get_name()` to just `.name`.
I'll add changelog, etc if you LMK what you think about the change in general.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
