### PR TITLE
Add option to deactivate non-finite values check 

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1122,13 +1122,13 @@ class _NonLinearLSQFitter(Fitter):
     calc_uncertainties : bool
         If the covariance matrix should be computed and set in the fit_info.
         Default: False
-    check_non_finite : bool
-        If set, the objective function checks for the presence of non-finite
-        values and raise a `NonFiniteValueError` if it finds one.
-        Default: True
     use_min_max_bounds : bool
         If set, the parameter bounds for a model will be enforced for each given
         parameter while fitting via a simple min/max condition.
+        Default: True
+    check_non_finite : bool
+        If set, the objective function checks for the presence of non-finite
+        values and raise a `NonFiniteValueError` if it finds one.
         Default: True
     """
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1122,6 +1122,10 @@ class _NonLinearLSQFitter(Fitter):
     calc_uncertainties : bool
         If the covariance matrix should be computed and set in the fit_info.
         Default: False
+    check_non_finite : bool
+        If set, the objective function checks for the presence of non-finite
+        values and raise a `NonFiniteValueError` if it finds one.
+        Default: True
     use_min_max_bounds : bool
         If set, the parameter bounds for a model will be enforced for each given
         parameter while fitting via a simple min/max condition.
@@ -1133,9 +1137,12 @@ class _NonLinearLSQFitter(Fitter):
     The constraint types supported by this fitter type.
     """
 
-    def __init__(self, calc_uncertainties=False, use_min_max_bounds=True):
+    def __init__(
+        self, calc_uncertainties=False, use_min_max_bounds=True, check_non_finite=True
+    ):
         self.fit_info = None
         self._calc_uncertainties = calc_uncertainties
+        self._check_non_finite = check_non_finite
         self._use_min_max_bounds = use_min_max_bounds
 
     def objective_function(self, fps, *args, fit_param_indices=None):
@@ -1173,7 +1180,7 @@ class _NonLinearLSQFitter(Fitter):
         else:
             value = np.ravel(weights * (model.evaluate(*inputs, *fps) - meas))
 
-        if not np.all(np.isfinite(value)):
+        if self._check_non_finite and not np.all(np.isfinite(value)):
             raise NonFiniteValueError(
                 "Objective function has encountered a non-finite value, "
                 "this will cause the fit to fail!\n"
@@ -1477,8 +1484,10 @@ class LevMarLSQFitter(_NonLinearLSQFitter):
 
     """
 
-    def __init__(self, calc_uncertainties=False):
-        super().__init__(calc_uncertainties)
+    def __init__(self, calc_uncertainties=False, check_non_finite=True):
+        super().__init__(
+            calc_uncertainties=calc_uncertainties, check_non_finite=check_non_finite
+        )
         self.fit_info = {
             "nfev": None,
             "fvec": None,
@@ -1562,8 +1571,18 @@ class _NLLSQFitter(_NonLinearLSQFitter):
         the most recent fit information
     """
 
-    def __init__(self, method, calc_uncertainties=False, use_min_max_bounds=False):
-        super().__init__(calc_uncertainties, use_min_max_bounds)
+    def __init__(
+        self,
+        method,
+        calc_uncertainties=False,
+        use_min_max_bounds=False,
+        check_non_finite=True,
+    ):
+        super().__init__(
+            calc_uncertainties=calc_uncertainties,
+            use_min_max_bounds=use_min_max_bounds,
+            check_non_finite=check_non_finite,
+        )
         self._method = method
 
     def _run_fitter(
@@ -1650,8 +1669,18 @@ class TRFLSQFitter(_NLLSQFitter):
     """
 
     @deprecated_renamed_argument("use_min_max_bounds", None, "7.0")
-    def __init__(self, calc_uncertainties=False, use_min_max_bounds=False):
-        super().__init__("trf", calc_uncertainties, use_min_max_bounds)
+    def __init__(
+        self,
+        calc_uncertainties=False,
+        use_min_max_bounds=False,
+        check_non_finite=True,
+    ):
+        super().__init__(
+            "trf",
+            calc_uncertainties=calc_uncertainties,
+            use_min_max_bounds=use_min_max_bounds,
+            check_non_finite=check_non_finite,
+        )
 
 
 class DogBoxLSQFitter(_NLLSQFitter):
@@ -1672,8 +1701,18 @@ class DogBoxLSQFitter(_NLLSQFitter):
     """
 
     @deprecated_renamed_argument("use_min_max_bounds", None, "7.0")
-    def __init__(self, calc_uncertainties=False, use_min_max_bounds=False):
-        super().__init__("dogbox", calc_uncertainties, use_min_max_bounds)
+    def __init__(
+        self,
+        calc_uncertainties=False,
+        use_min_max_bounds=False,
+        check_non_finite=True,
+    ):
+        super().__init__(
+            "dogbox",
+            calc_uncertainties=calc_uncertainties,
+            use_min_max_bounds=use_min_max_bounds,
+            check_non_finite=check_non_finite,
+        )
 
 
 class LMLSQFitter(_NLLSQFitter):
@@ -1693,8 +1732,13 @@ class LMLSQFitter(_NLLSQFitter):
         the most recent fit information
     """
 
-    def __init__(self, calc_uncertainties=False):
-        super().__init__("lm", calc_uncertainties, True)
+    def __init__(self, calc_uncertainties=False, check_non_finite=True):
+        super().__init__(
+            "lm",
+            calc_uncertainties=calc_uncertainties,
+            use_min_max_bounds=True,
+            check_non_finite=check_non_finite,
+        )
 
     @fitter_unit_support
     def __call__(

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1417,10 +1417,20 @@ def test_non_finite_error(fitter, weights):
     m_init = models.Gaussian1D()
     fit = fitter()
 
-    # Raise warning, notice fit fails due to nans
+    # Raise exception, notice fit fails due to nans
     with pytest.raises(
         NonFiniteValueError, match=r"Objective function has encountered.*"
     ):
+        fit(m_init, x, y, weights=weights)
+
+    # No exception if the check is deactivated
+    fit = fitter(check_non_finite=False)
+    if fitter == LevMarLSQFitter:
+        exc, msg = RuntimeWarning, "invalid value encountered in multiply"
+    else:
+        exc, msg = ValueError, "Residuals are not finite in the initial point."
+
+    with pytest.raises(exc, match=msg):
         fit(m_init, x, y, weights=weights)
 
 

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -1425,12 +1425,8 @@ def test_non_finite_error(fitter, weights):
 
     # No exception if the check is deactivated
     fit = fitter(check_non_finite=False)
-    if fitter == LevMarLSQFitter:
-        exc, msg = RuntimeWarning, "invalid value encountered in multiply"
-    else:
-        exc, msg = ValueError, "Residuals are not finite in the initial point."
 
-    with pytest.raises(exc, match=msg):
+    with pytest.raises(RuntimeWarning, match="invalid value encountered in multiply"):
         fit(m_init, x, y, weights=weights)
 
 

--- a/docs/changes/modeling/17851.feature.rst
+++ b/docs/changes/modeling/17851.feature.rst
@@ -1,0 +1,1 @@
+Add option to deactivate non-finite values check for non-linear fitters.


### PR DESCRIPTION
As discussed in #13986, I think it would be useful to have the possibility to deactivate this check, 1) for performance and 2) to get the fit result and diagnostics from the fitter. It is True by default so no behavior change.

Note the branch is based on #17850, I can rebase later.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
