### PR TITLE
BUG: Fix `bayesian_blocks` to handle binned data with zero entries correctly

### DIFF
--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -473,7 +473,11 @@ class Events(FitnessFunc):
 
     def fitness(self, N_k: NDArray[float], T_k: NDArray[float]) -> NDArray[float]:
         # eq. 19 from Scargle 2013
-        return N_k * (np.log(N_k / T_k))
+        tmp = np.zeros(N_k.shape)
+        mask = N_k > 0
+        rate = np.divide(N_k, T_k, out=tmp, where=mask)
+        ln_rate = np.log(rate, out=tmp, where=mask)
+        return np.multiply(N_k, ln_rate, out=tmp, where=mask)
 
     def validate_input(
         self,

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -472,12 +472,18 @@ class Events(FitnessFunc):
     """
 
     def fitness(self, N_k: NDArray[float], T_k: NDArray[float]) -> NDArray[float]:
-        # eq. 19 from Scargle 2013
-        tmp = np.zeros(N_k.shape)
+        # Implement Eq. 19 from Scargle (2013), i.e., N_k * ln(N_k / T_k).
+        # Note that when N_k -> 0, the limit of N_k * ln(N_k / T_k) is 0.
+        # N_k is guaranteed to be non-negative integers by the `validate_input`
+        # method, so no need to check for negative values here.
+        # First, initialize an array of zeros to store the fitness values,
+        # then calculate the fitness values only where N_k > 0.
+        # For N_k == 0, the corresponding fitness values are zero already.
+        out = np.zeros(N_k.shape)
         mask = N_k > 0
-        rate = np.divide(N_k, T_k, out=tmp, where=mask)
-        ln_rate = np.log(rate, out=tmp, where=mask)
-        return np.multiply(N_k, ln_rate, out=tmp, where=mask)
+        rate = np.divide(N_k, T_k, out=out, where=mask)
+        ln_rate = np.log(rate, out=out, where=mask)
+        return np.multiply(N_k, ln_rate, out=out, where=mask)
 
     def validate_input(
         self,
@@ -486,8 +492,10 @@ class Events(FitnessFunc):
         sigma: float | ArrayLike | None,
     ) -> tuple[NDArray[float], NDArray[float], NDArray[float]]:
         t, x, sigma = super().validate_input(t, x, sigma)
-        if x is not None and np.any(x % 1 > 0):
-            raise ValueError("x must be integer counts for fitness='events'")
+        if x is not None and np.any(x % 1 > 0) and np.any(x < 0):
+            raise ValueError(
+                "x must be non-negative integer counts for fitness='events'"
+            )
         return t, x, sigma
 
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -492,7 +492,7 @@ class Events(FitnessFunc):
         sigma: float | ArrayLike | None,
     ) -> tuple[NDArray[float], NDArray[float], NDArray[float]]:
         t, x, sigma = super().validate_input(t, x, sigma)
-        if x is not None and np.any(x % 1 > 0) and np.any(x < 0):
+        if (x is not None) and (np.any(x % 1 > 0) or np.any(x < 0)):
             raise ValueError(
                 "x must be non-negative integer counts for fitness='events'"
             )

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -176,6 +176,7 @@ def test_zero_change_points(rseed=0):
     assert values.min() == bins[0]
     assert values.max() == bins[-1]
 
+
 def test_binned_data_with_zeros(rseed=0):
     """
     Ensure that binned data with zero entries is handled correctly.
@@ -186,7 +187,7 @@ def test_binned_data_with_zeros(rseed=0):
     n = 100
     t = np.arange(n)
     x = rng.poisson(1.0, n)
-    x[n//2] = 999
+    x[n // 2] = 999
     edges = bayesian_blocks(t, x)
-    expected = [t[0], t[n//2] - 0.5, t[n//2] + 0.5, t[-1]]
+    expected = [t[0], t[n // 2] - 0.5, t[n // 2] + 0.5, t[-1]]
     assert_allclose(edges, expected)

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -82,9 +82,12 @@ def test_errors():
     rng = np.random.default_rng(0)
     t = rng.random(100)
 
-    # x must be integer or None for events
+    # x must be non-negative integer or None for events
     with pytest.raises(ValueError):
         bayesian_blocks(t, fitness="events", x=t)
+
+    with pytest.raises(ValueError):
+        bayesian_blocks(t, fitness="events", x=np.full(t.size, -1))
 
     # x must be binary for regular events
     with pytest.raises(ValueError):

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -180,7 +180,7 @@ def test_binned_data_with_zeros(rseed=0):
     """
     Ensure that binned data with zero entries is handled correctly.
     """
-    np.random.seed(rseed)
+    rng = np.random.default_rng(rseed)
     # Using the failed edge case from
     # https://github.com/astropy/astropy/issues/17786
     n = 100

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -177,17 +177,23 @@ def test_zero_change_points(rseed=0):
     assert values.max() == bins[-1]
 
 
-def test_binned_data_with_zeros(rseed=0):
+def test_binned_data_with_zeros():
     """
     Ensure that binned data with zero entries is handled correctly.
     """
-    rng = np.random.default_rng(rseed)
     # Using the failed edge case from
     # https://github.com/astropy/astropy/issues/17786
+    rng = np.random.default_rng(0)
     n = 100
     t = np.arange(n)
+
+    # Generate data from Poisson distribution of mean 1. The data, x,
+    # contains zeros with default seed 0. A single outlier is set to be 999
+    # at the midpoint to ensure that the outlier is detected by the algorithm.
     x = rng.poisson(1.0, n)
     x[n // 2] = 999
-    edges = bayesian_blocks(t, x)
+
+    # Check events fitness function with binned data
+    edges = bayesian_blocks(t, x, fitness="events")
     expected = [t[0], t[n // 2] - 0.5, t[n // 2] + 0.5, t[-1]]
     assert_allclose(edges, expected)

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -175,3 +175,18 @@ def test_zero_change_points(rseed=0):
     bins = bayesian_blocks(values)
     assert values.min() == bins[0]
     assert values.max() == bins[-1]
+
+def test_binned_data_with_zeros(rseed=0):
+    """
+    Ensure that binned data with zero entries is handled correctly.
+    """
+    np.random.seed(rseed)
+    # Using the failed edge case from
+    # https://github.com/astropy/astropy/issues/17786
+    n = 100
+    t = np.arange(n)
+    x = rng.poisson(1.0, n)
+    x[n//2] = 999
+    edges = bayesian_blocks(t, x)
+    expected = [t[0], t[n//2] - 0.5, t[n//2] + 0.5, t[-1]]
+    assert_allclose(edges, expected)

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -190,13 +190,17 @@ def test_binned_data_with_zeros():
     n = 100
     t = np.arange(n)
 
-    # Generate data from Poisson distribution of mean 1. The data, x,
-    # contains zeros with default seed 0. A single outlier is set to be 999
-    # at the midpoint to ensure that the outlier is detected by the algorithm.
+    # Generate data from Poisson distribution of mean 1.
+    # We set the first bin to have zero counts to test the edge case.
+    # A single outlier is set to be 999 at the midpoint to ensure that the
+    # outlier is detected by the algorithm.
     x = rng.poisson(1.0, n)
+    x[0] = 0
     x[n // 2] = 999
 
     # Check events fitness function with binned data
-    edges = bayesian_blocks(t, x, fitness="events")
+    edges1 = bayesian_blocks(t, x)
+    edges2 = bayesian_blocks(t, x, fitness="events")
     expected = [t[0], t[n // 2] - 0.5, t[n // 2] + 0.5, t[-1]]
-    assert_allclose(edges, expected)
+    assert_allclose(edges1, expected)
+    assert_allclose(edges2, expected)

--- a/docs/changes/stats/17787.bugfix.rst
+++ b/docs/changes/stats/17787.bugfix.rst
@@ -1,2 +1,2 @@
 Now ``bayesian_blocks(t, x, fitness="events")`` correctly handles the case
-when the input data `x` contains zeros.
+when the input data ``x`` contains zeros.

--- a/docs/changes/stats/17787.bugfix.rst
+++ b/docs/changes/stats/17787.bugfix.rst
@@ -1,0 +1,2 @@
+Now ``bayesian_blocks(t, x, fitness="events")`` correctly handles the case
+when the input data `x` contains zeros.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix #17786. The `Events.fitness` method now correctly handles cases where `N_k` contains zeros.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
