### PR TITLE
ENH: ensure that dir(astropy) lists subpackages

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -26,6 +26,7 @@ __all__ = [  # noqa: RUF100, RUF022
     "samp",
     "stats",
     "table",
+    "tests",
     "time",
     "timeseries",
     "uncertainty",

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -11,6 +11,54 @@ from pathlib import Path
 
 from astropy.utils.system_info import system_info
 
+__all__ = [  # noqa: RUF100, RUF022
+    "__version__",
+    "__bibtex__",
+    # Subpackages (mostly lazy-loaded)
+    "config",
+    "constants",
+    "convolution",
+    "coordinates",
+    "cosmology",
+    "io",
+    "modeling",
+    "nddata",
+    "samp",
+    "stats",
+    "table",
+    "time",
+    "timeseries",
+    "uncertainty",
+    "units",
+    "utils",
+    "visualization",
+    "wcs",
+    # Functions
+    "test",
+    "log",
+    "find_api_page",
+    "online_help",
+    "online_docs_root",
+    "conf",
+    "physical_constants",
+    "astronomical_constants",
+    "system_info",
+]
+
+
+def __getattr__(attr):
+    if attr in __all__:
+        from importlib import import_module
+
+        return import_module("astropy." + attr)
+
+    raise AttributeError(f"module 'astropy' has no attribute {attr!r}")
+
+
+def __dir__():
+    return sorted(set(globals()).union(__all__))
+
+
 from .version import version as __version__
 
 # The location of the online documentation for astropy
@@ -198,30 +246,14 @@ def online_help(query):
     webbrowser.open(url)
 
 
-__dir_inc__ = [
-    "__version__",
-    "__githash__",
-    "__bibtex__",
-    "test",
-    "log",
-    "find_api_page",
-    "online_help",
-    "online_docs_root",
-    "conf",
-    "physical_constants",
-    "astronomical_constants",
-    "system_info",
-]
-
-
 from types import ModuleType as __module_type__
 
-# Clean up top-level namespace--delete everything that isn't in __dir_inc__
+# Clean up top-level namespace--delete everything that isn't in __all__
 # or is a magic attribute, and that isn't a submodule of this package
 for varname in dir():
     if not (
         (varname.startswith("__") and varname.endswith("__"))
-        or varname in __dir_inc__
+        or varname in __all__
         or (
             varname[0] != "_"
             and isinstance(locals()[varname], __module_type__)

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -3,6 +3,7 @@
 import pkgutil
 import subprocess
 import sys
+from pathlib import Path
 from textwrap import dedent
 from types import ModuleType
 
@@ -58,3 +59,20 @@ def test_toplevel_attribute_error():
     # Ensure that our __getattr__ does not leak an import error or so.
     with pytest.raises(AttributeError, match="module 'astropy' has no"):
         astropy.nonsense
+
+
+def test_completeness_toplevel__all__():
+    # Implicitly check that all items in __all__ exist.
+    all_items = {getattr(astropy, attr) for attr in astropy.__all__}
+    # Verify that the list of modules in __all__ is complete.
+    module_names = {
+        item.__name__.partition(".")[2]
+        for item in all_items
+        if isinstance(item, ModuleType)
+    }
+    module_dirs = {
+        f.name
+        for f in Path(astropy.__file__).parent.glob("[a-z]*")
+        if f.is_dir() and f.name != "extern"
+    }
+    assert module_names == module_dirs

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -338,9 +338,9 @@ def find_mod_objs(modname, onlylocals=False):
     mod = import_module(modname)
 
     if hasattr(mod, "__all__"):
-        pkgitems = [(k, mod.__dict__[k]) for k in mod.__all__]
+        pkgitems = [(k, getattr(mod, k)) for k in mod.__all__]
     else:
-        pkgitems = [(k, mod.__dict__[k]) for k in dir(mod) if k[0] != "_"]
+        pkgitems = [(k, getattr(mod, k)) for k in dir(mod) if k[0] != "_"]
 
     # filter out modules and pull the names and objs out
     ismodule = inspect.ismodule

--- a/docs/changes/17598.other.rst
+++ b/docs/changes/17598.other.rst
@@ -1,0 +1,4 @@
+After ``import astropy``, ``dir(astropy)`` will now list all subpackages,
+including those that have not yet been loaded. This also means tab
+completion will work as expected (e.g., ``from astropy.coo<TAB>`` will
+expand to ``from astropy.coordinates``).

--- a/docs/changes/coordinates/17503.api.rst
+++ b/docs/changes/coordinates/17503.api.rst
@@ -1,2 +1,2 @@
-On representations the method `get_name` has been deprecated in favor of the class-level
-attribute `name`. The method will be removed in a future release.
+On representations the method ``get_name`` has been deprecated in favor of the class-level
+attribute ``name``. The method will be removed in a future release.

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -74,6 +74,7 @@ py:class None.  Remove all items from D.
 py:class a set-like object providing a view on D's items
 py:class a set-like object providing a view on D's keys
 py:class None.  Update D from dict/iterable E and F.
+py:class None.  Update D from mapping/iterable E and F.
 py:class an object providing a view on D's values
 py:class a shallow copy of D
 


### PR DESCRIPTION
After ``import astropy``, ``dir(astropy)`` will now list all subpackages, including those that have not yet been loaded explicitly. This also means tab completion will work as expected (e.g., ``from astropy.coo<TAB>`` will expand to ``from astropy.coordinates``).

Fixes #17589

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
