### PR TITLE
Partial fix to fix_inputs bug

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3294,7 +3294,12 @@ class CompoundModel(Model):
 
     @property
     def fit_deriv(self):
-        # If either side of the model is missing analytical derivative then we can't compute one
+        # If either side is missing an analytical derivative, we can't compute one.
+        if self.op == "fix_inputs":
+            # The "right" side is just a dict, so let's rely on the left side derivative:
+            # e.g., Linear1D.fit_deriv exists. If that's None, we just return None.
+            return self.left.fit_deriv
+
         if self.left.fit_deriv is None or self.right.fit_deriv is None:
             return None
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3511,8 +3511,16 @@ class CompoundModel(Model):
         return self._param_names
 
     def _make_leaflist(self):
+        if self.op == "fix_inputs":
+            # The right side is a dict of fixed inputs, not a Model.
+            # So the only real submodel is the left side.
+            self._leaflist = [self.left]  # store just that one submodel
+            self._tdict = {}
+            return
+
         tdict = {}
         leaflist = []
+        # This function is normally used for +, -, *, /, |, & ...
         make_subtree_dict(self, "", tdict, leaflist)
         self._leaflist = leaflist
         self._tdict = tdict

--- a/astropy/modeling/tests/test_fixed_inputs.py
+++ b/astropy/modeling/tests/test_fixed_inputs.py
@@ -16,27 +16,28 @@ def test_fix_inputs_fittable():
 
 def test_fix_inputs_zero_input_fitting():
     """
-    Test if we can fit a model whose entire input is fixed.
-    This is not fully supported by default; we pass a dummy `x` or
-    see if the fitter can handle no x at all.
+    Test if we can fit a model whose entire input is fixed, but still
+    have enough data points to avoid m < n in Levenberg–Marquardt.
     """
-    # Our model still has free parameters (slope, intercept),
-    # but the x input is fixed to 3.
+    # Model still has two free parameters
     photon = models.Linear1D(slope=2, intercept=1)
     p = fix_inputs(photon, {"x": 3.0})
 
-    # Suppose we want to fit for intercept given y_data at that single point:
-    y_data = np.array(
-        [7.0]
-    )  # we want slope*3 + intercept=7 => 2*3 + 1=7 => intercept=1
+    # Provide TWO identical data points for the same x=3.0
+    # We effectively have the system:
+    #   slope*3 + intercept = y_data[i] for i in {0, 1}
+    # Here both are 7, so the exact fit is slope=2, intercept=1
+    # but we now have m=2 data points for n=2 parameters => OK for LM
+    y_data = np.array([7.0, 7.0])
 
     fitter = fitting.LMLSQFitter()
 
-    # Typically, `__call__` expects `fitter(model, x, y)`:
-    # a minimal workaround is to pass a dummy array for x.
-    x_dummy = np.zeros_like(y_data)  # shape matches y_data
+    # Provide a dummy x array of the same shape as y_data
+    # The x values are irrelevant since the model input is "fixed",
+    # but the shape must match for the fitter's internal checks.
+    x_dummy = np.zeros_like(y_data)
+
     fitted_p = fitter(p, x_dummy, y_data)
 
-    # Check that it recovers slope=2, intercept=1
-    # param order for a Linear1D is slope, intercept
-    np.testing.assert_allclose(fitted_p.parameters, [2.0, 1.0], rtol=1e-6)
+    # Check it recovers slope=2, intercept=1
+    np.testing.assert_allclose(fitted_p.parameters, [2.0, 1.0], atol=1e-7)

--- a/astropy/modeling/tests/test_fixed_inputs.py
+++ b/astropy/modeling/tests/test_fixed_inputs.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from astropy.modeling import fitting, models
+from astropy.modeling.models import fix_inputs
+
+
+def test_fix_inputs_fittable():
+    """Test that fix_inputs(...).fittable does not raise AttributeError."""
+    photon = models.Linear1D(slope=2, intercept=1)
+    p = fix_inputs(photon, {"x": 3.0})
+    # Prior to the patch, we might get an AttributeError
+    # After the patch, we expect this to succeed:
+    assert hasattr(p, "fittable")
+    assert p.fittable is True
+
+
+def test_fix_inputs_zero_input_fitting():
+    """
+    Test if we can fit a model whose entire input is fixed.
+    This is not fully supported by default; we pass a dummy `x` or
+    see if the fitter can handle no x at all.
+    """
+    # Our model still has free parameters (slope, intercept),
+    # but the x input is fixed to 3.
+    photon = models.Linear1D(slope=2, intercept=1)
+    p = fix_inputs(photon, {"x": 3.0})
+
+    # Suppose we want to fit for intercept given y_data at that single point:
+    y_data = np.array(
+        [7.0]
+    )  # we want slope*3 + intercept=7 => 2*3 + 1=7 => intercept=1
+
+    fitter = fitting.LMLSQFitter()
+
+    # Typically, `__call__` expects `fitter(model, x, y)`:
+    # a minimal workaround is to pass a dummy array for x.
+    x_dummy = np.zeros_like(y_data)  # shape matches y_data
+    fitted_p = fitter(p, x_dummy, y_data)
+
+    # Check that it recovers slope=2, intercept=1
+    # param order for a Linear1D is slope, intercept
+    np.testing.assert_allclose(fitted_p.parameters, [2.0, 1.0], rtol=1e-6)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a `fix_inputs` bug. 

Two issues were described by @Cadair in #17550. This PR addresses the first issue, so now a model created from `fix_inputs` will return `fittable = True`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Partially Fixes #17550

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
