### PR TITLE
cosmo: feat: “traits” module

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -7,7 +7,7 @@ measures and other cosmology-related calculations.
 See the :ref:`astropy-cosmology` for more detailed usage examples and references.
 """
 
-from . import io, realizations, units
+from . import io, realizations, traits, units
 from ._src.core import Cosmology, CosmologyError, FlatCosmologyMixin
 from ._src.flrw import (
     FLRW,
@@ -31,6 +31,7 @@ __all__ = [  #  noqa: RUF100, RUF022
     # Public Submodules
     "realizations",
     "units",
+    "traits",
     "io",
     # Core
     "Cosmology",

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -37,9 +37,9 @@ from astropy.cosmology._src.parameter import (
 )
 from astropy.cosmology._src.traits import (
     ScaleFactor,
+    TemperatureCMB,
     _BaryonComponent,
     _CriticalDensity,
-    _TemperatureCMB,
 )
 from astropy.cosmology._src.utils import (
     aszarr,
@@ -97,7 +97,7 @@ ParameterOde0 = Parameter(
 
 
 @dataclass_decorator
-class FLRW(Cosmology, ScaleFactor, _TemperatureCMB, _CriticalDensity, _BaryonComponent):
+class FLRW(Cosmology, ScaleFactor, TemperatureCMB, _CriticalDensity, _BaryonComponent):
     """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
     This is an abstract base class -- you cannot instantiate examples of this

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -13,7 +13,7 @@ from functools import cached_property
 from inspect import signature
 from math import exp, floor, log, pi, sqrt
 from numbers import Number
-from typing import TYPE_CHECKING, Any, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 import numpy as np
 from numpy import inf, sin
@@ -35,6 +35,12 @@ from astropy.cosmology._src.parameter import (
     validate_non_negative,
     validate_with_unit,
 )
