### PR TITLE
fix ruff rule B007 violation in astropy/table

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -253,7 +253,6 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/table/*" = [
-    "B007",  # UnusedLoopControlVariable
     "S605",  # Starting a process with a shell, possible injection detected
     "TRY300",  # Consider `else` block
 ]

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -1275,7 +1275,7 @@ def _join(
 
     out = _get_out_class([left, right])()
 
-    for out_name, _, _ in out_descrs:
+    for out_name, _dtype, _shape in out_descrs:
         if out_name == cartesian_index_name:
             continue
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -1275,7 +1275,7 @@ def _join(
 
     out = _get_out_class([left, right])()
 
-    for out_name, dtype, shape in out_descrs:
+    for out_name, _, _ in out_descrs:
         if out_name == cartesian_index_name:
             continue
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -378,7 +378,7 @@ def test_join(table_types):
     t2 = table_types.Table(t1)
     t2["a"] = ["b", "c", "a", "d"]
 
-    for name, col in MIXIN_COLS.items():
+    for name, _ in MIXIN_COLS.items():
         t1[name].info.description = name
         t2[name].info.description = name + "2"
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -378,7 +378,7 @@ def test_join(table_types):
     t2 = table_types.Table(t1)
     t2["a"] = ["b", "c", "a", "d"]
 
-    for name, _ in MIXIN_COLS.items():
+    for name in MIXIN_COLS:
         t1[name].info.description = name
         t2[name].info.description = name + "2"
 

--- a/astropy/table/tests/test_np_utils.py
+++ b/astropy/table/tests/test_np_utils.py
@@ -20,8 +20,8 @@ def test_common_dtype():
     arr = np.empty(1, dtype=dtype)
     fail = set()
     succeed = set()
-    for name1, type1 in dtype:
-        for name2, type2 in dtype:
+    for name1, _ in dtype:
+        for name2, _ in dtype:
             try:
                 np_utils.common_dtype([arr[name1], arr[name2]])
                 succeed.add(f"{name1} {name2}")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address to split pull request #17844  , and it ensure compliance of astropy/table Ruff rule [unused-loop-control-variable (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes partially  #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
