### PR TITLE
TST: Use image for exotic platforms

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -113,8 +113,11 @@ jobs:
       matrix:
         include:
           - arch: s390x
+            image: '--platform=linux/s390x ubuntu:rolling'
           - arch: ppc64le
+            image: '--platform=linux/ppc64le ubuntu:rolling'
           - arch: armv7
+            image: '--platform=linux/armv7 ubuntu:rolling'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -125,8 +128,7 @@ jobs:
         name: Run tests
         id: build
         with:
-          arch: ${{ matrix.arch }}
-          distro: ubuntu_rolling
+          base_image: ${{ matrix.image }}
 
           shell: /bin/bash
           env: |

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -113,11 +113,8 @@ jobs:
       matrix:
         include:
           - arch: s390x
-            image: '--platform=linux/s390x ubuntu:rolling'
           - arch: ppc64le
-            image: '--platform=linux/ppc64le ubuntu:rolling'
           - arch: armv7
-            image: '--platform=linux/armv7 ubuntu:rolling'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -128,7 +125,8 @@ jobs:
         name: Run tests
         id: build
         with:
-          base_image: ${{ matrix.image }}
+          arch: ${{ matrix.arch }}
+          distro: ubuntu22.04
 
           shell: /bin/bash
           env: |

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -126,7 +126,7 @@ jobs:
         id: build
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu22.04
+          distro: ubuntu_rolling
 
           shell: /bin/bash
           env: |
@@ -135,7 +135,9 @@ jobs:
 
           install: |
             apt-get update -q -y
+            apt-get install -q -y clang
             apt-get install -q -y gnupg2
+            CC=clang pyenv install 3.12.3
             # Add test-support repository for wcslib8
             echo "deb http://ppa.launchpadcontent.net/astropy/test-support/ubuntu lunar main" > /etc/apt/sources.list.d/test-support.list
             gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv CC75F07B3EF41EFC


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to use image for exotic platforms instead of arch and distro, as suggested by martin-g in https://github.com/uraimo/run-on-arch-action/issues/160#issuecomment-2613541616

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

* fix #17663
* fix #17664 
* close https://github.com/uraimo/run-on-arch-action/issues/160

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
