### PR TITLE
Apply monthly `pre-commit` update manually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.3.0
+    rev: v1.4.1
     hooks:
     - id: zizmor
 
@@ -64,7 +64,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.9
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -733,7 +733,7 @@ def generate_config(pkgname="astropy", filename=None, verbose=False):
                     else:
                         fp.write(
                             f"# {item.name} ="
-                            f' {",".join(map(str, item.defaultvalue))}\n\n'
+                            f" {','.join(map(str, item.defaultvalue))}\n\n"
                         )
                 else:
                     fp.write(f"# {item.name} = {item.defaultvalue}\n\n")

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -356,9 +356,7 @@ class MrtHeader(cds.CdsHeader):
                         else:
                             lim_vals = f"[{col.min}/{col.max}]"
                 elif col.fortran_format[0] in ("E", "F"):
-                    lim_vals = (
-                        f"[{floor(col.min * 100) / 100.}/{ceil(col.max * 100) / 100.}]"
-                    )
+                    lim_vals = f"[{floor(col.min * 100) / 100.0}/{ceil(col.max * 100) / 100.0}]"
 
             if lim_vals != "" or nullflag != "":
                 description = f"{lim_vals}{nullflag} {description}"

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1186,7 +1186,7 @@ def test_data_out_of_range(fast_reader, guess):
     if fast_reader:  # Assert precision warnings for cols 2-5
         assert len(w) == 4
         for i in range(len(w)):
