### PR TITLE
Enforce Ruff rule I001 in `astropy/io/ascii/__init__.py`

### DIFF
--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """An extensible ASCII table reader and writer."""
 
+from astropy import config as _config
+
 from . import connect
 from .basic import (
     Basic,
@@ -62,9 +64,6 @@ from .qdp import QDP
 from .rst import RST
 from .sextractor import SExtractor
 from .ui import get_read_trace, get_reader, get_writer, read, set_guess, write
-
-
-from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,7 +399,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 [tool.ruff.lint.extend-per-file-ignores]
 "setup.py" = ["INP001"]  # Part of configuration, not a package.
 ".github/workflows/*.py" = ["INP001"]
-"astropy/io/ascii/__init__.py" = ["I001"]  # unsorted-imports
 "astropy/modeling/models/__init__.py" = ["F405"]
 "astropy/utils/decorators.py" = [
     "D214", "D215",  # keep Examples section indented.


### PR DESCRIPTION
### Description

27abe26a86ed6a5a1b48ef2f1620e19335b2c5e3 added an exception of the Ruff rule [I001 (unsorted-imports)](https://docs.astral.sh/ruff/rules/unsorted-imports/) for `astropy/io/ascii/__init__.py`, but enforcing the rule is simpler.

Commits like 27abe26a86ed6a5a1b48ef2f1620e19335b2c5e3 should be caught in review.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
