### PR TITLE
fix: do not crash when using IPython but no kernel is available

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -27,7 +27,8 @@ try:
 except NameError:
     _WITHIN_IPYTHON = False
 else:
-    _WITHIN_IPYTHON = True
+    from IPython import get_ipython
+    _WITHIN_IPYTHON = get_ipython() is not None
 
 __all__ = [
     "CRITICAL",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a crash of astropy when using it in combination with solara (see https://github.com/widgetti/solara/issues/965)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

When _WITHIN_IPYTHON was true, it was assumed a kernel would exists. However, looking at
https://github.com/ipython/ipython/blob/637e037d668db7aebe61ae04261ebfc5cb7f32c5/IPython/core/interactiveshell.py#L788
This only means an interactive shell is available, so we should also check if get_ipython() returns a kernel object.


Fixes https://github.com/widgetti/solara/issues/965

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
