### PR TITLE
Support using quantities in erfa.apco13

### DIFF
--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -474,50 +474,50 @@ def helper_atoiq(f, unit_type, unit_ri, unit_di, unit_astrom):
 
 
 def get_erfa_helpers():
-    ERFA_HELPERS = {}
-    ERFA_HELPERS[erfa_ufunc.s2c] = helper_s2c
-    ERFA_HELPERS[erfa_ufunc.s2p] = helper_s2p
-    ERFA_HELPERS[erfa_ufunc.c2s] = helper_c2s
-    ERFA_HELPERS[erfa_ufunc.p2s] = helper_p2s
-    ERFA_HELPERS[erfa_ufunc.pm] = helper_invariant
-    ERFA_HELPERS[erfa_ufunc.cpv] = helper_invariant
-    ERFA_HELPERS[erfa_ufunc.p2pv] = helper_p2pv
-    ERFA_HELPERS[erfa_ufunc.pv2p] = helper_pv2p
-    ERFA_HELPERS[erfa_ufunc.pv2s] = helper_pv2s
-    ERFA_HELPERS[erfa_ufunc.pvdpv] = helper_pv_multiplication
-    ERFA_HELPERS[erfa_ufunc.pvxpv] = helper_pv_multiplication
-    ERFA_HELPERS[erfa_ufunc.pvm] = helper_pvm
-    ERFA_HELPERS[erfa_ufunc.pvmpv] = helper_twoarg_invariant
-    ERFA_HELPERS[erfa_ufunc.pvppv] = helper_twoarg_invariant
-    ERFA_HELPERS[erfa_ufunc.pvstar] = helper_pvstar
-    ERFA_HELPERS[erfa_ufunc.pvtob] = helper_pvtob
-    ERFA_HELPERS[erfa_ufunc.pvu] = helper_pvu
-    ERFA_HELPERS[erfa_ufunc.pvup] = helper_pvup
-    ERFA_HELPERS[erfa_ufunc.pdp] = helper_multiplication
-    ERFA_HELPERS[erfa_ufunc.pxp] = helper_multiplication
-    ERFA_HELPERS[erfa_ufunc.rxp] = helper_multiplication
-    ERFA_HELPERS[erfa_ufunc.rxpv] = helper_multiplication
-    ERFA_HELPERS[erfa_ufunc.s2pv] = helper_s2pv
-    ERFA_HELPERS[erfa_ufunc.s2xpv] = helper_s2xpv
-    ERFA_HELPERS[erfa_ufunc.starpv] = helper_starpv
-    ERFA_HELPERS[erfa_ufunc.sxpv] = helper_multiplication
-    ERFA_HELPERS[erfa_ufunc.trxpv] = helper_multiplication
-    ERFA_HELPERS[erfa_ufunc.gc2gd] = helper_gc2gd
-    ERFA_HELPERS[erfa_ufunc.gc2gde] = helper_gc2gde
-    ERFA_HELPERS[erfa_ufunc.gd2gc] = helper_gd2gc
-    ERFA_HELPERS[erfa_ufunc.gd2gce] = helper_gd2gce
-    ERFA_HELPERS[erfa_ufunc.ldn] = helper_ldn
-    ERFA_HELPERS[erfa_ufunc.aper] = helper_aper
-    ERFA_HELPERS[erfa_ufunc.apco13] = helper_apco13
-    ERFA_HELPERS[erfa_ufunc.apio] = helper_apio
-    ERFA_HELPERS[erfa_ufunc.atciq] = helper_atciq
-    ERFA_HELPERS[erfa_ufunc.atciqn] = helper_atciqn
-    ERFA_HELPERS[erfa_ufunc.atciqz] = helper_atciqz_aticq
-    ERFA_HELPERS[erfa_ufunc.aticq] = helper_atciqz_aticq
-    ERFA_HELPERS[erfa_ufunc.aticqn] = helper_aticqn
-    ERFA_HELPERS[erfa_ufunc.atioq] = helper_atioq
-    ERFA_HELPERS[erfa_ufunc.atoiq] = helper_atoiq
-    return ERFA_HELPERS
+    return {
+        erfa_ufunc.apco13: helper_apco13,
+        erfa_ufunc.aper: helper_aper,
+        erfa_ufunc.apio: helper_apio,
+        erfa_ufunc.atciq: helper_atciq,
+        erfa_ufunc.atciqn: helper_atciqn,
+        erfa_ufunc.atciqz: helper_atciqz_aticq,
+        erfa_ufunc.aticq: helper_atciqz_aticq,
+        erfa_ufunc.aticqn: helper_aticqn,
+        erfa_ufunc.atioq: helper_atioq,
+        erfa_ufunc.atoiq: helper_atoiq,
+        erfa_ufunc.c2s: helper_c2s,
+        erfa_ufunc.cpv: helper_invariant,
+        erfa_ufunc.gc2gd: helper_gc2gd,
+        erfa_ufunc.gc2gde: helper_gc2gde,
+        erfa_ufunc.gd2gc: helper_gd2gc,
+        erfa_ufunc.gd2gce: helper_gd2gce,
+        erfa_ufunc.ldn: helper_ldn,
+        erfa_ufunc.p2pv: helper_p2pv,
+        erfa_ufunc.p2s: helper_p2s,
+        erfa_ufunc.pdp: helper_multiplication,
+        erfa_ufunc.pm: helper_invariant,
+        erfa_ufunc.pv2p: helper_pv2p,
+        erfa_ufunc.pv2s: helper_pv2s,
+        erfa_ufunc.pvdpv: helper_pv_multiplication,
+        erfa_ufunc.pvm: helper_pvm,
+        erfa_ufunc.pvmpv: helper_twoarg_invariant,
+        erfa_ufunc.pvppv: helper_twoarg_invariant,
+        erfa_ufunc.pvstar: helper_pvstar,
+        erfa_ufunc.pvtob: helper_pvtob,
+        erfa_ufunc.pvu: helper_pvu,
+        erfa_ufunc.pvup: helper_pvup,
+        erfa_ufunc.pvxpv: helper_pv_multiplication,
+        erfa_ufunc.pxp: helper_multiplication,
+        erfa_ufunc.rxp: helper_multiplication,
+        erfa_ufunc.rxpv: helper_multiplication,
+        erfa_ufunc.s2c: helper_s2c,
+        erfa_ufunc.s2p: helper_s2p,
+        erfa_ufunc.s2pv: helper_s2pv,
+        erfa_ufunc.s2xpv: helper_s2xpv,
+        erfa_ufunc.starpv: helper_starpv,
+        erfa_ufunc.sxpv: helper_multiplication,
+        erfa_ufunc.trxpv: helper_multiplication,
+    }
 
 
 UFUNC_HELPERS.register_module("erfa.ufunc", erfa_ufuncs, get_erfa_helpers)

