### PR TITLE
Remove help messages for legacy setup.py commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,67 +4,9 @@
 # NOTE: The configuration for the package, including the name, version, and
 # other information are set in the pyproject.toml file.
 
-import sys
+from setuptools import setup
 
-# First provide helpful messages if contributors try and run legacy commands
-# for tests or docs.
-
-TEST_HELP = """
-Note: running tests is no longer done using 'python setup.py test'. Instead
-you will need to run:
-
-    tox -e test
-
-If you don't already have tox installed, you can install it with:
-
-    pip install tox
-
-If you only want to run part of the test suite, you can also use pytest
-directly with::
-
-    pip install -e .[test]
-    pytest
-
-For more information, see:
-
-  https://docs.astropy.org/en/latest/development/testguide.html#running-tests
-"""
-
-if "test" in sys.argv:
-    print(TEST_HELP)
-    sys.exit(1)
-
-DOCS_HELP = """
-Note: building the documentation is no longer done using
-'python setup.py build_docs'. Instead you will need to run:
-
-    tox -e build_docs
-
-If you don't already have tox installed, you can install it with:
-
-    pip install tox
-
-You can also build the documentation with Sphinx directly using::
-
-    pip install -e .[docs]
-    cd docs
-    make html
-
-For more information, see:
-
-  https://docs.astropy.org/en/latest/install.html#builddocs
-"""
-
-if "build_docs" in sys.argv or "build_sphinx" in sys.argv:
-    print(DOCS_HELP)
-    sys.exit(1)
-
-
-# Only import these if the above checks are okay
-# to avoid masking the real problem with import error.
-from setuptools import setup  # noqa: E402
-
-from extension_helpers import get_extensions  # noqa: E402
+from extension_helpers import get_extensions
 
 ext_modules = get_extensions()
 


### PR DESCRIPTION
### Description

The help messages I am removing were added in 45cdbb124b59ca174639cdf4ccf5c062b5c5f4ff almost five years ago. Whoever still hasn't gotten the message never will.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
