### PR TITLE
add public modules to use direct import first stage like 'import astr…

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -211,29 +211,77 @@ __dir_inc__ = [
     "physical_constants",
     "astronomical_constants",
     "system_info",
+    "system_info",
+] + [
+    # add public modules to use direct import first stage like
+    # import astropy.stats as st
+    "config",
+    "constants",
+    "convolution",
+    "coordinates",
+    "cosmology",
+    "io",
+    "modeling",
+    "nddata",
+    "samp",
+    "stats",
+    "table",
+    "time",
+    "timeseries",
+    "uncertainty",
+    "units",
+    "utils",
+    "visualization",
+    "wcs",
+]
+
+# Define __all__ to control what gets imported with 'from module import *'
+# Combine global names (explicitly defined in the module) and dynamically available names
+__all__ = [
+    name
+    for name in map(str, set(globals()).union(dir()).union(__dir_inc__))
+    # Exclude private/internal names (those starting with '_')
+    if not (
+        (name.startswith("_") and not name.endswith("_"))
+        or name
+        in [
+            "set",
+            "Conf",
+            "Path",
+            "ScienceState",
+            "TestRunner",
+            "__dir_inc__",
+            "sys",
+        ]
+    )
 ]
 
 
-from types import ModuleType as __module_type__
+# Custom attributes we want to be displayed when dir() is called
+def __dir__():
+    return sorted(__all__)
 
-# Clean up top-level namespace--delete everything that isn't in __dir_inc__
-# or is a magic attribute, and that isn't a submodule of this package
-for varname in dir():
-    if not (
-        (varname.startswith("__") and varname.endswith("__"))
-        or varname in __dir_inc__
-        or (
-            varname[0] != "_"
-            and isinstance(locals()[varname], __module_type__)
-            and locals()[varname].__name__.startswith(__name__ + ".")
-        )
-    ):
-        # The last clause in the above disjunction deserves explanation:
-        # When using relative imports like ``from .. import config``, the
-        # ``config`` variable is automatically created in the namespace of
-        # whatever module ``..`` resolves to (in this case astropy).  This
-        # happens a few times just in the module setup above.  This allows
-        # the cleanup to keep any public submodules of the astropy package
-        del locals()[varname]
 
-del varname, __module_type__
+# from types import ModuleType as __module_type__
+
+# # Clean up top-level namespace--delete everything that isn't in __dir_inc__
+# # or is a magic attribute, and that isn't a submodule of this package
+# for varname in dir():
+#     if not (
+#         (varname.startswith("__") and varname.endswith("__"))
+#         or varname in __dir_inc__
+#         or (
+#             varname[0] != "_"
+#             and isinstance(locals()[varname], __module_type__)
+#             and locals()[varname].__name__.startswith(__name__ + ".")
+#         )
+#     ):
+#         # The last clause in the above disjunction deserves explanation:
+#         # When using relative imports like ``from .. import config``, the
+#         # ``config`` variable is automatically created in the namespace of
+#         # whatever module ``..`` resolves to (in this case astropy).  This
+#         # happens a few times just in the module setup above.  This allows
+#         # the cleanup to keep any public submodules of the astropy package
+#         del locals()[varname]
+
+# del varname, __module_type__


### PR DESCRIPTION
… 'import astropy.stats as st'

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
