### PR TITLE
RFC: fix new lint violations in `io.ascii`

### DIFF
--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -80,7 +80,7 @@ def sortmore(*args, **kw):
                  [2, 4, 0, 5, 7, 1, 3, 8, 9, 6])
     """
     first = list(args[0])
-    if not len(first):
+    if not first:
         return args
 
     globalkey = kw.get("globalkey")

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -950,13 +950,35 @@ def test_full_subtypes():
     f_double columns.
     """
     t = Table.read(os.path.join(TEST_DIR, "data", "subtypes.ecsv"))
-    colnames = (
-        "i_index,"
-        "s_byte,s_short,s_int,s_long,s_float,s_double,s_string,s_boolean,"
-        "f_byte,f_short,f_int,f_long,f_float,f_double,f_string,f_boolean,"
-        "v_byte,v_short,v_int,v_long,v_float,v_double,v_string,v_boolean,"
-        "m_int,m_double"
-    ).split(",")
+    colnames = [
+        "i_index",
+        "s_byte",
+        "s_short",
+        "s_int",
+        "s_long",
+        "s_float",
+        "s_double",
+        "s_string",
+        "s_boolean",
+        "f_byte",
+        "f_short",
+        "f_int",
+        "f_long",
+        "f_float",
+        "f_double",
+        "f_string",
+        "f_boolean",
+        "v_byte",
+        "v_short",
+        "v_int",
+        "v_long",
+        "v_float",
+        "v_double",
+        "v_string",
+        "v_boolean",
+        "m_int",
+        "m_double",
+    ]
     assert t.colnames == colnames
 
     type_map = {


### PR DESCRIPTION
### Description
ref #17885
note that these fixes are automated

new rules are:
- [`PLC1802`](https://docs.astral.sh/ruff/rules/len-test/)
- [`SIM905`](https://docs.astral.sh/ruff/rules/split-static-string/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