--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -600,22 +600,24 @@ class TestGeodetic:
         cls.ellipsoid = 1
         cls.length_unit = u.Unit("m")
         cls.equatorial_radius_value = 6378136.0
-        cls.equatorial_radius = cls.equatorial_radius_value << cls.length_unit
+        cls.equatorial_radius = (cls.equatorial_radius_value << cls.length_unit).to(
+            u.km
+        )
         cls.flattening = 0.0033528 * u.dimensionless_unscaled
         cls.lon_value = 0.9827937232473290680
         cls.lon_unit = u.Unit("rad")
-        cls.lon = cls.lon_value << cls.lon_unit
+        cls.lon = (cls.lon_value << cls.lon_unit).to(u.deg)
         cls.lat_value = 0.9716018377570411532
         cls.lat_unit = u.Unit("rad")
-        cls.lat = cls.lat_value << cls.lat_unit
+        cls.lat = (cls.lat_value << cls.lat_unit).to(u.deg)
         cls.height_value = 332.36862495764397
         cls.height = cls.height_value << cls.length_unit
         cls.x_value = 2e6
-        cls.x = cls.x_value << cls.length_unit
+        cls.x = (cls.x_value << cls.length_unit).to(u.cm)
         cls.y_value = 3e6
-        cls.y = cls.y_value << cls.length_unit
+        cls.y = (cls.y_value << cls.length_unit).to(u.km)
         cls.z_value = 5.244e6
