### PR TITLE
BUG: ensure that docstrings in classes from `astropy.io.ascii` are always available for inspection at runtime

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -15,7 +15,7 @@ from . import core
 
 
 class BasicHeader(core.BaseHeader):
-    """
+    __doc__ = """
     Basic table Header Reader.
 
     Set a few defaults for common ascii table formats
@@ -28,7 +28,7 @@ class BasicHeader(core.BaseHeader):
 
 
 class BasicData(core.BaseData):
-    """
+    __doc__ = """
     Basic table Data Reader.
 
     Set a few defaults for common ascii table formats
@@ -41,7 +41,7 @@ class BasicData(core.BaseData):
 
 
 class Basic(core.BaseReader):
-    r"""Character-delimited table with a single header line at the top.
+    __doc__ = r"""Character-delimited table with a single header line at the top.
 
     Lines beginning with a comment character (default='#') as the first
     non-whitespace character are comments.
@@ -66,7 +66,7 @@ class Basic(core.BaseReader):
 
 
 class NoHeaderHeader(BasicHeader):
-    """
+    __doc__ = """
     Reader for table header without a header.
 
     Set the start of header line number to `None`, which tells the basic
@@ -77,7 +77,7 @@ class NoHeaderHeader(BasicHeader):
 
 
 class NoHeaderData(BasicData):
-    """
+    __doc__ = """
     Reader for table data without a header.
 
     Data starts at first uncommented line since there is no header line.
@@ -87,7 +87,7 @@ class NoHeaderData(BasicData):
 
 
 class NoHeader(Basic):
-    """Character-delimited table with no header line.
+    __doc__ = """Character-delimited table with no header line.
 
     When reading, columns are autonamed using header.auto_format which defaults
     to "col%d".  Otherwise this reader the same as the :class:`Basic` class
@@ -106,7 +106,7 @@ class NoHeader(Basic):
 
 
 class CommentedHeaderHeader(BasicHeader):
-    """
+    __doc__ = """
     Header class for which the column definition line starts with the
     comment character.  See the :class:`CommentedHeader` class  for an example.
     """
@@ -127,7 +127,7 @@ class CommentedHeaderHeader(BasicHeader):
 
 
 class CommentedHeader(Basic):
-    """Character-delimited table with column names in a comment line.
+    __doc__ = """Character-delimited table with column names in a comment line.
 
     When reading, ``header_start`` can be used to specify the
     line index of column names, and it can be a negative index (for example -1
@@ -182,7 +182,7 @@ class CommentedHeader(Basic):
 
 
 class TabHeaderSplitter(core.DefaultSplitter):
-    """Split lines on tab and do not remove whitespace."""
+    __doc__ = """Split lines on tab and do not remove whitespace."""
 
     delimiter = "\t"
 
@@ -191,7 +191,7 @@ class TabHeaderSplitter(core.DefaultSplitter):
 
 
 class TabDataSplitter(TabHeaderSplitter):
-    """
+    __doc__ = """
     Don't strip data value whitespace since that is significant in TSV tables.
     """
 
@@ -200,7 +200,7 @@ class TabDataSplitter(TabHeaderSplitter):
 
 
 class TabHeader(BasicHeader):
-    """
+    __doc__ = """
     Reader for header of tables with tab separated header.
     """
 
@@ -208,7 +208,7 @@ class TabHeader(BasicHeader):
 
 
 class TabData(BasicData):
-    """
+    __doc__ = """
     Reader for data of tables with tab separated data.
     """
 
@@ -216,7 +216,8 @@ class TabData(BasicData):
 
 
 class Tab(Basic):
-    """Tab-separated table.
+    __doc__ = """
+    Tab-separated table.
 
     Unlike the :class:`Basic` reader, whitespace is not stripped from the
     beginning and end of either lines or individual column values.
@@ -236,7 +237,7 @@ class Tab(Basic):
 
 
 class CsvSplitter(core.DefaultSplitter):
