### PR TITLE
Fix filtering of non-finite values

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1308,20 +1308,25 @@ class _NonLinearLSQFitter(Fitter):
 
     def _filter_non_finite(self, x, y, z=None, weights=None):
         """
-        Filter out non-finite values in x, y, z.
+        Filter out non-finite values in x, y, z, and weights.
 
         Returns
         -------
-        x, y, z : ndarrays
-            x, y, and z with non-finite values filtered out.
+        x, y, z, weights : `~numpy.ndarray`
+            x, y, z, and weights with non-finite values filtered out.
         """
         MESSAGE = "Non-Finite input data has been removed by the fitter."
 
-        mask = np.ones_like(x, dtype=bool) if weights is None else np.isfinite(weights)
-        mask &= np.isfinite(y) if z is None else np.isfinite(z)
+        mask = np.isfinite(x) & np.isfinite(y)
+        if z is not None:
+            mask &= np.isfinite(z)
+        if weights is not None:
+            mask &= np.isfinite(weights)
 
         if not np.all(mask):
             warnings.warn(MESSAGE, AstropyUserWarning)
+        if not np.any(mask):
+            raise ValueError("All input data or weights are non-finite.")
 
         return (
             x[mask],

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -6,6 +6,7 @@ Module to test fitting routines
 # pylint: disable=invalid-name
 import os.path
 import unittest.mock as mk
+from contextlib import nullcontext
 from importlib.metadata import EntryPoint
 from itertools import combinations
 from unittest import mock
@@ -1424,54 +1425,63 @@ def test_non_finite_error(fitter, weights):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
-@pytest.mark.parametrize("weights", [np.ones(8), None])
-def test_non_finite_filter_1D(fitter, weights):
-    """Regression test filter introduced to remove non-finte values from data"""
+@pytest.mark.parametrize("fitobj", non_linear_fitters_bounds)
+@pytest.mark.parametrize("ndim", (1, 2))
+@pytest.mark.parametrize("all_nonfinite", (False, True))
+def test_filter_non_finite(fitobj, ndim, all_nonfinite):
+    """
+    Test that non-finite values are removed from the data before
+    fitting.
 
-    x = np.array([1, 2, 3, 4, 5, 6, 7, 8])
-    y = np.array([9, np.nan, 11, np.nan, 13, np.nan, 15, np.inf])
+    If all the values are non-finite, a ValueError should be raised.
 
-    m_init = models.Gaussian1D()
-    fit = fitter()
+    The test is performed for both 1D and 2D models. The x, y, z, and
+    weights arrays are each independently tested for non-finite values.
+    """
 
-    if weights is not None:
-        weights[[1, 4]] = np.nan
+    def perform_fit(fitter, m_init, params, ndim):
+        if ndim == 1:
+            fitter(
+                m_init,
+                params[0],
+                params[1],
+                weights=params[2],
+                filter_non_finite=True,
+            )
+        elif ndim == 2:
+            fitter(
+                m_init,
+                params[0],
+                params[1],
+                params[2],
+                weights=params[3],
+                filter_non_finite=True,
+            )
 
-    with pytest.warns(
-        AstropyUserWarning,
-        match=r"Non-Finite input data has been removed by the fitter",
-    ):
-        fit(m_init, x, y, filter_non_finite=True, weights=weights)
+    if ndim == 1:
+        m_init = models.Gaussian1D()
+    elif ndim == 2:
+        m_init = models.Gaussian2D()
+    fitter = fitobj()
 
+    ctx1 = pytest.warns(
+        AstropyUserWarning, match="Non-Finite input data has been removed by the fitter"
+    )
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
-@pytest.mark.parametrize("fitter", non_linear_fitters_bounds)
-@pytest.mark.parametrize("weights", [np.ones((10, 10)), None])
-def test_non_finite_filter_2D(fitter, weights):
-    """Regression test filter introduced to remove non-finte values from data"""
+    params = np.tile(np.arange(10.0), (4, 1))
+    if all_nonfinite:
+        params[-1] = np.nan
+        ctx2 = pytest.raises(
+            ValueError, match="All input data or weights are non-finite"
+        )
+    else:
+        params[-1, [1, 6, 7]] = np.nan
+        ctx2 = nullcontext()
 
-    x, y = np.mgrid[0:10, 0:10]
-
-    m_true = models.Gaussian2D(amplitude=1, x_mean=5, y_mean=5, x_stddev=2, y_stddev=2)
-    with NumpyRNGContext(_RANDOM_SEED):
-        z = m_true(x, y) + np.random.rand(*x.shape)
-    z[0, 0] = np.nan
-    z[3, 3] = np.inf
-    z[7, 5] = -np.inf
-
-    if weights is not None:
-        weights[1, 1] = np.nan
-        weights[4, 3] = np.inf
-
-    m_init = models.Gaussian2D()
-    fit = fitter()
-
-    with pytest.warns(
-        AstropyUserWarning,
-        match=r"Non-Finite input data has been removed by the fitter",
-    ):
-        fit(m_init, x, y, z, filter_non_finite=True, weights=weights)
+    for i in range(2 + ndim):
+        params = np.roll(params, 1, axis=0)
+        with ctx1, ctx2:
+            perform_fit(fitter, m_init, params, ndim)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")

--- a/docs/changes/modeling/17869.bugfix.rst
+++ b/docs/changes/modeling/17869.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed an issue where the ``filter_non_finite`` option was not working
+for 2D models. An error is raised when the ``filter_non_finite`` option
+is set to ``True`` and all values are non-finite.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR address a few issues with the filtering of non-finite values in model fitting:

* Fixes a bug for 2D models where non-finite values were not filtered from the `y` values
* Raises an informative `ValueError` if all input data or weights are non-finite. Previous this case would raise an uninformative error.  
* ~Changes the error message if non-finite values are present and `filter_non_finite=False` to mention the weight array and the conditions by which non-finite values can be introduced in the fitting process~

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
