### PR TITLE
fix ruff rule c408 violations in all remaining subpackages

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -242,7 +242,6 @@ lint.unfixable = [
     "PTH",
 ]
 "astropy/logger.py" = [
-    "C408",
     "RET505",
 ]
 "astropy/modeling/*" = [
@@ -251,9 +250,7 @@ lint.unfixable = [
     "TRY300",  # Consider `else` block
     "F811",  # see https://github.com/astropy/astropy/pull/16633
 ]
-"astropy/nddata/*" = [
-    "C408",
-]
+"astropy/nddata/*" = []
 "astropy/samp/*" = [
     "PTH",      # all flake8-use-pathlib
 ]
@@ -265,7 +262,6 @@ lint.unfixable = [
     "TRY300",  # Consider `else` block
 ]
 "astropy/tests/*" = [
-    "C408",
     "PTH",      # all flake8-use-pathlib
     "RET505"
 ]
@@ -296,7 +292,6 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/wcs/*" = [
-    "C408",  # unnecessary-collection-call
     "F821",  # undefined-name
     "PTH",      # all flake8-use-pathlib
     "S608",  # Posslibe SQL injection

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -377,7 +377,7 @@ class AstropyLogger(Logger):
             # IPython has its own way of dealing with exceptions
             from IPython import get_ipython
 
-            get_ipython().set_custom_exc(tuple(), None)
+            get_ipython().set_custom_exc({}, None)
         else:
             # standard python interpreter
             if sys.excepthook != self._excepthook:

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -377,7 +377,7 @@ class AstropyLogger(Logger):
             # IPython has its own way of dealing with exceptions
             from IPython import get_ipython
 
-            get_ipython().set_custom_exc({}, None)
+            get_ipython().set_custom_exc((), None)
         else:
             # standard python interpreter
             if sys.excepthook != self._excepthook:

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -86,7 +86,7 @@ class BitFlagNameMeta(type):
         attrl = list(map(str.lower, attr))
 
         if _ENABLE_BITFLAG_CACHING:
-            cache = dict()
+            cache = {}
 
         for b in bases:
             for k, v in b.__dict__.items():

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -477,7 +477,7 @@ class NDArithmeticMixin:
             # Both have uncertainties so just propagate.
 
             # only supply the axis kwarg if one has been specified for a collapsing operation
-            axis_kwarg = dict(axis=kwds["axis"]) if "axis" in kwds else dict()
+            axis_kwarg = dict(axis=kwds["axis"]) if "axis" in kwds else {}
             return self.uncertainty.propagate(
                 operation, operand, result, correlation, **axis_kwarg
             )

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -144,7 +144,7 @@ def generic_recursive_equality_test(a, b, class_history):
     # For a class with `__slots__` the default state is not a `dict`;
     # with neither `__dict__` nor `__slots__` it is `None`.
     state = a.__getstate__(a) if isinstance(a, type) else a.__getstate__()
-    dict_a = state if isinstance(state, dict) else getattr(a, "__dict__", dict())
+    dict_a = state if isinstance(state, dict) else getattr(a, "__dict__", {})
     dict_b = b.__dict__
     for key in dict_a:
         assert key in dict_b, f"Did not pickle {key}"

--- a/astropy/uncertainty/distributions.py
+++ b/astropy/uncertainty/distributions.py
@@ -199,7 +199,7 @@ def uniform(
         )
 
     newshape = lower.shape + (n_samples,)
-    if lower.shape == tuple() and upper.shape == tuple():
+    if lower.shape == () and upper.shape == ():
         width = upper - lower  # scalar
     else:
         width = (upper - lower)[:, np.newaxis]

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -174,7 +174,7 @@ class SlicedLowLevelWCS(BaseWCSWrapper):
                 continue
 
             if "world_axis_object_classes" not in dropped_info:
-                dropped_info["world_axis_object_classes"] = dict()
+                dropped_info["world_axis_object_classes"] = {}
 
             wao_classes = self._wcs.world_axis_object_classes
             wao_components = self._wcs.world_axis_object_components


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Address remaining violations of the ruff rule C408 across all subpackages byrefactoring dict() and tuple() calls by literals. 

This PR affects the following subpackages:

- astropy/logger
- astropy/nddata
- astropy/tests
- astropy/uncertainty
- astropy/wcs

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes part of #14818 