### PR TITLE
ENH: also catch `TimeoutError`s in `download_file`

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1548,6 +1548,10 @@ def download_file(
                 e.reason.strerror = f"{e.reason.strerror}. requested URL: {remote_url}"
                 e.reason.args = (e.reason.errno, e.reason.strerror)
             errors[source_url] = e
+
+        except TimeoutError as e:
+            errors[source_url] = e
+
     else:  # No success
         if not sources:
             raise KeyError(

--- a/docs/changes/utils/17691.feature.rst
+++ b/docs/changes/utils/17691.feature.rst
@@ -1,0 +1,4 @@
+``astropy.utils.data.download_file`` can now recover from a ``TimeoutError``
+when given a list of alternative source URLs. Previously, only ``URLError``
+exceptions were recoverable. An exception is still being raised after trying all
+URLs provided if none of them could be reached.


### PR DESCRIPTION
### Description
Close #17690
Although trivial to fix, this seems difficult to systematically test.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
