### PR TITLE
BUG: fix writing table to a file object as fits

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -435,7 +435,7 @@ def write_table_fits(input, output, overwrite=False, append=False):
     ----------
     input : Table
         The table to write out.
-    output : str or os.PathLike[str]
+    output : str or os.PathLike[str] or file-like
         The filename to write the table to.
     overwrite : bool
         Whether to overwrite any existing file without warning.
@@ -448,7 +448,7 @@ def write_table_fits(input, output, overwrite=False, append=False):
     table_hdu = table_to_hdu(input, character_as_bytes=True)
 
     # Check if output file already exists
-    if os.path.exists(output):
+    if isinstance(output, (str, os.PathLike)) and os.path.exists(output):
         if overwrite:
             os.remove(output)
         elif not append:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -67,7 +67,6 @@ class TestSingleTable:
             dtype=[("a", int), ("b", "U1"), ("c", float)],
         )
 
-    @pytest.mark.xfail
     def test_overwrite_with_path(self, tmp_path):
         filename = "temp.fits"
         t1 = Table(self.data)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1,6 +1,7 @@
 import contextlib
 import gc
 import warnings
+from io import BytesIO
 from pathlib import Path
 
 import numpy as np
@@ -66,6 +67,7 @@ class TestSingleTable:
             dtype=[("a", int), ("b", "U1"), ("c", float)],
         )
 
+    @pytest.mark.xfail
     def test_overwrite_with_path(self, tmp_path):
         filename = "temp.fits"
         t1 = Table(self.data)
@@ -73,6 +75,15 @@ class TestSingleTable:
             t1.write(filename, format="fits")
             t1.write(Path(filename), format="fits", overwrite=True)
         t1.write(Path(tmp_path / filename), format="fits", overwrite=True)
+
+    def test_write_to_fileobj(self):
+        # regression test for https://github.com/astropy/astropy/issues/17703
+        t = Table(self.data)
+        buff = BytesIO()
+        t.write(buff, format="fits")
+        buff.seek(0)
+        t2 = Table.read(buff)
+        assert equal_data(t2, t)
 
     def test_simple(self, tmp_path):
         filename = tmp_path / "test_simple.fts"


### PR DESCRIPTION
### Description
Follow up to #17552, close #17703
Not including a changelog as the regression doesn't affect a release.
This however needs to be backported along #17552

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
