### PR TITLE
BUG: avoid test pollution in `astropy.units`

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -124,6 +124,13 @@ class TestUfuncHelpers:
         }
         assert all_q_ufuncs - all_np_ufuncs - all_erfa_ufuncs == set()
 
+    @pytest.mark.skipif(
+        HAS_SCIPY,
+        reason=(
+            "UFUNC_HELPERS.modules might be in a different state "
+            "(by design) if scipy.special already registered"
+        ),
+    )
     def test_scipy_registered(self):
         # Should be registered as existing even if scipy is not available.
         assert "scipy.special" in qh.UFUNC_HELPERS.modules
@@ -1564,7 +1571,9 @@ if HAS_SCIPY:
 
     def test_scipy_registration():
         """Check that scipy gets loaded upon first use."""
-        assert sps.erf not in qh.UFUNC_HELPERS
+        if sps.erf in qh.UFUNC_HELPERS:
+            # Generally, scipy will not be loaded here, but in a double run it might.
+            pytest.skip()
         sps.erf(1.0 * u.percent)
         assert sps.erf in qh.UFUNC_HELPERS
 


### PR DESCRIPTION
### Description
Partially address #17745

This fixes two issues:
- `UfuncHelpers.import_module` was needlessly destructive (removing keys from `self.modules`), which led made `test_scipy_registered` fail if run after scipy.special was imported.
- `test_scipy_registration` relies on being run before any scipy.special method is called (which implicitly triggers registration), so it cannot possibly succeed when run at a later point. I don't see a good solution here and I would like to avoid mocking global state too much, so I hope that simply skipping the test on a second run is acceptable.

reprod (requires scipy)
```
pytest astropy/units/tests/test_quantity_ufuncs.py::TestScipySpecialUfuncs::test_erf_scalar  astropy/units/tests/test_quantity_ufuncs.py::test_scipy_registration astropy/units/tests/test_quantity_ufuncs.py::TestUfuncHelpers
```

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
