### PR TITLE
RFC: Introduce pending deprecation warning of test runner

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -185,10 +185,10 @@ class astronomical_constants(base_constants_version):
 
 
 # Create the test() function
+from .tests.runner import TestRunner
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
-    from .tests.runner import TestRunner
-
     test = TestRunner.make_test_runner_in(__path__[0])
 
 

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -7,6 +7,7 @@ managing them.
 """
 
 import sys
+import warnings
 from pathlib import Path
 
 from astropy.utils.system_info import system_info
@@ -184,9 +185,11 @@ class astronomical_constants(base_constants_version):
 
 
 # Create the test() function
-from .tests.runner import TestRunner
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
+    from .tests.runner import TestRunner
 
-test = TestRunner.make_test_runner_in(__path__[0])
+    test = TestRunner.make_test_runner_in(__path__[0])
 
 
 # if we are *not* in setup mode, import the logger and possibly populate the

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This file contains pytest configuration settings that are astropy-specific
-(i.e.  those that would not necessarily be shared by affiliated packages
-making use of astropy's test runner).
+This file contains pytest configuration settings that are astropy-specific.
 """
 
 import builtins

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -13,7 +13,11 @@ from importlib.util import find_spec
 from pathlib import Path
 
 from astropy.utils import deprecated, find_current_module
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy.utils.exceptions import (
+    AstropyDeprecationWarning,
+    AstropyPendingDeprecationWarning,
+    AstropyWarning,
+)
 
 __all__ = ["TestRunner", "TestRunnerBase"]
 
@@ -162,6 +166,9 @@ class TestRunnerBase:
 
         This method builds arguments for and then calls ``pytest.main``.
 
+        .. deprecated:: 7.2
+            Use pytest instead.
+
         Parameters
         ----------
 {keywords}
@@ -200,6 +207,13 @@ class TestRunnerBase:
                     raise RuntimeError(cls._missing_dependancy_error.format(module))
 
     def run_tests(self, **kwargs):
+        # This method is weirdly hooked into various things with docstring
+        # overrides, so we keep it simple and not use @deprecated here.
+        warnings.warn(
+            "The test runner will be deprecated in a future version.\n        Use pytest instead.",
+            AstropyPendingDeprecationWarning,
+        )
+
         # The following option will include eggs inside a .eggs folder in
         # sys.path when running the tests. This is possible so that when
         # running pytest, test dependencies installed via e.g.

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -48,7 +48,7 @@ class keyword:
         return keyword
 
 
-@deprecated("7.1", alternative="pytest", pending=True)
+@deprecated("7.2", alternative="pytest", pending=True)
 class TestRunnerBase:
     """
     The base class for the TestRunner.
@@ -290,7 +290,7 @@ class TestRunnerBase:
         return test
 
 
-@deprecated("7.1", alternative="pytest", pending=True)
+@deprecated("7.2", alternative="pytest", pending=True)
 class TestRunner(TestRunnerBase):
     """
     A test runner for astropy tests.

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -12,10 +12,10 @@ from functools import wraps
 from importlib.util import find_spec
 from pathlib import Path
 
-from astropy.utils import find_current_module
+from astropy.utils import deprecated, find_current_module
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
-__all__ = ["TestRunner", "TestRunnerBase", "keyword"]
+__all__ = ["TestRunner", "TestRunnerBase"]
 
 
 class keyword:
@@ -48,13 +48,14 @@ class keyword:
         return keyword
 
 
+@deprecated("7.1", alternative="pytest", pending=True)
 class TestRunnerBase:
     """
     The base class for the TestRunner.
 
     A test runner can be constructed by creating a subclass of this class and
     defining 'keyword' methods. These are methods that have the
-    :class:`~astropy.tests.runner.keyword` decorator, these methods are used to
+    ``astropy.tests.runner.keyword`` decorator, these methods are used to
     construct allowed keyword arguments to the
     `~astropy.tests.runner.TestRunnerBase.run_tests` method as a way to allow
     customization of individual keyword arguments (and associated logic)
@@ -289,6 +290,7 @@ class TestRunnerBase:
         return test
 
 
+@deprecated("7.1", alternative="pytest", pending=True)
 class TestRunner(TestRunnerBase):
     """
     A test runner for astropy tests.

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -7,11 +7,11 @@ from astropy import test as run_tests
 
 # run_tests should raise ValueError when asked to run on a module it can't find
 def test_module_not_found():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError), pytest.deprecated_call(match="The test runner"):
         run_tests(package="fake.module")
 
 
 # run_tests should raise ValueError when passed an invalid pastebin= option
 def test_pastebin_keyword():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError), pytest.deprecated_call(match="The test runner"):
         run_tests(pastebin="not_an_option")

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -15,7 +15,3 @@ def test_module_not_found():
 def test_pastebin_keyword():
     with pytest.raises(ValueError):
         run_tests(pastebin="not_an_option")
