### PR TITLE
CLN: remove unneeded warning filter conftest.py

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -23,16 +23,6 @@ import pytest
 from astropy import __version__
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
-# This is needed to silence a warning from matplotlib caused by
-# PyInstaller's matplotlib runtime hook.  This can be removed once the
-# issue is fixed upstream in PyInstaller, and only impacts us when running
-# the tests from a PyInstaller bundle.
-# See https://github.com/astropy/astropy/issues/10785
-if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-    # The above checks whether we are running in a PyInstaller bundle.
-    warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*", category=UserWarning)
-
-
 if HAS_MATPLOTLIB:
     import matplotlib as mpl
 


### PR DESCRIPTION
### Description
Follow up to #17877
As noted by @saimn, `MATPLOTLIBDATA` was removed in matplotlib 3.3 so this clean up should be more than safe now.
see https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.3.0.html


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