-    """
+    __doc__ = """
     Split on comma for CSV (comma-separated-value) tables.
     """
 
@@ -244,7 +245,7 @@ class CsvSplitter(core.DefaultSplitter):
 
 
 class CsvHeader(BasicHeader):
-    """
+    __doc__ = """
     Header that uses the :class:`astropy.io.ascii.basic.CsvSplitter`.
     """
 
@@ -254,7 +255,7 @@ class CsvHeader(BasicHeader):
 
 
 class CsvData(BasicData):
-    """
+    __doc__ = """
     Data that uses the :class:`astropy.io.ascii.basic.CsvSplitter`.
     """
 
@@ -265,7 +266,8 @@ class CsvData(BasicData):
 
 
 class Csv(Basic):
-    """CSV (comma-separated-values) table.
+    __doc__ = """
+    CSV (comma-separated-values) table.
 
     This file format may contain rows with fewer entries than the number of
     columns, a situation that occurs in output from some spreadsheet editors.
@@ -326,7 +328,7 @@ class Csv(Basic):
 
 
 class RdbHeader(TabHeader):
-    """
+    __doc__ = """
     Header for RDB tables.
     """
 
@@ -387,7 +389,7 @@ class RdbHeader(TabHeader):
 
 
 class RdbData(TabData):
-    """
+    __doc__ = """
     Data reader for RDB data. Starts reading at line 2.
     """
 
@@ -395,7 +397,7 @@ class RdbData(TabData):
 
 
 class Rdb(Tab):
-    """Tab-separated file with an extra line after the column definition line that
+    __doc__ = """Tab-separated file with an extra line after the column definition line that
     specifies either numeric (N) or string (S) data.
 
     See: https://www.drdobbs.com/rdb-a-unix-command-line-database/199101326

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -228,7 +228,7 @@ class CdsHeader(core.BaseHeader):
 
 
 class CdsData(core.BaseData):
-    """CDS table data reader."""
+    __doc__ = """CDS table data reader."""
 
     _subfmt = "CDS"
     splitter_class = fixedwidth.FixedWidthSplitter
@@ -250,7 +250,8 @@ class CdsData(core.BaseData):
 
 
 class Cds(core.BaseReader):
-    """CDS format table.
+    __doc__ = """
+    CDS format table.
 
     See: https://vizier.unistra.fr/doc/catstd.htx
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -301,7 +301,7 @@ class Column:
 
 
 class BaseInputter:
-    """
+    __doc__ = """
     Get the lines from the table input and return a list of lines.
 
     """
@@ -382,7 +382,7 @@ class BaseInputter:
 
 
 class BaseSplitter:
-    """
+    __doc__ = """
     Base splitter that uses python's split method to do the work.
 
     This does not handle quoted values.  A key feature is the formulation of
@@ -433,7 +433,8 @@ class BaseSplitter:
 
 
 class DefaultSplitter(BaseSplitter):
-    """Default class to split strings into columns using python csv.  The class
+    __doc__ = """
+    Default class to split strings into columns using python csv.  The class
     attributes are taken from the csv Dialect class.
 
     Typical usage::
@@ -574,7 +575,7 @@ def _get_line_index(line_or_func, lines):
 
 
 class BaseHeader:
-    """
+    __doc__ = """
     Base table header reader.
     """
 
@@ -784,7 +785,7 @@ class BaseHeader:
 
 
 class BaseData:
-    """
+    __doc__ = """
     Base table data reader.
     """
 
@@ -1055,7 +1056,8 @@ def convert_numpy(numpy_type):
 
 
 class BaseOutputter:
-    """Output table as a dict of column objects keyed on column name.  The
+    __doc__ = """
+    Output table as a dict of column objects keyed on column name.  The
     table data are stored as plain python lists within the column objects.
     """
 
@@ -1182,7 +1184,7 @@ def _deduplicate_names(names: list[str]) -> list[str]:
 
 
 class TableOutputter(BaseOutputter):
-    """
+    __doc__ = """
     Output the table as an astropy.table.Table object.
     """
 
@@ -1323,7 +1325,8 @@ def _apply_include_exclude_names(table, names, include_names, exclude_names):
 
 
 class BaseReader(metaclass=MetaBaseReader):
