### PR TITLE
Add initial type annotations to `units/physical.py`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -38,7 +38,13 @@ if TYPE_CHECKING:
     from .format import Base
     from .physical import PhysicalType
     from .quantity import Quantity
-    from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
+    from .typing import (
+        PhysicalTypeID,
+        UnitPower,
+        UnitPowerLike,
+        UnitScale,
+        UnitScaleLike,
+    )
 
 __all__ = [
     "CompositeUnit",
@@ -669,7 +675,7 @@ class UnitBase:
         return f'Unit("{self}")'
 
     @cached_property
-    def _physical_type_id(self) -> tuple[tuple[str, UnitPower], ...]:
+    def _physical_type_id(self) -> PhysicalTypeID:
         """
         Returns an identifier that uniquely identifies the physical
         type of this unit.  It is comprised of the bases and powers of
@@ -2204,9 +2210,7 @@ class Unit(NamedUnit, metaclass=_UnitMetaClass):
         return hash((self.name, self._represents))
 
     @classmethod
-    def _from_physical_type_id(
-        cls, physical_type_id: tuple[tuple[str, UnitPower], ...]
-    ) -> UnitBase:
+    def _from_physical_type_id(cls, physical_type_id: PhysicalTypeID) -> UnitBase:
         if len(physical_type_id) == 1 and physical_type_id[0][1] == 1:
             return cls(physical_type_id[0][0])
         # get string bases and powers from the ID tuple

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
     from typing import Self
 
-    from astropy.units.typing import UnitPower
+    from astropy.units.typing import PhysicalTypeID
 
 __all__ = ["FunctionQuantity", "FunctionUnitBase"]
 
@@ -195,7 +195,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
         return self._copy(self.physical_unit.cgs)
 
     @cached_property
-    def _physical_type_id(self) -> tuple[tuple[str, UnitPower], ...]:
+    def _physical_type_id(self) -> PhysicalTypeID:
         """Get physical type corresponding to physical unit."""
         return self.physical_unit._physical_type_id
 

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -79,3 +79,4 @@ UnitScale: TypeAlias = float | complex
 UnitScaleLike: TypeAlias = UnitScale | int | Fraction | np.number
 """Alias for types that can be used to create scale factors of a
 `~astropy.units.CompositeUnit`"""
+PhysicalTypeID: TypeAlias = tuple[tuple[str, UnitPower], ...]

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -97,6 +97,7 @@ py:class np.ma.MaskedArray
 # locally defined type variable for ndarray dtype
 py:class DT
 # type aliases
+py:class QuantityLike
 py:class UnitPower
 py:class UnitPowerLike
 py:class UnitScale


### PR DESCRIPTION
### Description

I am adding initial type annotations to `astropy/units/physical.py`. I avoided making any changes to the code for now, so there might be follow-up pull requests to make the code more understandable for type checkers.

I also decided that the type `tuple[tuple[str, UnitPower], ...]` is complicated enough and (with this pull request) is used often enough that it would be a good idea to define an alias for it. In order to keep the Git history cleaner the new `PhysicalTypeID` alias is introduced in the first commit. The second commit edits only `astropy/units/physical.py` (and `docs/nitpick-exceptions`).

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
