### PR TITLE
TST: use earlier ubuntu to see if that allows docker images to work

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -104,7 +104,7 @@ jobs:
     # we include them just in the weekly cron. These also serve as a test
     # of using system libraries and using pytest directly.
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Python 3.12
     # keep condition in sync with test_arm64
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))


### PR DESCRIPTION
Using ubuntu-22.04 as base worked for me in `baseband` to get the exotic architecture tests working again, so I thought I might give it a try for astropy too.

* fixes #17663
* fixes https://github.com/astropy/astropy/issues/17664