-    """Class providing methods to read and write an ASCII table using the specified
+    __doc__ = """
+    Class providing methods to read and write an ASCII table using the specified
     header, data, inputter, and outputter instances.
 
     Typical usage is to instantiate a Reader() object and customize the
@@ -1599,7 +1602,8 @@ class BaseReader(metaclass=MetaBaseReader):
 
 
 class ContinuationLinesInputter(BaseInputter):
-    """Inputter where lines ending in ``continuation_char`` are joined with the subsequent line.
+    __doc__ = """
+    Inputter where lines ending in ``continuation_char`` are joined with the subsequent line.
 
     Example::
 

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -19,7 +19,7 @@ from .misc import first_false_index, first_true_index, groupmore
 
 
 class DaophotHeader(core.BaseHeader):
-    """
+    __doc__ = """
     Read the header from a file produced by the IRAF DAOphot routine.
     """
 
@@ -312,7 +312,7 @@ class DaophotInputter(core.ContinuationLinesInputter):
 
 
 class Daophot(core.BaseReader):
-    """
+    __doc__ = """
     DAOphot format table.
 
     Example::

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -45,7 +45,8 @@ class InvalidEcsvDatatypeWarning(AstropyUserWarning):
 
 
 class EcsvHeader(basic.BasicHeader):
-    """Header class for which the column definition line starts with the
+    __doc__ = """
+    Header class for which the column definition line starts with the
     comment character.  See the :class:`CommentedHeader` class  for an example.
     """
 
@@ -242,7 +243,7 @@ def _check_dtype_is_str(col):
 
 
 class EcsvOutputter(core.TableOutputter):
-    """
+    __doc__ = """
     After reading the input lines and processing, convert the Reader columns
     and metadata to an astropy.table.Table object.  This overrides the default
     converters to be an empty list because there is no "guessing" of the
@@ -456,7 +457,8 @@ class EcsvData(basic.BasicData):
 
 
 class Ecsv(basic.Basic):
-    """ECSV (Enhanced Character Separated Values) format table.
+    __doc__ = """
+    ECSV (Enhanced Character Separated Values) format table.
 
     Th ECSV format allows for specification of key table and column meta-data, in
     particular the data type and unit.

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -10,7 +10,7 @@ from . import core, cparser
 
 
 class FastBasic(metaclass=core.MetaBaseReader):
-    """
+    __doc__ = """
     This class is intended to handle the same format addressed by the
     ordinary :class:`Basic` writer, but it acts as a wrapper for underlying C
     code and is therefore much faster. Unlike the other ASCII readers and
@@ -214,7 +214,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
 
 
 class FastCsv(FastBasic):
-    """
+    __doc__ = """
     A faster version of the ordinary :class:`Csv` writer that uses the
     optimized C parsing engine. Note that this reader will append empty
     field values to the end of any row with not enough columns, while
@@ -238,7 +238,7 @@ class FastCsv(FastBasic):
 
 
 class FastTab(FastBasic):
-    """
+    __doc__ = """
     A faster version of the ordinary :class:`Tab` reader that uses
     the optimized C parsing engine.
     """
@@ -254,7 +254,7 @@ class FastTab(FastBasic):
 
 
 class FastNoHeader(FastBasic):
-    """
+    __doc__ = """
     This class uses the fast C engine to read tables with no header line. If
     the names parameter is unspecified, the columns will be autonamed with
     "col{}".
@@ -276,7 +276,7 @@ class FastNoHeader(FastBasic):
 
 
 class FastCommentedHeader(FastBasic):
-    """
+    __doc__ = """
     A faster version of the :class:`CommentedHeader` reader, which looks for
     column names in a commented line. ``header_start`` denotes the index of
     the header line among all commented lines and is 0 by default.
@@ -339,7 +339,7 @@ class FastCommentedHeader(FastBasic):
 
 
 class FastRdb(FastBasic):
-    """
+    __doc__ = """
     A faster version of the :class:`Rdb` reader. This format is similar to
     tab-delimited, but it also contains a header line after the column
     name line denoting the type of each column (N for numeric, S for string).

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -13,7 +13,7 @@ from .core import DefaultSplitter, InconsistentTableError
 
 
 class FixedWidthSplitter(core.BaseSplitter):
-    """
+    __doc__ = """
     Split line based on fixed start and end positions for each ``col`` in
     ``self.cols``.
 
@@ -56,13 +56,13 @@ class FixedWidthSplitter(core.BaseSplitter):
 
 
 class FixedWidthHeaderSplitter(DefaultSplitter):
-    """Splitter class that splits on ``|``."""
+    __doc__ = """Splitter class that splits on ``|``."""
 
     delimiter = "|"
 
 
 class FixedWidthHeader(basic.BasicHeader):
-    """
+    __doc__ = """
     Fixed width table header reader.
     """
 
