### PR TITLE
Backport PR #17721 on branch v7.0.x (MNT: upgrade zizmor (v1.0.0 -> v1.3.0))

### DIFF
--- a/.github/workflows/CFF-test.yml
+++ b/.github/workflows/CFF-test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cffconvert:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: read
+
 jobs:
   changelog_checker:
     name: Check if towncrier change log entry is correct

--- a/.github/workflows/check_milestone.yml
+++ b/.github/workflows/check_milestone.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  pull-requests: read
 
 jobs:
   # https://stackoverflow.com/questions/69434370/how-can-i-get-the-latest-pr-data-specifically-milestones-when-running-yaml-jobs

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -28,6 +28,9 @@ concurrency:
 env:
   IS_CRON: 'true'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -17,6 +17,9 @@ env:
   ARCH_ON_CI: "normal"
   IS_CRON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   initial_checks:
     name: Mandatory checks before CI

--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -8,6 +8,9 @@ on:
     types:
     - opened
 
+permissions:
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -7,6 +7,9 @@ on:
     - cron: '30 5 * * *'
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
   stalebot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #17721

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
