### PR TITLE
Re-enable analytics tracking for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,9 +245,6 @@ modindex_common_prefix = ["astropy."]
 
 html_theme_options.update(
     {
-        "analytics": [
-            {"google_analytics_id": "G-R0510VK4B6"},
-        ],
         "analytics": {
             "google_analytics_id": "G-R0510VK4B6",
         },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,6 +248,9 @@ html_theme_options.update(
         "analytics": [
             {"google_analytics_id": "G-R0510VK4B6"},
         ],
+        "analytics": {
+            "google_analytics_id": "G-R0510VK4B6",
+        },
         "github_url": "https://github.com/astropy/astropy",
         "external_links": [
             {"name": "Tutorials", "url": "https://learn.astropy.org/"},

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,6 +245,9 @@ modindex_common_prefix = ["astropy."]
 
 html_theme_options.update(
     {
+        "analytics": [
+            {"google_analytics_id": "G-R0510VK4B6"},
+        ],
         "github_url": "https://github.com/astropy/astropy",
         "external_links": [
             {"name": "Tutorials", "url": "https://learn.astropy.org/"},


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR re-enables google analytics on the docs. Having analytics again would be especially useful now for comparison to results of the astropy community survey. 

Discussion about the content of the PR is in #17778 - in short, this 2-line change should get analytics back up; if not, I could open a separate PR that adds a lightweight (~40 lines) sphinx package dependency. There was also discussion in that issue about using Plausible analytics rather than Google, but it looks to me like Plausible is a subscription service with a recurring fee, while Google analytics is free at the scale needed for the docs site. I was also able to reduce the amount of information tracked in the Google analytics account, in order to improve privacy.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17778 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