@@ -248,7 +248,7 @@ class FixedWidthHeader(basic.BasicHeader):
 
 
 class FixedWidthData(basic.BasicData):
-    """
+    __doc__ = """
     Base table data reader.
     """
 
@@ -299,7 +299,8 @@ class FixedWidthData(basic.BasicData):
 
 
 class FixedWidth(basic.Basic):
-    """Fixed width table with single header line defining column names and positions.
+    __doc__ = """
+    Fixed width table with single header line defining column names and positions.
 
     Examples::
 
@@ -353,19 +354,20 @@ class FixedWidth(basic.Basic):
 
 
 class FixedWidthNoHeaderHeader(FixedWidthHeader):
-    """Header reader for fixed with tables with no header line."""
+    __doc__ = """Header reader for fixed with tables with no header line."""
 
     start_line = None
 
 
 class FixedWidthNoHeaderData(FixedWidthData):
-    """Data reader for fixed width tables with no header line."""
+    __doc__ = """Data reader for fixed width tables with no header line."""
 
     start_line = 0
 
 
 class FixedWidthNoHeader(FixedWidth):
-    """Fixed width table which has no header line.
+    __doc__ = """
+    Fixed width table which has no header line.
 
     When reading, column names are either input (``names`` keyword) or
     auto-generated.  Column positions are determined either by input
@@ -408,7 +410,8 @@ class FixedWidthNoHeader(FixedWidth):
 
 
 class FixedWidthTwoLineHeader(FixedWidthHeader):
-    """Header reader for fixed width tables splitting on whitespace.
+    __doc__ = """
+    Header reader for fixed width tables splitting on whitespace.
 
     For fixed width tables with several header lines, there is typically
     a white-space delimited format line, so splitting on white space is
@@ -419,19 +422,20 @@ class FixedWidthTwoLineHeader(FixedWidthHeader):
 
 
 class FixedWidthTwoLineDataSplitter(FixedWidthSplitter):
-    """Splitter for fixed width tables splitting on ``' '``."""
+    __doc__ = """Splitter for fixed width tables splitting on ``' '``."""
 
     delimiter = " "
 
 
 class FixedWidthTwoLineData(FixedWidthData):
-    """Data reader for fixed with tables with two header lines."""
+    __doc__ = """Data reader for fixed with tables with two header lines."""
 
     splitter_class = FixedWidthTwoLineDataSplitter
 
 
 class FixedWidthTwoLine(FixedWidth):
-    """Fixed width table which has two header lines.
+    __doc__ = """
+    Fixed width table which has two header lines.
 
     The first header line defines the column names and the second implicitly
     defines the column positions.

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -64,7 +64,7 @@ def identify_table(soup, htmldict, numtable):
 
 
 class HTMLInputter(core.BaseInputter):
-    """
+    __doc__ = """
     Input lines of HTML in a valid form.
 
     This requires `BeautifulSoup
@@ -112,7 +112,7 @@ class HTMLInputter(core.BaseInputter):
 
 
 class HTMLSplitter(core.BaseSplitter):
-    """
+    __doc__ = """
     Split HTML table data.
     """
 
