### PR TITLE
Avoid using `classproperty` in unit formatters

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -252,12 +252,12 @@ class _ParsingFormatMixin:
         msg : str
             A message with alternatives, or the empty string.
         """
-        return did_you_mean(unit, cls._units, fix=cls._fix_deprecated)
+        return did_you_mean(unit, cls._get_units(), fix=cls._fix_deprecated)
 
     @classmethod
     def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
         try:
-            return cls._units[unit]
+            return cls._get_units()[unit]
         except KeyError:
             if detailed_exception:
                 raise ValueError(cls._invalid_unit_error_message(unit)) from None

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import re
+from functools import cache
 from typing import TYPE_CHECKING
 
 from astropy.units.core import CompositeUnit, Unit
@@ -60,8 +61,9 @@ class CDS(Base, _ParsingFormatMixin):
         "DIMENSIONLESS",
     )
 
-    @classproperty(lazy=True)
-    def _units(cls) -> dict[str, UnitBase]:
+    @classmethod
+    @cache
+    def _get_units(cls) -> dict[str, UnitBase]:
         from astropy import units as u
         from astropy.units import cds
 

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -6,13 +6,13 @@ Handles the "FITS" unit format.
 
 from __future__ import annotations
 
+from functools import cache
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from astropy.units.core import CompositeUnit
 from astropy.units.errors import UnitScaleError
-from astropy.utils import classproperty
 
 from . import Base, utils
 from .generic import _GenericParserMixin
@@ -31,8 +31,9 @@ class FITS(Base, _GenericParserMixin):
     Standard <https://fits.gsfc.nasa.gov/fits_standard.html>`_.
     """
 
-    @classproperty(lazy=True)
-    def _units(cls) -> dict[str, UnitBase]:
+    @classmethod
+    @cache
+    def _get_units(cls) -> dict[str, UnitBase]:
         from astropy import units as u
 
         # add some units up-front for which we don't want to use prefixes

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import math
 import warnings
 from fractions import Fraction
+from functools import cache
 from typing import TYPE_CHECKING
 
 from astropy.units.core import CompositeUnit
@@ -66,8 +67,9 @@ class OGIP(Base, _ParsingFormatMixin):
 
     _deprecated_units: ClassVar[frozenset[str]] = frozenset(("Crab", "mCrab"))
 
-    @classproperty(lazy=True)
-    def _units(cls) -> dict[str, UnitBase]:
+    @classmethod
+    @cache
+    def _get_units(cls) -> dict[str, UnitBase]:
         from astropy import units as u
 
         bases = [

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import warnings
+from functools import cache
 from typing import TYPE_CHECKING
 
 from astropy.units.core import (
@@ -95,8 +96,9 @@ class VOUnit(Base, _GenericParserMixin):
 
         return names, frozenset(deprecated_names)
 
-    @classproperty(lazy=True)
-    def _units(cls) -> dict[str, UnitBase]:
+    @classmethod
+    @cache
+    def _get_units(cls) -> dict[str, UnitBase]:
         return cls._all_units[0]
 
     @classproperty(lazy=True)
@@ -220,7 +222,7 @@ class VOUnit(Base, _GenericParserMixin):
     @classmethod
     def _fix_deprecated(cls, x: str) -> list[str]:
         return (
-            [f"{x} (deprecated)", cls.to_string(cls._units[x]._represents)]
+            [f"{x} (deprecated)", cls.to_string(cls._get_units()[x]._represents)]
             if x in cls._deprecated_units
             else [x]
         )
@@ -231,7 +233,7 @@ class VOUnit(Base, _GenericParserMixin):
             warnings.warn(
                 UnitsWarning(
                     f"The unit '{unit}' has been deprecated in the VOUnit standard."
-                    f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
+                    f" Suggested: {cls.to_string(cls._get_units()[unit]._represents)}."
                 )
             )
         return super()._validate_unit(unit, detailed_exception)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -404,7 +404,11 @@ class TestRoundtripVOUnit(RoundtripBase):
 
     @pytest.mark.parametrize(
         "unit",
-        [u for u in u_format.VOUnit._units.values() if not isinstance(u, PrefixUnit)],
+        [
+            u
+            for u in u_format.VOUnit._get_units().values()
+            if not isinstance(u, PrefixUnit)
+        ],
         ids=str,
     )
     def test_roundtrip(self, unit):
@@ -418,7 +422,11 @@ class TestRoundtripFITS(RoundtripBase):
 
     @pytest.mark.parametrize(
         "unit",
-        [u for u in u_format.FITS._units.values() if not isinstance(u, PrefixUnit)],
+        [
+            u
+            for u in u_format.FITS._get_units().values()
+            if not isinstance(u, PrefixUnit)
+        ],
         ids=str,
     )
     def test_roundtrip(self, unit):
@@ -430,7 +438,11 @@ class TestRoundtripCDS(RoundtripBase):
 
     @pytest.mark.parametrize(
         "unit",
-        [u for u in u_format.CDS._units.values() if not isinstance(u, PrefixUnit)],
+        [
+            u
+            for u in u_format.CDS._get_units().values()
+            if not isinstance(u, PrefixUnit)
+        ],
         ids=str,
     )
     def test_roundtrip(self, unit):
@@ -457,7 +469,7 @@ class TestRoundtripOGIP(RoundtripBase):
         "unit",
         [
             unit
-            for unit in u_format.OGIP._units.values()
+            for unit in u_format.OGIP._get_units().values()
             if (isinstance(unit, UnitBase) and not isinstance(unit, PrefixUnit))
         ],
         ids=str,
@@ -494,7 +506,7 @@ class TestRoundtripOGIP(RoundtripBase):
     [(u_format.FITS, 765), (u_format.VOUnit, 1297), (u_format.CDS, 3124)],
 )
 def test_units_available(unit_formatter_class, n_units):
-    assert len(unit_formatter_class._units) == n_units
+    assert len(unit_formatter_class._get_units()) == n_units
 
 
 def test_cds_non_ascii_unit():


### PR DESCRIPTION
### Description

Trying to check our unit formatter code with Mypy results in a large number of errors that look like
```
astropy/units/format/ogip.py:69: error: Missing positional argument "fget" in call to "classproperty"  [call-arg]
astropy/units/format/ogip.py:69: error: "classproperty" not callable  [operator]
```
This because our `@classproperty` is too dynamic for type checkers. Luckily the unit formatters don't really need `@classproperty` because very similar functionality can be achieved with standard library `@classmethod` and `@functools.cache`, which don't cause problems for type checkers. Replacing our custom utilities with standard library ones is a good thing to do independently of type checking.

I'm opening this as a draft where I have replaced just one class property. If the maintainers think this is a good idea then I can replace all of them.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
