### PR TITLE
Fix CCDData.read logger message for matching units

### DIFF
--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # Tests of NDDataBase
 
+import numpy as np
 
+from astropy import units as u
+from astropy.io import fits
+from astropy.nddata import CCDData
 from astropy.nddata.nddata_base import NDDataBase
 
 
@@ -82,3 +86,24 @@ def test_omitting_psf_is_ok():
     # Make sure that psf does not need to be overridden when creating a subclass
     b = MinimalSubclassNoPSF()
     assert b.psf is None
+
+
+def test_read_with_matching_units(tmp_path, caplog):
+    """Test reading a FITS file with a matching unit in BUNIT."""
+    # Create a temporary FITS file
+    fits_file = tmp_path / "test.fits"
+    hdu = fits.PrimaryHDU(data=np.zeros((10, 10)))
+    hdu.header["BUNIT"] = "adu"
+    hdu.writeto(fits_file, overwrite=True)
+
+    # Read the FITS file and capture log messages
+    with caplog.at_level("WARNING"):  # Set the logging level to WARNING
+        ccd = CCDData.read(fits_file, unit="adu")
+
+    # Assert no warnings were logged
+    assert len(caplog.records) == 0
+
+    # Assert that the CCDData object has the correct unit
+    assert isinstance(ccd, CCDData)
+    assert ccd.unit == u.adu
+    assert ccd.data.shape == (10, 10)


### PR DESCRIPTION
This pull request addresses an issue in the CCDData.read() method where unnecessary logging messages were emitted when the unit in the FITS file matched the desired unit. This update ensures that no log messages are generated when the unit is already correct, improving the logging behavior.

Additionally, a test has been added to verify that no logging message is emitted when the units match, which will help in ensuring consistent and proper functionality.
Changes:

    Modified the CCDData.read() method to avoid emitting unnecessary logging messages when the units match.
    Added a test to confirm that no logging messages are produced in this case.

Fixes #13539 