### PR TITLE
Add a decorator for skipping docstring tests

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -6,6 +6,7 @@ from the installed astropy.  It makes use of the |pytest| testing framework.
 
 import os
 import pickle
+import sys
 
 import pytest
 
@@ -198,3 +199,8 @@ def assert_quantity_allclose(actual, desired, rtol=1.0e-7, atol=None, **kwargs):
     np.testing.assert_allclose(
         *_unquantify_allclose_arguments(actual, desired, rtol, atol), **kwargs
     )
+
+
+_skip_docstring_tests_with_optimized_python = pytest.mark.skipif(
+    sys.flags.optimize >= 2, reason="docstrings are not testable in optimized mode"
+)

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,6 +1,6 @@
-import sys
-
 import pytest
+
+from astropy.tests.helper import _skip_docstring_tests_with_optimized_python
 
 # Renamed these imports so that them being in the namespace will not
 # cause pytest 3 to discover them as tests and then complain that
@@ -68,10 +68,7 @@ def test_priority():
     assert ["eggs", "spam"] == args
 
 
-@pytest.mark.skipif(
-    sys.flags.optimize >= 2,
-    reason="docstrings are not available at runtime",
-)
+@_skip_docstring_tests_with_optimized_python
 def test_docs():
     class Spam(_TestRunnerBase):
         @keyword()

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import functools
 import itertools
-import sys
 
 import erfa
 import numpy as np
 import pytest
 
 from astropy import units as u
+from astropy.tests.helper import _skip_docstring_tests_with_optimized_python
 from astropy.time import Time
 from astropy.time.core import SIDEREAL_TIME_MODELS
 from astropy.utils import iers
@@ -18,10 +18,7 @@ within_1_second = functools.partial(np.allclose, rtol=1.0, atol=1.0 / 3600.0)
 within_2_seconds = functools.partial(np.allclose, rtol=1.0, atol=2.0 / 3600.0)
 
 
