### PR TITLE
Remove "indx" from `codespell` ignore list

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1794,11 +1794,7 @@ class ColDefs(NotifierMixin):
         if not isinstance(other, (list, tuple)):
             other = [other]
         _other = [_get_index(self.names, key) for key in other]
-        indx = list(range(len(self)))
-        for x in _other:
-            indx.remove(x)
-        tmp = [self[i] for i in indx]
-        return ColDefs(tmp)
+        return ColDefs([self[i] for i in range(len(self)) if i not in _other])
 
     def _update_column_attribute_changed(self, column, attr, old_value, new_value):
         """
@@ -1862,10 +1858,10 @@ class ColDefs(NotifierMixin):
         # Ask the HDU object to load the data before we modify our columns
         self._notify("load_data")
 
-        indx = _get_index(self.names, col_name)
-        col = self.columns[indx]
+        index = _get_index(self.names, col_name)
+        col = self.columns[index]
 
-        del self._arrays[indx]
+        del self._arrays[index]
         # Obliterate caches of certain things
         del self.dtype
         del self._recformats
@@ -1873,7 +1869,7 @@ class ColDefs(NotifierMixin):
         del self.names
         del self.formats
 
-        del self.columns[indx]
+        del self.columns[index]
 
         col._remove_listener(self)
 
@@ -1881,7 +1877,7 @@ class ColDefs(NotifierMixin):
         # any other listeners) that the column has been removed
         # Just send a reference to self, and the index of the column that was
         # removed
-        self._notify("column_removed", self, indx)
+        self._notify("column_removed", self, index)
         return self
 
     def change_attrib(self, col_name, attrib, new_value):
@@ -2139,26 +2135,20 @@ def _get_index(names, key):
         field('Xyz'), etc. will get this field.
     """
     if _is_int(key):
-        indx = int(key)
-    elif isinstance(key, str):
-        # try to find exact match first
-        try:
-            indx = names.index(key.rstrip())
-        except ValueError:
-            # try to match case-insentively,
-            _key = key.lower().rstrip()
-            names = [n.lower().rstrip() for n in names]
-            count = names.count(_key)  # occurrence of _key in names
-            if count == 1:
-                indx = names.index(_key)
-            elif count == 0:
-                raise KeyError(f"Key '{key}' does not exist.")
-            else:  # multiple match
-                raise KeyError(f"Ambiguous key name '{key}'.")
-    else:
+        return int(key)
+    if not isinstance(key, str):
         raise KeyError(f"Illegal key '{key!r}'.")
-
-    return indx
+    try:  # try to find exact match first
+        return names.index(key.rstrip())
+    except ValueError:  # try to match case-insentively,
+        _key = key.lower().rstrip()
+        names = [n.lower().rstrip() for n in names]
+        count = names.count(_key)  # occurrence of _key in names
+        if count == 1:
+            return names.index(_key)
+        if count == 0:
+            raise KeyError(f"Key '{key}' does not exist.")
+        raise KeyError(f"Ambiguous key name '{key}'.")  # multiple match
 
 
 def _unwrapx(input, output, repeat):

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1535,8 +1535,8 @@ class TableDataDiff(_BaseDiff):
             return
 
         # Finally, let's go through and report column data differences:
