### PR TITLE
TST: declare `str` `ufunc np._core.umath._slice` as unsupported

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -13,7 +13,12 @@ import numpy as np
 
 from astropy.units.core import dimensionless_unscaled, unit_scale_converter
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
+from astropy.utils.compat.numpycompat import (
+    NUMPY_LT_2_0,
+    NUMPY_LT_2_1,
+    NUMPY_LT_2_2,
+    NUMPY_LT_2_3,
+)
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
@@ -413,6 +418,10 @@ if not NUMPY_LT_2_1:
         np._core.umath._rpartition,
         np._core.umath._rpartition_index,
         np._core.umath._partition,
+    }
+if not NUMPY_LT_2_3:
+    UNSUPPORTED_UFUNCS |= {
+        np._core.umath._slice,
     }
 
 # SINGLE ARGUMENT UFUNCS


### PR DESCRIPTION
### Description
Caught this watching upstream development. It looks like this function hasn't landed in nightly wheels yet. Next nightlies should launch on Sunday, and this PR will be ready then.

https://github.com/numpy/numpy/pull/27789

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
