### PR TITLE
Rewrite unit formatter `get_format()`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -745,7 +745,13 @@ class UnitBase:
         """
         from .format import get_format
 
-        return get_format(format).to_string(self, **kwargs)
+        try:
+            return get_format(format).to_string(self, **kwargs)
+        except (TypeError, ValueError) as err:
+            from .format import known_formats
+
+            err.add_note(known_formats())
+            raise err
 
     def __format__(self, format_spec: str) -> str:
         try:
@@ -2019,7 +2025,13 @@ class _UnitMetaClass(type):
 
             from .format import Generic, get_format
 
-            f = get_format(format)
+            try:
+                f = get_format(format)
+            except (TypeError, ValueError) as err:
+                from .format import known_parsers
+
+                err.add_note(known_parsers())
+                raise err
             if isinstance(s, bytes):
                 s = s.decode("ascii")
 

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -50,20 +50,15 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def _known_formats() -> str:
-    in_out = [
-        name
+def known_formats() -> str:
+    return "Valid formatter names are: " + ", ".join(map(repr, Base.registry))
+
+
+def known_parsers() -> str:
+    return "Valid parser names are: " + ", ".join(
+        repr(name)
         for name, cls in Base.registry.items()
         if cls.parse.__func__ is not Base.parse.__func__
-    ]
-    out_only = [
-        name
-        for name, cls in Base.registry.items()
-        if cls.parse.__func__ is Base.parse.__func__
-    ]
-    return (
-        f"Valid formatter names are: {in_out} for input and output, "
-        f"and {out_only} for output only."
     )
 
 
@@ -87,9 +82,7 @@ def get_format(format: str | type[Base] | None = None) -> type[Base]:
         try:
             return Base.registry[format.lower()]
         except KeyError:
-            raise ValueError(
-                f"Unknown format {format!r}.  {_known_formats()}"
-            ) from None
+            raise ValueError(f"Unknown format {format!r}.") from None
     if isinstance(format, type) and issubclass(format, Base):
         return format
-    raise TypeError(f"Expected a formatter name, not {format!r}.  {_known_formats()}.")
+    raise TypeError(f"Expected a formatter name, not {format!r}.")

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -83,17 +83,13 @@ def get_format(format: str | type[Base] | None = None) -> type[Base]:
     """
     if format is None:
         return Generic
-
+    if isinstance(format, str):
+        try:
+            return Base.registry[format.lower()]
+        except KeyError:
+            raise ValueError(
+                f"Unknown format {format!r}.  {_known_formats()}"
+            ) from None
     if isinstance(format, type) and issubclass(format, Base):
         return format
-    elif not (isinstance(format, str) or format is None):
-        raise TypeError(
-            f"Expected a formatter name, not {format!r}.  {_known_formats()}."
-        )
-
-    format_lower = format.lower()
-
-    if format_lower in Base.registry:
-        return Base.registry[format_lower]
-
-    raise ValueError(f"Unknown format {format!r}.  {_known_formats()}")
+    raise TypeError(f"Expected a formatter name, not {format!r}.  {_known_formats()}.")

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -1047,22 +1047,48 @@ def test_parse_error_message_for_output_only_format(format_):
         u.Unit("m", format=format_)
 
 
-class TestUnknownFormat:
-    # Check full message to ensure we correctly classify in-out and
-    # output only formats.
-    UNKNOWN_MSG = (
-        r"Unknown format {!r}.  Valid formatter names are: "
-        r"\['cds', 'generic', 'fits', 'ogip', 'vounit'\] for input and output, "
-        r"and \['console', 'latex', 'latex_inline', 'unicode'\] for output only."
-    )
+@pytest.mark.parametrize(
+    "parser,error_type,err_msg_start",
+    [
+        pytest.param("foo", ValueError, "Unknown format 'foo'", id="ValueError"),
+        pytest.param(
+            {}, TypeError, "Expected a formatter name, not {}", id="TypeError"
+        ),
+    ],
+)
+def test_unknown_parser(parser, error_type, err_msg_start):
+    with pytest.raises(
+        error_type,
+        match=(
+            f"^{err_msg_start}\\.\nValid parser names are: "
+            "'cds', 'generic', 'fits', 'ogip', 'vounit'$"
+        ),
+    ):
+        u.Unit("m", format=parser)
 
-    def test_unknown_parser(self):
-        with pytest.raises(ValueError, match=self.UNKNOWN_MSG.format("foo")):
-            u.Unit("m", format="foo")
 
-    def test_unknown_output_format(self):
-        with pytest.raises(ValueError, match=self.UNKNOWN_MSG.format("abc")):
-            u.m.to_string("abc")
+@pytest.mark.parametrize(
+    "formatter,error_type,err_msg_start",
+    [
+        pytest.param("abc", ValueError, "Unknown format 'abc'", id="ValueError"),
+        pytest.param(
+            float,
+            TypeError,
+            "Expected a formatter name, not <class 'float'>",
+            id="TypeError",
+        ),
+    ],
+)
+def test_unknown_output_format(formatter, error_type, err_msg_start):
+    with pytest.raises(
+        error_type,
+        match=(
+            f"^{err_msg_start}\\.\nValid formatter names are: "
+            "'cds', 'console', 'generic', 'fits', 'latex', 'latex_inline', 'ogip', "
+            "'unicode', 'vounit'$"
+        ),
+    ):
+        u.m.to_string(formatter)
 
 
 def test_celsius_fits():


### PR DESCRIPTION
### Description

The main reason I wanted to edit the function was an `is None` check which bothered me a lot because of how obviously unnecessary it was. But when I rewrote the function I made it handle strings faster, at the cost of handling formatter classes slower. This is a good tradeoff because using strings is unavoidable in e.g. f-string format specifiers, and also because using strings does not require explicitly importing the formatters.

UPDATE

I've added a second commit that updates the error messages that the user sees if they specified an invalid formatter. Because not all formatters can be used for parsing then the list of valid formatter names depends on whether the user was formatting units or parsing strings. The previous error messages therefore had two separate lists with the formatter names, but the error messages contained both lists regardless of whether the user was formatting or parsing. [Exception notes](https://peps.python.org/pep-0678/) introduced in Python 3.11 make it quite simple to create context-specific error messages, which is exactly what is needed here.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