-
-
-def test_unicode_literal_conversion():
-    assert isinstance("ångström", str)

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -10,6 +10,9 @@ from astropy.tests.runner import TestRunnerBase as _TestRunnerBase
 from astropy.tests.runner import keyword
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The TestRunner.* class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
+)
 def test_disable_kwarg():
     class no_remote_data(_TestRunner):
         @keyword()
@@ -21,12 +24,18 @@ def test_disable_kwarg():
         r.run_tests(remote_data="bob")
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The TestRunner.* class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
+)
 def test_wrong_kwarg():
     r = _TestRunner(".")
     with pytest.raises(TypeError):
         r.run_tests(spam="eggs")
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
+)
 def test_invalid_kwarg():
     class bad_return(_TestRunnerBase):
         @keyword()
@@ -38,6 +47,9 @@ def test_invalid_kwarg():
         r.run_tests(remote_data="bob")
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
+)
 def test_new_kwarg():
     class Spam(_TestRunnerBase):
         @keyword()
@@ -51,6 +63,9 @@ def test_new_kwarg():
     assert ["spam"] == args
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
+)
 def test_priority():
     class Spam(_TestRunnerBase):
         @keyword()
@@ -68,6 +83,9 @@ def test_priority():
     assert ["eggs", "spam"] == args
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
+)
 @_skip_docstring_tests_with_optimized_python
 def test_docs():
     class Spam(_TestRunnerBase):

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -10,62 +10,51 @@ from astropy.tests.runner import TestRunnerBase as _TestRunnerBase
 from astropy.tests.runner import keyword
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The TestRunner.* class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
-)
 def test_disable_kwarg():
     class no_remote_data(_TestRunner):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return NotImplemented
 
-    r = no_remote_data(".")
-    with pytest.raises(TypeError):
+    with pytest.deprecated_call(match="The TestRunner"):
+        r = no_remote_data(".")
+    with pytest.raises(TypeError), pytest.deprecated_call(match="The test runner"):
         r.run_tests(remote_data="bob")
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The TestRunner.* class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
-)
 def test_wrong_kwarg():
-    r = _TestRunner(".")
-    with pytest.raises(TypeError):
+    with pytest.deprecated_call(match="The TestRunner"):
+        r = _TestRunner(".")
+    with pytest.raises(TypeError), pytest.deprecated_call(match="The test runner"):
         r.run_tests(spam="eggs")
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
-)
 def test_invalid_kwarg():
     class bad_return(_TestRunnerBase):
         @keyword()
         def remote_data(self, remote_data, kwargs):
             return "bob"
 
-    r = bad_return(".")
-    with pytest.raises(TypeError):
+    with pytest.deprecated_call(match="The TestRunner"):
+        r = bad_return(".")
+    with pytest.raises(TypeError), pytest.deprecated_call(match="The test runner"):
         r.run_tests(remote_data="bob")
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
-)
 def test_new_kwarg():
     class Spam(_TestRunnerBase):
         @keyword()
         def spam(self, spam, kwargs):
             return [spam]
 
-    r = Spam(".")
+    with pytest.deprecated_call(match="The TestRunner"):
+        r = Spam(".")
 
     args = r._generate_args(spam="spam")
 
     assert ["spam"] == args
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
-)
 def test_priority():
     class Spam(_TestRunnerBase):
         @keyword()
@@ -76,16 +65,14 @@ def test_priority():
         def eggs(self, eggs, kwargs):
             return [eggs]
 
-    r = Spam(".")
+    with pytest.deprecated_call(match="The TestRunner"):
+        r = Spam(".")
 
     args = r._generate_args(spam="spam", eggs="eggs")
 
     assert ["eggs", "spam"] == args
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The TestRunnerBase class:astropy.utils.exceptions.AstropyPendingDeprecationWarning"
-)
 @_skip_docstring_tests_with_optimized_python
 def test_docs():
     class Spam(_TestRunnerBase):
