### PR TITLE
BUG: fix a crash where a string was prematurely converted to pathlib.Path in an internal heuristic function

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1497,6 +1497,13 @@ def test_probably_html(home_is_data):
         ],
         (" <! doctype htm > ", " hello world"),
         [[1, 2, 3]],
+        # regression tests for https://github.com/astropy/astropy/issues/17562
+        "~itsatrap",  # looks like a Path, but isn't
+        (
+            "~0FR1K19A00A  C2011 01 29.24643 01 18 02.537-02 41 30.21         22.2 wL~3JL8F51\n"
+            "~0FR1K19A00A  C2011 01 29...47 46 56.60         20.93GV~7ukZG96\n"
+            "~0FR1K19A00A 1C2024 03 03.20377105 56 18.827+47 46 54.95         20.97GV~7ukZG96"
+        ),
     ):
         assert _probably_html(tabl0) is False
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -145,8 +145,10 @@ def _probably_html(table, maxchars=100000):
             return True
 
         # Filename ending in .htm or .html which exists
-        table_path = Path(table).expanduser()
-        if re.search(r"\.htm[l]?$", table[-5:], re.IGNORECASE) and table_path.is_file():
+        if (
+            re.search(r"\.htm[l]?$", table[-5:], re.IGNORECASE)
+            and Path(table).expanduser().is_file()
+        ):
             return True
 
         # Table starts with HTML document type declaration

--- a/docs/changes/io.ascii/17565.bugfix.rst
+++ b/docs/changes/io.ascii/17565.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed parsing ASCII table with data that starts with a tilda.


### PR DESCRIPTION
### Description
Fixes #17562

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
