### PR TITLE
fix ruff rule B007 violation in astropy/tests

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -258,7 +258,6 @@ lint.unfixable = [
     "TRY300",  # Consider `else` block
 ]
 "astropy/tests/*" = [
-    "B007",  # UnusedLoopControlVariable
     "PTH",      # all flake8-use-pathlib
 ]
 "astropy/time/*" = [

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -27,7 +27,7 @@ def test_imports():
         except Warning:
             pass
 
-    for imper, nm, ispkg in pkgutil.walk_packages(
+    for imper, nm, _ in pkgutil.walk_packages(
         ["astropy"], "astropy.", onerror=onerror
     ):
         imper.find_spec(nm)

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -27,7 +27,7 @@ def test_imports():
         except Warning:
             pass
 
-    for imper, nm, _ in pkgutil.walk_packages(
+    for imper, nm, _ispkg in pkgutil.walk_packages(
         ["astropy"], "astropy.", onerror=onerror
     ):
         imper.find_spec(nm)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address to split pull request #17844  , and it ensure compliance of astropy/tests Ruff rule [unused-loop-control-variable (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes partially  #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