-            assert f"OverflowError converting to FloatType in column col{i+2}" in str(
+            assert f"OverflowError converting to FloatType in column col{i + 2}" in str(
                 w[i].message
             )
     read_values = np.array([col[0] for col in t.itercols()])
@@ -1218,7 +1218,7 @@ def test_data_out_of_range(fast_reader, guess):
         else:
             assert len(w) == 3
         for i in range(len(w)):
-            assert f"OverflowError converting to FloatType in column col{i+4}" in str(
+            assert f"OverflowError converting to FloatType in column col{i + 4}" in str(
                 w[i].message
             )
     read_values = np.array([col[0] for col in t.itercols()])
@@ -1344,7 +1344,7 @@ def test_int_out_of_range(guess):
     """
     imin = np.iinfo(np.int64).min + 1
     imax = np.iinfo(np.int64).max - 1
-    huge = f"{imax+2:d}"
+    huge = f"{imax + 2:d}"
 
     text = f"P M S\n {imax:d} {imin:d} {huge:s}"
     expected = Table([[imax], [imin], [huge]], names=("P", "M", "S"))

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -256,7 +256,7 @@ def _get_format_class(format):
     if format in core.FORMAT_CLASSES:
         return core.FORMAT_CLASSES[format]
     raise ValueError(
-        f"ASCII format {format!r} not in allowed list " f"{sorted(core.FORMAT_CLASSES)}"
+        f"ASCII format {format!r} not in allowed list {sorted(core.FORMAT_CLASSES)}"
     )
 
 

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -255,9 +255,7 @@ def _get_compression_setting(header, name, default):
 
 
 def _column_dtype(compressed_coldefs, column_name):
-    tform = compressed_coldefs[column_name].format
-    if tform.startswith("1"):
-        tform = tform[1:]
+    tform = compressed_coldefs[column_name].format.removeprefix("1")
     if tform[1] == "B":
         dtype = np.uint8
     elif tform[1] == "I":

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -53,7 +53,7 @@ COMPRESSION_KEYWORDS = set(REMAPPED_KEYWORDS.values()).union(
 class CompImageHeader(Header):
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "The CompImageHeader class is deprecated and will be " "removed in future",
+            "The CompImageHeader class is deprecated and will be removed in future",
             AstropyDeprecationWarning,
         )
         super().__init__(*args, **kwargs)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1642,9 +1642,7 @@ class Header:
         keyword, value, comment = card
 
         # Lookups for existing/known keywords are case-insensitive
-        keyword = keyword.strip().upper()
-        if keyword.startswith("HIERARCH "):
-            keyword = keyword[9:]
+        keyword = keyword.strip().upper().removeprefix("HIERARCH ")
 
         if keyword not in _commentary_keywords and keyword in self._keyword_indices:
             # Easy; just update the value/comment

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -829,9 +829,9 @@ class TestDiff(FitsTestCase):
         report_as_string = diffobj.report()
         diffobj.report(fileobj=outpath, overwrite=True)
         with open(outpath) as fout:
-            assert (
-                fout.read() == report_as_string
-            ), "overwritten output file is not identical to report string"
+            assert fout.read() == report_as_string, (
+                "overwritten output file is not identical to report string"
+            )
 
     def test_rawdatadiff_nodiff(self):
         a = np.arange(100, dtype="uint8").reshape(10, 10)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3018,9 +3018,9 @@ def _refcounting(type_):
     refcount = len(objgraph.by_type(type_))
     yield refcount
     gc.collect()
-    assert (
-        len(objgraph.by_type(type_)) <= refcount
-    ), "More {0!r} objects still in memory than before."
+    assert len(objgraph.by_type(type_)) <= refcount, (
+        "More {0!r} objects still in memory than before."
+    )
 
 
 class TestVLATables(FitsTestCase):

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -323,8 +323,7 @@ class Char(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
-            if field.arraysize.endswith("*"):
-                field.arraysize = field.arraysize[:-1]
+            field.arraysize = field.arraysize.removesuffix("*")
             try:
                 self.arraysize = int(field.arraysize)
             except ValueError:
@@ -432,7 +431,7 @@ class UnicodeChar(Converter):
             self.format = f"U{self.arraysize:d}"
             self.binparse = self._binparse_fixed
             self.binoutput = self._binoutput_fixed
-            self._struct_format = f">{self.arraysize*2:d}s"
+            self._struct_format = f">{self.arraysize * 2:d}s"
 
     def parse(self, value, config=None, pos=None):
         if self.arraysize != "*" and len(value) > self.arraysize:
@@ -1053,10 +1052,8 @@ class Complex(FloatingPoint, Array):
         real = self._output_format.format(float(value.real))
         imag = self._output_format.format(float(value.imag))
         if self._output_format[2] == "s":
-            if real.endswith(".0"):
-                real = real[:-2]
-            if imag.endswith(".0"):
-                imag = imag[:-2]
+            real = real.removesuffix(".0")
+            imag = imag.removesuffix(".0")
         return real + " " + imag
 
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -642,8 +642,7 @@ class W19(VOTableSpecWarning):
     """
 
     message_template = (
-        "The fields defined in the VOTable do not match those in the "
-        "embedded FITS file"
+        "The fields defined in the VOTable do not match those in the embedded FITS file"
     )
 
 

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -103,9 +103,9 @@ def test_table(tmp_path):
 
     for field, (name, d) in zip(t.fields, field_types):
         assert field.ID == name
-        assert (
-            field.datatype == d["datatype"]
-        ), f'{name} expected {d["datatype"]} but get {field.datatype}'
+        assert field.datatype == d["datatype"], (
+            f"{name} expected {d['datatype']} but get {field.datatype}"
+        )
         if "arraysize" in d:
             assert field.arraysize == d["arraysize"]
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -91,7 +91,7 @@ class Covariance:
         # Print rows for params up to `max_lines`, round floats to 'round_val'
         longest_name = max(len(x) for x in self.param_names)
         ret_str = "parameter variances / covariances \n"
-        fstring = f'{"": <{longest_name}}| {{0}}\n'
+        fstring = f"{'': <{longest_name}}| {{0}}\n"
         for i, row in enumerate(self.cov_matrix):
             if i <= max_lines - 1:
                 param = self.param_names[i]

--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -490,7 +490,7 @@ class Spline1D(_Spline):
             else:
                 if len(knots) < 2 * (self._degree + 1):
                     raise ValueError(
-                        f"Must have at least {2*(self._degree + 1)} knots."
+                        f"Must have at least {2 * (self._degree + 1)} knots."
                     )
                 self._t = np.array(knots)
         else:

--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -6,26 +6,26 @@ import re
 import pytest
 
 pytest.importorskip("dask")
-import numpy as np  # noqa: E402
-from dask import array as da  # noqa: E402
-from numpy.testing import assert_allclose  # noqa: E402
+import numpy as np
+from dask import array as da
+from numpy.testing import assert_allclose
 
-from astropy import units as u  # noqa: E402
-from astropy.modeling.fitting import (  # noqa: E402
+from astropy import units as u
+from astropy.modeling.fitting import (
     LevMarLSQFitter,
     TRFLSQFitter,
     parallel_fit_dask,
 )
-from astropy.modeling.models import (  # noqa: E402
+from astropy.modeling.models import (
     Const1D,
     Gaussian1D,
     Linear1D,
     Planar2D,
 )
-from astropy.nddata import NDData, StdDevUncertainty  # noqa: E402
-from astropy.tests.helper import assert_quantity_allclose  # noqa: E402
-from astropy.utils.compat.optional_deps import HAS_PLT  # noqa: E402
-from astropy.wcs import WCS  # noqa: E402
+from astropy.nddata import NDData, StdDevUncertainty
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.compat.optional_deps import HAS_PLT
+from astropy.wcs import WCS
 
 
 def gaussian(x, amplitude, mean, stddev):
@@ -529,7 +529,7 @@ class TestDiagnostics:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "diagnostics should be None, " "'error', 'error+warn', or 'all'"
+                "diagnostics should be None, 'error', 'error+warn', or 'all'"
             ),
         ):
             parallel_fit_dask(

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -944,7 +944,7 @@ class TestParameterInitialization:
         assert t.e.shape == (2,)
 
     def test_single_model_1d_array_different_length_parameters(self):
-        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with" " shape .*"
+        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with shape .*"
         with pytest.raises(InputParameterError, match=MESSAGE):
             # Not broadcastable
             TParModel([1, 2], [3, 4, 5])
@@ -1003,7 +1003,7 @@ class TestParameterInitialization:
         assert t2.e.shape == (2, 3)
 
         # Not broadcastable
-        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with" " shape .*"
+        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with shape .*"
         with pytest.raises(InputParameterError, match=MESSAGE):
             TParModel(coeff, e.T)
 
@@ -1106,7 +1106,7 @@ class TestParameterInitialization:
         assert t2.e.shape == (2, 3)
 
     def test_two_model_mixed_dimension_array_parameters(self):
-        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with" " shape .*"
+        MESSAGE = "Mismatch is between arg 0 with shape .* and arg 1 with shape .*"
         with pytest.raises(InputParameterError, match=MESSAGE):
             # Can't broadcast different array shapes
             TParModel(

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -345,7 +345,7 @@ class NDData(NDDataBase):
                     attr_prefix = f"\n  {attr}="
                     attr_repr = repr(attr_data)
                     attr_repr = attr_repr.replace(
-                        "\n", f'\n{" " * (len(attr_prefix) - 1)}'
+                        "\n", f"\n{' ' * (len(attr_prefix) - 1)}"
                     )
                     contents.append(attr_prefix + attr_repr)
             return prefix + ",".join(contents) + "\n)"

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -264,9 +264,9 @@ def _convert_sequence_data_to_array(data, dtype=None):
         if ii == 0:
             any_statement = f"any({any_statement} for d0 in data)"
         elif ii == np_data.ndim - 1:
-            any_statement = f"any(d{ii} is ma_masked for d{ii} in d{ii-1})"
+            any_statement = f"any(d{ii} is ma_masked for d{ii} in d{ii - 1})"
         else:
-            any_statement = f"any({any_statement} for d{ii} in d{ii-1})"
+            any_statement = f"any({any_statement} for d{ii} in d{ii - 1})"
     context = {"ma_masked": np.ma.masked, "data": data}
     has_masked = eval(any_statement, context)
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -866,7 +866,7 @@ class TestJoin:
         t12 = table.join(t1, t2, join_type="outer", join_funcs={"col": join_func})
         exp = [
             "col_id   col_1       col_2   ",
-            f'{t12["col_id"].dtype.name}  float64[2]  float64[2]',  # int32 or int64
+            f"{t12['col_id'].dtype.name}  float64[2]  float64[2]",  # int32 or int64
             "------ ---------- -----------",
             "     1 1.0 .. 0.0 1.05 .. 0.0",
             "     2 2.0 .. 0.0  2.1 .. 0.0",

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1256,9 +1256,9 @@ class TestNumericalSubFormat:
         with localcontext() as ctx:
             ctx.prec = 40
             t2_s_40 = t.to_value(fmt, "str")
-        assert (
-            t_s_2 == t2_s_40
-        ), "String representation should not depend on Decimal context"
+        assert t_s_2 == t2_s_40, (
+            "String representation should not depend on Decimal context"
+        )
 
     def test_decimal_context_caching(self):
         t = Time(val=58000, val2=1e-14, format="mjd", scale="tai")

--- a/astropy/timeseries/io/tests/test_kepler.py
+++ b/astropy/timeseries/io/tests/test_kepler.py
@@ -147,9 +147,9 @@ def test_tess_astropy():
             ),
         ),
     }
-    assert (
-        unique_warnings == expected
-    ), f"Got some unexpected warnings\n{unique_warnings - expected}"
+    assert unique_warnings == expected, (
+        f"Got some unexpected warnings\n{unique_warnings - expected}"
+    )
     assert timeseries["time"].format == "isot"
     assert timeseries["time"].scale == "tdb"
     assert timeseries["sap_flux"].unit.to_string() == "electron / s"

--- a/astropy/timeseries/periodograms/bls/tests/test_bls.py
+++ b/astropy/timeseries/periodograms/bls/tests/test_bls.py
@@ -28,9 +28,9 @@ def assert_allclose_blsresults(blsresult, other, **kwargs):
         if k not in other:
             raise AssertionError(f"missing key '{k}'")
         if k == "objective":
-            assert (
-                v == other[k]
-            ), f"Mismatched objectives. Expected '{v}', got '{other[k]}'"
+            assert v == other[k], (
+                f"Mismatched objectives. Expected '{v}', got '{other[k]}'"
+            )
             continue
         assert_quantity_allclose(v, other[k], **kwargs)
 

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -433,9 +433,9 @@ def test_tess_astropy():
         ),
         (UserWarning, "Ignoring 815 rows with NaN times"),
     }
