### PR TITLE
DOC: improve table.unique's docstring to reflect that the return table is expected to be sorted

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -805,7 +805,7 @@ def hstack(
 
 def unique(input_table, keys=None, silent=False, keep="first"):
     """
-    Returns the unique rows of a table.
+    Return a new table with unique rows, sorted by ``keys``.
 
     Parameters
     ----------


### PR DESCRIPTION
### Description
Fixes #17650

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
