### PR TITLE
Refactor some pieces in fits.ImageHDU (mostly)

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -560,26 +560,8 @@ class _BaseHDU:
     # TODO: The BaseHDU class shouldn't even handle checksums since they're
     # only implemented on _ValidHDU...
     def _prewriteto(self, checksum=False, inplace=False):
-        self._update_pseudo_int_scale_keywords()
-
         # Handle checksum
         self._update_checksum(checksum)
-
-    def _update_pseudo_int_scale_keywords(self):
-        """
-        If the data is signed int 8, unsigned int 16, 32, or 64,
-        add BSCALE/BZERO cards to header.
-        """
-        if self._has_data and self._standard and _is_pseudo_integer(self.data.dtype):
-            # CompImageHDUs need TFIELDS immediately after GCOUNT,
-            # so BSCALE has to go after TFIELDS if it exists.
-            if "TFIELDS" in self._header:
-                self._header.set("BSCALE", 1, after="TFIELDS")
-            elif "GCOUNT" in self._header:
-                self._header.set("BSCALE", 1, after="GCOUNT")
-            else:
-                self._header.set("BSCALE", 1)
-            self._header.set("BZERO", _pseudo_zero(self.data.dtype), after="BSCALE")
 
     def _update_checksum(
         self, checksum, checksum_keyword="CHECKSUM", datasum_keyword="DATASUM"

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -554,14 +554,15 @@ class CompImageHDU(ImageHDU):
 
         bintable.data = data
 
-    def _prewriteto(self, checksum=False, inplace=False):
+    def _prewriteto(self, inplace=False):
         if (
             self._bintable is not None
             and not self._has_data
             and not self.header._modified
         ):
             self._tmp_bintable = self._bintable
-            return self._tmp_bintable._prewriteto(checksum=checksum, inplace=inplace)
+            self._tmp_bintable._output_checksum = self._output_checksum
+            return self._tmp_bintable._prewriteto(inplace=inplace)
 
         if self._scale_back:
             self._scale_internal(
@@ -580,7 +581,8 @@ class CompImageHDU(ImageHDU):
             self._bintable.data = self._tmp_bintable.data
             self._tmp_bintable = self._bintable
 
-        return self._tmp_bintable._prewriteto(checksum=checksum, inplace=inplace)
+        self._tmp_bintable._output_checksum = self._output_checksum
+        return self._tmp_bintable._prewriteto(inplace=inplace)
 
     def _writeto(self, fileobj, inplace=False, copy=False):
         if self._tmp_bintable is not None:

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -930,7 +930,7 @@ class HDUList(list, _Verify):
 
                 # only append HDU's which are "new"
                 if hdu._new:
-                    hdu._prewriteto(checksum=hdu._output_checksum)
+                    hdu._prewriteto()
                     with _free_space_check(self):
                         hdu._writeto(self._file)
                         if verbose:
@@ -1040,7 +1040,8 @@ class HDUList(list, _Verify):
         try:
             with _free_space_check(self, dirname=dirname):
                 for hdu in self:
-                    hdu._prewriteto(checksum=checksum)
+                    hdu._output_checksum = checksum
+                    hdu._prewriteto()
                     hdu._writeto(hdulist._file)
                     hdu._postwriteto()
         finally:
@@ -1424,7 +1425,7 @@ class HDUList(list, _Verify):
         for hdu in self:
             # Need to all _prewriteto() for each HDU first to determine if
             # resizing will be necessary
-            hdu._prewriteto(checksum=hdu._output_checksum, inplace=True)
+            hdu._prewriteto(inplace=True)
 
         try:
             self._wasresized()

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -53,8 +53,6 @@ class _ImageBaseHDU(_ValidHDU):
         ignore_blank=False,
         **kwargs,
     ):
-        from .groups import GroupsHDU
-
         super().__init__(data=data, header=header)
 
         if data is DELAYED:
@@ -67,6 +65,8 @@ class _ImageBaseHDU(_ValidHDU):
             # TODO: Some of this card manipulation should go into the
             # PrimaryHDU and GroupsHDU subclasses
             # construct a list of cards of minimal header
+            from .groups import GroupsHDU
+
             if isinstance(self, ExtensionHDU):
                 c0 = ("XTENSION", "IMAGE", self.standard_keyword_comments["XTENSION"])
             else:
@@ -84,17 +84,12 @@ class _ImageBaseHDU(_ValidHDU):
                 cards.append(("PCOUNT", 0, self.standard_keyword_comments["PCOUNT"]))
                 cards.append(("GCOUNT", 1, self.standard_keyword_comments["GCOUNT"]))
 
+            new_header = Header(cards)
             if header is not None:
-                orig = header.copy()
-                header = Header(cards)
-                header.extend(orig, strip=True, update=True, end=True)
-            else:
-                header = Header(cards)
-
-            self._header = header
+                new_header.extend(header.copy(), strip=True, update=True, end=True)
+            self._header = new_header
 
         self._do_not_scale_image_data = do_not_scale_image_data
-
         self._uint = uint
         self._scale_back = scale_back
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -398,15 +398,6 @@ class _ImageBaseHDU(_ValidHDU):
         # special cases of BZERO/BSCALE, if any, are auto-detected as following
         # the FITS unsigned int convention.
 
-        # Added original_was_unsigned with the intent of facilitating the
-        # special case of do_not_scale_image_data=True and uint=True
-        # eventually.
-        # FIXME: unused, maybe it should be useful?
-        # if self._dtype_for_bitpix() is not None:
-        #     original_was_unsigned = self._dtype_for_bitpix().kind == 'u'
-        # else:
-        #     original_was_unsigned = False
-
         if self._do_not_scale_image_data or (
             self._orig_bzero == 0 and self._orig_bscale == 1
         ):
@@ -435,8 +426,6 @@ class _ImageBaseHDU(_ValidHDU):
             except KeyError:
                 pass
 
-        if dtype is None:
-            dtype = self._dtype_for_bitpix()
         if dtype is not None:
             self._header["BITPIX"] = DTYPE2BITPIX[dtype.name]
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -388,29 +388,17 @@ class _ImageBaseHDU(_ValidHDU):
 
         self._modified = False
 
-    def _update_header_scale_info(self, dtype=None):
+    def _update_header_scale_info(self, dtype):
         """
-        Delete BSCALE/BZERO from header if necessary.
+        Delete BSCALE/BZERO from header if necessary, i.e. if data has been
+        scaled or replaced by another dtype.
         """
-        # Note that _dtype_for_bitpix determines the dtype based on the
-        # "original" values of bitpix, bscale, and bzero, stored in
-        # self._orig_bitpix, etc. It contains the logic for determining which
-        # special cases of BZERO/BSCALE, if any, are auto-detected as following
-        # the FITS unsigned int convention.
-
         if self._do_not_scale_image_data or (
             self._orig_bzero == 0 and self._orig_bscale == 1
         ):
             return
 
-        if dtype is None:
-            dtype = self._dtype_for_bitpix()
-
-        if (
-            dtype is not None
-            and dtype.kind == "u"
-            and (self._scale_back or self._scale_back is None)
-        ):
+        if dtype.kind == "u" and (self._scale_back or self._scale_back is None):
             # Data is pseudo-unsigned integers, and the scale_back option
             # was not explicitly set to False, so preserve all the scale
             # factors
@@ -426,12 +414,9 @@ class _ImageBaseHDU(_ValidHDU):
             except KeyError:
                 pass
 
-        if dtype is not None:
-            self._header["BITPIX"] = DTYPE2BITPIX[dtype.name]
-
+        self._bitpix = self._header["BITPIX"] = DTYPE2BITPIX[dtype.name]
         self._bzero = 0
         self._bscale = 1
-        self._bitpix = self._header["BITPIX"]
         self._blank = self._header.pop("BLANK", None)
 
     def _update_pseudo_int_scale_keywords(self):
@@ -759,6 +744,12 @@ class _ImageBaseHDU(_ValidHDU):
         Determine the dtype that the data should be converted to depending on
         the BITPIX value in the header, and possibly on the BSCALE value as
         well.  Returns None if there should not be any change.
+
+        Note that _dtype_for_bitpix determines the dtype based on the
+        "original" values of bitpix, bscale, and bzero, stored in
+        self._orig_bitpix, etc. It contains the logic for determining which
+        special cases of BZERO/BSCALE, if any, are auto-detected as following
+        the FITS unsigned int convention.
         """
         bitpix = self._orig_bitpix
         # Handle possible conversion to uints if enabled

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -629,7 +629,7 @@ class _ImageBaseHDU(_ValidHDU):
         for msg in messages:
             warnings.warn(msg, VerifyWarning)
 
-    def _prewriteto(self, checksum=False, inplace=False):
+    def _prewriteto(self, inplace=False):
         if self._scale_back:
             self._scale_internal(
                 BITPIX2DTYPE[self._orig_bitpix], blank=self._orig_blank
@@ -643,7 +643,7 @@ class _ImageBaseHDU(_ValidHDU):
 
         self._update_pseudo_int_scale_keywords()
 
-        return super()._prewriteto(checksum, inplace)
+        return super()._prewriteto(inplace)
 
     def _writedata_internal(self, fileobj):
         size = 0

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -477,7 +477,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         # FITS file)
         return self.__class__(data=self.data.copy(), header=self._header.copy())
 
-    def _prewriteto(self, checksum=False, inplace=False):
+    def _prewriteto(self, inplace=False):
         if self._has_data:
             self.data._scale_back(update_heap_pointers=not self._manages_own_heap)
             # check TFIELDS and NAXIS2
@@ -508,7 +508,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                     format_cls = format.__class__
                     format = format_cls(format.dtype, repeat=format.repeat, max=_max)
                     self._header["TFORM" + str(idx + 1)] = format.tform
-        return super()._prewriteto(checksum, inplace)
+        return super()._prewriteto(inplace)
 
     def _verify(self, option="warn"):
         """

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -261,10 +261,10 @@ class TestChecksumFunctions(BaseChecksumTests):
         hdu.writeto(self.temp("tmp.fits"), overwrite=True, checksum="datasum")
         with fits.open(self.temp("tmp.fits"), checksum=True) as hdul:
             if not (hasattr(hdul[0], "_datasum") and hdul[0]._datasum):
-                pytest.fail(msg="Missing DATASUM keyword")
+                pytest.fail("Missing DATASUM keyword")
 
             if not (hasattr(hdul[0], "_checksum") and not hdul[0]._checksum):
-                pytest.fail(msg="Non-empty CHECKSUM keyword")
+                pytest.fail("Non-empty CHECKSUM keyword")
 
     def test_open_update_mode_preserve_checksum(self):
         """
@@ -366,7 +366,7 @@ class TestChecksumFunctions(BaseChecksumTests):
 
     def _check_checksums(self, hdu):
         if not (hasattr(hdu, "_datasum") and hdu._datasum):
-            pytest.fail(msg="Missing DATASUM keyword")
+            pytest.fail("Missing DATASUM keyword")
 
         if not (hasattr(hdu, "_checksum") and hdu._checksum):
-            pytest.fail(msg="Missing CHECKSUM keyword")
+            pytest.fail("Missing CHECKSUM keyword")


### PR DESCRIPTION
While looking at the scaling code, moved a few code blocks to more logical places (addressing some TODOs) and simplified a few things. Probably easier to review each commit.



<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