@@ -143,7 +143,7 @@ class HTMLSplitter(core.BaseSplitter):
 
 
 class HTMLOutputter(core.TableOutputter):
-    """
+    __doc__ = """
     Output the HTML data as an ``astropy.table.Table`` object.
 
     This subclass allows for the final table to contain
@@ -260,7 +260,8 @@ class HTMLData(core.BaseData):
 
 
 class HTML(core.BaseReader):
-    """HTML format table.
+    __doc__ = """
+    HTML format table.
 
     In order to customize input and output, a dict of parameters may
     be passed to this class holding specific customizations.

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -36,7 +36,8 @@ class IpacFormatError(Exception):
 
 
 class IpacHeaderSplitter(core.BaseSplitter):
-    """Splitter for Ipac Headers.
+    __doc__ = """
+    Splitter for Ipac Headers.
 
     This splitter is similar its parent when reading, but supports a
     fixed width format (as required for Ipac table headers) for writing.
@@ -64,7 +65,7 @@ class IpacHeaderSplitter(core.BaseSplitter):
 
 
 class IpacHeader(fixedwidth.FixedWidthHeader):
-    """IPAC table header."""
+    __doc__ = """IPAC table header."""
 
     splitter_class = IpacHeaderSplitter
 
@@ -328,7 +329,7 @@ class IpacDataSplitter(fixedwidth.FixedWidthSplitter):
 
 
 class IpacData(fixedwidth.FixedWidthData):
-    """IPAC table data reader."""
+    __doc__ = """IPAC table data reader."""
 
     comment = r"[|\\]"
     start_line = 0
@@ -343,7 +344,7 @@ class IpacData(fixedwidth.FixedWidthData):
 
 
 class Ipac(basic.Basic):
-    r"""IPAC format table.
+    __doc__ = r"""IPAC format table.
 
     See: https://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html
 

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -100,7 +100,7 @@ class LatexInputter(core.BaseInputter):
 
 
 class LatexSplitter(core.BaseSplitter):
-    """Split LaTeX table data. Default delimiter is `&`."""
+    __doc__ = """Split LaTeX table data. Default delimiter is `&`."""
 
     delimiter = "&"
 
@@ -136,7 +136,7 @@ class LatexSplitter(core.BaseSplitter):
 
 
 class LatexHeader(core.BaseHeader):
-    """Class to read the header of Latex Tables."""
+    __doc__ = """Class to read the header of Latex Tables."""
 
     header_start = r"\begin{tabular}"
     splitter_class = LatexSplitter
@@ -185,7 +185,7 @@ class LatexHeader(core.BaseHeader):
 
 
 class LatexData(core.BaseData):
-    """Class to read the data in LaTeX tables."""
+    __doc__ = """Class to read the data in LaTeX tables."""
 
     data_start: ClassVar[str | None] = None
     data_end = r"\end{tabular}"
@@ -217,7 +217,8 @@ class LatexData(core.BaseData):
 
 
 class Latex(core.BaseReader):
