### PR TITLE
RFC: fix new lint violations in `table`

### DIFF
--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -202,9 +202,9 @@ def serialize_method_as(tbl, serialize_method):
                     # is not actually known (this gets determined by the write function
                     # in registry.py).  Note this creates a new temporary dict object
                     # so that the restored version is the same original object.
-                    col.info.serialize_method = {
-                        fmt: override_sm for fmt in col.info.serialize_method
-                    }
+                    col.info.serialize_method = dict.fromkeys(
+                        col.info.serialize_method, override_sm
+                    )
 
     # Finally yield for the context block
     try:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3914,7 +3914,7 @@ class Table:
                 # other = {'a': 2, 'b': 2} and then equality does a
                 # column-by-column broadcasting.
                 names = self.colnames
-                other = {name: other for name in names}
+                other = dict.fromkeys(names, other)
 
         # Require column names match but do not require same column order
         if set(self.colnames) != set(names):

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -54,7 +54,7 @@ def test_table_info_attributes(table_types):
     t["f"].info.description = "skycoord"
 
     tinfo = t.info(out=None)
-    assert np.all(tinfo["name"] == "a b c d e f".split())
+    assert np.all(tinfo["name"] == ["a", "b", "c", "d", "e", "f"])
     assert np.all(
         tinfo["dtype"]
         == ["int32", "float32", dtype_info_name("S1"), "float64", "object", "object"]


### PR DESCRIPTION
### Description

ref #17885
note that these fixes are automated

new rules are:
- [`C420`](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/)
- [`SIM905`](https://docs.astral.sh/ruff/rules/split-static-string/)


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
