### PR TITLE
Fix configuring `astropy` cache location

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -28,10 +28,9 @@ def _get_dir_path(rootname: str, cls: type, fallback: str) -> Path:
             path.mkdir(exist_ok=True)
         return path.resolve()
 
-    # first look for XDG_CONFIG_HOME
     if (
-        (xdg_config_home := os.getenv("XDG_CONFIG_HOME")) is not None
-        and (xch := Path(xdg_config_home)).exists()
+        (xdg_dir := os.getenv(f"XDG_{fallback.upper()}_HOME")) is not None
+        and (xch := Path(xdg_dir)).exists()
         and not (xchpth := xch / rootname).is_symlink()
     ):
         if xchpth.exists():

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -37,6 +37,21 @@ def test_paths():
     assert "testpkg" in paths.get_cache_dir(rootname="testpkg")
 
 
+@pytest.mark.parametrize(
+    "environment_variable,func",
+    [
+        # Regression test for #17514 - XDG_CACHE_HOME had no effect
+        pytest.param("XDG_CACHE_HOME", paths.get_cache_dir_path, id="cache"),
+        pytest.param("XDG_CONFIG_HOME", paths.get_config_dir_path, id="config"),
+    ],
+)
+def test_xdg_variables(monkeypatch, tmp_path, environment_variable, func):
+    config_dir = tmp_path / "astropy"
+    config_dir.mkdir()
+    monkeypatch.setenv(environment_variable, str(tmp_path))
+    assert func() == config_dir
+
+
 def test_set_temp_config(tmp_path, monkeypatch):
     # Check that we start in an understood state.
     assert configuration._cfgobjs == OLD_CONFIG

--- a/docs/changes/config/17514.bugfix.rst
+++ b/docs/changes/config/17514.bugfix.rst
@@ -1,0 +1,11 @@
+With ``astropy`` v7.0.0 the cache directory cannot be customized with the
+``XDG_CACHE_HOME`` environment variable.
+Instead, ``XDG_CONFIG_HOME`` erroneously controls both configuration and cache
+directories.
+The correct pre-v7.0.0 behaviour has been restored, but it is possible that
+``astropy`` v7.0.0 has written cache files to surprising locations.
+Concerned users can use the ``get_cache_dir_path()`` function to check where
+the cache files are written.
+
+The bug in question does not affect systems where the ``XDG_CACHE_HOME`` and
+``XDG_CONFIG_HOME`` environment variables are unset.


### PR DESCRIPTION
### Description

657c91a53e7bf049a7e29e9910bcbdd8453bd3dd (from #16997) introduced a bug to customizing the `astropy` cache directory. The `XDG_CACHE_HOME` environment variable has no effect, instead `XDG_CONFIG_HOME` controls both configuration and cache directories.

The first commit adds a regression test to reveal the bug, the second fixes it.

PS https://www.astropy.org/team does not document who the maintainers for `config` are.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
