### PR TITLE
MNT: ignore undesired `PYI019` flags on mixin cosmology class

### DIFF
--- a/astropy/cosmology/_src/core.py
+++ b/astropy/cosmology/_src/core.py
@@ -482,7 +482,7 @@ class FlatCosmologyMixin(metaclass=ABCMeta):
     _parameters: ClassVar[MappingProxyType[str, Parameter]]
     _parameters_derived: ClassVar[MappingProxyType[str, Parameter]]
 
-    def __init_subclass__(cls: type[_FlatCosmoT]) -> None:
+    def __init_subclass__(cls: type[_FlatCosmoT]) -> None:  # noqa: PYI019, RUF100
         super().__init_subclass__()
 
         # Determine the non-flat class.

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -1702,7 +1702,7 @@ class FlatFLRWMixin(FlatCosmologyMixin):
         self.__dict__["Ode0"] = 1.0 - (self.Om0 + self.Ogamma0 + self.Onu0 + self.Ok0)
 
     @lazyproperty
-    def nonflat(self: _FlatFLRWMixinT) -> _FLRWT:
+    def nonflat(self: _FlatFLRWMixinT) -> _FLRWT:  # noqa: PYI019, RUF100
         # Create BoundArgument to handle args versus kwargs.
         # This also handles all errors from mismatched arguments
         ba = inspect.signature(self.__nonflatclass__).bind_partial(


### PR DESCRIPTION
### Description
Following #17887
ref #17885
close #17887

cc @nstarman

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