-        cls.z = cls.z_value << cls.length_unit
+        cls.z = (cls.z_value << cls.length_unit).to(u.Mm)
         cls.xyz = np.stack([cls.x, cls.y, cls.z])
 
     def test_unit_errors(self):
@@ -657,11 +659,10 @@ class TestGeodetic:
     def test_gc2gde(self):
         """Test that we reproduce erfa/src/t_erfa_c.c t_gc2gd"""
 
-        status = 0
         e, p, h, status = erfa_ufunc.gc2gde(
             self.equatorial_radius, self.flattening, self.xyz
         )
-
+        assert status == 0
         vvd(e, self.lon_value, 1e-14, "eraGc2gde", "e", status)
         vvd(p, self.lat_value, 1e-14, "eraGc2gde", "p", status)
         vvd(h, self.height_value, 1e-8, "eraGc2gde", "h", status)
@@ -669,11 +670,10 @@ class TestGeodetic:
     def test_gd2gce(self):
         """Test that we reproduce erfa/src/t_erfa_c.c t_gc2gd"""
 
-        status = 0
         xyz, status = erfa_ufunc.gd2gce(
             self.equatorial_radius, self.flattening, self.lon, self.lat, self.height
         )
-
+        assert status == 0
         vvd(xyz[0], self.x_value, 1e-7, "eraGd2gce", "e", status)
         vvd(xyz[1], self.y_value, 1e-7, "eraGd2gce", "p", status)
         vvd(xyz[2], self.z_value, 1e-7, "eraGd2gce", "h", status)

--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -21,16 +21,17 @@ def vvd(val, valok, dval, func, test, status):
 
 
 class TestPVUfuncs:
