### PR TITLE
Fix Ruff rules for astropy/constants

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -191,7 +191,7 @@ lint.unfixable = [
 ]
 
 [lint.extend-per-file-ignores]
-"__init__.py" = ["E402", "F401"]
+"__init__.py" = ["F401"]
 "test_*.py" = [
     "PTH", # all flake8-use-pathlib
     "RUF015",  # Prefer next({iterable}) over single element slice

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -201,9 +201,7 @@ lint.unfixable = [
 # is better to fix for subpackages individually. The general exclusion should be
 # copied to these subpackage sections and fixed there.
 "astropy/config/*" = []
-"astropy/constants/*" = [
-    "N817",    # camelcase-imported-as-acronym
-]
+"astropy/constants/*" = []
 "astropy/convolution/*" = [
     "PLR0911",  # too-many-return-statements
 ]

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -5,7 +5,7 @@ import copy
 import pytest
 
 from astropy.constants import Constant
-from astropy.units import Quantity as Q
+from astropy.units import Quantity
 
 
 def test_c():
@@ -45,7 +45,7 @@ def test_e():
     from astropy.constants import e
 
     # A test quantity
-    E = Q(100, "V/m")
+    E = Quantity(100, "V/m")
 
     # Without specifying a system e should not combine with other quantities
     pytest.raises(TypeError, lambda: e * E)
@@ -57,13 +57,13 @@ def test_e():
     # e.cgs is too ambiguous and should not work at all
     pytest.raises(TypeError, lambda: e.cgs * E)
 
-    assert isinstance(e.si, Q)
-    assert isinstance(e.gauss, Q)
-    assert isinstance(e.esu, Q)
+    assert isinstance(e.si, Quantity)
+    assert isinstance(e.gauss, Quantity)
+    assert isinstance(e.esu, Quantity)
 
-    assert e.si * E == Q(100, "eV/m")
-    assert e.gauss * E == Q(e.gauss.value * E.value, "Fr V/m")
-    assert e.esu * E == Q(e.esu.value * E.value, "Fr V/m")
+    assert e.si * E == Quantity(100, "eV/m")
+    assert e.gauss * E == Quantity(e.gauss.value * E.value, "Fr V/m")
+    assert e.esu * E == Quantity(e.esu.value * E.value, "Fr V/m")
 
 
 def test_g0():
@@ -133,19 +133,19 @@ def test_view():
     assert c2.reference == c.reference
     assert c2.unit == c.unit
 
-    q1 = c.view(Q)
+    q1 = c.view(Quantity)
     assert q1 == c
     assert q1.value == c.value
-    assert type(q1) is Q
+    assert type(q1) is Quantity
     assert not hasattr(q1, "reference")
 
-    q2 = Q(c)
+    q2 = Quantity(c)
     assert q2 == c
     assert q2.value == c.value
-    assert type(q2) is Q
+    assert type(q2) is Quantity
     assert not hasattr(q2, "reference")
 
-    c3 = Q(c, subok=True)
+    c3 = Quantity(c, subok=True)
     assert c3 == c
     assert c3.value == c.value
     # make sure it has the necessary attributes and they're not blank
@@ -154,5 +154,5 @@ def test_view():
     assert c3.reference == c.reference
     assert c3.unit == c.unit
 
-    c4 = Q(c, subok=True, copy=False)
+    c4 = Quantity(c, subok=True, copy=False)
     assert c4 is c

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -136,13 +136,13 @@ def test_view():
     q1 = c.view(u.Quantity)
     assert q1 == c
     assert q1.value == c.value
-    assert type(q1) is u.u.Quantity
+    assert type(q1) is u.Quantity
     assert not hasattr(q1, "reference")
 
     q2 = u.Quantity(c)
     assert q2 == c
     assert q2.value == c.value
-    assert type(q2) is u.u.Quantity
+    assert type(q2) is u.Quantity
     assert not hasattr(q2, "reference")
 
     c3 = u.Quantity(c, subok=True)

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -63,7 +63,7 @@ def test_e():
 
     assert e.si * E == u.Quantity(100, "eV/m")
     assert e.gauss * E == u.Quantity(e.gauss.value * E.value, "Fr V/m")
-    assert e.esu * E == u.u.Quantity(e.esu.value * E.value, "Fr V/m")
+    assert e.esu * E == u.Quantity(e.esu.value * E.value, "Fr V/m")
 
 
 def test_g0():

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -4,8 +4,8 @@ import copy
 
 import pytest
 
+import astropy.units as u
 from astropy.constants import Constant
-from astropy.units import Quantity
 
 
 def test_c():
@@ -45,7 +45,7 @@ def test_e():
     from astropy.constants import e
 
     # A test quantity
-    E = Quantity(100, "V/m")
+    E = u.Quantity(100, "V/m")
 
     # Without specifying a system e should not combine with other quantities
     pytest.raises(TypeError, lambda: e * E)
@@ -57,13 +57,13 @@ def test_e():
     # e.cgs is too ambiguous and should not work at all
     pytest.raises(TypeError, lambda: e.cgs * E)
 
-    assert isinstance(e.si, Quantity)
-    assert isinstance(e.gauss, Quantity)
-    assert isinstance(e.esu, Quantity)
+    assert isinstance(e.si, u.Quantity)
+    assert isinstance(e.gauss, u.Quantity)
+    assert isinstance(e.esu, u.Quantity)
 
-    assert e.si * E == Quantity(100, "eV/m")
-    assert e.gauss * E == Quantity(e.gauss.value * E.value, "Fr V/m")
-    assert e.esu * E == Quantity(e.esu.value * E.value, "Fr V/m")
+    assert e.si * E == u.Quantity(100, "eV/m")
+    assert e.gauss * E == u.Quantity(e.gauss.value * E.value, "Fr V/m")
+    assert e.esu * E == u.u.Quantity(e.esu.value * E.value, "Fr V/m")
 
 
 def test_g0():
@@ -133,19 +133,19 @@ def test_view():
     assert c2.reference == c.reference
     assert c2.unit == c.unit
 
-    q1 = c.view(Quantity)
+    q1 = c.view(u.Quantity)
     assert q1 == c
     assert q1.value == c.value
-    assert type(q1) is Quantity
+    assert type(q1) is u.u.Quantity
     assert not hasattr(q1, "reference")
 
-    q2 = Quantity(c)
+    q2 = u.Quantity(c)
     assert q2 == c
     assert q2.value == c.value
-    assert type(q2) is Quantity
+    assert type(q2) is u.u.Quantity
     assert not hasattr(q2, "reference")
 
-    c3 = Quantity(c, subok=True)
+    c3 = u.Quantity(c, subok=True)
     assert c3 == c
     assert c3.value == c.value
     # make sure it has the necessary attributes and they're not blank
@@ -154,5 +154,5 @@ def test_view():
     assert c3.reference == c.reference
     assert c3.unit == c.unit
 
-    c4 = Quantity(c, subok=True, copy=False)
+    c4 = u.Quantity(c, subok=True, copy=False)
     assert c4 is c

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from astropy.constants import Constant
-from astropy.units import Quantity as Q
+from astropy.units import Quantity
 
 
 def test_c():
@@ -47,18 +47,18 @@ def test_e():
     from astropy.constants.astropyconst13 import e as e_13
 
     # A test quantity
-    E = Q(100.00000348276221, "V/m")
+    E = Quantity(100.00000348276221, "V/m")
 
     # e.cgs is too ambiguous and should not work at all
     with pytest.raises(TypeError):
         e_13.cgs * E
 
-    assert isinstance(e_13.si, Q)
-    assert isinstance(e_13.gauss, Q)
-    assert isinstance(e_13.esu, Q)
+    assert isinstance(e_13.si, Quantity)
+    assert isinstance(e_13.gauss, Quantity)
+    assert isinstance(e_13.esu, Quantity)
 
-    assert e_13.gauss * E == Q(e_13.gauss.value * E.value, "Fr V/m")
-    assert e_13.esu * E == Q(e_13.esu.value * E.value, "Fr V/m")
+    assert e_13.gauss * E == Quantity(e_13.gauss.value * E.value, "Fr V/m")
+    assert e_13.esu * E == Quantity(e_13.esu.value * E.value, "Fr V/m")
 
 
 def test_g0():
@@ -169,19 +169,19 @@ def test_view():
     assert c2.reference == c.reference
     assert c2.unit == c.unit
 
-    q1 = c.view(Q)
+    q1 = c.view(Quantity)
     assert q1 == c
     assert q1.value == c.value
-    assert type(q1) is Q
+    assert type(q1) is Quantity
     assert not hasattr(q1, "reference")
 
-    q2 = Q(c)
+    q2 = Quantity(c)
     assert q2 == c
     assert q2.value == c.value
-    assert type(q2) is Q
+    assert type(q2) is Quantity
     assert not hasattr(q2, "reference")
 
-    c3 = Q(c, subok=True)
+    c3 = Quantity(c, subok=True)
     assert c3 == c
     assert c3.value == c.value
     # make sure it has the necessary attributes and they're not blank
@@ -190,5 +190,5 @@ def test_view():
     assert c3.reference == c.reference
     assert c3.unit == c.unit
 
-    c4 = Q(c, subok=True, copy=False)
+    c4 = Quantity(c, subok=True, copy=False)
     assert c4 is c

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -5,8 +5,8 @@ import copy
 import numpy as np
 import pytest
 
+import astropy.units as u
 from astropy.constants import Constant
-from astropy.units import Quantity
 
 
 def test_c():
@@ -47,18 +47,18 @@ def test_e():
     from astropy.constants.astropyconst13 import e as e_13
 
     # A test quantity
-    E = Quantity(100.00000348276221, "V/m")
+    E = u.Quantity(100.00000348276221, "V/m")
 
     # e.cgs is too ambiguous and should not work at all
     with pytest.raises(TypeError):
         e_13.cgs * E
 
-    assert isinstance(e_13.si, Quantity)
-    assert isinstance(e_13.gauss, Quantity)
-    assert isinstance(e_13.esu, Quantity)
+    assert isinstance(e_13.si, u.Quantity)
+    assert isinstance(e_13.gauss, u.Quantity)
+    assert isinstance(e_13.esu, u.Quantity)
 
-    assert e_13.gauss * E == Quantity(e_13.gauss.value * E.value, "Fr V/m")
-    assert e_13.esu * E == Quantity(e_13.esu.value * E.value, "Fr V/m")
+    assert e_13.gauss * E == u.Quantity(e_13.gauss.value * E.value, "Fr V/m")
+    assert e_13.esu * E == u.Quantity(e_13.esu.value * E.value, "Fr V/m")
 
 
 def test_g0():
@@ -169,19 +169,19 @@ def test_view():
     assert c2.reference == c.reference
     assert c2.unit == c.unit
 
-    q1 = c.view(Quantity)
+    q1 = c.view(u.Quantity)
     assert q1 == c
     assert q1.value == c.value
-    assert type(q1) is Quantity
+    assert type(q1) is u.Quantity
     assert not hasattr(q1, "reference")
 
-    q2 = Quantity(c)
+    q2 = u.Quantity(c)
     assert q2 == c
     assert q2.value == c.value
-    assert type(q2) is Quantity
+    assert type(q2) is u.Quantity
     assert not hasattr(q2, "reference")
 
-    c3 = Quantity(c, subok=True)
+    c3 = u.Quantity(c, subok=True)
     assert c3 == c
     assert c3.value == c.value
     # make sure it has the necessary attributes and they're not blank
@@ -190,5 +190,5 @@ def test_view():
     assert c3.reference == c.reference
     assert c3.unit == c.unit
 
-    c4 = Quantity(c, subok=True, copy=False)
+    c4 = u.Quantity(c, subok=True, copy=False)
     assert c4 is c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -415,7 +415,10 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 "docs/*.py" = [
     "INP001",  # implicit-namespace-package. The examples are not a package.
 ]
-"__init__.py" = ["F403"]  # Wildcard imports
+"__init__.py" = [
+    "E402", # module level import not at top of file
+    "F403", # Wildcard imports
+]
 
 [tool.ruff.lint.flake8-annotations]
 ignore-fully-untyped = true


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR improves compliance with more Ruff rules of `astropy/constants`. All per-subpackage rules ignored are now enforced. Globally ignored rules are not covered. The following changes are made:

- [N817 (camelcase-imported-as-acronym)](https://docs.astral.sh/ruff/rules/camelcase-imported-as-acronym/) enforced in the test scripts from `astropy/constants`
- [E402 (module-import-not-at-top-of-file)](https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/#module-import-not-at-top-of-file-e402) moved to permanently ignored rules following [global config item rules](https://docs.astropy.org/en/stable/config/index.html#adding-new-configuration-items)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes part of #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
