### PR TITLE
TST: fix incorrect branching on numpy version

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from astropy.units.core import dimensionless_unscaled, unit_scale_converter
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_3
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
@@ -546,7 +546,7 @@ UFUNC_HELPERS[np.multiply] = helper_multiplication
 UFUNC_HELPERS[np.matmul] = helper_multiplication
 if not NUMPY_LT_2_0:
     UFUNC_HELPERS[np.vecdot] = helper_multiplication
-if not NUMPY_LT_2_3:
+if not NUMPY_LT_2_2:
     UFUNC_HELPERS[np.vecmat] = helper_multiplication
     UFUNC_HELPERS[np.matvec] = helper_multiplication
 UFUNC_HELPERS[np.divide] = helper_division


### PR DESCRIPTION
### Description
A quick follow up to #17464 after `np.matvec` and `np.vecmat` were actually released yesterday under NumPy 2.2.0
[example logs](https://github.com/astropy/astropy/actions/runs/12225185366/job/34098870170?pr=16312)


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
