### PR TITLE
RFC: fix new lint violations in `modeling`

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -185,8 +185,7 @@ class _ModelMeta(abc.ABCMeta):
 
         # Delete custom __init__ and __call__ if they exist:
         for key in ("__init__", "__call__"):
-            if key in members:
-                del members[key]
+            members.pop(key, None)
 
         return (type(cls), (cls.__name__, cls.__bases__, members))
 
@@ -827,14 +826,14 @@ class Model(metaclass=_ModelMeta):
         mapping input name to a boolean value.
         """
         if isinstance(self._input_units_strict, bool):
-            self._input_units_strict = {
-                key: self._input_units_strict for key in self.inputs
-            }
+            self._input_units_strict = dict.fromkeys(
+                self.inputs, self._input_units_strict
+            )
 
         if isinstance(self._input_units_allow_dimensionless, bool):
-            self._input_units_allow_dimensionless = {
-                key: self._input_units_allow_dimensionless for key in self.inputs
-            }
+            self._input_units_allow_dimensionless = dict.fromkeys(
+                self.inputs, self._input_units_allow_dimensionless
+            )
 
     @property
     def input_units_strict(self):
@@ -847,7 +846,7 @@ class Model(metaclass=_ModelMeta):
         """
         val = self._input_units_strict
         if isinstance(val, bool):
-            return {key: val for key in self.inputs}
+            return dict.fromkeys(self.inputs, val)
         return dict(zip(self.inputs, val.values()))
 
     @property
@@ -861,7 +860,7 @@ class Model(metaclass=_ModelMeta):
         """
         val = self._input_units_allow_dimensionless
         if isinstance(val, bool):
-            return {key: val for key in self.inputs}
+            return dict.fromkeys(self.inputs, val)
         return dict(zip(self.inputs, val.values()))
 
     @property

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -63,8 +63,8 @@ class Mapping(FittableModel):
         self.outputs = tuple("x" + str(idx) for idx in range(self._n_outputs))
 
         self._mapping = mapping
-        self._input_units_strict = {key: False for key in self._inputs}
-        self._input_units_allow_dimensionless = {key: False for key in self._inputs}
+        self._input_units_strict = dict.fromkeys(self._inputs, False)
+        self._input_units_allow_dimensionless = dict.fromkeys(self._inputs, False)
 
     @property
     def n_inputs(self):

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -172,7 +172,7 @@ class _Tabular(Model):
         pts = self.points[0]
         if not isinstance(pts, u.Quantity):
             return None
-        return {x: pts.unit for x in self.inputs}
+        return dict.fromkeys(self.inputs, pts.unit)
 
     @property
     def return_units(self):


### PR DESCRIPTION
### Description
ref https://github.com/astropy/astropy/issues/17885
note that these fixes are automated

new rules are:
- [`C420`](https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/)
- [`RUF051`](https://docs.astral.sh/ruff/rules/if-key-in-dict-del/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
