### PR TITLE
Define `__all__` in all unit definition files

### DIFF
--- a/astropy/units/deprecated.py
+++ b/astropy/units/deprecated.py
@@ -17,39 +17,25 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 
 """
 
-_ns = globals()
+from . import astrophys, cgs
+from .core import UnitBase, _add_prefixes, add_enabled_units, def_unit
+from .utils import generate_prefixonly_unit_summary, generate_unit_summary
 
+def_unit(["emu"], cgs.Bi, namespace=globals(), doc="Biot: CGS (EMU) unit of current")
+# Add only some *prefixes* as deprecated units.
+_add_prefixes(astrophys.jupiterMass, namespace=globals(), prefixes=True)
+_add_prefixes(astrophys.earthMass, namespace=globals(), prefixes=True)
+_add_prefixes(astrophys.jupiterRad, namespace=globals(), prefixes=True)
+_add_prefixes(astrophys.earthRad, namespace=globals(), prefixes=True)
 
-def _initialize_module():
-    # Local imports to avoid polluting top-level namespace
-    from . import astrophys, cgs
-    from .core import _add_prefixes, def_unit
-
-    def_unit(["emu"], cgs.Bi, namespace=_ns, doc="Biot: CGS (EMU) unit of current")
-
-    # Add only some *prefixes* as deprecated units.
-    _add_prefixes(astrophys.jupiterMass, namespace=_ns, prefixes=True)
-    _add_prefixes(astrophys.earthMass, namespace=_ns, prefixes=True)
-    _add_prefixes(astrophys.jupiterRad, namespace=_ns, prefixes=True)
-    _add_prefixes(astrophys.earthRad, namespace=_ns, prefixes=True)
-
-
-_initialize_module()
-
-
-###########################################################################
-# DOCSTRING
+__all__ = [name for (name, member) in globals().items() if isinstance(member, UnitBase)]
+__all__ += ["enable"]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import (
-        generate_prefixonly_unit_summary as _generate_prefixonly_unit_summary,
-    )
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
-    __doc__ += _generate_prefixonly_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())
+    __doc__ += generate_prefixonly_unit_summary(globals())
 
 
 def enable():
@@ -61,10 +47,4 @@ def enable():
     This may be used with the ``with`` statement to enable deprecated
     units only temporarily.
     """
-    import inspect
-
-    # Local import to avoid cyclical import
-    # Local import to avoid polluting namespace
-    from .core import add_enabled_units
-
-    return add_enabled_units(inspect.getmodule(enable))
+    return add_enabled_units(globals())

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -10,32 +10,18 @@ but that are rarely used in practice and liable to lead to confusion (such as
 possible for the non-prefixed unit, ``astropy.units.solMass``.
 """
 
-_ns = globals()
+from . import astrophys
+from .core import UnitBase, _add_prefixes
+from .utils import generate_prefixonly_unit_summary, generate_unit_summary
 
+_add_prefixes(astrophys.solMass, namespace=globals(), prefixes=True)
+_add_prefixes(astrophys.solRad, namespace=globals(), prefixes=True)
+_add_prefixes(astrophys.solLum, namespace=globals(), prefixes=True)
 
-def _initialize_module():
-    # Local imports to avoid polluting top-level namespace
-    from . import astrophys
-    from .core import _add_prefixes
-
-    _add_prefixes(astrophys.solMass, namespace=_ns, prefixes=True)
-    _add_prefixes(astrophys.solRad, namespace=_ns, prefixes=True)
-    _add_prefixes(astrophys.solLum, namespace=_ns, prefixes=True)
-
-
-_initialize_module()
-
-
-###########################################################################
-# DOCSTRING
+__all__ = [name for (name, member) in globals().items() if isinstance(member, UnitBase)]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import (
-        generate_prefixonly_unit_summary as _generate_prefixonly_unit_summary,
-    )
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
-    __doc__ += _generate_prefixonly_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())
+    __doc__ += generate_prefixonly_unit_summary(globals())


### PR DESCRIPTION
### Description

Two unit definition files carefully avoided adding public-looking names to their module namespaces, but it is much simpler to define `__all__` explicitly. Our unit definition machinery is complicated enough even without wrapping everything in private functions.

I'm guessing the files in question were missed in cdcaa0dbb73b13f69c32e3b580b2a663308b7657 because they were not referred to in `astropy/units/__init__.py`.


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
