### PR TITLE
Fix Polynomial2D fitting when used in compound model

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3321,10 +3321,10 @@ class CompoundModel(Model):
             right_deriv = np.asanyarray(right_deriv)
 
             if not self.left.col_fit_deriv:
-                left_deriv = left_deriv.T
+                left_deriv = np.moveaxis(left_deriv, -1, 0)
 
             if not self.right.col_fit_deriv:
-                right_deriv = right_deriv.T
+                right_deriv = np.moveaxis(right_deriv, -1, 0)
 
             # Some models preserve the shape of the input in the output of
             # fit_deriv whereas some do not. For example for a 6-parameter model,
@@ -3333,6 +3333,9 @@ class CompoundModel(Model):
             # ravel all but the first dimension
             left_deriv = left_deriv.reshape((left_deriv.shape[0], -1))
             right_deriv = right_deriv.reshape((right_deriv.shape[0], -1))
+
+            print(left_deriv.shape)
+            print(right_deriv.shape)
 
             # Convert the arrays back to lists over the first dimension so as to
             # be able to concatenate them (we don't use .tolist() which would
@@ -3374,8 +3377,8 @@ class CompoundModel(Model):
 
                 return np.array(left_deriv + right_deriv)
 
-            leftval = self.left.evaluate(*left_inputs, *left_params)
-            rightval = self.right.evaluate(*right_inputs, *right_params)
+            leftval = self.left.evaluate(*left_inputs, *left_params).ravel()
+            rightval = self.right.evaluate(*right_inputs, *right_params).ravel()
 
             if op == "*":
                 return np.array(

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3334,9 +3334,6 @@ class CompoundModel(Model):
             left_deriv = left_deriv.reshape((left_deriv.shape[0], -1))
             right_deriv = right_deriv.reshape((right_deriv.shape[0], -1))
 
-            print(left_deriv.shape)
-            print(right_deriv.shape)
-
             # Convert the arrays back to lists over the first dimension so as to
             # be able to concatenate them (we don't use .tolist() which would
             # convert to a list of lists instead of a list of arrays)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3332,7 +3332,7 @@ class CompoundModel(Model):
             # shape (6, 5, 3) or (6, 15). We therefore normalize this to always
             # ravel all but the first dimension
             left_deriv = left_deriv.reshape((left_deriv.shape[0], -1))
-            right_deriv = right_deriv.reshape((left_deriv.shape[0], -1))
+            right_deriv = right_deriv.reshape((right_deriv.shape[0], -1))
 
             # Convert the arrays back to lists over the first dimension so as to
             # be able to concatenate them (we don't use .tolist() which would

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3312,11 +3312,33 @@ class CompoundModel(Model):
             right_params = self._get_right_params_from_args(args)
 
             left_deriv = self.left.fit_deriv(*left_inputs, *left_params)
-            if not self.left.col_fit_deriv:
-                left_deriv = (np.asanyarray(left_deriv).T).tolist()
             right_deriv = self.right.fit_deriv(*right_inputs, *right_params)
+
+            # Not all fit_deriv methods return consistent types, some return
+            # single arrays, some return lists of arrays, etc. We now convert
+            # this to a single array.
+            left_deriv = np.asanyarray(left_deriv)
+            right_deriv = np.asanyarray(right_deriv)
+
+            if not self.left.col_fit_deriv:
+                left_deriv = left_deriv.T
+
             if not self.right.col_fit_deriv:
-                right_deriv = (np.asanyarray(right_deriv).T).tolist()
+                right_deriv = right_deriv.T
+
+            # Some models preserve the shape of the input in the output of
+            # fit_deriv whereas some do not. For example for a 6-parameter model,
+            # passing input with shape (5, 3) might produce a deriv array with
+            # shape (6, 5, 3) or (6, 15). We therefore normalize this to always
+            # ravel all but the first dimension
+            left_deriv = left_deriv.reshape((left_deriv.shape[0], -1))
+            right_deriv = right_deriv.reshape((left_deriv.shape[0], -1))
+
+            # Convert the arrays back to lists over the first dimension so as to
+            # be able to concatenate them (we don't use .tolist() which would
+            # convert to a list of lists instead of a list of arrays)
+            left_deriv = list(left_deriv)
+            right_deriv = list(right_deriv)
 
             # We now have to use various differentiation rules to apply the
             # arithmetic operators to the derivatives.
@@ -3350,18 +3372,18 @@ class CompoundModel(Model):
                 if op == "-":
                     right_deriv = [-x for x in right_deriv]
 
-                return left_deriv + right_deriv
+                return np.array(left_deriv + right_deriv)
 
             leftval = self.left.evaluate(*left_inputs, *left_params)
             rightval = self.right.evaluate(*right_inputs, *right_params)
 
             if op == "*":
-                return (
+                return np.array(
                     [rightval * dparam for dparam in left_deriv] +
                     [leftval * dparam for dparam in right_deriv]
                 )  # fmt: skip
             if op == "/":
-                return (
+                return np.array(
                     [dparam / rightval for dparam in left_deriv] +
                     [-leftval * (dparam / rightval**2) for dparam in right_deriv]
                 )  # fmt: skip

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -1295,6 +1295,7 @@ def test_compound_fit_deriv(model, input_ndim):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_fit_compound_polynomial2d():
+
     # Regression test for a bug that caused compound models with Polynomial2D
     # to not be fittable due to a bug in CompoundModel.fit_deriv
 
@@ -1309,4 +1310,5 @@ def test_fit_compound_polynomial2d():
     p_init = Polynomial2D(degree=2) + Gaussian2D(amplitude=50000, x_mean=60, y_mean=60)
     fit_p = DogBoxLSQFitter()
 
-    p = fit_p(p_init, x, y, z)
+    # We just make sure the fitting works, as it previously crashed
+    fit_p(p_init, x, y, z)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 import astropy.units as u
 from astropy.modeling.core import CompoundModel, Model, ModelDefinitionError
-from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.fitting import LevMarLSQFitter, DogBoxLSQFitter
 from astropy.modeling.models import (
     Chebyshev1D,
     Chebyshev2D,
@@ -1265,7 +1265,7 @@ def test_compound_fit_deriv(model):
     """
     Given some compound models compare the numerical derivatives to analytical ones.
     """
-    x = np.linspace(1, 5, num=10)
+    x = np.linspace(1, 5, num=10).reshape((5, 2))
     numerical = [
         numerical_partial_deriv(model, x, param_idx=i)
         for i in range(len(model.parameters))
@@ -1274,3 +1274,29 @@ def test_compound_fit_deriv(model):
 
     for n, a in zip(numerical, analytical):
         assert np.allclose(n, a)
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
+def test_fit_compound_polynomial2d():
+
+    # Regression test for a bug that caused compound models with Polynomial2D
+    # to not be fittable due to a bug in CompoundModel.fit_deriv
+
+    # Generate fake data
+    rng = np.random.default_rng(0)
+    y, x = np.mgrid[:128, :128]
+    z = 2. * x ** 2 - 0.5 * x ** 2 + 1.5 * x * y - 1.
+    z += rng.normal(0., 0.1, z.shape) * 50000.
+    z += Gaussian2D(
+        amplitude=50000,
+        x_mean=60,
+        y_mean=60,
+        x_stddev=5,
+        y_stddev=5
+    )(x, y)
+
+    # Fit the data using astropy.modeling
+    p_init = Polynomial2D(degree=2) + Gaussian2D(amplitude=50000, x_mean=60, y_mean=60)
+    fit_p = DogBoxLSQFitter()
+
+    p = fit_p(p_init, x, y, z)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -1295,8 +1295,10 @@ def test_compound_fit_deriv(model, input_ndim):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_fit_compound_polynomial2d():
-    # Regression test for a bug that caused compound models with Polynomial2D
-    # to not be fittable due to a bug in CompoundModel.fit_deriv
+    """
+    Regression test for a bug that caused compound models with Polynomial2D
+    to not be fittable due to a bug in CompoundModel.fit_deriv
+    """
 
     # Generate fake data
     rng = np.random.default_rng(0)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -1295,7 +1295,6 @@ def test_compound_fit_deriv(model, input_ndim):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_fit_compound_polynomial2d():
-
     # Regression test for a bug that caused compound models with Polynomial2D
     # to not be fittable due to a bug in CompoundModel.fit_deriv
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 import astropy.units as u
 from astropy.modeling.core import CompoundModel, Model, ModelDefinitionError
-from astropy.modeling.fitting import LevMarLSQFitter, DogBoxLSQFitter
+from astropy.modeling.fitting import DogBoxLSQFitter, LevMarLSQFitter
 from astropy.modeling.models import (
     Chebyshev1D,
     Chebyshev2D,
@@ -1295,22 +1295,15 @@ def test_compound_fit_deriv(model, input_ndim):
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_fit_compound_polynomial2d():
-
     # Regression test for a bug that caused compound models with Polynomial2D
     # to not be fittable due to a bug in CompoundModel.fit_deriv
 
     # Generate fake data
     rng = np.random.default_rng(0)
     y, x = np.mgrid[:128, :128]
-    z = 2. * x ** 2 - 0.5 * x ** 2 + 1.5 * x * y - 1.
-    z += rng.normal(0., 0.1, z.shape) * 50000.
-    z += Gaussian2D(
-        amplitude=50000,
-        x_mean=60,
-        y_mean=60,
-        x_stddev=5,
-        y_stddev=5
-    )(x, y)
+    z = 2.0 * x**2 - 0.5 * x**2 + 1.5 * x * y - 1.0
+    z += rng.normal(0.0, 0.1, z.shape) * 50000.0
+    z += Gaussian2D(amplitude=50000, x_mean=60, y_mean=60, x_stddev=5, y_stddev=5)(x, y)
 
     # Fit the data using astropy.modeling
     p_init = Polynomial2D(degree=2) + Gaussian2D(amplitude=50000, x_mean=60, y_mean=60)

--- a/docs/changes/modeling/17618.bugfix.rst
+++ b/docs/changes/modeling/17618.bugfix.rst
@@ -1,0 +1,2 @@
+Fix fitting of compound models when inputs has more than one dimension,
+and specifically fix fitting of compound models with Polynomial2D components


### PR DESCRIPTION
This fixes https://github.com/astropy/astropy/issues/17509

The issue was that Polynomial2D 'forgets' about the dimensionality of the input and so always returns a 2D array, whereas other models don't. I really think we should at some point tighten up the fit_deriv methods to be more consistent, but since that usage has been allowed for now, I am fixing our implementation of ``CompoundModel.fit_deriv`` to be more robust.

I have expanded the tests compared to the numerical derivatives and while Polynomial2D works, in fact some other models are failing when passing 2D inputs so I am going to try and see how to fix that.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
