### PR TITLE
API: make `delay_doc_updates` context manager a noop under Python's optimized mode

### DIFF
--- a/astropy/io/registry/base.py
+++ b/astropy/io/registry/base.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import re
+import sys
 import warnings
 from operator import itemgetter
 
@@ -187,10 +188,17 @@ class _UnifiedIORegistryBase:
         because the documentation of the corresponding ``read`` and ``write``
         methods are build every time.
 
+        This context manager has no effect when running Python in optimized mode
+        (-OO CLI flag).
+
         Examples
         --------
         see for example the source code of ``astropy.table.__init__``.
         """
+        if sys.flags.optimize >= 2:
+            yield
+            return
+
         self._delayed_docs_classes.add(cls)
 
         yield

--- a/docs/changes/io.registry/17572.api.rst
+++ b/docs/changes/io.registry/17572.api.rst
@@ -1,0 +1,2 @@
+``UnifiedInputRegistry`` and ``UnifiedOutputRegistry``'s ``delay_doc_updates``
+method's effect is disabled under Python's optimized mode (``-OO`` flag).


### PR DESCRIPTION
### Description
ref #17472
I'm not 100% sure this needs a changelog entry (because I don't know if this method is used downstream and/or considered public) but if so, I got one.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
