### PR TITLE
ENH: add support for setting astropy's cache and config directories via environment variables

### DIFF
--- a/docs/changes/config/17567.feature.rst
+++ b/docs/changes/config/17567.feature.rst
@@ -1,0 +1,2 @@
+Add support for setting astropy's cache and config directories via the
+``ASTROPY_CACHE_DIR`` and ``ASTROPY_CONFIG_DIR`` environment variables.


### PR DESCRIPTION
### Description
This is a proof of concept solution to #17507, based atop #17554
Fixes #17507


TODO:
- [x] implement `ASTROPY_CACHE_DIR`
- [x] stabilize CI
- [x] implement `ASTROPY_CONFIG_DIR`


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
