### PR TITLE
MNT: update `setuptools-scm` section in `pyproject.toml` (`write_to` option is deprecated)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ wcslint = "astropy.wcs.wcslint:main"
 
 [build-system]
 requires = ["setuptools",
-            "setuptools_scm>=6.2",
+            "setuptools_scm>=8.0.0",
             "cython>=3.0.0, <4",
             "numpy>=2.0.0, <3",
             "extension-helpers>=1,<2"]
@@ -193,7 +193,7 @@ namespaces = true
 "astropy.utils.tests" = ["data/.hidden_file.txt"]
 
 [tool.setuptools_scm]
-write_to = "astropy/_version.py"
+version_file = "astropy/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
### Description
see https://setuptools-scm.readthedocs.io/en/latest/config/

I'm also bumping the minimal requirement for setuptools-scm to 8.0 because it's the first version with the replacement option `version_file`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
