### PR TITLE
auto fix C420 and SIM905 in astropy/coordinates

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -963,7 +963,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
         from .cartesian import CartesianDifferential, CartesianRepresentation
 
         # route transformation through Cartesian
-        difs_cls = {k: CartesianDifferential for k in self.differentials.keys()}
+        difs_cls = dict.fromkeys(self.differentials.keys(), CartesianDifferential)
         crep = self.represent_as(
             CartesianRepresentation, differential_class=difs_cls
         ).transform(matrix)

--- a/astropy/coordinates/tests/test_polarization.py
+++ b/astropy/coordinates/tests/test_polarization.py
@@ -36,7 +36,7 @@ def test_vector_list_init():
 
 def test_undefined():
     sk = StokesCoord(np.arange(-10, 7))
-    assert_equal(sk.symbol, "? ? YX XY YY XX LR RL LL RR ? I Q U V ? ?".split())
+    assert_equal(sk.symbol, ["?", "?", "YX", "XY", "YY", "XX", "LR", "RL", "LL", "RR", "?", "I", "Q", "U", "V", "?", "?"])
 
 
 def test_undefined_init():

--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -289,7 +289,7 @@ class TransformGraph:
         nodes = {}
         for node, node_graph in self._graph.items():
             nodes[node] = None
-            nodes |= {node: None for node in node_graph}
+            nodes |= dict.fromkeys(node_graph)
 
         if fromsys not in nodes or tosys not in nodes:
             # fromsys or tosys are isolated or not registered, so there's
@@ -475,8 +475,8 @@ class TransformGraph:
         nodes = {}
         for node, node_graph in self._graph.items():
             nodes[node] = None
-            nodes |= {node: None for node in node_graph}
-        nodes |= {node: None for node in addnodes}
+            nodes |= dict.fromkeys(node_graph)
+        nodes |= dict.fromkeys(addnodes)
         nodenames = []
         invclsaliases = {
             f: [k for k, v in self._cached_names.items() if v == f]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

this is auto fix

This PR ensures compliance of astropy/coordinates to Ruff rule [C420] (https://docs.astral.sh/ruff/rules/unnecessary-dict-comprehension-for-iterable/) and [SIM905](https://docs.astral.sh/ruff/rules/split-static-string/)

Fixes partially #14818 
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
