### PR TITLE
RFC: refactor an internal path sanitizing function and avoid duplicated logic

### DIFF
--- a/astropy/io/registry/core.py
+++ b/astropy/io/registry/core.py
@@ -192,14 +192,14 @@ class UnifiedInputRegistry(_UnifiedIORegistryBase):
         ctx = None
         try:
             # Expand a tilde-prefixed path if present in args[0]
-            if len(args):
+            if args:
                 args = (_expand_user_in_arg0(args[0]), *args[1:])
 
             if format is None:
                 path = None
                 fileobj = None
 
-                if len(args):
+                if args:
                     if isinstance(args[0], PATH_TYPES) and not os.path.isdir(args[0]):
                         from astropy.utils.data import get_readable_fileobj
 
@@ -373,13 +373,13 @@ class UnifiedOutputRegistry(_UnifiedIORegistryBase):
             .. versionadded:: 4.3
         """
         # Expand a tilde-prefixed path if present in args[0]
-        if len(args):
+        if args:
             args = (_expand_user_in_arg0(args[0]), *args[1:])
 
         if format is None:
             path = None
             fileobj = None
-            if len(args):
+            if args:
                 if isinstance(args[0], PATH_TYPES):
                     path = args[0]
                     fileobj = None


### PR DESCRIPTION
### Description
Found this while reviving my follow up patch to #17552: `_expand_user_in_args` is only used in two places, where part of its logic was duplicated everytime. Rewriting it as a function that takes only the first element of `args` as its argument also allows to type-annotate it.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
