### PR TITLE
refactor: ReadOnlyDict as MappingProxyType

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -13,9 +13,6 @@ import io
 import os
 import re
 import shutil
-
-# import ssl moved inside functions using ssl to avoid import failure
-# when running in pyodide/Emscripten
 import sys
 import urllib.error
 import urllib.parse
@@ -23,6 +20,7 @@ import urllib.request
 import zipfile
 from importlib import import_module
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
+from types import MappingProxyType as ReadOnlyDict
 from warnings import warn
 
 import astropy_iers_data
@@ -1913,11 +1911,6 @@ def _url_to_dirname(url):
         urlobj[2] = "/"
     url_c = urllib.parse.urlunsplit(urlobj)
     return hashlib.md5(url_c.encode("utf-8"), usedforsecurity=False).hexdigest()
-
-
-class ReadOnlyDict(dict):
-    def __setitem__(self, key, value):
-        raise TypeError("This object is read-only.")
 
 
 _NOTHING = ReadOnlyDict({})

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -20,7 +20,7 @@ import urllib.request
 import zipfile
 from importlib import import_module
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
-from types import MappingProxyType as ReadOnlyDict
+from types import MappingProxyType
 from warnings import warn
 
 import astropy_iers_data
@@ -1913,7 +1913,7 @@ def _url_to_dirname(url):
     return hashlib.md5(url_c.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
-_NOTHING = ReadOnlyDict({})
+_NOTHING = MappingProxyType({})
 
 
 class CacheDamaged(ValueError):
@@ -2178,7 +2178,7 @@ def cache_contents(pkgname="astropy"):
                     os.path.join(dldir, entry.name, "url"), encoding="utf-8"
                 )
                 r[url] = os.path.abspath(os.path.join(dldir, entry.name, "contents"))
-    return ReadOnlyDict(r)
+    return MappingProxyType(r)
 
 
 def export_download_cache(


### PR DESCRIPTION
Clean up a semi-private API in a way that doesn't change API, e.g. for `isinstance(x, astropy.utils.data.ReadOnlyDict)`.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