-@pytest.mark.skipif(
-    sys.flags.optimize >= 2,
-    reason="docstrings are not testable in optimized mode",
-)
+@_skip_docstring_tests_with_optimized_python
 def test_doc_string_contains_models():
     """The doc string is formatted; this ensures this remains working."""
     for kind in ("mean", "apparent"):

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 
+from astropy.tests.helper import _skip_docstring_tests_with_optimized_python
 from astropy.utils.decorators import (
     classproperty,
     deprecated,
@@ -669,6 +670,7 @@ def test_lazyproperty_threadsafe(fast_thread_switching):
             assert values == [a.foo] * workers
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_stringInput_simple():
     # Simple tests with string input
     docstring = "test"
@@ -678,17 +680,17 @@ def test_format_doc_stringInput_simple():
     def testfunc_1():
         pass
 
-    expected_doc = docstring if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(testfunc_1) == expected_doc
+    assert inspect.getdoc(testfunc_1) == "test"
 
     # Test that it replaces an existing docstring
     @format_doc(docstring)
     def testfunc_2():
         """not test"""
 
-    assert inspect.getdoc(testfunc_2) == expected_doc
+    assert inspect.getdoc(testfunc_2) == "test"
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_stringInput_format():
     # Tests with string input and formatting
 
@@ -699,8 +701,7 @@ def test_format_doc_stringInput_format():
     def testfunc2():
         pass
 
-    expected_doc = "yes / no = life" if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(testfunc2) == expected_doc
+    assert inspect.getdoc(testfunc2) == "yes / no = life"
 
     # Test that we can include the original docstring
 
@@ -710,8 +711,7 @@ def test_format_doc_stringInput_format():
     def testfunc3():
         """= 2 / 2 * life"""
 
-    expected_doc = "yes / no = 2 / 2 * life" if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(testfunc3) == expected_doc
+    assert inspect.getdoc(testfunc3) == "yes / no = 2 / 2 * life"
 
 
 def test_format_doc_objectInput_simple():
@@ -735,6 +735,7 @@ def test_format_doc_objectInput_simple():
     assert inspect.getdoc(testfunc_2) == inspect.getdoc(docstring0)
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_objectInput_format():
     # Tests with object input and formatting
 
@@ -746,9 +747,7 @@ def test_format_doc_objectInput_format():
     def testfunc2():
         pass
 
-    expected_doc = "test + test = 2 * test" if sys.flags.optimize < 2 else None
-
-    assert inspect.getdoc(testfunc2) == expected_doc
+    assert inspect.getdoc(testfunc2) == "test + test = 2 * test"
 
     # Test that we can include the original docstring
 
@@ -759,11 +758,10 @@ def test_format_doc_objectInput_format():
     def testfunc3():
         """= 4 / 2 * test"""
 
-    expected_doc = "test + test = 4 / 2 * test" if sys.flags.optimize < 2 else None
-
-    assert inspect.getdoc(testfunc3) == expected_doc
+    assert inspect.getdoc(testfunc3) == "test + test = 4 / 2 * test"
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_selfInput_simple():
     # Simple tests with self input
 
@@ -772,10 +770,10 @@ def test_format_doc_selfInput_simple():
     def testfunc_1():
         """not test"""
 
-    expected_doc = "not test" if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(testfunc_1) == expected_doc
+    assert inspect.getdoc(testfunc_1) == "not test"
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_selfInput_format():
     # Tests with string input which is '__doc__' (special case) and formatting
 
@@ -784,8 +782,7 @@ def test_format_doc_selfInput_format():
     def testfunc1():
         """dum {0} dum {opt}"""
 
-    expected_doc = "dum di dum da dum" if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(testfunc1) == expected_doc
+    assert inspect.getdoc(testfunc1) == "dum di dum da dum"
 
     # Test that we cannot recursively insert the original documentation
 
@@ -793,10 +790,10 @@ def test_format_doc_selfInput_format():
     def testfunc2():
         """dum {0} dum {__doc__}"""
 
-    expected_doc = "dum di dum " if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(testfunc2) == expected_doc
+    assert inspect.getdoc(testfunc2) == "dum di dum "
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_onMethod():
     # Check if the decorator works on methods too, to spice it up we try double
     # decorator
@@ -808,10 +805,10 @@ def test_format_doc_onMethod():
         def test_method(self):
             """is {0}"""
 
-    expected_doc = "what we do is strange." if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(TestClass.test_method) == expected_doc
+    assert inspect.getdoc(TestClass.test_method) == "what we do is strange."
 
 
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_onClass():
     # Check if the decorator works on classes too
     docstring = "what we do {__doc__} {0}{opt}"
@@ -820,14 +817,10 @@ def test_format_doc_onClass():
     class TestClass:
         """is"""
 
-    expected_doc = "what we do is strange." if sys.flags.optimize < 2 else None
-    assert inspect.getdoc(TestClass) == expected_doc
+    assert inspect.getdoc(TestClass) == "what we do is strange."
 
 
-@pytest.mark.skipif(
-    sys.flags.optimize >= 2,
-    reason="NA for Python optimized mode",
-)
+@_skip_docstring_tests_with_optimized_python
 @pytest.mark.parametrize(
     "docstring, expected_exception",
     [
@@ -849,10 +842,7 @@ def test_format_doc_exceptions(docstring, expected_exception):
             pass
 
 
-@pytest.mark.skipif(
-    sys.flags.optimize >= 2,
-    reason="NA for Python optimized mode",
-)
+@_skip_docstring_tests_with_optimized_python
 def test_format_doc_indexerrors():
     def _FUNC_WITH_TEMPLATE_DOCSTRING():
         """test {0} test {opt}"""


### PR DESCRIPTION
### Description

Some of our tests check the contents of docstrings. Those checks are skipped if Python is running with doctests disabled because they serve little purpose in that case. The number of such tests is large enough that it makes sense to introduce a decorator for this purpose.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
