### PR TITLE
Add proper support for the "μ" unit prefix

### DIFF
--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -51,12 +51,12 @@ def _initialize_module():
 
     from . import core
 
+    prefixes = []
     # The CDS format also supports power-of-2 prefixes as defined here:
     # http://physics.nist.gov/cuu/Units/binary.html
-    prefixes = core.si_prefixes + core.binary_prefixes
-
-    # CDS only uses the short prefixes
-    prefixes = [(short, short, factor) for (short, long, factor) in prefixes]
+    for short, long, factor in core.si_prefixes + core.binary_prefixes:
+        short = [s for s in short if s.isascii()]
+        prefixes.append((short, short, factor))  # CDS only uses the short prefixes
 
     # The following units are defined in alphabetical order, directly from
     # here: https://vizier.unistra.fr/viz-bin/Unit

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2443,7 +2443,7 @@ si_prefixes: Final[list[tuple[list[str], list[str], float]]] = [
     (["d"], ["deci"], 1e-1),
     (["c"], ["centi"], 1e-2),
     (["m"], ["milli"], 1e-3),
-    (["u"], ["micro"], 1e-6),
+    (["u", "\N{MICRO SIGN}", "\N{GREEK SMALL LETTER MU}"], ["micro"], 1e-6),
     (["n"], ["nano"], 1e-9),
     (["p"], ["pico"], 1e-12),
     (["f"], ["femto"], 1e-15),

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -446,9 +446,7 @@ class Generic(Base, _GenericParserMixin):
             s = cls._unit_symbols[s]
 
         elif not s.isascii():
-            if s[0] == "\N{MICRO SIGN}":
-                s = "u" + s[1:]
-            elif s[0] == "°":
+            if s[0].startswith("°"):
                 s = "deg" if len(s) == 1 else "deg_" + s[1:]
             if s[-1] in cls._prefixable_unit_symbols:
                 s = s[:-1] + cls._prefixable_unit_symbols[s[-1]]
@@ -489,17 +487,8 @@ class Generic(Base, _GenericParserMixin):
         "\N{LATIN SUBSCRIPT SMALL LETTER P}": "_p",
     }
 
-    _translations: ClassVar[dict[int, str]] = str.maketrans(
-        {
-            "\N{GREEK SMALL LETTER MU}": "\N{MICRO SIGN}",
-            "\N{MINUS SIGN}": "-",
-        }
-    )
-    """Character translations that should be applied before parsing a string.
-
-    Note that this does explicitly *not* generally translate MICRO SIGN to u,
-    since then a string like 'µ' would be interpreted as unit mass.
-    """
+    _translations: ClassVar[dict[int, str]] = str.maketrans({"\N{MINUS SIGN}": "-"})
+    """Character translations that should be applied before parsing a string."""
 
     _superscripts: Final[str] = (
         "\N{SUPERSCRIPT MINUS}"

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -145,7 +145,7 @@ def_unit(
     doc="milli arc second: angular measurement",
 )
 def_unit(
-    ["uas"],
+    ["uas", "\N{MICRO SIGN}as", "\N{GREEK SMALL LETTER MU}as"],
     0.000001 * arcsec,
     namespace=_ns,
     doc="micro arc second: angular measurement",

--- a/docs/changes/units/17651.feature.rst
+++ b/docs/changes/units/17651.feature.rst
@@ -1,0 +1,3 @@
+Units with the "micro" prefix can now be imported using ``"μ"`` in the name.
+For example, the microgram can now be imported with
+``from astropy.units import μg``.


### PR DESCRIPTION
### Description

"μ" is the only SI prefix that is not ASCII-compatible, so it common to use "u" as a replacement, including in `astropy.units`. However, Python 3 does allow variable names to start with a "μ". The patch here adds proper support for the two relevant Unicode code points: U+00B5 (MICRO SIGN) and U+03BC (GREEK SMALL LETTER MU). The new names are true aliases:
```python
>>> from astropy import units as u
>>> u.um is u.μm
True
```

It was already possible to parse strings containing non-ASCII "micro" prefixes with the `Generic` formatter, which can now be simplified. I suspect it would be possible to simplify `Generic` even further by defining a few more Unicode-aware names.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
