### PR TITLE
TST: avoid non-falsifiable matches (`match=''`) in `pytest.raises`

### DIFF
--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -923,7 +923,7 @@ def test_tabular1d_inverse():
     points = np.arange(5)
     values = np.array([1.5, 3.4, 3.4, 32, 25])
     t = models.Tabular1D(points, values)
-    with pytest.raises(NotImplementedError, match=r""):
+    with pytest.raises(NotImplementedError, match=r"^$"):
         t.inverse((3.4, 7.0))
 
     # Check that Tabular2D.inverse raises an error
@@ -931,7 +931,10 @@ def test_tabular1d_inverse():
     points = np.arange(0, 5)
     points = (points, points)
     t3 = models.Tabular2D(points=points, lookup_table=table)
-    with pytest.raises(NotImplementedError, match=r""):
+    with pytest.raises(
+        NotImplementedError,
+        match=r"An analytical inverse transform has not been implemented for this model\.",
+    ):
         t3.inverse((3, 3))
 
     # Check that it uses the same kwargs as the original model

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ deps =
     mpl360: numpy<2.0
 
     image: latex
-    image: scipy
+    image, devinfra: scipy
     image: pytest-mpl>=0.17
 
     # Some FITS tests use fitsio as a comparison


### PR DESCRIPTION
### Description
Avoid an incoming warning in pytest 8.4 (dev)
Follow up to #13919

reprod
```shell
pip install git+https://github.com/pytest-dev/pytest scipy
pytest astropy/modeling/tests/test_models.py
```
output (truncated)
```
...
pytest.PytestWarning: matching against an empty string will *always* pass. If you want to check for an empty message you need to pass '^$'. If you don't want to match you should pass `None` or leave out the parameter.
```

xref https://github.com/pytest-dev/pytest/pull/13192


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
