### PR TITLE
TST: Use free Linux ARM64 runner

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -191,4 +191,4 @@ jobs:
       - name: Set up dependencies
         run: pip install tox
       - name: Run tests
-        run: tox -e py312-test -- -n=2
+        run: sudo tox -e py312-test -- -n=2

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -189,6 +189,6 @@ jobs:
         with:
           python-version: '3.12'
       - name: Set up dependencies
-        run: pip install tox
+        run: python3 -m pip install tox
       - name: Run tests
-        run: sudo tox -e py312-test -- -n=2
+        run: python3 -m tox -e py312-test -- -n=2

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -171,10 +171,9 @@ jobs:
 
   test_arm64:
 
-    # Native arm64 testing - we keep this in the weekly cron as we need to pay for it so we should
-    # minimize how many jobs we do.
+    # Native arm64 testing - we keep this in the weekly cron to avoid exceeding free quota.
 
-    runs-on: linux-arm64
+    runs-on: ubuntu-24.04-arm
     name: Python 3.12 (arm64)
     # keep condition in sync with test_more_architectures
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to switch from paid to free Linux ARM64 runner (in public beta now). Also see:

* https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
* https://github.com/orgs/community/discussions/148648
* https://github.com/sunpy/sunpy/pull/8024

### TODO

- [x] Get past permission error.
- [x] See if we can also apply to photutils. https://github.com/astropy/photutils/pull/1997

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