-        for indx, values in self.diff_values:
-            self._writeln(" Column {} data differs in row {}:".format(*indx))
+        for (col, row), values in self.diff_values:
+            self._writeln(f" Column {col} data differs in row {row}:")
             report_diff_values(
                 values[0],
                 values[1],

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -71,38 +71,37 @@ class FITS_record:
 
     def __getitem__(self, key):
         if isinstance(key, str):
-            indx = _get_index(self.array.names, key)
+            index = _get_index(self.array.names, key)
 
-            if indx < self.start or indx > self.end - 1:
+            if index < self.start or index > self.end - 1:
                 raise KeyError(f"Key '{key}' does not exist.")
         elif isinstance(key, slice):
             return type(self)(self.array, self.row, key.start, key.stop, key.step, self)
         else:
-            indx = self._get_index(key)
+            index = self._get_index(key)
 
-            if indx > self.array._nfields - 1:
+            if index > self.array._nfields - 1:
                 raise IndexError("Index out of bounds")
 
-        return self.array.field(indx)[self.row]
+        return self.array.field(index)[self.row]
 
     def __setitem__(self, key, value):
         if isinstance(key, str):
-            indx = _get_index(self.array.names, key)
+            index = _get_index(self.array.names, key)
 
-            if indx < self.start or indx > self.end - 1:
+            if index < self.start or index > self.end - 1:
                 raise KeyError(f"Key '{key}' does not exist.")
         elif isinstance(key, slice):
             start, stop, step = key.indices(self.array._nfields)
             for i, val in zip(range(start, stop, step), value, strict=True):
-                indx = self._get_index(i)
-                self.array.field(indx)[self.row] = val
+                self.array.field(self._get_index(i))[self.row] = val
             return
         else:
-            indx = self._get_index(key)
-            if indx > self.array._nfields - 1:
+            index = self._get_index(key)
+            if index > self.array._nfields - 1:
                 raise IndexError("Index out of bounds")
 
-        self.array.field(indx)[self.row] = value
+        self.array.field(index)[self.row] = value
 
     def __len__(self):
         return len(range(self.start, self.end, self.step))
@@ -137,7 +136,7 @@ class FITS_record:
             base = base.base
         return bases
 
-    def _get_index(self, indx):
+    def _get_index(self, index):
         indices = np.ogrid[: self.array._nfields]
         for base in reversed(self._bases):
             if base.step < 1:
@@ -145,7 +144,7 @@ class FITS_record:
             else:
                 s = slice(base.start, base.end, base.step)
             indices = indices[s]
-        return indices[indx]
+        return indices[index]
 
 
 class FITS_rec(np.recarray):
@@ -872,10 +871,10 @@ class FITS_rec(np.recarray):
         try:
             dummy = np.array(dummy, dtype=recformat)
         except ValueError as exc:
-            indx = self.names.index(column.name)
             raise ValueError(
-                f"{exc}; the header may be missing the necessary TNULL{indx + 1} "
-                "keyword or the table contains invalid data"
+                f"{exc}; the header may be missing the necessary "
+                f"TNULL{self.names.index(column.name) + 1} keyword or the table "
+                "contains invalid data"
             )
 
         return dummy
@@ -893,7 +892,7 @@ class FITS_rec(np.recarray):
         scale_factors = self._get_scale_factors(column)
         _str, _bool, _number, _scale, _zero, bscale, bzero, dim = scale_factors
 
-        indx = self.names.index(column.name)
+        index = self.names.index(column.name)
 
         # ASCII table, convert strings to numbers
         # TODO:
@@ -932,9 +931,9 @@ class FITS_rec(np.recarray):
                     actual_nitems = field.shape[1]
                 if nitems > actual_nitems and not isinstance(recformat, _FormatP):
                     warnings.warn(
-                        f"TDIM{indx + 1} value {self._coldefs[indx].dims:d} does not "
+                        f"TDIM{index + 1} value {self._coldefs[index].dims:d} does not "
                         f"fit with the size of the array items ({actual_nitems:d}).  "
-                        f"TDIM{indx + 1:d} will be ignored."
+                        f"TDIM{index + 1:d} will be ignored."
                     )
                     dim = None
 
@@ -980,7 +979,7 @@ class FITS_rec(np.recarray):
                         test_overflow += bzero64
                     except OverflowError:
                         warnings.warn(
-                            f"Overflow detected while applying TZERO{indx + 1:d}. "
+                            f"Overflow detected while applying TZERO{index + 1:d}. "
                             "Returning unscaled data."
                         )
                     else:
@@ -1095,10 +1094,10 @@ class FITS_rec(np.recarray):
         # Running total for the new heap size
         heapsize = 0
 
-        for indx, name in enumerate(self.dtype.names):
-            column = self._coldefs[indx]
+        for index, name in enumerate(self.dtype.names):
+            column = self._coldefs[index]
             recformat = column.format.recformat
-            raw_field = _get_recarray_field(self, indx)
+            raw_field = _get_recarray_field(self, index)
 
             # add the location offset of the heap area for each
             # variable length column
@@ -1155,10 +1154,10 @@ class FITS_rec(np.recarray):
 
                 # ASCII table, convert numbers to strings
                 if isinstance(self._coldefs, _AsciiColDefs):
-                    self._scale_back_ascii(indx, dummy, raw_field)
+                    self._scale_back_ascii(index, dummy, raw_field)
                 # binary table string column
                 elif isinstance(raw_field, chararray.chararray):
-                    self._scale_back_strings(indx, dummy, raw_field)
+                    self._scale_back_strings(index, dummy, raw_field)
                 # all other binary table columns
                 else:
                     if len(raw_field) and isinstance(raw_field[0], np.integer):

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -40,18 +40,14 @@ class Group(FITS_record):
         Get the group parameter value.
         """
         if _is_int(parname):
-            result = self.array[self.row][parname]
-        else:
-            indx = self._unique[parname.upper()]
-            if len(indx) == 1:
-                result = self.array[self.row][indx[0]]
-
-            # if more than one group parameter have the same name
-            else:
-                result = self.array[self.row][indx[0]].astype("f8")
-                for i in indx[1:]:
-                    result += self.array[self.row][i]
-
+            return self.array[self.row][parname]
+        first_index, *others = self._unique[parname.upper()]
+        if not others:
+            return self.array[self.row][first_index]
+        # if more than one group parameter have the same name
+        result = self.array[self.row][first_index].astype("f8")
+        for i in others:
+            result += self.array[self.row][i]
         return result
 
     def setpar(self, parname, value):
@@ -66,21 +62,20 @@ class Group(FITS_record):
         if _is_int(parname):
             self.array[self.row][parname] = value
         else:
-            indx = self._unique[parname.upper()]
-            if len(indx) == 1:
-                self.array[self.row][indx[0]] = value
+            index = self._unique[parname.upper()]
+            if len(index) == 1:
+                self.array[self.row][index[0]] = value
 
             # if more than one group parameter have the same name, the
             # value must be a list (or tuple) containing arrays
+            elif isinstance(value, (list, tuple)) and len(index) == len(value):
+                for value_elem, index_elem in zip(value, index):
+                    self.array[self.row][index_elem] = value_elem
             else:
-                if isinstance(value, (list, tuple)) and len(indx) == len(value):
-                    for i in range(len(indx)):
-                        self.array[self.row][indx[i]] = value[i]
-                else:
-                    raise ValueError(
-                        "Parameter value must be a sequence with "
-                        f"{len(indx)} arrays/numbers."
-                    )
+                raise ValueError(
+                    "Parameter value must be a sequence with "
+                    f"{len(index)} arrays/numbers."
+                )
 
 
 class GroupData(FITS_rec):
@@ -252,18 +247,14 @@ class GroupData(FITS_rec):
         Get the group parameter values.
         """
         if _is_int(parname):
-            result = self.field(parname)
-        else:
-            indx = self._unique[parname.upper()]
-            if len(indx) == 1:
-                result = self.field(indx[0])
-
-            # if more than one group parameter have the same name
-            else:
-                result = self.field(indx[0]).astype("f8")
-                for i in indx[1:]:
-                    result += self.field(i)
-
+            return self.field(parname)
+        first_index, *others = self._unique[parname.upper()]
+        if not others:
+            return self.field(first_index)
+        # if more than one group parameter have the same name
+        result = self.field(first_index).astype("f8")
+        for i in others:
+            result += self.field(i)
         return result
 
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1012,18 +1012,18 @@ class Section:
         # Find all leading axes for which a single point is used.
         for idx in range(naxis):
             axis = self.hdu.shape[idx]
-            indx = _IndexInfo(key[idx], axis)
-            offset = offset * axis + indx.offset
+            index = _IndexInfo(key[idx], axis)
+            offset = offset * axis + index.offset
             if not _is_int(key[idx]):
-                dims.append(indx.npts)
+                dims.append(index.npts)
                 break
 
-        is_contiguous = indx.contiguous
+        is_contiguous = index.contiguous
         for jdx in range(idx + 1, naxis):
             axis = self.hdu.shape[jdx]
-            indx = _IndexInfo(key[jdx], axis)
-            dims.append(indx.npts)
-            if indx.npts == axis and indx.contiguous:
+            index = _IndexInfo(key[jdx], axis)
+            dims.append(index.npts)
+            if index.npts == axis and index.contiguous:
                 # The offset needs to multiply the length of all remaining axes
                 offset *= axis
             else:
@@ -1269,24 +1269,24 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
 
 
 class _IndexInfo:
-    def __init__(self, indx, naxis):
-        if _is_int(indx):
-            if indx < 0:  # support negative indexing
-                indx = indx + naxis
-            if 0 <= indx < naxis:
+    def __init__(self, index, naxis):
+        if _is_int(index):
+            if index < 0:  # support negative indexing
+                index = index + naxis
+            if 0 <= index < naxis:
                 self.npts = 1
-                self.offset = indx
+                self.offset = index
                 self.contiguous = True
             else:
-                raise IndexError(f"Index {indx} out of range.")
-        elif isinstance(indx, slice):
-            start, stop, step = indx.indices(naxis)
+                raise IndexError(f"Index {index} out of range.")
+        elif isinstance(index, slice):
+            start, stop, step = index.indices(naxis)
             self.npts = (stop - start) // step
             self.offset = start
             self.contiguous = step == 1
-        elif isiterable(indx):
-            self.npts = len(indx)
+        elif isiterable(index):
+            self.npts = len(index)
             self.offset = 0
             self.contiguous = False
         else:
-            raise IndexError(f"Illegal index {indx}")
+            raise IndexError(f"Illegal index {index}")

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -107,8 +107,8 @@ class QuantityIterator:
     def __iter__(self):
         return self
 
-    def __getitem__(self, indx):
-        out = self._dataiter.__getitem__(indx)
+    def __getitem__(self, index):
+        out = self._dataiter.__getitem__(index)
         # For single elements, ndarray.flat.__getitem__ returns scalars; these
         # need a new view as a Quantity.
         if isinstance(out, type(self._quantity)):

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -552,9 +552,9 @@ class MaskedIterator:
     def __iter__(self):
         return self
 
-    def __getitem__(self, indx):
-        out = self._dataiter.__getitem__(indx)
-        mask = self._maskiter.__getitem__(indx)
+    def __getitem__(self, index):
+        out = self._dataiter.__getitem__(index)
+        mask = self._maskiter.__getitem__(index)
         # For single elements, ndarray.flat.__getitem__ returns scalars; these
         # need a new view as a Masked array.
         if not isinstance(out, np.ndarray):

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1266,8 +1266,7 @@ class TestSortFunctions(MaskedArraySetup):
             mask=[True, False, False, False],
         )
         o = np.sort_complex(ma)
