### PR TITLE
Remove three useless properties from `UnitBase`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -677,27 +677,6 @@ class UnitBase:
         return tuple(zip((base.name for base in unit.bases), unit.powers))
 
     @property
-    def names(self) -> list[str]:
-        """All the names associated with the unit."""
-        raise AttributeError(
-            "Can not get names from unnamed units. Perhaps you meant to_string()?"
-        )
-
-    @property
-    def name(self) -> str:
-        """The canonical (short) name associated with the unit."""
-        raise AttributeError(
-            "Can not get names from unnamed units. Perhaps you meant to_string()?"
-        )
-
-    @property
-    def aliases(self) -> list[str]:
-        """The aliases (long) names for the unit."""
-        raise AttributeError(
-            "Can not get aliases from unnamed units. Perhaps you meant to_string()?"
-        )
-
-    @property
     def scale(self) -> UnitScale:
         """The scale of the unit."""
         return 1.0


### PR DESCRIPTION
### Description

The purpose of the `names`, `name` and `aliases` properties of `UnitBase` is to produce more helpful error messages if a user tries to access them on units that are not `NamedUnit` instances. In practice the presence of these properties makes them appear in autocompletion, which is misleading for users, and they also confuse type checkers.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.