### PR TITLE
Fix Ruff rule PLE0101 violations

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -102,7 +102,6 @@ lint.ignore = [
     "PERF401",  # Use a list comprehension to create a transformed list
 
     # Pylint (PLC, PLE, PLR, PLW)
-    "PLE0101",  # return-in-init
     "PLR0124",  # Name compared with itself
     "PLR0402",  # ConsiderUsingFromImport
     "PLR0912",  # too-many-branches

--- a/astropy/coordinates/representation/cartesian.py
+++ b/astropy/coordinates/representation/cartesian.py
@@ -74,7 +74,8 @@ class CartesianRepresentation(BaseRepresentation):
                 if differentials is None:
                     differentials = x._differentials
 
-                return super().__init__(x, differentials=differentials, copy=copy)
+                super().__init__(x, differentials=differentials, copy=copy)
+                return
 
             else:
                 x, y, z = x

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -56,7 +56,7 @@ class CompImageHeader(Header):
             "The CompImageHeader class is deprecated and will be " "removed in future",
             AstropyDeprecationWarning,
         )
-        return super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 def _is_reserved_table_keyword(keyword):

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -118,7 +118,7 @@ class BlackBody(Fittable1DModel):
         else:
             self._output_units = self._native_units
 
-        return super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def evaluate(self, x, temperature, scale):
         """Evaluate the model.

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -61,7 +61,7 @@ class FixRemoteDataOption(type):
         else:
             sys.argv[idx] = "-R=any"
 
-        return super().__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
 
 @deprecated("6.0")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request address the Ruff rule [PLE0101](https://docs.astral.sh/ruff/rules/return-in-init/) violations globally.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Partially addresses #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
