### PR TITLE
TYP: set up typechecking for `units` with `basedpyright`

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -103,6 +103,15 @@ jobs:
             ARCH_ON_CI: "arm64"
             IS_CRON: "false"
 
+  typechecking:
+    needs: [initial_checks]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0
+    with:
+      submodules: false
+      envs: |
+        - name: Type checking
+          linux: typecheck
+
   allowed_failures:
     needs: [initial_checks]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@8c0fde6f7e926df6ed7057255d29afa9c1ad5320  # v1.16.0

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2195,7 +2195,7 @@ class Unit(NamedUnit, metaclass=_UnitMetaClass):
         NamedUnit.__init__(self, st, namespace=namespace, doc=doc, format=format)
 
     @property
-    def represents(self) -> UnitBase:
+    def represents(self) -> NamedUnit | CompositeUnit:
         """The unit that this named unit represents."""
         return self._represents
 

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -288,7 +288,7 @@ class _ParsingFormatMixin:
                 return cls._validate_unit(unit._get_format_name(cls.name))
             except ValueError:
                 if isinstance(unit, Unit):
-                    return cls._decompose_to_known_units(unit._represents)
+                    return cls._decompose_to_known_units(unit.represents)
                 raise
         raise TypeError(
             f"unit argument must be a 'NamedUnit' or 'CompositeUnit', not {type(unit)}"

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from typing import ClassVar, Literal
 
     from astropy.extern.ply.lex import Lexer
-    from astropy.units import UnitBase
+    from astropy.units import NamedUnit, UnitBase
     from astropy.utils.parsing import ThreadSafeParser
 
 
@@ -275,15 +275,17 @@ class CDS(Base, _ParsingFormatMixin):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = False
+        cls,
+        unit: CompositeUnit | NamedUnit,
+        fraction: bool | Literal["inline", "multiline"] = False,
     ) -> str:
         # Remove units that aren't known to the format
-        unit = cls._decompose_to_known_units(unit)
+        base_unit = cls._decompose_to_known_units(unit)
 
-        if not unit.bases:
-            if unit.scale == 1:
+        if not base_unit.bases:
+            if base_unit.scale == 1:
                 return "---"
-            elif is_effectively_unity(unit.scale * 100.0):
+            elif is_effectively_unity(base_unit.scale * 100.0):
                 return "%"
 
-        return super().to_string(unit, fraction=fraction)
+        return super().to_string(base_unit, fraction=fraction)

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -351,7 +351,7 @@ class OGIP(Base, _ParsingFormatMixin):
 
         if isinstance(unit, CompositeUnit):
             # Can't use np.log10 here, because p[0] may be a Python long.
