### PR TITLE
Fixed a numerical-precision bug with the Cylindrical->PhysicsSpherical conversion

### DIFF
--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -144,7 +144,7 @@ class CylindricalRepresentation(BaseRepresentation):
                 r = np.hypot(self.rho, self.z)
                 return other_class(
                     r=r,
-                    theta=np.arccos(self.z / r),
+                    theta=np.arctan2(self.rho, self.z),
                     phi=self.phi,
                     differentials=diffs,
                 )

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1446,6 +1446,14 @@ class TestCylindricalRepresentation:
         assert_allclose(sph.theta, 0 * u.deg)
         assert cyl.phi == 23.5 * u.deg  # phi is preserved exactly
 
+    def test_to_physicsspherical_small_theta(self):
+        """Test that the transformation to physicsspherical is accurate for small theta."""
+        cyl = CylindricalRepresentation(rho=1 * u.m, phi=10 * u.deg, z=1e8 * u.m)
+        got = cyl.represent_as(PhysicsSphericalRepresentation)
+        assert_allclose(got.r, 1e8 * u.m)
+        assert_allclose(got.phi, 10 * u.deg)
+        assert_allclose(got.theta, 1e-8 * u.rad)
+
 
 class TestUnitSphericalCosLatDifferential:
     @pytest.mark.parametrize("matrix", list(matrices.values()))

--- a/docs/changes/coordinates/17693.bugfix.rst
+++ b/docs/changes/coordinates/17693.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a numerical-precision bug with the calculation of the ``theta``
+component when converting from ``CylindricalRepresentation`` to
+``PhysicsSphericalRepresentation`` for vectors very close to the Z axis (within
+milliarcseconds).


### PR DESCRIPTION
The fast-path conversion from CylindricalRepresentation to PhysicsSphericalRepresentation (#16135) has a numerical-precision issue when the vector is very close to the Z axis (within milliarcseconds).  This is due to the use of `np.arccos()` instead of `np.arctan2()`.

Before this PR:
```python
>>> CylindricalRepresentation(1*u.m, 0*u.deg, 1e8*u.m).represent_as(PhysicsSphericalRepresentation).theta
<Angle 0. rad>
```

After this PR:
```python
>>> CylindricalRepresentation(1*u.m, 0*u.deg, 1e8*u.m).represent_as(PhysicsSphericalRepresentation).theta
<Angle 1.e-08 rad>
```