### PR TITLE
Fixes issue #17680 by adding a limit_rounding_paramter in the cutout2d

### DIFF
--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -34,7 +34,13 @@ class PartialOverlapError(ValueError):
     """Raised when arrays only partially overlap."""
 
 
-def overlap_slices(large_array_shape, small_array_shape, position, mode="partial", limit_rounding_method="ceil"):
+def overlap_slices(
+    large_array_shape,
+    small_array_shape,
+    position,
+    mode="partial",
+    limit_rounding_method="ceil",
+):
     """
     Get slices for the overlapping part of a small and a large array.
 
@@ -106,7 +112,7 @@ def overlap_slices(large_array_shape, small_array_shape, position, mode="partial
         raise ValueError(
             '"position" must have the same number of dimensions as "small_array_shape".'
         )
-    
+
     if limit_rounding_method == "ceil" or limit_rounding_method is None:
         round_func = np.ceil
     elif limit_rounding_method == "floor":
@@ -171,7 +177,7 @@ def extract_array(
     mode="partial",
     fill_value=np.nan,
     return_position=False,
-    limit_rounding_method= "ceil"
+    limit_rounding_method="ceil",
 ):
     """
     Extract a smaller array of the given shape and position from a
@@ -247,7 +253,11 @@ def extract_array(
         raise ValueError("Valid modes are 'partial', 'trim', and 'strict'.")
 
     large_slices, small_slices = overlap_slices(
-        array_large.shape, shape, position, mode=mode, limit_rounding_method=limit_rounding_method
+        array_large.shape,
+        shape,
+        position,
+        mode=mode,
+        limit_rounding_method=limit_rounding_method,
     )
     extracted_array = array_large[large_slices]
     if return_position:
@@ -324,7 +334,10 @@ def add_array(array_large, array_small, position, limit_rounding_method="ceil"):
         for (large_shape, small_shape) in zip(array_large.shape, array_small.shape)
     ):
         large_slices, small_slices = overlap_slices(
-            array_large.shape, array_small.shape, position, limit_rounding_method=limit_rounding_method
+            array_large.shape,
+            array_small.shape,
+            position,
+            limit_rounding_method=limit_rounding_method,
         )
         array_large[large_slices] += array_small[small_slices]
         return array_large
@@ -554,7 +567,15 @@ class Cutout2D:
     """
 
     def __init__(
-        self, data, position, size, wcs=None, mode="trim", fill_value=np.nan, copy=False, limit_rounding_method = "ceil"
+        self,
+        data,
+        position,
+        size,
+        wcs=None,
+        mode="trim",
+        fill_value=np.nan,
+        copy=False,
+        limit_rounding_method="ceil",
     ):
         if wcs is None:
             wcs = getattr(data, "wcs", None)
@@ -623,7 +644,11 @@ class Cutout2D:
 
         self.input_position_cutout = input_position_cutout[::-1]  # (x, y)
         slices_original, slices_cutout = overlap_slices(
-            data.shape, shape, pos_yx, mode=mode, limit_rounding_method = limit_rounding_method
+            data.shape,
+            shape,
+            pos_yx,
+            mode=mode,
+            limit_rounding_method=limit_rounding_method,
         )
 
         self.slices_original = slices_original


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix https://github.com/astropy/astropy/issues/17680

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
