### PR TITLE
Apply NFKC normalization to unit names before injecting them into a namespace

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import inspect
 import operator
 import textwrap
+import unicodedata
 import warnings
 from functools import cached_property
 from threading import RLock
@@ -1829,10 +1830,10 @@ class NamedUnit(UnitBase):
 
         # Loop through all of the names first, to ensure all of them
         # are new, then add them all as a single "transaction" below.
-        for name in self._names:
+        for name in (unicodedata.normalize("NFKC", name) for name in self._names):
             if name in namespace and self != namespace[name]:
                 raise ValueError(
-                    f"Object with name {name!r} already exists in "
+                    f"Object with NFKC normalized name {name!r} already exists in "
                     f"given namespace ({namespace[name]!r})."
                 )
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -708,9 +708,21 @@ def test_pickle_unrecognized_unit():
     assert isinstance(pickle.loads(pickle.dumps(a)), u.UnrecognizedUnit)
 
 
-def test_duplicate_define():
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("h", id="simple_conflict"),
+        pytest.param(
+            "ʰ",
+            id="NFKC_normalization",
+            marks=pytest.mark.xfail(reason="new regression test that reveals a bug"),
+        ),
+    ],
+)
+def test_duplicate_define(name):
+    namespace = {"h": u.h}
     with pytest.raises(ValueError):
-        u.def_unit("m", namespace=u.__dict__)
+        u.def_unit(name, u.hourangle, namespace=namespace)
 
 
 def test_all_units():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -712,16 +712,18 @@ def test_pickle_unrecognized_unit():
     "name",
     [
         pytest.param("h", id="simple_conflict"),
-        pytest.param(
-            "ʰ",
-            id="NFKC_normalization",
-            marks=pytest.mark.xfail(reason="new regression test that reveals a bug"),
-        ),
+        pytest.param("ʰ", id="NFKC_normalization"),
     ],
 )
 def test_duplicate_define(name):
     namespace = {"h": u.h}
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "^Object with NFKC normalized name 'h' already exists in given namespace "
+            r'\(Unit\("h"\)\)\.$'
+        ),
+    ):
         u.def_unit(name, u.hourangle, namespace=namespace)
 
 

--- a/docs/changes/units/17853.bugfix.rst
+++ b/docs/changes/units/17853.bugfix.rst
@@ -1,0 +1,4 @@
+The machinery that injects units into a namespace (used e.g. by ``def_unit()``)
+now applies NFKC normalization to unit names when checking for name collisions.
+This prevents name collisions if the namespace belongs to a module and the unit
+is accessed as an attribute of that module.


### PR DESCRIPTION
### Description

[Python applies the NFKC normalization to identifiers.](https://docs.python.org/3.11/reference/lexical_analysis.html#identifiers) As an example, because
```python
>>> import unicodedata
>>> unicodedata.normalize("NFKC", "ₘeᵗeᵣ")
'meter'
```
then the meter can be accessed as
```python
>>> from astropy import units as u
>>> u.ₘeᵗeᵣ
Unit("m")
```
The `astropy` machinery that injects units into a namespace checks for name collisions, but does not apply NFKC normalization, which can lead to bugs like
```python
>>> from astropy import units as u
>>> u.h
Unit("h")
>>> u.Unit("ʰ")
Unit("hourangle")
>>> u.def_unit("ʰ", u.hourangle, namespace=vars(u))
Unit("ʰ")
>>> vars(u)["ʰ"] == u.hourangle
True
>>> u.ʰ == u.hourangle
False
>>> u.ʰ is u.hour
True
```
It is best to apply NFKC normalization when checking for name collisions because then users get early explicit errors instead of mysterious failures later on.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
