### PR TITLE
fix ruff rule B007 violation in astropy/wcs

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -299,7 +299,6 @@ lint.unfixable = [
     "B007",  # UnusedLoopControlVariable
     "B015",
     "PLR0911",  # too-many-return-statements
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/wcs/*" = [
     "B007",  # UnusedLoopControlVariable

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -204,7 +204,6 @@ lint.unfixable = [
 "astropy/coordinates/*" = [
     "PTH",     # all flake8-use-pathlib
     "DTZ007",  # call-datetime-strptime-without-zone
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/cosmology/*" = [
     "PT019",   # pytest-fixture-param-without-value
@@ -220,7 +219,6 @@ lint.unfixable = [
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception
     "TRY300",  # Consider `else` block
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/io/ascii/*" = [
     "B007",  # UnusedLoopControlVariable
@@ -228,7 +226,6 @@ lint.unfixable = [
 "astropy/io/fits/*" = [
     "B007",  # UnusedLoopControlVariable
     "PTH",
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/io/misc/*" = [
     "B007",  # UnusedLoopControlVariable
@@ -246,34 +243,28 @@ lint.unfixable = [
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
     "TRY300",  # Consider `else` block
     "F811",  # see https://github.com/astropy/astropy/pull/16633
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/nddata/*" = []
 "astropy/samp/*" = [
     "PTH",      # all flake8-use-pathlib
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/stats/*" = [
     "B007",  # UnusedLoopControlVariable
     "PLR0911",  # too-many-return-statements
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/table/*" = [
     "B007",  # UnusedLoopControlVariable
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/tests/*" = [
     "B007",  # UnusedLoopControlVariable
     "PTH",      # all flake8-use-pathlib
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/time/*" = [
     "B007",  # UnusedLoopControlVariable
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/timeseries/*" = [
     "PLR0911",  # too-many-return-statements
@@ -283,7 +274,6 @@ lint.unfixable = [
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
     "TRY300",  # Consider `else` block
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/uncertainty/*" = []
 "astropy/utils/*" = [
@@ -293,7 +283,6 @@ lint.unfixable = [
     "PTH",      # all flake8-use-pathlib
     "S321",  # Suspicious-ftp-lib-usage
     "TRY300",  # Consider `else` block
-    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/visualization/*" = [
     "B007",  # UnusedLoopControlVariable
@@ -301,7 +290,6 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/wcs/*" = [
-    "B007",  # UnusedLoopControlVariable
     "F821",  # undefined-name
     "PTH",      # all flake8-use-pathlib
     "S608",  # Posslibe SQL injection

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -253,12 +253,10 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/table/*" = [
-    "B007",  # UnusedLoopControlVariable
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
 ]
 "astropy/tests/*" = [
-    "B007",  # UnusedLoopControlVariable
     "PTH",      # all flake8-use-pathlib
 ]
 "astropy/time/*" = [
@@ -270,7 +268,6 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/units/*" = [
-    "B007",  # UnusedLoopControlVariable
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
     "TRY300",  # Consider `else` block
@@ -285,7 +282,6 @@ lint.unfixable = [
     "TRY300",  # Consider `else` block
 ]
 "astropy/visualization/*" = [
-    "B007",  # UnusedLoopControlVariable
     "B015",
     "PLR0911",  # too-many-return-statements
 ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -204,6 +204,7 @@ lint.unfixable = [
 "astropy/coordinates/*" = [
     "PTH",     # all flake8-use-pathlib
     "DTZ007",  # call-datetime-strptime-without-zone
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/cosmology/*" = [
     "PT019",   # pytest-fixture-param-without-value
@@ -219,6 +220,7 @@ lint.unfixable = [
     "TD005",  # Missing issue description after `TODO`
     "TRY400",  # error-instead-of-exception
     "TRY300",  # Consider `else` block
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/io/ascii/*" = [
     "B007",  # UnusedLoopControlVariable
@@ -226,6 +228,7 @@ lint.unfixable = [
 "astropy/io/fits/*" = [
     "B007",  # UnusedLoopControlVariable
     "PTH",
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/io/misc/*" = [
     "B007",  # UnusedLoopControlVariable
@@ -243,28 +246,34 @@ lint.unfixable = [
     "SLOT001",  # Subclasses of `tuple` should define `__slots__`
     "TRY300",  # Consider `else` block
     "F811",  # see https://github.com/astropy/astropy/pull/16633
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/nddata/*" = []
 "astropy/samp/*" = [
     "PTH",      # all flake8-use-pathlib
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/stats/*" = [
     "B007",  # UnusedLoopControlVariable
     "PLR0911",  # too-many-return-statements
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/table/*" = [
     "B007",  # UnusedLoopControlVariable
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/tests/*" = [
     "B007",  # UnusedLoopControlVariable
     "PTH",      # all flake8-use-pathlib
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/time/*" = [
     "B007",  # UnusedLoopControlVariable
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/timeseries/*" = [
     "PLR0911",  # too-many-return-statements
@@ -274,6 +283,7 @@ lint.unfixable = [
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
     "TRY300",  # Consider `else` block
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/uncertainty/*" = []
 "astropy/utils/*" = [
@@ -283,11 +293,13 @@ lint.unfixable = [
     "PTH",      # all flake8-use-pathlib
     "S321",  # Suspicious-ftp-lib-usage
     "TRY300",  # Consider `else` block
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/visualization/*" = [
     "B007",  # UnusedLoopControlVariable
     "B015",
     "PLR0911",  # too-many-return-statements
+    "B007",  # UnusedLoopControlVariable
 ]
 "astropy/wcs/*" = [
     "B007",  # UnusedLoopControlVariable

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2942,11 +2942,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         if display_warning:
             full_header = self.to_header(relax=True, key=key)
-            missing_keys = []
-            for kw in full_header.keys():
-                if kw not in header:
-                    missing_keys.append(kw)
-
+            missing_keys = [k for k in full_header if k not in header]
             if missing_keys:
                 warnings.warn(
                     "Some non-standard WCS keywords were excluded:"

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2943,7 +2943,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         if display_warning:
             full_header = self.to_header(relax=True, key=key)
             missing_keys = []
-            for kw, val in full_header.items():
+            for kw in full_header.keys():
                 if kw not in header:
                     missing_keys.append(kw)
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address to split pull request https://github.com/astropy/astropy/pull/17844 , and it ensure compliance of astropy/wcs to Ruff rule [unused-loop-control-variable (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes partially #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
