### PR TITLE
Update links to VOUnit 1.0 standard

### DIFF
--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1074,9 +1074,10 @@ class W49(VOTableSpecWarning):
 class W50(VOTableSpecWarning):
     """
     Invalid unit string as defined in the `Units in the VO, Version 1.0
-    <https://www.ivoa.net/documents/VOUnits>`_ (VOTable version >= 1.4)
-    or `Standards for Astronomical Catalogues, Version 2.0
-    <https://cdsarc.cds.unistra.fr/doc/catstd-3.2.htx>`_ (version < 1.4).
+    <https://www.ivoa.net/documents/VOUnits/20140523/index.html>`_
+    (VOTable version >= 1.4) or `Standards for Astronomical Catalogues,
+    Version 2.0 <https://cdsarc.cds.unistra.fr/doc/catstd-3.2.htx>`_
+    (version < 1.4).
 
     Consider passing an explicit ``unit_format`` parameter if the units
     in this file conform to another specification.

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -44,7 +44,7 @@ class VOUnit(Base, _GenericParserMixin):
     The IVOA standard for units used by the VO.
 
     This is an implementation of `Units in the VO 1.0
-    <http://www.ivoa.net/documents/VOUnits/>`_.
+    <https://www.ivoa.net/documents/VOUnits/20140523/index.html>`_.
     """
 
     _explicit_custom_unit_regex: ClassVar[Pattern[str]] = re.compile(

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -161,7 +161,7 @@ formats:
     generate units defined in the FITS standard.
 
   - ``"vounit"``: The `Units in the VO 1.0
-    <http://www.ivoa.net/documents/VOUnits/>`__ standard for
+    <https://www.ivoa.net/documents/VOUnits/20140523/index.html>`__ standard for
     representing units in the VO. Again, based on the FITS syntax,
     but the collection of supported units is different.
 

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -205,8 +205,8 @@ See Also
   units in FITS.
 
 - The `Units in the VO 1.0 Standard
-  <http://www.ivoa.net/documents/VOUnits/>`_ for representing units in
-  the VO.
+  <https://www.ivoa.net/documents/VOUnits/20140523/index.html>`_ for
+  representing units in the VO.
 
 - OGIP Units: A standard for storing units in `OGIP FITS files
   <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`_.


### PR DESCRIPTION
### Description

We refer to the VOUnit 1.0 standard in a few places, but the URL actually leads to the latest standard, which is now 1.1. I am updating the links to point to the 1.0 standard as intended.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
