### PR TITLE
BUG: Table can be created empty with rows=[] to be same as rows=None

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -732,10 +732,14 @@ class Table:
         # a list of dict. If data are not list of dict then this is None.
         names_from_list_of_dict = None
 
+        # Treat empty rows same as None case.
+        if isinstance(rows, (list, tuple)) and len(rows) < 1:
+            rows = None
+
         # Row-oriented input, e.g. list of lists or list of tuples, list of
         # dict, Row instance.  Set data to something that the subsequent code
         # will parse correctly.
-        if rows is not None and len(rows) > 0:
+        if rows is not None:
             if data is not None:
                 raise ValueError("Cannot supply both `data` and `rows` values")
             if isinstance(rows, types.GeneratorType):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -732,20 +732,6 @@ class Table:
         # a list of dict. If data are not list of dict then this is None.
         names_from_list_of_dict = None
 
-        # Treat empty rows same as None case.
-        if isinstance(rows, (list, tuple, np.ndarray)):
-            try:
-                # Any warning means rows not empty, so abort.
-                with warnings.catch_warnings():
-                    warnings.simplefilter("error")
-                    x = np.asarray(rows)
-            except Exception:
-                # Skip if check not feasible, don't fail # pragma: no cover
-                pass
-            else:
-                if x.size == 0:  # Empty array could still have valid shape
-                    rows = None
-
         # Row-oriented input, e.g. list of lists or list of tuples, list of
         # dict, Row instance.  Set data to something that the subsequent code
         # will parse correctly.
@@ -796,6 +782,13 @@ class Table:
             )
 
         if isinstance(data, np.ndarray) and data.shape == (0,) and not data.dtype.names:
+            data = None
+
+        # Init with rows=[] or data=[] (or tuples) is allowed and taken to mean no data.
+        # This allows supplying names and dtype if desired. `data=[]` is ambiguous,
+        # because it could mean no columns, or it could mean no rows for list of dict.
+        # For compatibility with the latter, interpret data=[] as data=None.
+        if isinstance(data, (list, tuple)) and len(data) == 0:
             data = None
 
         if isinstance(data, self.Row):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -733,8 +733,15 @@ class Table:
         names_from_list_of_dict = None
 
         # Treat empty rows same as None case.
-        if isinstance(rows, (list, tuple)) and len(rows) < 1:
-            rows = None
+        if isinstance(rows, (list, tuple, np.ndarray)):
+            try:
+                x = np.asarray(rows)
+            except Exception:
+                # Skip if check not feasible, don't fail # pragma: no cover
+                pass
+            else:
+                if x.size == 0:  # Empty array could still have valid shape
+                    rows = None
 
         # Row-oriented input, e.g. list of lists or list of tuples, list of
         # dict, Row instance.  Set data to something that the subsequent code

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -735,7 +735,10 @@ class Table:
         # Treat empty rows same as None case.
         if isinstance(rows, (list, tuple, np.ndarray)):
             try:
-                x = np.asarray(rows)
+                # Any warning means rows not empty, so abort.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error")
+                    x = np.asarray(rows)
             except Exception:
                 # Skip if check not feasible, don't fail # pragma: no cover
                 pass

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -735,7 +735,7 @@ class Table:
         # Row-oriented input, e.g. list of lists or list of tuples, list of
         # dict, Row instance.  Set data to something that the subsequent code
         # will parse correctly.
-        if rows is not None:
+        if rows is not None and len(rows) > 0:
             if data is not None:
                 raise ValueError("Cannot supply both `data` and `rows` values")
             if isinstance(rows, types.GeneratorType):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3594,7 +3594,9 @@ def test_table_replace_column_with_scalar(empty_table):
         t.replace_column("a", 2)
 
 
-@pytest.mark.parametrize("rows", [None, [], (), np.array([])])
+@pytest.mark.parametrize(
+    "rows", [None, [], [[], []], (), ((), ()), np.array([]), np.array([[], []])]
+)
 def test_table_create_no_rows(rows):
     t = Table(rows=rows, names=["foo", "bar"], dtype=[int, int])
     assert len(t) == 0

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3592,3 +3592,10 @@ def test_table_replace_column_with_scalar(empty_table):
     # Direct replacement should never work.
     with pytest.raises(ValueError, match="cannot replace.*with a scalar"):
         t.replace_column("a", 2)
