### PR TITLE
Add type annotations to  `astropy/units/format/__init__.py`

### DIFF
--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -56,7 +56,7 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def _known_formats():
+def _known_formats() -> str:
     in_out = [
         name
         for name, cls in Base.registry.items()
@@ -73,7 +73,7 @@ def _known_formats():
     )
 
 
-def get_format(format=None):
+def get_format(format: str | type[Base] | None = None) -> type[Base]:
     """
     Get a formatter by name.
 


### PR DESCRIPTION
### Description

The file has functions that should be annotated, but they have escaped our attention until now.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
