### PR TITLE
fix ruff rule B007 violation in astropy/time

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -260,7 +260,6 @@ lint.unfixable = [
     "PTH",      # all flake8-use-pathlib
 ]
 "astropy/time/*" = [
-    "B007",  # UnusedLoopControlVariable
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
 ]

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -547,11 +547,11 @@ class TimeNumeric(TimeFormat):
             val1.dtype if orig_val2_is_none else np.result_type(val1.dtype, val2.dtype)
         )
         subfmts = self._select_subfmts(self.in_subfmt)
-        for _subfmt, dtype, convert, _ in subfmts:
-            if np.issubdtype(val_dtype, dtype):
-                if convert is not None:
+        for subfmt in subfmts:
+            if np.issubdtype(val_dtype, subfmt[1]):
+                if subfmt[2] is not None:
                     try:
-                        val1, val2 = convert(val1, val2)
+                        val1, val2 = subfmt[2](val1, val2)
                     except Exception:
                         raise TypeError(
                             f"for {self.name} class, input should be (long) doubles, string, "
@@ -562,7 +562,6 @@ class TimeNumeric(TimeFormat):
                 break
         else:
             raise ValueError("input type not among selected sub-formats.")
-
 
         return val1, val2
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -547,21 +547,22 @@ class TimeNumeric(TimeFormat):
             val1.dtype if orig_val2_is_none else np.result_type(val1.dtype, val2.dtype)
         )
         subfmts = self._select_subfmts(self.in_subfmt)
-        for subfmt, dtype, convert, _ in subfmts:
+        for _subfmt, dtype, convert, _ in subfmts:
             if np.issubdtype(val_dtype, dtype):
+                if convert is not None:
+                    try:
+                        val1, val2 = convert(val1, val2)
+                    except Exception:
+                        raise TypeError(
+                            f"for {self.name} class, input should be (long) doubles, string, "
+                            "or Decimal, and second values are only allowed for "
+                            "(long) doubles."
+                        )
+
                 break
         else:
             raise ValueError("input type not among selected sub-formats.")
 
-        if convert is not None:
-            try:
-                val1, val2 = convert(val1, val2)
-            except Exception:
-                raise TypeError(
-                    f"for {self.name} class, input should be (long) doubles, string, "
-                    "or Decimal, and second values are only allowed for "
-                    "(long) doubles."
-                )
 
         return val1, val2
 

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -23,12 +23,7 @@ class TestTimeComparisons:
         operators should raise a TypeError.
         """
         t1 = Time("J2000", scale="utc")
-        for op in (
-            (operator.ge),
-            (operator.gt),
-            (operator.le),
-            (operator.lt),
-        ):
+        for op in (operator.ge, operator.gt, operator.le, operator.lt):
             with pytest.raises(TypeError):
                 op(t1, None)
         # Keep == and != as they are specifically meant to test Time.__eq__

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -23,11 +23,11 @@ class TestTimeComparisons:
         operators should raise a TypeError.
         """
         t1 = Time("J2000", scale="utc")
-        for op, _op_str in (
-            (operator.ge, ">="),
-            (operator.gt, ">"),
-            (operator.le, "<="),
-            (operator.lt, "<"),
+        for op in (
+            (operator.ge),
+            (operator.gt),
+            (operator.le),
+            (operator.lt),
         ):
             with pytest.raises(TypeError):
                 op(t1, None)

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -23,7 +23,7 @@ class TestTimeComparisons:
         operators should raise a TypeError.
         """
         t1 = Time("J2000", scale="utc")
-        for op, op_str in (
+        for op, _op_str in (
             (operator.ge, ">="),
             (operator.gt, ">"),
             (operator.le, "<="),


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

 This pull request is to address to split pull request #17844  , and it ensure compliance of astropy/time Ruff rule [unused-loop-control-variable (B007)](https://docs.astral.sh/ruff/rules/unused-loop-control-variable/)


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes partially  #14818 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
