### PR TITLE
BUG: ensure `Config `classes' docstrings remain available at runtime for introspection (fix calling `ConfigNamespace.help` under Python's optimized mode)

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -24,7 +24,7 @@ from . import config as _config
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy`.
     """
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -16,6 +16,7 @@ import os
 import pkgutil
 import warnings
 from contextlib import contextmanager, nullcontext
+from inspect import getdoc
 from pathlib import Path
 from textwrap import TextWrapper
 from warnings import warn
@@ -89,9 +90,9 @@ class ConfigNamespace:
                 yield key
 
     def __str__(self):
-        try:
-            header = f"{self.__doc__.strip()}\n\n"
-        except AttributeError:
+        if (docstring := getdoc(self)) is not None:
+            header = f"{docstring}\n\n"
+        else:
             current_module = str(find_current_module(2)).split("'")[1]
             header = f"Configuration parameters for `{current_module}`\n\n"
         return header + "\n\n".join(map(str, self.values()))

--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -69,7 +69,7 @@ from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.io.ascii`.
     """
 

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -20,7 +20,7 @@ from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.io.fits`.
     """
 

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -37,7 +37,7 @@ VERIFY_OPTIONS = ["ignore", "warn", "exception"]  # First one is default
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.io.votable`.
     """
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -59,7 +59,7 @@ __all__ = [
 
 # NOTE: Cannot put this in __init__.py due to circular import.
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.io.votable.exceptions`.
     """
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -68,7 +68,7 @@ class _AstLogIPYExc(Exception):
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.logger`.
     """
 

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -27,7 +27,7 @@ from .utils import *
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.nddata`.
     """
 

--- a/astropy/samp/__init__.py
+++ b/astropy/samp/__init__.py
@@ -21,7 +21,7 @@ from .utils import *
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.samp`.
     """
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.table`.
     """
 

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -11,7 +11,7 @@ from .table import Table
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.table.jsviewer`.
     """
 

--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -3,7 +3,7 @@ from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.time`.
     """
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -60,7 +60,7 @@ _UFUNCS_FILTER_WARNINGS = {np.arcsin, np.arccos, np.arccosh, np.arctanh}
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for Quantity.
     """
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -104,7 +104,7 @@ class _NonClosingTextIOWrapper(io.TextIOWrapper):
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.utils.data`.
     """
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -165,7 +165,7 @@ def _none_to_float(value):
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.utils.iers`.
     """
 

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -22,7 +22,7 @@ from .wcsapi import custom_ucd_coord_meta_mapping
 
 
 class Conf(_config.ConfigNamespace):
-    """
+    __doc__ = """
     Configuration parameters for `astropy.visualization.wcsaxes`.
     """
 

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -292,7 +292,7 @@ each sub-package that has configuration items)::
     from astropy import config as _config
 
     class Conf(_config.ConfigNamespace):
-        """
+        __doc__ = """
         Configuration parameters for my subpackage.
         """
         some_setting = _config.ConfigItem(


### PR DESCRIPTION
### Description
ref #17472
This is a direct follow up to #13499 by @eerovaher
Since `ConfigNamespace.help` relies on the availability of docstrings at runtime, we can override the optimization that drops them by setting a class level `__doc__` attribute instead of writing a docstring normally.
To be clear, it is probably not a great idea to use the optimized mode (supposedly meant for production-ready applications) with the `help` (which I think is targetted at REPL users), but if we can make it work for cheap, I think it's still worth a shot.

Specifically, this patch allows the following tests to pass with `PYTHONOPTIMIZE=2`:

```
astropy/config/tests/test_configs.py::test_help
docs/config/index.rst::index.rst
```

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