-    def setup_class(self):
-        self.pv_unit = u.Unit("AU,AU/day")
-        self.pv_value = np.array(
+    @classmethod
+    def setup_class(cls):
+        cls.pv_unit = u.Unit("AU,AU/day")
+        cls.pv_value = np.array(
             [
                 ([1.0, 0.0, 0.0], [0.0, 0.0125, 0.0]),
                 ([0.0, 1.0, 0.0], [-0.0125, 0.0, 0.0]),
             ],
             dtype=erfa_ufunc.dt_pv,
         )
-        self.pv = self.pv_value << self.pv_unit
+        cls.pv = cls.pv_value << cls.pv_unit
 
     def test_cpv(self):
         pv_copy = erfa_ufunc.cpv(self.pv)
@@ -321,7 +322,8 @@ class TestPVUfuncs:
 
 
 class TestEraStructUfuncs:
-    def setup_class(self):
+    @classmethod
+    def setup_class(cls):
         ldbody = np.array(
             [
                 (0.00028574, 3e-10, ([-7.81014427, -5.60956681, -1.98079819],
@@ -334,19 +336,19 @@ class TestEraStructUfuncs:
             dtype=erfa_ufunc.dt_eraLDBODY
         )  # fmt: skip
         ldbody_unit = u.StructuredUnit("Msun,radian,(AU,AU/day)", ldbody.dtype)
-        self.ldbody = ldbody << ldbody_unit
-        self.ob = [-0.974170437, -0.2115201, -0.0917583114] << u.AU
-        self.sc = np.array([-0.763276255, -0.608633767, -0.216735543])
+        cls.ldbody = ldbody << ldbody_unit
+        cls.ob = [-0.974170437, -0.2115201, -0.0917583114] << u.AU
+        cls.sc = np.array([-0.763276255, -0.608633767, -0.216735543])
 
         # From t_atciq in t_erfa_c.c
         astrom, eo = erfa_ufunc.apci13(2456165.5, 0.401182685)
-        self.astrom = astrom << ASTROM_UNIT
-        self.rc = 2.71 * u.rad
-        self.dc = 0.174 * u.rad
-        self.pr = 1e-5 * u.rad / u.year
-        self.pd = 5e-6 * u.rad / u.year
-        self.px = 0.1 * u.arcsec
-        self.rv = 55.0 * u.km / u.s
+        cls.astrom = astrom << ASTROM_UNIT
+        cls.rc = 2.71 * u.rad
+        cls.dc = 0.174 * u.rad
+        cls.pr = 1e-5 * u.rad / u.year
+        cls.pd = 5e-6 * u.rad / u.year
+        cls.px = 0.1 * u.arcsec
+        cls.rv = 55.0 * u.km / u.s
 
     def test_ldn_basic(self):
         sn = erfa_ufunc.ldn(self.ldbody, self.ob, self.sc)
@@ -593,27 +595,28 @@ class TestAp:
 
 
 class TestGeodetic:
-    def setup_class(self):
-        self.ellipsoid = 1
-        self.length_unit = u.Unit("m")
-        self.equatorial_radius_value = 6378136.0
-        self.equatorial_radius = self.equatorial_radius_value << self.length_unit
-        self.flattening = 0.0033528 * u.dimensionless_unscaled
-        self.lon_value = 0.9827937232473290680
-        self.lon_unit = u.Unit("rad")
-        self.lon = self.lon_value << self.lon_unit
-        self.lat_value = 0.9716018377570411532
-        self.lat_unit = u.Unit("rad")
-        self.lat = self.lat_value << self.lat_unit
-        self.height_value = 332.36862495764397
-        self.height = self.height_value << self.length_unit
-        self.x_value = 2e6
-        self.x = self.x_value << self.length_unit
-        self.y_value = 3e6
-        self.y = self.y_value << self.length_unit
-        self.z_value = 5.244e6
-        self.z = self.z_value << self.length_unit
-        self.xyz = np.stack([self.x, self.y, self.z])
+    @classmethod
+    def setup_class(cls):
+        cls.ellipsoid = 1
+        cls.length_unit = u.Unit("m")
+        cls.equatorial_radius_value = 6378136.0
+        cls.equatorial_radius = cls.equatorial_radius_value << cls.length_unit
+        cls.flattening = 0.0033528 * u.dimensionless_unscaled
+        cls.lon_value = 0.9827937232473290680
+        cls.lon_unit = u.Unit("rad")
+        cls.lon = cls.lon_value << cls.lon_unit
+        cls.lat_value = 0.9716018377570411532
+        cls.lat_unit = u.Unit("rad")
+        cls.lat = cls.lat_value << cls.lat_unit
+        cls.height_value = 332.36862495764397
+        cls.height = cls.height_value << cls.length_unit
+        cls.x_value = 2e6
+        cls.x = cls.x_value << cls.length_unit
+        cls.y_value = 3e6
+        cls.y = cls.y_value << cls.length_unit
+        cls.z_value = 5.244e6
+        cls.z = cls.z_value << cls.length_unit
+        cls.xyz = np.stack([cls.x, cls.y, cls.z])
 
     def test_unit_errors(self):
         """Test unit errors when dimensionless parameters are used"""


### PR DESCRIPTION
In https://github.com/astropy/astropy/pull/17729#discussion_r1944968631, I suggested that a test could be written more simply by relying on Quantity support for erfa functions. Unfortunately, that was not true: `erfa.apco13` was not yet supported. In part, this is because none of the functions that also take a time are supported, as at some point I had hoped to ensure that those could just take a `Time` instance. But I realized that while that would be good, it is somewhat of a separate concern, so this PR adds Quantity support for `apco13` -- and uses it in the coordinate tests (which becomes just a little nicer). In the process, I also cleaned up the erfa tests a little.

There are obviously more functions that could be done, but it takes considerable time to write both the wrappers and the tests... And I actually prefer to try adding `Time` support first, so that all `erfa` functions can take astropy input. Since for a single erfa function, it seems a bit silly to make a changelog entry, I didn't add any.

Fixes #17738

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
