### PR TITLE
Remove a needless pair of `fmt: off/on` instructions

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -4098,15 +4098,13 @@ class Table:
 
         badcols = [name for name, col in self.columns.items() if len(col.shape) > 1]
         if badcols:
-            # fmt: off
             raise ValueError(
-                f'Cannot convert a table with multidimensional columns to a '
-                f'pandas DataFrame. Offending columns are: {badcols}\n'
-                f'One can filter out such columns using:\n'
-                f'names = [name for name in tbl.colnames if len(tbl[name].shape) <= 1]\n'
-                f'tbl[names].to_pandas(...)'
+                f"Cannot convert a table with multidimensional columns to a "
+                f"pandas DataFrame. Offending columns are: {badcols}\n"
+                f"One can filter out such columns using:\n"
+                f"names = [name for name in tbl.colnames if len(tbl[name].shape) <= 1]\n"
+                f"tbl[names].to_pandas(...)"
             )
-            # fmt: on
 
         out = OrderedDict()
 


### PR DESCRIPTION
### Description

The [`fmt: off/on` pair](https://docs.astral.sh/ruff/formatter/#format-suppression) I found prevents Ruff from replacing single quotes (`'`) with double quotes (`"`). I don't think this deserves an exception from our normal formatting rules. The fewer magic comments we have the better.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
