### PR TITLE
FEAT: Make common Masked subclasses importable for ASDF support

### DIFF
--- a/astropy/utils/masked/tests/test_dynamic_subclasses.py
+++ b/astropy/utils/masked/tests/test_dynamic_subclasses.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test importability of common Masked classes."""
+
+import pytest
+
+from astropy.coordinates.angles.core import Angle, Latitude, Longitude
+from astropy.units.quantity import Quantity
+from astropy.utils.masked import core
+
+
+@pytest.mark.parametrize("base_class", [Quantity, Angle, Latitude, Longitude])
+def test_importable(base_class):
+    assert getattr(core, f"Masked{base_class.__name__}") is core.Masked(base_class)

--- a/docs/changes/utils/17685.feature.rst
+++ b/docs/changes/utils/17685.feature.rst
@@ -1,0 +1,11 @@
+Make commonly used Masked subclasses importable for ASDF support.
+
+Registered types associated with ASDF converters must be importable by
+their fully qualified name. Masked classes are dynamically created and have
+apparent names like ``astropy.utils.masked.core.MaskedQuantity`` although
+they aren't actually attributes of this module. Customize module attribute
+lookup so that certain commonly used Masked classes are importable.
+
+See:
+- https://asdf.readthedocs.io/en/latest/asdf/extending/converters.html#entry-point-performance-considerations
+- https://github.com/astropy/asdf-astropy/pull/253

--- a/docs/changes/utils/17685.feature.rst
+++ b/docs/changes/utils/17685.feature.rst
@@ -7,5 +7,6 @@ they aren't actually attributes of this module. Customize module attribute
 lookup so that certain commonly used Masked classes are importable.
 
 See:
+
 - https://asdf.readthedocs.io/en/latest/asdf/extending/converters.html#entry-point-performance-considerations
 - https://github.com/astropy/asdf-astropy/pull/253


### PR DESCRIPTION
Registered types associated with ASDF converters must be importable by their fully qualified name. Masked classes are dynamically created and have apparent names like
``astropy.utils.masked.core.MaskedQuantity`` although they aren't actually attributes of this module. Customize module attribute lookup so that certain commonly used Masked classes are importable.

See:
- https://asdf.readthedocs.io/en/latest/asdf/extending/converters.html#entry-point-performance-considerations
- https://github.com/astropy/asdf-astropy/pull/253

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
