### PR TITLE
BUG: avoid test pollution in `astropy.modeling`

### DIFF
--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -1075,20 +1075,23 @@ def test_format_input_arrays_transposed():
 
 
 @pytest.mark.parametrize(
-    "model",
+    "cls, kwargs",
     [
-        models.Gaussian2D(),
-        models.Polynomial2D(1),
-        models.Rotation2D(),
-        models.Pix2Sky_TAN(),
-        models.Tabular2D(lookup_table=np.ones((4, 5))),
+        pytest.param(models.Gaussian2D, {}, id="Gaussian2D"),
+        pytest.param(models.Polynomial2D, {"degree": 1}, id="Polynomial2D"),
+        pytest.param(models.Rotation2D, {}, id="Rotation2D"),
+        pytest.param(models.Pix2Sky_TAN, {}, id="Pix2Sky_TAN"),
+        pytest.param(
+            models.Tabular2D, {"lookup_table": np.ones((4, 5))}, id="Tabular2D"
+        ),
     ],
 )
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-def test_call_keyword_args_1(model):
+def test_call_keyword_args_1(cls, kwargs):
     """
     Test calling a model with positional, keywrd and a mixture of both arguments.
     """
+    model = cls(**kwargs)
     positional = model(1, 2)
     assert_allclose(positional, model(x=1, y=2))
     assert_allclose(positional, model(1, y=2))
@@ -1111,18 +1114,19 @@ def test_call_keyword_args_1(model):
 
 
 @pytest.mark.parametrize(
-    "model",
+    "cls, kwargs",
     [
-        models.Gaussian1D(),
-        models.Polynomial1D(1),
-        models.Tabular1D(lookup_table=np.ones((5,))),
+        pytest.param(models.Gaussian1D, {}, id="Gaussian1D"),
+        pytest.param(models.Polynomial1D, {"degree": 1}, id="Polynomial1D"),
+        pytest.param(models.Tabular1D, {"lookup_table": np.ones((5,))}, id="Tabular1D"),
     ],
 )
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-def test_call_keyword_args_2(model):
+def test_call_keyword_args_2(cls, kwargs):
     """
     Test calling a model with positional, keywrd and a mixture of both arguments.
     """
+    model = cls(**kwargs)
     positional = model(1)
     assert_allclose(positional, model(x=1))
 


### PR DESCRIPTION
### Description
Partially address #17745

The problem here is that these tests mutate the objects they are parametrized with (which I assume is expected). The solution is to only create the objects within the test itself so they are not reused if the test runs more than once.

reprod (requires scipy)
```
pytest astropy/modeling/tests/test_input.py astropy/modeling/tests/test_input.py -k test_call_keyword_args --keep-duplicates
```

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
