### PR TITLE
Add more type annotations to `config`

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -9,6 +9,8 @@ configuration files for Astropy and affiliated packages.
     found at https://configobj.readthedocs.io .
 """
 
+from __future__ import annotations
+
 import contextlib
 import importlib
 import io
@@ -18,6 +20,7 @@ import warnings
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from textwrap import TextWrapper
+from typing import TYPE_CHECKING
 from warnings import warn
 
 from astropy.extern.configobj import configobj, validate
@@ -25,6 +28,10 @@ from astropy.utils import find_current_module, isiterable, silence
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .paths import get_config_dir_path
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import Final
 
 __all__ = (
     "ConfigItem",
@@ -83,7 +90,7 @@ class ConfigNamespace:
         conf = Conf()
     """
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[str, None, None]:
         for key, val in self.__class__.__dict__.items():
             if isinstance(val, ConfigItem):
                 yield key
@@ -99,19 +106,19 @@ class ConfigNamespace:
     keys = __iter__
     """Iterate over configuration item names."""
 
-    def values(self):
+    def values(self) -> Generator[ConfigItem, None, None]:
         """Iterate over configuration item values."""
         for val in self.__class__.__dict__.values():
             if isinstance(val, ConfigItem):
                 yield val
 
-    def items(self):
+    def items(self) -> Generator[tuple[str, ConfigItem], None, None]:
         """Iterate over configuration item ``(name, value)`` pairs."""
         for key, val in self.__class__.__dict__.items():
             if isinstance(val, ConfigItem):
                 yield key, val
 
-    def help(self, name=None):
+    def help(self, name: str | None = None) -> None:
         """Print info about configuration items.
 
         Parameters
@@ -184,7 +191,7 @@ class ConfigNamespace:
         for item in self.values():
             item.reload()
 
-    def reset(self, attr=None):
+    def reset(self, attr: str | None = None) -> None:
         """
         Reset a configuration item to its default.
 
@@ -425,13 +432,13 @@ class ConfigItem:
             baseobj[self.name] = newobj[self.name]
         return baseobj.get(self.name)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<{self.__class__.__name__}: name={self.name!r} value={self()!r} at"
             f" 0x{id(self):x}>"
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "\n".join(
             (
                 f"{self.__class__.__name__}: {self.name}",
@@ -528,7 +535,7 @@ class ConfigItem:
 
 # this dictionary stores the primary copy of the ConfigObj's for each
 # root package
-_cfgobjs = {}
+_cfgobjs: Final[dict[str, configobj.ConfigObj]] = {}
 
 
 def get_config_filename(packageormod=None, rootname=None):


### PR DESCRIPTION
### Description

`astropy/config/paths.py` was already partially annotated, but I've improved the annotations so that 
```
mypy --strict --follow-imports silent astropy/config/paths.py
```
 now succeeds. I also added some annotations to `astropy/config/configuration.py`. The annotations there are not good enough for `mypy --strict` and the coverage is not complete, both because `astropy.extern.configobj` is not annotated and because some code would have to be rewritten to be more friendly towards type-checkers. However, all the annotations that are present in `config` are self-consistent, as can be verified with
```
mypy --follow-imports silent astropy/config/*.py
```

https://www.astropy.org/team does not list who the maintainers for `config` are, so I'm asking quite a few people to review in the hope that at least one of them actually does.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
