### PR TITLE
RFC: fix new lint violations in `coordinates`

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -963,9 +963,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         from .cartesian import CartesianDifferential, CartesianRepresentation
 
         # route transformation through Cartesian
-        difs_cls = {k: CartesianDifferential for k in self.differentials.keys()}
         crep = self.represent_as(
-            CartesianRepresentation, differential_class=difs_cls
+            CartesianRepresentation,
+            differential_class=dict.fromkeys(self.differentials, CartesianDifferential),
         ).transform(matrix)
 
         # move back to original representation

--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -289,7 +289,7 @@ class TransformGraph:
         nodes = {}
         for node, node_graph in self._graph.items():
             nodes[node] = None
-            nodes |= {node: None for node in node_graph}
+            nodes |= dict.fromkeys(node_graph)
 
         if fromsys not in nodes or tosys not in nodes:
             # fromsys or tosys are isolated or not registered, so there's
@@ -475,8 +475,8 @@ class TransformGraph:
         nodes = {}
         for node, node_graph in self._graph.items():
             nodes[node] = None
-            nodes |= {node: None for node in node_graph}
-        nodes |= {node: None for node in addnodes}
+            nodes |= dict.fromkeys(node_graph)
+        nodes |= dict.fromkeys(addnodes)
         nodenames = []
         invclsaliases = {
             f: [k for k, v in self._cached_names.items() if v == f]


### PR DESCRIPTION
### Description
ref #17885
note that these fixes are automated

new rules are:
- [`C420`](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/)
- [`SIM905`](https://docs.astral.sh/ruff/rules/split-static-string/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
