### PR TITLE
Annotate `UnitBase.bases` as `list[NamedUnit]`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -685,7 +685,7 @@ class UnitBase:
         return 1.0
 
     @property
-    def bases(self) -> list[UnitBase]:
+    def bases(self) -> list[NamedUnit]:
         """The bases of the unit."""
         return [self]
 
@@ -2347,7 +2347,7 @@ class CompositeUnit(UnitBase):
         return self._scale
 
     @property
-    def bases(self) -> list[UnitBase]:
+    def bases(self) -> list[NamedUnit]:
         """The bases of the composite unit."""
         return self._bases
 


### PR DESCRIPTION
### Description

In current `main` `UnitBase.bases` and `CompositeUnit.bases` are annotated as `list[UnitBase]`, but we have code that assumes that all elements of `bases` have a `name` attribute, e.g. https://github.com/astropy/astropy/blob/662ccb3811e5f092f3bf7ed8556ca71e8d015dcf/astropy/units/core.py#L671-L680 or https://github.com/astropy/astropy/blob/662ccb3811e5f092f3bf7ed8556ca71e8d015dcf/astropy/units/core.py#L903-L907
`CompositeUnit` instances have no `name`, so Mypy marks the aforementioned functions as erroneous unless the elements of `bases` are limited to `NamedUnit`.

The reason for writing the annotations as `list[UnitBase]` in the first place was that adding `assert all(isinstance(x, NamedUnit) for x in self._bases)` to `CompositeUnit.bases` causes a failure in https://github.com/astropy/astropy/blob/662ccb3811e5f092f3bf7ed8556ca71e8d015dcf/astropy/units/tests/test_units.py#L757-L763
However, `G_decomposed.unit.bases` is a `list` of `NamedUnit` instances, so it is not entirely clear to me what is happening in that test. I suspect that the signatures of the `decompose()` methods of `UnitBase` and its subclasses should be `def decompose(self, bases: Collection[NamedUnit] = ()) -> UnitBase` instead of the current `def decompose(self, bases: Collection[UnitBase] = ()) -> UnitBase`, but I will have to investigate this further. The more rigorous our annotations are, the simpler it will be to use type checkers to diagnose problems, so this small patch is a step in the right direction.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