+from astropy.cosmology._src.traits import (
+    ScaleFactor,
+    _BaryonComponent,
+    _CriticalDensity,
+    _TemperatureCMB,
+)
 from astropy.cosmology._src.utils import (
     aszarr,
     deprecated_keywords,
@@ -42,12 +48,10 @@ from astropy.cosmology._src.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Mapping
     from typing import Self
 
-    from numpy.typing import ArrayLike, NDArray
-
-    from astropy.units import Quantity
+    import astropy.units
 
 
 # isort: split
@@ -86,154 +90,6 @@ _FlatFLRWMixinT = TypeVar("_FlatFLRWMixinT", bound="FlatFLRWMixin")
 ##############################################################################
 
 
-class _ScaleFactor:
-    """The object has attributes and methods for computing the cosmological scale factor.
-
-    The scale factor is defined as :math:`a = 1 / (1 + z)`.
-
-    Attributes
-    ----------
-    scale_factor0 : `~astropy.units.Quantity`
-        Scale factor at redshift 0.
-
-    Methods
-    -------
-    scale_factor
-        Compute the scale factor at a given redshift.
-    """
-
-    @property
-    def scale_factor0(self) -> Quantity:
-        r"""Scale factor at redshift 0.
-
-        The scale factor is defined as :math:`a = \frac{a_0}{1 + z}`. The common
-        convention is to set :math:`a_0 = 1`. However, in some cases, e.g. in
-        some old CMB papers, :math:`a_0` is used to normalize `a` to be a
-        convenient number at the redshift of interest for that paper. Explicitly
-        using :math:`a_0` in both calculation and code avoids ambiguity.
-        """
-        return self.scale_factor(0) << u.one
-
-    @deprecated_keywords("z", since="7.0")
-    def scale_factor(self, z: Quantity | ArrayLike) -> Quantity | NDArray[Any] | float:
-        """Scale factor at redshift ``z``.
-
-        The scale factor is defined as :math:`a = 1 / (1 + z)`.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'] | array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        |Quantity| | ndarray | float
-            Scale factor at each input redshift.
-            Returns `float` if the input is scalar.
-        """
-        return 1.0 / (aszarr(z) + 1.0)
-
-
-class _TemperatureCMB:
-    """The object has attributes and methods for computing the cosmological background temperature.
-
-    Attributes
-    ----------
-    Tcmb0 : |Quantity|
-        Temperature of the CMB at redshift 0.
-
-    Methods
-    -------
-    Tcmb
-        Compute the CMB temperature at a given redshift.
-    """
-
-    Tcmb0: Quantity
-    """Temperature of the CMB as |Quantity| at z=0."""
-
-    @deprecated_keywords("z", since="7.0")
-    def Tcmb(self, z: Quantity | ArrayLike) -> Quantity:
-        """Return the CMB temperature at redshift ``z``.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        Tcmb : Quantity ['temperature']
-            The temperature of the CMB in K.
-        """
-        return self.Tcmb0 * (aszarr(z) + 1.0)
-
-
-class _CriticalDensity:
-    """The object has attributes and methods for the critical density."""
-
-    critical_density0: Quantity
-    """Critical density at redshift 0."""
-
-    efunc: Callable[[Any], NDArray[Any]]
-
-    @deprecated_keywords("z", since="7.0")
-    def critical_density(self, z: Quantity | ArrayLike) -> Quantity:
-        """Critical density in grams per cubic cm at redshift ``z``.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        rho : Quantity ['mass density']
-            Critical density at each input redshift.
-        """
-        return self.critical_density0 * self.efunc(z) ** 2
-
-
-class _BaryonComponent:
-    """The cosmology has attributes and methods for the baryon density."""
-
-    Ob0: float
-    """Omega baryons: density of baryonic matter in units of the critical density at z=0."""
-
-    inv_efunc: Callable[[NDArray[Any]], NDArray[Any]]
-
-    @deprecated_keywords("z", since="7.0")
-    def Ob(self, z: Quantity | ArrayLike) -> NDArray[Any] | float:
-        """Return the density parameter for baryonic matter at redshift ``z``.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        Ob : ndarray or float
-            The density of baryonic matter relative to the critical density at
-            each redshift.
-            Returns `float` if the input is scalar.
-
-        """
-        z = aszarr(z)
-        return self.Ob0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2
-
-
 ParameterOde0 = Parameter(
     doc="Omega dark energy; dark energy density/critical density at z=0.",
     fvalidate="float",
@@ -241,9 +97,7 @@ ParameterOde0 = Parameter(
 
 
 @dataclass_decorator
-class FLRW(
-    Cosmology, _ScaleFactor, _TemperatureCMB, _CriticalDensity, _BaryonComponent
-):
+class FLRW(Cosmology, ScaleFactor, _TemperatureCMB, _CriticalDensity, _BaryonComponent):
     """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
     This is an abstract base class -- you cannot instantiate examples of this
@@ -1226,14 +1080,16 @@ class FLRW(
     # Comoving distance
 
     @overload
-    def comoving_distance(self, z: _InputT) -> Quantity: ...
+    def comoving_distance(self, z: _InputT) -> astropy.units.Quantity: ...
 
     @overload
-    def comoving_distance(self, z: _InputT, z2: _InputT) -> Quantity: ...
+    def comoving_distance(self, z: _InputT, z2: _InputT) -> astropy.units.Quantity: ...
 
     @deprecated_keywords("z2", since="7.1")
     @deprecated_keywords("z", since="7.0")
-    def comoving_distance(self, z: _InputT, z2: _InputT | None = None) -> Quantity:
+    def comoving_distance(
+        self, z: _InputT, z2: _InputT | None = None
+    ) -> astropy.units.Quantity:
         r"""Comoving line-of-sight distance :math:`d_c(z1, z2)` in Mpc.
 
         The comoving distance along the line-of-sight between two objects

--- a/astropy/cosmology/_src/traits/__init__.py
+++ b/astropy/cosmology/_src/traits/__init__.py
@@ -6,12 +6,12 @@ The public API is provided by `astropy.cosmology.parts`.
 
 __all__ = [
     "ScaleFactor",
+    "TemperatureCMB",
     "_BaryonComponent",
     "_CriticalDensity",
-    "_TemperatureCMB",
 ]
 
 from .baryons import _BaryonComponent
 from .rhocrit import _CriticalDensity
 from .scale_factor import ScaleFactor
-from .tcmb import _TemperatureCMB
+from .tcmb import TemperatureCMB

--- a/astropy/cosmology/_src/traits/__init__.py
+++ b/astropy/cosmology/_src/traits/__init__.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Astropy Cosmology. **NOT public API**.
+
+The public API is provided by `astropy.cosmology.parts`.
+"""
+
+__all__ = [
+    "ScaleFactor",
+    "_BaryonComponent",
+    "_CriticalDensity",
+    "_TemperatureCMB",
+]
+
+from .baryons import _BaryonComponent
+from .rhocrit import _CriticalDensity
+from .scale_factor import ScaleFactor
+from .tcmb import _TemperatureCMB

--- a/astropy/cosmology/_src/traits/__init__.py
+++ b/astropy/cosmology/_src/traits/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Astropy Cosmology. **NOT public API**.
 
-The public API is provided by `astropy.cosmology.parts`.
+The public API is provided by `astropy.cosmology.traits`.
 """
 
 __all__ = [

--- a/astropy/cosmology/_src/traits/baryons.py
+++ b/astropy/cosmology/_src/traits/baryons.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Baryon component.
+
+This is private API. See `~astropy.cosmology.parts` for public API.
+
+"""
+
+__all__ = ["_BaryonComponent"]
+
+from collections.abc import Callable
+from typing import Any
+
+from numpy.typing import ArrayLike, NDArray
+
+from astropy.cosmology._src.utils import aszarr, deprecated_keywords
+from astropy.units import Quantity
+
+
+class _BaryonComponent:
+    """The cosmology has attributes and methods for the baryon density."""
+
+    Ob0: float
+    """Omega baryons: density of baryonic matter in units of the critical density at z=0."""
+
+    inv_efunc: Callable[[NDArray[Any]], NDArray[Any]]
+
+    @deprecated_keywords("z", since="7.0")
+    def Ob(self, z: Quantity | ArrayLike) -> NDArray[Any] | float:
+        """Return the density parameter for baryonic matter at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        Ob : ndarray or float
+            The density of baryonic matter relative to the critical density at
+            each redshift.
+            Returns `float` if the input is scalar.
+
+        """
+        z = aszarr(z)
+        return self.Ob0 * (z + 1.0) ** 3 * self.inv_efunc(z) ** 2

--- a/astropy/cosmology/_src/traits/baryons.py
+++ b/astropy/cosmology/_src/traits/baryons.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Baryon component.
 
-This is private API. See `~astropy.cosmology.parts` for public API.
+This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
 

--- a/astropy/cosmology/_src/traits/rhocrit.py
+++ b/astropy/cosmology/_src/traits/rhocrit.py
@@ -1,0 +1,44 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Critical density.
+
+This is private API. See `~astropy.cosmology.parts` for public API.
+
+"""
+
+__all__ = ["_CriticalDensity"]
+
+from collections.abc import Callable
+from typing import Any
+
+from numpy.typing import ArrayLike, NDArray
+
+from astropy.cosmology._src.utils import deprecated_keywords
+from astropy.units import Quantity
+
+
+class _CriticalDensity:
+    """The object has attributes and methods for the critical density."""
+
+    critical_density0: Quantity
+    """Critical density at redshift 0."""
+
+    efunc: Callable[[Any], NDArray[Any]]
+
+    @deprecated_keywords("z", since="7.0")
+    def critical_density(self, z: Quantity | ArrayLike) -> Quantity:
+        """Critical density in grams per cubic cm at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        rho : Quantity ['mass density']
+            Critical density at each input redshift.
+        """
+        return self.critical_density0 * self.efunc(z) ** 2

--- a/astropy/cosmology/_src/traits/rhocrit.py
+++ b/astropy/cosmology/_src/traits/rhocrit.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Critical density.
 
-This is private API. See `~astropy.cosmology.parts` for public API.
+This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
 

--- a/astropy/cosmology/_src/traits/scale_factor.py
+++ b/astropy/cosmology/_src/traits/scale_factor.py
@@ -1,9 +1,9 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Scale factor.
 
-This is private API. See `~astropy.cosmology.parts` for public API.
+This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 __all__ = ["ScaleFactor"]
 
@@ -15,7 +15,7 @@ from astropy.cosmology._src.utils import aszarr, deprecated_keywords
 
 
 class ScaleFactor:
-    """The object has attributes and methods for computing the cosmological scale factor.
+    """The trait for computing the cosmological scale factor.
 
     The scale factor is defined as :math:`a = a_0 / (1 + z)`.
 
@@ -25,17 +25,17 @@ class ScaleFactor:
     def scale_factor0(self) -> u.Quantity:
         r"""Scale factor at redshift 0.
 
-        The scale factor is defined as :math:`a = \frac{a_0}{1 + z}`. The common
-        convention is to set :math:`a_0 = 1`. However, in some cases, e.g. in
-        some old CMB papers, :math:`a_0` is used to normalize `a` to be a
-        convenient number at the redshift of interest for that paper. Explicitly
-        using :math:`a_0` in both calculation and code avoids ambiguity.
+        The scale factor is defined as :math:`a = a_0 / (1 + z)`. The common convention
+        is to set :math:`a_0 = 1`. However, in some cases, like in some old CMB papers,
+        :math:`a_0` is used to normalize `a` to be a convenient number at the redshift
+        of interest for that paper. Explicitly using :math:`a_0` in both calculation and
+        code avoids ambiguity.
         """
         return 1 << u.one
 
     @deprecated_keywords("z", since="7.0")
     def scale_factor(self, z: u.Quantity | ArrayLike) -> u.Quantity:
-        """Scale factor at redshift ``z``.
+        """Compute the scale factor at redshift ``z``.
 
         The scale factor is defined as :math:`a = a_0 / (1 + z)`.
 
@@ -49,8 +49,7 @@ class ScaleFactor:
 
         Returns
         -------
-        |Quantity| | ndarray | float
+        |Quantity|
             Scale factor at each input redshift.
-            Returns `float` if the input is scalar.
         """
         return self.scale_factor0 / (aszarr(z) + 1)

--- a/astropy/cosmology/_src/traits/scale_factor.py
+++ b/astropy/cosmology/_src/traits/scale_factor.py
@@ -1,0 +1,56 @@
+"""Scale factor.
+
+This is private API. See `~astropy.cosmology.parts` for public API.
+
+"""
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+__all__ = ["ScaleFactor"]
+
+
+from numpy.typing import ArrayLike
+
+import astropy.units as u
+from astropy.cosmology._src.utils import aszarr, deprecated_keywords
+
+
+class ScaleFactor:
+    """The object has attributes and methods for computing the cosmological scale factor.
+
+    The scale factor is defined as :math:`a = 1 / (1 + z)`.
+
+    """
+
+    @property
+    def scale_factor0(self) -> u.Quantity:
+        r"""Scale factor at redshift 0.
+
+        The scale factor is defined as :math:`a = \frac{a_0}{1 + z}`. The common
+        convention is to set :math:`a_0 = 1`. However, in some cases, e.g. in
+        some old CMB papers, :math:`a_0` is used to normalize `a` to be a
+        convenient number at the redshift of interest for that paper. Explicitly
+        using :math:`a_0` in both calculation and code avoids ambiguity.
+        """
+        return self.scale_factor(0)
+
+    @deprecated_keywords("z", since="7.0")
+    def scale_factor(self, z: u.Quantity | ArrayLike) -> u.Quantity:
+        """Scale factor at redshift ``z``.
+
+        The scale factor is defined as :math:`a = 1 / (1 + z)`.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'] | array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        |Quantity| | ndarray | float
+            Scale factor at each input redshift.
+            Returns `float` if the input is scalar.
+        """
+        return (1.0 / (aszarr(z) + 1.0)) << u.one

--- a/astropy/cosmology/_src/traits/scale_factor.py
+++ b/astropy/cosmology/_src/traits/scale_factor.py
@@ -17,7 +17,7 @@ from astropy.cosmology._src.utils import aszarr, deprecated_keywords
 class ScaleFactor:
     """The object has attributes and methods for computing the cosmological scale factor.
 
-    The scale factor is defined as :math:`a = 1 / (1 + z)`.
+    The scale factor is defined as :math:`a = a_0 / (1 + z)`.
 
     """
 
@@ -31,13 +31,13 @@ class ScaleFactor:
         convenient number at the redshift of interest for that paper. Explicitly
         using :math:`a_0` in both calculation and code avoids ambiguity.
         """
-        return self.scale_factor(0)
+        return 1 << u.one
 
     @deprecated_keywords("z", since="7.0")
     def scale_factor(self, z: u.Quantity | ArrayLike) -> u.Quantity:
         """Scale factor at redshift ``z``.
 
-        The scale factor is defined as :math:`a = 1 / (1 + z)`.
+        The scale factor is defined as :math:`a = a_0 / (1 + z)`.
 
         Parameters
         ----------
@@ -53,4 +53,4 @@ class ScaleFactor:
             Scale factor at each input redshift.
             Returns `float` if the input is scalar.
         """
-        return (1.0 / (aszarr(z) + 1.0)) << u.one
+        return self.scale_factor0 / (aszarr(z) + 1)

--- a/astropy/cosmology/_src/traits/tcmb.py
+++ b/astropy/cosmology/_src/traits/tcmb.py
@@ -5,7 +5,7 @@ This is private API. See `~astropy.cosmology.parts` for public API.
 
 """
 
-__all__ = ["_TemperatureCMB"]
+__all__ = ["TemperatureCMB"]
 
 
 from numpy.typing import ArrayLike
@@ -14,22 +14,11 @@ from astropy.cosmology._src.utils import aszarr, deprecated_keywords
 from astropy.units import Quantity
 
 
-class _TemperatureCMB:
-    """The object has attributes and methods for computing the cosmological background temperature.
-
-    Attributes
-    ----------
-    Tcmb0 : |Quantity|
-        Temperature of the CMB at redshift 0.
-
-    Methods
-    -------
-    Tcmb
-        Compute the CMB temperature at a given redshift.
-    """
+class TemperatureCMB:
+    """The object has attributes and methods for computing the cosmological background temperature."""
 
     Tcmb0: Quantity
-    """Temperature of the CMB as |Quantity| at z=0."""
+    """Temperature of the CMB at z=0."""
 
     @deprecated_keywords("z", since="7.0")
     def Tcmb(self, z: Quantity | ArrayLike) -> Quantity:
@@ -47,5 +36,22 @@ class _TemperatureCMB:
         -------
         Tcmb : Quantity ['temperature']
             The temperature of the CMB in K.
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> from astropy.cosmology import Planck18, units as cu
+
+        >>> Planck18.Tcmb(u.Quantity([0.5, 1.0], cu.redshift))
+        <Quantity [4.08825, 5.451  ] K>
+
+        >>> Planck18.Tcmb(u.Quantity(0.5, ''))
+        <Quantity 4.08825 K>
+
+        >>> Planck18.Tcmb(0.5)
+        <Quantity 4.08825 K>
+
+        >>> Planck18.Tcmb([0.5, 1.0])
+        <Quantity [4.08825, 5.451  ] K>
         """
         return self.Tcmb0 * (aszarr(z) + 1.0)

--- a/astropy/cosmology/_src/traits/tcmb.py
+++ b/astropy/cosmology/_src/traits/tcmb.py
@@ -1,0 +1,51 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""CMB Temperature.
+
+This is private API. See `~astropy.cosmology.parts` for public API.
+
+"""
+
+__all__ = ["_TemperatureCMB"]
+
+
+from numpy.typing import ArrayLike
+
+from astropy.cosmology._src.utils import aszarr, deprecated_keywords
+from astropy.units import Quantity
+
+
+class _TemperatureCMB:
+    """The object has attributes and methods for computing the cosmological background temperature.
+
+    Attributes
+    ----------
+    Tcmb0 : |Quantity|
+        Temperature of the CMB at redshift 0.
+
+    Methods
+    -------
+    Tcmb
+        Compute the CMB temperature at a given redshift.
+    """
+
+    Tcmb0: Quantity
+    """Temperature of the CMB as |Quantity| at z=0."""
+
+    @deprecated_keywords("z", since="7.0")
+    def Tcmb(self, z: Quantity | ArrayLike) -> Quantity:
+        """Return the CMB temperature at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        Tcmb : Quantity ['temperature']
+            The temperature of the CMB in K.
+        """
+        return self.Tcmb0 * (aszarr(z) + 1.0)

--- a/astropy/cosmology/_src/traits/tcmb.py
+++ b/astropy/cosmology/_src/traits/tcmb.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """CMB Temperature.
 
-This is private API. See `~astropy.cosmology.parts` for public API.
+This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
 
@@ -15,14 +15,14 @@ from astropy.units import Quantity
 
 
 class TemperatureCMB:
-    """The object has attributes and methods for computing the cosmological background temperature."""
+    """The trait for computing the cosmological background temperature."""
 
     Tcmb0: Quantity
     """Temperature of the CMB at z=0."""
 
     @deprecated_keywords("z", since="7.0")
     def Tcmb(self, z: Quantity | ArrayLike) -> Quantity:
-        """Return the CMB temperature at redshift ``z``.
+        """Compute the CMB temperature at redshift ``z``.
 
         Parameters
         ----------
@@ -35,7 +35,7 @@ class TemperatureCMB:
         Returns
         -------
         Tcmb : Quantity ['temperature']
-            The temperature of the CMB in K.
+            The temperature of the CMB.
 
         Examples
         --------

--- a/astropy/cosmology/traits.py
+++ b/astropy/cosmology/traits.py
@@ -1,0 +1,8 @@
+"""Traits for building Astropy :class:`~astropy.cosmology.Cosmology` objects."""
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+__all__ = [
+    "ScaleFactor",
+]
+
+from ._src.traits import ScaleFactor

--- a/astropy/cosmology/traits.py
+++ b/astropy/cosmology/traits.py
@@ -3,6 +3,7 @@
 
 __all__ = [
     "ScaleFactor",
+    "TemperatureCMB",
 ]
 
-from ._src.traits import ScaleFactor
+from ._src.traits import ScaleFactor, TemperatureCMB

--- a/astropy/cosmology/traits.py
+++ b/astropy/cosmology/traits.py
@@ -1,5 +1,5 @@
-"""Traits for building Astropy :class:`~astropy.cosmology.Cosmology` objects."""
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Traits for building ``astropy`` :class:`~astropy.cosmology.Cosmology` classes."""
 
 __all__ = [
     "ScaleFactor",

--- a/docs/changes/cosmology/17702.api.rst
+++ b/docs/changes/cosmology/17702.api.rst
@@ -1,2 +1,4 @@
 A new public module, ``astropy.cosmology.traits``, has been added to provide building
-blocks for custom cosmologies.
+blocks for custom cosmologies. The currently available traits are:
+- ``astropy.cosmology.traits.ScaleFactor``
+- ``astropy.cosmology.traits.TemperatureCMB``

--- a/docs/changes/cosmology/17702.api.rst
+++ b/docs/changes/cosmology/17702.api.rst
@@ -1,0 +1,2 @@
+A new public module, ``astropy.cosmology.traits``, has been added to provide building
+blocks for custom cosmologies.

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -110,6 +110,7 @@ listed below.
 * :ref:`astropy-cosmology-realizations`
 * :ref:`Units and Equivalencies <astropy-cosmology-units-and-equivalencies>`
 * :ref:`cosmology_io`
+* :ref:`astropy-cosmology-traits`
 * :ref:`For Developers <astropy-cosmology-for-developers>`
 
 Most of the functionality is enabled by the |FLRW| object. This represents a
@@ -481,5 +482,6 @@ Reference/API
    realizations
    Units and Equivalencies <units>
    io/index
+   Traits <traits>
    For Developers <dev>
    ref_api

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -11,7 +11,7 @@ The ``traits`` module hosts various parts of cosmologies, such as the
 construct custom cosmologies by combining different components.
 
 As a simple example, the :class:`~astropy.cosmology.traits.TemperatureCMB` trait
-provides the :attr:`~astropy.cosmology.traits.TemperatureCMB.Tcmb0` property and
+provides the ``Tcmb0`` property and
 :meth:`~astropy.cosmology.traits.TemperatureCMB.Tcmb` method for computing the
 cosmological CMB temperature at specified redshifts. By using this trait, you can add
 temperature-related  functionality to your custom cosmology class without having to

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -6,9 +6,10 @@ Cosmology Traits
 
 .. currentmodule:: astropy.cosmology.traits
 
-The ``traits`` module hosts various parts of cosmologies, such as the
-:class:`~astropy.cosmology.traits.ScaleFactor` or :class:`~astropy.cosmology.traits.TemperatureCMB`. These traits can be used to more easily
-construct custom cosmologies by combining different components.
+The :mod:`~astropy.cosmology.traits` module hosts various parts of cosmologies, such as
+the :class:`~astropy.cosmology.traits.ScaleFactor` or
+:class:`~astropy.cosmology.traits.TemperatureCMB`. These :term:`traits <trait type>` can
+be used to more easily construct custom cosmologies by combining different components.
 
 As a simple example, the :class:`~astropy.cosmology.traits.TemperatureCMB` trait
 provides the ``Tcmb0`` property and
@@ -23,7 +24,7 @@ Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFact
 >>> import astropy.units as u
 >>> from astropy.cosmology.traits import ScaleFactor, TemperatureCMB
 >>> from astropy.cosmology import Cosmology
-
+>>>
 >>> class CustomCosmology(Cosmology, ScaleFactor, TemperatureCMB):
 ...     def __init__(self, H0, Om0, Ode0, Tcmb0=2.725):
 ...         self.H0 = H0
@@ -36,10 +37,10 @@ Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFact
 ...     # Additional custom methods and properties can be added here
 
 >>> cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
->>> print(cosmo.scale_factor(0))
-1.0
->>> print(cosmo.Tcmb(1))
-5.45 K
+>>> cosmo.scale_factor(0)
+<Quantity 1.>
+>>> cosmo.Tcmb(1)
+<Quantity 5.45 K>
 
 By combining different traits, you can create fully-featured cosmology classes with
 minimal effort.

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -1,0 +1,49 @@
+.. _astropy-cosmology-traits:
+
+****************
+Cosmology Traits
+****************
+
+.. currentmodule:: astropy.cosmology.traits
+
+The ``traits`` module hosts various parts of cosmologies, such as the
+:class:`~astropy.cosmology.traits.ScaleFactor`. These traits can be used to more easily
+construct custom cosmologies by combining different components.
+
+As a simple example, the :class:`~astropy.cosmology.traits.ScaleFactor` trait provides
+the ``scale_factor0`` property and ``scale_factor0(z)`` method for computing the
+cosmological scale factor, which is defined as :math:`a = a_0 / (1 + z)`. By using this
+trait, you can add scale factor functionality to your custom cosmology class without
+having to implement it from scratch.
+
+Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFactor`
+trait in a custom cosmology class:
+
+.. code-block:: python
+
+    from astropy.cosmology.traits import ScaleFactor
+    from astropy.cosmology import Cosmology
+
+    class CustomCosmology(Cosmology, ScaleFactor):
+        def __init__(self, H0, Om0, Ode0):
+            self.H0 = H0
+            self.Om0 = Om0
+            self.Ode0 = Ode0
+            super().__init__()
+
+        # Additional custom methods and properties can be added here
+
+    cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
+    print(cosmo.scale_factor(0))  # Output: 1.0
+
+By combining different traits, you can create fully-featured cosmology classes with
+minimal effort.
+
+
+Reference/API
+*************
+
+.. py:currentmodule:: astropy.cosmology.traits
+
+.. automodapi:: astropy.cosmology.traits
+   :inherited-members:

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -7,34 +7,39 @@ Cosmology Traits
 .. currentmodule:: astropy.cosmology.traits
 
 The ``traits`` module hosts various parts of cosmologies, such as the
-:class:`~astropy.cosmology.traits.ScaleFactor`. These traits can be used to more easily
+:class:`~astropy.cosmology.traits.ScaleFactor` or :class:`~astropy.cosmology.traits.TemperatureCMB`. These traits can be used to more easily
 construct custom cosmologies by combining different components.
 
-As a simple example, the :class:`~astropy.cosmology.traits.ScaleFactor` trait provides
-the ``scale_factor0`` property and ``scale_factor0(z)`` method for computing the
-cosmological scale factor, which is defined as :math:`a = a_0 / (1 + z)`. By using this
-trait, you can add scale factor functionality to your custom cosmology class without
-having to implement it from scratch.
+As a simple example, the :class:`~astropy.cosmology.traits.TemperatureCMB` trait
+provides the :attr:`~astropy.cosmology.traits.TemperatureCMB.Tcmb0` property and
+:meth:`~astropy.cosmology.traits.TemperatureCMB.Tcmb` method for computing the
+cosmological CMB temperature at specified redshifts. By using this trait, you can add
+temperature-related  functionality to your custom cosmology class without having to
+implement it from scratch.
 
-Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFactor`
-trait in a custom cosmology class:
+Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFactor` and
+:class:`~astropy.cosmology.traits.TemperatureCMB` traits in a custom cosmology class:
 
-.. code-block:: python
+>>> import astropy.units as u
+>>> from astropy.cosmology.traits import ScaleFactor, TemperatureCMB
+>>> from astropy.cosmology import Cosmology
 
-    from astropy.cosmology.traits import ScaleFactor
-    from astropy.cosmology import Cosmology
+>>> class CustomCosmology(Cosmology, ScaleFactor, TemperatureCMB):
+...     def __init__(self, H0, Om0, Ode0, Tcmb0=2.725):
+...         self.H0 = H0
+...         self.Om0 = Om0
+...         self.Ode0 = Ode0
+...         self.Tcmb0 = u.Quantity(Tcmb0, "K")
+...         super().__init__()
+...
+...     is_flat = False
+...     # Additional custom methods and properties can be added here
 
-    class CustomCosmology(Cosmology, ScaleFactor):
-        def __init__(self, H0, Om0, Ode0):
-            self.H0 = H0
-            self.Om0 = Om0
-            self.Ode0 = Ode0
-            super().__init__()
-
-        # Additional custom methods and properties can be added here
-
-    cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
-    print(cosmo.scale_factor(0))  # Output: 1.0
+>>> cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
+>>> print(cosmo.scale_factor(0))
+1.0
+>>> print(cosmo.Tcmb(1))
+5.45 K
 
 By combining different traits, you can create fully-featured cosmology classes with
 minimal effort.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -77,6 +77,19 @@ Astropy Glossary
       :class:`~astropy.time.Time`, e.g. `str`, array-like[str], `~datetime.datetime`, or
       `~numpy.datetime64`.
 
+   trait type
+      In short, a trait type is a class with the following properties:
+
+      - It is a class that can be used as a mixin to add functionality to another class.
+      - It should never be instantiated directly.
+      - It should not be used as a base class for other classes, but only as a mixin.
+      - It can define methods, properties, and attributes -- any of which can be abstract.
+      - It can be generic, i.e. it can have type parameters.
+      - It can subclass other traits, but should have a linear MRO.
+
+      These are the same set of properties as orthogonal mixin classes, with the added
+      emphasis that they can serve as compiled types, if so enabled by a compilation system such as `mypyc <https://mypyc.readthedocs.io/en/latest/>`_.
+
    unit-like
       :class:`~astropy.units.UnitBase` subclass instance or a valid initializer for
       :class:`~astropy.units.Unit`, e.g., `str` or scalar `~astropy.units.Quantity`.

--- a/docs/whatsnew/7.1.rst
+++ b/docs/whatsnew/7.1.rst
@@ -61,28 +61,45 @@ documentation.
 Cosmology
 =========
 
-The new ``traits`` module hosts various parts of cosmologies, such as the
-``ScaleFactor``. These traits can be used to more easily construct custom cosmologies by
-combining different components.
 
-Here is an example of how to use the ``ScaleFactor`` trait in a custom cosmology class:
+The `astropy.cosmology.traits` module hosts various parts of cosmologies, such as the
+:class:`~astropy.cosmology.traits.ScaleFactor` or
+:class:`~astropy.cosmology.traits.TemperatureCMB`. These traits can be used to more
+easily construct custom cosmologies by combining different components.
 
-.. code-block:: python
+As a simple example, the :class:`~astropy.cosmology.traits.TemperatureCMB` trait
+provides the :attr:`~astropy.cosmology.traits.TemperatureCMB.Tcmb0` property and
+:meth:`~astropy.cosmology.traits.TemperatureCMB.Tcmb` method for computing the
+cosmological CMB temperature at specified redshifts. By using this trait, you can add
+temperature-related  functionality to your custom cosmology class without having to
+implement it from scratch.
 
-    from astropy.cosmology.traits import ScaleFactor
-    from astropy.cosmology import Cosmology
+Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFactor` and
+:class:`~astropy.cosmology.traits.TemperatureCMB` traits in a custom cosmology class:
 
-    class CustomCosmology(Cosmology, ScaleFactor):
-        def __init__(self, H0, Om0, Ode0):
-            self.H0 = H0
-            self.Om0 = Om0
-            self.Ode0 = Ode0
-            super().__init__()
+>>> import astropy.units as u
+>>> from astropy.cosmology.traits import ScaleFactor, TemperatureCMB
+>>> from astropy.cosmology import Cosmology
 
-        # Additional custom methods and properties can be added here
+>>> class CustomCosmology(Cosmology, ScaleFactor, TemperatureCMB):
+...     def __init__(self, H0, Om0, Ode0, Tcmb0=2.725):
+...         self.H0 = H0
+...         self.Om0 = Om0
+...         self.Ode0 = Ode0
+...         self.Tcmb0 = u.Quantity(Tcmb0, "K")
+...         super().__init__()
+...
+...     is_flat = False
+...     # Additional custom methods and properties can be added here
 
-    cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
-    print(cosmo.scale_factor(0))  # Output: 1.0
+>>> cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
+>>> print(cosmo.scale_factor(0))
+1.0
+>>> print(cosmo.Tcmb(1))
+5.45 K
+
+By combining different traits, you can create fully-featured cosmology classes with
+minimal effort.
 
 
 Full change log

--- a/docs/whatsnew/7.1.rst
+++ b/docs/whatsnew/7.1.rst
@@ -68,7 +68,7 @@ The `astropy.cosmology.traits` module hosts various parts of cosmologies, such a
 easily construct custom cosmologies by combining different components.
 
 As a simple example, the :class:`~astropy.cosmology.traits.TemperatureCMB` trait
-provides the :attr:`~astropy.cosmology.traits.TemperatureCMB.Tcmb0` property and
+provides the ``Tcmb0`` property and
 :meth:`~astropy.cosmology.traits.TemperatureCMB.Tcmb` method for computing the
 cosmological CMB temperature at specified redshifts. By using this trait, you can add
 temperature-related  functionality to your custom cosmology class without having to

--- a/docs/whatsnew/7.1.rst
+++ b/docs/whatsnew/7.1.rst
@@ -61,10 +61,9 @@ documentation.
 Cosmology
 =========
 
-
-The `astropy.cosmology.traits` module hosts various parts of cosmologies, such as the
+The :mod:`astropy.cosmology.traits` module hosts various parts of cosmologies, such as the
 :class:`~astropy.cosmology.traits.ScaleFactor` or
-:class:`~astropy.cosmology.traits.TemperatureCMB`. These traits can be used to more
+:class:`~astropy.cosmology.traits.TemperatureCMB`. These :term:`traits <trait type>` can be used to more
 easily construct custom cosmologies by combining different components.
 
 As a simple example, the :class:`~astropy.cosmology.traits.TemperatureCMB` trait
@@ -80,7 +79,7 @@ Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFact
 >>> import astropy.units as u
 >>> from astropy.cosmology.traits import ScaleFactor, TemperatureCMB
 >>> from astropy.cosmology import Cosmology
-
+>>>
 >>> class CustomCosmology(Cosmology, ScaleFactor, TemperatureCMB):
 ...     def __init__(self, H0, Om0, Ode0, Tcmb0=2.725):
 ...         self.H0 = H0
@@ -93,20 +92,13 @@ Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFact
 ...     # Additional custom methods and properties can be added here
 
 >>> cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
->>> print(cosmo.scale_factor(0))
-1.0
->>> print(cosmo.Tcmb(1))
-5.45 K
+>>> cosmo.scale_factor(0)
+<Quantity 1.>
+>>> cosmo.Tcmb(1)
+<Quantity 5.45 K>
 
 By combining different traits, you can create fully-featured cosmology classes with
 minimal effort.
-
-
-Full change log
-===============
-
-To see a detailed list of all changes in version v7.1, including changes in
-API, please see the :ref:`changelog`.
 
 
 Full change log

--- a/docs/whatsnew/7.1.rst
+++ b/docs/whatsnew/7.1.rst
@@ -56,6 +56,42 @@ matrices associated `~astropy.nddata.NDData` objects via the new
 `~astropy.nddata.Covariance` class.  See the full :ref:`nddata-covariance`
 documentation.
 
+.. _whatsnew-7.1-cosmology:
+
+Cosmology
+=========
+
+The new ``traits`` module hosts various parts of cosmologies, such as the
+``ScaleFactor``. These traits can be used to more easily construct custom cosmologies by
+combining different components.
+
+Here is an example of how to use the ``ScaleFactor`` trait in a custom cosmology class:
+
+.. code-block:: python
+
+    from astropy.cosmology.traits import ScaleFactor
+    from astropy.cosmology import Cosmology
+
+    class CustomCosmology(Cosmology, ScaleFactor):
+        def __init__(self, H0, Om0, Ode0):
+            self.H0 = H0
+            self.Om0 = Om0
+            self.Ode0 = Ode0
+            super().__init__()
+
+        # Additional custom methods and properties can be added here
+
+    cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
+    print(cosmo.scale_factor(0))  # Output: 1.0
+
+
+Full change log
+===============
+
+To see a detailed list of all changes in version v7.1, including changes in
+API, please see the :ref:`changelog`.
+
+
 Full change log
 ===============
 


### PR DESCRIPTION
- feat: “traits” module for cosmology building blocks. These are essentially trait types, in the style of https://mypyc.readthedocs.io/en/latest/using_type_annotations.html#trait-types
- public scope `ScaleFactor`
- and make `scale_factor` always return a Quantity

The longer term plan with this module is to make public all the currently private trait classes, e.g. TemperatureCMB, as well as to keep moving traits out of `FLRW` into this module. Eventually `FLRW` will be something like this:

```
class FLRW(Trait1, Trait2, ..., Cosmology):
    <parameters>: Parameter
    ...  # cosmology-specific methods.
```

Where the usage of traits means it'll be easy to build more focused cosmology classes, e.g. pedagogical ones, that share API and methods with FLRW.



- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
