### PR TITLE
MNT: avoid a `blanket-noqa` (`PGH004`) in `io.ascii`

### DIFF
--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """An extensible ASCII table reader and writer."""
-# flake8: noqa
 
 from . import connect
 from .basic import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,6 +399,7 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 [tool.ruff.lint.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
 ".github/workflows/*.py" = ["INP001"]
+"astropy/io/ascii/__init__.py" = ["I001"]  # unsorted-imports
 "astropy/modeling/models/__init__.py" = ["F405"]
 "astropy/utils/decorators.py" = [
     "D214", "D215",  # keep Examples section indented.


### PR DESCRIPTION
### Description
ref #17885
fixes our only violation of the one rule that got stabilized in ruff 0.11: [`PGH004`](https://docs.astral.sh/ruff/rules/blanket-noqa/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
