### PR TITLE
Ensure `cds.solMass` and `u.solMass` have the same string representation

### DIFF
--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -195,10 +195,10 @@ def test_hide_unit(capsys):
     showtable.main([os.path.join(ASCII_ROOT, "data/cds.dat"), "--format", "ascii.cds"])
     out, err = capsys.readouterr()
     assert out.splitlines() == [
-        "Index RAh RAm  RAs  DE- DEd  DEm    DEs   Match Class  AK  Fit ",
-        "       h  min   s       deg arcmin arcsec             mag GMsun",
-        "----- --- --- ----- --- --- ------ ------ ----- ----- --- -----",
-        "    1   3  28 39.09   +  31      6    1.9    --    I*  --  1.35",
+        "Index RAh RAm  RAs  DE- DEd  DEm    DEs   Match Class  AK   Fit   ",
+        "       h  min   s       deg arcmin arcsec             mag GsolMass",
+        "----- --- --- ----- --- --- ------ ------ ----- ----- --- --------",
+        "    1   3  28 39.09   +  31      6    1.9    --    I*  --     1.35",
     ]
 
     showtable.main(

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -119,7 +119,7 @@ def _initialize_module():
         (["mmHg"], 133.322387415 * u.Pa, "millimeter of mercury"),
         (["mol"], u.mol, "mole"),
         (["mp"], _si.m_p, "proton mass"),
-        (["Msun", "solMass"], u.solMass, "solar mass"),
+        (["solMass", "Msun"], u.solMass, "solar mass"),
         ((["mu0", "µ0"], []), _si.mu0, "magnetic constant"),
         (["muB"], _si.muB, "Bohr magneton"),
         (["N"], u.N, "Newton"),

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -192,6 +192,14 @@ def test_cds_angstrom_str():
     assert u.cds.Angstrom.name == "Angstrom"
 
 
+@pytest.mark.xfail(reason="reveals an inconsistency between u.solMass and cds.solMass")
+def test_cds_solMass_str():
+    # CDS allows writing solar mass as Msun or solMass,
+    # but cds.solMass and u.solMass should be consistent.
+    assert u.solMass.to_string("cds") == "solMass"
+    assert u.cds.solMass.to_string("cds") == "solMass"
+
+
 # These examples are taken from the EXAMPLES section of
 # https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/
 @pytest.mark.parametrize(

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -192,7 +192,6 @@ def test_cds_angstrom_str():
     assert u.cds.Angstrom.name == "Angstrom"
 
 
-@pytest.mark.xfail(reason="reveals an inconsistency between u.solMass and cds.solMass")
 def test_cds_solMass_str():
     # CDS allows writing solar mass as Msun or solMass,
     # but cds.solMass and u.solMass should be consistent.

--- a/docs/changes/units/17560.bugfix.rst
+++ b/docs/changes/units/17560.bugfix.rst
@@ -1,0 +1,7 @@
+Previously the string representation of the ``solMass`` unit in the ``"cds"``
+format depended on whether the unit was imported directly from ``units`` or
+from ``units.cds``.
+Although both representations were valid according to the CDS standard, the
+inconsistency was nonetheless needlessly surprising.
+The representation of ``units.cds.solMass`` has been changed to match the
+representation of ``units.solMass``.


### PR DESCRIPTION
### Description

Currently the string representation of the solar mass unit in the CDS format depends on whether the unit is imported directly from `units` or from `units.cds`: 
```python
>>> from astropy import units as u
>>> u.solMass.to_string("cds")
'solMass'
>>> u.cds.solMass.to_string("cds")
'Msun'
```
https://vizier.unistra.fr/viz-bin/Unit lists both, so I don't think this behavior is violating the CDS standard, but it is surprising for no good reason, and this inconsistency is preventing a code simplification in another pull request. I've added a change log entry for a bugfix, but I don't think we have to backport.

I've become convinced that we should get rid of `astropy/units/cds.py` because there is no good reason for it to exist and it keeps causing problems (see e.g. the very similar #17536). But removing it requires some effort and we need to deprecate it first.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
