### PR TITLE
API: make help methods raise an error if called under Python's optimized mode

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -17,6 +17,7 @@ import io
 import operator
 import os
 import pkgutil
+import sys
 import warnings
 from collections.abc import Generator
 from contextlib import contextmanager, nullcontext
@@ -140,6 +141,15 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
             provided then info about all the configuration items will be
             printed.
 
+        Raises
+        ------
+        KeyError
+           If name is not a valid configuration item.
+
+        RuntimeError
+            If called within a python runtime running with optimization level >= 2
+            (-OO CLI flag).
+
         Examples
         --------
         >>> from astropy import conf
@@ -151,6 +161,11 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
           module=astropy
           value=False
         """
+        if sys.flags.optimize >= 2:
+            raise RuntimeError(
+                "The help method is not available under Python's optimized mode."
+            )
+
         if name is None:
             print(self)
         else:

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -562,6 +562,7 @@ def test_configitem_options(tmp_path):
     assert "tstnmo = op2" in f.read_text().splitlines()
 
 
+@pytest.mark.no_optimized_interpreter
 def test_help(capsys):
     from astropy import conf
 
@@ -586,6 +587,7 @@ def test_help(capsys):
     assert use_color_msg in help_text
 
 
+@pytest.mark.no_optimized_interpreter
 def test_help_invalid_config_item():
     from astropy import conf
 
@@ -597,6 +599,17 @@ def test_help_invalid_config_item():
         ),
     ):
         conf.help("bad_name")
+
+
+@pytest.mark.only_optimized_interpreter
+def test_help_in_optimized_python():
+    from astropy import conf
+
+    with pytest.raises(
+        RuntimeError,
+        match=("The help method is not available under Python's optimized mode."),
+    ):
+        conf.help()
 
 
 @pytest.mark.usefixtures("ignore_config_paths_global_state")

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -135,6 +135,23 @@ def pytest_configure(config):
             threads_per_worker = max(max_threads // int(xdist_worker_count), 1)
             threadpool_limits(threads_per_worker)
 
+    config.addinivalue_line(
+        "markers",
+        "only_optimized_interpreter: mark a test as skipped if the interpreter is not running with -OO flags",
+    )
+    config.addinivalue_line(
+        "markers",
+        "no_optimized_interpreter: mark a test as skipped if the interpreter is running with -OO flags",
+    )
+
+
+def pytest_runtest_setup(item):
+    for m in item.iter_markers():
+        if m.name == "only_optimized_interpreter" and sys.flags.optimize < 2:
+            pytest.skip("interpreter isn't running in optimized mode")
+        if m.name == "no_optimized_interpreter" and sys.flags.optimize >= 2:
+            pytest.skip("interpreter is running in optimized mode")
+
 
 def pytest_unconfigure(config):
     # Undo settings related to number of lines/columns to show

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import locale
 import pathlib
 import platform
@@ -2089,6 +2088,7 @@ def test_read_converters_simplified():
             )
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_read_help_ascii():
     """
     Test dynamically created documentation help via the I/O registry for 'ascii'.
@@ -2103,6 +2103,7 @@ def test_table_read_help_ascii():
     assert "Character-delimited table with a single header line" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_read_help_ascii_html():
     """
     Test dynamically created documentation help via the I/O registry for 'ascii.html'.
@@ -2117,6 +2118,7 @@ def test_table_read_help_ascii_html():
     assert "**htmldict** : Dictionary of parameters for HTML input/output." in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_write_help_ascii():
     """
     Test dynamically created documentation help via the I/O registry for 'ascii'.
