### PR TITLE
samp_hub command line: infer valid --log-level from the logging module

### DIFF
--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -3,6 +3,7 @@
 
 import argparse
 import copy
+import logging
 import sys
 import time
 
@@ -106,16 +107,20 @@ def hub_script(timeout=0):
         "specify the output files where redirect the logging messages.",
     )
 
+    # valid logging levels as strings, reverse ordered by level.
+    # the default 'INFO' is assumed to exist (...)
+    log_levels = sorted(d := logging.getLevelNamesMapping(), key=d.get, reverse=True)
     log_group.add_argument(
         "-L",
         "--log-level",
         dest="loglevel",
         metavar="LEVEL",
-        help="set the Hub instance log level (OFF, ERROR, WARNING, INFO, DEBUG).",
+        help=f"set the Hub instance log level ({', '.join(log_levels)}).",
         type=str,
-        choices=["OFF", "ERROR", "WARNING", "INFO", "DEBUG"],
+        choices=log_levels,
         default="INFO",
     )
+    del log_levels
 
     log_group.add_argument(
         "-O",
@@ -170,8 +175,7 @@ def hub_script(timeout=0):
     options = parser.parse_args()
 
     try:
-        if options.loglevel in ("OFF", "ERROR", "WARNING", "DEBUG", "INFO"):
-            log.setLevel(options.loglevel)
+        log.setLevel(options.loglevel)
 
         if options.logout != "":
             context = log.log_to_file(options.logout)

--- a/astropy/samp/tests/test_hub_script.py
+++ b/astropy/samp/tests/test_hub_script.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 import pytest
@@ -20,7 +21,13 @@ def teardown_function(function):
 
 
 @pytest.mark.slow
-def test_hub_script():
+def test_hub_script(monkeypatch):
+    mock_logger = logging.getLogger(__name__)
+    monkeypatch.setattr("astropy.samp.hub_script.log", mock_logger)
     sys.argv.append("-m")  # run in multiple mode
     sys.argv.append("-w")  # disable web profile
+    sys.argv.extend(["--log-level", "CRITICAL"])  # set the logging level
+
     hub_script(timeout=3)
+
+    assert mock_logger.level == logging.getLevelNamesMapping()["CRITICAL"]

--- a/docs/changes/samp/17673.bugfix.rst
+++ b/docs/changes/samp/17673.bugfix.rst
@@ -1,0 +1,4 @@
+Fix setting logging level from the ``samp_hub`` command line.
+Previously, ``samp_hub --log-level OFF`` was documented as supported but actually caused an exception to be raised.
+The patch infers valid choices from the standard library's ``logging`` module.
+A ``CRITICAL`` level will closely emulate the intended ``OFF`` setting.


### PR DESCRIPTION
Fixes #17670
