### PR TITLE
Refactor validation in unit formatters

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2026,9 +2026,9 @@ class _UnitMetaClass(type):
                 s = s.decode("ascii")
 
             try:
-                return f._parse_unit(s, detailed_exception=False)  # Try a shortcut
+                return f._validate_unit(s, detailed_exception=False)  # Try a shortcut
             except (AttributeError, ValueError):
-                # No `f._parse_unit()` (AttributeError)
+                # No `f._validate_unit()` (AttributeError)
                 # or `s` was a composite unit (ValueError).
                 pass
 

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -272,8 +272,6 @@ class _ParsingFormatMixin:
             if detailed_exception:
                 raise ValueError(cls._invalid_unit_error_message(unit))
             raise ValueError()
-        if unit in cls._deprecated_units:
-            warnings.warn(cls._deprecated_unit_warning_message(unit), UnitsWarning)
 
     @classmethod
     def _invalid_unit_error_message(cls, unit: str) -> str:
@@ -281,10 +279,6 @@ class _ParsingFormatMixin:
             f"Unit '{unit}' not supported by the {cls.__name__} standard. "
             + cls._did_you_mean_units(unit)
         )
-
-    @classmethod
-    def _deprecated_unit_warning_message(cls, unit: str) -> str:
-        return f"The unit '{unit}' has been deprecated in the {cls.__name__} standard."
 
     @classmethod
     def _decompose_to_known_units(

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -239,12 +239,6 @@ class _ParsingFormatMixin:
             raise ValueError(f"At col {t.lexpos}, {str(e)}")
 
     @classmethod
-    def _get_unit_name(cls, unit: NamedUnit) -> str:
-        name = unit._get_format_name(cls.name)
-        cls._validate_unit(name)
-        return name
-
-    @classmethod
     def _fix_deprecated(cls, x: str) -> list[str]:
         return [x + " (deprecated)" if x in cls._deprecated_units else x]
 
@@ -297,7 +291,7 @@ class _ParsingFormatMixin:
             )
         if isinstance(unit, core.NamedUnit):
             try:
-                cls._get_unit_name(unit)
+                cls._validate_unit(unit._get_format_name(cls.name))
             except ValueError:
                 if isinstance(unit, core.Unit):
                     return cls._decompose_to_known_units(unit._represents)

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -419,7 +419,7 @@ class _GenericParserMixin(_ParsingFormatMixin):
                 p[0] = p[3] ** 0.5
                 return
             elif p[1] in ("mag", "dB", "dex"):
-                function_unit = cls._parse_unit(p[1])
+                function_unit = cls._validate_unit(p[1])
                 # In Generic, this is callable, but that does not have to
                 # be the case in subclasses (e.g., in VOUnit it is not).
                 if callable(function_unit):
