### PR TITLE
RFC: fix `RUF046` (`unnecessary-cast-to-int`) package-wise

### DIFF
--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -372,7 +372,7 @@ class TestCompressedImage(FitsTestCase):
             assert hdul[1].header["BZERO"] == orig_bzero
             assert hdul[1].header["BSCALE"] == orig_bscale
 
-            zero_point = int(math.floor(-orig_bzero / orig_bscale))
+            zero_point = math.floor(-orig_bzero / orig_bscale)
             assert (hdul[1].data[0] == zero_point).all()
 
         with fits.open(self.temp("scale.fits")) as hdul:

--- a/astropy/io/fits/hdu/compressed/utils.py
+++ b/astropy/io/fits/hdu/compressed/utils.py
@@ -99,7 +99,7 @@ def _validate_tile_shape(*, tile_shape, compression_type, image_header):
 
 
 def _n_tiles(data_shape, tile_shape):
-    return [int(ceil(d / t)) for d, t in zip(data_shape, tile_shape)]
+    return [ceil(d / t) for d, t in zip(data_shape, tile_shape)]
 
 
 def _iter_array_tiles(

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1007,7 +1007,7 @@ class TestImageFunctions(FitsTestCase):
             assert hdul[0].header["BZERO"] == orig_bzero
             assert hdul[0].header["BSCALE"] == orig_bscale
 
-            zero_point = int(math.floor(-orig_bzero / orig_bscale))
+            zero_point = math.floor(-orig_bzero / orig_bscale)
             assert (hdul[0].data[0] == zero_point).all()
 
         with fits.open(self.temp("scale.fits")) as hdul:

--- a/astropy/io/votable/validator/html.py
+++ b/astropy/io/votable/validator/html.py
@@ -243,7 +243,7 @@ def write_table(basename, name, results, root="results", chunk_size=500):
             if j < npages - 1:
                 w.element("a", ">>", href=f"{basename}_{j + 1:02d}.html")
 
-    npages = int(ceil(float(len(results)) / chunk_size))
+    npages = ceil(float(len(results)) / chunk_size)
 
     for i, j in enumerate(range(0, max(len(results), 1), chunk_size)):
         subresults = results[j : j + chunk_size]

--- a/astropy/modeling/_fitting_parallel.py
+++ b/astropy/modeling/_fitting_parallel.py
@@ -191,7 +191,7 @@ def _fit_models_to_chunk(
             index_abs = np.array(index) + np.array(
                 [block_info[0]["array-location"][idx][0] for idx in iterating_axes]
             )
-            maxlen = int(ceil(log10(max(iterating_shape))))
+            maxlen = ceil(log10(max(iterating_shape)))
             fmt = "{0:0" + str(maxlen) + "d}"
             index_folder = Path(diagnostics_path).joinpath(
                 "_".join(fmt.format(idx) for idx in index_abs)

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -362,7 +362,7 @@ def human_file_size(size):
     if size == 0:
         num_scale = 0
     else:
-        num_scale = int(math.floor(math.log(size) / math.log(1000)))
+        num_scale = math.floor(math.log(size) / math.log(1000))
     if num_scale > 7:
         suffix = "?"
     else:


### PR DESCRIPTION
### Description
ref #17885
note that these fixes were automated with `--fix --unsafe-fixes`

quoting from [the docs](https://docs.astral.sh/ruff/rules/unnecessary-cast-to-int/#fix-safety), this is the reason why the fix is marked as unsafe:

> The fix for round, math.ceil, math.floor, and math.truncate is unsafe because removing the int conversion can change the semantics for values overriding the __round__, __ceil__, __floor__, or __trunc__ dunder methods such that they don't return an integer.

I don't believe this impacts the affected code at all, so the refactir should actually  be safe.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
