### PR TITLE
BUG: ensure cds.Angstrom and u.Angstrom have the same short name

### DIFF
--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -68,7 +68,7 @@ def _initialize_module():
         (["al"], u.lyr, "Light year", ["c", "d"]),
         (["lyr"], u.lyr, "Light year"),
         (["alpha"], _si.alpha, "Fine structure constant"),
-        ((["AA", "Å"], ["Angstrom", "Angstroem"]), u.AA, "Angstrom"),
+        (["Angstrom", "Å", "Angstroem", "AA"], u.AA, "Angstrom"),
         (["arcmin", "arcm"], u.arcminute, "minute of arc"),
         (["arcsec", "arcs"], u.arcsecond, "second of arc"),
         (["atm"], _si.atm, "atmosphere"),

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -183,6 +183,15 @@ def test_cds_log10_dimensionless():
     assert u.dex(u.dimensionless_unscaled).to_string(format="cds") == "[-]"
 
 
+def test_cds_angstrom_str():
+    # Regression test for a problem noticed in
+    # https://github.com/astropy/astropy/pull/17527#discussion_r1880555481
+    # that the string representation of the cds version of Angstrom was "AA".
+    assert str(u.cds.Angstrom) == str(u.Angstrom) == "Angstrom"
+    # Since this is a NamedUnit, let's check the name for completeness.
+    assert u.cds.Angstrom.name == "Angstrom"
+
+
 # These examples are taken from the EXAMPLES section of
 # https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/
 @pytest.mark.parametrize(

--- a/docs/changes/units/17536.bugfix.rst
+++ b/docs/changes/units/17536.bugfix.rst
@@ -1,0 +1,3 @@
+For the Angstrom unit in the CDS module, ``u.cds.Angstrom``, the string
+representation is now "Angstrom" (instead of "AA"), consistent with what was
+always the case for ``u.Angstrom``, and conformant with the CDS standard.


### PR DESCRIPTION
In the CDS format, the order in which entries for Ångstrom appear has been changed to ensure that the basic name will not be "AA" but "Angstrom" consistent with the standard units.  "Å" and "Angstroem" continue to be aliases, as does "AA" for backward compatibility (it is not formally supported by the CDS standard). This ensures that one gets the same name for ``u.Angstrom.name`` and ``u.cds.Angstrom.name``.

I label this as a bugfix, since I think that is mostly what it is, but since arguably it would also be a micro-api-change, I don't backport it.

p.s. I've been convinced that adding commits with test cases that fail is not necessarily that great an idea, so have just a single commit. I confirmed the test failed on current main.