### PR TITLE
ENH: add support for setting astropy's cache and config directories via environment variables

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -36,8 +36,8 @@ def get_config_dir_path(rootname: str = "astropy") -> Path:
     directory if it doesn't exist.
 
     This directory is typically ``$HOME/.astropy/config``, but if the
-    XDG_CONFIG_HOME environment variable is set and the
-    ``$XDG_CONFIG_HOME/astropy`` directory exists, it will be that directory.
+    ASTROPY_CONFIG_DIR (or XDG_CONFIG_HOME) environment variable is set and the
+    ``$ASTROPY_CONFIG_DIR/astropy`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
     Parameters
@@ -79,8 +79,8 @@ def get_cache_dir_path(rootname: str = "astropy") -> Path:
     doesn't exist.
 
     This directory is typically ``$HOME/.astropy/cache``, but if the
-    XDG_CACHE_HOME environment variable is set and the
-    ``$XDG_CACHE_HOME/astropy`` directory exists, it will be that directory.
+    ASTROPY_CACHE_DIR (or XDG_CACHE_HOME) environment variable is set and the
+    ``$ASTROPY_CACHE_DIR/astropy`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
     Parameters
@@ -122,7 +122,8 @@ class _SetTempPath:
     # This base class serves as a deduplication layer for its only two intended
     # children (set_temp_cache and set_temp_config)
     _directory_type: Literal["cache", "config"]
-    _directory_env_var: Literal["XDG_CACHE_HOME", "XDG_CONFIG_HOME"]
+    _xdg_env_dir: Literal["XDG_CACHE_HOME", "XDG_CONFIG_HOME"]
+    _astropy_env_dir: Literal["ASTROPY_CACHE_DIR", "ASTROPY_CONFIG_DIR"]
 
     def __init__(
         self, path: os.PathLike[str] | str | None = None, delete: bool = False
@@ -171,16 +172,18 @@ class _SetTempPath:
                 path.mkdir(exist_ok=True)
             return path.resolve()
 
-        if (
-            (dir_ := os.getenv(cls._directory_env_var)) is not None
-            and (xch := Path(dir_)).exists()
-            and not (xchpth := xch / rootname).is_symlink()
-        ):
-            if xchpth.exists():
-                return xchpth.resolve()
+        for env_dir in (cls._astropy_env_dir, cls._xdg_env_dir):
+            if (
+                (dir_ := os.getenv(env_dir)) is not None
+                and (xch := Path(dir_)).exists()
+                and not (xchpth := xch / rootname).is_symlink()
+            ):
+                if xchpth.exists():
+                    return xchpth.resolve()
 
-            # symlink will be set to this if the directory is created
-            linkto = xchpth
+                # symlink will be set to this if the directory is created
+                linkto = xchpth
+                break
         else:
             linkto = None
 
@@ -243,7 +246,8 @@ class set_temp_config(_SetTempPath):
     """
 
     _directory_type = "config"
-    _directory_env_var = "XDG_CONFIG_HOME"
+    _xdg_env_dir = "XDG_CONFIG_HOME"
+    _astropy_env_dir = "ASTROPY_CONFIG_DIR"
 
     def __enter__(self) -> str:
         # Special case for the config case, where we need to reset all the
@@ -299,4 +303,5 @@ class set_temp_cache(_SetTempPath):
     """
 
     _directory_type = "cache"
-    _directory_env_var = "XDG_CACHE_HOME"
+    _xdg_env_dir = "XDG_CACHE_HOME"
+    _astropy_env_dir = "ASTROPY_CACHE_DIR"

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -38,14 +38,14 @@ def test_paths():
     assert "testpkg" in paths.get_cache_dir(rootname="testpkg")
 
 
-_ISOLATED_SETUP_LOCK = Lock()
+_IGNORE_CONFIG_PATHS_GLOBAL_STATE_LOCK = Lock()
 
 
 @pytest.fixture
-def isolated_setup(monkeypatch):
+def ignore_config_paths_global_state(monkeypatch):
     # ignore global state of the test session
     # and preserve thread safety across all users of this fixture
-    with _ISOLATED_SETUP_LOCK:
+    with _IGNORE_CONFIG_PATHS_GLOBAL_STATE_LOCK:
         monkeypatch.delenv("ASTROPY_CACHE_DIR", raising=False)
         monkeypatch.delenv("ASTROPY_CONFIG_DIR", raising=False)
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
@@ -59,10 +59,12 @@ def isolated_setup(monkeypatch):
 
 @pytest.mark.parametrize(
     "env_var_template",
+    # make sure all XDG_* and ASTROPY_* env variables have the desired effect
+    # when used in isolation (no shadowing of the former by the latter).
+    # This serve as regression tests for gh-17514 (XDG_CACHE_HOME had no effect)
     [
-        # Regression test for #17514 - XDG_CACHE_HOME had no effect
         pytest.param("XDG_{}_HOME", id="xdg"),
-        pytest.param("ASTROPY_{}_DIR", id="astropy", marks=pytest.mark.xfail),
+        pytest.param("ASTROPY_{}_DIR", id="astropy"),
     ],
 )
 @pytest.mark.parametrize(
@@ -72,7 +74,7 @@ def isolated_setup(monkeypatch):
         pytest.param("CONFIG", paths.get_config_dir_path, id="config"),
     ],
 )