@@ -2131,6 +2133,7 @@ def test_table_write_help_ascii():
     assert "Character-delimited table with a single header line" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_write_help_ascii_html():
     """
     Test dynamically created documentation help via the I/O registry for 'ascii.html'.
@@ -2143,6 +2146,19 @@ def test_table_write_help_ascii_html():
     assert "Parameters" in doc
     assert "ASCII writer 'ascii.html' details" in doc
     assert "**htmldict** : Dictionary of parameters for HTML input/output." in doc
+
+
+@pytest.mark.only_optimized_interpreter
+@pytest.mark.parametrize("method", [ascii.read, ascii.write])
+@pytest.mark.parametrize("format", ["ascii", "html"])
+def test_table_read_write_help_ascii_optimized_mode(method, format):
+    out = StringIO()
+    with pytest.raises(
+        RuntimeError,
+        match="The help method is not available under Python's optimized mode.",
+    ):
+        method.help(format, out=out)
+    assert out.getvalue() == ""
 
 
 @pytest.mark.parametrize(

--- a/astropy/io/registry/interface.py
+++ b/astropy/io/registry/interface.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import pydoc
 import re
+import sys
 
 from .base import IORegistryError
 
@@ -60,6 +61,12 @@ class UnifiedReadWrite:
         Instead one can supplied a file handle object as ``out`` and the output
         will be written to that handle.
 
+        Raises
+        ------
+        RuntimeError
+            If called within a python runtime running with optimization level >= 2
+            (-OO CLI flag).
+
         Parameters
         ----------
         format : str
@@ -67,6 +74,11 @@ class UnifiedReadWrite:
         out : None or file-like
             Output destination (default is stdout via a pager)
         """
+        if sys.flags.optimize >= 2:
+            raise RuntimeError(
+                "The help method is not available under Python's optimized mode."
+            )
+
         cls = self._cls
         method_name = self._method_name
 

--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -10,7 +10,6 @@ Test :mod:`astropy.io.registry`.
 """
 
 import os
-import sys
 from collections import Counter
 from copy import deepcopy
 from io import StringIO
@@ -30,15 +29,6 @@ from astropy.io.registry import (
 from astropy.io.registry.base import _UnifiedIORegistryBase
 from astropy.io.registry.compat import default_registry
 from astropy.table import Table
-
-SKIPIF_OPTIMIZED_PYTHON = pytest.mark.skipif(
-    sys.flags.optimize >= 2, reason="docstrings are not available at runtime"
-)
-ONLY_OPTIMIZED_PYTHON = pytest.mark.skipif(
-    sys.flags.optimize < 2,
-    reason="checking behavior specifically if docstrings are not present",
-)
-
 
 ###############################################################################
 # pytest setup and fixtures
@@ -165,14 +155,14 @@ class TestUnifiedIORegistryBase:
         # (kw)args don't matter
         assert registry.get_formats(data_class=24) is None
 
-    @SKIPIF_OPTIMIZED_PYTHON
+    @pytest.mark.no_optimized_interpreter
     def test_delay_doc_updates(self, registry, fmtcls1):
         """Test ``registry.delay_doc_updates()``."""
         # TODO! figure out what can be tested
         with registry.delay_doc_updates(EmptyData):
             registry.register_identifier(*fmtcls1, empty_identifier)
 
-    @ONLY_OPTIMIZED_PYTHON
+    @pytest.mark.only_optimized_interpreter
     def test_compat_delay_doc_updates_optimized_mode(self, registry, fmtcls1):
         # check that the context manager doesn't raise an exception
         # but otherwise it should be a pure no-op
@@ -435,7 +425,7 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
         for row in formats:
             assert row["Auto-identify"] == "Yes"
 
-    @SKIPIF_OPTIMIZED_PYTHON
+    @pytest.mark.no_optimized_interpreter
     def test_delay_doc_updates(self, registry, fmtcls1):
         """Test ``registry.delay_doc_updates()``."""
         super().test_delay_doc_updates(registry, fmtcls1)
@@ -805,7 +795,7 @@ class TestUnifiedOutputRegistry(TestUnifiedIORegistryBase):
 
     # ===========================================
 
-    @SKIPIF_OPTIMIZED_PYTHON
+    @pytest.mark.no_optimized_interpreter
     def test_delay_doc_updates(self, registry, fmtcls1):
         """Test ``registry.delay_doc_updates()``."""
         super().test_delay_doc_updates(registry, fmtcls1)

--- a/astropy/io/registry/tests/test_registry_help.py
+++ b/astropy/io/registry/tests/test_registry_help.py
@@ -2,10 +2,13 @@
 
 from io import StringIO
 
+import pytest
+
 from astropy.nddata import CCDData
 from astropy.table import Table
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_read_help_fits():
     """
     Test dynamically created documentation help via the I/O registry for 'fits'.
