### PR TITLE
API: Require that bases to decompose into are named units

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -754,12 +754,19 @@ def test_comparison():
         u.m > u.kg  # noqa: B015
 
 
+def test_decompose_requires_named_unit():
+    with pytest.raises(TypeError, match="NamedUnit"):
+        u.m.decompose(bases=[u.Unit("8 m")])
+
+    decomposed = u.m.decompose(bases=[u.Unit("eightmeter", "8 m")])
+    assert decomposed.scale == 0.125
+
+
 def test_compose_into_arbitrary_units():
-    # Issue #1438
+    # Issue #1438, but adjusted to require a NamedUnit after #17780.
     from astropy.constants import G
 
-    G_decomposed = G.decompose([u.kg, u.km, u.Unit("100 s")])
-    assert_allclose(G_decomposed.unit.scale, 1e-4)
+    G_decomposed = G.decompose([u.kg, u.km, u.Unit("hundredsecond", "100 s")])
     assert G_decomposed == G
 
 

--- a/docs/changes/units/17794.api.rst
+++ b/docs/changes/units/17794.api.rst
@@ -1,0 +1,4 @@
+If the various ``.decompose()`` functions are used with explicit ``bases``,
+these bases are now required to be named units.  This was always meant to be
+the case, but was not checked, and inclusion of unnamed composite units could
+lead to broken output ``CompositeUnit``.


### PR DESCRIPTION
If the various `.decompose()` functions are used with explicit `bases`, these bases are now required to be named units.  This was always meant to be the case, but was not checked, and inclusion of unnamed composite units could lead to broken output `CompositeUnit`.

Fixes #17780

p.s. Since this is an API change, even if a minor one, I milestoned it for 8.0.
 
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
