### PR TITLE
DEP: add missing lower bound to `array-api-strict` test requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ test_all = [
     "objgraph>=1.6.0",
     "skyfield>=1.20",
     "sgp4>=2.3",
-    "array-api-strict",
+    "array-api-strict>=1.0",
 ]
 typing = [
     "pandas-stubs>=2.0",


### PR DESCRIPTION
### Description
Effectively, using the first-ever version as the lower bound doesn't change how resolvers treat this dependency, but it's still good to have as it eliminates a source of uncertainty when inspecting broken CI jobs as the one we're currently see on #17900


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
