### PR TITLE
maint: update domain name for vizier ftp server

### DIFF
--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -311,8 +311,8 @@ class Cds(core.BaseReader):
     to directly load tables from the Internet.  For example, Vizier tables from the
     CDS::
 
-      >>> table = ascii.read("ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/snrs.dat",
-      ...             readme="ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/ReadMe")
+      >>> table = ascii.read("ftp://cdsarc.unistra.fr/pub/cats/VII/253/snrs.dat",
+      ...             readme="ftp://cdsarc.unistra.fr/pub/cats/VII/253/ReadMe")
 
     If the header (ReadMe) and data are stored in a single file and there
     is content between the header and the data (for instance Notes), then the

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -75,8 +75,8 @@ It is possible to load tables directly from the Internet using URLs. For
 example, download tables from Vizier catalogues in CDS format
 (``'ascii.cds'``)::
 
-    >>> t = Table.read("ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/snrs.dat",
-    ...         readme="ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/ReadMe",
+    >>> t = Table.read("ftp://cdsarc.unistra.fr/pub/cats/VII/253/snrs.dat",
+    ...         readme="ftp://cdsarc.unistra.fr/pub/cats/VII/253/ReadMe",
     ...         format="ascii.cds")  # doctest: +SKIP
 
 For certain file formats the format can be automatically detected, for

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -33,8 +33,8 @@ It is possible to load tables directly from the Internet using URLs. For
 example, download tables from `VizieR catalogs <https://vizier.unistra.fr/>`_
 in CDS format (``'ascii.cds'``)::
 
-    >>> t = Table.read("ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/snrs.dat",
-    ...         readme="ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/ReadMe",
+    >>> t = Table.read("ftp://cdsarc.unistra.fr/pub/cats/VII/253/snrs.dat",
+    ...         readme="ftp://cdsarc.unistra.fr/pub/cats/VII/253/ReadMe",
     ...         format="ascii.cds")  # doctest: +SKIP
 
 .. EXAMPLE END


### PR DESCRIPTION
Hi astropy maintainers,

This is just a follow-up PR for #14681 

At the time of writing the former PR, all CDS services did switch to the new domain except for VizieR's FTP server. This is now done so the few examples calling our FTP server in the documentation can now be updated. 
