### PR TITLE
BUG: Ensure that CompositeUnit bases are always NamedUnit.

### DIFF
--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -1027,3 +1027,9 @@ def test_magnetic_flux_field():
     assert_allclose(B.to_value(u.Oe, u.magnetic_flux_field()), 1)
     assert_allclose(H.to_value(u.G, u.magnetic_flux_field(mu_r=0.8)), 0.8)
     assert_allclose(B.to_value(u.Oe, u.magnetic_flux_field(mu_r=0.8)), 1.25)
+
+
+def test_custom_dimensionless():
+    q = 100 * u.s
+    converted = q.to_value(u.one, equivalencies=[(u.Unit("5 s"), None)])
+    assert converted == 20.0

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -754,12 +754,23 @@ def test_comparison():
         u.m > u.kg  # noqa: B015
 
 
+def test_decompose_removes_scale_from_unnamed_unit():
+    decomposed = u.km.decompose(bases=[u.Unit("8 m")])
+    assert decomposed.scale == 1000.0
+    assert decomposed.bases[0] is u.m
+
+    decomposed = u.m.decompose(bases=[u.Unit("eightmeter", "8 m")])
+    assert decomposed.scale == 0.125
+
+
 def test_compose_into_arbitrary_units():
-    # Issue #1438
+    # Issue #1438, though note that after dealing with #17780, the unit
+    # no longer has a scale of 1e-4, as should be the case given that
+    # it calls _decompose(allowscaledunits=False, bases).
     from astropy.constants import G
 
     G_decomposed = G.decompose([u.kg, u.km, u.Unit("100 s")])
-    assert_allclose(G_decomposed.unit.scale, 1e-4)
+    assert_allclose(G_decomposed.unit.scale, 1.0)
     assert G_decomposed == G
 
 

--- a/docs/changes/units/17796.bugfix.rst
+++ b/docs/changes/units/17796.bugfix.rst
@@ -1,0 +1,9 @@
+Ensure that ``CompositeUnit`` always have bases consisting of named units.
+A consequence of this is that decompositions into unnamed units such as
+``u.ks.decompose([u.Unit("100 s")])``, while now representable, will have
+different scale and bases (effectively, "1000 s" instead of "10 100 s",
+where the latter could not be represented as a standard unit).
+
+In practice, this should not affect anything, since the physical meaning of
+the unit has not changed.  If the scale is important, one should use named
+units (e.g., ``u.ks.decompose([u.Unit("mytime", "100 s")])``).


### PR DESCRIPTION
Ensure that ``CompositeUnit`` always have bases consisting of named units. A consequence of this is that decompositions into unnamed units such as `u.ks.decompose([u.Unit("100 s")])`, while now representable, will have different scale and bases (effectively, "1000 s" instead of "10 100 s", where the latter could not be represented as a standard unit).

In practice, this should not affect anything, since the physical meaning of the unit has not changed.  If the scale is important, one should use named units (e.g., ``u.ks.decompose([u.Unit("mytime", "100 s")])``).

Fixes #17780 

I think for this PR there is no real API change: every input that was possible before is still possible, though the output is now representable and in some cases slightly different. The one adjusted test arguably was arguably testing unintended behaviour (since it gave a scaled unit even though it passed through a routine with `allowscaledunits=False`). That said, just to be safe, we should not backport it.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
