### PR TITLE
Algorithm Improvements for Fast Lomb Scargle

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/_testing.py
+++ b/astropy/timeseries/periodograms/lombscargle/_testing.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+def assert_not_strictly_equal(
+    a, b, err="Output arrays are the same - dispatch test has failed"
+):
+    """
+    Asserts that passed arguments are not bitwise equal.
+
+    Failure means that arrays can be considered to be a copy of each other.
+
+    Parameters
+    ----------
+    a : array-like
+    b : array-like
+    err : str (optional)
+        Custom error message for the assertion failure.
+    """
+    assert np.bitwise_xor(
+        np.ascontiguousarray(a).view(np.uint8),
+        np.ascontiguousarray(b).view(np.uint8),
+    ).any(), err

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -310,6 +310,10 @@ class LombScargle(BasePeriodogram):
         -------
         frequency, power : ndarray
             The frequency and Lomb-Scargle power
+
+        .. versionchanged:: 8.0
+           The default method chosen when ``method='auto'`` now prefers the
+           low-rank approximation implementation when applicable.
         """
         frequency = self.autofrequency(
             samples_per_peak=samples_per_peak,

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -45,8 +45,8 @@ def lombscargle_fast(
         extra keyword arguments to pass to the ``trig_sum`` utility.
         Options are ``oversampling``, ``Mfft`` and ``eps``. See documentation
         of ``trig_sum`` for details.
-    algorithm : str, optional
-        This option is ignored if if use_fft is False.
+    algorithm : 'fasper' (default), or 'lra'
+        This option is ignored if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
         Supported options are:
 
@@ -72,8 +72,7 @@ def lombscargle_fast(
         of unevenly sampled data". ApJ 1:338, p277, 1989
     .. [2] M. Zechmeister and M. Kurster, A&A 496, 577-584 (2009)
     .. [3] W. Press et al, Numerical Recipes in C (2002)
-    .. [4] Ruiz-Antolin, D. and Townsend, A. *A nonuniform fast Fourier transform based on low rank approximation*
-        SIAM 40.1 (2018)
+    .. [4] Ruiz-Antolin, D. and Townsend, A. "A nonuniform fast Fourier transform based on low rank approximation". SIAM 40.1 (2018)
     """
     if dy is None:
         dy = 1

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -15,7 +15,8 @@ def lombscargle_fast(
     normalization="standard",
     use_fft=True,
     trig_sum_kwds=None,
-    algorithm='fasper',
+    *,
+    algorithm="fasper",
 ):
     """Fast Lomb-Scargle Periodogram.
 
@@ -45,11 +46,11 @@ def lombscargle_fast(
         Options are ``oversampling``, ``Mfft`` and ``eps``. See documentation
         of ``trig_sum`` for details.
     algorithm : str, optional
-        Referenced only if use_fft is true.
+        This option is ignored if if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
-        Currently there are two available options:
+        Supported options are:
 
-        - 'fasper': use Press & Rybicki's Lagrangian extirpolation instead. This is the default option.
+        - 'fasper': use Press & Rybicki's piecewise Lagrange polynomial extirpolation. This is the default option.
         - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
 
     Returns

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -14,11 +14,12 @@ def lombscargle_fast(
     fit_mean=True,
     normalization="standard",
     use_fft=True,
+    prefer_lra=True,
     trig_sum_kwds=None,
 ):
     """Fast Lomb-Scargle Periodogram.
 
-    This implements the Press & Rybicki method [1]_ for fast O[N log(N)]
+    This implements the Press & Rybicki [1]_ or Low Rank Approximation [4]_ method for fast O[N log(N)]
     Lomb-Scargle periodograms.
 
     Parameters
