### PR TITLE
BLD: set `NPY_NO_DEPRECATED_API` at the root level of the package

### DIFF
--- a/astropy/convolution/setup_package.py
+++ b/astropy/convolution/setup_package.py
@@ -22,7 +22,6 @@ def get_extensions():
     ]
     _convolve_ext = Extension(
         name="astropy.convolution._convolve",
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         extra_compile_args=extra_compile_args,
         include_dirs=[get_numpy_include()],
         sources=sources,

--- a/astropy/io/ascii/setup_package.py
+++ b/astropy/io/ascii/setup_package.py
@@ -15,7 +15,6 @@ def get_extensions():
     ]
     ascii_ext = Extension(
         name="astropy.io.ascii.cparser",
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         include_dirs=[get_numpy_include()],
         sources=sources,
     )

--- a/astropy/stats/setup_package.py
+++ b/astropy/stats/setup_package.py
@@ -15,14 +15,12 @@ SRCFILES = [str(ROOT / "src" / srcfile) for srcfile in SRCFILES]
 def get_extensions() -> list[Extension, Extension]:
     _sigma_clip_ext = Extension(
         name="astropy.stats._fast_sigma_clip",
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=SRCFILES,
         include_dirs=[get_numpy_include()],
         language="c",
     )
     _stats_ext = Extension(
         name="astropy.stats._stats",
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[str(ROOT / "_stats.pyx")],
         include_dirs=[get_numpy_include()],
     )

--- a/astropy/table/setup_package.py
+++ b/astropy/table/setup_package.py
@@ -16,7 +16,6 @@ def get_extensions():
     exts = [
         Extension(
             name=f"astropy.table.{source.stem}",
-            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
             sources=[str(source)],
             include_dirs=include_dirs,
         )

--- a/astropy/timeseries/periodograms/bls/setup_package.py
+++ b/astropy/timeseries/periodograms/bls/setup_package.py
@@ -11,7 +11,6 @@ BLS_ROOT = Path(__file__).parent.resolve().relative_to(Path.cwd())
 def get_extensions():
     ext = Extension(
         "astropy.timeseries.periodograms.bls._impl",
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[
             str(BLS_ROOT / "bls.c"),
             str(BLS_ROOT / "_impl.pyx"),

--- a/astropy/timeseries/periodograms/lombscargle/setup_package.py
+++ b/astropy/timeseries/periodograms/lombscargle/setup_package.py
@@ -11,7 +11,6 @@ ROOT = Path(__file__).parent.resolve().relative_to(Path.cwd())
 def get_extensions():
     ext = Extension(
         "astropy.timeseries.periodograms.lombscargle.implementations.cython_impl",
-        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
         sources=[str(ROOT / "implementations" / "cython_impl.pyx")],
         include_dirs=[get_numpy_include()],
     )

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ ext_modules = get_extensions()
 for ext in ext_modules:
     if ext.include_dirs and "numpy" in ext.include_dirs[0]:
         ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_23_API_VERSION"))
+        ext.define_macros.append(("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"))
 
 setup(ext_modules=ext_modules)


### PR DESCRIPTION
### Description
While studying the existing infrastructure for #17760, I noticed that this pre-processor macro was defined in multiple places when it should be possible to do it just once, just like we do for `NPY_TARGET_VERSION`.

This should help switching to a different build system if we elect to, as well as ensure that we don't have a single extension using deprecated C APIs from numpy lying around.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
