### PR TITLE
Add limit_rounding_method parameter to Cutout2D

### DIFF
--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -151,27 +151,37 @@ def test_slices_nonfinite_position(position):
 def test_slices_limit_rounding_method():
     """Call overlap_slices with different limit rounding methods."""
     # Using ceil (default)
-    slc_lg, slc_sm = overlap_slices((10, 10), (3, 5), (4, 5), limit_rounding_method="ceil")
+    slc_lg, slc_sm = overlap_slices(
+        (10, 10), (3, 5), (4, 5), limit_rounding_method="ceil"
+    )
     assert slc_lg == (slice(3, 6), slice(3, 8))
     assert slc_sm == (slice(0, 3), slice(0, 5))
 
     # Using floor
-    slc_lg, slc_sm = overlap_slices((10, 10), (3, 5), (4, 5), limit_rounding_method="floor")
+    slc_lg, slc_sm = overlap_slices(
+        (10, 10), (3, 5), (4, 5), limit_rounding_method="floor"
+    )
     assert slc_lg == (slice(2, 5), slice(2, 7))
     assert slc_sm == (slice(0, 3), slice(0, 5))
 
     # Using round
-    slc_lg, slc_sm = overlap_slices((10, 10), (3, 5), (4.2, 5.6), limit_rounding_method="round")
+    slc_lg, slc_sm = overlap_slices(
+        (10, 10), (3, 5), (4.2, 5.6), limit_rounding_method="round"
+    )
     assert slc_lg == (slice(3, 6), slice(3, 8))
     assert slc_sm == (slice(0, 3), slice(0, 5))
 
     # Case where limits round to numbers that create a larger array than requested
-    slc_lg, slc_sm = overlap_slices((10, 10), (3, 3), (6, 6), limit_rounding_method="round")
+    slc_lg, slc_sm = overlap_slices(
+        (10, 10), (3, 3), (6, 6), limit_rounding_method="round"
+    )
     assert slc_lg == (slice(5, 8), slice(5, 8))
     assert slc_sm == (slice(0, 3), slice(0, 3))
 
     # Case where limits round to numbers that create a smaller array than requested
-    slc_lg, slc_sm = overlap_slices((10, 10), (3, 3), (5, 5), limit_rounding_method="round")
+    slc_lg, slc_sm = overlap_slices(
+        (10, 10), (3, 3), (5, 5), limit_rounding_method="round"
+    )
     assert slc_lg == (slice(4, 7), slice(4, 7))
     assert slc_sm == (slice(0, 3), slice(0, 3))
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -154,35 +154,35 @@ def test_slices_nonfinite_position(position):
         (
             (3, 5),
             (4, 5),
-            "ceil",
+            np.ceil,
             (slice(3, 6), slice(3, 8)),
             (slice(0, 3), slice(0, 5)),
         ),
         (
             (3, 5),
             (4, 5),
-            "floor",
+            np.floor,
             (slice(2, 5), slice(2, 7)),
             (slice(0, 3), slice(0, 5)),
         ),
         (
             (3, 5),
             (4.2, 5.6),
-            "round",
+            np.round,
             (slice(3, 6), slice(3, 8)),
             (slice(0, 3), slice(0, 5)),
         ),
         (
             (3, 3),
             (6, 6),
-            "round",
+            np.round,
             (slice(4, 7), slice(4, 7)),
             (slice(0, 3), slice(0, 3)),
         ),
         (
             (3, 3),
             (5, 5),
-            "round",
+            np.round,
             (slice(4, 7), slice(4, 7)),
             (slice(0, 3), slice(0, 3)),
         ),