@@ -103,6 +90,8 @@ def test_docs():
             """
             return [eggs]
 
-    r = Spam(".")
+    with pytest.deprecated_call(match="The TestRunner"):
+        r = Spam(".")
+    assert "deprecated" in r.run_tests.__doc__
     assert "eggs" in r.run_tests.__doc__
     assert "Spam Spam Spam" in r.run_tests.__doc__

--- a/docs/changes/tests/17874.api.rst
+++ b/docs/changes/tests/17874.api.rst
@@ -4,6 +4,7 @@ API changes towards a future deprecation of astropy test runner:
   It is used internally as a decorator within astropy test runner and
   its exposure as public API was a mistake. In the future, it will be
   removed without any deprecation.
-* ``astropy.tests.runner.TestRunnerBase`` and ``astropy.tests.runner.TestRunner``
+* ``astropy.test``, ``astropy.tests.runner.TestRunnerBase``, and ``astropy.tests.runner.TestRunner``
   are now pending deprecation (``AstropyPendingDeprecationWarning``).
+  This will also affect downstream ``packagename.test`` generated using ``TestRunner``.
   They may start to emit ``AstropyDeprecationWarning`` in v8.0 (but no earlier).

--- a/docs/changes/tests/17874.api.rst
+++ b/docs/changes/tests/17874.api.rst
@@ -1,0 +1,9 @@
+API changes towards a future deprecation of astropy test runner:
+
+* ``astropy.tests.runner.keyword`` is removed from public API.
+  It is used internally as a decorator within astropy test runner and
+  its exposure as public API was a mistake. In the future, it will be
+  removed without any deprecation.
+* ``astropy.tests.runner.TestRunnerBase`` and ``astropy.tests.runner.TestRunner``
+  are now pending deprecation (``AstropyPendingDeprecationWarning``).
+  They may start to emit ``AstropyDeprecationWarning`` in v8.0 (but no earlier).

--- a/docs/development/maintainers/testhelpers.rst
+++ b/docs/development/maintainers/testhelpers.rst
@@ -76,7 +76,8 @@ Astropy Test Runner
 
 .. warning::
 
-    ``TestRunner`` and ``TestRunnerBase`` are pending deprecation.
+    ``astropy.test``, ``TestRunner``, and ``TestRunnerBase`` are pending deprecation.
+    This will also affect downstream ``packagename.test`` generated using ``TestRunner``.
     If you use any of the API referenced in this section, please consider
     switching away to using ``pytest`` natively.
     For example, running ``astropy.test()`` in Python is equivalent to

--- a/docs/development/maintainers/testhelpers.rst
+++ b/docs/development/maintainers/testhelpers.rst
@@ -10,7 +10,8 @@ overview of running or writing the tests.
 
 Details
 =======
-The dependencies used by the Astropy test runner are provided by a separate
+
+The dependencies used by the Astropy test suite are provided by a separate
 package called |pytest-astropy|. This package provides the ``pytest``
 dependency itself, in addition to several ``pytest`` plugins that are used by
 Astropy, and will also be of general use to other packages.
@@ -73,6 +74,14 @@ Reference/API
 Astropy Test Runner
 ===================
 
+.. warning::
+
+    ``TestRunner`` and ``TestRunnerBase`` are pending deprecation.
+    If you use any of the API referenced in this section, please consider
+    switching away to using ``pytest`` natively.
+    For example, running ``astropy.test()`` in Python is equivalent to
+    running ``pytest --pyargs astropy`` from the command line.
+
 When executing tests with ``packagename.test`` the call to pytest is controlled
 by the `astropy.tests.runner.TestRunner` class.
 
@@ -82,7 +91,7 @@ arguments to pytest. The arguments to pytest are defined in the
 `~astropy.tests.runner.TestRunner.run_tests` method, the arguments to
 ``run_tests`` and their respective logic are defined in methods of
 `~astropy.tests.runner.TestRunner` decorated with the
-`~astropy.tests.runner.keyword` decorator. For an example of this see
+``astropy.tests.runner.keyword`` decorator. For an example of this see
 `~astropy.tests.runner.TestRunnerBase`. This design makes it easy for
 packages to add or remove keyword arguments to their test runners, or define a
 whole new set of arguments by subclassing from

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -326,15 +326,15 @@ large, we will need to design a mechanism for removing test data immediately.
 Tests that use the file cache
 -----------------------------
 
-By default, the Astropy test runner sets up a clean file cache in a temporary
+By default, Astropy's test configuration sets up a clean file cache in a temporary
 directory that is used only for that test run and then destroyed.  This is to
 ensure consistency between test runs, as well as to not clutter users' caches
-(i.e. the cache directory returned by `~astropy.config.get_cache_dir`) with
+(i.e., the cache directory returned by `~astropy.config.get_cache_dir`) with
 test files.
 
 However, some test authors (especially for affiliated packages) may find it
 desirable to cache files downloaded during a test run in a more permanent
-location (e.g. for large data sets).  To this end the
+location (e.g., for large data sets).  To this end the
 `~astropy.config.set_temp_cache` helper may be used.  It can be used either as
 a context manager within a test to temporarily set the cache to a custom
 location, or as a *decorator* that takes effect for an entire test function
@@ -351,7 +351,7 @@ Some tests involve writing files. These files should not be saved permanently.
 The :ref:`pytest 'tmp_path' fixture <pytest:tmp_path>` allows for the
 convenient creation of temporary directories, which ensures test files will be
 cleaned up. Temporary directories can also be helpful in the case where the
-tests are run in an environment where the runner would otherwise not have write
+tests are run in an environment where ``pytest`` would otherwise not have write
 access.
 
 
@@ -638,7 +638,7 @@ Testing configuration parameters
 ================================
 
 In order to ensure reproducibility of tests, all configuration items
-are reset to their default values when the test runner starts up.
+are reset to their default values when ``pytest`` starts up.
 
 Sometimes you'll want to test the behavior of code when a certain
 configuration item is set to a particular value.  In that case, you


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to pave the way for formal deprecation of astropy test runner, as laid out in #16177 . ~Also a follow-up of https://github.com/astropy/astropy/pull/15204 .~

xref #16208

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
