### PR TITLE
SEC: add zizmor pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,11 @@ repos:
       - id: text-unicode-replacement-char
         # Forbid files which have a UTF-8 Unicode replacement character.
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v0.9.2
+    hooks:
+    - id: zizmor
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:


### PR DESCRIPTION
### Description

This is a direct follow up to https://github.com/astropy/astropy/pull/17315, were adding `zizmor` to our pre-commit toolbelt was already proposed. The reason we didn't do it then was that `zizmor` requirement a newer version of the rust compiler than the one that was available on `pre-commit.ci`, which [is now resolved upstream](https://github.com/woodruffw/zizmor/issues/236). The fix is actually that `pre-commit` now gets `zizmor` from PyPI instead of compiling it, so the fact that it's written in rust doesn't mean that we need a different toolchain at all anymore !

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
