### PR TITLE
Split the `test_si_prefixes()` unit test

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1034,45 +1034,82 @@ def test_raise_to_negative_power():
 
 
 @pytest.mark.parametrize(
-    "name, symbol, multiplying_factor",
+    "name, factor",
     [
-        ("quetta", "Q", 1e30),
-        ("ronna", "R", 1e27),
-        ("yotta", "Y", 1e24),
-        ("zetta", "Z", 1e21),
-        ("exa", "E", 1e18),
-        ("peta", "P", 1e15),
-        ("tera", "T", 1e12),
-        ("giga", "G", 1e9),
-        ("mega", "M", 1e6),
-        ("kilo", "k", 1e3),
-        ("deca", "da", 1e1),
-        ("deci", "d", 1e-1),
-        ("centi", "c", 1e-2),
-        ("milli", "m", 1e-3),
-        ("micro", "u", 1e-6),
-        ("nano", "n", 1e-9),
-        ("pico", "p", 1e-12),
-        ("femto", "f", 1e-15),
-        ("atto", "a", 1e-18),
-        ("zepto", "z", 1e-21),
-        ("yocto", "y", 1e-24),
-        ("ronto", "r", 1e-27),
-        ("quecto", "q", 1e-30),
+        pytest.param(name, factor, id=name)
+        for name, factor in [
+            ("quetta", 1e30),
+            ("ronna", 1e27),
+            ("yotta", 1e24),
+            ("zetta", 1e21),
+            ("exa", 1e18),
+            ("peta", 1e15),
+            ("tera", 1e12),
+            ("giga", 1e9),
+            ("mega", 1e6),
+            ("kilo", 1e3),
+            ("deca", 1e1),
+            ("deka", 1e1),  # American spelling of deca
+            ("deci", 1e-1),
+            ("centi", 1e-2),
+            ("milli", 1e-3),
+            ("micro", 1e-6),
+            ("nano", 1e-9),
+            ("pico", 1e-12),
+            ("femto", 1e-15),
+            ("atto", 1e-18),
+            ("zepto", 1e-21),
+            ("yocto", 1e-24),
+            ("ronto", 1e-27),
+            ("quecto", 1e-30),
+        ]
     ],
 )
-def test_si_prefixes(name, symbol, multiplying_factor):
-    base = 1 * u.g
-
-    quantity_from_symbol = base.to(f"{symbol}g")
-    quantity_from_name = base.to(f"{name}gram")
-
+def test_si_prefix_names(name, factor):
+    base = 1 * u.s
+    quantity_from_name = base.to(f"{name}second")
     assert u.isclose(quantity_from_name, base)
+    assert np.isclose(base.value / quantity_from_name.value, factor, atol=0)
+
+
+@pytest.mark.parametrize(
+    "symbol, factor",
+    [
+        pytest.param(symbol, factor, id=symbol)
+        for symbol, factor in [
+            ("Q", 1e30),
+            ("R", 1e27),
+            ("Y", 1e24),
+            ("Z", 1e21),
+            ("E", 1e18),
+            ("P", 1e15),
+            ("T", 1e12),
+            ("G", 1e9),
+            ("M", 1e6),
+            ("k", 1e3),
+            ("da", 1e1),
+            ("d", 1e-1),
+            ("c", 1e-2),
+            ("m", 1e-3),
+            ("\N{MICRO SIGN}", 1e-6),
+            ("\N{GREEK SMALL LETTER MU}", 1e-6),
+            ("u", 1e-6),
+            ("n", 1e-9),
+            ("p", 1e-12),
+            ("f", 1e-15),
+            ("a", 1e-18),
+            ("z", 1e-21),
+            ("y", 1e-24),
+            ("r", 1e-27),
+            ("q", 1e-30),
+        ]
+    ],
+)
+def test_si_prefix_symbols(symbol, factor):
+    base = 1 * u.m
+    quantity_from_symbol = base.to(f"{symbol}m")
     assert u.isclose(quantity_from_symbol, base)
-
-    value_ratio = base.value / quantity_from_symbol.value
-
-    assert u.isclose(value_ratio, multiplying_factor)
+    assert np.isclose(base.value / quantity_from_symbol.value, factor, atol=0)
 
 
 def test_cm_uniqueness():


### PR DESCRIPTION
### Description

The old test checks the SI prefix names and symbols together, but it is better to check them separately because the number of recognized names and symbols of a prefix can be different. Indeed, `test_si_prefixes()` has 23 parametrizations, but `test_si_prefix_names()` has 24 because it is now testing the "deka" name and `test_si_prefix_symbols()` has 25 parametrizations because it is now testing the non-ASCII symbols for the micro-prefix.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
