### PR TITLE
BUG: fix a crash in `Table.show_in_browser` due to an internal type inconsistency

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1924,7 +1924,7 @@ class Table:
         except webbrowser.Error:
             log.error(f"Browser '{browser}' not found.")
         else:
-            br.open(urljoin("file:", pathname2url(path)))
+            br.open(urljoin("file:", pathname2url(str(path))))
 
     @format_doc(_pformat_docs, id="{id}")
     def pformat(

--- a/docs/changes/table/17513.bugfix.rst
+++ b/docs/changes/table/17513.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash in ``Table.show_in_browser`` due to an internal type inconsistency.


### PR DESCRIPTION
### Description

Follow up to #16939
Fixes #17512

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
