### PR TITLE
Add back bzero and bscale keywords when `do_not_scale_image_data` is true for the appended hdu

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -19,7 +19,6 @@ from astropy.io.fits.util import (
     _free_space_check,
     _get_array_mmap,
     _is_int,
-    _is_pseudo_integer,
     decode_ascii,
     first,
     itersubclasses,
@@ -555,11 +554,7 @@ class _BaseHDU:
             return None
 
     def _postwriteto(self):
-        # If data is unsigned integer 16, 32 or 64, remove the
-        # BSCALE/BZERO cards
-        if self._has_data and self._standard and _is_pseudo_integer(self.data.dtype):
-            for keyword in ("BSCALE", "BZERO"):
-                self._header.remove(keyword, ignore_missing=True)
+        pass
 
     def _writeheader(self, fileobj):
         offset = 0

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -759,9 +759,6 @@ class HDUList(list, _Verify):
                     hdu.header,
                     do_not_scale_image_data=hdu._do_not_scale_image_data,
                 )
-                if hdu._do_not_scale_image_data:
-                    hdu.header["BZERO"] = bzero
-                    hdu.header["BSCALE"] = bscale
         else:
             if not isinstance(hdu, (PrimaryHDU, _NonstandardHDU)):
                 # You passed in an Extension HDU but we need a Primary
@@ -774,15 +771,17 @@ class HDUList(list, _Verify):
                         hdu.header,
                         do_not_scale_image_data=hdu._do_not_scale_image_data,
                     )
-                    if hdu._do_not_scale_image_data:
-                        hdu.header["BZERO"] = bzero
-                        hdu.header["BSCALE"] = bscale
                 else:
                     # You didn't provide an ImageHDU so we create a
                     # simple Primary HDU and append that first before
                     # we append the new Extension HDU.
                     phdu = PrimaryHDU()
                     super().append(phdu)
+
+        # Add back BZERO and BSCALE if relevant
+        if hasattr(hdu, "_do_not_scale_image_data") and hdu._do_not_scale_image_data:
+            hdu.header["BZERO"] = bzero
+            hdu.header["BSCALE"] = bscale
 
         super().append(hdu)
         hdu._new = True

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1065,6 +1065,7 @@ class HDUList(list, _Verify):
                     hdu._output_checksum = checksum
                     hdu._prewriteto()
                     hdu._writeto(hdulist._file)
+                    hdu._postwriteto()
         finally:
             hdulist.close(output_verify=output_verify, closed=closed)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1065,7 +1065,6 @@ class HDUList(list, _Verify):
                     hdu._output_checksum = checksum
                     hdu._prewriteto()
                     hdu._writeto(hdulist._file)
-                    hdu._postwriteto()
         finally:
             hdulist.close(output_verify=output_verify, closed=closed)
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -740,10 +740,8 @@ class HDUList(list, _Verify):
             raise ValueError("HDUList can only append an HDU.")
 
         # store BZERO and BSCALE if present
-        if "BZERO" in hdu.header:
-            bzero = hdu.header["BZERO"]
-        if "BSCALE" in hdu.header:
-            bscale = hdu.header["BSCALE"]
+        bzero = hdu.header.get("BZERO")
+        bscale = hdu.header.get("BSCALE")
 
         if len(self) > 0:
             if isinstance(hdu, GroupsHDU):
@@ -779,9 +777,11 @@ class HDUList(list, _Verify):
                     super().append(phdu)
 
         # Add back BZERO and BSCALE if relevant
-        if hasattr(hdu, "_do_not_scale_image_data") and hdu._do_not_scale_image_data:
-            hdu.header["BZERO"] = bzero
-            hdu.header["BSCALE"] = bscale
+        if getattr(hdu, "_do_not_scale_image_data", False):
+            if bzero is not None:
+                hdu.header["BZERO"] = bzero
+            if bscale is not None:
+                hdu.header["BSCALE"] = bscale
 
         super().append(hdu)
         hdu._new = True

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -178,22 +178,38 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(ValueError):
             hdul.append(hdu)
 
