### PR TITLE
DOC: fix incorrect description of the `unique` parameter in `Table.add_index`'s docstring. Add missing Raises section.

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1075,8 +1075,17 @@ class Table:
             Indexing engine class to use, either `~astropy.table.SortedArray`,
             `~astropy.table.BST`, or `~astropy.table.SCEngine`. If the supplied
             argument is None (by default), use `~astropy.table.SortedArray`.
-        unique : bool
-            Whether the values of the index must be unique. Default is False.
+        unique : bool (default: False)
+            If set to True, an exception will be raised if duplicate rows exist.
+
+        Raises
+        ------
+        ValueError
+            If any selected column does not support indexing, or has more than
+            one dimension.
+        ValueError
+            If unique=True and duplicate rows are found.
+
         """
         if isinstance(colnames, str):
             colnames = (colnames,)

--- a/docs/changes/table/17677.bugfix.rst
+++ b/docs/changes/table/17677.bugfix.rst
@@ -1,0 +1,2 @@
+Fix incorrect description of the ``unique`` parameter in ``Table.add_index``'s
+docstring. Add missing Raises section.


### PR DESCRIPTION
### Description
Fixes #17672

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