-        indx = np.lexsort((ma.unmasked.imag, ma.unmasked.real, ma.mask))
-        expected = ma[indx]
+        expected = ma[np.lexsort((ma.unmasked.imag, ma.unmasked.real, ma.mask))]
         assert_masked_equal(o, expected)
 
     @pytest.mark.skipif(not NUMPY_LT_1_24, reason="np.msort is deprecated")

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -54,8 +54,7 @@ def _toindex(value):
             arr = fill_value
     else:
         arr[np.isnan(arr)] = fill_value
-    indx = np.asarray(arr, dtype=int)
-    return indx
+    return np.asarray(arr, dtype=int)
 
 
 class BaseHighLevelWCS(metaclass=abc.ABCMeta):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -629,7 +629,6 @@ ignore-words-list = """
     dum,
     fo,
     hel,
-    indx,
     lightyear,
     lond,
     nax,


### PR DESCRIPTION
### Description

The upgraded `codespell` doesn't like the variable name `indx`. In #17720 those variables are renamed to `index`, but `indx` is quite a common name, so the question was raised in that pull request if the code churn is worth it. In many places it is simple enough to rewrite the code so that the `indx/index` variable is not needed at all. I thought that if we are editing the code because `codespell` anyways then we might as well edit it properly, so I am opening this as an alternative for #17720.

EDIT: Close #17720

I also found a line of code in `io.fits` that I suspect has a bug in it. It is possible the labels might have to change the labels if maintainer confirms. See the inline comment for details.

### UPDATE

#17720 has been merged, so now this pull request only removes "indx" from the `codespell` ignore list.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
