### PR TITLE
TST: Pin bs4 in oldestdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ deps =
     oldestdeps: asdf==2.8.*  # asdf-astropy==0.3.*
     oldestdeps: asdf-astropy==0.3.*
     oldestdeps: attrs < 24.1.0  # ASDF_LT_3_4
+    oldestdeps: beautifulsoup4==4.9.3
     oldestdeps: scipy==1.9.2
     oldestdeps: pyyaml==6.0.0
     oldestdeps: ipython==8.0.0


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address failure in oldestdeps job when bs4 was bumped from 4.12.3 to 4.13.1. This patch pins bs4 in oldestdeps to the minversion declared in pyproject.toml.

This can be merged way sooner than #16963 though that PR would provide a more permanent solution if it goes forward.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
