### PR TITLE
Ensure that equal units have equal hashes

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -902,9 +902,7 @@ class UnitBase:
 
     @cached_property
     def _hash(self) -> int:
-        return hash(
-            (str(self.scale), *[x.name for x in self.bases], *map(str, self.powers))
-        )
+        return hash((self.scale, *[x.name for x in self.bases], *map(str, self.powers)))
 
     def __getstate__(self) -> dict[str, object]:
         # If we get pickled, we should *not* store the memoized members since

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1233,9 +1233,8 @@ class UnitBase:
             return all(base in namespace for base in unit.bases)
 
         unit = self.decompose()
-        key = hash(unit)
 
-        cached = cached_results.get(key)
+        cached = cached_results.get(unit)
         if cached is not None:
             if isinstance(cached, Exception):
                 raise cached
@@ -1244,7 +1243,7 @@ class UnitBase:
         # Prevent too many levels of recursion
         # And special case for dimensionless unit
         if depth >= max_depth:
-            cached_results[key] = [unit]
+            cached_results[unit] = [unit]
             return [unit]
 
         # Make a list including all of the equivalent units
@@ -1297,7 +1296,7 @@ class UnitBase:
         for final_result in final_results:
             if len(final_result):
                 results = final_results[0].union(final_results[1])
-                cached_results[key] = results
+                cached_results[unit] = results
                 return results
 
         partial_results.sort(key=operator.itemgetter(0))
@@ -1332,17 +1331,17 @@ class UnitBase:
                     subresults.add(factored)
 
             if len(subresults):
-                cached_results[key] = subresults
+                cached_results[unit] = subresults
                 return subresults
 
         if not is_final_result(self):
             result = UnitsError(
                 f"Cannot represent unit {self} in terms of the given units"
             )
-            cached_results[key] = result
+            cached_results[unit] = result
             raise result
 
-        cached_results[key] = [self]
+        cached_results[unit] = [self]
         return [self]
 
     def compose(

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1150,20 +1150,15 @@ def test_hash_represents_unit(unit, power):
     assert hash(tu2) == hash(unit)
 
 
-bug_revealing_xfail = pytest.mark.xfail(
-    reason="regression test to demonstrate an existing bug"
-)
-
-
 @pytest.mark.parametrize(
     "scale1, scale2",
     [
-        pytest.param(10, 10.0, marks=bug_revealing_xfail),
+        (10, 10.0),
         (2, Fraction(2, 1)),
-        pytest.param(4, 4 + 0j, marks=bug_revealing_xfail),
-        pytest.param(0.5, Fraction(1, 2), marks=bug_revealing_xfail),
+        (4, 4 + 0j),
+        (0.5, Fraction(1, 2)),
         (2.4, 2.4 + 0j),
-        pytest.param(Fraction(1, 4), 0.25 + 0j, marks=bug_revealing_xfail),
+        (Fraction(1, 4), 0.25 + 0j),
     ],
     ids=type,
 )

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1150,6 +1150,31 @@ def test_hash_represents_unit(unit, power):
     assert hash(tu2) == hash(unit)
 
 
+bug_revealing_xfail = pytest.mark.xfail(
+    reason="regression test to demonstrate an existing bug"
+)
+
+
+@pytest.mark.parametrize(
+    "scale1, scale2",
+    [
+        pytest.param(10, 10.0, marks=bug_revealing_xfail),
+        (2, Fraction(2, 1)),
+        pytest.param(4, 4 + 0j, marks=bug_revealing_xfail),
+        pytest.param(0.5, Fraction(1, 2), marks=bug_revealing_xfail),
+        (2.4, 2.4 + 0j),
+        pytest.param(Fraction(1, 4), 0.25 + 0j, marks=bug_revealing_xfail),
+    ],
+    ids=type,
+)
+def test_hash_scale_type(scale1, scale2):
+    # Regression test for #17820 - hash could depend on scale type, not just its value
+    unit1 = u.CompositeUnit(scale1, [u.m], [-1])
+    unit2 = u.CompositeUnit(scale2, [u.m], [-1])
+    assert unit1 == unit2
+    assert hash(unit1) == hash(unit2)
+
+
 @pytest.mark.skipif(not HAS_ARRAY_API_STRICT, reason="tests array_api_strict")
 def test_array_api_strict_arrays():
     # Ensure strict array api arrays can be passed in/out of Unit.to()

--- a/docs/changes/units/17822.bugfix.rst
+++ b/docs/changes/units/17822.bugfix.rst
@@ -1,0 +1,7 @@
+Previously the hashes of units could depend on the type of their scale factor,
+but now the hashes depend on the scale factor values, not the types.
+For example, previously a ``dict`` would consider two otherwise identical units
+with scale factors ``1`` (``int``) and ``1.0`` (``float``) as different keys,
+but now they are considered to be the same key.
+In practice this bug was rare because the number of units with a scale factor
+that is not a ``float`` is very small.


### PR DESCRIPTION
### Description

The first commit simplifies `UnitBase._compose()` by removing explicit hash handling from it. The way the hashes were handled made `_compose()` defenseless against hash collisions. This has not been a problem in practice because of how rare hash collisions are, but it is both simpler and more reliable to let `dict` deal with them.

The second commit adds regression tests that check that the hashes of equal units are equal. On current `main` they can differ if the type of their `scale` is not the same.

The third commit changes how the hash of a `UnitBase` is computed. The new algorithm ensures that equal units have equal hashes. ~It should be pointed out that the new algorithm makes hash collisions quite common (because `-1` and `-2` have the same hash, at least in CPython, and they commonly occur as powers of unit components). Without the first commit the third commit would cause `UnitBase._compose()` to fail quite often, so the first commit really does belong in this pull request.~ EDIT: There will be hash conflicts with scale factors of -1 and -2, but negative scale factors are very rare.

Closes #17820

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
