### PR TITLE
Enable units from `required_by_vounit` properly

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -20,6 +20,7 @@ from . import (
     photometric,
     physical,
     quantity,
+    required_by_vounit,
     si,
     structured,
 )
@@ -62,4 +63,6 @@ globals()["__all__"].sort()
 
 # Enable the set of default units.  This notably does *not* include
 # Imperial units.
-set_enabled_units([si, cgs, astrophys, function.units, misc, photometric])
+set_enabled_units(
+    [si, cgs, astrophys, function.units, misc, photometric, required_by_vounit]
+)

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -39,24 +39,3 @@ if __doc__ is not None:
 
     __doc__ += _generate_unit_summary(globals())
     __doc__ += _generate_prefixonly_unit_summary(globals())
-
-
-def _enable():
-    """
-    Enable the VOUnit-required extra units so they appear in results of
-    `~astropy.units.UnitBase.find_equivalent_units` and
-    `~astropy.units.UnitBase.compose`, and are recognized in the ``Unit('...')``
-    idiom.
-    """
-    # Local import to avoid cyclical import
-    # Local import to avoid polluting namespace
-    import inspect
-
-    from .core import add_enabled_units
-
-    return add_enabled_units(inspect.getmodule(_enable))
-
-
-# Because these are VOUnit mandated units, they start enabled (which is why the
-# function is hidden).
-_enable()

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -156,7 +156,7 @@ def generate_prefixonly_unit_summary(namespace: Mapping[str, object]) -> str:
     docstring : str
         A docstring containing a summary table of the units.
     """
-    from . import PrefixUnit
+    from .core import PrefixUnit
 
     faux_namespace = {}
     for unit in namespace.values():

--- a/docs/changes/units/17868.bugfix.rst
+++ b/docs/changes/units/17868.bugfix.rst
@@ -1,0 +1,4 @@
+The string representations of the prefixed versions of ``solLum``, ``solMass``
+and ``solRad`` units can now be parsed by default.
+Previously they could only be parsed if the ``required_by_vounit`` module had
+been imported, possibly indirectly by using the ``"vounit"`` format.


### PR DESCRIPTION
### Description

In #5661 it was decided that the prefixed versions of `solLum`, `solMass` and `solRad` units should not be present in the main `units` namespace. However, they are valid units in the VOUnit format, so they are defined in a separate `required_by_vounit` module. Furthermore, because the (default) `"generic"` format is supposed to be a superset of the other formats then parsing those units should work with the `"generic"` format too. Currently the `required_by_vounit` module adds its units to the registry the `"generic"` format uses, but that is a side-effect of `required_by_vounit` being imported, which happens by using the `"vounit"` format:
```python
>>> from astropy import units as u
>>> u.Unit("ksolRad")
Traceback (most recent call last):
  ...
ValueError: 'ksolRad' did not parse as unit...
>>> f"{u.m:vounit}"
'm'
>>> u.Unit("ksolRad")
Unit("ksolRad")
```
Fixing this bug is quite simple, but there isn't a good way of writing an automated regression test that would reliably fail on current `main` because using the `"vounit"` format anywhere before the regression test runs would trigger the side-effect that hides the bug.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
