### PR TITLE
BLD: Temporarily disable aarch64 wheels because they crash non-deterministically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,8 +59,9 @@ jobs:
 
         # Note that following wheels are not currently tested:
 
-        - cp311-manylinux_aarch64
-        - cp312-manylinux_aarch64
+        # FIXME: Also see https://github.com/astropy/astropy/issues/17663
+        #- cp311-manylinux_aarch64
+        #- cp312-manylinux_aarch64
         - cp313-manylinux_aarch64
 
         - cp311-musllinux_x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         # FIXME: Also see https://github.com/astropy/astropy/issues/17663
         #- cp311-manylinux_aarch64
         #- cp312-manylinux_aarch64
-        - cp313-manylinux_aarch64
+        #- cp313-manylinux_aarch64
 
         - cp311-musllinux_x86_64
         - cp312-musllinux_x86_64


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Also see:

* https://github.com/astropy/astropy/issues/17663 (different errors but linked upstream issues probably related)
* https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2613863177
* https://github.com/tonistiigi/binfmt/issues/215

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Without this patch, the wheels build skips the upload step, causing our nightly dev wheel not be updated nightly, impacting all the other archs.

- [ ] After merge, open follow up issue to revert before v7.1 release process starts.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