-    r"""LaTeX format table.
+    __doc__ = r"""
+    LaTeX format table.
 
     This class implements some LaTeX specific commands.  Its main
     purpose is to write out a table in a form that LaTeX can compile. It

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -50,7 +50,7 @@ MRT_TEMPLATE = [
 
 
 class MrtSplitter(fixedwidth.FixedWidthSplitter):
-    """
+    __doc__ = """
     Contains the join function to left align the MRT columns
     when writing to a file.
     """
@@ -631,7 +631,7 @@ class MrtHeader(cds.CdsHeader):
 
 
 class MrtData(cds.CdsData):
-    """MRT table data reader."""
+    __doc__ = """MRT table data reader."""
 
     _subfmt = "MRT"
     splitter_class = MrtSplitter
@@ -642,7 +642,8 @@ class MrtData(cds.CdsData):
 
 
 class Mrt(core.BaseReader):
-    """AAS MRT (Machine-Readable Table) format table.
+    __doc__ = """
+    AAS MRT (Machine-Readable Table) format table.
 
     **Reading**
     ::

--- a/astropy/io/ascii/qdp.py
+++ b/astropy/io/ascii/qdp.py
@@ -494,7 +494,7 @@ def _write_table_qdp(table, filename=None, err_specs=None):
 
 
 class QDPSplitter(core.DefaultSplitter):
-    """
+    __doc__ = """
     Split on space for QDP tables.
     """
 
@@ -502,7 +502,7 @@ class QDPSplitter(core.DefaultSplitter):
 
 
 class QDPHeader(basic.CommentedHeaderHeader):
-    """
+    __doc__ = """
     Header that uses the :class:`astropy.io.ascii.basic.QDPSplitter`.
     """
 
@@ -512,7 +512,7 @@ class QDPHeader(basic.CommentedHeaderHeader):
 
 
 class QDPData(basic.BasicData):
-    """
+    __doc__ = """
     Data that uses the :class:`astropy.io.ascii.basic.CsvSplitter`.
     """
 
@@ -523,7 +523,8 @@ class QDPData(basic.BasicData):
 
 
 class QDP(basic.Basic):
-    """Quick and Dandy Plot table.
+    __doc__ = """
+    Quick and Dandy Plot table.
 
     Example::
 

--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -31,7 +31,8 @@ class SimpleRSTData(FixedWidthData):
 
 
 class RST(FixedWidth):
-    """reStructuredText simple format table.
+    __doc__ = """
+    reStructuredText simple format table.
 
     See: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#simple-tables
 

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -13,7 +13,7 @@ from . import core
 
 
 class SExtractorHeader(core.BaseHeader):
-    """Read the header from a file produced by SExtractor."""
+    __doc__ = """Read the header from a file produced by SExtractor."""
 
     comment = r"^\s*#\s*\S\D.*"  # Find lines that don't have "# digit"
 
@@ -115,7 +115,8 @@ class SExtractorData(core.BaseData):
 
 
 class SExtractor(core.BaseReader):
-    """SExtractor format table.
+    __doc__ = """
+    SExtractor format table.
 
     SExtractor is a package for faint-galaxy photometry (Bertin & Arnouts
     1996, A&A Supp. 317, 393.)

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -673,7 +673,8 @@ the basic reader, but header and data start in different lines of the file::
 
   # Note: NoHeader is already included in astropy.io.ascii for convenience.
   class NoHeaderHeader(BasicHeader):
-      """Reader for table header without a header
+      __doc__ = """
+      Reader for table header without a header
 
       Set the start of header line number to `None`, which tells the basic
       reader there is no header line.
@@ -681,14 +682,16 @@ the basic reader, but header and data start in different lines of the file::
       start_line = None
 
   class NoHeaderData(BasicData):
-      """Reader for table data without a header
+      __doc__ = """
+      Reader for table data without a header
 
       Data starts at first uncommented line since there is no header line.
       """
       start_line = 0
 
   class NoHeader(Basic):
-      """Read a table with no header line.  Columns are autonamed using
+      __doc__ = """
+      Read a table with no header line.  Columns are autonamed using
       header.auto_format which defaults to "col%d".  Otherwise this reader
       the same as the :class:`Basic` class from which it is derived.  Example::
 
@@ -706,7 +709,8 @@ the methods in the base class::
 
   # Note: CommentedHeader is already included in astropy.io.ascii for convenience.
   class CommentedHeaderHeader(BasicHeader):
-      """Header class for which the column definition line starts with the
+      __doc__ = """
+      Header class for which the column definition line starts with the
       comment character.  See the :class:`CommentedHeader` class  for an example.
       """
       def process_lines(self, lines):
@@ -723,7 +727,8 @@ the methods in the base class::
 
 
   class CommentedHeader(Basic):
-      """Read a file where the column names are given in a line that begins with
+      __doc__ = """
+      Read a file where the column names are given in a line that begins with
       the header comment character. ``header_start`` can be used to specify the
       line index of column names, and it can be a negative index (for example -1
       for the last commented line).  The default delimiter is the <space>


### PR DESCRIPTION
### Description
ref #17472

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