@@ -212,7 +212,8 @@ def test_slices_limit_rounding_method(
 @pytest.mark.parametrize(
     "limit_rounding_method, error_msg",
     [
-        ("invalid", "^Limit rounding method can be only"),
+        (None, "^Limit rounding method must be a callable"),
+        ("invalid", "^Limit rounding method must be a callable"),
         (lambda x: (1, 2), "^Limit rounding method must accept a single number"),
         (lambda x: "invalid", "^Limit rounding method must accept a single number"),
         (lambda x, y: 1, "^Limit rounding method must accept a single number"),
@@ -634,9 +635,9 @@ class TestCutout2D:
     @pytest.mark.parametrize(
         "position, limit_rounding_method, expected_slices_original",
         [
-            ((2, 2), "ceil", (slice(1, 4), slice(1, 4))),
-            ((2, 2), "floor", (slice(0, 3), slice(0, 3))),
-            ((1.9, 2.9), "round", (slice(1, 4), slice(0, 3))),
+            ((2, 2), np.ceil, (slice(1, 4), slice(1, 4))),
+            ((2, 2), np.floor, (slice(0, 3), slice(0, 3))),
+            ((1.9, 2.9), np.round, (slice(1, 4), slice(0, 3))),
             ((2, 2), np.trunc, (slice(0, 3), slice(0, 3))),
         ],
     )

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -174,7 +174,7 @@ def test_slices_limit_rounding_method():
     slc_lg, slc_sm = overlap_slices((10, 10), (3, 3), (5, 5), limit_rounding_method="round")
     assert slc_lg == (slice(4, 7), slice(4, 7))
     assert slc_sm == (slice(0, 3), slice(0, 3))
-    
+
 
 def test_slices_wrong_limit_rounding_method():
     """Call overlap_slices with non-existing limit rounding method."""

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -34,8 +34,13 @@ class PartialOverlapError(ValueError):
     """Raised when arrays only partially overlap."""
 
 
-def overlap_slices(large_array_shape, small_array_shape, position, mode="partial",
-                   limit_rounding_method="ceil"):
+def overlap_slices(
+    large_array_shape,
+    small_array_shape,
+    position,
+    mode="partial",
+    limit_rounding_method="ceil",
+):
     """
     Get slices for the overlapping part of a small and a large array.
 
@@ -91,7 +96,9 @@ def overlap_slices(large_array_shape, small_array_shape, position, mode="partial
     if mode not in ["partial", "trim", "strict"]:
         raise ValueError('Mode can be only "partial", "trim", or "strict".')
     if limit_rounding_method not in ["ceil", "floor", "round"]:
-        raise ValueError('Limit rounding method can be only "ceil", "floor", or "round".')
+        raise ValueError(
+            'Limit rounding method can be only "ceil", "floor", or "round".'
+        )
     if np.isscalar(small_array_shape):
         small_array_shape = (small_array_shape,)
     if np.isscalar(large_array_shape):
@@ -136,7 +143,9 @@ def overlap_slices(large_array_shape, small_array_shape, position, mode="partial
         # only applies with `np.round` because it uses "round to even"
         # does not apply when the small array dimension is zero
         if small_array_shape[axis] != indices_max[axis] - index:
-            indices_min[axis] = int(np.ceil(position[axis] - (small_array_shape[axis] / 2.0)))
+            indices_min[axis] = int(
+                np.ceil(position[axis] - (small_array_shape[axis] / 2.0))
+            )
             indices_max[axis] = indices_min[axis] + small_array_shape[axis]
 
     for e_max in indices_max:
@@ -184,7 +193,7 @@ def extract_array(
     mode="partial",
     fill_value=np.nan,
     return_position=False,
-    limit_rounding_method="ceil"
+    limit_rounding_method="ceil",
 ):
     """
     Extract a smaller array of the given shape and position from a
@@ -266,7 +275,11 @@ def extract_array(
         raise ValueError("Valid modes are 'partial', 'trim', and 'strict'.")
 
     large_slices, small_slices = overlap_slices(
-        array_large.shape, shape, position, mode=mode, limit_rounding_method=limit_rounding_method
+        array_large.shape,
+        shape,
+        position,
+        mode=mode,
+        limit_rounding_method=limit_rounding_method,
     )
     extracted_array = array_large[large_slices]
     if return_position:
@@ -349,7 +362,10 @@ def add_array(array_large, array_small, position, limit_rounding_method="ceil"):
         for (large_shape, small_shape) in zip(array_large.shape, array_small.shape)
     ):
         large_slices, small_slices = overlap_slices(
-            array_large.shape, array_small.shape, position, limit_rounding_method=limit_rounding_method
+            array_large.shape,
+            array_small.shape,
+            position,
+            limit_rounding_method=limit_rounding_method,
         )
         array_large[large_slices] += array_small[small_slices]
         return array_large
@@ -586,8 +602,15 @@ class Cutout2D:
     """
 
     def __init__(
-        self, data, position, size, wcs=None, mode="trim", fill_value=np.nan, copy=False,
-        limit_rounding_method="ceil"
+        self,
+        data,
+        position,
+        size,
+        wcs=None,
+        mode="trim",
+        fill_value=np.nan,
+        copy=False,
+        limit_rounding_method="ceil",
     ):
         if wcs is None:
             wcs = getattr(data, "wcs", None)
@@ -649,7 +672,7 @@ class Cutout2D:
             mode=mode,
             fill_value=fill_value,
             return_position=True,
-            limit_rounding_method=limit_rounding_method
+            limit_rounding_method=limit_rounding_method,
         )
         if copy:
             cutout_data = np.copy(cutout_data)
@@ -657,7 +680,11 @@ class Cutout2D:
 
         self.input_position_cutout = input_position_cutout[::-1]  # (x, y)
         slices_original, slices_cutout = overlap_slices(
-            data.shape, shape, pos_yx, mode=mode, limit_rounding_method=limit_rounding_method
+            data.shape,
+            shape,
+            pos_yx,
+            mode=mode,
+            limit_rounding_method=limit_rounding_method,
         )
 
         self.slices_original = slices_original

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -76,11 +76,12 @@ def overlap_slices(
         otherwise an `~astropy.nddata.utils.PartialOverlapError` is
         raised.  In all modes, non-overlapping arrays will raise a
         `~astropy.nddata.utils.NoOverlapError`.
-    limit_rounding_method : 'ceil' (default), 'floor' or 'round'
+    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
         The rounding method when calculating the minimum and maximum pixel indices.
         - ``'ceil'`` uses `~numpy.ceil`.
         - ``'floor'`` uses `~numpy.floor`.
         - ``'round'`` uses `~numpy.round`.
+        - A callable function can also be provided.
 
     Returns
     -------
@@ -117,26 +118,34 @@ def overlap_slices(
         )
 
     # get the rounding function based on limit_rounding_method
-    match limit_rounding_method:
-        case "ceil":
-            round_func = np.ceil
-        case "floor":
-            round_func = np.floor
-        case "round":
-            round_func = np.round
-        case _:
-            raise ValueError(
-                'Limit rounding method can be only "ceil", "floor", or "round".'
-            )
+    if callable(limit_rounding_method):
+        round_func = limit_rounding_method
+    else:
+        match limit_rounding_method:
+            case "ceil":
+                round_func = np.ceil
+            case "floor":
+                round_func = np.floor
+            case "round":
+                round_func = np.round
+            case _:
+                raise ValueError(
+                    'Limit rounding method can be only "ceil", "floor", or "round", or a callable function.'
+                )
 
     # define the min/max pixel indices
     # round according to the limit_rounding_method
-    indices_min = [
-        int(round_func(pos - (small_shape / 2.0)))
-        for (pos, small_shape) in zip(position, small_array_shape)
-    ]
+    try:
+        indices_min = [
+            int(round_func(pos - (small_shape / 2.0)))
+            for (pos, small_shape) in zip(position, small_array_shape)
+        ]
+    except (TypeError, ValueError):
+        raise ValueError(
+            "Limit rounding method must accept a single number as input and return a single number."
+        )
     indices_max = [
-        idx_min + small_shape
+        int(idx_min + small_shape)
         for (idx_min, small_shape) in zip(indices_min, small_array_shape)
     ]
 
@@ -227,11 +236,12 @@ def extract_array(
     return_position : bool, optional
         If `True`, return the coordinates of ``position`` in the
         coordinate system of the returned array.
-    limit_rounding_method : 'ceil' (default), 'floor' or 'round'
+    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
         The rounding method when calculating the minimum and maximum pixel indices.
         - ``'ceil'`` uses `~numpy.ceil`.
         - ``'floor'`` uses `~numpy.floor`.
         - ``'round'`` uses `~numpy.round`.
+        - A callable function can also be provided.
 
     Returns
     -------
@@ -315,11 +325,12 @@ def add_array(array_large, array_small, position, *, limit_rounding_method="ceil
     position : tuple
         Position of the small array's center, with respect to the large array.
         Coordinates should be in the same order as the array shape.
-    limit_rounding_method : 'ceil' (default), 'floor' or 'round'
+    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
         The rounding method when calculating the minimum and maximum pixel indices.
         - ``'ceil'`` uses `~numpy.ceil`.
         - ``'floor'`` uses `~numpy.floor`.
         - ``'round'`` uses `~numpy.round`.
+        - A callable function can also be provided.
 
     Returns
     -------
@@ -493,11 +504,12 @@ class Cutout2D:
         into the original ``data`` array.  If `True`, then the
         cutout data will hold a copy of the original ``data`` array.
 
-    limit_rounding_method : 'ceil' (default), 'floor' or 'round'
+    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
         The rounding method when calculating the minimum and maximum pixel indices.
         - ``'ceil'`` uses `~numpy.ceil`.
         - ``'floor'`` uses `~numpy.floor`.
         - ``'round'`` uses `~numpy.round`.
+        - A callable function can also be provided.
 
     Attributes
     ----------

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -125,10 +125,10 @@ def overlap_slices(
             int(limit_rounding_method(pos - (small_shape / 2.0)))
             for (pos, small_shape) in zip(position, small_array_shape)
         ]
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
         raise ValueError(
             "Limit rounding method must accept a single number as input and return a single number."
-        )
+        ) from exc
     indices_max = [
         int(idx_min + small_shape)
         for (idx_min, small_shape) in zip(indices_min, small_array_shape)

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -40,7 +40,7 @@ def overlap_slices(
     position,
     mode="partial",
     *,
-    limit_rounding_method="ceil",
+    limit_rounding_method=np.ceil,
 ):
     """
     Get slices for the overlapping part of a small and a large array.
@@ -76,12 +76,10 @@ def overlap_slices(
         otherwise an `~astropy.nddata.utils.PartialOverlapError` is
         raised.  In all modes, non-overlapping arrays will raise a
         `~astropy.nddata.utils.NoOverlapError`.
-    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
+    limit_rounding_method : callable
         The rounding method when calculating the minimum and maximum pixel indices.
-        - ``'ceil'`` uses `~numpy.ceil`.
-        - ``'floor'`` uses `~numpy.floor`.
-        - ``'round'`` uses `~numpy.round`.
-        - A callable function can also be provided.
+        This must be a callable function. Examples: `~numpy.ceil`, `~numpy.floor`,
+        `~numpy.round`. Default is `~numpy.ceil`.
 
     Returns
     -------
@@ -117,27 +115,14 @@ def overlap_slices(
             '"position" must have the same number of dimensions as "small_array_shape".'
         )
 
-    # get the rounding function based on limit_rounding_method
-    if callable(limit_rounding_method):
-        round_func = limit_rounding_method
-    else:
-        match limit_rounding_method:
-            case "ceil":
-                round_func = np.ceil
-            case "floor":
-                round_func = np.floor
-            case "round":
-                round_func = np.round
-            case _:
-                raise ValueError(
-                    'Limit rounding method can be only "ceil", "floor", or "round", or a callable function.'
-                )
+    if not callable(limit_rounding_method):
+        raise ValueError("Limit rounding method must be a callable function.")
 
     # define the min/max pixel indices
     # round according to the limit_rounding_method
     try:
         indices_min = [
-            int(round_func(pos - (small_shape / 2.0)))
+            int(limit_rounding_method(pos - (small_shape / 2.0)))
             for (pos, small_shape) in zip(position, small_array_shape)
         ]
     except (TypeError, ValueError):
@@ -195,7 +180,7 @@ def extract_array(
     fill_value=np.nan,
     return_position=False,
     *,
-    limit_rounding_method="ceil",
+    limit_rounding_method=np.ceil,
 ):
     """
     Extract a smaller array of the given shape and position from a
@@ -236,12 +221,10 @@ def extract_array(
     return_position : bool, optional
         If `True`, return the coordinates of ``position`` in the
         coordinate system of the returned array.
-    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
+    limit_rounding_method : callable
         The rounding method when calculating the minimum and maximum pixel indices.
-        - ``'ceil'`` uses `~numpy.ceil`.
-        - ``'floor'`` uses `~numpy.floor`.
-        - ``'round'`` uses `~numpy.round`.
-        - A callable function can also be provided.
+        This must be a callable function. Examples: `~numpy.ceil`, `~numpy.floor`,
+        `~numpy.round`. Default is `~numpy.ceil`.
 
     Returns
     -------
@@ -311,7 +294,7 @@ def extract_array(
         return extracted_array
 
 
-def add_array(array_large, array_small, position, *, limit_rounding_method="ceil"):
+def add_array(array_large, array_small, position, *, limit_rounding_method=np.ceil):
     """
     Add a smaller array at a given position in a larger array.
 
@@ -325,12 +308,10 @@ def add_array(array_large, array_small, position, *, limit_rounding_method="ceil
     position : tuple
         Position of the small array's center, with respect to the large array.
         Coordinates should be in the same order as the array shape.
-    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
+    limit_rounding_method : callable
         The rounding method when calculating the minimum and maximum pixel indices.
-        - ``'ceil'`` uses `~numpy.ceil`.
-        - ``'floor'`` uses `~numpy.floor`.
-        - ``'round'`` uses `~numpy.round`.
-        - A callable function can also be provided.
+        This must be a callable function. Examples: `~numpy.ceil`, `~numpy.floor`,
+        `~numpy.round`. Default is `~numpy.ceil`.
 
     Returns
     -------
@@ -504,12 +485,10 @@ class Cutout2D:
         into the original ``data`` array.  If `True`, then the
         cutout data will hold a copy of the original ``data`` array.
 
-    limit_rounding_method : 'ceil' (default), 'floor', 'round', or callable
+    limit_rounding_method : callable
         The rounding method when calculating the minimum and maximum pixel indices.
-        - ``'ceil'`` uses `~numpy.ceil`.
-        - ``'floor'`` uses `~numpy.floor`.
-        - ``'round'`` uses `~numpy.round`.
-        - A callable function can also be provided.
+        This must be a callable function. Examples: `~numpy.ceil`, `~numpy.floor`,
+        `~numpy.round`. Default is `~numpy.ceil`.
 
     Attributes
     ----------
@@ -613,7 +592,7 @@ class Cutout2D:
         fill_value=np.nan,
         copy=False,
         *,
-        limit_rounding_method="ceil",
+        limit_rounding_method=np.ceil,
     ):
         if wcs is None:
             wcs = getattr(data, "wcs", None)

--- a/docs/changes/nddata/17876.feature.rst
+++ b/docs/changes/nddata/17876.feature.rst
@@ -1,0 +1,1 @@
+Add the ``limit_rounding_method`` parameter to `~astropy.nddata.Cutout2D`, `~astropy.nddata.overlap_slices`, `~astropy.nddata.extract_array`, and `~astropy.nddata.add_array` to allow users to specify the rounding method used when calculating the pixel limits of the cutout. The default method is to use `~numpy.ceil`.

--- a/docs/changes/nddata/17876.feature.rst
+++ b/docs/changes/nddata/17876.feature.rst
@@ -1,1 +1,5 @@
-Add the ``limit_rounding_method`` parameter to `~astropy.nddata.Cutout2D`, `~astropy.nddata.overlap_slices`, `~astropy.nddata.extract_array`, and `~astropy.nddata.add_array` to allow users to specify the rounding method used when calculating the pixel limits of the cutout. The default method is to use `~numpy.ceil`.
+Add the ``limit_rounding_method`` parameter to `~astropy.nddata.Cutout2D`, 
+`~astropy.nddata.overlap_slices`, `~astropy.nddata.extract_array`, and 
+`~astropy.nddata.add_array` to allow users to specify the rounding method 
+used when calculating the pixel limits of the cutout. The default method 
+is to use `~numpy.ceil`.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds a parameter, `limit_rounding_method`, that allows users to specify the rounding method to use when calculating the pixel limits of a cutout array. This parameter is added to `overlap_slices`, `extract_array`, `add_array`, and `Cutout2D` in `astropy.nddata.utils.py`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17680

Close #17718

edit by @neutrinoceros : linked alternative PR #17718

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
