### PR TITLE
Allow passing additional kwargs through NDArithmetic

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -238,12 +238,12 @@ class NDArithmeticMixin:
         # if data and uncertainty are ever used ...)
         kwargs = {}
         kwds2 = {"mask": {}, "meta": {}, "wcs": {}, "data": {}, "uncertainty": {}}
-        for kwd in kwds:
-            splitted = kwd.split("_", 1)
+        for key, kwd in kwds.items():
+            splitted = key.split("_", 1)
             if splitted[0] in kwds2:
-                kwds2[splitted[0]][splitted[1]] = kwds[kwd]
+                kwds2[splitted[0]][splitted[1]] = kwd
             else:
-                kwargs[kwd] = kwds[kwd]
+                kwargs[key] = kwd
 
         # First check that the WCS allows the arithmetic operation
         if compare_wcs is None:

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -236,15 +236,14 @@ class NDArithmeticMixin:
         """
         # Find the appropriate keywords for the appropriate method (not sure
         # if data and uncertainty are ever used ...)
-        kwds2 = {"mask": {}, "meta": {}, "wcs": {}, "data": {}, "uncertainty": {}}
-        for i, kwd in kwds.items():
-            splitted = i.split("_", 1)
-            try:
-                kwds2[splitted[0]][splitted[1]] = kwd
-            except KeyError:
-                raise KeyError(f"Unknown prefix {splitted[0]} for parameter {i}")
-
         kwargs = {}
+        kwds2 = {"mask": {}, "meta": {}, "wcs": {}, "data": {}, "uncertainty": {}}
+        for kwd in kwds:
+            splitted = kwd.split("_", 1)
+            if splitted[0] in kwds2:
+                kwds2[splitted[0]][splitted[1]] = kwds[kwd]
+            else:
+                kwargs[kwd] = kwds[kwd]
 
         # First check that the WCS allows the arithmetic operation
         if compare_wcs is None:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a problem in `specutils` 2.0 (under development). Essentially, there is an initialization keyword needed to create a `Spectrum` object if it's ambiguous which axis corresponds to the spectral axis (we no longer force it to always be the last axis). This means, in cases where that keyword was needed, doing arithmetic on the Spectrum results in a failure to create a new `Spectrum` from the result. This PR solves this by allowing additional initialization keywords to be passed through `NDArithmetic` so that the resulting class instance can be created successfully - a demonstration of how this can be done is shown in the test.

If you all don't want this change, I can probably find another way to handle this in `Spectrum` itself, but this was the first/easiest fix that came to mind.