### PR TITLE
fix Ruff rule B007 violation in astropy/utils

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -270,7 +270,6 @@ lint.unfixable = [
     "PLR0911",  # too-many-return-statements
 ]
 "astropy/units/*" = [
-    "B007",  # UnusedLoopControlVariable
     "N812",  # lowercase-imported-as-non-lowercase
     "PLR0911",  # too-many-return-statements
     "TRY300",  # Consider `else` block

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -54,7 +54,7 @@ def _initialize_module():
     prefixes = []
     # The CDS format also supports power-of-2 prefixes as defined here:
     # http://physics.nist.gov/cuu/Units/binary.html
-    for short, long, factor in core.si_prefixes + core.binary_prefixes:
+    for short, _, factor in core.si_prefixes + core.binary_prefixes:
         short = [s for s in short if s.isascii()]
         prefixes.append((short, short, factor))  # CDS only uses the short prefixes
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1000,7 +1000,7 @@ class UnitBase:
         elif len(equivalencies):
             unit = self.decompose()
             other = other.decompose()
-            for a, b, forward, backward in equivalencies:
+            for a, b, _, _ in equivalencies:
                 if b is None:
                     # after canceling, is what's left convertible
                     # to dimensionless (according to the equivalency)?
@@ -1119,7 +1119,7 @@ class UnitBase:
             # We assume the equivalencies have the unit itself as first item.
             # TODO: maybe better for other to have a `_back_converter` method?
             if hasattr(other, "equivalencies"):
-                for funit, tunit, a, b in other.equivalencies:
+                for funit, tunit, _, b in other.equivalencies:
                     if other is funit:
                         try:
                             converter = self.get_converter(tunit, equivalencies)
@@ -1307,7 +1307,7 @@ class UnitBase:
 
         # ...we have to recurse and try to further compose
         results = []
-        for len_bases, composed, tunit in partial_results:
+        for _, composed, tunit in partial_results:
             try:
                 composed_list = composed._compose(
                     equivalencies=equivalencies,
@@ -1406,7 +1406,7 @@ class UnitBase:
         def has_bases_in_common_with_equiv(unit: UnitBase, other: UnitBase) -> bool:
             if has_bases_in_common(unit, other):
                 return True
-            for funit, tunit, a, b in equivalencies:
+            for funit, tunit, _, _ in equivalencies:
                 if tunit is not None:
                     if unit._is_equivalent(funit):
                         if has_bases_in_common(tunit.decompose(), other):
@@ -1577,7 +1577,7 @@ class UnitBase:
         """
         unit_registry = get_current_unit_registry()
         units = set(unit_registry.get_units_with_physical_type(self))
-        for funit, tunit, a, b in equivalencies:
+        for funit, tunit, _, _ in equivalencies:
             if tunit is not None:
                 if self.is_equivalent(funit) and tunit not in units:
                     units.update(unit_registry.get_units_with_physical_type(tunit))

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -165,7 +165,7 @@ class VOUnit(Base, _GenericParserMixin):
         if unit in cls._custom_units:
             return cls._custom_units[unit]
 
-        for short, full, factor in si_prefixes:
+        for short, _, factor in si_prefixes:
             for prefix in short:
                 if unit.startswith(prefix):
                     base_name = unit[len(prefix) :]

--- a/astropy/units/tests/test_aliases.py
+++ b/astropy/units/tests/test_aliases.py
@@ -48,7 +48,7 @@ class TestAliases:
             u.Unit(bad)
 
     def test_set_enabled_aliases(self):
-        for i, (aliases, bad, unit) in enumerate(trials):
+        for aliases, bad, unit in trials:
             u.set_enabled_aliases(aliases)
 
             assert u.get_current_unit_registry().aliases == aliases

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -155,7 +155,7 @@ class TestUfuncHelpers:
 
         workers = 8
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-            for p in range(10000):
+            for _ in range(10000):
                 helpers = UfuncHelpers()
                 helpers.register_module(
                     "astropy.units.tests.test_quantity_ufuncs",

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -851,7 +851,7 @@ class Spinner:
             flush()
             yield
 
-            for i in range(self._step):
+            for _ in range(self._step):
                 yield
 
             index = (index + 1) % len(chars)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1630,7 +1630,7 @@ def cache_total_size(pkgname="astropy"):
     """Return the total size in bytes of all files in the cache."""
     size = 0
     dldir = _get_download_cache_loc(pkgname=pkgname)
-    for root, dirs, files in os.walk(dldir):
+    for root, _, files in os.walk(dldir):
         size += sum(os.path.getsize(os.path.join(root, name)) for name in files)
     return size
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -153,7 +153,7 @@ def data_info_factory(names, funcs):
 
     def func(dat):
         outs = []
-        for name, func in zip(names, funcs):
+        for func in  funcs:
             try:
                 if isinstance(func, str):
                     out = getattr(dat, func)()

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -153,7 +153,7 @@ def data_info_factory(names, funcs):
 
     def func(dat):
         outs = []
-        for func in  funcs:
+        for func in funcs:
             try:
                 if isinstance(func, str):
                     out = getattr(dat, func)()

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -228,7 +228,7 @@ def find_current_module(
 
     """
     frm = inspect.currentframe()
-    for i in range(depth):
+    for _ in range(depth):
         frm = frm.f_back
         if frm is None:
             return None

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -122,12 +122,12 @@ def test_spinner_non_unicode_console():
 def test_progress_bar():
     # This stuff is hard to test, at least smoke test it
     with console.ProgressBar(50) as bar:
-        for i in range(50):
+        for _ in range(50):
             bar.update()
 
 
 def test_progress_bar2():
-    for x in console.ProgressBar(range(50)):
+    for _ in console.ProgressBar(range(50)):
         pass
 
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -142,7 +142,7 @@ def change_tree_permission(d, writable=False):
     else:
         dirperm = stat.S_IRUSR | stat.S_IXUSR
         fileperm = stat.S_IRUSR
-    for dirpath, dirnames, filenames in os.walk(d):
+    for dirpath, _, filenames in os.walk(d):
         os.chmod(dirpath, dirperm)
         for f in filenames:
             os.chmod(os.path.join(dirpath, f), fileperm)
@@ -172,7 +172,7 @@ def readonly_cache(tmp_path, valid_urls):
         # to make into the cache
         d = pathlib.Path(d)
         with paths.set_temp_cache(d):
-            us = {u for u, c in islice(valid_urls, FEW)}
+            us = {u for u, _ in islice(valid_urls, FEW)}
             urls = {u: download_file(u, cache=True) for u in us}
             files = set(d.iterdir())
             with readonly_dir(d):
@@ -199,7 +199,7 @@ def fake_readonly_cache(tmp_path, valid_urls, monkeypatch):
         # to make into the cache
         d = pathlib.Path(d)
         with paths.set_temp_cache(d):
-            us = {u for u, c in islice(valid_urls, FEW)}
+            us = {u for u, _ in islice(valid_urls, FEW)}
             urls = {u: download_file(u, cache=True) for u in us}
             files = set(d.iterdir())
             monkeypatch.setattr(os, "mkdir", no_mkdir)
@@ -392,7 +392,7 @@ def test_download_file_threaded_many(temp_cache, valid_urls):
         r = list(P.map(lambda u: download_file(u, cache=True), [u for (u, c) in urls]))
     check_download_cache()
     assert len(r) == len(urls)
-    for r_, (u, c) in zip(r, urls):
+    for r_, (_, c) in zip(r, urls):
         assert get_file_contents(r_) == c
 
 
@@ -725,7 +725,7 @@ def test_download_parallel_fills_cache(tmp_path, valid_urls, method):
         assert len(rs) == len(urls)
         url_set = {u for (u, c) in urls}
         assert url_set <= set(get_cached_urls())
-        for r, (u, c) in zip(rs, urls):
+        for r, (_, c) in zip(rs, urls):
             assert get_file_contents(r) == c
         check_download_cache()
     assert not url_set.intersection(get_cached_urls())
@@ -744,7 +744,7 @@ def test_download_parallel_with_empty_sources(valid_urls, temp_cache):
     # u = set(u for (u, c) in urls)
     # assert u <= set(get_cached_urls())
     check_download_cache()
-    for r, (u, c) in zip(rs, urls):
+    for r, (_, c) in zip(rs, urls):
         assert get_file_contents(r) == c
 
 
@@ -765,7 +765,7 @@ def test_download_parallel_with_sources_and_bogus_original(
     assert len(rs) == len(urls)
     # u = set(u for (u, c, c_bad) in urls)
     # assert u <= set(get_cached_urls())
-    for r, (u, c, c_bad) in zip(rs, urls):
+    for r, (_, c, c_bad) in zip(rs, urls):
         assert get_file_contents(r) == c
         assert get_file_contents(r) != c_bad
 
@@ -841,7 +841,7 @@ def test_download_parallel_update(temp_cache, tmp_path):
 
     r1 = download_files_in_parallel([u for (fn, u, c) in td])
     assert len(r1) == len(td)
-    for r_1, (fn, u, c) in zip(r1, td):
+    for r_1, (_, _, c) in zip(r1, td):
         assert get_file_contents(r_1) == c
 
     td2 = []
@@ -854,13 +854,13 @@ def test_download_parallel_update(temp_cache, tmp_path):
 
     r2 = download_files_in_parallel([u for (fn, u, c) in td], cache=True)
     assert len(r2) == len(td)
-    for r_2, (fn, u, c, c_plus) in zip(r2, td2):
+    for r_2, (_, _, c, c_plus) in zip(r2, td2):
         assert get_file_contents(r_2) == c
         assert c != c_plus
     r3 = download_files_in_parallel([u for (fn, u, c) in td], cache="update")
 
     assert len(r3) == len(td)
-    for r_3, (fn, u, c, c_plus) in zip(r3, td2):
+    for r_3, (_, _, c, c_plus) in zip(r3, td2):
         assert get_file_contents(r_3) != c
         assert get_file_contents(r_3) == c_plus
 
@@ -1360,7 +1360,7 @@ def test_import_one(tmp_path, temp_cache, valid_urls):
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_import_roundtrip(tmp_path, temp_cache, valid_urls):
     zip_file_name = tmp_path / "the.zip"
-    for u, c in islice(valid_urls, FEW):
+    for u, _ in islice(valid_urls, FEW):
         download_file(u, cache=True)
 
     initial_urls_in_cache = set(get_cached_urls())
@@ -1374,7 +1374,7 @@ def test_export_import_roundtrip(tmp_path, temp_cache, valid_urls):
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_export_import_roundtrip_stream(temp_cache, valid_urls):
-    for u, c in islice(valid_urls, FEW):
+    for u, _ in islice(valid_urls, FEW):
         download_file(u, cache=True)
     initial_urls_in_cache = set(get_cached_urls())
 
@@ -1414,7 +1414,7 @@ def test_export_import_roundtrip_different_location(tmp_path, valid_urls):
     urls = list(islice(valid_urls, FEW))
     initial_urls_in_cache = {u for (u, c) in urls}
     with paths.set_temp_cache(original_cache):
-        for u, c in urls:
+        for u, _ in urls:
             download_file(u, cache=True)
         assert set(get_cached_urls()) == initial_urls_in_cache
         export_download_cache(zip_file_name)
@@ -1455,7 +1455,7 @@ def test_cache_contents_agrees_with_get_urls(temp_cache, valid_urls):
         a_f = download_file(a, cache=True)
         r.append((a, a_c, a_f))
     assert set(cache_contents().keys()) == set(get_cached_urls())
-    for u, c, h in r:
+    for u, _, h in r:
         assert cache_contents()[u] == h
 
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -623,7 +623,7 @@ def test_classproperty_lazy_threadsafe(fast_thread_switching):
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
         # This is testing for race conditions, so try many times in the
         # hope that we'll get the timing right.
-        for p in range(10000):
+        for _ in range(10000):
 
             class A:
                 @classproperty(lazy=True)
@@ -661,7 +661,7 @@ def test_lazyproperty_threadsafe(fast_thread_switching):
 
     workers = 8
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        for p in range(10000):
+        for _ in range(10000):
             a = A()
             futures = [executor.submit(lambda: a.foo) for i in range(workers)]
             values = [future.result() for future in futures]

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -58,7 +58,7 @@ def test_is_path_hidden_deprecation():
 # This is the only test that uses astropy/utils/tests/data/.hidden_file.txt
 def test_skip_hidden():
     path = data.get_pkg_data_path("data")
-    for root, dirs, files in os.walk(path):
+    for _, _, files in os.walk(path):
         assert ".hidden_file.txt" in files
         assert "local.dat" in files
         # break after the first level since the data dir contains some other
@@ -67,7 +67,7 @@ def test_skip_hidden():
     with pytest.warns(
         AstropyDeprecationWarning, match="^The .*_hidden function is deprecated"
     ):
-        for root, dirs, files in misc.walk_skip_hidden(path):
+        for _, _, files in misc.walk_skip_hidden(path):
             assert ".hidden_file.txt" not in files
             assert "local.dat" in files
             break


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address to split pull request #17844  , and it ensure compliance of astropy/tests Ruff rule [unused-loop-control-variable (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes partially #14818 


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
