### PR TITLE
Followup fixes for HIERARCH cards with long values

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -428,14 +428,13 @@ class Card(_Verify):
     @property
     def comment(self):
         """Get the comment attribute from the card image if not already set."""
-        if self._comment is not None:
-            return self._comment
-        elif self._image:
-            self._comment = self._parse_comment()
-            return self._comment
+        if self._comment is None:
+            self._comment = self._parse_comment() if self._image else ""
+
+        if conf.strip_header_whitespace and isinstance(self._comment, str):
+            return self._comment.rstrip()
         else:
-            self._comment = ""
-            return ""
+            return self._comment
 
     @comment.setter
     def comment(self, comment):

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -1029,7 +1029,9 @@ class Card(_Verify):
             # longstring case (CONTINUE card)
             # try not to use CONTINUE if the string value can fit in one line.
             # Instead, just truncate the comment
-            if isinstance(self.value, str) and len(value) > (self.length - 10):
+            if isinstance(self.value, str) and len(value) > (
+                self.length - len(keyword) - 2
+            ):
                 output = self._format_long_image()
             else:
                 warnings.warn(
@@ -1054,7 +1056,7 @@ class Card(_Verify):
         # We have to be careful that the first line may be able to hold less
         # of the value, if it is a HIERARCH keyword.
         headstr = self._format_keyword() + VALUE_INDICATOR
-        first_value_length = value_length + KEYWORD_LENGTH + 1 - len(headstr)
+        first_value_length = value_length + KEYWORD_LENGTH + 2 - len(headstr)
 
         # do the value string
         value = self._value.replace("'", "''")

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -735,7 +735,6 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'HANDLE THE TRUTH'                                                    "
         )
 
-    @pytest.mark.xfail
     def test_hierarch_key_with_long_value_no_spaces(self):
         # regression test for gh-3746
         long_key = "A VERY LONG KEY HERE"
@@ -749,7 +748,6 @@ class TestHeaderFunctions(FitsTestCase):
             "CONTINUE  'IJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ'                        "
         )
 
-    @pytest.mark.xfail
     def test_hierarch_key_with_medium_value_and_comment(self):
         long_key = "A VERY LONG KEY HERE"
         medium_value = "ABCD EFGH IJKL MNOP QRST " * 2

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -728,12 +728,13 @@ def _words_group(s, width, first_width=None):
 
     # locations of the blanks
     blank_loc = np.nonzero(arr == b" ")[0]
-    offset = 0 if first_width is None else first_width - width
+    current_width = width if first_width is None else first_width
+    offset = 0
     xoffset = 0
 
     while True:
         try:
-            loc = np.nonzero(blank_loc >= width + offset)[0][0]
+            loc = np.nonzero(blank_loc >= current_width + offset)[0][0]
         except IndexError:
             loc = len(blank_loc)
 
@@ -744,13 +745,14 @@ def _words_group(s, width, first_width=None):
 
         # check for one word longer than strlen, break in the middle
         if offset <= xoffset:
-            offset = min(xoffset + width, slen)
+            offset = min(xoffset + current_width, slen)
 
         # collect the pieces in a list
         words.append(s[xoffset:offset])
         if offset >= slen:
             break
         xoffset = offset
+        current_width = width
 
     return words
 


### PR DESCRIPTION
In #17748, I tried to ensure that HIERARCH fits header cards could be represented correctly also if they had long values, using CONTINUE cards. It turned out that solution was not quite complete, as it did not fix the case there the value was a string with no spaces, and could go wrong when a comment was also present. See https://github.com/astropy/astropy/issues/3746#issuecomment-2660251154 and https://github.com/astropy/astropy/issues/3746#issuecomment-2660339006.

This PR fixes those additional problems. Since they just fix my original PR, a changelog entry is not needed.

Note that this also adds roundtrip tests, where the card is written to a file and read back. When I did that, I noticed that another test I included now failed, because spaces at the end of comments were not stripped. I thought that was a buglet, so now do that in `Card.comment`, following the pattern for `Card.value`, but if this is considered too risky, I can also just make the test pass. (I can also move it to a separate PR if needed.)

Fixes #3746

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
