### PR TITLE
fix ruff rule B007 violation in astropy/modeling

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -239,7 +239,6 @@ lint.unfixable = [
 ]
 "astropy/logger.py" = []
 "astropy/modeling/*" = [
-    "B007",  # UnusedLoopControlVariable
     "PLR0911",  # too-many-return-statements
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
     "TRY300",  # Consider `else` block

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -127,7 +127,7 @@ def _fit_models_to_chunk(
     for index in np.ndindex(iterating_shape_chunk):
         # If all data values are NaN, just set parameters to NaN and move on
         if np.all(np.isnan(data[index])):
-            for ipar, name in enumerate(model.param_names):
+            for ipar in range(len(model.param_names)):
                 parameters[(ipar,) + index] = np.nan
             continue
 
@@ -171,7 +171,7 @@ def _fit_models_to_chunk(
             if diagnostics is not None and diagnostics.startswith("error"):
                 output = True
             error = traceback.format_exc()
-            for ipar, name in enumerate(model_i.param_names):
+            for ipar in range(len(model_i.param_names)):
                 parameters[(ipar,) + index] = np.nan
         else:
             # Put fitted parameters back into parameters arrays. These arrays are

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1010,10 +1010,11 @@ class FittingWithOutlierRemoval:
             filtered_data.mask = False
         filtered_weights = weights
         last_n_masked = filtered_data.mask.sum()
-        n = 0  # (allow recording no. of iterations when 0)
+        niter = 0  # (allow recording no. of iterations when 0)
 
         # Perform the iterative fitting:
-        for n in range(1, self.niter + 1):
+        for _ in range(1, self.niter + 1):
+            niter += 1
             # (Re-)evaluate the last model:
             model_vals = fitted_model(*coords, model_set_axis=False)
 
@@ -1105,7 +1106,7 @@ class FittingWithOutlierRemoval:
                 break
             last_n_masked = this_n_masked
 
-        self.fit_info = {"niter": n}
+        self.fit_info = {"niter": niter}
         self.fit_info.update(getattr(self.fitter, "fit_info", {}))
 
         return fitted_model, filtered_data.mask
@@ -2198,7 +2199,7 @@ def fitter_to_model_params_array(
         # Update model parameters before calling ``tied`` constraints.
         model.parameters = parameters
 
-        for idx, name in enumerate(model.param_names):
+        for name in model.param_names:
             if model.tied[name]:
                 value = model.tied[name](model)
                 slice_ = param_metrics[name]["slice"]

--- a/astropy/modeling/tests/test_spline.py
+++ b/astropy/modeling/tests/test_spline.py
@@ -127,7 +127,7 @@ class TestSpline:
 
         spl = Spline()
         new_kwargs = spl._intercept_optional_inputs(**self.extra_kwargs)
-        for arg, value in self.optional_inputs.items():
+        for arg in self.optional_inputs.keys():
             attribute = spl._optional_arg(arg)
             assert getattr(spl, attribute) is None
         assert new_kwargs == self.extra_kwargs


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address to split pull request #17844 , and it ensure compliance of ```astropy/modeling``` to Ruff rule [unused-loop-control-variable (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/)

fixes partially #14818 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
