### PR TITLE
Remove an import loop from `units`

### DIFF
--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -8,15 +8,9 @@ in the :meth:`~astropy.units.UnitBase.to_string` method, i.e.,
 these classes rarely if ever need to be imported directly.
 """
 
-import sys
 import warnings
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
-# This is pretty atrocious, but it will prevent a circular import for those
-# formatters that need access to the units.core module An entry for it should
-# exist in sys.modules since astropy.units.core imports this module
-core = sys.modules["astropy.units.core"]
 
 from .base import Base
 from .cds import CDS

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
+from astropy.units.core import CompositeUnit, NamedUnit, Unit, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
 from astropy.units.utils import maybe_simple_fraction
 from astropy.utils.misc import did_you_mean
-
-from . import core
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
     import numpy as np
 
     from astropy.extern.ply.lex import LexToken
-    from astropy.units import NamedUnit, UnitBase
+    from astropy.units import UnitBase
     from astropy.units.typing import UnitPower, UnitScale
 
 
@@ -227,7 +226,7 @@ class _ParsingFormatMixin:
         try:
             return cls._validate_unit(t.value)
         except ValueError as e:
-            registry = core.get_current_unit_registry()
+            registry = get_current_unit_registry()
             if t.value in registry.aliases:
                 return registry.aliases[t.value]
 
@@ -272,25 +271,23 @@ class _ParsingFormatMixin:
         )
 
     @classmethod
-    def _decompose_to_known_units(
-        cls, unit: core.CompositeUnit | core.NamedUnit
-    ) -> UnitBase:
+    def _decompose_to_known_units(cls, unit: CompositeUnit | NamedUnit) -> UnitBase:
         """
         Partially decomposes a unit so it is only composed of units that
         are "known" to a given format.
         """
-        if isinstance(unit, core.CompositeUnit):
-            return core.CompositeUnit(
+        if isinstance(unit, CompositeUnit):
+            return CompositeUnit(
                 unit.scale,
                 [cls._decompose_to_known_units(base) for base in unit.bases],
                 unit.powers,
                 _error_check=False,
             )
-        if isinstance(unit, core.NamedUnit):
+        if isinstance(unit, NamedUnit):
             try:
                 return cls._validate_unit(unit._get_format_name(cls.name))
             except ValueError:
-                if isinstance(unit, core.Unit):
+                if isinstance(unit, Unit):
                     return cls._decompose_to_known_units(unit._represents)
                 raise
         raise TypeError(

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from astropy.units.core import CompositeUnit, Unit
 from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
 
@@ -147,7 +148,6 @@ class CDS(Base, _ParsingFormatMixin):
                  | factor
             """
             from astropy.units import dex
-            from astropy.units.core import CompositeUnit, Unit
 
             if len(p) == 3:
                 p[0] = CompositeUnit(p[1] * p[2].scale, p[2].bases, p[2].powers)

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -10,10 +10,11 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from astropy.units.core import CompositeUnit
 from astropy.units.errors import UnitScaleError
 from astropy.utils import classproperty
 
-from . import Base, core, utils
+from . import Base, utils
 from .generic import _GenericParserMixin
 
 if TYPE_CHECKING:
@@ -85,7 +86,7 @@ class FITS(Base, _GenericParserMixin):
             # all values in FITS are set that way.  So, instead do it
             # here, and use a unity-scale unit for the rest.
             parts.append(f"10**{int(base)}")
-            unit = core.CompositeUnit(1, unit.bases, unit.powers)
+            unit = CompositeUnit(1, unit.bases, unit.powers)
 
         if unit.bases:
             parts.append(super().to_string(unit, fraction=fraction))

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -22,11 +22,11 @@ import warnings
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
+from astropy.units.core import CompositeUnit, Unit, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
 
-from . import core
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
@@ -204,8 +204,6 @@ class _GenericParserMixin(_ParsingFormatMixin):
                  | factor product inverse_unit
                  | factor
             """
-            from astropy.units.core import CompositeUnit, Unit
-
             if len(p) == 2:
                 p[0] = Unit(p[1])
             elif len(p) == 3:
@@ -218,8 +216,6 @@ class _GenericParserMixin(_ParsingFormatMixin):
             division_product_of_units : division_product_of_units division product_of_units
                                       | product_of_units
             """
-            from astropy.units.core import Unit
-
             if len(p) == 4:
                 p[0] = Unit(p[1] / p[3])
             else:
@@ -445,7 +441,7 @@ class Generic(Base, _GenericParserMixin):
 
     @classmethod
     def _validate_unit(cls, s: str, detailed_exception: bool = True) -> UnitBase:
-        registry = core.get_current_unit_registry().registry
+        registry = get_current_unit_registry().registry
         if s in cls._unit_symbols:
             s = cls._unit_symbols[s]
 

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -23,10 +23,11 @@ import warnings
 from fractions import Fraction
 from typing import TYPE_CHECKING
 
+from astropy.units.core import CompositeUnit
 from astropy.units.errors import UnitParserWarning, UnitsWarning
 from astropy.utils import classproperty, parsing
 
-from . import core, utils
+from . import utils
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
@@ -173,9 +174,7 @@ class OGIP(Base, _ParsingFormatMixin):
             """
             match p[1:]:
                 case (factor, unit) | (factor, _, unit):
-                    p[0] = core.CompositeUnit(
-                        factor * unit.scale, unit.bases, unit.powers
-                    )
+                    p[0] = CompositeUnit(factor * unit.scale, unit.bases, unit.powers)
                 case _:
                     p[0] = p[1]
 
@@ -350,7 +349,7 @@ class OGIP(Base, _ParsingFormatMixin):
         # Remove units that aren't known to the format
         unit = cls._decompose_to_known_units(unit)
 
-        if isinstance(unit, core.CompositeUnit):
+        if isinstance(unit, CompositeUnit):
             # Can't use np.log10 here, because p[0] may be a Python long.
             if math.log10(unit.scale) % 1.0 != 0.0:
                 warnings.warn(


### PR DESCRIPTION
### Description

There is an import loop between `units.core` and `units.format` which only works because `units.format` hacks `sys.modules` at runtime: https://github.com/astropy/astropy/blob/71a2eafd6c09f1992f8b4132e6e40ba68a675bde/astropy/units/format/__init__.py#L16-L19
A better solution is to move imports from `format` in `core` inside the functions that need them, which allows importing `core` without importing `format` and breaks the loop. An additional small edit is required in the signature of `UnitBase.to_string()`, but it doesn't  change the behavior of the method.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
