### PR TITLE
Improve error message for trying to dynamically document a `CompositeUnit`

### DIFF
--- a/astropy/units/tests/data/bad_module.py
+++ b/astropy/units/tests/data/bad_module.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# ruff: noqa: INP001
+
+# The machinery that dynamically creates docstrings for the modules that contain unit
+# definitions assumes that all the units are `NamedUnit` instances. If the units are
+# created using `def_unit()` then they are, but multiplying or dividing existing units
+# creates `CompositeUnit` instances. This module deliberately creates a `CompositeUnit`
+# to allow testing that the resulting error message is informative.
+
+from astropy import units as u
+from astropy.units.utils import generate_unit_summary
+
+km_per_h = u.km / u.h
+
+__doc__ = generate_unit_summary(globals())

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -4,6 +4,7 @@ Test utilities for `astropy.units`.
 """
 
 import numpy as np
+import pytest
 
 from astropy.units.quantity import Quantity
 from astropy.units.utils import quantity_asanyarray
@@ -22,3 +23,12 @@ def test_quantity_asanyarray():
 
     np_array = quantity_asanyarray(array_of_integers, dtype=np.inexact)
     assert np.issubdtype(np_array.dtype, np.inexact)
+
+
+@pytest.mark.xfail(reason="Regression test to reveal a bug not fixed yet")
+def test_composite_unit_definition():
+    # Regression test for #17781 - error message was not informative
+    with pytest.raises(
+        TypeError, match=r"^'km_per_h' must be defined with 'def_unit\(\)'$"
+    ):
+        from astropy.units.tests.data import bad_module  # noqa: F401

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -25,7 +25,6 @@ def test_quantity_asanyarray():
     assert np.issubdtype(np_array.dtype, np.inexact)
 
 
-@pytest.mark.xfail(reason="Regression test to reveal a bug not fixed yet")
 def test_composite_unit_definition():
     # Regression test for #17781 - error message was not informative
     with pytest.raises(

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from .core import UnitBase
+    from .core import NamedUnit
     from .quantity import Quantity
     from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
 
@@ -52,7 +52,7 @@ def _get_first_sentence(s: str) -> str:
 
 def _iter_unit_summary(
     namespace: dict[str, object],
-) -> Generator[tuple[UnitBase, str, str, str, Literal["Yes", "No"]], None, None]:
+) -> Generator[tuple[NamedUnit, str, str, str, Literal["Yes", "No"]], None, None]:
     """
     Generates the ``(unit, doc, represents, aliases, prefixes)``
     tuple used to format the unit summary docs in `generate_unit_summary`.
@@ -67,6 +67,9 @@ def _iter_unit_summary(
         # Skip non-unit items
         if not isinstance(val, core.UnitBase):
             continue
+
+        if not isinstance(val, core.NamedUnit):
+            raise TypeError(f"{key!r} must be defined with 'def_unit()'")
 
         # Skip aliases
         if key != val.name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ norecursedirs = [
     "docs[\\/]generated",
     "astropy[\\/]extern",
     "astropy[\\/]_dev",
+    "astropy[\\/]units[\\/]tests[\\/]data",
 ]
 astropy_header = true
 doctest_plus = "enabled"


### PR DESCRIPTION
### Description

Running `mypy --follow-imports silent astropy/units/{core,utils}.py` currently produces 28 errors, 4 of which are relevant for this pull request:
```
astropy/units/utils.py:72: error: "UnitBase" has no attribute "name"  [attr-defined]
astropy/units/utils.py:83: error: "UnitBase" has no attribute "name"  [attr-defined]
astropy/units/utils.py:90: error: "UnitBase" has no attribute "aliases"  [attr-defined]
astropy/units/utils.py:97: error: "UnitBase" has no attribute "name"  [attr-defined]
```
The code in question is responsible for dynamically generating docstrings for the modules that contain unit definitions (e.g. `astropy/units/si.py`). The safe way to define units is using `def_unit()`, which ensures they are `NamedUnit` instances. If a unit is created by dividing or multiplying other units then it will be a `CompositeUnit`, and its presence will cause importing the module where it is defined to fail with an uninformative error message: `AttributeError: 'CompositeUnit' object has no attribute 'name'` (which is what Mypy is warning about). Although defining `CompositeUnit` instances will still cause errors with my patch, the error messages will be much more informative. Furthermore, the check I am adding is useful even if nobody ever triggers this error because it resolves the aforementioned Mypy errors.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