-@pytest.mark.usefixtures("isolated_setup")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_env_variables(monkeypatch, tmp_path, env_var_template, dir_type, func):
     environment_variable = env_var_template.format(dir_type)
     target_dir = tmp_path / "astropy"
@@ -89,18 +91,16 @@ def test_env_variables(monkeypatch, tmp_path, env_var_template, dir_type, func):
             "XDG_CACHE_HOME",
             paths.get_cache_dir_path,
             id="cache",
-            marks=pytest.mark.xfail,
         ),
         pytest.param(
             "ASTROPY_CONFIG_DIR",
             "XDG_CONFIG_HOME",
             paths.get_config_dir_path,
             id="config",
-            marks=pytest.mark.xfail,
         ),
     ],
 )
-@pytest.mark.usefixtures("isolated_setup")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_env_variables_priority(
     monkeypatch, tmp_path, astropy_env_var, xdg_env_var, func
 ):
@@ -120,31 +120,24 @@ def test_env_variables_priority(
     "env_var_template",
     [
         pytest.param("XDG_{}_HOME", id="xdg"),
-        pytest.param("ASTROPY_{}_DIR", id="astropy", marks=pytest.mark.xfail),
+        pytest.param("ASTROPY_{}_DIR", id="astropy"),
     ],
 )
-@pytest.mark.parametrize("dir_type", ["cache", "config"])
-@pytest.mark.usefixtures("isolated_setup")
+@pytest.mark.parametrize(
+    "dir_type, cls, func",
+    [
+        ("CACHE", paths.set_temp_cache, paths.get_cache_dir_path),
+        ("CONFIG", paths.set_temp_config, paths.get_config_dir_path),
+    ],
+)
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_context_over_environment(
-    monkeypatch,
-    tmp_path,
-    env_var_template,
-    dir_type,
+    monkeypatch, tmp_path, env_var_template, dir_type, cls, func
 ):
-    match dir_type:
-        case "cache":
-            cls = paths.set_temp_cache
-            func = paths.get_cache_dir_path
-        case "config":
-            cls = paths.set_temp_config
-            func = paths.get_config_dir_path
-        case _:
-            raise ValueError
-
     # context managers should shadow environment variables
     env_target_dir = tmp_path / "astropy"
     env_target_dir.mkdir()
-    monkeypatch.setenv(env_var_template.format(dir_type.upper()), str(tmp_path))
+    monkeypatch.setenv(env_var_template.format(dir_type), str(tmp_path))
 
     assert func() == env_target_dir
 
