### PR TITLE
MNT: upgrade zizmor (`v1.0.0` -> `v1.3.0`)

### DIFF
--- a/.github/workflows/CFF-test.yml
+++ b/.github/workflows/CFF-test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cffconvert:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: read
+
 jobs:
   changelog_checker:
     name: Check if towncrier change log entry is correct

--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  pull-requests: read
 
 jobs:
   # https://stackoverflow.com/questions/69434370/how-can-i-get-the-latest-pr-data-specifically-milestones-when-running-yaml-jobs

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -28,6 +28,9 @@ concurrency:
 env:
   IS_CRON: 'true'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -17,6 +17,9 @@ env:
   ARCH_ON_CI: "normal"
   IS_CRON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   initial_checks:
     name: Mandatory checks before CI

--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -8,6 +8,9 @@ on:
     types:
     - opened
 
+permissions:
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -7,6 +7,9 @@ on:
     - cron: '30 5 * * *'
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
   stalebot:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.0.0
+    rev: v1.3.0
     hooks:
     - id: zizmor
 


### PR DESCRIPTION
### Description
This is a manual upgrade for zizmor, previously attempted automatically in #17710

The one new error flagged is explained in [zizmor's doc](https://woodruffw.github.io/zizmor/audits/#excessive-permissions). I've attempted to set explicit permissions in all places reported by zizmor 1.3.0, but I expect a couple iterations might be needed to get this right.

EDIT: Also close #14072

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
