### PR TITLE
Annotate `did_you_mean()`

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -4,6 +4,8 @@ A "grab bag" of relatively small general-purpose utilities that don't have
 a clear module/package to live in.
 """
 
+from __future__ import annotations
+
 import contextlib
 import difflib
 import inspect
@@ -16,8 +18,12 @@ import threading
 import traceback
 import unicodedata
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from astropy.utils import deprecated
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 __all__ = [
     "JsonCustomEncoder",
@@ -410,7 +416,7 @@ class JsonCustomEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def strip_accents(s):
+def strip_accents(s: str) -> str:
     """
     Remove accents from a Unicode string.
 
@@ -421,7 +427,13 @@ def strip_accents(s):
     )
 
 
-def did_you_mean(s, candidates, n=3, cutoff=0.8, fix=None):
+def did_you_mean(
+    s: str,
+    candidates: Iterable[str],
+    n: int = 3,
+    cutoff: float = 0.8,
+    fix: Callable[[str], list[str]] | None = None,
+) -> str:
     """
     When a string isn't found in a set of candidates, we can be nice
     to provide a list of alternatives in the exception.  This
@@ -431,7 +443,9 @@ def did_you_mean(s, candidates, n=3, cutoff=0.8, fix=None):
     ----------
     s : str
 
-    candidates : sequence of str or dict of str keys
+    candidates : iterable of str
+        Note that str itself does not cause an error, but the output
+        might not be what was expected.
 
     n : int
         The maximum number of results to include.  See
@@ -444,7 +458,7 @@ def did_you_mean(s, candidates, n=3, cutoff=0.8, fix=None):
 
     fix : callable
         A callable to modify the results after matching.  It should
-        take a single string and return a sequence of strings
+        take a single string and return a list of strings
         containing the fixed matches.
 
     Returns

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -17,7 +17,9 @@ import sys
 import threading
 import traceback
 import unicodedata
+from collections import defaultdict
 from contextlib import contextmanager
+from itertools import chain
 from typing import TYPE_CHECKING
 
 from astropy.utils import deprecated
@@ -467,50 +469,32 @@ def did_you_mean(
         Returns the string "Did you mean X, Y, or Z?", or the empty
         string if no alternatives were found.
     """
-    if isinstance(s, str):
-        s = strip_accents(s)
-    s_lower = s.lower()
+    s_lower = strip_accents(s).lower()
 
     # Create a mapping from the lower case name to all capitalization
     # variants of that name.
-    candidates_lower = {}
+    candidates_lower = defaultdict(list)
     for candidate in candidates:
-        candidate_lower = candidate.lower()
-        candidates_lower.setdefault(candidate_lower, [])
-        candidates_lower[candidate_lower].append(candidate)
+        candidates_lower[candidate.lower()].append(candidate)
 
     # The heuristic here is to first try "singularizing" the word.  If
     # that doesn't match anything use difflib to find close matches in
     # original, lower and upper case.
-    if s_lower.endswith("s") and s_lower[:-1] in candidates_lower:
-        matches = [s_lower[:-1]]
-    else:
-        matches = difflib.get_close_matches(
-            s_lower, candidates_lower, n=n, cutoff=cutoff
-        )
+    matches: Iterable[str] = (
+        [s_lower[:-1]]
+        if s_lower.endswith("s") and s_lower[:-1] in candidates_lower
+        else difflib.get_close_matches(s_lower, candidates_lower, n=n, cutoff=cutoff)
+    )
 
-    if len(matches):
-        capitalized_matches = set()
-        for match in matches:
-            capitalized_matches.update(candidates_lower[match])
-        matches = capitalized_matches
-
-        if fix is not None:
-            mapped_matches = []
-            for match in matches:
-                mapped_matches.extend(fix(match))
-            matches = mapped_matches
-
-        matches = list(set(matches))
-        matches = sorted(matches)
-
-        if len(matches) == 1:
-            matches = matches[0]
-        else:
-            matches = ", ".join(matches[:-1]) + " or " + matches[-1]
-        return f"Did you mean {matches}?"
-
-    return ""
+    if not matches:
+        return ""
+    matches = chain.from_iterable(candidates_lower[match] for match in matches)
+    if fix is not None:
+        matches = chain.from_iterable(fix(match) for match in matches)
+    *first_matches, suggestion = sorted(set(matches))
+    if first_matches:
+        suggestion = ", ".join(first_matches) + " or " + suggestion
+    return f"Did you mean {suggestion}?"
 
 
 LOCALE_LOCK = threading.Lock()


### PR DESCRIPTION
### Description

The first commit adds type annotations to `did_you_mean()` and `strip_accents()`, which is called by `did_you_mean()`. The second commit rewrites `did_you_mean()` so that its friendlier towards type checkers.

Somewhat surprisingly, `did_you_mean()` is only used in `units`, so maybe the `units` maintainers want to have a look at this.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