-    assert (
-        unique_warnings == expected
-    ), f"Got some unexpected warnings\n{unique_warnings - expected}"
+    assert unique_warnings == expected, (
+        f"Got some unexpected warnings\n{unique_warnings - expected}"
+    )
 
     assert timeseries["time"].format == "isot"
     assert timeseries["time"].scale == "tdb"

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -437,7 +437,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
                 # functional string is aligned with the fraction line
                 # (second one), and all other lines are indented
                 # accordingly.
-                f = f"{{0:^{len(self_str)+1}s}}{{1:s}}"
+                f = f"{{0:^{len(self_str) + 1}s}}{{1:s}}"
                 lines = [
                     f.format("", pu_lines[0]),
                     f.format(f"{self_str}(", f"{pu_lines[1]})"),

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -542,8 +542,7 @@ def arange_impl(*args, start=None, stop=None, step=None, dtype=None, **kwargs):
     if out_unit is UNIT_FROM_LIKE_ARG:
         if hasattr(start, "unit") or hasattr(step, "unit"):
             raise TypeError(
-                "stop without a unit cannot be combined with "
-                "start or step with a unit."
+                "stop without a unit cannot be combined with start or step with a unit."
             )
         kwargs.update(qty_kwargs)
     else:

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -450,9 +450,9 @@ class TestDefPhysType:
 
         try:
             physical.def_physical_type(self.weird_unit, weird_name)
-            assert (
-                self.weird_unit.physical_type == weird_name
-            ), f"unable to set physical type for {self.weird_unit}"
+            assert self.weird_unit.physical_type == weird_name, (
+                f"unable to set physical type for {self.weird_unit}"
+            )
         finally:  # cleanup added name
             physical._attrname_physical_mapping.pop(weird_name.replace(" ", "_"), None)
             physical._name_physical_mapping.pop(weird_name, None)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2972,19 +2972,19 @@ class CheckSignatureCompatibilityBase:
                     # it is not passed down to dispatched functions
                     pass
                 elif kt is KEYWORD_ONLY:
-                    assert (
-                        have_kwargs_helper
-                    ), f"argument {nt!r} is not re-exposed as keyword"
+                    assert have_kwargs_helper, (
+                        f"argument {nt!r} is not re-exposed as keyword"
+                    )
                 elif kt is POSITIONAL_OR_KEYWORD:
-                    assert (
-                        have_args_helper and have_kwargs_helper
-                    ), f"argument {nt!r} is not re-exposed as positional-or-keyword"
+                    assert have_args_helper and have_kwargs_helper, (
+                        f"argument {nt!r} is not re-exposed as positional-or-keyword"
+                    )
             elif kt is VAR_POSITIONAL:
                 assert have_args_helper, "helper is missing a catch-all *args argument"
             elif kt is VAR_KEYWORD:
-                assert (
-                    have_kwargs_helper
-                ), "helper is missing a catch-all **kwargs argument"
+                assert have_kwargs_helper, (
+                    "helper is missing a catch-all **kwargs argument"
+                )
 
     def test_known_arguments(self, target, helper):
         # validate that all exposed arguments map to something in the target

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -919,7 +919,7 @@ class IERS_Auto(IERS_A):
                 # predictive values.
                 warn(
                     AstropyWarning(
-                        f'failed to download {" and ".join(all_urls)}: {err}.\nA'
+                        f"failed to download {' and '.join(all_urls)}: {err}.\nA"
                         " coordinate or time-related calculation might be compromised"
                         " or fail because the dates are not covered by the available"
                         ' IERS file.  See the "IERS data access" section of the'

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -512,14 +512,14 @@ def test_clear_download_multiple_references_doesnt_corrupt_storage(
     clear_download_cache(f_url)
     assert not is_url_in_cache(f_url)
     assert is_url_in_cache(g_url)
-    assert os.path.exists(
-        g_filename
-    ), "Contents should not be deleted while a reference exists"
+    assert os.path.exists(g_filename), (
+        "Contents should not be deleted while a reference exists"
+    )
 
     clear_download_cache(g_url)
-    assert not os.path.exists(
-        g_filename
-    ), "No reference exists any more, file should be deleted"
+    assert not os.path.exists(g_filename), (
+        "No reference exists any more, file should be deleted"
+    )
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
@@ -615,15 +615,15 @@ def test_update_url(tmp_path, temp_cache):
     with pytest.raises(urllib.error.URLError):
         # Direct download should fail
         download_file(f_url, cache=False)
-    assert (
-        get_file_contents(download_file(f_url, cache=True)) == "new"
-    ), "Cached version should still exist"
+    assert get_file_contents(download_file(f_url, cache=True)) == "new", (
+        "Cached version should still exist"
+    )
     with pytest.raises(urllib.error.URLError):
         # cannot download new version to check for updates
         download_file(f_url, cache="update")
-    assert (
-        get_file_contents(download_file(f_url, cache=True)) == "new"
-    ), "Failed update should not remove the current version"
+    assert get_file_contents(download_file(f_url, cache=True)) == "new", (
+        "Failed update should not remove the current version"
+    )
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
@@ -1136,9 +1136,9 @@ def test_data_noastropy_fallback(monkeypatch):
             if partial_msg in cur_w:
                 del partial_warn_msgs[i]
                 break
-    assert (
-        len(partial_warn_msgs) == 0
-    ), f"Got some unexpected warnings: {partial_warn_msgs}"
+    assert len(partial_warn_msgs) == 0, (
+        f"Got some unexpected warnings: {partial_warn_msgs}"
+    )
 
     assert n_warns in (2, 4), f"Expected 2 or 4 warnings, got {n_warns}"
 
@@ -2368,7 +2368,7 @@ def test_download_ftp_file_properly_handles_socket_error():
         if cur_msg in errmsg:
             found_msg = True
             break
-    assert found_msg, f'Got {errmsg}, expected one of these: {",".join(possible_msgs)}'
+    assert found_msg, f"Got {errmsg}, expected one of these: {','.join(possible_msgs)}"
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")

--- a/astropy/version.py
+++ b/astropy/version.py
@@ -10,7 +10,7 @@ except Exception:
     import warnings
 
     warnings.warn(
-        f'could not determine {__name__.split(".")[0]} package version; '
+        f"could not determine {__name__.split('.')[0]} package version; "
         "this indicates a broken installation"
     )
     del warnings

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1388,7 +1388,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             size = a.shape[0]
             trdir = "sky to detector" if name[-1] == "P" else "detector to sky"
             comment = (
-                f'SIP polynomial order, axis {ord(name[0]) - ord("A"):d}, {trdir:s}'
+                f"SIP polynomial order, axis {ord(name[0]) - ord('A'):d}, {trdir:s}"
             )
             keywords[f"{name}_ORDER"] = size - 1, comment
 
@@ -1573,7 +1573,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {docstrings.TWO_OR_MORE_ARGS('naxis', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("naxis", 8)}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
@@ -1583,7 +1583,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         Returns
         -------
 
-        {docstrings.RETURNS('sky coordinates, in degrees', 8)}
+        {docstrings.RETURNS("sky coordinates, in degrees", 8)}
 
         Notes
         -----
@@ -1640,7 +1640,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {docstrings.TWO_OR_MORE_ARGS('naxis', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("naxis", 8)}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
@@ -1650,7 +1650,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         Returns
         -------
 
-        {docstrings.RETURNS('world coordinates, in degrees', 8)}
+        {docstrings.RETURNS("world coordinates, in degrees", 8)}
 
         Raises
         ------
@@ -2133,7 +2133,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {docstrings.TWO_OR_MORE_ARGS('naxis', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("naxis", 8)}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
@@ -2268,7 +2268,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         Returns
         -------
 
-        {docstrings.RETURNS('pixel coordinates', 8)}
+        {docstrings.RETURNS("pixel coordinates", 8)}
 
         Notes
         -----
@@ -2459,7 +2459,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {docstrings.TWO_OR_MORE_ARGS('naxis', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("naxis", 8)}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
@@ -2469,7 +2469,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         Returns
         -------
 
-        {docstrings.RETURNS('pixel coordinates', 8)}
+        {docstrings.RETURNS("pixel coordinates", 8)}
 
         Notes
         -----
@@ -2521,12 +2521,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {docstrings.TWO_OR_MORE_ARGS('2', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("2", 8)}
 
         Returns
         -------
 
-        {docstrings.RETURNS('focal coordinates', 8)}
+        {docstrings.RETURNS("focal coordinates", 8)}
 
         Raises
         ------
@@ -2550,12 +2550,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {docstrings.TWO_OR_MORE_ARGS('2', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("2", 8)}
 
         Returns
         -------
 
-        {docstrings.RETURNS('focal coordinates', 8)}
+        {docstrings.RETURNS("focal coordinates", 8)}
 
         Raises
         ------
@@ -2579,12 +2579,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {docstrings.TWO_OR_MORE_ARGS('2', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("2", 8)}
 
         Returns
         -------
 
-        {docstrings.RETURNS('pixel coordinates', 8)}
+        {docstrings.RETURNS("pixel coordinates", 8)}
 
         Raises
         ------
@@ -2620,12 +2620,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {docstrings.TWO_OR_MORE_ARGS('2', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("2", 8)}
 
         Returns
         -------
 
-        {docstrings.RETURNS('focal coordinates', 8)}
+        {docstrings.RETURNS("focal coordinates", 8)}
 
         Raises
         ------
@@ -2657,12 +2657,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {docstrings.TWO_OR_MORE_ARGS('2', 8)}
+        {docstrings.TWO_OR_MORE_ARGS("2", 8)}
 
         Returns
         -------
 
-        {docstrings.RETURNS('pixel coordinates', 8)}
+        {docstrings.RETURNS("pixel coordinates", 8)}
 
         Raises
         ------

--- a/conftest.py
+++ b/conftest.py
@@ -32,9 +32,9 @@ def pytest_configure(config):
 def pytest_report_header(config):
     # This gets added after the pytest-astropy-header output.
     return (
-        f'CI: {os.environ.get("CI", "undefined")}\n'
-        f'ARCH_ON_CI: {os.environ.get("ARCH_ON_CI", "undefined")}\n'
-        f'IS_CRON: {os.environ.get("IS_CRON", "undefined")}\n'
+        f"CI: {os.environ.get('CI', 'undefined')}\n"
+        f"ARCH_ON_CI: {os.environ.get('ARCH_ON_CI', 'undefined')}\n"
+        f"IS_CRON: {os.environ.get('IS_CRON', 'undefined')}\n"
     )
 
 


### PR DESCRIPTION
### Description

The manual updates allow implementing better fixes to Ruff rule [FURB188 (slice-to-remove-prefix-or-suffix)](https://docs.astral.sh/ruff/rules/slice-to-remove-prefix-or-suffix/) in two files in `io.*`. Note that #17619 and #17620 were opened almost two months ago with the purpose of making the patches the `pre-commit` autoupdates would apply smaller, but they still haven't been merged. Given that `pre-commit` has already tried to apply its monthly updates twice since their opening, they are no longer valuable as separate pull requests.

Closes #17615, closes #17619, closes #17620, closes #17841


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


edit by @neutrinoceros: use the correct path for where files with FURB188 are.