### PR TITLE
Ensure doctests do not have side effects

### DIFF
--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -793,9 +793,11 @@ the :ref:`io_registry` (note that our format has no mechanism to write out the u
 .. testcleanup::
 
     >>> from astropy.io import registry
+    >>> from astropy.io.ascii.core import FORMAT_CLASSES
     >>> for format_name in ['custom_no_header', 'custom_commented_header', 'fixed_width_commented_header']:
     ...     registry.unregister_reader(f"ascii.{format_name}", Table)
     ...     registry.unregister_writer(f"ascii.{format_name}", Table)
+    ...     del FORMAT_CLASSES[format_name]
 
 **Define a custom reader functionally**
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1645,6 +1645,11 @@ standard `~astropy.time.TimeISO` class from which it inherits::
   >>> t2.iso
   '2016-01-01 00:00:00.000'
 
+.. testcleanup::
+
+  >>> from astropy.time import TIME_FORMATS
+  >>> del TIME_FORMATS["yday_custom"]
+
 .. EXAMPLE END
 
 .. EXAMPLE START: Customizing the TimeFormat Class with Time Since an Epoch
@@ -1674,6 +1679,11 @@ from the `~astropy.time.TimeFromEpoch` class and define a few class attributes::
   np.float64(946684832.0)
   >>> t.unix_leap - t.unix
   np.float64(32.0)
+
+.. testcleanup::
+
+  >>> from astropy.time import TIME_FORMATS
+  >>> del TIME_FORMATS["unix_leap"]
 
 .. EXAMPLE END
 

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -116,4 +116,8 @@ Now, the prefixed units can be parsed etc::
   >>> print(u.Unit("megafoo").to(u.Unit("kFo")))
   1000.0
 
+.. testcleanup::
+
+    >>> u.core._unit_registries.pop()  # doctest: +IGNORE_OUTPUT
+
 .. EXAMPLE END

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -262,6 +262,9 @@ To enable Imperial units, do::
       yd           | 0.9144 m        | yard                             ,
     ]
 
+.. testcleanup::
+
+    >>> u.core._unit_registries.pop()  # doctest: +IGNORE_OUTPUT
 
 This may also be used with the `Python "with" statement
 <https://docs.python.org/3/reference/compound_stmts.html#with>`_, to

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -269,3 +269,7 @@ UT1Flag, PM_x, PM_y, PolPMFlag::
   57877.0 -0.6573705        P 0.010328 0.451777         P
   57878.0 -0.6587712        P 0.011924 0.453209         P
   57879.0  -0.660187        P 0.013544 0.454617         P
+
+.. testcleanup::
+
+   >>> iers.earth_orientation_table.set(None)  # doctest: +IGNORE_OUTPUT

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ commands =
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
 
-    double: pytest --keep-duplicates --pyargs astropy astropy
+    double: pytest --keep-duplicates --pyargs astropy {toxinidir}/docs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
 
 pip_pre =
     devdeps: true


### PR DESCRIPTION
In #17732, @pllim found that a double run of both the regular tests and the doctests caused failures. While in principle we should not necessarily be as strict for the doctests that there are no side effects, I thought we might as well clean it up. So, I did, and also picked @pllim's first commit from #17743 so that it gets tested.

Note may not fix #17745, as I haven't tied loading all the dependencies. One step at a time, I guess! (cc @neutrinoceros)

closes #17743 (since this PR uses its first commit that also includes the positional arguments)