### PR TITLE
Rename `Complex` and `Real` type aliases

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from .format import Base
     from .physical import PhysicalType
     from .quantity import Quantity
-    from .typing import Complex, Real, UnitPower, UnitScale
+    from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
 
 __all__ = [
     "CompositeUnit",
@@ -774,7 +774,7 @@ class UnitBase:
 
         return normalized
 
-    def __pow__(self, p: Real) -> CompositeUnit:
+    def __pow__(self, p: UnitPowerLike) -> CompositeUnit:
         try:  # Handling scalars should be as quick as possible
             return CompositeUnit(1, [self], [sanitize_power(p)], _error_check=False)
         except Exception:
@@ -2081,9 +2081,9 @@ class _UnitMetaClass(type):
                 _error_check=False,
             )
 
-        from .typing import Complex
+        from .typing import UnitScaleLike
 
-        if isinstance(s, Complex):  # same as the annotation in sanitize_scale_type()
+        if isinstance(s, UnitScaleLike):
             return CompositeUnit(s, [], [])
 
         if isinstance(s, tuple):
@@ -2261,9 +2261,9 @@ class CompositeUnit(UnitBase):
     @overload
     def __init__(
         self,
-        scale: Complex,
+        scale: UnitScaleLike,
         bases: Sequence[UnitBase],
-        powers: Sequence[Real],
+        powers: Sequence[UnitPowerLike],
         decompose: bool = False,
         decompose_bases: Collection[UnitBase] = (),
         _error_check: Literal[True] = True,

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -68,12 +68,7 @@ For more examples see the :mod:`numpy.typing` definition of
 """
 
 
-# The classes from the standard library `numbers` module are not suitable for
-# type checking (https://github.com/python/mypy/issues/3186). For now we define
-# our own number types, but if a good definition becomes available upstream
-# then we should switch to that.
-Real: TypeAlias = int | float | Fraction | np.integer | np.floating
-Complex: TypeAlias = Real | complex | np.complexfloating
-
 UnitPower: TypeAlias = int | float | Fraction
+UnitPowerLike: TypeAlias = UnitPower | np.integer | np.floating
 UnitScale: TypeAlias = int | float | Fraction | complex
+UnitScaleLike: TypeAlias = UnitScale | np.number

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from .core import UnitBase
     from .quantity import Quantity
-    from .typing import Complex, Real, UnitPower, UnitScale
+    from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
 
     DType = TypeVar("DType", bound=np.generic)
     FloatLike = TypeVar("FloatLike", bound=SupportsFloat)
@@ -181,7 +181,7 @@ def generate_prefixonly_unit_summary(namespace: dict[str, object]) -> str:
     return docstring.getvalue()
 
 
-def is_effectively_unity(value: Complex) -> bool:
+def is_effectively_unity(value: UnitScaleLike) -> bool:
     # value is *almost* always real, except, e.g., for u.mag**0.5, when
     # it will be complex.  Use try/except to ensure normal case is fast
     try:
@@ -193,7 +193,7 @@ def is_effectively_unity(value: Complex) -> bool:
         )
 
 
-def sanitize_scale_type(scale: Complex) -> UnitScale:
+def sanitize_scale_type(scale: UnitScaleLike) -> UnitScale:
     if not scale:
         raise UnitScaleError("cannot create a unit with a scale of 0.")
 
@@ -226,7 +226,7 @@ def sanitize_scale_value(scale: UnitScale) -> UnitScale:
         return scale.real
 
 
-def maybe_simple_fraction(p: Real, max_denominator: int = 100) -> UnitPower:
+def maybe_simple_fraction(p: UnitPowerLike, max_denominator: int = 100) -> UnitPower:
     """Fraction very close to x with denominator at most max_denominator.
 
     The fraction has to be such that fraction/x is unity to within 4 ulp.
@@ -257,7 +257,7 @@ def maybe_simple_fraction(p: Real, max_denominator: int = 100) -> UnitPower:
     return float(p)
 
 
-def sanitize_power(p: Real) -> UnitPower:
+def sanitize_power(p: UnitPowerLike) -> UnitPower:
     """Convert the power to a float, an integer, or a Fraction.
 
     If a fractional power can be represented exactly as a floating point
@@ -297,7 +297,9 @@ def sanitize_power(p: Real) -> UnitPower:
     return p
 
 
-def resolve_fractions(a: Real, b: Real) -> tuple[Real, Real]:
+def resolve_fractions(
+    a: UnitPowerLike, b: UnitPowerLike
+) -> tuple[UnitPowerLike, UnitPowerLike]:
     """
     If either input is a Fraction, convert the other to a Fraction
     (at least if it does not have a ridiculous denominator).

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -94,10 +94,10 @@ py:class np.ma.MaskedArray
 # locally defined type variable for ndarray dtype
 py:class DT
 # type aliases
-py:class Complex
-py:class Real
 py:class UnitPower
+py:class UnitPowerLike
 py:class UnitScale
+py:class UnitScaleLike
 
 # Classes from `astropy.extern` that are nonetheless exposed in documentation
 py:class Lexer


### PR DESCRIPTION
### Description

The type aliases in question currently have names that reflect what they consist of, but the new names `UnitScaleLike` and `UnitPowerLike` better reflect that these types can be converted to `UnitScale` and `UnitPower` respectively. The main reason we didn't use the better names when the aliases were introduced was that we hadn't defined `UnitScale` and `UnitPower` yet.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
