### PR TITLE
Simplify `PhysicalType`

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -356,10 +356,6 @@ class PhysicalType:
         else:
             return NotImplemented
 
-    def __ne__(self, other: object) -> bool:
-        equality = self.__eq__(other)
-        return not equality if isinstance(equality, bool) else NotImplemented
-
     def __repr__(self) -> str:
         if len(self._physical_type) == 1:
             names = "'" + self._physical_type[0] + "'"

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -360,14 +360,11 @@ class PhysicalType:
         equality = self.__eq__(other)
         return not equality if isinstance(equality, bool) else NotImplemented
 
-    def _name_string_as_ordered_set(self) -> str:
-        return "{" + str(self._physical_type)[1:-1] + "}"
-
     def __repr__(self) -> str:
         if len(self._physical_type) == 1:
             names = "'" + self._physical_type[0] + "'"
         else:
-            names = self._name_string_as_ordered_set()
+            names = "{" + str(self._physical_type)[1:-1] + "}"
         return f"PhysicalType({names})"
 
     def __str__(self) -> str:

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -338,11 +338,10 @@ class PhysicalType:
 
     def __init__(self, unit: core.UnitBase, physical_types: str | set[str]) -> None:
         self._unit = _replace_temperatures_with_kelvin(unit)
-        self._physical_type = _standardize_physical_type_names(physical_types)
-        self._physical_type_list = sorted(self._physical_type)
+        self._physical_type = sorted(_standardize_physical_type_names(physical_types))
 
     def __iter__(self) -> Iterator[str]:
-        yield from self._physical_type_list
+        yield from self._physical_type
 
     def __eq__(self, other: object) -> bool:
         """
@@ -362,17 +361,17 @@ class PhysicalType:
         return not equality if isinstance(equality, bool) else NotImplemented
 
     def _name_string_as_ordered_set(self) -> str:
-        return "{" + str(self._physical_type_list)[1:-1] + "}"
+        return "{" + str(self._physical_type)[1:-1] + "}"
 
     def __repr__(self) -> str:
         if len(self._physical_type) == 1:
-            names = "'" + self._physical_type_list[0] + "'"
+            names = "'" + self._physical_type[0] + "'"
         else:
             names = self._name_string_as_ordered_set()
         return f"PhysicalType({names})"
 
     def __str__(self) -> str:
-        return "/".join(self._physical_type_list)
+        return "/".join(self._physical_type)
 
     @staticmethod
     def _dimensionally_compatible_unit(


### PR DESCRIPTION
### Description

Currently `PhysicalType` stores two copies of its names - once as a `set` and once as a sorted `list`. But the `list` alone is good enough, so I am deleting the `set` and giving the `list` the name the `set` had because it's shorter.

`PhysicalType._name_string_as_ordered_set()` returns a `str`, but you wouldn't know that based on its name. Luckily the method is called from a single location, so instead of coming up with a better name it was even simpler to inline it.

`PhysicalType.__ne__()` is not needed because it just re-implements `object.__ne__()` that it would inherit otherwise.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
