### PR TITLE
MNT: upgrade sp-repo-review (`v2024.08.19` -> `v2025.01.22`)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/scientific-python/cookie
-    rev: 2024.08.19
+    rev: 2025.01.22
     hooks:
       - id: sp-repo-review
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,7 @@ ignore = [
     "PC180", # ignore using `prettier` in pre-commit
     "PC901", # ignore using custom update message (we have many of the default ones in our history already)
     "PP308", # ignore requiring `-ra` flag for pytest, astropy's test suite is too large for this to be useful
+    "PY005", # ignore requiring a root level "test*" directory
 ]
 
 [tool.towncrier]


### PR DESCRIPTION
### Description
Close #17719

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
