### PR TITLE
BUG: Fix VOTable unit format on write so it does not hardcode to CDS format always

### DIFF
--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -13,7 +13,7 @@ import pytest
 
 from astropy import units as u
 from astropy.io.votable import conf, from_table, is_votable, tree, validate
-from astropy.io.votable.exceptions import E25, W39, VOWarning
+from astropy.io.votable.exceptions import E25, W39, W50, VOWarning
 from astropy.io.votable.table import parse, writeto
 from astropy.table import Column, Table
 from astropy.table.table_helpers import simple_table
@@ -372,9 +372,9 @@ def test_write_jybeam_unit(tmp_path, recwarn):
     n_warns = len(recwarn)
     assert n_warns in (1, 3)
     if n_warns == 3:
-        assert issubclass(recwarn[1].category, u.UnitsWarning)
+        assert issubclass(recwarn[1].category, W50)
         assert "Crab" in str(recwarn[1].message)
-        assert issubclass(recwarn[2].category, u.UnitsWarning)
+        assert issubclass(recwarn[2].category, W50)
         assert "my_unit" in str(recwarn[2].message)
 
     t_rt = Table.read(filename, format="votable")

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -349,6 +349,17 @@ def test_stored_parquet_votable(format):
     assert stored_votable["sfr"].unit == u.solMass / u.year
 
 
+def test_write_jybeam_unit(tmp_path):
+    t = Table()
+    t["flux"] = [5]
+    t["flux"].unit = u.Jy / u.beam
+    filename = tmp_path / "test.xml"
+    t.write(filename, format="votable", overwrite=True)
+
+    t_rt = Table.read(filename, format="votable")
+    assert t_rt["flux"].unit == t["flux"].unit
+
+
 def test_write_overwrite(tmp_path):
     t = simple_table(3, 3)
     filename = tmp_path / "overwrite_test.vot"

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1675,7 +1675,8 @@ class Field(
     def to_xml(self, w, **kwargs):
         attrib = w.object_attrs(self, self._attr_list)
         if "unit" in attrib:
-            attrib["unit"] = self.unit.to_string("cds")
+            format = _get_unit_format(self._config)
+            attrib["unit"] = self.unit.to_string(format)
         with w.tag(self._element_name, attrib=attrib):
             if self.description is not None:
                 w.element("DESCRIPTION", self.description, wrap=True)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -9,7 +9,6 @@ import io
 import os
 import re
 import urllib.request
-import warnings
 
 # THIRD-PARTY
 import numpy as np
@@ -17,7 +16,6 @@ from numpy import ma
 
 # LOCAL
 from astropy import __version__ as astropy_version
-from astropy import units as u
 from astropy.io import fits
 from astropy.utils import deprecated
 from astropy.utils.collections import HomogeneousList
@@ -1684,7 +1682,7 @@ class Field(
                 # Allow non-standard units with a warning, see
                 # https://github.com/astropy/astropy/issues/17497#issuecomment-2520472495
                 attrib["unit"] = self.unit.to_string()
-                warnings.warn(str(e), u.UnitsWarning)
+                warn_or_raise(W50, W50, (attrib["unit"],), self._config, self._pos)
         with w.tag(self._element_name, attrib=attrib):
             if self.description is not None:
                 w.element("DESCRIPTION", self.description, wrap=True)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -9,6 +9,7 @@ import io
 import os
 import re
 import urllib.request
+import warnings
 
 # THIRD-PARTY
 import numpy as np
@@ -16,6 +17,7 @@ from numpy import ma
 
 # LOCAL
 from astropy import __version__ as astropy_version
+from astropy import units as u
 from astropy.io import fits
 from astropy.utils import deprecated
 from astropy.utils.collections import HomogeneousList
@@ -1676,7 +1678,13 @@ class Field(
         attrib = w.object_attrs(self, self._attr_list)
         if "unit" in attrib:
             format = _get_unit_format(self._config)
-            attrib["unit"] = self.unit.to_string(format)
+            try:
+                attrib["unit"] = self.unit.to_string(format)
+            except ValueError as e:
+                # Allow non-standard units with a warning, see
+                # https://github.com/astropy/astropy/issues/17497#issuecomment-2520472495
+                attrib["unit"] = self.unit.to_string()
+                warnings.warn(str(e), u.UnitsWarning)
         with w.tag(self._element_name, attrib=attrib):
             if self.description is not None:
                 w.element("DESCRIPTION", self.description, wrap=True)

--- a/docs/changes/io.votable/17570.bugfix.rst
+++ b/docs/changes/io.votable/17570.bugfix.rst
@@ -3,3 +3,5 @@ could not be represented in the CDS format.
 Now ``astropy`` correctly chooses the unit format based on the VOTable version.
 The bug in question did not cause any corruption in tables that were successfully
 written because the newer VOUnit format is backwards compatible with the CDS format.
+Furthermore, any unit that is in neither formats would still be written out
+but would issue a warning.

--- a/docs/changes/io.votable/17570.bugfix.rst
+++ b/docs/changes/io.votable/17570.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where VOTable writes out unit in CDS format instead of VOUnit.

--- a/docs/changes/io.votable/17570.bugfix.rst
+++ b/docs/changes/io.votable/17570.bugfix.rst
@@ -1,1 +1,5 @@
-Fixed a bug where VOTable writes out unit in CDS format instead of VOUnit.
+``astropy`` v7.0.0 erroneously refused to write a VOTable if it contained units that
+could not be represented in the CDS format.
+Now ``astropy`` correctly chooses the unit format based on the VOTable version.
+The bug in question did not cause any corruption in tables that were successfully
+written because the newer VOUnit format is backwards compatible with the CDS format.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix #17497 . Also see https://github.com/astropy/astropy/pull/11032 (v4.3)

### Blocked by

* https://github.com/astropy/astropy/pull/17732

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