+
+
+@pytest.mark.parametrize("rows", [[], None])
+def test_table_create_no_rows(rows):
+    t = Table(rows=rows, names=["foo", "bar"], dtype=[int, int])
+    assert len(t) == 0
+    assert t.colnames == ["foo", "bar"]

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3594,7 +3594,7 @@ def test_table_replace_column_with_scalar(empty_table):
         t.replace_column("a", 2)
 
 
-@pytest.mark.parametrize("rows", [[], None])
+@pytest.mark.parametrize("rows", [[], (), None])
 def test_table_create_no_rows(rows):
     t = Table(rows=rows, names=["foo", "bar"], dtype=[int, int])
     assert len(t) == 0

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3594,7 +3594,7 @@ def test_table_replace_column_with_scalar(empty_table):
         t.replace_column("a", 2)
 
 
-@pytest.mark.parametrize("rows", [[], (), None])
+@pytest.mark.parametrize("rows", [None, [], (), np.array([])])
 def test_table_create_no_rows(rows):
     t = Table(rows=rows, names=["foo", "bar"], dtype=[int, int])
     assert len(t) == 0

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3600,6 +3600,15 @@ def test_table_replace_column_with_scalar(empty_table):
 @pytest.mark.parametrize("arg_type", ["rows", "data"])
 def test_table_create_no_rows(arg_type, arr):
     kwargs = {arg_type: arr}
-    t = Table(names=["foo", "bar"], dtype=[int, int], **kwargs)
-    assert len(t) == 0
-    assert t.colnames == ["foo", "bar"]
+
+    if arg_type == "data" and isinstance(arr, np.ndarray) and arr.shape == (2, 0):
+        # np.array() is always interpreted as row-ordered, so
+        # np.array([[], []]) is a 2-row table of 0 columns and should throw error.
+        ctx = pytest.raises(ValueError, match=".* must match number of columns")
+    else:
+        ctx = nullcontext()
+
+    with ctx:
+        t = Table(names=["foo", "bar"], dtype=[int, int], **kwargs)
+        assert len(t) == 0
+        assert t.colnames == ["foo", "bar"]

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3595,9 +3595,11 @@ def test_table_replace_column_with_scalar(empty_table):
 
 
 @pytest.mark.parametrize(
-    "rows", [None, [], [[], []], (), ((), ()), np.array([]), np.array([[], []])]
+    "arr", [None, [], [[], []], (), ((), ()), np.array([]), np.array([[], []])]
 )
-def test_table_create_no_rows(rows):
-    t = Table(rows=rows, names=["foo", "bar"], dtype=[int, int])
+@pytest.mark.parametrize("arg_type", ["rows", "data"])
+def test_table_create_no_rows(arg_type, arr):
+    kwargs = {arg_type: arr}
+    t = Table(names=["foo", "bar"], dtype=[int, int], **kwargs)
     assert len(t) == 0
     assert t.colnames == ["foo", "bar"]

--- a/docs/changes/table/17689.bugfix.rst
+++ b/docs/changes/table/17689.bugfix.rst
@@ -1,0 +1,1 @@
+``rows=[]`` now behaves like ``rows=None`` when creating a Table with no data.

--- a/docs/changes/table/17689.bugfix.rst
+++ b/docs/changes/table/17689.bugfix.rst
@@ -1,1 +1,5 @@
-``rows=[]`` now behaves like ``rows=None`` when creating a Table with no data.
+Initializing a Table with ``rows=[]`` or ``data=[]`` is now equivalent to
+``Table(data=None, ...)`` and creates a table with no data values. This allows
+defining the table names and/or dtype when creating the table, for instance:
+``Table(rows=[], names=["a", "b"], dtype=[int, float])``. Previously this
+raised an exception.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the inability to create empty table with `rows=[]`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17688

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
