### PR TITLE
Deprecate multiplying and dividing units with `str` or `bytes`

### DIFF
--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -16,7 +16,7 @@ from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
 from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
 
 """ The Quantity class will represent a number + unit + uncertainty """
@@ -1608,16 +1608,33 @@ def test_quantity_initialized_with_quantity():
 
 
 def test_quantity_string_unit():
-    q1 = 1.0 * u.m / "s"
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^divisions involving a unit and a 'str' instance are deprecated since "
+            r"v7\.1\. Convert 's' to a unit explicitly\.$"
+        ),
+    ):
+        q1 = 1.0 * u.m / "s"
     assert q1.value == 1
     assert q1.unit == (u.m / u.s)
 
-    q2 = q1 * "m"
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^products involving a unit and a 'str' instance are deprecated since "
+            r"v7\.1\. Convert 'm' to a unit explicitly\.$"
+        ),
+    ):
+        q2 = q1 * "m"
     assert q2.unit == ((u.m * u.m) / u.s)
 
 
 def test_quantity_invalid_unit_string():
-    with pytest.raises(ValueError):
+    with (
+        pytest.raises(ValueError),
+        pytest.warns(AstropyDeprecationWarning, match="^products involving .* a 'str'"),
+    ):
         "foo" * u.m
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -731,9 +731,23 @@ def test_repr_latex():
 
 
 def test_operations_with_strings():
-    assert u.m / "5s" == (u.m / (5.0 * u.s))
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^divisions involving a unit and a 'str' instance are deprecated since "
+            r"v7\.1\. Convert '5s' to a unit explicitly\.$"
+        ),
+    ):
+        assert u.m / "5s" == (u.m / (5.0 * u.s))
 
-    assert u.m * "5s" == (5.0 * u.m * u.s)
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^products involving a unit and a 'str' instance are deprecated since "
+            r"v7\.1\. Convert '5s' to a unit explicitly\.$"
+        ),
+    ):
+        assert u.m * "5s" == (5.0 * u.m * u.s)
 
 
 def test_comparison():
@@ -756,19 +770,29 @@ def test_compose_into_arbitrary_units():
 
 
 def test_unit_multiplication_with_string():
-    """Check that multiplication with strings produces the correct unit."""
-    u1 = u.cm
-    us = "kg"
-    assert us * u1 == u.Unit(us) * u1
-    assert u1 * us == u1 * u.Unit(us)
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^products involving a unit and a 'str' instance are deprecated since "
+            r"v7\.1\. Convert 'kg' to a unit explicitly\.$"
+        ),
+    ):
+        assert "kg" * u.cm == u.kg * u.cm
+    with pytest.warns(AstropyDeprecationWarning, match="^products involving .* 'str'"):
+        assert u.cm * "kg" == u.cm * u.kg
 
 
 def test_unit_division_by_string():
-    """Check that multiplication with strings produces the correct unit."""
-    u1 = u.cm
-    us = "kg"
-    assert us / u1 == u.Unit(us) / u1
-    assert u1 / us == u1 / u.Unit(us)
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=(
+            "^divisions involving a unit and a 'str' instance are deprecated since "
+            r"v7\.1\. Convert 'kg' to a unit explicitly\.$"
+        ),
+    ):
+        assert "kg" / u.cm == u.kg / u.cm
+    with pytest.warns(AstropyDeprecationWarning, match="^divisions involving .* 'str'"):
+        assert u.cm / "kg" == u.cm / u.kg
 
 
 def test_sorted_bases():

--- a/docs/changes/units/17586.api.rst
+++ b/docs/changes/units/17586.api.rst
@@ -1,0 +1,2 @@
+Automatic conversion of a ``str`` or ``bytes`` instance to a unit when it is
+multiplied or divided with an existing unit or quantity is deprecated.


### PR DESCRIPTION
### Description

When multiplying or dividing a `UnitBase` instance with a `str` or a `bytes` instance an attempt is made to convert the `str` or `bytes` to a unit. This behavior is shared with `Quantity`:
```python
>>> from astropy import units as u
>>> 2 * u.m * "m"
<Quantity 2. m2>
```
That being said, multiplication should be commutative and associative, but this isn't:
```python
>>> 2 * "m" * u.m
Unit("m mm")
```
With some numerical values the outcome is even worse:
```python
>>> (u.m * 3) * "m"
<Quantity 3. m2>
>>> u.m * (3 * "m")
Traceback (most recent call last):
  ...
ValueError: 'mmm' did not parse as unit: At col 0, mmm is not ...
```
The above examples prove that the products of units and `str` don't behave like products should and the automatic conversion feature is error-prone. I also think that parsing strings should not be one of the responsibilities of `UnitBase.__mul__()`. Using units directly is simple enough. All of the above suggests that this feature should be deprecated so that it could eventually be removed. If converting strings doesn't happen automatically with multiplication then there is no reason why it should also happen with division, so that should be deprecated too. And although the above examples used `str`, the same reasoning also applies to `bytes`.

I am confident that deprecating the automatic conversion of `bytes` is not controversial. My understanding is that this functionality is a left-over from the Python 2 era anyways. The reason I've opened this pull request as a draft is that I'd like the `units` maintainers to confirm if deprecating the automatic conversion of `str` is also a good idea.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
