### PR TITLE
BUG: ensure `custom_ucd_coord_meta_mapping` context manager performs a (correct) cleanup

### DIFF
--- a/docs/changes/visualization/17749.bugfix.rst
+++ b/docs/changes/visualization/17749.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that the ``astropy.visualization.wcsaxes.custom_ucd_coord_meta_mapping``
+context manager performs a (correct) cleanup.


### PR DESCRIPTION
### Description
This fixes test pollution seen in two tests (partially address #17745).
Follow up to #16347.
Reprod:
```
pytest astropy/visualization/wcsaxes/tests/test_wcsapi.py astropy/visualization/wcsaxes/tests/test_wcsapi.py --keep-duplicate
```

There were a couple defects in this context managers:
- its cleanup stage wasn't performed if an exception was raised during execution
- there was no attempt to restore overwritten parts of the dictionary that represents the global state

I augmented the affected tests to make them fail on their own if the global state is changed.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
