### PR TITLE
Add a doc example for an io.ascii writer with fixed width and commented header

### DIFF
--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -673,6 +673,7 @@ the basic reader, but header and data start in different lines of the file::
 
   >>> # Note: NoHeader is already included in astropy.io.ascii for convenience.
   >>> from astropy.io.ascii.basic import BasicHeader, BasicData, Basic
+  >>>
   >>> class NoHeaderHeader(BasicHeader):
   ...     """Reader for table header without a header
   ...
@@ -751,6 +752,7 @@ commented. So, we now want to make a writer that can write this format; for this
 not bother to work out how to read this format, but just raise an error on reading:
 
   >>> from astropy.io.ascii.fixedwidth import FixedWidthData, FixedWidth
+  >>>
   >>> class FixedWidthDataCommentedHeaderData(FixedWidthData):
   ...     def write(self, lines):
   ...         lines = super().write(lines)
@@ -758,6 +760,7 @@ not bother to work out how to read this format, but just raise an error on readi
   ...         for i in range(1, len(lines)):
   ...             lines[i] = ' ' * len(self.write_comment) + lines[i]
   ...         return lines
+  >>>
   >>> class FixedWidthCommentedHeader(FixedWidth):
   ...     _format_name = "fixed_width_commented_header"
   ...     _description = "Fixed width with commented header"
@@ -771,8 +774,8 @@ This new format is automatically added to the list of formats that can be read b
 the :ref:`io_registry` (note that our format has no mechanism to write out the units):
 
     >>> import sys
-    >>> from astropy.table import Table
     >>> import astropy.units as u
+    >>> from astropy.table import Table
     >>> tab = Table({'v': [15.4, 223.45] * u.km/u.s, 'type': ['star', 'jet']})
     >>> tab.write(sys.stdout, format='ascii.fixed_width', delimiter=None)
          v  type
@@ -801,6 +804,7 @@ of a reader, and then to modify the properties of this one reader instance
 in a function::
 
   >>> from astropy.io import ascii
+  >>>
   >>> def read_rdb_table(table):
   ...     reader = ascii.Basic()
   ...     reader.header.splitter.delimiter = '\t'

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -671,74 +671,75 @@ one class that handles the data, and a reader class that ties it all together.
 Here is an example from the code that defines a reader that is just like
 the basic reader, but header and data start in different lines of the file::
 
-  # Note: NoHeader is already included in astropy.io.ascii for convenience.
-  class NoHeaderHeader(BasicHeader):
-      """Reader for table header without a header
-
-      Set the start of header line number to `None`, which tells the basic
-      reader there is no header line.
-      """
-      start_line = None
-
-  class NoHeaderData(BasicData):
-      """Reader for table data without a header
-
-      Data starts at first uncommented line since there is no header line.
-      """
-      start_line = 0
-
-  class NoHeader(Basic):
-      """Read a table with no header line.  Columns are autonamed using
-      header.auto_format which defaults to "col%d".  Otherwise this reader
-      the same as the :class:`Basic` class from which it is derived.  Example::
-
-        # Table data
-        1 2 "hello there"
-        3 4 world
-      """
-      _format_name = 'no_header'
-      _description = 'Basic table with no headers'
-      header_class = NoHeaderHeader
-      data_class = NoHeaderData
+  >>> # Note: NoHeader is already included in astropy.io.ascii for convenience.
+  >>> from astropy.io.ascii.basic import BasicHeader, BasicData, Basic
+  >>> class NoHeaderHeader(BasicHeader):
+  ...     """Reader for table header without a header
+  ...
+  ...     Set the start of header line number to `None`, which tells the basic
+  ...     reader there is no header line.
+  ...     """
+  ...     start_line = None
+  >>>
+  >>> class NoHeaderData(BasicData):
+  ...     """Reader for table data without a header
+  ...
+  ...     Data starts at first uncommented line since there is no header line.
+  ...     """
+  ...     start_line = 0
+  >>>
+  >>> class NoHeader(Basic):
+  ...     """Read a table with no header line.  Columns are autonamed using
+  ...     header.auto_format which defaults to "col%d".  Otherwise this reader
+  ...     the same as the :class:`Basic` class from which it is derived.  Example::
+  ...
+  ...       # Table data
+  ...       1 2 "hello there"
+  ...       3 4 world
+  ...     """
+  ...     _format_name = 'custom_no_header'
+  ...     _description = 'Basic table with no headers'
+  ...     header_class = NoHeaderHeader
+  ...     data_class = NoHeaderData
 
 In a slightly more involved case, the implementation can also override some of
 the methods in the base class::
 
-  # Note: CommentedHeader is already included in astropy.io.ascii for convenience.
-  class CommentedHeaderHeader(BasicHeader):
-      """Header class for which the column definition line starts with the
-      comment character.  See the :class:`CommentedHeader` class  for an example.
-      """
-      def process_lines(self, lines):
-          """Return only lines that start with the comment regexp.  For these
-          lines strip out the matching characters."""
-          re_comment = re.compile(self.comment)
-          for line in lines:
-              match = re_comment.match(line)
-              if match:
-                  yield line[match.end():]
-
-      def write(self, lines):
-          lines.append(self.write_comment + self.splitter.join(self.colnames))
-
-
-  class CommentedHeader(Basic):
-      """Read a file where the column names are given in a line that begins with
-      the header comment character. ``header_start`` can be used to specify the
-      line index of column names, and it can be a negative index (for example -1
-      for the last commented line).  The default delimiter is the <space>
-      character.::
-
-        # col1 col2 col3
-        # Comment line
-        1 2 3
-        4 5 6
-      """
-      _format_name = 'commented_header'
-      _description = 'Column names in a commented line'
-
-      header_class = CommentedHeaderHeader
-      data_class = NoHeaderData
+  >>> # Note: CommentedHeader is already included in astropy.io.ascii for convenience.
+  >>> class CommentedHeaderHeader(BasicHeader):
+  ...     """Header class for which the column definition line starts with the
+  ...     comment character.  See the :class:`CommentedHeader` class  for an example.
+  ...     """
+  ...     def process_lines(self, lines):
+  ...         """Return only lines that start with the comment regexp.  For these
+  ...         lines strip out the matching characters."""
+  ...         re_comment = re.compile(self.comment)
+  ...         for line in lines:
+  ...             match = re_comment.match(line)
+  ...             if match:
+  ...                 yield line[match.end():]
+  ...
+  ...     def write(self, lines):
+  ...         lines.append(self.write_comment + self.splitter.join(self.colnames))
+  >>>
+  >>>
+  >>> class CommentedHeader(Basic):
+  ...     """Read a file where the column names are given in a line that begins with
+  ...     the header comment character. ``header_start`` can be used to specify the
+  ...     line index of column names, and it can be a negative index (for example -1
+  ...     for the last commented line).  The default delimiter is the <space>
+  ...     character.::
+  ...
+  ...       # col1 col2 col3
+  ...       # Comment line
+  ...       1 2 3
+  ...       4 5 6
+  ...     """
+  ...     _format_name = 'custom_commented_header'
+  ...     _description = 'Column names in a commented line'
+  ...
+  ...     header_class = CommentedHeaderHeader
+  ...     data_class = NoHeaderData
 
 **Application: Write a "fixed_width" table with a "commented_header"**
 
@@ -750,7 +751,7 @@ commented. So, we now want to make a writer that can write this format; for this
 not bother to work out how to read this format, but just raise an error on reading:
 
   >>> from astropy.io.ascii.fixedwidth import FixedWidthData, FixedWidth
-  >>> class FixedWidthDataCommentedHeader(FixedWidthData):
+  >>> class FixedWidthDataCommentedHeaderData(FixedWidthData):
   ...     def write(self, lines):
   ...         lines = super().write(lines)
   ...         lines[0] = self.write_comment + lines[0]
@@ -761,7 +762,7 @@ not bother to work out how to read this format, but just raise an error on readi
   ...     _format_name = "fixed_width_commented_header"
   ...     _description = "Fixed width with commented header"
   ...
-  ...     data_class = FixedWidthDataCommentedHeader
+  ...     data_class = FixedWidthDataCommentedHeaderData
   ...
   ...     def read(self, table):
   ...         raise NotImplementedError
@@ -789,8 +790,9 @@ the :ref:`io_registry` (note that our format has no mechanism to write out the u
 .. testcleanup::
 
     >>> from astropy.io import registry
-    >>> registry.unregister_reader("ascii.fixed_width_commented_header", Table)
-    >>> registry.unregister_writer("ascii.fixed_width_commented_header", Table)
+    >>> for format_name in ['custom_no_header', 'custom_commented_header', 'fixed_width_commented_header']:
+    ...     registry.unregister_reader(f"ascii.{format_name}", Table)
+    ...     registry.unregister_writer(f"ascii.{format_name}", Table)
 
 **Define a custom reader functionally**
 
@@ -798,33 +800,34 @@ Instead of defining a new class, it is also possible to obtain an instance
 of a reader, and then to modify the properties of this one reader instance
 in a function::
 
-   def read_rdb_table(table):
-       reader = astropy.io.ascii.Basic()
-       reader.header.splitter.delimiter = '\t'
-       reader.data.splitter.delimiter = '\t'
-       reader.header.splitter.process_line = None
-       reader.data.splitter.process_line = None
-       reader.data.start_line = 2
-
-       return reader.read(table)
+  >>> from astropy.io import ascii
+  >>> def read_rdb_table(table):
+  ...     reader = ascii.Basic()
+  ...     reader.header.splitter.delimiter = '\t'
+  ...     reader.data.splitter.delimiter = '\t'
+  ...     reader.header.splitter.process_line = None
+  ...     reader.data.splitter.process_line = None
+  ...     reader.data.start_line = 2
+  ...
+  ...     return reader.read(table)
 
 
 **Create a custom splitter.process_val function**
 ::
 
-   # The default process_val() normally just strips whitespace.
-   # In addition have it replace empty fields with -999.
-   def process_val(x):
-       """Custom splitter process_val function: Remove whitespace at the beginning
-       or end of value and substitute -999 for any blank entries."""
-       x = x.strip()
-       if x == '':
-           x = '-999'
-       return x
-
-   # Create an RDB reader and override the splitter.process_val function
-   rdb_reader = astropy.io.ascii.get_reader(reader_cls=astropy.io.ascii.Rdb)
-   rdb_reader.data.splitter.process_val = process_val
+   >>> # The default process_val() normally just strips whitespace.
+   >>> # In addition have it replace empty fields with -999.
+   >>> def process_val(x):
+   ...     """Custom splitter process_val function: Remove whitespace at the beginning
+   ...     or end of value and substitute -999 for any blank entries."""
+   ...     x = x.strip()
+   ...     if x == '':
+   ...         x = '-999'
+   ...     return x
+   >>>
+   >>> # Create an RDB reader and override the splitter.process_val function
+   >>> rdb_reader = ascii.get_reader(reader_cls=ascii.Rdb)
+   >>> rdb_reader.data.splitter.process_val = process_val
 
 ..
   EXAMPLE END
@@ -869,6 +872,13 @@ Examples
   EXAMPLE START
   Reading Large Tables in Chunks with astropy.io.ascii
 
+.. testsetup::
+
+   >>> # For performance we don't actually make a > 100 MB table.
+   >>> # The code works this way, too.
+   >>> tab = Table({'Vmag': [7] * 10})
+   >>> tab.write('large_table.csv')
+
 To read an entire table while limiting peak memory usage:
 ::
 
@@ -899,6 +909,11 @@ them at the end.
           out_tbls.append(tbl[bright])
 
   out_tbl = vstack(out_tbls)
+
+.. testcleanup::
+
+      >>> import pathlib
+      >>> pathlib.Path.unlink('large_table.csv')
 
 .. Note:: **Performance**
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

It has been suggested more than once (#4112 and #5922, which was closed as a dublicate) that it would be useful to write a fixed-format ASCII table with a commented header. However, as a "format" this is reqest is somewhat ambiguous, for example  if the fixed format has delimiters like "|" would they be shifted by the comment symbols? Replaced by the comment symbols? What about tables with more than one header line, e.g. a second line like `--- ------- -------` that delinated the fixed-width columns. Would that line be commented or not?

So, instead, I suggested in the discussion for #4112  that this might make a good example for the "advanced customization" section of the docs, and that is what this PR implements.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #4112

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
