### PR TITLE
MNT: bump ubuntu image (`22.04` -> `24.04`) and `uraimo/run-on-arch-action` (`v2.8.1` -> `v3.0.0`) on exotic archs

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -104,7 +104,7 @@ jobs:
     # we include them just in the weekly cron. These also serve as a test
     # of using system libraries and using pytest directly.
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Python 3.12
     # keep condition in sync with test_arm64
     if: (github.repository == 'astropy/astropy' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: uraimo/run-on-arch-action@5397f9e30a9b62422f302092631c99ae1effcd9e # v2.8.1
+      - uses: uraimo/run-on-arch-action@4141da824ffb5eda88d221d9cf835f6a61ed98d9 # v3.0.0
         name: Run tests
         id: build
         with:


### PR DESCRIPTION
### Description
This reverts #17807 but still keeps the image pinned
xref: https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2689340770

* Fix https://github.com/astropy/astropy/issues/17663
* Fix https://github.com/astropy/astropy/issues/17664

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
