### PR TITLE
Backport PR #17692 on branch v7.0.x (Implement zebi and yobi binary prefixes)

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2506,6 +2506,8 @@ binary_prefixes: Final[list[tuple[list[str], list[str], int]]] = [
     (["Ti"], ["tebi"], 2**40),
     (["Pi"], ["pebi"], 2**50),
     (["Ei"], ["exbi"], 2**60),
+    (["Zi"], ["zebi"], 2**70),
+    (["Yi"], ["yobi"], 2**80),
 ]
 
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -63,9 +63,7 @@ class VOUnit(FITS):
             "y", "z", "a", "f", "p", "n", "u", "m", "c", "d",
             "", "da", "h", "k", "M", "G", "T", "P", "E", "Z", "Y"
         ]  # fmt: skip
-        # While zebi and yobi are part of the standard for binary prefixes,
-        # they are not implemented here due to computation limitations
-        binary_prefixes = ["Ki", "Mi", "Gi", "Ti", "Pi", "Ei"]
+        binary_prefixes = ["Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"]
         deprecated_units = {"angstrom", "Angstrom", "Ba", "barn", "erg", "G", "ta"}
 
         def do_defines(bases, prefixes, skips=[]):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -475,7 +475,7 @@ class TestRoundtripOGIP(RoundtripBase):
 
 @pytest.mark.parametrize(
     "unit_formatter_class,n_units",
-    [(u_format.FITS, 765), (u_format.VOUnit, 1297), (u_format.CDS, 3124)],
+    [(u_format.FITS, 765), (u_format.VOUnit, 1303), (u_format.CDS, 3326)],
 )
 def test_units_available(unit_formatter_class, n_units):
     assert len(unit_formatter_class._units) == n_units

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1049,6 +1049,35 @@ def test_si_prefixes(name, symbol, multiplying_factor):
     assert u.isclose(value_ratio, multiplying_factor)
 
 
+@pytest.mark.parametrize(
+    "name,symbol,factor",
+    [
+        pytest.param(name, symbol, factor, id=name)
+        for name, symbol, factor in [
+            ("kibi", "Ki", 2**10),
+            ("mebi", "Mi", 2**20),
+            ("gibi", "Gi", 2**30),
+            ("tebi", "Ti", 2**40),
+            ("pebi", "Pi", 2**50),
+            ("exbi", "Ei", 2**60),
+            # We now switch to float factors because with numpy < 2.0
+            # np.isclose() doesn't like ints this large
+            ("zebi", "Zi", 2.0**70),
+            ("yobi", "Yi", 2.0**80),
+        ]
+    ],
+)
+def test_si_binary_prefixes(name, symbol, factor):
+    base = 1 * u.byte
+    quantity_from_name = base.to(f"{name}byte")
+    assert u.isclose(quantity_from_name, base)
+    assert np.isclose(base.value / quantity_from_name.value, factor, atol=0)
+
+    quantity_from_symbol = base.to(f"{symbol}B")
+    assert u.isclose(quantity_from_symbol, base)
+    assert np.isclose(base.value / quantity_from_symbol.value, factor, atol=0)
+
+
 def test_cm_uniqueness():
     # Ensure we have defined cm only once; see gh-15200.
     assert u.si.cm is u.cgs.cm is u.cm

--- a/docs/changes/units/17692.bugfix.rst
+++ b/docs/changes/units/17692.bugfix.rst
@@ -1,0 +1,1 @@
+The zebi (Zi, 2^70) and yobi (Yi, 2^80) binary prefixes are now supported.

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -55,8 +55,8 @@ Prefixes
 
 Most units can be used with prefixes, with both the standard `SI
 <https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf>`_ prefixes
-and the `IEEE 1514-2002
-<https://ieeexplore.ieee.org/document/5254933>`_ binary prefixes
+and the `IEEE 1541-2021
+<https://ieeexplore.ieee.org/document/9714443>`_ binary prefixes
 (for ``bit`` and ``byte``) supported:
 
 +------------------------------+
@@ -129,6 +129,10 @@ and the `IEEE 1514-2002
 |   Pi   |  pebi- | 2 ** 50 |
 +--------+--------+---------+
 |   Ei   |  exbi- | 2 ** 60 |
++--------+--------+---------+
+|   Zi   |  zebi- | 2 ** 70 |
++--------+--------+---------+
+|   Yi   |  yobi- | 2 ** 80 |
 +--------+--------+---------+
 
 


### PR DESCRIPTION
### Description
Manual backport for #17692 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
