### PR TITLE
Allow long header values also for HIERARCH keys

### DIFF
--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -719,6 +719,23 @@ class TestHeaderFunctions(FitsTestCase):
         assert c.value == "calFileVersion"
         assert c.comment == ""
 
+    @pytest.mark.xfail(reason="astropy cannot create long HIERARCH headers.")
+    def test_hierarch_key_with_long_value(self):
+        # regression test for gh-3746
+        long_key = "A VERY LONG KEY HERE"
+        long_value = (
+            "A VERY VERY VERY VERY LONG STRING THAT SOMETHING MAY BE MAD"
+            " ABOUT PERSISTING BECAUSE ASTROPY CAN'T HANDLE THE TRUTH"
+        )
+        with pytest.warns(fits.verify.VerifyWarning, match="greater than 8"):
+            card = fits.Card(long_key, long_value)
+        card.verify()
+        assert str(card) == (
+            "HIERARCH A VERY LONG KEY HERE = 'A VERY VERY VERY VERY LONG STRING THAT &'      "
+            "CONTINUE  'SOMETHING MAY BE MAD ABOUT PERSISTING BECAUSE ASTROPY CAN''T &'      "
+            "CONTINUE  'HANDLE THE TRUTH'                                                    "
+        )
+
     def test_verify_mixed_case_hierarch(self):
         """Regression test for
         https://github.com/spacetelescope/PyFITS/issues/7

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -719,7 +719,6 @@ class TestHeaderFunctions(FitsTestCase):
         assert c.value == "calFileVersion"
         assert c.comment == ""
 
-    @pytest.mark.xfail(reason="astropy cannot create long HIERARCH headers.")
     def test_hierarch_key_with_long_value(self):
         # regression test for gh-3746
         long_key = "A VERY LONG KEY HERE"

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -711,12 +711,13 @@ def _str_to_num(val):
     return num
 
 
-def _words_group(s, width):
+def _words_group(s, width, first_width=None):
     """
-    Split a long string into parts where each part is no longer than ``strlen``
+    Split a long string into parts where each part is no longer than ``width``
     and no word is cut into two pieces.  But if there are any single words
-    which are longer than ``strlen``, then they will be split in the middle of
-    the word.
+    which are longer than ``width``, then they will be split in the middle of
+    the word.  If the width of the first part should be smaller, e.g., because
+    of a long HIERARCH header key, one can pass in ``first_width``.
     """
     words = []
     slen = len(s)
@@ -727,7 +728,7 @@ def _words_group(s, width):
 
     # locations of the blanks
     blank_loc = np.nonzero(arr == b" ")[0]
-    offset = 0
+    offset = 0 if first_width is None else first_width - width
     xoffset = 0
 
     while True:

--- a/docs/changes/io.fits/17748.feature.rst
+++ b/docs/changes/io.fits/17748.feature.rst
@@ -1,0 +1,3 @@
+Astropy can now not only read but also write headers that have ``HIERARCH``
+keys with long values, by allowing the use of ``CONTINUE`` cards for those
+(as was already the case for regular FITS keys).


### PR DESCRIPTION
This pull request is to address a long-standing bug, #3746, where astropy could read FITS files with HIERARCH keys that had very long values, included with `CONTINUE` cards, but could not write them. It mainly removes a stanza where someone "guessed" that this should not be allowed.

Fixes #3746

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
