### PR TITLE
MNT: upgrade codespell (`v2.3.0` -> `v2.4.1`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     - id: zizmor
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: ["--write-changes"]

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -894,7 +894,7 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
 
         It stores anything that should be computed from the coordinate data (*not* from
         the frame attributes). This can be used in functions to store anything that
-        might be expensive to compute but might be re-used by some other function.
+        might be expensive to compute but might be reused by some other function.
         E.g.::
 
             if 'user_data' in myframe.cache:

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -303,7 +303,7 @@ def test_transform_api():
         FK5(equinox=J2001).transform_to(ICRS())
 
     # To actually define a new transformation, the same scheme as in the
-    # 0.2/0.3 coordinates framework can be re-used - a graph of transform functions
+    # 0.2/0.3 coordinates framework can be reused - a graph of transform functions
     # connecting various coordinate classes together.  The main changes are:
     # 1) The transform functions now get the frame object they are transforming the
     #    current data into.

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -390,7 +390,7 @@ def _encode_mixins(tbl):
         encode_tbl = Table(tbl.columns, meta=meta_copy, copy=False)
 
     # Get the YAML serialization of information describing the table columns.
-    # This is re-using ECSV code that combined existing table.meta with with
+    # This is reusing ECSV code that combined existing table.meta with with
     # the extra __serialized_columns__ key.  For FITS the table.meta is handled
     # by the native FITS connect code, so don't include that in the YAML
     # output.

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1067,7 +1067,9 @@ class TestHeaderFunctions(FitsTestCase):
     def test_wildcard_slice(self):
         """Test selecting a subsection of a header via wildcard matching."""
 
-        header = fits.Header([("ABC", 0), ("DEF", 1), ("ABD", 2)])
+        header = fits.Header(
+            [("ABC", 0), ("DEF", 1), ("ABD", 2)]  # codespell:ignore abd
+        )
         newheader = header["AB*"]
         assert len(newheader) == 2
         assert newheader[0] == 0
@@ -1087,7 +1089,9 @@ class TestHeaderFunctions(FitsTestCase):
     def test_wildcard_slice_assignment(self):
         """Test assigning to a header slice selected via wildcard matching."""
 
-        header = fits.Header([("ABC", 0), ("DEF", 1), ("ABD", 2)])
+        header = fits.Header(
+            [("ABC", 0), ("DEF", 1), ("ABD", 2)]  # codespell:ignore abd
+        )
 
         # Test assigning slice to the same value; this works similarly to numpy
         # arrays
@@ -1108,7 +1112,9 @@ class TestHeaderFunctions(FitsTestCase):
     def test_wildcard_slice_deletion(self):
         """Test deleting cards from a header that match a wildcard pattern."""
 
-        header = fits.Header([("ABC", 0), ("DEF", 1), ("ABD", 2)])
+        header = fits.Header(
+            [("ABC", 0), ("DEF", 1), ("ABD", 2)]  # codespell:ignore abd
+        )
         del header["AB*"]
         assert len(header) == 1
         assert header[0] == 1

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1031,7 +1031,7 @@ class TestTableFunctions(FitsTestCase):
         """Regression test for https://github.com/astropy/astropy/issues/5280
         and https://github.com/astropy/astropy/issues/5287
 
-        multidimentional tables can now be written with the correct TDIM.
+        multidimensional tables can now be written with the correct TDIM.
         Author: Stephen Bailey.
         """
 

--- a/astropy/samp/integrated_client.py
+++ b/astropy/samp/integrated_client.py
@@ -429,7 +429,7 @@ class SAMPIntegratedClient:
         >>> from astropy.samp import SAMPIntegratedClient, SAMP_STATUS_ERROR
         >>> cli = SAMPIntegratedClient()
         >>> ...
-        >>> cli.ereply("abd", SAMP_STATUS_ERROR, result={},
+        >>> cli.ereply("message_id", SAMP_STATUS_ERROR, result={},
         ...            error={"samp.errortxt": "Test error message"})
         """
         return self.reply(msg_id, self._format_easy_response(status, result, error))

--- a/astropy/uncertainty/distributions.py
+++ b/astropy/uncertainty/distributions.py
@@ -149,7 +149,7 @@ def uniform(
     **kwargs,
 ):
     """
-    Create a Uniform distriution from the lower and upper bounds.
+    Create a Uniform distribution from the lower and upper bounds.
 
     Note that this function requires keywords to be explicit, and requires
     either ``lower``/``upper`` or ``center``/``width``.

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -38,7 +38,7 @@ class CoordinatesMap:
         :class:`~astropy.visualization.wcsaxes.frame.RectangularFrame`
     previous_frame_path : `~matplotlib.path.Path`, optional
         When changing the WCS of the axes, the frame instance will change but
-        we might want to keep re-using the same underlying matplotlib
+        we might want to keep reusing the same underlying matplotlib
         `~matplotlib.path.Path` - in that case, this can be passed to this
         keyword argument.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,6 +627,7 @@ ignore-words-list = """
     dum,
     fo,
     hel,
+    indx,
     lightyear,
     lond,
     nax,


### PR DESCRIPTION
### Description
This is a semi manual upgrade (originally automated in https://github.com/astropy/astropy/pull/17710).
All changes are automatic, except for a couple `# codespell:ignore` comments that I added manually.
The update is a bit noisy because of `indx` variables being re-named `index`, though I checked that it only happened in private scopes so it shouldn't have any user-visible effect.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
