### PR TITLE
Stop storing unit scale as `Fraction` or `int`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -27,8 +27,7 @@ from .utils import (
     is_effectively_unity,
     resolve_fractions,
     sanitize_power,
-    sanitize_scale_type,
-    sanitize_scale_value,
+    sanitize_scale,
 )
 
 if TYPE_CHECKING:
@@ -2074,7 +2073,7 @@ class _UnitMetaClass(type):
             if is_effectively_unity(s.value):
                 return s.unit
             return CompositeUnit(
-                sanitize_scale_type(s.value) * s.unit.scale,
+                sanitize_scale(s.value) * s.unit.scale,
                 bases=s.unit.bases,
                 powers=s.unit.powers,
                 _error_check=False,
@@ -2294,7 +2293,7 @@ class CompositeUnit(UnitBase):
         # kwarg `_error_check` is False, the error checking is turned
         # off.
         if _error_check:
-            scale = sanitize_scale_type(scale)
+            scale = sanitize_scale(scale)
             for base in bases:
                 if not isinstance(base, UnitBase):
                     raise TypeError("bases must be sequence of UnitBase instances")
@@ -2321,7 +2320,7 @@ class CompositeUnit(UnitBase):
                     for p in unit.powers
                 ]
 
-            self._scale = sanitize_scale_value(scale)
+            self._scale = sanitize_scale(scale)
         else:
             # Regular case: use inputs as preliminary scale, bases, and powers,
             # then "expand and gather" identical bases, sanitize the scale, &c.
@@ -2395,7 +2394,7 @@ class CompositeUnit(UnitBase):
 
         self._bases = [x[0] for x in new_parts]
         self._powers = [sanitize_power(x[1]) for x in new_parts]
-        self._scale = sanitize_scale_value(scale)
+        self._scale = sanitize_scale(scale)
 
     def __copy__(self) -> CompositeUnit:
         return CompositeUnit(self._scale, self._bases[:], self._powers[:])

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -164,7 +164,7 @@ class Base:
         # First the scale.  Normally unity, in which case we omit
         # it, but non-unity scale can happen, e.g., in decompositions
         # like u.Ry.decompose(), which gives "2.17987e-18 kg m2 / s2".
-        s = "" if unit.scale == 1 else cls.format_exponential_notation(unit.scale)
+        s = "" if unit.scale == 1.0 else cls.format_exponential_notation(unit.scale)
 
         # dimensionless does not have any bases, but can have a scale;
         # e.g., u.percent.decompose() gives "0.01".

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1164,26 +1164,6 @@ def test_hash_represents_unit(unit, power):
     assert hash(tu2) == hash(unit)
 
 
-@pytest.mark.parametrize(
-    "scale1, scale2",
-    [
-        (10, 10.0),
-        (2, Fraction(2, 1)),
-        (4, 4 + 0j),
-        (0.5, Fraction(1, 2)),
-        (2.4, 2.4 + 0j),
-        (Fraction(1, 4), 0.25 + 0j),
-    ],
-    ids=type,
-)
-def test_hash_scale_type(scale1, scale2):
-    # Regression test for #17820 - hash could depend on scale type, not just its value
-    unit1 = u.CompositeUnit(scale1, [u.m], [-1])
-    unit2 = u.CompositeUnit(scale2, [u.m], [-1])
-    assert unit1 == unit2
-    assert hash(unit1) == hash(unit2)
-
-
 @pytest.mark.skipif(not HAS_ARRAY_API_STRICT, reason="tests array_api_strict")
 def test_array_api_strict_arrays():
     # Ensure strict array api arrays can be passed in/out of Unit.to()

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -74,8 +74,8 @@ UnitPower: TypeAlias = int | float | Fraction
 UnitPowerLike: TypeAlias = UnitPower | np.integer | np.floating
 """Alias for types that can be used to create powers of the components of a
 `~astropy.units.UnitBase` instance"""
-UnitScale: TypeAlias = int | float | Fraction | complex
+UnitScale: TypeAlias = float | complex
 "Alias for types that can be scale factors of a `~astropy.units.CompositeUnit`"
-UnitScaleLike: TypeAlias = UnitScale | np.number
+UnitScaleLike: TypeAlias = UnitScale | int | Fraction | np.number
 """Alias for types that can be used to create scale factors of a
 `~astropy.units.CompositeUnit`"""

--- a/docs/changes/units/17822.bugfix.rst
+++ b/docs/changes/units/17822.bugfix.rst
@@ -1,7 +1,0 @@
-Previously the hashes of units could depend on the type of their scale factor,
-but now the hashes depend on the scale factor values, not the types.
-For example, previously a ``dict`` would consider two otherwise identical units
-with scale factors ``1`` (``int``) and ``1.0`` (``float``) as different keys,
-but now they are considered to be the same key.
-In practice this bug was rare because the number of units with a scale factor
-that is not a ``float`` is very small.


### PR DESCRIPTION
### Description

The scale factor of a unit is now a `float` if it is real or a `complex` otherwise. Previously it was also allowed to be a `Fraction` or an `int`. Those types are still allowed for creating a unit, but they will be converted to a `float`. It should be pointed out that the scale factor of a `NamedUnit` (inherited from `UnitBase`) is defined to be a `1.0`, i.e. a `float`: https://github.com/astropy/astropy/blob/1477470d26611aef227a2a3dee6b6de32502f34b/astropy/units/core.py#L683-L686
Because the product of a `Fraction` and a `float` is a `float` and the product of an `int` and a `float` is also a `float` then `float` scale factors already had a tendency to proliferate in practice. #17846 provides an example of such unexpected `float` conversion.

Preventing `int` and `Fraction` unit scales (which are edge-cases anyways) makes it simpler to write code to handle them. Most notably, testing with `np.testing.assert_allclose()` works just fine with `float`, but not `Fraction` or very large `int`.

I'm not quite sure if this requires a change log entry or not because I am not sure we have even changed our API. Not having to handle `Fraction` or `int` scale factors anymore should not cause any new problems downstream. In any case the only places that stated that a scale could be a `Fraction` or an `int` were the definition of the `UnitScale` type alias, which was not included in the public documentation of the last `astropy` release, and a comment in a private function (which was the reason `UnitScale` was defined as it was).

Closes #17846

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
