### PR TITLE
Add proper support for the Å, ℓ and Ω unit symbols

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -419,7 +419,7 @@ def set_enabled_units(units: object) -> _UnitContext:
       Primary name | Unit definition | Aliases
     [
       AU           | 1.49598e+11 m   | au, astronomical_unit            ,
-      Angstrom     | 1e-10 m         | AA, angstrom                     ,
+      Angstrom     | 1e-10 m         | AA, angstrom, Å                  ,
       cm           | 0.01 m          | centimeter                       ,
       earthRad     | 6.3781e+06 m    | R_earth, Rearth                  ,
       jupiterRad   | 7.1492e+07 m    | R_jup, Rjup, R_jupiter, Rjupiter ,
@@ -467,7 +467,7 @@ def add_enabled_units(units: object) -> _UnitContext:
       Primary name | Unit definition | Aliases
     [
       AU           | 1.49598e+11 m   | au, astronomical_unit            ,
-      Angstrom     | 1e-10 m         | AA, angstrom                     ,
+      Angstrom     | 1e-10 m         | AA, angstrom, Å                  ,
       cm           | 0.01 m          | centimeter                       ,
       earthRad     | 6.3781e+06 m    | R_earth, Rearth                  ,
       ft           | 0.3048 m        | foot                             ,

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -448,9 +448,7 @@ class Generic(Base, _GenericParserMixin):
         elif not s.isascii():
             if s[0].startswith("°"):
                 s = "deg" if len(s) == 1 else "deg_" + s[1:]
-            if s[-1] in cls._prefixable_unit_symbols:
-                s = s[:-1] + cls._prefixable_unit_symbols[s[-1]]
-            elif len(s) > 1 and s[-1] in cls._unit_suffix_symbols:
+            if len(s) > 1 and s[-1] in cls._unit_suffix_symbols:
                 s = s[:-1] + cls._unit_suffix_symbols[s[-1]]
             elif s.endswith("R\N{INFINITY}"):
                 s = s[:-2] + "Ry"
@@ -469,12 +467,6 @@ class Generic(Base, _GenericParserMixin):
         "\N{DOUBLE PRIME}": "arcsec",
         "\N{MODIFIER LETTER SMALL H}": "hourangle",
         "e\N{SUPERSCRIPT MINUS}": "electron",
-    }
-
-    _prefixable_unit_symbols: ClassVar[dict[str, str]] = {
-        "\N{GREEK CAPITAL LETTER OMEGA}": "Ohm",
-        "\N{LATIN CAPITAL LETTER A WITH RING ABOVE}": "Angstrom",
-        "\N{SCRIPT SMALL L}": "l",
     }
 
     _unit_suffix_symbols: ClassVar[dict[str, str]] = {

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -54,7 +54,7 @@ def_unit(
     format={"latex": r"\mu m", "unicode": "\N{MICRO SIGN}m"},
 )
 def_unit(
-    ["Angstrom", "AA", "angstrom"],
+    ["Angstrom", "AA", "angstrom", "Å"],
     0.1 * nm,
     namespace=_ns,
     doc="ångström: 10 ** -10 m",
@@ -84,7 +84,7 @@ def_unit(
 # VOLUMES
 
 def_unit(
-    (["l", "L"], ["liter"]),
+    (["l", "L", "ℓ"], ["liter"]),
     1000 * cm**3.0,
     namespace=_ns,
     prefixes=True,
@@ -363,7 +363,7 @@ def_unit(
     doc="Volt: electric potential or electromotive force",
 )
 def_unit(
-    (["Ohm", "ohm"], ["Ohm"]),
+    (["Ohm", "ohm", "Ω"], ["Ohm"]),
     V * A**-1,
     namespace=_ns,
     prefixes=True,

--- a/docs/changes/units/17829.feature.rst
+++ b/docs/changes/units/17829.feature.rst
@@ -1,0 +1,2 @@
+It is now possible to import angström, litre and ohm from ``astropy.units``
+using the ``Å``, ``ℓ`` and ``Ω`` symbols.

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -668,7 +668,7 @@ all kinds of things that ``Hz`` can be converted to::
   Primary name | Unit definition        | Aliases
   [
     AU           | 1.49598e+11 m          | au, astronomical_unit            ,
-    Angstrom     | 1e-10 m                | AA, angstrom                     ,
+    Angstrom     | 1e-10 m                | AA, angstrom, Å                  ,
     Bq           | 1 / s                  | becquerel                        ,
     Ci           | 3.7e+10 / s            | curie                            ,
     Hz           | 1 / s                  | Hertz, hertz                     ,

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -243,7 +243,7 @@ To enable Imperial units, do::
       Primary name | Unit definition | Aliases
     [
       AU           | 1.49598e+11 m   | au, astronomical_unit            ,
-      Angstrom     | 1e-10 m         | AA, angstrom                     ,
+      Angstrom     | 1e-10 m         | AA, angstrom, Å                  ,
       cm           | 0.01 m          | centimeter                       ,
       earthRad     | 6.3781e+06 m    | R_earth, Rearth                  ,
       ft           | 0.3048 m        | foot                             ,


### PR DESCRIPTION
### Description

#17651 recently added proper support for the "μ" unit prefix. This pull request adds proper support for Unicode symbols of three units. In all cases the new Unicode symbols are true aliases. In other words `astropy` does not know if the units are accessed using the new Unicode names or the old ASCII-compatible names:
```python3
>>> from astropy import units as u
>>> u.Å is u.angstrom
True
>>> u.ℓ is u.liter
True
>>> u.Ω is u.ohm
True
```
The `"generic"` parser already knew how to parse those symbols, so now that proper support is implemented the parser can be simplified.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
