### PR TITLE
Read LaTeX tables where there is whitespace before the `\begin{tabular}`

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -87,7 +87,7 @@ def find_latex_line(lines: list[str], latex: str) -> int | None:
         Line number. Returns None, if no match was found
 
     """
-    re_string = re.compile(latex.replace("\\", "\\\\"))
+    re_string = re.compile(r"\s*" + latex.replace("\\", "\\\\"))
     for i, line in enumerate(lines):
         if re_string.match(line):
             return i
@@ -228,6 +228,11 @@ class Latex(core.BaseReader):
     This class can also read simple LaTeX tables (one line per table
     row, no ``\multicolumn`` or similar constructs), specifically, it
     can read the tables that it writes.
+    When reading, it will look for the Latex commands to start and end tabular
+    data (``\begin{tabular}`` and ``\end{tabular}``). That means that
+    those lines have to be present in the input file; the benefit is that this
+    reader can be used on a LaTeX file with text, tables, and figures and it
+    will read the first valid table.
 
     Reading a LaTeX table, the following keywords are accepted:
 

--- a/astropy/io/ascii/tests/data/latex3.tex
+++ b/astropy/io/ascii/tests/data/latex3.tex
@@ -1,8 +1,8 @@
-\begin{tabular}{lrr}\hline
+     \begin{tabular}{lrr}\hline
 cola & colb & colc\\
 \hline
 a & 1 & 2\\
 \midrule
 b & 3 & 4\\
 \hline
-\end{tabular}
+    \end{tabular}

--- a/docs/changes/io.ascii/17624.bugfix.rst
+++ b/docs/changes/io.ascii/17624.bugfix.rst
@@ -1,0 +1,1 @@
+Find and read ASCII tables even if there is white space before \begin{tabular}, \tablehead, and similar markers.

--- a/docs/changes/io.ascii/17624.bugfix.rst
+++ b/docs/changes/io.ascii/17624.bugfix.rst
@@ -1,1 +1,1 @@
-Find and read ASCII tables even if there is white space before \begin{tabular}, \tablehead, and similar markers.
+Find and read ASCII tables even if there is white space before ``\begin{tabular}``, ``\tablehead``, and similar markers.


### PR DESCRIPTION
This commit  fixes #4595 as discussed in that issue:
It makes the finding of the \begin{tabular} (and similar keywords) a little bit more flexible by allowing extra white space. Extra white space is easy to introduce when copying and pasting from a LaTeX file. It does not implement any further flexibility. It does not allow extra text in front of the tag because the reader cannot replace a full LaTeX parser an we prefer to fail in cases like `1 & 3 & 4 \\ \end{tabular}` instead of silently dropping the last row of data just because it happens to be in the same line as the `\end{tabular}`.
It also does not add a reader to read LaTeX tables without the \bgin{tabular} \end{tabular} lines. Every full LaTeX table has those and if users copy and paste from a longer LaTeX file, they can simply include those lines. Documentation has been added to that effect.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
