### PR TITLE
TST: Add downstream testing

### DIFF
--- a/.github/workflows/ci_downstream.yml
+++ b/.github/workflows/ci_downstream.yml
@@ -1,0 +1,40 @@
+# Downstream integration testing, especially for bugfix releases.
+name: Downstream
+
+on:
+  workflow_dispatch:
+  pull_request:
+    # We also want this workflow triggered if the 'Extra CI' label is added
+    # or present when PR is updated
+    types:
+      - synchronize
+      - labeled
+  push:
+    # We want this workflow to always run on release branches as well as
+    # all tags since we want to be really sure we don't introduce
+    # regressions on the release branches, and it's also important to run
+    # this on pre-release and release tags.
+    branches:
+    - 'v*'
+    tags:
+    - '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    if: (github.repository == 'astropy/astropy' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Extra CI')))
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0
+    with:
+      setenv: |
+        ARCH_ON_CI: "normal"
+        IS_CRON: "true"
+      submodules: false
+      coverage: ''
+      envs: |
+        - linux: downstream

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     build_docs
     linkcheck
     codestyle
+    pyinstaller
+    downstream
 requires =
     tox-uv
 
@@ -172,3 +174,53 @@ commands =
                 --hidden-import pytest_doctestplus.plugin \
                 --hidden-import pytest_mpl.plugin
     ./run_astropy_tests --astropy-root {toxinidir}
+
+[testenv:downstream]
+# Check that astropy, especially a bugfix release, does not break downstream.
+# This does not replace https://github.com/astropy/astropy-integration-testing
+# because we only cover Astropy Coordinated packages here, and only their dev versions.
+description = Downstream integration testing with dev Coordinated packages
+
+# Pass through the following environment variables which are needed for the CI
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI
+
+setenv =
+    NUMPY_WARN_IF_NO_MEM_POLICY = 1
+    UV_INDEX = https://pypi.anaconda.org/astropy/simple
+    UV_INDEX_STRATEGY = unsafe-best-match # match pip's behavior
+
+# Run the tests in a temporary directory to make sure that we don't import
+# from the source tree
+changedir = .tmp/{envname}
+
+deps =
+    # for ccdproc
+    psutil
+
+    asdf_astropy[test] @ git+https://github.com/astropy/asdf-astropy.git
+    astropy-healpix>=0.0.dev0
+    astroquery[test,all] @ git+https://github.com/astropy/astroquery.git
+    ccdproc[test,all] @ git+https://github.com/astropy/ccdproc.git
+    photutils>=0.0.dev0
+    regions[test,all] @ git+https://github.com/astropy/regions.git
+    reproject>=0.0.dev0
+    specreduce[test] @ git+https://github.com/astropy/specreduce.git
+    specutils[all,test] @ git+https://github.com/astropy/specutils.git
+
+extras =
+    test
+    all
+
+commands =
+    {list_dependencies_command}
+    pytest --pyargs asdf_astropy
+    pytest --pyargs astropy_healpix
+    pytest --pyargs astroquery -k "not test_deprecated_namespace_import_warning and not test_raises_deprecation_warning"
+    pytest --pyargs ccdproc
+    pytest --pyargs photutils
+    pytest --pyargs regions
+    pytest --pyargs reproject
+    pytest --pyargs specreduce
+    pytest --pyargs specutils
+
+pip_pre = true


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to add downstream testing for Astropy Coordinated packages to prevent bugfix release regression.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes astropy/astropy-integration-testing#25

xref https://github.com/astropy/astropy/issues/12889#issuecomment-2682465393

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
