### PR TITLE
BUG: Fix parsing ASCII table when data starts with tilda

### DIFF
--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -17,6 +17,7 @@ import pytest
 
 from astropy.io import ascii
 from astropy.io.ascii import core, html
+from astropy.io.ascii.ui import _probably_html
 from astropy.table import Table
 from astropy.utils.compat.optional_deps import HAS_BLEACH, HAS_BS4
 
@@ -837,3 +838,13 @@ def test_read_html_unicode():
     ]
     dat = Table.read(table_in, format="ascii.html")
     assert np.all(dat["col1"] == ["Δ", "Δ"])
+
+
+def test_html_check():
+    """Regression test for GH Issue 17562"""
+    table_in = (
+        "~0FR1K19A00A  C2011 01 29.24643 01 18 02.537-02 41 30.21         22.2 wL~3JL8F51\n"
+        "~0FR1K19A00A  C2011 01 29...47 46 56.60         20.93GV~7ukZG96\n"
+        "~0FR1K19A00A 1C2024 03 03.20377105 56 18.827+47 46 54.95         20.97GV~7ukZG96"
+    )
+    assert not _probably_html(table_in)

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -145,8 +145,10 @@ def _probably_html(table, maxchars=100000):
             return True
 
         # Filename ending in .htm or .html which exists
-        table_path = Path(table).expanduser()
-        if re.search(r"\.htm[l]?$", table[-5:], re.IGNORECASE) and table_path.is_file():
+        if (
+            re.search(r"\.htm[l]?$", table[-5:], re.IGNORECASE)
+            and Path(table).expanduser().is_file()
+        ):
             return True
 
         # Table starts with HTML document type declaration

--- a/docs/changes/io.ascii/17564.bugfix.rst
+++ b/docs/changes/io.ascii/17564.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug parsing ASCII table with data that starts with a tilda.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix https://github.com/astropy/astropy/issues/17562

Bug was introduced in https://github.com/astropy/astropy/pull/16954 that was released in v7.0.0

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
