### PR TITLE
BUG: treatment of some units in erfa.apio

### DIFF
--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -340,9 +340,9 @@ def helper_apio(
         get_converter(unit_phi, radian),
         get_converter(unit_hm, m),
         get_converter(unit_xp, radian),
-        get_converter(unit_xp, radian),
-        get_converter(unit_xp, radian),
-        get_converter(unit_xp, radian),
+        get_converter(unit_yp, radian),
+        get_converter(unit_refa, radian),
+        get_converter(unit_refb, radian),
     ], astrom_unit()
 
 

--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -500,8 +500,9 @@ class TestEraStructUfuncs:
         refa = 0.000201418779 * u.rad
         refb = -2.36140831e-7 * u.rad
         astrom = erfa_ufunc.apio(
-            sp.to(u.deg), theta, elong, phi, hm.to(u.km), xp, yp, refa, refb
-        )
+            sp.to(u.deg), theta, elong, phi, hm.to(u.km),
+            xp.to(u.arcsec), yp, refa, refb.to(u.deg),
+        )  # fmt: skip
         assert astrom.unit == self.astrom_unit
         for name, value in [
             ("along", -0.5278008060295995734),

--- a/docs/changes/units/17742.bugfix.rst
+++ b/docs/changes/units/17742.bugfix.rst
@@ -1,0 +1,3 @@
+Ensured that the units of ``yp``, ``refa`` and ``refb`` are properly
+taken into account when calling ``erfa.apio`` (previously, the
+conversion required for ``xp`` was applied to those inputs too).


### PR DESCRIPTION
While trying to address #17738, I noticed that the units machinery was not set up correctly for `erfa.apio`. This fixes it.