@@ -39,9 +40,12 @@ def lombscargle_fast(
     use_fft : bool (default=True)
         If True, then use the Press & Rybicki O[NlogN] algorithm to compute
         the result. Otherwise, use a slower O[N^2] algorithm
+    prefer_lra : bool
+        if True and SciPy is available, use the more accurate Low Rank Approximation by Ruiz-Antolin and Townsend.
+        If False or SciPy is not available use Press & Rybicki's Lagrangian extirpolation instead.
     trig_sum_kwds : dict or None, optional
         extra keyword arguments to pass to the ``trig_sum`` utility.
-        Options are ``oversampling`` and ``Mfft``. See documentation
+        Options are ``oversampling``, ``Mfft`` and ``eps``. See documentation
         of ``trig_sum`` for details.
 
     Returns
@@ -63,6 +67,8 @@ def lombscargle_fast(
         of unevenly sampled data". ApJ 1:338, p277, 1989
     .. [2] M. Zechmeister and M. Kurster, A&A 496, 577-584 (2009)
     .. [3] W. Press et al, Numerical Recipes in C (2002)
+    .. [4] Ruiz-Antolin, D. and Townsend, A. *A nonuniform fast Fourier transform based on low rank approximation*
+        SIAM 40.1 (2018)
     """
     if dy is None:
         dy = 1
@@ -90,7 +96,7 @@ def lombscargle_fast(
 
     # set up arguments to trig_sum
     kwargs = dict.copy(trig_sum_kwds or {})
-    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf)
+    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf, prefer_lra=prefer_lra)
 
     # ----------------------------------------------------------------------
     # 1. compute functions of the time-shift tau at each frequency

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -14,8 +14,8 @@ def lombscargle_fast(
     fit_mean=True,
     normalization="standard",
     use_fft=True,
-    prefer_lra=True,
     trig_sum_kwds=None,
+    algorithm='fasper',
 ):
     """Fast Lomb-Scargle Periodogram.
 
@@ -40,13 +40,17 @@ def lombscargle_fast(
     use_fft : bool (default=True)
         If True, then use the Press & Rybicki O[NlogN] algorithm to compute
         the result. Otherwise, use a slower O[N^2] algorithm
-    prefer_lra : bool
-        if True and SciPy is available, use the more accurate Low Rank Approximation by Ruiz-Antolin and Townsend.
-        If False or SciPy is not available use Press & Rybicki's Lagrangian extirpolation instead.
     trig_sum_kwds : dict or None, optional
         extra keyword arguments to pass to the ``trig_sum`` utility.
         Options are ``oversampling``, ``Mfft`` and ``eps``. See documentation
         of ``trig_sum`` for details.
+    algorithm : str, optional
+        Referenced only if use_fft is true.
+        Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
+        Currently there are two available options:
+
+        - 'fasper': use Press & Rybicki's Lagrangian extirpolation instead. This is the default option.
+        - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
 
     Returns
     -------
@@ -96,7 +100,7 @@ def lombscargle_fast(
 
     # set up arguments to trig_sum
     kwargs = dict.copy(trig_sum_kwds or {})
-    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf, prefer_lra=prefer_lra)
+    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf, algorithm=algorithm)
 
     # ----------------------------------------------------------------------
     # 1. compute functions of the time-shift tau at each frequency

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -73,6 +73,9 @@ def lombscargle_fast(
     .. [2] M. Zechmeister and M. Kurster, A&A 496, 577-584 (2009)
     .. [3] W. Press et al, Numerical Recipes in C (2002)
     .. [4] Ruiz-Antolin, D. and Townsend, A. "A nonuniform fast Fourier transform based on low rank approximation". SIAM 40.1 (2018)
+
+    .. versionchanged:: 8.0
+        The default algorithm has been changed from 'fasper' to 'lra'
     """
     if dy is None:
         dy = 1

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -16,7 +16,7 @@ def lombscargle_fast(
     use_fft=True,
     trig_sum_kwds=None,
     *,
-    algorithm="fasper",
+    algorithm="lra",
 ):
     """Fast Lomb-Scargle Periodogram.
 
@@ -45,13 +45,13 @@ def lombscargle_fast(
         extra keyword arguments to pass to the ``trig_sum`` utility.
         Options are ``oversampling``, ``Mfft`` and ``eps``. See documentation
         of ``trig_sum`` for details.
-    algorithm : 'fasper' (default), or 'lra'
+    algorithm : 'lra' (default), or 'fasper'
         This option is ignored if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
         Supported options are:
 
-        - 'fasper': use Press & Rybicki's piecewise Lagrange polynomial extirpolation. This is the default option.
-        - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
+        - 'fasper': use Press & Rybicki's piecewise Lagrange polynomial extirpolation.
+        - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend. This is the default option.
 
     Returns
     -------

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -47,8 +47,8 @@ def lombscargle_fastchi2(
         of the input data. This is especially important if ``fit_mean = False``
     nterms : int, optional
         Number of Fourier terms in the fit
-    algorithm : str, optional
-        This option is ignored if if use_fft is False.
+    algorithm : 'lra' (default), or 'fasper'
+        This option is ignored if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
         Supported options are:
 
@@ -67,8 +67,7 @@ def lombscargle_fastchi2(
     .. [2] W. Press et al, Numerical Recipes in C (2002)
     .. [3] Scargle, J.D. ApJ 263:835-853 (1982)
     .. [4] Palmer, J. ApJ 695:496-502 (2009)
-    .. [5] Ruiz-Antolin, D. and Townsend, A. *A nonuniform fast Fourier transform based on low rank approximation*
-        SIAM 40.1 (2018)
+    .. [5] Ruiz-Antolin, D. and Townsend, A. "A nonuniform fast Fourier transform based on low rank approximation". SIAM 40.1 (2018)
     """
     if nterms == 0 and not fit_mean:
         raise ValueError("Cannot have nterms = 0 without fitting bias")

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -17,6 +17,7 @@ def lombscargle_fastchi2(
     center_data=True,
     nterms=1,
     use_fft=True,
+    prefer_lra=True,
     trig_sum_kwds=None,
 ):
     """Lomb-Scargle Periodogram.
@@ -43,6 +44,9 @@ def lombscargle_fastchi2(
     center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if ``fit_mean = False``
+    prefer_lra : bool
+        if True and SciPy is available, use the more accurate Low Rank Approximation by Ruiz-Antolin and Townsend.
+        If False or SciPy is not available use Press & Rybicki's Lagrangian extirpolation instead.
     nterms : int, optional
         Number of Fourier terms in the fit
 
@@ -58,6 +62,8 @@ def lombscargle_fastchi2(
     .. [2] W. Press et al, Numerical Recipes in C (2002)
     .. [3] Scargle, J.D. ApJ 263:835-853 (1982)
     .. [4] Palmer, J. ApJ 695:496-502 (2009)
+    .. [5] Ruiz-Antolin, D. and Townsend, A. *A nonuniform fast Fourier transform based on low rank approximation*
+        SIAM 40.1 (2018)
     """
     if nterms == 0 and not fit_mean:
         raise ValueError("Cannot have nterms = 0 without fitting bias")
@@ -89,7 +95,7 @@ def lombscargle_fastchi2(
     chi2_ref = np.dot(yw, yw)
 
     kwargs = dict.copy(trig_sum_kwds or {})
-    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf)
+    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf, prefer_lra=prefer_lra)
 
     # Here we build-up the matrices XTX and XTy using pre-computed
     # sums. The relevant identities are

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -18,7 +18,8 @@ def lombscargle_fastchi2(
     nterms=1,
     use_fft=True,
     trig_sum_kwds=None,
-    algorithm='lra',
+    *,
+    algorithm="lra",
 ):
     """Lomb-Scargle Periodogram.
 
@@ -47,11 +48,11 @@ def lombscargle_fastchi2(
     nterms : int, optional
         Number of Fourier terms in the fit
     algorithm : str, optional
-        Referenced only if use_fft is true.
+        This option is ignored if if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
-        Currently there are two available options:
+        Supported options are:
 
-        - 'fasper': use Press & Rybicki's Lagrangian extirpolation instead. This is the default option.
+        - 'fasper': use Press & Rybicki's piecewise Lagrange polynomial extirpolation. This is the default option.
         - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
 
     Returns

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -17,8 +17,8 @@ def lombscargle_fastchi2(
     center_data=True,
     nterms=1,
     use_fft=True,
-    prefer_lra=True,
     trig_sum_kwds=None,
+    algorithm='lra',
 ):
     """Lomb-Scargle Periodogram.
 
@@ -44,11 +44,15 @@ def lombscargle_fastchi2(
     center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if ``fit_mean = False``
-    prefer_lra : bool
-        if True and SciPy is available, use the more accurate Low Rank Approximation by Ruiz-Antolin and Townsend.
-        If False or SciPy is not available use Press & Rybicki's Lagrangian extirpolation instead.
     nterms : int, optional
         Number of Fourier terms in the fit
+    algorithm : str, optional
+        Referenced only if use_fft is true.
+        Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
+        Currently there are two available options:
+
+        - 'fasper': use Press & Rybicki's Lagrangian extirpolation instead. This is the default option.
+        - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
 
     Returns
     -------
@@ -95,7 +99,7 @@ def lombscargle_fastchi2(
     chi2_ref = np.dot(yw, yw)
 
     kwargs = dict.copy(trig_sum_kwds or {})
-    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf, prefer_lra=prefer_lra)
+    kwargs.update(f0=f0, df=df, use_fft=use_fft, N=Nf, algorithm=algorithm)
 
     # Here we build-up the matrices XTX and XTy using pre-computed
     # sums. The relevant identities are

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -68,6 +68,9 @@ def lombscargle_fastchi2(
     .. [3] Scargle, J.D. ApJ 263:835-853 (1982)
     .. [4] Palmer, J. ApJ 695:496-502 (2009)
     .. [5] Ruiz-Antolin, D. and Townsend, A. "A nonuniform fast Fourier transform based on low rank approximation". SIAM 40.1 (2018)
+
+    .. versionchanged:: 8.0
+        The default algorithm has been changed from 'fasper' to 'lra'
     """
     if nterms == 0 and not fit_mean:
         raise ValueError("Cannot have nterms = 0 without fitting bias")

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -216,8 +216,10 @@ def lombscargle(
         f0, df, Nf = _get_frequency_grid(
             kwds.pop("frequency"), assume_regular_frequency
         )
-        kwds.update(f0=f0, df=df, Nf=Nf)
-
+        if HAS_SCIPY:
+            kwds.update(f0=f0, df=df, Nf=Nf)
+        else:
+            kwds.update(f0=f0, df=df, Nf=Nf, prefer_lra=False)
     # only chi2 methods support nterms
     if not method.endswith("chi2"):
         if kwds.pop("nterms") != 1:

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -216,7 +216,7 @@ def lombscargle(
         f0, df, Nf = _get_frequency_grid(
             kwds.pop("frequency"), assume_regular_frequency
         )
-            kwds.update(f0=f0, df=df, Nf=Nf, algorithm='lra')
+        kwds.update(f0=f0, df=df, Nf=Nf, algorithm="lra")
     # only chi2 methods support nterms
     if not method.endswith("chi2"):
         if kwds.pop("nterms") != 1:

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -216,10 +216,7 @@ def lombscargle(
         f0, df, Nf = _get_frequency_grid(
             kwds.pop("frequency"), assume_regular_frequency
         )
-        if HAS_SCIPY:
-            kwds.update(f0=f0, df=df, Nf=Nf)
-        else:
-            kwds.update(f0=f0, df=df, Nf=Nf, prefer_lra=False)
+            kwds.update(f0=f0, df=df, Nf=Nf, algorithm='lra')
     # only chi2 methods support nterms
     if not method.endswith("chi2"):
         if kwds.pop("nterms") != 1:

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -216,7 +216,7 @@ def lombscargle(
         f0, df, Nf = _get_frequency_grid(
             kwds.pop("frequency"), assume_regular_frequency
         )
-        kwds.update(f0=f0, df=df, Nf=Nf, algorithm="lra")
+        kwds.update(f0=f0, df=df, Nf=Nf)
     # only chi2 methods support nterms
     if not method.endswith("chi2"):
         if kwds.pop("nterms") != 1:

--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
@@ -64,9 +64,7 @@ def trig_sum_data():
 @pytest.mark.parametrize("adjust_t", [True, False])
 @pytest.mark.parametrize("freq_factor", [1, 2])
 @pytest.mark.parametrize("df", [0.1])
-@pytest.mark.filterwarnings(
-    "ignore:SciPy is not installed:astropy.utils.exceptions.AstropyUserWarning"
-)
+
 def test_trig_sum(f0, adjust_t, freq_factor, df, trig_sum_data):
     t, h = trig_sum_data
 
@@ -91,5 +89,18 @@ def test_trig_sum(f0, adjust_t, freq_factor, df, trig_sum_data):
         freq_factor=freq_factor,
         oversampling=10,
     )
+        S3, C3 = trig_sum(
+        tfit,
+        h,
+        df,
+        N=1000,
+        use_fft=False,
+        f0=f0,
+        freq_factor=freq_factor,
+        oversampling=10,
+        algorithm='lra'
+    )
     assert_allclose(S1, S2, atol=1e-2)
     assert_allclose(C1, C2, atol=1e-2)
+    assert_allclose(C1, C3, atol=1e-7)
+    assert_allclose(C1, C3, atol=1e-7)

--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
@@ -64,6 +64,9 @@ def trig_sum_data():
 @pytest.mark.parametrize("adjust_t", [True, False])
 @pytest.mark.parametrize("freq_factor", [1, 2])
 @pytest.mark.parametrize("df", [0.1])
+@pytest.mark.filterwarnings(
+    "ignore:SciPy is not installed:astropy.utils.exceptions.AstropyUserWarning"
+)
 def test_trig_sum(f0, adjust_t, freq_factor, df, trig_sum_data):
     t, h = trig_sum_data
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
@@ -2,6 +2,9 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
+from astropy.timeseries.periodograms.lombscargle._testing import (
+    assert_not_strictly_equal,
+)
 from astropy.timeseries.periodograms.lombscargle.implementations.utils import (
     bitceil,
     extirpolate,
@@ -97,13 +100,7 @@ def test_trig_sum(f0, adjust_t, freq_factor, df, trig_sum_data):
         assert_allclose(C0, C, atol=tol)
 
         for prev_S, prev_C in results:
-            assert np.bitwise_xor(
-                np.ascontiguousarray(prev_S).view(np.uint8),
-                np.ascontiguousarray(S).view(np.uint8),
-            ).any(), "Output arrays are the same - dispatch test has failed"
-            assert np.bitwise_xor(
-                np.ascontiguousarray(prev_C).view(np.uint8),
-                np.ascontiguousarray(C).view(np.uint8),
-            ).any(), "Output arrays are the same - dispatch test has failed"
+            assert_not_strictly_equal(prev_S, S)
+            assert_not_strictly_equal(prev_C, C)
 
         results.append((S, C))

--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_utils.py
@@ -8,8 +8,10 @@ from astropy.timeseries.periodograms.lombscargle._testing import (
 from astropy.timeseries.periodograms.lombscargle.implementations.utils import (
     bitceil,
     extirpolate,
+    jn,
     trig_sum,
 )
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 
 @pytest.mark.parametrize("N", 2 ** np.arange(1, 12))
@@ -53,6 +55,19 @@ def test_extirpolate_with_integers(N, M, extirpolate_int_data):
     y_hat = extirpolate(x, y, N, M)
     x_hat = np.arange(len(y_hat))
     assert_allclose(np.dot(f(x), y), np.dot(f(x_hat), y_hat), rtol=1.7e-5)
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="SciPy is required to test jn() against jv()")
+def test_jn():
+    from scipy.special import jv
+
+    # Test the range used by NuFFT
+    n_vals = np.arange(-7, 16)
+    x_vals = np.linspace(-np.pi / 4, np.pi / 4, 1000)
+    N_grid, X_grid = np.meshgrid(n_vals, x_vals, indexing="ij")
+    custom_res = jn(N_grid, X_grid)
+    scipy_res = jv(N_grid, X_grid)
+    assert_allclose(custom_res, scipy_res, atol=1e-14, rtol=1e-13)
 
 
 @pytest.fixture

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -1,14 +1,6 @@
-import warnings
 from math import factorial
 
 import numpy as np
-
-from astropy.utils.compat.optional_deps import HAS_SCIPY
-from astropy.utils.exceptions import AstropyUserWarning
-
-if HAS_SCIPY:
-    from scipy.fft import next_fast_len
-    from scipy.special import jv, lambertw
 
 
 def bitceil(N):
@@ -18,6 +10,29 @@ def bitceil(N):
     Roughly equivalent to int(2 ** np.ceil(np.log2(N))).
     """
     return 1 << int(N - 1).bit_length()
+
+
+def next_fast_len(N):
+    """
+    Find the next number greater, than N, which can be expressed
+    as 2^n * 3^m for integer values of n and m and m <= 4.
+    """
+    Nfft = bitceil(N)
+
+    if((Nfft // 16) * 9 > N):
+        Nfft //= 16
+        Nfft *= 9
+    elif((Nfft // 128) * 81 > N):
+        Nfft //= 128
+        Nfft *= 81
+    elif((Nfft // 4) * 3 > N):
+        Nfft //= 4
+        Nfft *= 3
+    elif((Nfft // 32) * 27 > N):
+        Nfft //= 32
+        Nfft *= 27
+
+    return Nfft
 
 
 def extirpolate(x, y, N=None, M=4):
@@ -87,198 +102,245 @@ def extirpolate(x, y, N=None, M=4):
     return result
 
 
-if HAS_SCIPY:
+def jn(n, x, num_terms=10):
+    """
+    Approximate the Bessel function of the first kind
+    of an integer order n for small values of x.
+    Approximately equivalent to scipy.special.jv(n, x)
+    """
+    n = np.asarray(n, dtype=np.int32)
+    x = np.asarray(x)
+    half_x = 0.5 * x
 
-    def get_lra_params(x, N, eps):
-        """
-        Compute parameters for the Low Rank Approximation (LRA) NUFFT.
+    n = n.astype(np.int64)
 
-        Parameters
-        ----------
-        x : array-like
-            Non-uniform sample locations, shape (n,).
-        N : int
-            Required number of grid points in the frequency domain.
-        eps : float
-            Desired relative error tolerance.
+    # Keep the array longer to approximately ignore the factorials of negative integers in the denominator
+    n_max = int(np.max(n)) + num_terms + 10
+    fact = np.empty(n_max + 1, dtype=np.float64)
+    fact[0] = 1.0
+    for i in range(1, n_max + 1):
+        fact[i] = fact[i - 1] * i
 
-        Returns
-        -------
-        s : ndarray, int
-            Wrapped grid indices, shape (n,).
-        gamma : float
-            Maximum absolute deviation from nearest uniform grid point.
-        K : int
-            Number of FFTs required to achieve desired precision (eps) when round-off errors are ignored.
-        """
-        s = np.mod(np.rint(N * x), N).astype(int)
-        er = (N * x - np.rint(N * x) + 0.5) % 1 - 0.5
-        gamma = np.max(np.abs(er))
-        if gamma <= eps:
-            K = 1
-        else:
-            val = lambertw(np.log(10 / eps) / (7 * gamma)).real
-            K = int(np.ceil(5 * gamma * np.exp(val)))
-        return s, gamma, K
+    result = np.zeros(np.broadcast(n, x).shape, dtype=np.float64)
 
-    def chebyshev_polynomials(n, x):
-        """
-        Compute Chebyshev polynomials of the first kind T_0(x) through T_n(x).
+    half_x2 = half_x * half_x
+    term_numer = half_x ** n
+    term_denom = fact[n]
 
-        Parameters
-        ----------
-        n : int
-            Maximum polynomial degree to compute.
-        x : array-like
-            Points at which to evaluate polynomials, shape (m,).
+    for k in range(num_terms):
+        term_denom = fact[k] * fact[(n + k)]
+        result += term_numer / term_denom
+        term_numer *= - half_x2
 
-        Returns
-        -------
-        T : ndarray
-            Polynomial values, shape (m, n+1). T[:, k] contains T_k(x).
-        """
-        x = np.asarray(x)
-        N = len(x)
-        T = np.empty((N, n + 1), dtype=np.float64)
-        T[:, 0] = 1.0
-        if n > 0:
-            T[:, 1] = x
-        for k in range(1, n):
-            T[:, k + 1] = 2 * x * T[:, k] - T[:, k - 1]
-        return T
+    return result
 
-    def bessel_coefficients(K, gamma):
-        """
-        Compute Bessel function coefficients for NUFFT low-rank approximation.
 
-        Parameters
-        ----------
-        K : int
-            Truncation parameter for series expansion.
-        gamma : float
-            Maximum grid deviation parameter from get_lra_params.
+def get_lra_params(x, N, eps):
+    """
+    Compute parameters for the Low Rank Approximation (LRA) NUFFT.
 
-        Returns
-        -------
-        cfs : ndarray
-            Complex coefficient matrix, shape (K, K).
+    Parameters
+    ----------
+    x : array-like
+        Non-uniform sample locations, shape (n,).
+    N : int
+        Required number of grid points in the frequency domain.
+    eps : float
+        Desired relative error tolerance.
 
-        Notes
-        -----
-        Only elements where (p+q) is even are non-zero.
-        """
-        cfs = np.zeros((K, K), dtype=np.complex128)
-        arg = -gamma * np.pi * 0.5
-        # Create full K x K arrays for p and q using meshgrid.
-        p, q = np.meshgrid(np.arange(K), np.arange(K), indexing="ij")
-        mask = (q - p) % 2 == 0
-        cfs[mask] = (
-            4
-            * (1j) ** q[mask]
-            * jv((p[mask] + q[mask]) * 0.5, arg)
-            * jv((q[mask] - p[mask]) * 0.5, arg)
-        )
-        cfs[0, :] *= 0.5
-        cfs[:, 0] *= 0.5
-        return cfs
+    Returns
+    -------
+    s : ndarray, int
+        Wrapped grid indices, shape (n,).
+    gamma : float
+        Maximum absolute deviation from nearest uniform grid point.
+    K : int
+        Number of FFTs required to achieve desired precision (eps) when round-off errors are ignored.
+    """
+    s = np.mod(np.rint(N * x), N).astype(int)
+    er = (N * x - np.rint(N * x) + 0.5) % 1 - 0.5
+    gamma = np.max(np.abs(er))
+    if gamma <= eps:
+        K = 1
+    if gamma <= eps:
+        K = 1
+    else:
+        lut = {5: 7.193e-01, 6: 7.812e-02, 7: 6.401e-03,
+            8: 4.148e-04, 9: 2.199e-05, 10: 9.786e-07,
+            11: 3.725e-08, 12: 1.233e-09, 13: 3.590e-11,
+            14: 9.305e-13, 15: 2.165e-14, 16: 4.559e-16}
 
-    def construct_UV(x, gamma, K, N):
-        """
-        Construct low-rank approximation matrices for NUFFT.
+        # Find the smallest K in the LUT where eps is less than or equal to the LUT value
+        K = 16  # Default to K=16 if eps is too small
+        for i in sorted(lut.keys()):
+            if eps >= lut[i]:
+                K = i
+                break
 
-        Parameters
-        ----------
-        x : array-like
-            Non-uniform sample locations, shape (N,).
-        gamma : float
-            Maximum grid deviation from get_lra_params.
-        K : int
-            Truncation parameter from get_lra_params.
-        N : int
-            Number of frequency grid points.
+    return s, gamma, K
 
-        Returns
-        -------
-        U : ndarray
-            Sample-space factor matrix, shape (M, K).
-        V : ndarray
-            Frequency-space factor matrix, shape (N, K).
 
-        Notes
-        -----
-        Constructs matrices such that the NUFFT kernel exp(-2πi x ω) ≈ U @ V^H.
-        U combines Chebyshev polynomials of (x - grid)/gamma with Bessel coefficients.
-        V contains Chebyshev polynomials of frequency grid points.
-        """
-        # Compute the periodic deviation for each sample point.
-        er = (N * x - np.rint(N * x) + 0.5) % 1 - 0.5
+def chebyshev_polynomials(d, x):
+    """
+    Compute Chebyshev polynomials of the first kind T_0(x) through T_n(x).
 
-        # Compute Chebyshev polynomials on a scaled variable for U.
-        if gamma == 0:
-            Tcheb_U = np.ones((len(x), K))
-        else:
-            Tcheb_U = chebyshev_polynomials(K - 1, er / gamma)
-        B = bessel_coefficients(K, gamma)
-        U = np.exp(-1j * np.pi * er)[:, None] * (Tcheb_U @ B)
+    Parameters
+    ----------
+    d : int
+        Maximum polynomial degree to compute.
+    x : array-like
+        Points at which to evaluate polynomials, shape (M,).
 
-        # For V: compute Chebyshev polynomials on the frequency variable.
-        omega = np.arange(N)
-        X = 2.0 * omega / N - 1
-        Tcheb_V = chebyshev_polynomials(K - 1, X)
-        V = Tcheb_V.astype(np.complex128)
+    Returns
+    -------
+    T : ndarray
+        Polynomial values, shape (M, d+1). T[:, k] contains T_k(x).
+    """
+    x = np.asarray(x)
+    N = len(x)
+    T = np.empty((N, d + 1), dtype=np.float64)
+    T[:, 0] = 1.0
+    if d > 0:
+        T[:, 1] = x
+    for k in range(1, d):
+        T[:, k + 1] = 2 * x * T[:, k] - T[:, k - 1]
+    return T
 
-        return U, V
 
-    def nufft1_lra(x, y, N, eps):
-        """
-        Adjoint NUFFT  (Type-I) using Low Rank Approximation.
+def bessel_coefficients(K, gamma):
+    """
+    Compute Bessel function coefficients for NUFFT low-rank approximation.
 
-        Computes: s[k] = sum_{j=0}^{M-1} y[j] * exp(2πi x[j] k) for k = 0, ..., N-1
+    Parameters
+    ----------
+    K : int
+        Truncation parameter for series expansion.
+    gamma : float
+        Maximum grid deviation parameter from get_lra_params.
 
-        Parameters
-        ----------
-        x : array-like
-            Non-uniform sample locations in shape (M,).
-        y : array-like
-            Complex input values at non-uniform points, shape (M,).
-        N : int
-            Number of desired frequency bins.
-        eps : float
-            Desired relative error tolerance.
+    Returns
+    -------
+    cfs : ndarray
+        Complex coefficient matrix, shape (K, K).
 
-        Returns
-        -------
-        y : ndarray
-            Complex Fourier coefficients, shape (N,).
+    Notes
+    -----
+    Only elements where (p+q) is even are non-zero.
+    """
+    cfs = np.zeros((K, K), dtype=np.complex128)
+    arg = -gamma * np.pi * 0.5
+    # Create full K x K arrays for p and q using meshgrid.
+    p, q = np.meshgrid(np.arange(K), np.arange(K), indexing="ij")
+    mask = (q - p) % 2 == 0
+    cfs[mask] = (
+        4
+        * (1j) ** q[mask]
+        * jn((p[mask] + q[mask]) * 0.5, arg)
+        * jn((q[mask] - p[mask]) * 0.5, arg)
+    )
+    cfs[0, :] *= 0.5
+    cfs[:, 0] *= 0.5
+    return cfs
 
-        Notes
-        -----
-        Implements the algorithm from Ruiz-Antolin & Townsend (2018) using
-        a low-rank approximation of the NUFFT kernel.
 
-        This implementation based on the MIT-licensed FastTransforms.jl Julia library.
-        """
-        # Not required, although it makes the computation noticeably faster
-        Nfft = next_fast_len(max(N, len(x)))
+def construct_UV(x, gamma, K, N):
+    """
+    Construct low-rank approximation matrices for NUFFT.
 
-        # Compute grid indices and parameters for the low-rank approximation.
-        T, gamma, K = get_lra_params(x, Nfft, eps)
-        U, V = construct_UV(x, gamma, K, Nfft)
+    Parameters
+    ----------
+    x : array-like
+        Non-uniform sample locations, shape (N,).
+    gamma : float
+        Maximum grid deviation from get_lra_params.
+    K : int
+        Truncation parameter from get_lra_params.
+    N : int
+        Number of frequency grid points.
 
-        # Scattering step: accumulate contributions via bin-counting.
-        temp = np.zeros((Nfft, K), dtype=np.complex128)
-        product = np.conjugate(U) * y[:, None]
-        for k in range(K):
-            real_part = np.bincount(T, weights=np.real(product[:, k]), minlength=Nfft)
-            imag_part = np.bincount(T, weights=np.imag(product[:, k]), minlength=Nfft)
-            temp[:, k] = real_part + 1j * imag_part
+    Returns
+    -------
+    U : ndarray
+        Sample-space factor matrix, shape (M, K).
+    V : ndarray
+        Frequency-space factor matrix, shape (N, K).
 
-        # Compute the inverse FFT (with normalization by Nfft) and combine with V.
-        temp_ifft = np.fft.ifft(temp, axis=0) * Nfft
-        s = np.sum(np.conjugate(V) * temp_ifft, axis=1)
+    Notes
+    -----
+    Constructs matrices such that the NUFFT kernel exp(-2πi x ω) ≈ U @ V^H.
+    U combines Chebyshev polynomials of (x - grid)/gamma with Bessel coefficients.
+    V contains Chebyshev polynomials of frequency grid points.
+    """
+    # Compute the periodic deviation for each sample point.
+    er = (N * x - np.rint(N * x) + 0.5) % 1 - 0.5
 
-        # Return the result truncated to the desired frequency grid length.
-        return s[:N]
+    # Compute Chebyshev polynomials on a scaled variable for U.
+    if gamma == 0:
+        Tcheb_U = np.ones((len(x), K))
+    else:
+        Tcheb_U = chebyshev_polynomials(K - 1, er / gamma)
+    B = bessel_coefficients(K, gamma)
+    U = np.exp(-1j * np.pi * er)[:, None] * (Tcheb_U @ B)
+
+    # For V: compute Chebyshev polynomials on the frequency variable.
+    omega = np.arange(N)
+    X = 2.0 * omega / N - 1
+    Tcheb_V = chebyshev_polynomials(K - 1, X)
+    V = Tcheb_V.astype(np.complex128)
+
+    return U, V
+
+
+def nufft1_lra(x, y, N, eps):
+    """
+    Adjoint NUFFT  (Type-I) using Low Rank Approximation.
+
+    Computes: s[k] = sum_{j=0}^{M-1} y[j] * exp(2πi x[j] k) for k = 0, ..., N-1
+
+    Parameters
+    ----------
+    x : array-like
+        Non-uniform sample locations in shape (M,).
+    y : array-like
+        Complex input values at non-uniform points, shape (M,).
+    N : int
+        Number of desired frequency bins.
+    eps : float
+        Desired relative error tolerance.
+
+    Returns
+    -------
+    y : ndarray
+        Complex Fourier coefficients, shape (N,).
+
+    Notes
+    -----
+    Implements the algorithm from Ruiz-Antolin & Townsend (2018) using
+    a low-rank approximation of the NUFFT kernel.
+
+    This implementation based on the MIT-licensed FastTransforms.jl Julia library.
+    """
+    # Not required, although it makes the computation noticeably faster
+    Nfft = next_fast_len(max(N, len(x)))
+
+    # Compute grid indices and parameters for the low-rank approximation.
+    T, gamma, K = get_lra_params(x, Nfft, eps)
+    U, V = construct_UV(x, gamma, K, Nfft)
+
+    # Scattering step: accumulate contributions via bin-counting.
+    temp = np.zeros((Nfft, K), dtype=np.complex128)
+    product = np.conjugate(U) * y[:, None]
+    for k in range(K):
+        real_part = np.bincount(T, weights=np.real(product[:, k]), minlength=Nfft)
+        imag_part = np.bincount(T, weights=np.imag(product[:, k]), minlength=Nfft)
+        temp[:, k] = real_part + 1j * imag_part
+
+    # Compute the inverse FFT (with normalization by Nfft) and combine with V.
+    temp_ifft = np.fft.ifft(temp, axis=0) * Nfft
+    s = np.sum(np.conjugate(V) * temp_ifft, axis=1)
+
+    # Return the result truncated to the desired frequency grid length.
+    return s[:N]
 
 
 def trig_sum(
@@ -291,7 +353,7 @@ def trig_sum(
     oversampling=5,
     use_fft=True,
     Mfft=4,
-    prefer_lra=True,
+    algorithm='fasper',
     eps=5e-13,
 ):
     """Compute (approximate) trigonometric sums for a number of frequencies.
@@ -321,20 +383,25 @@ def trig_sum(
         Factor which multiplies the frequency
     use_fft : bool
         if True, use the approximate FFT algorithm to compute the result.
-    prefer_lra : bool
-        if True and SciPy is available, use the more accurate Low Rank Approximation by Ruiz-Antolin and Townsend.
-        If False or SciPy is not available use Press & Rybicki's Lagrangian extirpolation instead.
     oversampling : int (default = 5)
         oversampling freq_factor for the approximation; roughly the number of
         time samples across the highest-frequency sinusoid. This parameter
-        contains the trade-off between accuracy and speed. Not referenced
-        if use_fft is False or prefer_lra is True and SciPy is available.
+        contains the trade-off between accuracy and speed.
+        Referenced only when use_fft is True and algorithm is set to 'fasper'
     Mfft : int
         The number of adjacent points to use in the FFT approximation.
         Not referenced if use_fft is False  or prefer_lra is True and SciPy is available.
+    algorithm : str, optional
+        Referenced only if use_fft is true.
+        Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
+        Currently there are two available options:
+
+        - 'fasper': use Press & Rybicki's Lagrangian extirpolation instead. This is the default option.
+        - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
+
     eps : float
         Desired relative error tolerance. Not referenced
-        if use_fft is False or SciPy is not available.
+        if use_fft is False or algorithm is set to 'fasper'.
 
     Returns
     -------
@@ -347,24 +414,12 @@ def trig_sum(
     # Ensure t and h are 1D arrays.
     t, h = map(np.ravel, np.broadcast_arrays(t, h))
 
-    if prefer_lra and not HAS_SCIPY:
-        warnings.warn(
-            "SciPy is not installed. The low-rank approximation (LRA) method for NUFFT "
-            "requires SciPy and will be disabled. Astropy will use the less accurate "
-            "Lagrangian interpolation-based method instead.\n"
-            "To improve accuracy, install SciPy.\n"
-            "To silence this warning, explicitly set `prefer_lra=False`.",
-            AstropyUserWarning,
-        )
-        prefer_lra = False
-        print("\n")
-
     df *= freq_factor
     f0 *= freq_factor
 
     if use_fft:
         t0 = t.min()
-        if prefer_lra:
+        if algorithm == 'lra':
             if f0 != 0:
                 h = h * np.exp(2j * np.pi * f0 * (t - t0))
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -19,16 +19,16 @@ def next_fast_len(N):
     """
     Nfft = bitceil(N)
 
-    if((Nfft // 16) * 9 > N):
+    if (Nfft // 16) * 9 > N:
         Nfft //= 16
         Nfft *= 9
-    elif((Nfft // 128) * 81 > N):
+    elif (Nfft // 128) * 81 > N:
         Nfft //= 128
         Nfft *= 81
-    elif((Nfft // 4) * 3 > N):
+    elif (Nfft // 4) * 3 > N:
         Nfft //= 4
         Nfft *= 3
-    elif((Nfft // 32) * 27 > N):
+    elif (Nfft // 32) * 27 > N:
         Nfft //= 32
         Nfft *= 27
 
@@ -124,13 +124,13 @@ def jn(n, x, num_terms=10):
     result = np.zeros(np.broadcast(n, x).shape, dtype=np.float64)
 
     half_x2 = half_x * half_x
-    term_numer = half_x ** n
+    term_numer = half_x**n
     term_denom = fact[n]
 
     for k in range(num_terms):
         term_denom = fact[k] * fact[(n + k)]
         result += term_numer / term_denom
-        term_numer *= - half_x2
+        term_numer *= -half_x2
 
     return result
 
@@ -165,10 +165,23 @@ def get_lra_params(x, N, eps):
     if gamma <= eps:
         K = 1
     else:
-        lut = {5: 7.193e-01, 6: 7.812e-02, 7: 6.401e-03,
-            8: 4.148e-04, 9: 2.199e-05, 10: 9.786e-07,
-            11: 3.725e-08, 12: 1.233e-09, 13: 3.590e-11,
-            14: 9.305e-13, 15: 2.165e-14, 16: 4.559e-16}
+        lut = {
+            2: 2.6e-1,
+            3: 5.4e-2,
+            4: 8.6e-3,
+            5: 1.1e-3,
+            6: 1.3e-4,
+            7: 1.2e-5,
+            8: 1.2e-6,
+            9: 9.0e-8,
+            10: 6.8e-9,
+            11: 4.3e-10,
+            12: 2.9e-11,
+            13: 1.6e-12,
+            14: 8.4e-14,
+            15: 2.2e-14,
+            16: 4.6e-16,
+        }
 
         # Find the smallest K in the LUT where eps is less than or equal to the LUT value
         K = 16  # Default to K=16 if eps is too small
@@ -353,7 +366,7 @@ def trig_sum(
     oversampling=5,
     use_fft=True,
     Mfft=4,
-    algorithm='fasper',
+    algorithm="fasper",
     eps=5e-13,
 ):
     """Compute (approximate) trigonometric sums for a number of frequencies.
@@ -392,11 +405,11 @@ def trig_sum(
         The number of adjacent points to use in the FFT approximation.
         Not referenced if use_fft is False  or prefer_lra is True and SciPy is available.
     algorithm : str, optional
-        Referenced only if use_fft is true.
+        This option is ignored if if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
         Currently there are two available options:
 
-        - 'fasper': use Press & Rybicki's Lagrangian extirpolation instead. This is the default option.
+        - 'fasper': use Press & Rybicki's piecewise Lagrange polynomial extirpolation. This is the default option.
         - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
 
     eps : float
@@ -419,7 +432,7 @@ def trig_sum(
 
     if use_fft:
         t0 = t.min()
-        if algorithm == 'lra':
+        if algorithm == "lra":
             if f0 != 0:
                 h = h * np.exp(2j * np.pi * f0 * (t - t0))
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -1,6 +1,14 @@
+import warnings
 from math import factorial
 
 import numpy as np
+
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+from astropy.utils.exceptions import AstropyUserWarning
+
+if HAS_SCIPY:
+    from scipy.fft import next_fast_len
+    from scipy.special import jv, lambertw
 
 
 def bitceil(N):
@@ -79,7 +87,213 @@ def extirpolate(x, y, N=None, M=4):
     return result
 
 
-def trig_sum(t, h, df, N, f0=0, freq_factor=1, oversampling=5, use_fft=True, Mfft=4):
+if HAS_SCIPY:
+
+    def get_lra_params(x, N, eps):
+        """
+        Compute parameters for the Low Rank Approximation (LRA) NUFFT.
+
+        Parameters
+        ----------
+        x : array-like
+            Non-uniform sample locations, shape (n,).
+        N : int
+            Required number of grid points in the frequency domain.
+        eps : float
+            Desired relative error tolerance.
+
+        Returns
+        -------
+        s : ndarray, int
+            Wrapped grid indices, shape (n,).
+        gamma : float
+            Maximum absolute deviation from nearest uniform grid point.
+        K : int
+            Number of FFTs required to achieve desired precision (eps) when round-off errors are ignored.
+        """
+        s = np.mod(np.rint(N * x), N).astype(int)
+        er = (N * x - np.rint(N * x) + 0.5) % 1 - 0.5
+        gamma = np.max(np.abs(er))
+        if gamma <= eps:
+            K = 1
+        else:
+            val = lambertw(np.log(10 / eps) / (7 * gamma)).real
+            K = int(np.ceil(5 * gamma * np.exp(val)))
+        return s, gamma, K
+
+    def chebyshev_polynomials(n, x):
+        """
+        Compute Chebyshev polynomials of the first kind T_0(x) through T_n(x).
+
+        Parameters
+        ----------
+        n : int
+            Maximum polynomial degree to compute.
+        x : array-like
+            Points at which to evaluate polynomials, shape (m,).
+
+        Returns
+        -------
+        T : ndarray
+            Polynomial values, shape (m, n+1). T[:, k] contains T_k(x).
+        """
+        x = np.asarray(x)
+        N = len(x)
+        T = np.empty((N, n + 1), dtype=np.float64)
+        T[:, 0] = 1.0
+        if n > 0:
+            T[:, 1] = x
+        for k in range(1, n):
+            T[:, k + 1] = 2 * x * T[:, k] - T[:, k - 1]
+        return T
+
+    def bessel_coefficients(K, gamma):
+        """
+        Compute Bessel function coefficients for NUFFT low-rank approximation.
+
+        Parameters
+        ----------
+        K : int
+            Truncation parameter for series expansion.
+        gamma : float
+            Maximum grid deviation parameter from get_lra_params.
+
+        Returns
+        -------
+        cfs : ndarray
+            Complex coefficient matrix, shape (K, K).
+
+        Notes
+        -----
+        Only elements where (p+q) is even are non-zero.
+        """
+        cfs = np.zeros((K, K), dtype=np.complex128)
+        arg = -gamma * np.pi * 0.5
+        # Create full K x K arrays for p and q using meshgrid.
+        p, q = np.meshgrid(np.arange(K), np.arange(K), indexing="ij")
+        mask = (q - p) % 2 == 0
+        cfs[mask] = (
+            4
+            * (1j) ** q[mask]
+            * jv((p[mask] + q[mask]) * 0.5, arg)
+            * jv((q[mask] - p[mask]) * 0.5, arg)
+        )
+        cfs[0, :] *= 0.5
+        cfs[:, 0] *= 0.5
+        return cfs
+
+    def construct_UV(x, gamma, K, N):
+        """
+        Construct low-rank approximation matrices for NUFFT.
+
+        Parameters
+        ----------
+        x : array-like
+            Non-uniform sample locations, shape (N,).
+        gamma : float
+            Maximum grid deviation from get_lra_params.
+        K : int
+            Truncation parameter from get_lra_params.
+        N : int
+            Number of frequency grid points.
+
+        Returns
+        -------
+        U : ndarray
+            Sample-space factor matrix, shape (M, K).
+        V : ndarray
+            Frequency-space factor matrix, shape (N, K).
+
+        Notes
+        -----
+        Constructs matrices such that the NUFFT kernel exp(-2πi x ω) ≈ U @ V^H.
+        U combines Chebyshev polynomials of (x - grid)/gamma with Bessel coefficients.
+        V contains Chebyshev polynomials of frequency grid points.
+        """
+        # Compute the periodic deviation for each sample point.
+        er = (N * x - np.rint(N * x) + 0.5) % 1 - 0.5
+
+        # Compute Chebyshev polynomials on a scaled variable for U.
+        if gamma == 0:
+            Tcheb_U = np.ones((len(x), K))
+        else:
+            Tcheb_U = chebyshev_polynomials(K - 1, er / gamma)
+        B = bessel_coefficients(K, gamma)
+        U = np.exp(-1j * np.pi * er)[:, None] * (Tcheb_U @ B)
+
+        # For V: compute Chebyshev polynomials on the frequency variable.
+        omega = np.arange(N)
+        X = 2.0 * omega / N - 1
+        Tcheb_V = chebyshev_polynomials(K - 1, X)
+        V = Tcheb_V.astype(np.complex128)
+
+        return U, V
+
+    def nufft1_lra(x, y, N, eps):
+        """
+        Adjoint NUFFT  (Type-I) using Low Rank Approximation.
+
+        Computes: s[k] = sum_{j=0}^{M-1} y[j] * exp(2πi x[j] k) for k = 0, ..., N-1
+
+        Parameters
+        ----------
+        x : array-like
+            Non-uniform sample locations in shape (M,).
+        y : array-like
+            Complex input values at non-uniform points, shape (M,).
+        N : int
+            Number of desired frequency bins.
+        eps : float
+            Desired relative error tolerance.
+
+        Returns
+        -------
+        y : ndarray
+            Complex Fourier coefficients, shape (N,).
+
+        Notes
+        -----
+        Implements the algorithm from Ruiz-Antolin & Townsend (2018) using
+        a low-rank approximation of the NUFFT kernel.
+
+        This implementation based on the MIT-licensed FastTransforms.jl Julia library.
+        """
+        # Not required, although it makes the computation noticeably faster
+        Nfft = next_fast_len(max(N, len(x)))
+
+        # Compute grid indices and parameters for the low-rank approximation.
+        T, gamma, K = get_lra_params(x, Nfft, eps)
+        U, V = construct_UV(x, gamma, K, Nfft)
+
+        # Scattering step: accumulate contributions via bin-counting.
+        temp = np.zeros((Nfft, K), dtype=np.complex128)
+        product = np.conjugate(U) * y[:, None]
+        for k in range(K):
+            real_part = np.bincount(T, weights=np.real(product[:, k]), minlength=Nfft)
+            imag_part = np.bincount(T, weights=np.imag(product[:, k]), minlength=Nfft)
+            temp[:, k] = real_part + 1j * imag_part
+
+        # Compute the inverse FFT (with normalization by Nfft) and combine with V.
+        temp_ifft = np.fft.ifft(temp, axis=0) * Nfft
+        s = np.sum(np.conjugate(V) * temp_ifft, axis=1)
+
+        # Return the result truncated to the desired frequency grid length.
+        return s[:N]
+
+
+def trig_sum(
+    t,
+    h,
+    df,
+    N,
+    f0=0,
+    freq_factor=1,
+    oversampling=5,
+    use_fft=True,
+    Mfft=4,
+    prefer_lra=True,
+    eps=5e-13,
+):
     """Compute (approximate) trigonometric sums for a number of frequencies.
 
     This routine computes weighted sine and cosine sums::
@@ -107,50 +321,82 @@ def trig_sum(t, h, df, N, f0=0, freq_factor=1, oversampling=5, use_fft=True, Mff
         Factor which multiplies the frequency
     use_fft : bool
         if True, use the approximate FFT algorithm to compute the result.
-        This uses the FFT with Press & Rybicki's Lagrangian extirpolation.
+    prefer_lra : bool
+        if True and SciPy is available, use the more accurate Low Rank Approximation by Ruiz-Antolin and Townsend.
+        If False or SciPy is not available use Press & Rybicki's Lagrangian extirpolation instead.
     oversampling : int (default = 5)
         oversampling freq_factor for the approximation; roughly the number of
         time samples across the highest-frequency sinusoid. This parameter
         contains the trade-off between accuracy and speed. Not referenced
-        if use_fft is False.
+        if use_fft is False or prefer_lra is True and SciPy is available.
     Mfft : int
         The number of adjacent points to use in the FFT approximation.
-        Not referenced if use_fft is False.
+        Not referenced if use_fft is False  or prefer_lra is True and SciPy is available.
+    eps : float
+        Desired relative error tolerance. Not referenced
+        if use_fft is False or SciPy is not available.
 
     Returns
     -------
     S, C : ndarray
         summation arrays for frequencies f = df * np.arange(1, N + 1)
     """
+    if df <= 0:
+        raise ValueError("df must be positive")
+
+    # Ensure t and h are 1D arrays.
+    t, h = map(np.ravel, np.broadcast_arrays(t, h))
+
+    if prefer_lra and not HAS_SCIPY:
+        warnings.warn(
+            "SciPy is not installed. The low-rank approximation (LRA) method for NUFFT "
+            "requires SciPy and will be disabled. Astropy will use the less accurate "
+            "Lagrangian interpolation-based method instead.\n"
+            "To improve accuracy, install SciPy.\n"
+            "To silence this warning, explicitly set `prefer_lra=False`.",
+            AstropyUserWarning,
+        )
+        prefer_lra = False
+        print("\n")
+
     df *= freq_factor
     f0 *= freq_factor
 
-    if df <= 0:
-        raise ValueError("df must be positive")
-    t, h = map(np.ravel, np.broadcast_arrays(t, h))
-
     if use_fft:
-        Mfft = int(Mfft)
-        if Mfft <= 0:
-            raise ValueError("Mfft must be positive")
-
-        # required size of fft is the power of 2 above the oversampling rate
-        Nfft = bitceil(N * oversampling)
         t0 = t.min()
+        if prefer_lra:
+            if f0 != 0:
+                h = h * np.exp(2j * np.pi * f0 * (t - t0))
 
-        if f0 > 0:
-            h = h * np.exp(2j * np.pi * f0 * (t - t0))
+            tnorm = (t - t0) * df
 
-        tnorm = ((t - t0) * Nfft * df) % Nfft
-        grid = extirpolate(tnorm, h, Nfft, Mfft)
+            fftgrid = nufft1_lra(tnorm, h, N, eps)
 
-        fftgrid = np.fft.ifft(grid)[:N]
-        if t0 != 0:
-            f = f0 + df * np.arange(N)
-            fftgrid *= np.exp(2j * np.pi * t0 * f)
+            if t0 > 0:
+                f = f0 + df * np.arange(N)
+                fftgrid = fftgrid * np.exp(2j * np.pi * t0 * f)
 
-        C = Nfft * fftgrid.real
-        S = Nfft * fftgrid.imag
+            C = fftgrid.real
+            S = fftgrid.imag
+
+        else:
+            # required size of fft is the power of 2 above the oversampling rate
+            Nfft = bitceil(int(N * oversampling))
+
+            if f0 > 0:
+                h = h * np.exp(2j * np.pi * f0 * (t - t0))
+
+            tnorm = ((t - t0) * Nfft * df) % Nfft
+            grid = extirpolate(tnorm, h, Nfft, Mfft)
+
+            fftgrid = np.fft.ifft(grid)[:N]
+            if t0 != 0:
+                f = f0 + df * np.arange(N)
+                fftgrid *= np.exp(2j * np.pi * t0 * f)
+
+            C = Nfft * fftgrid.real
+            S = Nfft * fftgrid.imag
+
     else:
         f = f0 + df * np.arange(N)
         C = np.dot(h, np.cos(2 * np.pi * f * t[:, np.newaxis]))

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -102,11 +102,12 @@ def extirpolate(x, y, N=None, M=4):
     return result
 
 
-def jn(n, x, num_terms=10):
+def jn(n, x, num_terms=8):
     """
     Approximate the Bessel function of the first kind
     of an integer order n for small values of x.
     Approximately equivalent to scipy.special.jv(n, x)
+    for -π/4 < x < π/4.
     """
     n = np.asarray(n, dtype=np.int32)
     x = np.asarray(x)
@@ -114,8 +115,11 @@ def jn(n, x, num_terms=10):
 
     n = n.astype(np.int64)
 
-    # Keep the array longer to approximately ignore the factorials of negative integers in the denominator
-    n_max = int(np.max(n)) + num_terms + 10
+    # Use J_{-m}(x) = (-1)^m J_m(x) to reduce to non-negative order
+    m = np.abs(n)
+    sign = np.where((n < 0) & (m % 2 == 1), -1.0, 1.0)
+
+    n_max = int(m.max()) + num_terms
     fact = np.empty(n_max + 1, dtype=np.float64)
     fact[0] = 1.0
     for i in range(1, n_max + 1):
@@ -124,15 +128,15 @@ def jn(n, x, num_terms=10):
     result = np.zeros(np.broadcast_shapes(n.shape, x.shape), dtype=np.float64)
 
     half_x2 = half_x * half_x
-    term_numer = half_x**n
-    term_denom = fact[n]
+    term_numer = half_x**m
+    term_denom = fact[m]
 
     for k in range(num_terms):
-        term_denom = fact[k] * fact[n + k]
+        term_denom = fact[k] * fact[m + k]
         result += term_numer / term_denom
         term_numer *= -half_x2
 
-    return result
+    return sign * result
 
 
 def get_lra_params(x, N, eps):
@@ -146,7 +150,7 @@ def get_lra_params(x, N, eps):
     N : int
         Required number of grid points in the frequency domain.
     eps : float
-        Desired relative error tolerance.
+        Desired average relative error of the output.
 
     Returns
     -------
@@ -181,7 +185,7 @@ def get_lra_params(x, N, eps):
             16: 4.6e-16,
         }
 
-        # Find the smallest K in the LUT where eps is less than or equal to the LUT value
+        # Find the smallest K in the LUT where eps is equal to or greater than the LUT value
         for i, threshold in lut.items():
             if eps >= threshold:
                 K = i
@@ -317,7 +321,7 @@ def nufft1_lra(x, y, N, eps):
     N : int
         Number of desired frequency bins.
     eps : float
-        Desired relative error tolerance.
+        Desired average relative error of the output.
 
     Returns
     -------
@@ -401,7 +405,7 @@ def trig_sum(
         Referenced only when use_fft is True and algorithm is set to 'fasper'
     Mfft : int
         The number of adjacent points to use in the FFT approximation.
-        Not referenced if use_fft is False  or prefer_lra is True and SciPy is available.
+        Not referenced if use_fft is False.
     algorithm : 'fasper' (default), or 'lra'
         This option is ignored if if use_fft is False.
         Specify the approximation used to approximate the NUDFT of type 1. If the value is not valid falls back to the default option.
@@ -411,7 +415,7 @@ def trig_sum(
         - 'lra': Use the more accurate (but slower) Low Rank Approximation by Ruiz-Antolin and Townsend.
 
     eps : float
-        Desired relative error tolerance. Not referenced
+        Desired average relative error of the output. Not referenced
         if use_fft is False or algorithm is set to 'fasper'.
 
     Returns
@@ -438,7 +442,7 @@ def trig_sum(
 
             fftgrid = nufft1_lra(tnorm, h, N, eps)
 
-            if t0 > 0:
+            if t0 != 0:
                 f = f0 + df * np.arange(N)
                 fftgrid = fftgrid * np.exp(2j * np.pi * t0 * f)
 

--- a/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
@@ -6,6 +6,7 @@ from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time, TimeDelta
 from astropy.timeseries.periodograms.lombscargle import LombScargle
+from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 ALL_METHODS = LombScargle.available_methods
 ALL_METHODS_NO_AUTO = [method for method in ALL_METHODS if method != "auto"]
@@ -99,9 +100,12 @@ def test_all_methods(
     )
     P_expected = ls.power(frequency)
 
-    # don't use the fft approximation here; we'll test this elsewhere
+    # don't use the fft approximation here if the SciPy is not available; we'll test this elsewhere
     if method in FAST_METHODS:
-        kwds["method_kwds"] = dict(use_fft=False)
+        if not HAS_SCIPY:
+            kwds["method_kwds"] = dict(use_fft=False)
+        else:
+            kwds["method_kwds"] = dict(prefer_lra=True)
     P_method = ls.power(frequency, method=method, **kwds)
 
     if with_units:
@@ -186,10 +190,14 @@ def test_nterms_methods(
     else:
         P_expected = ls.power(frequency)
 
-        # don't use fast fft approximations here
+        # don't use fast fft approximations here if the SciPy is not available
         kwds = {}
         if "fast" in method:
-            kwds["method_kwds"] = dict(use_fft=False)
+            if not HAS_SCIPY:
+                kwds["method_kwds"] = dict(use_fft=False)
+            else:
+                kwds["method_kwds"] = dict(prefer_lra=True)
+
         P_method = ls.power(frequency, method=method, **kwds)
 
         assert_allclose(P_expected, P_method, rtol=1e-7, atol=1e-25)
@@ -225,6 +233,7 @@ def test_fast_approximations(method, center_data, fit_mean, errors, nterms, data
 
     # use only standard normalization because we compare via absolute tolerance
     kwds = dict(method=method)
+    kwds.setdefault("method_kwds", {}).update(prefer_lra=False)
 
     if method == "fast" and nterms != 1:
         with pytest.raises(ValueError, match=r"nterms"):

--- a/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
@@ -6,6 +6,9 @@ from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time, TimeDelta
 from astropy.timeseries.periodograms.lombscargle import LombScargle
+from astropy.timeseries.periodograms.lombscargle._testing import (
+    assert_not_strictly_equal,
+)
 
 ALL_METHODS = LombScargle.available_methods
 ALL_METHODS_NO_AUTO = [method for method in ALL_METHODS if method != "auto"]
@@ -242,10 +245,7 @@ def test_fast_approximations(method, center_data, fit_mean, errors, nterms, data
 
         assert_allclose(P_fast, P_slow, atol=0.008)
         if nterms != 0:
-            assert np.bitwise_xor(
-                np.ascontiguousarray(P_fast).view(np.uint8),
-                np.ascontiguousarray(P_slow).view(np.uint8),
-            ).any(), "Output arrays are the same - dispatch test has failed"
+            assert_not_strictly_equal(P_fast, P_slow)
 
 
 @pytest.mark.parametrize("method", LombScargle.available_methods)

--- a/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
@@ -241,10 +241,11 @@ def test_fast_approximations(method, center_data, fit_mean, errors, nterms, data
         P_slow = ls.power(frequency, **kwds)
 
         assert_allclose(P_fast, P_slow, atol=0.008)
-        assert np.bitwise_xor(
-            np.ascontiguousarray(P_fast).view(np.uint8),
-            np.ascontiguousarray(P_slow).view(np.uint8),
-        ).any(), "Output arrays are the same - dispatch test has failed"
+        if nterms != 0:
+            assert np.bitwise_xor(
+                np.ascontiguousarray(P_fast).view(np.uint8),
+                np.ascontiguousarray(P_slow).view(np.uint8),
+            ).any(), "Output arrays are the same - dispatch test has failed"
 
 
 @pytest.mark.parametrize("method", LombScargle.available_methods)

--- a/docs/changes/timeseries/17842.feature.rst
+++ b/docs/changes/timeseries/17842.feature.rst
@@ -1,3 +1,2 @@
-The ``prefer_lra`` option is now available for ``trig_sum``.
-The function increases the accuracy of trig_sum utility.
-To disable use it, pass ``trig_sum(..., my_new_feature=False)``.
+Add support for Low Rank Approximation (LRA) to ``trig_sum``.
+This is enabled by passing the new argument ``algorithm='lra'``.

--- a/docs/changes/timeseries/17842.feature.rst
+++ b/docs/changes/timeseries/17842.feature.rst
@@ -1,0 +1,3 @@
+The ``prefer_lra`` option is now available for ``trig_sum``.
+The function increases the accuracy of trig_sum utility.
+To disable use it, pass ``trig_sum(..., my_new_feature=False)``.

--- a/docs/changes/timeseries/17842.feature.rst
+++ b/docs/changes/timeseries/17842.feature.rst
@@ -1,2 +1,4 @@
-Add support for Low Rank Approximation (LRA) to ``trig_sum``.
-This is enabled by passing the new argument ``algorithm='lra'``.
+Adds support for Low Rank Approximation (LRA) to ``trig_sum``.
+This is enabled by passing the new argument ``algorithm='lra'``,
+which is now the default option for ``fast`` and
+``fastchi2`` implementations.

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -3,16 +3,19 @@
 *************************
 Lomb-Scargle Periodograms
 *************************
+
 The Lomb-Scargle periodogram (after Lomb [1]_, and Scargle [2]_) is a commonly
 used statistical tool designed to detect periodic signals in unevenly spaced
 observations. The :class:`~astropy.timeseries.LombScargle` class is a unified
 interface to several implementations of the Lomb-Scargle periodogram, including
 a fast *O[NlogN]* implementation following the algorithm presented by Press &
 Rybicki [3]_ or Ruiz-Antolin & Townsend [12]_.
+
 Not all of the available implementations are mathematically equivalent: Press & Rybicki [3]_ is the fastest
 option but trades accuracy for speed, while Ruiz-Antolin & Townsend [12]_
 achieves significantly higher accuracy at an acceptable cost and is therefore
 used by default.
+
 The code here is adapted from the `astroml`_ package ([4]_, [5]_), the
 `gatspy`_ package ([6]_, [7]_) and the `FastTransforms.jl`_ library. For a detailed practical discussion of the
 Lomb-Scargle periodogram, with code examples based on ``astropy``, see

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -9,16 +9,17 @@ used statistical tool designed to detect periodic signals in unevenly spaced
 observations. The :class:`~astropy.timeseries.LombScargle` class is a unified
 interface to several implementations of the Lomb-Scargle periodogram, including
 a fast *O[NlogN]* implementation following the algorithm presented by Press &
-Rybicki [3]_.
+Rybicki [3]_ or Ruiz-Antolin & Townsend [12]_.
 
-The code here is adapted from the `astroml`_ package ([4]_, [5]_) and the
-`gatspy`_ package ([6]_, [7]_).  For a detailed practical discussion of the
+The code here is adapted from the `astroml`_ package ([4]_, [5]_), the
+`gatspy`_ package ([6]_, [7]_) and the `FastTransforms.jl`_ library. For a detailed practical discussion of the
 Lomb-Scargle periodogram, with code examples based on ``astropy``, see
 *Understanding the Lomb-Scargle Periodogram* [11]_, with associated code at
 https://github.com/jakevdp/PracticalLombScargle/.
 
 .. _gatspy: https://www.astroml.org/gatspy/
 .. _astroml: https://www.astroml.org/
+.. _FastTransforms.jl: https://juliaapproximation.github.io/FastTransforms.jl/stable/
 
 Basic Usage
 ===========
@@ -532,16 +533,16 @@ component, we can start by simulating 60 observations of a sine wave with noise:
 >>> ls = LombScargle(t, y, dy)
 >>> freq, power = ls.autopower()
 >>> print(power.max())  # doctest: +FLOAT_CMP
-0.29154492887882927
+0.28800558204470955
 
-The peak of the periodogram has a value of 0.33, but how significant is
+The peak of the periodogram has a value of 0.288, but how significant is
 this peak? We can address this question using the
 :func:`~astropy.timeseries.LombScargle.false_alarm_probability` method:
 
 .. doctest-requires:: scipy
 
   >>> ls.false_alarm_probability(power.max())  # doctest: +FLOAT_CMP
-  np.float64(0.028959671719328808)
+  np.float64(0.03302491900289183)
 
 What this tells us is that under the assumption that there is no periodic
 signal in the data, we will observe a peak this high or higher approximately
@@ -597,7 +598,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='baluev')  # doctest: +FLOAT_CMP
-    np.float64(0.028959671719328808)
+    np.float64(0.03302491900289183)
 
 - ``method="bootstrap"`` implements a bootstrap simulation: effectively it
   computes many Lomb-Scargle periodograms on simulated data at the same
@@ -618,7 +619,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='davies')  # doctest: +FLOAT_CMP
-    np.float64(0.029387277355227746)
+    np.float64(0.03358255130320076)
 
 - ``method="naive"`` is a basic method based on the assumption that
   well-separated areas in the periodogram are independent. In general, it
@@ -628,7 +629,7 @@ which can be chosen using the ``method`` keyword:
 .. doctest-requires:: scipy
 
     >>> ls.false_alarm_probability(power.max(), method='naive')  # doctest: +FLOAT_CMP
-    np.float64(0.00810080828660202)
+    np.float64(0.009331314848518398)
 
 The following figure compares these false alarm estimates at a range of
 peak heights for 100 observations with a heavily aliased observing pattern:
@@ -744,7 +745,7 @@ data or extensions such as the floating mean. The scaling is approximately
 -----------------
 
 The ``fast`` method is a pure Python implementation of the fast periodogram of
-Press & Rybicki [3]_. It uses an *extrapolation* approach to approximate the
+Press & Rybicki [3]_ and Ruiz-Antolin & Townsend [12]_. It uses an *extrapolation* approach to approximate the
 periodogram frequencies using a fast Fourier transform. As with the ``slow``
 method, it can handle data errors and floating mean.  The scaling is
 approximately :math:`O[N\log M]` for :math:`N` data points and :math:`M`
@@ -938,5 +939,8 @@ Literature References
        periodogram. A new formalism for the floating-mean and Keplerian
        periodograms*, A&A 496, 577-584 (2009)
 .. [11] VanderPlas, J. *Understanding the Lomb-Scargle Periodogram*
-        ApJS 236.1:16 (2018)
-        https://ui.adsabs.harvard.edu/abs/2018ApJS..236...16V
+       ApJS 236.1:16 (2018)
+       https://ui.adsabs.harvard.edu/abs/2018ApJS..236...16V
+.. [12] Ruiz-Antolin, D. and Townsend, A. *A nonuniform fast Fourier transform based on low rank approximation*
+       SIAM 40.1 (2018)
+       https://ui.adsabs.harvard.edu/abs/2018SJSC...40A.529R

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -21,6 +21,7 @@ The code here is adapted from the `astroml`_ package ([4]_, [5]_), the
 Lomb-Scargle periodogram, with code examples based on ``astropy``, see
 *Understanding the Lomb-Scargle Periodogram* [11]_, with associated code at
 https://github.com/jakevdp/PracticalLombScargle/.
+
 .. _gatspy: https://www.astroml.org/gatspy/
 .. _astroml: https://www.astroml.org/
 .. _FastTransforms.jl: https://juliaapproximation.github.io/FastTransforms.jl/stable/
@@ -930,7 +931,7 @@ Literature References
        astroML: Machine learning for astrophysics*. Proceedings of the
        Conference on Intelligent Data Understanding (2012)
 .. [5]  Vanderplas, J., Connolly, A. Ivezic, Z. & Gray, A. *Statistics,
-        Data Mining and Machine Learning in Astronomy*. Princeton Press (2014)}
+        Data Mining and Machine Learning in Astronomy*. Princeton Press (2014)
 .. [6] VanderPlas, J. *Gatspy: General Tools for Astronomical Time Series
        in Python* (2015) https://zenodo.org/record/14833
 .. [7] VanderPlas, J. & Ivezic, Z. *Periodograms for Multiband Astronomical

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -3,20 +3,21 @@
 *************************
 Lomb-Scargle Periodograms
 *************************
-
 The Lomb-Scargle periodogram (after Lomb [1]_, and Scargle [2]_) is a commonly
 used statistical tool designed to detect periodic signals in unevenly spaced
 observations. The :class:`~astropy.timeseries.LombScargle` class is a unified
 interface to several implementations of the Lomb-Scargle periodogram, including
 a fast *O[NlogN]* implementation following the algorithm presented by Press &
 Rybicki [3]_ or Ruiz-Antolin & Townsend [12]_.
-
+Not all of the available implementations are mathematically equivalent: Press & Rybicki [3]_ is the fastest
+option but trades accuracy for speed, while Ruiz-Antolin & Townsend [12]_
+achieves significantly higher accuracy at an acceptable cost and is therefore
+used by default.
 The code here is adapted from the `astroml`_ package ([4]_, [5]_), the
 `gatspy`_ package ([6]_, [7]_) and the `FastTransforms.jl`_ library. For a detailed practical discussion of the
 Lomb-Scargle periodogram, with code examples based on ``astropy``, see
 *Understanding the Lomb-Scargle Periodogram* [11]_, with associated code at
 https://github.com/jakevdp/PracticalLombScargle/.
-
 .. _gatspy: https://www.astroml.org/gatspy/
 .. _astroml: https://www.astroml.org/
 .. _FastTransforms.jl: https://juliaapproximation.github.io/FastTransforms.jl/stable/


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This pull request adds the [Low-Rank Approximation](https://arxiv.org/abs/1701.04492) implementation of the Nonuniform Fast Fourier Transform as an alternative backend to the trig_sum() utility in the Lomb-Scargle utils file and adjusts the tests and docs accordingly.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

The new implementation is up 4x slower, when compared to existing one, but also 8 to 10 orders of magnitude more accurate, nearly matching the accuracy of the slow method.

While not having a significant impact on the typical accuracy of the standard _fast_ implementation (except eliminating the negative powers issue) it significantly improves the _fastchi2_ method, causing it to nearly match the slow _chi2_ implementation in the terms of accuracy.

~~The new algorithm is now set as default for both _fast_ and _fastchi2_ methods, although it may be better keep the original defaults in the _fast_ method to avoid the slow-down. Additionally it requires SciPy installed to be functional (for the [jv](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.jv.html) bessel functions - if `prefer_lra=True` is passed, but the SciPy is not available it falls back to the current code printing a warning suggesting explicitely passing `prefer_lra=False`~~

The behaviour got modified after preliminary review and now the Low Rank approximation gets chosen by passing `algorithm='lra'` to either of the `fast` methods or the `trig_sum` function. Additionally the Bessel function approximation relies on the Taylor series around x=0 and as such no longer relies on SciPy for evaluation.

The new algorithm is default for the `fastchi2` and `auto` methods, although the less accurate approximation is kept as the default option for the `fast` method if it is called directly. The old (default) trig-sum algorithm additionally can be specified manually by passing `algorithm='fasper'` (sharing the name of the original Fortran subroutine published by Press and Rybicki in 1989), although currently it remains the default behaviour.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

Technically the code almost certainly could have been made faster than the 'old' fast method if rewritten in C (as the way the operations are performed with NumPy is at least awkward and probably far from optimal), although I'm not sure if it's even worth consideration, as the SciPy-independent `jv` implementation would probably take over 1000 lines of code, with the full implementation nearing 2 thousand (and causing a significant bloat to the library as a whole).

EDIT: Using the locally converging Taylor series would probably allow to fit the whole implementation in ~ 500 LOC making the rewrite significantly more feasible

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #5941, #9523 and #11302

<!-- Optional opt-out -->


