### PR TITLE
Make unit prefixes immutable

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -12,7 +12,7 @@ import textwrap
 import warnings
 from functools import cached_property
 from threading import RLock
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, NamedTuple, overload
 
 import numpy as np
 
@@ -47,6 +47,7 @@ __all__ = [
     "PrefixUnit",
     "Unit",
     "UnitBase",
+    "UnitPrefix",
     "UnrecognizedUnit",
     "add_enabled_aliases",
     "add_enabled_equivalencies",
@@ -2427,42 +2428,80 @@ class CompositeUnit(UnitBase):
         return len(unit.bases) == 0 and unit.scale == 1.0
 
 
-si_prefixes: Final[list[tuple[list[str], list[str], float]]] = [
-    (["Q"], ["quetta"], 1e30),
-    (["R"], ["ronna"], 1e27),
-    (["Y"], ["yotta"], 1e24),
-    (["Z"], ["zetta"], 1e21),
-    (["E"], ["exa"], 1e18),
-    (["P"], ["peta"], 1e15),
-    (["T"], ["tera"], 1e12),
-    (["G"], ["giga"], 1e9),
-    (["M"], ["mega"], 1e6),
-    (["k"], ["kilo"], 1e3),
-    (["h"], ["hecto"], 1e2),
-    (["da"], ["deka", "deca"], 1e1),
-    (["d"], ["deci"], 1e-1),
-    (["c"], ["centi"], 1e-2),
-    (["m"], ["milli"], 1e-3),
-    (["u", "\N{MICRO SIGN}", "\N{GREEK SMALL LETTER MU}"], ["micro"], 1e-6),
-    (["n"], ["nano"], 1e-9),
-    (["p"], ["pico"], 1e-12),
-    (["f"], ["femto"], 1e-15),
-    (["a"], ["atto"], 1e-18),
-    (["z"], ["zepto"], 1e-21),
-    (["y"], ["yocto"], 1e-24),
-    (["r"], ["ronto"], 1e-27),
-    (["q"], ["quecto"], 1e-30),
-]
+class UnitPrefix(NamedTuple):
+    """Prefix for representing multiples or sub-multiples of units.
+
+    Parameters
+    ----------
+    symbols : tuple of str
+        The symbols of the prefix, to be combined with symbols of units.
+        If multiple are specified then they will be treated as aliases.
+    names : tuple of str
+        The names of the prefix, to be combined with names of units.
+        If multiple are specified then they will be treated as aliases.
+    factor : `~astropy.units.typing.UnitScale`
+        The multiplicative factor represented by the prefix.
+
+    Examples
+    --------
+    >>> UnitPrefix(("k",), ("kilo",), 1e3)  # Simple prefix
+    UnitPrefix(symbols=('k',), names=('kilo',), factor=1000.0)
+    >>> UnitPrefix(("da",), ("deca", "deka"), 1e1)  # Multiple names
+    UnitPrefix(symbols=('da',), names=('deca', 'deka'), factor=10.0)
+    >>> UnitPrefix(("u", "\N{MICRO SIGN}"), ("micro",), 1e-6)  # Multiple symbols
+    UnitPrefix(symbols=('u', 'µ'), names=('micro',), factor=1e-06)
+    """
+
+    symbols: tuple[str, ...]
+    "The symbols of the prefix, to be combined with symbols of units."
+    names: tuple[str, ...]
+    "The names of the prefix, to be combined with names of units."
+    factor: UnitScale
+    "The multiplicative factor represented by the prefix."
 
 
-binary_prefixes: Final[list[tuple[list[str], list[str], int]]] = [
-    (["Ki"], ["kibi"], 2**10),
-    (["Mi"], ["mebi"], 2**20),
-    (["Gi"], ["gibi"], 2**30),
-    (["Ti"], ["tebi"], 2**40),
-    (["Pi"], ["pebi"], 2**50),
-    (["Ei"], ["exbi"], 2**60),
-]
+si_prefixes: Final = tuple(
+    UnitPrefix(symbols, names, factor)
+    for symbols, names, factor in (
+        (("Q",), ("quetta",), 1e30),
+        (("R",), ("ronna",), 1e27),
+        (("Y",), ("yotta",), 1e24),
+        (("Z",), ("zetta",), 1e21),
+        (("E",), ("exa",), 1e18),
+        (("P",), ("peta",), 1e15),
+        (("T",), ("tera",), 1e12),
+        (("G",), ("giga",), 1e9),
+        (("M",), ("mega",), 1e6),
+        (("k",), ("kilo",), 1e3),
+        (("h",), ("hecto",), 1e2),
+        (("da",), ("deka", "deca"), 1e1),
+        (("d",), ("deci",), 1e-1),
+        (("c",), ("centi",), 1e-2),
+        (("m",), ("milli",), 1e-3),
+        (("u", "\N{MICRO SIGN}", "\N{GREEK SMALL LETTER MU}"), ("micro",), 1e-6),
+        (("n",), ("nano",), 1e-9),
+        (("p",), ("pico",), 1e-12),
+        (("f",), ("femto",), 1e-15),
+        (("a",), ("atto",), 1e-18),
+        (("z",), ("zepto",), 1e-21),
+        (("y",), ("yocto",), 1e-24),
+        (("r",), ("ronto",), 1e-27),
+        (("q",), ("quecto",), 1e-30),
+    )
+)
+
+
+binary_prefixes: Final = tuple(
+    UnitPrefix(symbols, names, factor)
+    for symbols, names, factor in (
+        (("Ki",), ("kibi",), 2**10),
+        (("Mi",), ("mebi",), 2**20),
+        (("Gi",), ("gibi",), 2**30),
+        (("Ti",), ("tebi",), 2**40),
+        (("Pi",), ("pebi",), 2**50),
+        (("Ei",), ("exbi",), 2**60),
+    )
+)
 
 
 def _add_prefixes(u, excludes=[], namespace=None, prefixes=False):

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["QuantityLike"]
+__all__ = ["QuantityLike", "UnitScale"]
 
 
 from fractions import Fraction
@@ -71,4 +71,5 @@ For more examples see the :mod:`numpy.typing` definition of
 UnitPower: TypeAlias = int | float | Fraction
 UnitPowerLike: TypeAlias = UnitPower | np.integer | np.floating
 UnitScale: TypeAlias = int | float | Fraction | complex
+"Alias for types that can be scale factors of a `~astropy.units.CompositeUnit`"
 UnitScaleLike: TypeAlias = UnitScale | np.number


### PR DESCRIPTION
### Description

The SI and binary prefixes are defined in two module level variables in `astropy/units/core.py`, but 
1. ~their names do not make it clear that they are private~
2. the variables use mutable data structures (lists) even though they should be constants
3. their structure is complicated to write down in annotations and docstrings

~Point 1. can be addressed by renaming the variables.~ For points 2. and 3. it is convenient to introduce a new subclass of [`NamedTuple`](https://docs.python.org/3.11/library/typing.html#typing.NamedTuple), which I've named ~`_UnitPrefix`~ `UnitPrefix`. ~The new class could be made public in the future.~

EDIT:

One of the main motivations for introducing `UnitPrefix` was that it allows simplifying `def_unit()` documentation, but that means that `UnitPrefix` must be public too, which in turn necessitates making `UnitScale` public.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