@@ -21,6 +24,7 @@ def test_table_read_help_fits():
     assert "hdu : int or str, optional" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_read_help_ascii():
     """
     Test dynamically created documentation help via the I/O registry for 'ascii'.
@@ -38,6 +42,7 @@ def test_table_read_help_ascii():
     assert "Character-delimited table with a single header line" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_write_help_hdf5():
     """
     Test dynamically created documentation help via the I/O registry for 'hdf5'.
@@ -71,6 +76,7 @@ Format Read Write Auto-identify
     )
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_write_help_fits():
     """
     Test dynamically created documentation help via the I/O registry for 'fits'.
@@ -86,6 +92,7 @@ def test_table_write_help_fits():
     assert "Write a Table object to a FITS file" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_write_help_no_format():
     """
     Test dynamically created documentation help via the I/O registry for no
@@ -100,6 +107,7 @@ def test_table_write_help_no_format():
     assert "The available built-in formats" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_read_help_no_format():
     """
     Test dynamically created documentation help via the I/O registry for not
@@ -114,6 +122,7 @@ def test_table_read_help_no_format():
     assert "The available built-in formats" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_ccddata_write_help_fits():
     """
     Test dynamically created documentation help via the I/O registry for 'fits'.
@@ -128,6 +137,7 @@ def test_ccddata_write_help_fits():
     assert "key_uncertainty_type : str, optional" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_ccddata_read_help_fits():
     """Test dynamically created documentation help via the I/O registry for
     CCDData 'fits'.
@@ -143,6 +153,7 @@ def test_ccddata_read_help_fits():
     assert "hdu_uncertainty : str or None, optional" in doc
 
 
+@pytest.mark.no_optimized_interpreter
 def test_table_write_help_jsviewer():
     """
     Test dynamically created documentation help via the I/O registry for
@@ -156,3 +167,16 @@ def test_table_write_help_jsviewer():
     assert "Table.write general documentation" not in doc
     assert "The available built-in formats" not in doc
     assert "Table.write(format='jsviewer') documentation" in doc
+
+
+@pytest.mark.only_optimized_interpreter
+@pytest.mark.parametrize("method", [Table.read, Table.write])
+@pytest.mark.parametrize("format", [None, "fits", "jsviewer"])
+def test_table_read_help_optimized_mode(method, format):
+    out = StringIO()
+    with pytest.raises(
+        RuntimeError,
+        match="The help method is not available under Python's optimized mode.",
+    ):
+        method.help(format, out=out)
+    assert out.getvalue() == ""

--- a/docs/changes/config/17571.api.rst
+++ b/docs/changes/config/17571.api.rst
@@ -1,0 +1,2 @@
+The ``ConfNamespace.help`` method now raises an exception if called under
+Python's optimized mode (``-OO`` flag).

--- a/docs/changes/io.registry/17571.api.rst
+++ b/docs/changes/io.registry/17571.api.rst
@@ -1,0 +1,2 @@
+The ``help`` methods from ``Table.read`` and ``Table.write`` now raise an
+exception if called under Python's optimized mode (``-OO`` flag).


### PR DESCRIPTION
### Description
ref #17472
following the discussion in #17555
Although I marked this as an "API change" (because it technically is), I'd like to stress that this setup (``PYTHONOPTIMIZE=2``) was never explicitly supported and is very broken under astropy 7.0.x so it shouldn't actually be breaking to anyone.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
