### PR TITLE
Use native aarch runner for wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,13 +57,14 @@ jobs:
         - cp312-manylinux_x86_64
         - cp313-manylinux_x86_64
 
+        - target: cp311-manylinux_aarch64
+          runs-on: ubuntu-24.04-arm
+        - target: cp312-manylinux_aarch64
+          runs-on: ubuntu-24.04-arm
+        - target: cp313-manylinux_aarch64
+          runs-on: ubuntu-24.04-arm
+
         # Note that following wheels are not currently tested:
-
-        # FIXME: Also see https://github.com/astropy/astropy/issues/17663
-        #- cp311-manylinux_aarch64
-        #- cp312-manylinux_aarch64
-        #- cp313-manylinux_aarch64
-
         - cp311-musllinux_x86_64
         - cp312-musllinux_x86_64
         - cp313-musllinux_x86_64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,9 +255,8 @@ markers = [
 
 [tool.cibuildwheel]
 # We disable testing for the following wheels:
-# - Linux AArch64 (no native hardware, tests take too long)
 # - MuslLinux (tests hang non-deterministically)
-test-skip = "*-manylinux_aarch64 *-musllinux_x86_64"
+test-skip = "*-musllinux_x86_64"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
* fixes #17696
* close https://github.com/astropy/astropy/pull/17715

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.