### PR TITLE
RFC: fix new lint violations in `units`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1334,7 +1334,7 @@ class UnitBase:
                 if is_final_result(factored):
                     subresults.add(factored)
 
-            if len(subresults):
+            if subresults:
                 cached_results[unit] = subresults
                 return subresults
 
@@ -2550,7 +2550,7 @@ def _add_prefixes(
             for alias in u.long_names:
                 names.append(prefix + alias)
 
-        if len(names):
+        if names:
             PrefixUnit(
                 names,
                 CompositeUnit(factor, [u], [1], _error_check=False),

--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -516,11 +516,34 @@ class TestAp:
         cls.refb = (-2.36140831e-7 * u.rad).to(u.uas)
         cls.apco13_args = [
             getattr(cls, name)
-            for name in "utc1 utc2 dut1 elong phi hm xp yp phpa tc rh wl".split()
+            for name in [
+                "utc1",
+                "utc2",
+                "dut1",
+                "elong",
+                "phi",
+                "hm",
+                "xp",
+                "yp",
+                "phpa",
+                "tc",
+                "rh",
+                "wl",
+            ]
         ]
         cls.apio_args = [
             getattr(cls, name)
-            for name in "sp theta elong phi hm xp yp refa refb".split()
+            for name in [
+                "sp",
+                "theta",
+                "elong",
+                "phi",
+                "hm",
+                "xp",
+                "yp",
+                "refa",
+                "refb",
+            ]
         ]
 
     def test_apco13(self):


### PR DESCRIPTION
### Description
ref #17885
note that these fixes are automated

new rules are:
- [`PLC1802`](https://docs.astral.sh/ruff/rules/len-test/)
- [`SIM905`](https://docs.astral.sh/ruff/rules/split-static-string/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
