### PR TITLE
Use ``co_firstlineno`` to calculate line numbers in ``make_function_with_signature``

### DIFF
--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -115,10 +115,10 @@ def make_function_with_signature(
     # The lstrip is in case there were *no* positional arguments (a rare case)
     # in any context this will actually be used...
     template = textwrap.dedent(
-        """{0}\
-    def {name}({sig1}):
-        return __{name}__func({sig2})
-    """.format(blank_lines, name=name, sig1=def_signature, sig2=call_signature)
+        f"""{blank_lines}\
+    def {name}({def_signature}):
+        return __{name}__func({call_signature})
+    """
     )
 
     code = compile(template, filename, "single")

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -109,10 +109,8 @@ def make_function_with_signature(
         filename = "<string>"
         modname = "__main__"
 
-    # Subtract 2 from the line number since the length of the template itself
-    # is two lines.  Therefore we have to subtract those off in order for the
-    # pointer in tracebacks from __{name}__func to point to the right spot.
-    lineno = frm.f_lineno - 2
+    num_blank_lines = func.__code__.co_firstlineno - 1
+    blank_lines = "\n" * num_blank_lines
 
     # The lstrip is in case there were *no* positional arguments (a rare case)
     # in any context this will actually be used...
@@ -120,7 +118,7 @@ def make_function_with_signature(
         """{0}\
     def {name}({sig1}):
         return __{name}__func({sig2})
-    """.format("\n" * lineno, name=name, sig1=def_signature, sig2=call_signature)
+    """.format(blank_lines, name=name, sig1=def_signature, sig2=call_signature)
     )
 
     code = compile(template, filename, "single")

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -1159,10 +1159,17 @@ def format_doc(docstring, *args, **kwargs):
                 "docstring that is not empty."
             )
 
+        # Dedent both the original and the new docstring to ensure consistent
+        # leading whitespace, because from Python 3.13 the bytecode compiler
+        # strips leading whitespace from docstrings. If the text in ``doc``
+        # has any leading whitespace, this can lead to reST/Sphinx errors.
+        doc_dedent = textwrap.dedent(doc).lstrip("\n")
+        obj_doc = textwrap.dedent(obj.__doc__ or "").strip("\n")
+
         # If the original has a not-empty docstring append it to the format
         # kwargs.
-        kwargs["__doc__"] = obj.__doc__ or ""
-        obj.__doc__ = doc.format(*args, **kwargs)
+        kwargs["__doc__"] = obj_doc
+        obj.__doc__ = doc_dedent.format(*args, **kwargs)
         return obj
 
     return set_docstring

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -1163,13 +1163,13 @@ def format_doc(docstring, *args, **kwargs):
         # leading whitespace, because from Python 3.13 the bytecode compiler
         # strips leading whitespace from docstrings. If the text in ``doc``
         # has any leading whitespace, this can lead to reST/Sphinx errors.
-        doc_dedent = textwrap.dedent(doc).lstrip("\n")
-        obj_doc = textwrap.dedent(obj.__doc__ or "").strip("\n")
+        if sys.version_info[:2] >= (3, 13):
+            doc = textwrap.dedent(doc).lstrip("\n")
 
         # If the original has a not-empty docstring append it to the format
         # kwargs.
-        kwargs["__doc__"] = obj_doc
-        obj.__doc__ = doc_dedent.format(*args, **kwargs)
+        kwargs["__doc__"] = obj.__doc__ or ""
+        obj.__doc__ = doc.format(*args, **kwargs)
         return obj
 
     return set_docstring

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,14 +40,13 @@ from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from sphinx.util import logging
 
-
 # xref: https://github.com/sphinx-doc/sphinx/issues/13232#issuecomment-2608708175
 if sys.version_info[:2] >= (3, 13) and sphinx.version_info[:2] < (8, 2):
     import pathlib
 
     from sphinx.util.typing import _INVALID_BUILTIN_CLASSES
 
-    _INVALID_BUILTIN_CLASSES[pathlib.Path] = 'pathlib.Path'  # type: ignore
+    _INVALID_BUILTIN_CLASSES[pathlib.Path] = "pathlib.Path"
 
 
 # from docs import global_substitutions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,9 +35,20 @@ from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
 
+import sphinx
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from sphinx.util import logging
+
+
+# xref: https://github.com/sphinx-doc/sphinx/issues/13232#issuecomment-2608708175
+if sys.version_info[:2] >= (3, 13) and sphinx.version_info[:2] < (8, 2):
+    import pathlib
+
+    from sphinx.util.typing import _INVALID_BUILTIN_CLASSES
+
+    _INVALID_BUILTIN_CLASSES[pathlib.Path] = 'pathlib.Path'  # type: ignore
+
 
 # from docs import global_substitutions
 

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,8 +1,8 @@
-name: rtd311
+name: rtd313
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11
+  - python=3.13
   - pip
   - graphviz

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,8 +1,8 @@
-name: rtd313
+name: rtd312
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.13
+  - python=3.12
   - pip
   - graphviz

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,8 +1,8 @@
-name: rtd312
+name: rtd313
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.12
+  - python=3.13
   - pip
   - graphviz


### PR DESCRIPTION
cc @pllim 

I think this fixes the problems with `inspect.getsource()` and Python 3.13.

A more minimal reproducer of the original bug is:

```ps1con
PS> py -3.12 bug.py
frm.f_lineno=35    func.__code__.co_firstlineno=31
3.12.4
<function metaclass_init at 0x000001BB07BEDA80>
lnum: 31
found source: True

            def metaclass_init(self, *inputs, **kwargs):
                """Instantiate this class."""
                return super(cls, self).__init__(*inputs, **kwargs)
```

```ps1con
PS> py -3.13 bug.py
frm.f_lineno=35    func.__code__.co_firstlineno=31
3.13.0
<function metaclass_init at 0x0000027B4C2B0860>
lnum: 34
found source: False
```

```python
# bug.py
import abc, sys


def make_function_with_signature(func):
    # Subtract 2 from the line number since the length of the template itself
    # is two lines.  Therefore we have to subtract those off in order for the
    # pointer in tracebacks from __{name}__func to point to the right spot.
    frm = sys._getframe().f_back
    num_blank_lines = frm.f_lineno - 2
    # num_blank_lines = func.__code__.co_firstlineno - 1
    print(f'{frm.f_lineno=}    {func.__code__.co_firstlineno=}')
    blank_lines = '\n' * num_blank_lines
    template = f"""{blank_lines}\
def {func.__name__}(self, *inputs, **kwargs):
    return __{func.__name__}__func(self, *inputs, **kwargs)
"""

    code = compile(template, 'bug.py', 'single')
    locals_ns = {}
    eval(code, {f'__{func.__name__}__func': func}, locals_ns)
    return locals_ns[func.__name__]


class _ModelMeta(abc.ABCMeta):
    def __init__(cls, name, bases, members, /, **kwds):
        super().__init__(name, bases, members, **kwds)

        if True:  # note: indentation required to reproduce.

            def metaclass_init(self, *inputs, **kwargs):
                """Instantiate this class."""
                return super(cls, self).__init__(*inputs, **kwargs)

            new_init = make_function_with_signature(metaclass_init)

        cls.__init__ = new_init


class Model(metaclass=_ModelMeta): ...


if __name__ == '__main__':
    from inspect import getsourcelines
    import sys

    print(sys.version.partition(' ')[0])
    obj = Model.__init__
    print(obj)
    lines, lnum = getsourcelines(obj)
    print('lnum', lnum)
    source = ''.join(lines)
    print('found source:', source != '\n')
    print()
    print(source)
    print()
```

I think `getsource()` in Python 3.12 and earlier worked by accident, as it iterates backwards through the source lines looking for a `def` block. I haven't got a test environment set up for astropy though, so please feel free to close or rework this PR entirely -- I'm just opening to save pasting a diff on the Sphinx issue.

See also #17621, #17614, https://github.com/sphinx-doc/sphinx/issues/13232

A

Fix https://github.com/astropy/astropy/issues/17614