### PR TITLE
ENH: implement Python 3.13's `copy.replace` for `Time`

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1262,6 +1262,80 @@ class TimeBase(MaskableShapedLikeNDArray):
 
         return out
 
+    def __replace__(self, /, **changes):
+        for key, val in {
+            "jd1": self._time.jd1,
+            "jd2": self._time.jd2,
+            "scale": self.scale,
+            "format": self.format,
+            "precision": self.precision,
+            "in_subfmt": self.in_subfmt,
+            "out_subfmt": self.out_subfmt,
+            "delta_ut1_utc": getattr(self, "_delta_ut1_utc", None),
+            "delta_tdb_tt": getattr(self, "_delta_tdb_tt", None),
+        }.items():
+            if key not in changes:
+                changes[key] = copy.copy(val)
+
+        if "location" in changes:
+            location = changes.pop("location")
+        else:
+            try:
+                location = self.location
+            except AttributeError:
+                # some classes define a location property but return
+                # a possibly unbound _location from it
+                location = None
+            else:
+                location = copy.copy(location)
+
+        delta_ut1_utc = changes.pop("delta_ut1_utc")
+        delta_tdb_tt = changes.pop("delta_tdb_tt")
+
+        tm = super().__new__(self.__class__)
+        format = changes.pop("format")
+        format_cls = tm.FORMATS[format]
+
+        for key in ("in_subfmt", "out_subfmt"):
+            changes[key] = format_cls._get_allowed_subfmt(changes[key])
+
+        jd1 = changes.pop("jd1")
+        jd2 = changes.pop("jd2")
+        time_jd = TimeJD(
+            jd1,
+            jd2,
+            changes["scale"],
+            precision=changes["precision"],
+            in_subfmt="*",
+            out_subfmt="*",
+            from_jd=True,
+        )
+
+        tm._time = format_cls(
+            time_jd.jd1,
+            time_jd.jd2,
+            **changes,
+            from_jd=True,
+        )
+        tm._location = tm._time.location = location
+        tm._format = format
+        if delta_ut1_utc is not None:
+            tm.delta_ut1_utc = delta_ut1_utc
+        if delta_tdb_tt is not None:
+            tm.delta_tdb_tt = delta_tdb_tt
+
+        # This line is borrowed from _apply, but is apparently not tested
+        # tm.SCALES = self.SCALES
+
+        # Copy other 'info' attr only if it has actually been defined and the
+        # time object is not a scalar (issue #10688).
+        # See PR #3898 for further explanation and justification, along
+        # with Quantity.__array_finalize__
+        if "info" in self.__dict__:
+            tm.info = self.info
+
+        return tm
+
     def copy(self, format=None):
         """
         Return a fully independent copy the Time object, optionally changing
@@ -1285,7 +1359,7 @@ class TimeBase(MaskableShapedLikeNDArray):
         tm : Time object
             Copy of this object
         """
-        return self._apply("copy", format=format)
+        return self.__replace__(format=format or self.format)
 
     def replicate(self, format=None, copy=False, cls=None):
         """
@@ -1316,6 +1390,8 @@ class TimeBase(MaskableShapedLikeNDArray):
         tm : Time object
             Replica of this object
         """
+        if copy and cls is None:
+            return self.__replace__(format=format or self.format)
         return self._apply("copy" if copy else "replicate", format=format, cls=cls)
 
     def _apply(self, method, *args, format=None, cls=None, **kwargs):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -5,6 +5,7 @@ import datetime
 import functools
 import gc
 import os
+import sys
 from copy import deepcopy
 from decimal import Decimal, localcontext
 from io import StringIO
@@ -1422,12 +1423,26 @@ class TestCopyReplicate:
         assert t.location.x == t2.location.x
         assert t.location.x != t_loc_x  # prove that it changed
 
-    def test_copy(self):
+    @pytest.mark.parametrize(
+        "copy_lambda",
+        [
+            pytest.param(lambda t: t.copy(), id="copy method"),
+            pytest.param(
+                lambda t: copy.replace(t),
+                id="copy.replace (no args)",
+                marks=pytest.mark.skipif(
+                    sys.version_info < (3, 13),
+                    reason="copy.replace is new in Python 3.13",
+                ),
+            ),
+        ],
+    )
+    def test_copy(self, copy_lambda):
         """Test copy method"""
         t = Time("2000:001", format="yday", scale="tai", location=("45d", "45d"))
         t_yday = t.yday
         t_loc_x = t.location.x.copy()
-        t2 = t.copy()
+        t2 = copy_lambda(t)
         assert t.yday == t2.yday
         # This is not allowed publicly, but here we hack the internal time
         # and location values to show that t and t2 are not sharing references.
@@ -1445,6 +1460,23 @@ class TestCopyReplicate:
         assert t2.location.x == t2_loc_x_view
         assert t.location.x != t2.location.x
         assert t.location.x == t_loc_x  # prove that it changed
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13), reason="copy.replace is new in Python 3.13"
+    )
+    def test_copy_replace(self):
+        t = Time("2000:001", format="yday", scale="tai", location=("45d", "45d"))
+        t2 = copy.replace(t, format="mjd", scale="utc")
+        assert t2.format == "mjd"
+        assert t2.scale == "utc"
+        assert t2.jd1 == t.jd1
+        assert t2.jd2 == t.jd2
+        assert t2.location == t.location
+        assert t2.location is not t.location
+
+        # TimeInfo doesn't support comparison yet
+        # assert t2.info == t.info
+        assert t2.info is not t.info
 
 
 class TestStardate:


### PR DESCRIPTION
### Description
Taking a simple stab at #16887, focusing on the `TimeBase` class.
Note to reviewers:
evidently there's a signicant overlap between the `__replace__` method and existing `copy/replicate/_apply` methods. However, I'm not sure that deduplication is possible here if we also want to avoid spaghetti coding. I made changes to `copy` and `replicate` so they call `__replace__` instead of `_apply` whenever relevant, which allowed me to test my implementation pretty thoroughly without adding any new test (but possibly at the cost of reducing coverage for `_apply`).
I do want to add tests for `copy.replace`, but I'm opening early as a refactor and a proof of concept.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
