### PR TITLE
TST: Replace test with conf in test_find_mod_objs()

### DIFF
--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -61,10 +61,10 @@ def test_find_mod_objs():
     # find_mod_objs properly imports astropy on its own
     import astropy
 
-    # just check for astropy.test ... other things might be added, so we
+    # just check for astropy.conf ... other things might be added, so we
     # shouldn't check that it's the only thing
-    assert "test" in lnms
-    assert astropy.test in objs
+    assert "conf" in lnms
+    assert astropy.conf in objs
 
     with pytest.warns(AstropyDeprecationWarning, match=deprecation_message):
         lnms, fqns, objs = find_mod_objs(__name__, onlylocals=False)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to apply diff to `astropy/utils/tests/test_introspection.py` from https://github.com/astropy/astropy/pull/16208 and also apply comment from https://github.com/astropy/astropy/pull/16208/files#r1745565811 . This is a precursor for https://github.com/astropy/astropy/issues/16177 so it is one less thing we worry about when we deprecate the test runner. Should be uncontroversial but backport is also probably unnecessary.

- [x] Add Mridul and Marten as co-authors.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
