### PR TITLE
fix(cosmo): remove unneeded import

### DIFF
--- a/astropy/cosmology/realizations.py
+++ b/astropy/cosmology/realizations.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING
 from astropy.utils.data import get_pkg_data_path
 from astropy.utils.state import ScienceState
 
-from . import _io  # Ensure IO methods are registered, to read realizations # noqa: F401
 from .core import Cosmology
 
 if TYPE_CHECKING:


### PR DESCRIPTION

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