-    @pytest.mark.parametrize("do_not_scale", [True, False])
-    def test_append_scaled_image_with_do_not_scale_image_data(self, do_not_scale):
+    @pytest.mark.parametrize(
+        ["image", "do_not_scale"],
+        [
+            ["scale.fits", True],
+            ["o4sp040b0_raw.fits", True],
+            ["fixed-1890.fits", True],
+            ["scale.fits", False],
+            ["o4sp040b0_raw.fits", False],
+            ["fixed-1890.fits", False],
+        ],
+    )
+    def test_append_scaled_image_with_do_not_scale_image_data(
+        self, image, do_not_scale
+    ):
         """Tests appending a scaled ImageHDU to a HDUList."""
 
         with (
-            fits.open(
-                self.data("scale.fits"), do_not_scale_image_data=do_not_scale
-            ) as source,
+            fits.open(self.data(image), do_not_scale_image_data=do_not_scale) as source,
             fits.open(self.temp("dest.fits"), mode="append") as dest,
         ):
             # create the file
             dest.append(source[0])
             # append a second hdu
             dest.append(source[0])
-            assert dest[-1].header["BSCALE"] == source[0].header["BSCALE"]
-            assert dest[-1].header["BZERO"] == source[0].header["BZERO"]
+            assert dest[-1].header.get("BZERO") == source[0].header.get("BZERO")
+            assert dest[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
+            dest.writeto(self.temp("test-append.fits"))
+            with fits.open(
+                self.temp("test-append.fits"), do_not_scale_image_data=do_not_scale
+            ) as tmphdu:
+                assert tmphdu[-1].header.get("BZERO") == source[0].header.get("BZERO")
+                assert tmphdu[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
 
     def test_insert_primary_to_empty_list(self):
         """Tests inserting a Simple PrimaryHDU to an empty HDUList."""

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -194,22 +194,22 @@ class TestHDUListFunctions(FitsTestCase):
     ):
         """Tests appending a scaled ImageHDU to a HDUList."""
 
-        with (
-            fits.open(self.data(image), do_not_scale_image_data=do_not_scale) as source,
-            fits.open(self.temp("dest.fits"), mode="append") as dest,
-        ):
+        with fits.open(
+            self.data(image), do_not_scale_image_data=do_not_scale
+        ) as source:
             # create the file
+            dest = fits.HDUList()
             dest.append(source[0])
             # append a second hdu
             dest.append(source[0])
             assert dest[-1].header.get("BZERO") == source[0].header.get("BZERO")
             assert dest[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
             dest.writeto(self.temp("test-append.fits"))
-            with fits.open(
-                self.temp("test-append.fits"), do_not_scale_image_data=do_not_scale
-            ) as tmphdu:
-                assert tmphdu[-1].header.get("BZERO") == source[0].header.get("BZERO")
-                assert tmphdu[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
+        with fits.open(
+            self.temp("test-append.fits"), do_not_scale_image_data=do_not_scale
+        ) as tmphdu:
+            assert tmphdu[-1].header.get("BZERO") == source[0].header.get("BZERO")
+            assert tmphdu[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
 
     def test_insert_primary_to_empty_list(self):
         """Tests inserting a Simple PrimaryHDU to an empty HDUList."""

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -178,14 +178,19 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(ValueError):
             hdul.append(hdu)
 
-    def test_append_scaled_image_with_do_not_scale_image_data(self):
+    @pytest.mark.parametrize("do_not_scale", [True, False])
+    def test_append_scaled_image_with_do_not_scale_image_data(self, do_not_scale):
         """Tests appending a scaled ImageHDU to a HDUList."""
 
         with (
-            fits.open(self.data("scale.fits"), do_not_scale_image_data=True) as source,
+            fits.open(
+                self.data("scale.fits"), do_not_scale_image_data=do_not_scale
+            ) as source,
             fits.open(self.temp("dest.fits"), mode="append") as dest,
         ):
+            # create the file
             dest.append(source[0])
+            # append a second hdu
             dest.append(source[0])
             assert dest[-1].header["BSCALE"] == source[0].header["BSCALE"]
             assert dest[-1].header["BZERO"] == source[0].header["BZERO"]

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -179,16 +179,9 @@ class TestHDUListFunctions(FitsTestCase):
             hdul.append(hdu)
 
     @pytest.mark.parametrize(
-        ["image", "do_not_scale"],
-        [
-            ["scale.fits", True],
-            ["o4sp040b0_raw.fits", True],
-            ["fixed-1890.fits", True],
-            ["scale.fits", False],
-            ["o4sp040b0_raw.fits", False],
-            ["fixed-1890.fits", False],
-        ],
+        "image", ["scale.fits", "o4sp040b0_raw.fits", "fixed-1890.fits"]
     )
+    @pytest.mark.parametrize("do_not_scale", [True, False])
     def test_append_scaled_image_with_do_not_scale_image_data(
         self, image, do_not_scale
     ):

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -181,12 +181,14 @@ class TestHDUListFunctions(FitsTestCase):
     def test_append_scaled_image_with_do_not_scale_image_data(self):
         """Tests appending a scaled ImageHDU to a HDUList."""
 
-        with fits.open(self.data("scale.fits"), do_not_scale_image_data=True) as source:
-            with fits.open(self.temp("dest.fits"), mode="append") as dest:
-                dest.append(source[0])
-                dest.append(source[0])
-                assert dest[-1].header["BSCALE"] == source[0].header["BSCALE"]
-                assert dest[-1].header["BZERO"] == source[0].header["BZERO"]
+        with (
+            fits.open(self.data("scale.fits"), do_not_scale_image_data=True) as source,
+            fits.open(self.temp("dest.fits"), mode="append") as dest,
+        ):
+            dest.append(source[0])
+            dest.append(source[0])
+            assert dest[-1].header["BSCALE"] == source[0].header["BSCALE"]
+            assert dest[-1].header["BZERO"] == source[0].header["BZERO"]
 
     def test_insert_primary_to_empty_list(self):
         """Tests inserting a Simple PrimaryHDU to an empty HDUList."""

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -178,6 +178,16 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(ValueError):
             hdul.append(hdu)
 
+    def test_append_scaled_image_with_do_not_scale_image_data(self):
+        """Tests appending a scaled ImageHDU to a HDUList."""
+
+        with fits.open(self.data("scale.fits"), do_not_scale_image_data=True) as source:
+            with fits.open(self.temp("dest.fits"), mode="append") as dest:
+                dest.append(source[0])
+                dest.append(source[0])
+                assert dest[-1].header["BSCALE"] == source[0].header["BSCALE"]
+                assert dest[-1].header["BZERO"] == source[0].header["BZERO"]
+
     def test_insert_primary_to_empty_list(self):
         """Tests inserting a Simple PrimaryHDU to an empty HDUList."""
         hdul = fits.HDUList()

--- a/docs/changes/io.fits/17642.bugfix.rst
+++ b/docs/changes/io.fits/17642.bugfix.rst
@@ -1,0 +1,2 @@
+The scaling state from the source HDU to the new appended HDU is copied on the
+destination file, when the hdu is read with `do_not_scale_image_data=True`.

--- a/docs/changes/io.fits/17642.bugfix.rst
+++ b/docs/changes/io.fits/17642.bugfix.rst
@@ -1,2 +1,2 @@
-The scaling state from the source HDU to the new appended HDU is copied on the
-destination file, when the hdu is read with `do_not_scale_image_data=True`.
+Fixed a bug so that now the scaling state from the source HDU to the new appended HDU is copied on the
+destination file, when the HDU is read with ``do_not_scale_image_data=True``.


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the dropping of BSCALE BZERO keywords when appending a scaled image without scaling.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #4063 applying the suggested interim solution.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
