### PR TITLE
Reduce duplication of temporary test cache and configuration management

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -8,9 +8,7 @@ making use of astropy's test runner).
 import builtins
 import os
 import sys
-import tempfile
 import warnings
-from pathlib import Path
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -84,20 +82,6 @@ def pytest_configure(config):
             mpl.rcdefaults()
             mpl.use("Agg")
 
-    # Make sure we use temporary directories for the config and cache
-    # so that the tests are insensitive to local configuration. Note that this
-    # is also set in the test runner, but we need to also set it here for
-    # things to work properly in parallel mode
-
-    builtins._xdg_config_home_orig = os.environ.get("XDG_CONFIG_HOME")
-    builtins._xdg_cache_home_orig = os.environ.get("XDG_CACHE_HOME")
-
-    os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
-    os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
-
-    Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
-    Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
-
     config.option.astropy_header = True
     PYTEST_HEADER_MODULES["PyERFA"] = "erfa"
     PYTEST_HEADER_MODULES["Cython"] = "cython"
@@ -140,16 +124,6 @@ def pytest_unconfigure(config):
             warnings.simplefilter("ignore")
             mpl.rcParams.update(matplotlibrc_cache)
             matplotlibrc_cache.clear()
-
-    if builtins._xdg_config_home_orig is None:
-        os.environ.pop("XDG_CONFIG_HOME")
-    else:
-        os.environ["XDG_CONFIG_HOME"] = builtins._xdg_config_home_orig
-
-    if builtins._xdg_cache_home_orig is None:
-        os.environ.pop("XDG_CACHE_HOME")
-    else:
-        os.environ["XDG_CACHE_HOME"] = builtins._xdg_cache_home_orig
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -6,24 +6,9 @@
 # and the one in astropy/conftest.py
 
 import os
-import tempfile
 from pathlib import Path
 
 import pytest
-
-# Make sure we use temporary directories for the config and cache
-# so that the tests are insensitive to local configuration.
-
-os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
-os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
-
-Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
-Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
-
-# Note that we don't need to change the environment variables back or remove
-# them after testing, because they are only changed for the duration of the
-# Python process, and this configuration only matters if running pytest
-# directly, not from e.g. an IPython session.
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description

When running the tests, temporary directories should be created for cache and `astropy` configuration. This ensures both that the primary cache and configuration don't interfere with the tests and the tests don't modify the primary cache and configuration. When working on #17529 I noticed that running the tests in fact creates several temporary directories. I did not investigate this duplication much further at the time because I wanted to keep #17529 small to avoid any backporting complications, but now I've had a closer look. I've concluded that when running tests with the development version of `astropy`, managing the temporary directories with the root-level `conftest.py` file should be sufficient and the directory management in `astropy/conftest.py` and `docs/conftest.py` is not necessary. However, the `astropy` test runner is also available with released versions of `astropy` which do not include the root-level `conftest.py`. Duplicating the directory management in the test runner is therefore still required.

Apparently @astrofrog was involved in setting up much of this configuration, so it would be good if he could review.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