@@ -444,7 +444,7 @@ class Generic(Base, _GenericParserMixin):
     """
 
     @classmethod
-    def _parse_unit(cls, s: str, detailed_exception: bool = True) -> UnitBase:
+    def _validate_unit(cls, s: str, detailed_exception: bool = True) -> UnitBase:
         registry = core.get_current_unit_registry().registry
         if s in cls._unit_symbols:
             s = cls._unit_symbols[s]

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -367,10 +367,10 @@ class OGIP(Base, _ParsingFormatMixin):
         return format(val, format_spec)
 
     @classmethod
-    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
+    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
         if unit in cls._deprecated_units:
             warnings.warn(
                 f"The unit '{unit}' has been deprecated in the OGIP standard.",
                 UnitsWarning,
             )
-        super()._validate_unit(unit, detailed_exception)
+        return super()._validate_unit(unit, detailed_exception)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -365,3 +365,12 @@ class OGIP(Base, _ParsingFormatMixin):
         cls, val: UnitScale | np.number, format_spec: str = "g"
     ) -> str:
         return format(val, format_spec)
+
+    @classmethod
+    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
+        if unit in cls._deprecated_units:
+            warnings.warn(
+                f"The unit '{unit}' has been deprecated in the OGIP standard.",
+                UnitsWarning,
+            )
+        super()._validate_unit(unit, detailed_exception)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -222,7 +222,7 @@ class VOUnit(Base, _GenericParserMixin):
         )
 
     @classmethod
-    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
+    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
         if unit in cls._deprecated_units:
             warnings.warn(
                 UnitsWarning(
@@ -230,4 +230,4 @@ class VOUnit(Base, _GenericParserMixin):
                     f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
                 )
             )
-        super()._validate_unit(unit, detailed_exception)
+        return super()._validate_unit(unit, detailed_exception)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -9,7 +9,12 @@ import re
 import warnings
 from typing import TYPE_CHECKING
 
-from astropy.units.errors import UnitParserWarning, UnitScaleError, UnitsError
+from astropy.units.errors import (
+    UnitParserWarning,
+    UnitScaleError,
+    UnitsError,
+    UnitsWarning,
+)
 from astropy.utils import classproperty
 
 from . import Base, core, utils
@@ -222,8 +227,12 @@ class VOUnit(Base, _GenericParserMixin):
         )
 
     @classmethod
-    def _deprecated_unit_warning_message(cls, unit: str) -> str:
-        return (
-            super()._deprecated_unit_warning_message(unit)
-            + f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
-        )
+    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> None:
+        if unit in cls._deprecated_units:
+            warnings.warn(
+                UnitsWarning(
+                    f"The unit '{unit}' has been deprecated in the VOUnit standard."
+                    f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
+                )
+            )
+        super()._validate_unit(unit, detailed_exception)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     import numpy as np
 
     from astropy.extern.ply.lex import LexToken
-    from astropy.units import NamedUnit, UnitBase
+    from astropy.units import UnitBase
     from astropy.units.typing import UnitScale
 
 
@@ -129,24 +129,19 @@ class VOUnit(Base, _GenericParserMixin):
             raise
 
     @classmethod
-    def _get_unit_name(cls, unit: NamedUnit) -> str:
+    def _decompose_to_known_units(
+        cls, unit: core.CompositeUnit | core.NamedUnit
+    ) -> UnitBase:
         # The da- and d- prefixes are discouraged.  This has the
         # effect of adding a scale to value in the result.
-        if isinstance(unit, core.PrefixUnit):
-            if unit._represents.scale == 10.0:
-                raise ValueError(
-                    f"In '{unit}': VOUnit can not represent units with the 'da' "
-                    "(deka) prefix"
-                )
-            elif unit._represents.scale == 0.1:
-                raise ValueError(
-                    f"In '{unit}': VOUnit can not represent units with the 'd' "
-                    "(deci) prefix"
-                )
-        name = unit._get_format_name(cls.name)
-        if name not in cls._custom_units:
-            cls._validate_unit(name, detailed_exception=True)
-        return name
+        if isinstance(unit, core.PrefixUnit) and unit._represents.scale in (0.1, 10.0):
+            return cls._decompose_to_known_units(unit._represents)
+        if (
+            isinstance(unit, core.NamedUnit)
+            and unit._get_format_name(cls.name) in cls._custom_units
+        ):
+            return unit
+        return super()._decompose_to_known_units(unit)
 
     @classmethod
     def _def_custom_unit(cls, unit: str) -> UnitBase:


### PR DESCRIPTION
### Description

The first commit replaces two implementations of `_deprecated_unit_warning_message()` in `_ParsingFormatMixin` and `VOUnit` with implementations of `_validate_unit()` in `OGIP` and `VOUnit`. With that change the code that is responsible for emitting warnings when deprecated units are encountered is moved out from formatters that don't have any.

The second commit inlines the `_ParsingFormatMixin._get_unit_name()` call in `_ParsingFormatMixin._decompose_to_known_units()` and replaces `VOUnit._get_unit_name()` with `VOUnit._decompose_to_known_units()`. The `_get_unit_name()` method is not used anywhere else.

The third commit comes from the observation that `_validate_unit()` would be much more convenient if it returned the validated unit instead of `None`. In that case `_parse_unit()` is not needed at all. Removing `_parse_unit()` speeds up `"cds"`, `"fits"`, `"ogip"` and `"vounit"` formatters (but not `"generic"`), but I'm not sure it should be mentioned in the change log. Parsing non-composite units is getting so fast that how `format` is specified in `u.Unit()` calls makes a noticeable difference, which can make any numbers in change log entries misleading. Furthermore, although in relative terms the speedup is clear, in absolute terms it's tiny (less than 200 ns per call on my computer). A similar absolute speedup is also present when parsing composite units, but the relative speedup is not worth mentioning.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
