### PR TITLE
TST: temporarilly disable parallelism in double test jobs

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -95,10 +95,11 @@ jobs:
           runs-on: macos-latest
 
         # FIXME: Add aarch64 to name when bump Python version.
+        # FIXME: uncomment posargs when test pollution issues are addressed
         - name: Python 3.11 Double test (Run tests twice)
           linux: py311-test-double
           runs-on: ubuntu-24.04-arm
-          posargs: -n=4
+          # posargs: -n=4
           setenv: |
             ARCH_ON_CI: "arm64"
             IS_CRON: "false"


### PR DESCRIPTION
### Description

Double tests have been flaky these last couple days.
My main concern is that since #17747, we've enabled parallelism in these jobs, which adds randomization in the tests running order.
Seeing that the job can fail on a PR so clearly unrelated like https://github.com/astropy/astropy/pull/17766 makes me think we should (temporarilly !) disable parallelism there and make the builds deterministic while we work on reducing/eliminating test pollution (which we are currently addressing around #17745).

I'll make this (eliminating test pollution) my priority in the coming days so we can hopefully recover faster (and reliable) builds soon !

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
