### PR TITLE
RFC: fix `PYI019` (`custom-type-var-for-self`) for `cosmology`

### DIFF
--- a/astropy/cosmology/_src/core.py
+++ b/astropy/cosmology/_src/core.py
@@ -482,7 +482,7 @@ class FlatCosmologyMixin(metaclass=ABCMeta):
     _parameters: ClassVar[MappingProxyType[str, Parameter]]
     _parameters_derived: ClassVar[MappingProxyType[str, Parameter]]
 
-    def __init_subclass__(cls: type[_FlatCosmoT]) -> None:
+    def __init_subclass__(cls: type[Self]) -> None:
         super().__init_subclass__()
 
         # Determine the non-flat class.

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -79,7 +79,6 @@ _kB_evK = const.k_B.to(u.eV / u.K)
 
 # typing
 _FLRWT = TypeVar("_FLRWT", bound="FLRW")
-_FlatFLRWMixinT = TypeVar("_FlatFLRWMixinT", bound="FlatFLRWMixin")
 
 ##############################################################################
 
@@ -1702,7 +1701,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         self.__dict__["Ode0"] = 1.0 - (self.Om0 + self.Ogamma0 + self.Onu0 + self.Ok0)
 
     @lazyproperty
-    def nonflat(self: _FlatFLRWMixinT) -> _FLRWT:
+    def nonflat(self: Self) -> _FLRWT:
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         ba = inspect.signature(self.__nonflatclass__).bind_partial(


### PR DESCRIPTION
### Description
ref #17885
note that these fixes are manual

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
