### PR TITLE
DOC: FITS_rec init using recarray

### DIFF
--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -47,8 +47,11 @@ the third a floating point number, and the fourth a character string (of length
 The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` which is a specialized subclass of `numpy.recarray`. A
 :class:`FITS_rec` can be instantiated directly from a
-numpy recarray. You may also
-instantiate a new :class:`FITS_rec` from a list of `astropy.io.fits.Column`
+numpy recarray::
+
+    >>> data = fits.FITS_rec(bright)
+
+You may also instantiate a new :class:`FITS_rec` from a list of `astropy.io.fits.Column`
 objects using the :meth:`FITS_rec.from_columns` class method. This has the
 exact same semantics as :meth:`BinTableHDU.from_columns` and
 :meth:`TableHDU.from_columns`, except that it only returns an actual FITS_rec

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -46,8 +46,8 @@ the third a floating point number, and the fourth a character string (of length
 
 The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` which is a specialized subclass of `numpy.recarray`. A
-:class:`FITS_rec` can be instantiated directly using the same initialization
-format presented for plain recarrays as in the example above. You may also
+:class:`FITS_rec` can be instantiated by passing in the
+plain recarray as in the example above. You may also
 instantiate a new :class:`FITS_rec` from a list of `astropy.io.fits.Column`
 objects using the :meth:`FITS_rec.from_columns` class method. This has the
 exact same semantics as :meth:`BinTableHDU.from_columns` and

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -49,6 +49,7 @@ The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` can be instantiated directly from a
 numpy recarray::
 
+    >>> from astropy.io import fits
     >>> data = fits.FITS_rec(bright)
 
 You may also instantiate a new :class:`FITS_rec` from a list of `astropy.io.fits.Column`

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -46,8 +46,8 @@ the third a floating point number, and the fourth a character string (of length
 
 The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` which is a specialized subclass of `numpy.recarray`. A
-:class:`FITS_rec` can be instantiated by passing in the
-plain recarray as in the example above. You may also
+:class:`FITS_rec` can be instantiated directly from a
+numpy recarray. You may also
 instantiate a new :class:`FITS_rec` from a list of `astropy.io.fits.Column`
 objects using the :meth:`FITS_rec.from_columns` class method. This has the
 exact same semantics as :meth:`BinTableHDU.from_columns` and


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to clarify how to init FITS_rec using numpy recarray without crashing it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17852 but not sure about a more general issue at #4241

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
