### PR TITLE
Remove Ruff configuration for `examples/` directory

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -305,7 +305,6 @@ lint.unfixable = [
     "TRY300",  # Consider `else` block
 ]
 "docs/*" = []
-"examples/coordinates/*" = []
 
 ".pyinstaller/*.py" = ["PTH"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -414,11 +414,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 "docs/*.py" = [
     "INP001",  # implicit-namespace-package. The examples are not a package.
 ]
-"examples/*.py" = [
-    "E402",   # Imports are done as needed.
-    "INP001", # implicit-namespace-package. The examples are not a package.
-    "T203"    # pprint found
-]
 "__init__.py" = ["F403"]  # Wildcard imports
 
 [tool.ruff.lint.flake8-annotations]


### PR DESCRIPTION
### Description

The `examples/` directory itself was removed in dddab43bb6c7222948c1727025b9f10e9a2e4109.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