-            if math.log10(unit.scale) % 1.0 != 0.0:
+            if not isinstance(unit.scale, float) or math.log10(unit.scale) % 1.0 != 0.0:
                 warnings.warn(
                     f"'{unit.scale}' scale should be a power of 10 in OGIP format",
                     UnitsWarning,

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     import numpy as np
 
     from astropy.extern.ply.lex import Lexer
-    from astropy.units import UnitBase
+    from astropy.units import NamedUnit, UnitBase
     from astropy.units.typing import UnitScale
     from astropy.utils.parsing import ThreadSafeParser
 
@@ -344,16 +344,21 @@ class OGIP(Base, _ParsingFormatMixin):
 
     @classmethod
     def to_string(
-        cls, unit: UnitBase, fraction: bool | Literal["inline", "multiline"] = "inline"
+        cls,
+        unit: CompositeUnit | NamedUnit,
+        fraction: bool | Literal["inline", "multiline"] = "inline",
     ) -> str:
         # Remove units that aren't known to the format
-        unit = cls._decompose_to_known_units(unit)
+        base_unit = cls._decompose_to_known_units(unit)
 
         if isinstance(unit, CompositeUnit):
             # Can't use np.log10 here, because p[0] may be a Python long.
-            if not isinstance(unit.scale, float) or math.log10(unit.scale) % 1.0 != 0.0:
+            if (
+                not isinstance(base_unit.scale, float)
+                or math.log10(base_unit.scale) % 1.0 != 0.0
+            ):
                 warnings.warn(
-                    f"'{unit.scale}' scale should be a power of 10 in OGIP format",
+                    f"'{base_unit.scale}' scale should be a power of 10 in OGIP format",
                     UnitsWarning,
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,11 @@ namespaces = true
 [tool.setuptools_scm]
 version_file = "astropy/_version.py"
 
+[dependency-groups]
+typecheck = [
+    "basedpyright==1.28.1",
+]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ version_file = "astropy/_version.py"
 
 [dependency-groups]
 typecheck = [
-    "basedpyright==1.28.1",
+    "basedpyright>=1.28.3",
 ]
 
 [tool.pytest.ini_options]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,14 +1,14 @@
 {
     "typeCheckingMode": "basic",
     "include": [
-        "astropy/units"
+        "astropy/units/format"
     ],
     "exclude": [
-        "astropy/units/tests"
+        "astropy/units/format/vounit.py"
     ],
     "executionEnvironments": [
         {
-            "root": "astropy/units",
+            "root": "astropy/",
             "reportMissingImports": false,
             "reportAttributeAccessIssue": false,
             "reportUndefinedVariable": false

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,7 +11,8 @@
             "root": "astropy/",
             "reportMissingImports": false,
             "reportAttributeAccessIssue": false,
-            "reportUndefinedVariable": false
+            "reportUndefinedVariable": false,
+            "reportCallIssue": false
         }
     ]
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,17 @@
+{
+    "typeCheckingMode": "basic",
+    "include": [
+        "astropy/units"
+    ],
+    "exclude": [
+        "astropy/units/tests"
+    ],
+    "executionEnvironments": [
+        {
+            "root": "astropy/units",
+            "reportMissingImports": false,
+            "reportAttributeAccessIssue": false,
+            "reportUndefinedVariable": false
+        }
+    ]
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,7 +8,7 @@
     ],
     "executionEnvironments": [
         {
-            "root": "astropy/",
+            "root": "astropy/units",
             "reportMissingImports": false,
             "reportAttributeAccessIssue": false,
             "reportUndefinedVariable": false,

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+min_version = 4.22.0 # for pep 735 dependency groups
 envlist =
     py{311,312,313,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl360}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
@@ -7,6 +8,7 @@ envlist =
     build_docs
     linkcheck
     codestyle
+    typecheck
 requires =
     tox-uv
 
@@ -58,6 +60,7 @@ description =
     mpldev: with the latest developer version of matplotlib
     double: twice in a row to check for global state changes
     noscipy: without scipy-dev
+    typecheck: type check a selection of subpackages
 
 deps =
     numpy123: numpy==1.23.*
@@ -172,3 +175,9 @@ commands =
                 --hidden-import pytest_doctestplus.plugin \
                 --hidden-import pytest_mpl.plugin
     ./run_astropy_tests --astropy-root {toxinidir}
+
+[testenv:typecheck]
+changedir = {tox_root} # restore default
+dependency_groups = typecheck
+commands =
+  basedpyright astropy

--- a/tox.ini
+++ b/tox.ini
@@ -180,4 +180,4 @@ commands =
 changedir = {tox_root} # restore default
 dependency_groups = typecheck
 commands =
-  basedpyright astropy
+  basedpyright --stats


### PR DESCRIPTION
### Description
Close #16312

I propose using `basedpyright` as our type checker from the get go since it's been blessed by numpy devs, contrary to mypy.
Here I'm just laying out a fundation to build upon: a basic configuration with CI, outputing a reduced and hopefully manageable number of errors. The intention isn't to address said errors here but to provide a shared baseline for what to tackle next. This PR shouldn't be merged until we converge to a state where no errors are reported (either because they are fixed, or explicitly ignored, albeit temporarily).

notes
- I'm using a separate config file instead of `pyproject.toml`, although I note that in this instance this means no comments can be used (not a feature in `.json`)
- setting `basic` type checking mode (matching `pyright`'s default) instead of `recommended` (`basedpyight`'s default) because the number of errors and warnings is already in the thousands. Using `recommended` would add about 200 errors and 20k warnings...
- baseline (no configuration, other than selecting `astropy.units`): `5752 errors, 55 warnings, 0 notes`
- #17902 would already improve the situation by a lot: `4401 errors, 60 warnings, 0 notes`
- (temporarily) excluding tests reduces the number of errors to ~800
- (temporarily) turning off a selection of errors (e.g. `reportAttributeAccessIssue`) makes the baseline much more manageable (less than 200 errors)

I haven't managed to properly configure tox so far; at the time of opening it seems that pyright's config file is completely ignored when run from tox. As a results, the number of errors reported is 2 orders of magnitudes beyond what I just called "manageable". I'm still opening as a draft to see if CI is properly set up.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
