### PR TITLE
TST: skip a docstring-checking test under Python's optimized mode

### DIFF
--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 # Renamed these imports so that them being in the namespace will not
@@ -66,6 +68,10 @@ def test_priority():
     assert ["eggs", "spam"] == args
 
 
+@pytest.mark.skipif(
+    sys.flags.optimize >= 2,
+    reason="docstrings are not available at runtime",
+)
 def test_docs():
     class Spam(_TestRunnerBase):
         @keyword()


### PR DESCRIPTION
### Description
ref #17472

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
