### PR TITLE
Use correct UCD for air wavelengths (replay #16907)

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -132,7 +132,7 @@ CTYPE_TO_UCD1 = {
     "VRAD": "spect.dopplerVeloc.radio",  # Radio velocity
     "VOPT": "spect.dopplerVeloc.opt",  # Optical velocity
     "ZOPT": "src.redshift",  # Redshift
-    "AWAV": "em.wl",  # Air wavelength
+    "AWAV": "em.wl;obs.atmos",  # Air wavelength
     "VELO": "spect.dopplerVeloc",  # Apparent radial velocity
     "BETA": "custom:spect.doplerVeloc.beta",  # Beta factor (v/c)
     "STOKES": "phys.polarization.stokes",  # STOKES parameters

--- a/docs/changes/wcs/17769.bugfix.rst
+++ b/docs/changes/wcs/17769.bugfix.rst
@@ -1,0 +1,3 @@
+Fix UCD for air wavelengths, following the IVOA recommendation that ``'em.wl'``
+be reserved for vacuum wavelengths. ``'em.wl;obs.atmos'`` is now used to
+represent air wavelengths instead.


### PR DESCRIPTION
### Description

This replaces #16907 from @andycasey, adding the missing changelog fragment and using a dedicated branch that I could rebase without creating issues for the original author.

Close #16907

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
