### PR TITLE
TST: Clean up doctest example to avoid error in double run

### DIFF
--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -98,6 +98,10 @@ can be enabled by calling :func:`~astropy.units.add_enabled_units`::
     kmph         | 0.277778 m / s  |         ,
   ]
 
+.. testcleanup::
+
+    >>> u.core._unit_registries.pop()  # doctest: +IGNORE_OUTPUT
+
 If new units are defined with prefixes enabled, the prefixed units must be
 explicitly enabled as well, e.g., by using the ``namespace`` argument::
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to clean up doctest example as mhvk pointed out at https://github.com/astropy/astropy/pull/17770#issuecomment-2653914109 , whom I credited as co-author in the commit (thanks!).

Close #17770 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
