### PR TITLE
Improve message for fit failed with non-finite value

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1177,7 +1177,7 @@ class _NonLinearLSQFitter(Fitter):
                 "this will cause the fit to fail!\n"
                 "This can be caused by non-finite values in the input data, "
                 "which can be removed with fit(..., filter_non_finite=True), "
-                "or just by bad data leading to the fit iterations producing "
+                "or by bad data during the fit iterations producing "
                 "numerical errors."
             )
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1175,8 +1175,10 @@ class _NonLinearLSQFitter(Fitter):
             raise NonFiniteValueError(
                 "Objective function has encountered a non-finite value, "
                 "this will cause the fit to fail!\n"
-                "Please remove non-finite values from your input data before "
-                "fitting to avoid this error."
+                "This can be caused by non-finite values in the input data, "
+                "which can be removed with fit(..., filter_non_finite=True), "
+                "or just by bad data leading to the fit iterations producing "
+                "numerical errors."
             )
 
         return value


### PR DESCRIPTION
Fix #13986.

We encountered this with the Euclid pipeline and people got confused by the "Please remove non-finite values from your input data" message. So trying to explain here that non-finite values can appear during the fit. Not sure if this deserves a changelog entry, I think not ?

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