@@ -156,7 +149,7 @@ def test_context_over_environment(
     assert func() == env_target_dir
 
 
-@pytest.mark.usefixtures("isolated_setup")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_set_temp_config(tmp_path):
     # Check that we start in an understood state.
     assert configuration._cfgobjs == OLD_CONFIG
@@ -187,7 +180,7 @@ def test_set_temp_config(tmp_path):
     assert configuration._cfgobjs == OLD_CONFIG
 
 
-@pytest.mark.usefixtures("isolated_setup")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_set_temp_cache(tmp_path):
     orig_cache_dir = paths.get_cache_dir(rootname="astropy")
     (temp_cache_dir := tmp_path / "cache").mkdir()
@@ -516,7 +509,7 @@ def test_help_invalid_config_item():
         conf.help("bad_name")
 
 
-@pytest.mark.usefixtures("isolated_setup")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_config_noastropy_fallback(monkeypatch):
     """
     Tests to make sure configuration items fall back to their defaults when

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 from inspect import cleandoc
+from threading import Lock
 
 import pytest
 
@@ -37,26 +38,128 @@ def test_paths():
     assert "testpkg" in paths.get_cache_dir(rootname="testpkg")
 
 
+_ISOLATED_SETUP_LOCK = Lock()
+
+
+@pytest.fixture
+def isolated_setup(monkeypatch):
+    # ignore global state of the test session
+    # and preserve thread safety across all users of this fixture
+    with _ISOLATED_SETUP_LOCK:
+        monkeypatch.delenv("ASTROPY_CACHE_DIR", raising=False)
+        monkeypatch.delenv("ASTROPY_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)
+        monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
+
+        yield
+
+
 @pytest.mark.parametrize(
-    "environment_variable,func",
+    "env_var_template",
     [
         # Regression test for #17514 - XDG_CACHE_HOME had no effect
-        pytest.param("XDG_CACHE_HOME", paths.get_cache_dir_path, id="cache"),
-        pytest.param("XDG_CONFIG_HOME", paths.get_config_dir_path, id="config"),
+        pytest.param("XDG_{}_HOME", id="xdg"),
+        pytest.param("ASTROPY_{}_DIR", id="astropy", marks=pytest.mark.xfail),
     ],
 )
-def test_xdg_variables(monkeypatch, tmp_path, environment_variable, func):
-    config_dir = tmp_path / "astropy"
-    config_dir.mkdir()
+@pytest.mark.parametrize(
+    "dir_type, func",
+    [
+        pytest.param("CACHE", paths.get_cache_dir_path, id="cache"),
+        pytest.param("CONFIG", paths.get_config_dir_path, id="config"),
+    ],
+)
+@pytest.mark.usefixtures("isolated_setup")
+def test_env_variables(monkeypatch, tmp_path, env_var_template, dir_type, func):
+    environment_variable = env_var_template.format(dir_type)
+    target_dir = tmp_path / "astropy"
+    target_dir.mkdir()
     monkeypatch.setenv(environment_variable, str(tmp_path))
-    assert func() == config_dir
+    assert func() == target_dir
 
 
-def test_set_temp_config(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "astropy_env_var, xdg_env_var, func",
+    [
+        pytest.param(
+            "ASTROPY_CACHE_DIR",
+            "XDG_CACHE_HOME",
+            paths.get_cache_dir_path,
+            id="cache",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            "ASTROPY_CONFIG_DIR",
+            "XDG_CONFIG_HOME",
+            paths.get_config_dir_path,
+            id="config",
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("isolated_setup")
+def test_env_variables_priority(
+    monkeypatch, tmp_path, astropy_env_var, xdg_env_var, func
+):
+    # ASTROPY_* environment variables should have priority over XDG_*
+    astropy_target_dir = tmp_path / "astropy" / "astropy"
+    astropy_target_dir.mkdir(parents=True)
+    monkeypatch.setenv(astropy_env_var, str(tmp_path / "astropy"))
+
+    xdg_target_dir = tmp_path / "xdg" / "astropy"
+    xdg_target_dir.mkdir(parents=True)
+    monkeypatch.setenv(xdg_env_var, str(tmp_path / "xdg"))
+
+    assert func() == astropy_target_dir
+
+
+@pytest.mark.parametrize(
+    "env_var_template",
+    [
+        pytest.param("XDG_{}_HOME", id="xdg"),
+        pytest.param("ASTROPY_{}_DIR", id="astropy", marks=pytest.mark.xfail),
+    ],
+)
+@pytest.mark.parametrize("dir_type", ["cache", "config"])
+@pytest.mark.usefixtures("isolated_setup")
+def test_context_over_environment(
+    monkeypatch,
+    tmp_path,
+    env_var_template,
+    dir_type,
+):
+    match dir_type:
+        case "cache":
+            cls = paths.set_temp_cache
+            func = paths.get_cache_dir_path
+        case "config":
+            cls = paths.set_temp_config
+            func = paths.get_config_dir_path
+        case _:
+            raise ValueError
+
+    # context managers should shadow environment variables
+    env_target_dir = tmp_path / "astropy"
+    env_target_dir.mkdir()
+    monkeypatch.setenv(env_var_template.format(dir_type.upper()), str(tmp_path))
+
+    assert func() == env_target_dir
+
+    ctx_target_dir = tmp_path / "context"
+    ctx_target_dir.mkdir()
+    with cls(ctx_target_dir):
+        assert func() == ctx_target_dir / "astropy"
+
+    assert func() == env_target_dir
+
+
+@pytest.mark.usefixtures("isolated_setup")
+def test_set_temp_config(tmp_path):
     # Check that we start in an understood state.
     assert configuration._cfgobjs == OLD_CONFIG
-    # Temporarily remove any temporary overrides of the configuration dir.
-    monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
 
     orig_config_dir = paths.get_config_dir(rootname="astropy")
     (temp_config_dir := tmp_path / "config").mkdir()
@@ -84,9 +187,8 @@ def test_set_temp_config(tmp_path, monkeypatch):
     assert configuration._cfgobjs == OLD_CONFIG
 
 
-def test_set_temp_cache(tmp_path, monkeypatch):
-    monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)
-
+@pytest.mark.usefixtures("isolated_setup")
+def test_set_temp_cache(tmp_path):
     orig_cache_dir = paths.get_cache_dir(rootname="astropy")
     (temp_cache_dir := tmp_path / "cache").mkdir()
     temp_astropy_cache = temp_cache_dir / "astropy"
@@ -414,16 +516,12 @@ def test_help_invalid_config_item():
         conf.help("bad_name")
 
 
+@pytest.mark.usefixtures("isolated_setup")
 def test_config_noastropy_fallback(monkeypatch):
     """
     Tests to make sure configuration items fall back to their defaults when
     there's a problem accessing the astropy directory
     """
-
-    # make sure the config directory is not searched
-    monkeypatch.setenv("XDG_CONFIG_HOME", "foo")
-    monkeypatch.delenv("XDG_CONFIG_HOME")
-    monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
 
     # make sure the _find_or_create_root_dir function fails as though the
     # astropy dir could not be accessed

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -77,14 +77,14 @@ def pytest_configure(config):
     # is also set in the test runner, but we need to also set it here for
     # things to work properly in parallel mode
 
-    builtins._xdg_config_home_orig = os.environ.get("XDG_CONFIG_HOME")
-    builtins._xdg_cache_home_orig = os.environ.get("XDG_CACHE_HOME")
+    builtins._astropy_config_dir_orig = os.environ.get("ASTROPY_CONFIG_HOME")
+    builtins._astropy_cache_dir_orig = os.environ.get("ASTROPY_CACHE_HOME")
 
-    os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
-    os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
+    os.environ["ASTROPY_CONFIG_DIR"] = tempfile.mkdtemp("astropy_config")
+    os.environ["ASTROPY_CACHE_DIR"] = tempfile.mkdtemp("astropy_cache")
 
-    Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
-    Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
+    Path(os.environ["ASTROPY_CONFIG_DIR"]).joinpath("astropy").mkdir()
+    Path(os.environ["ASTROPY_CACHE_DIR"]).joinpath("astropy").mkdir()
 
     config.option.astropy_header = True
     PYTEST_HEADER_MODULES["PyERFA"] = "erfa"
@@ -129,15 +129,15 @@ def pytest_unconfigure(config):
             mpl.rcParams.update(matplotlibrc_cache)
             matplotlibrc_cache.clear()
 
-    if builtins._xdg_config_home_orig is None:
-        os.environ.pop("XDG_CONFIG_HOME")
+    if builtins._astropy_config_dir_orig is None:
+        os.environ.pop("ASTROPY_CONFIG_DIR")
     else:
-        os.environ["XDG_CONFIG_HOME"] = builtins._xdg_config_home_orig
+        os.environ["ASTROPY_CONFIG_DIR"] = builtins._astropy_config_dir_orig
 
-    if builtins._xdg_cache_home_orig is None:
-        os.environ.pop("XDG_CACHE_HOME")
+    if builtins._astropy_cache_dir_orig is None:
+        os.environ.pop("ASTROPY_CACHE_DIR")
     else:
-        os.environ["XDG_CACHE_HOME"] = builtins._xdg_cache_home_orig
+        os.environ["ASTROPY_CACHE_DIR"] = builtins._astropy_cache_dir_orig
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -243,17 +243,17 @@ class TestRunnerBase:
         # don't know about the temporary config/cache.
         # Note, this is superfluous if the config_dir option to pytest is in use,
         # but it's also harmless
-        orig_xdg_config = os.environ.get("XDG_CONFIG_HOME")
+        astropy_config_dir_orig = os.environ.get("ASTROPY_CONFIG_DI")
         with tempfile.TemporaryDirectory("astropy_config") as astropy_config:
             Path(astropy_config, "astropy").mkdir()
-            os.environ["XDG_CONFIG_HOME"] = astropy_config
+            os.environ["ASTROPY_CONFIG_DIR"] = astropy_config
             try:
                 return pytest.main(args=args, plugins=plugins)
             finally:
-                if orig_xdg_config is None:
-                    os.environ.pop("XDG_CONFIG_HOME", None)
+                if astropy_config_dir_orig is None:
+                    os.environ.pop("ASTROPY_CONFIG_DIR", None)
                 else:
-                    os.environ["XDG_CONFIG_HOME"] = orig_xdg_config
+                    os.environ["ASTROPY_CONFIG_DIR"] = astropy_config_dir_orig
 
     @classmethod
     def make_test_runner_in(cls, path):

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -243,7 +243,7 @@ class TestRunnerBase:
         # don't know about the temporary config/cache.
         # Note, this is superfluous if the config_dir option to pytest is in use,
         # but it's also harmless
-        astropy_config_dir_orig = os.environ.get("ASTROPY_CONFIG_DI")
+        astropy_config_dir_orig = os.environ.get("ASTROPY_CONFIG_DIR")
         with tempfile.TemporaryDirectory("astropy_config") as astropy_config:
             Path(astropy_config, "astropy").mkdir()
             os.environ["ASTROPY_CONFIG_DIR"] = astropy_config

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1099,10 +1099,10 @@ def test_data_noastropy_fallback(monkeypatch):
     conf.delete_temporary_downloads_at_exit = True
 
     # make sure the config and cache directories are not searched
-    monkeypatch.setenv("XDG_CONFIG_HOME", "foo")
-    monkeypatch.delenv("XDG_CONFIG_HOME")
-    monkeypatch.setenv("XDG_CACHE_HOME", "bar")
-    monkeypatch.delenv("XDG_CACHE_HOME")
+    monkeypatch.delenv("ASTROPY_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("ASTROPY_CACHE_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
 
     monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
     monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)

--- a/conftest.py
+++ b/conftest.py
@@ -69,11 +69,11 @@ hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", default))
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
 
-os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
-os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
+os.environ["ASTROPY_CONFIG_DIR"] = tempfile.mkdtemp("astropy_config")
+os.environ["ASTROPY_CACHE_DIR"] = tempfile.mkdtemp("astropy_cache")
 
-Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
-Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
+Path(os.environ["ASTROPY_CONFIG_DIR"]).joinpath("astropy").mkdir()
+Path(os.environ["ASTROPY_CACHE_DIR"]).joinpath("astropy").mkdir()
 
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the

--- a/docs/changes/config/17640.feature.rst
+++ b/docs/changes/config/17640.feature.rst
@@ -1,0 +1,4 @@
+Add support for setting astropy's cache and config directories via the
+``ASTROPY_CACHE_DIR`` and ``ASTROPY_CONFIG_DIR`` environment variables.
+If ``XDG_CACHE_HOME`` (respectively ``XDG_CONFIG_HOME``) is also defined,
+``ASTROPY_CACHE_DIR`` (respectively ``ASTROPY_CONFIG_DIR``) takes precedence.

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -35,17 +35,8 @@ The exact location of this file can be obtained with
     >>> get_config_dir()  # doctest: +SKIP
 
 And you should see the location of your configuration directory. The standard
-scheme generally puts your configuration directory in
-``$HOME/.astropy/config``. It can be customized with the environment variables
-``XDG_CONFIG_HOME`` (or ``ASTROPY_CONFIG_DIR``), in which case the
-``$XDG_CONFIG_HOME/astropy`` (respectively ``$ASTROPY_CONFIG_DIR/astropy``)
-directory must exist. Note that ``XDG_CONFIG_HOME`` comes from a Linux-centric
-specification (see `here
-<https://wiki.archlinux.org/index.php/XDG_Base_Directory_support>`_ for more
-details), but ``astropy`` will use this on any OS as a more general means to
-know where user-specific configurations should be written.
-If both ``XDG_CONFIG_HOME`` and ``ASTROPY_CONFIG_DIR`` are defined, the latter
-takes precedence.
+scheme generally puts your configuration directory in ``$HOME/.astropy/config``.
+See :ref:`environment_variables` for how to tweak this location.
 
 .. note::
     See :ref:`astropy_config_file` for the content of this configuration file.
@@ -61,21 +52,10 @@ changes immediately in your current ``astropy`` session::
     >>> reload_config()
 
 .. note::
-    ``astropy`` also respects ``XDG_CACHE_HOME`` and ``ASTROPY_CACHE_DIR`` for
-    defining cache location. If both are defined, the latter takes precedence.
-
-.. note::
     If for whatever reason your ``$HOME/.astropy`` directory is not accessible
     (i.e., you have ``astropy`` running somehow as root but you are not the root
-    user), the best solution is to set the ``ASTROPY_CONFIG_DIR`` and
-    ``ASTROPY_CACHE_DIR`` environment variables pointing to directories, and
-    create an ``astropy`` directory inside each of those. Both the configuration
-    and data download systems will then use those directories and never try to
-    access the ``$HOME/.astropy`` directory.
-
-.. note::
-    ``ASTROPY_CONFIG_DIR`` and ``ASTROPY_CACHE_DIR`` require ``astropy`` 7.1
-    or newer. They are ignored in older versions.
+    user), the best solution is to set environment variables pointing to
+    directories you control. See :ref:`environment_variables`.
 
 Using `astropy.config`
 ======================

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -36,13 +36,16 @@ The exact location of this file can be obtained with
 
 And you should see the location of your configuration directory. The standard
 scheme generally puts your configuration directory in
-``$HOME/.astropy/config``. It can be customized with the environment variable
-``XDG_CONFIG_HOME`` in which case the ``$XDG_CONFIG_HOME/astropy`` directory
-must exist. Note that ``XDG_CONFIG_HOME`` comes from a Linux-centric
+``$HOME/.astropy/config``. It can be customized with the environment variables
+``XDG_CONFIG_HOME`` (or ``ASTROPY_CONFIG_DIR``), in which case the
+``$XDG_CONFIG_HOME/astropy`` (respectively ``$ASTROPY_CONFIG_DIR/astropy``)
+directory must exist. Note that ``XDG_CONFIG_HOME`` comes from a Linux-centric
 specification (see `here
 <https://wiki.archlinux.org/index.php/XDG_Base_Directory_support>`_ for more
 details), but ``astropy`` will use this on any OS as a more general means to
 know where user-specific configurations should be written.
+If both ``XDG_CONFIG_HOME`` and ``ASTROPY_CONFIG_DIR`` are defined, the latter
+takes precedence.
 
 .. note::
     See :ref:`astropy_config_file` for the content of this configuration file.
@@ -58,14 +61,21 @@ changes immediately in your current ``astropy`` session::
     >>> reload_config()
 
 .. note::
+    ``astropy`` also respects ``XDG_CACHE_HOME`` and ``ASTROPY_CACHE_DIR`` for
+    defining cache location. If both are defined, the latter takes precedence.
+
+.. note::
     If for whatever reason your ``$HOME/.astropy`` directory is not accessible
     (i.e., you have ``astropy`` running somehow as root but you are not the root
-    user), the best solution is to set the ``XDG_CONFIG_HOME`` and
-    ``XDG_CACHE_HOME`` environment variables pointing to directories, and create
-    an ``astropy`` directory inside each of those. Both the configuration and
-    data download systems will then use those directories and never try to
+    user), the best solution is to set the ``ASTROPY_CONFIG_DIR`` and
+    ``ASTROPY_CACHE_DIR`` environment variables pointing to directories, and
+    create an ``astropy`` directory inside each of those. Both the configuration
+    and data download systems will then use those directories and never try to
     access the ``$HOME/.astropy`` directory.
 
+.. note::
+    ``ASTROPY_CONFIG_DIR`` and ``ASTROPY_CACHE_DIR`` require ``astropy`` 7.1
+    or newer. They are ignored in older versions.
 
 Using `astropy.config`
 ======================

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -14,11 +14,11 @@ import pytest
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
 
-os.environ["XDG_CONFIG_HOME"] = tempfile.mkdtemp("astropy_config")
-os.environ["XDG_CACHE_HOME"] = tempfile.mkdtemp("astropy_cache")
+os.environ["ASTROPY_CONFIG_DIR"] = tempfile.mkdtemp("astropy_config")
+os.environ["ASTROPY_CACHE_DIR"] = tempfile.mkdtemp("astropy_cache")
 
-Path(os.environ["XDG_CONFIG_HOME"]).joinpath("astropy").mkdir()
-Path(os.environ["XDG_CACHE_HOME"]).joinpath("astropy").mkdir()
+Path(os.environ["ASTROPY_CONFIG_DIR"]).joinpath("astropy").mkdir()
+Path(os.environ["ASTROPY_CACHE_DIR"]).joinpath("astropy").mkdir()
 
 # Note that we don't need to change the environment variables back or remove
 # them after testing, because they are only changed for the duration of the

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -341,8 +341,8 @@ location, or as a *decorator* that takes effect for an entire test function
 (not including setup or teardown, which would have to be decorated separately).
 
 Furthermore, it is possible to change the location of the cache directory
-for the duration of the test run by setting the ``XDG_CACHE_HOME``
-environment variable.
+for the duration of the test run via environment variables, see
+:ref:`environment_variables`.
 
 
 Tests that create files

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -1,0 +1,42 @@
+.. currentmodule:: astropy
+
+.. _environment_variables:
+
+*********************
+Environment variables
+*********************
+
+
+Runtime
+-------
+
+.. glossary::
+
+    ``ASTROPY_CONFIG_DIR`` / ``XDG_CONFIG_HOME``
+        These environment variables control where configuration files are read
+        and written. Astropy will look for configuration files in
+        ``$ASTROPY_CONFIG_DIR/astropy``, respectively
+        ``$XDG_CONFIG_HOME/astropy``, depending on which variable is defined,
+        the former taking priority.
+        See :ref:`astropy_config` for how to programmatically set or get the
+        location of the corresponding directory at runtime.
+        ``ASTROPY_CONFIG_DIR`` was introduced in astropy 7.1 and as such, it
+        will be ignored by older versions.
+
+    ``ASTROPY_CACHE_DIR`` / ``XDG_CACHE_HOME``
+        These environment variables control where data files are cached.
+        Astropy will cache files in ``$ASTROPY_CACHE_DIR/astropy``, respectively
+        ``$XDG_CACHE_HOME/astropy``, depending on which variable is defined,
+        the former taking priority.
+        See :ref:`utils-data` for how to programmatically set or get the
+        location of the corresponding directory at runtime.
+        ``ASTROPY_CACHE_DIR`` was introduced in astropy 7.1 and as such, it
+        will be ignored by older versions.
+
+
+.. note::
+    ``XDG_CONFIG_HOME`` and ``XDG_CACHE_HOME`` come from a Linux-centric
+    specification
+    (see `here <https://wiki.archlinux.org/index.php/XDG_Base_Directory_support>`_
+    for more details), but ``astropy`` will use them on any OS as a more
+    general means to know where user-specific configurations should be written.

--- a/docs/index_user_docs.rst
+++ b/docs/index_user_docs.rst
@@ -55,4 +55,5 @@ User Guide
    logging
    warnings
    utils/index
+   environment_variables
    glossary

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -22,9 +22,9 @@ cache) the data will only be downloaded if it is not already present in the
 cache. The tools can be instructed to obtain a new copy of data
 that is in the cache but has been updated online.
 
-The ``astropy`` cache is stored in a centralized place (on Linux machines by
-default it is ``$HOME/.astropy/cache``; see :ref:`astropy_config` for
-more details).  You can check its location on your machine::
+The ``astropy`` cache is stored in a centralized place (see :ref:`astropy_config`
+and :ref:`environment_variables` for more details).  You can check its location
+on your machine::
 
    >>> import astropy.config.paths
    >>> astropy.config.paths.get_cache_dir()  # doctest: +SKIP


### PR DESCRIPTION
### Description

* Replaces #17567
* Close #17567
* Close #10244
* Close #17507

The approach is different enough from #17507 that it warranted a separate PR. Hopefully this one satisfies the needs highlighted in @eerovaher's and @pllim's early review there.
I'll add documentation once everyone is happy with the approach !

### Blocked by

* #17932
* #17934

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
