### PR TITLE
Update `pytest` minversion setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,7 @@ namespaces = true
 version_file = "astropy/_version.py"
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "8.0"
 testpaths = [
     "astropy",
     "docs",


### PR DESCRIPTION
### Description

The minimum supported version has been 8.0 since f31ef437ca81426d166479e39f1eab26e5385be0

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
