### PR TITLE
DEP: add missing lower bound for objgraph (test-only dependency)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test_all = [
     "astropy[all]",  # installs all optional run-time dependencies
     "astropy[test]",
     # Install all remaining dependencies
-    "objgraph",
+    "objgraph>=1.6.0",
     "skyfield>=1.20",
     "sgp4>=2.3",
     "array-api-strict",


### PR DESCRIPTION
### Description

I discovered this while trying to analyse astropy's dependency tree as follow
```
❯ uv tree --resolution=lowest-direct
  × Failed to download and build `objgraph==1.2`
  ╰─▶ Build backend failed to determine requirements with `build_wheel()` (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File "/Users/clm/.cache/uv/builds-v0/.tmpEOTvaM/lib/python3.11/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/clm/.cache/uv/builds-v0/.tmpEOTvaM/lib/python3.11/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
        File "/Users/clm/.cache/uv/builds-v0/.tmpEOTvaM/lib/python3.11/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/Users/clm/.cache/uv/builds-v0/.tmpEOTvaM/lib/python3.11/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 16
          exec open(relative('objgraph.py')).read() in d
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      SyntaxError: Missing parentheses in call to 'exec'. Did you mean exec(...)?

  help: `objgraph` (v1.2) was included because `astropy[test-all]` (v7.1.dev266+g62be81ece7) depends on `objgraph`
```
This happens because `objgraph` 1.2 (the oldest stable version on PyPI) doesn't have wheels *and* doesn't build properly on modern tooling[^1]. Version 1.6 is the first one that doesn't have this issue. I checked that affected tests are still compatible with it via:

```
pytest astropy/io/fits/tests -ra
```


[^1]: if you're wondering why a dependency resolver even needs a build, this is a known shortcoming of the current packaging standards. See https://peps.python.org/pep-0777/#add-wheel-version-metadata-field-to-core-metadata

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
