### PR TITLE
Rewrite "deprecated" units tests

### DIFF
--- a/astropy/units/tests/test_deprecated.py
+++ b/astropy/units/tests/test_deprecated.py
@@ -1,13 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-"""Regression tests for deprecated units or those that are "soft" deprecated
-because they are required for VOUnit support but are not in common use."""
-
 import pytest
 
 from astropy import units as u
-from astropy.units import deprecated, required_by_vounit
+from astropy.units import deprecated
 
 
 def test_emu():
@@ -35,26 +32,3 @@ def test_emu():
                 assert getattr(deprecated, unitname).represents.bases[0] == getattr(
                     u, namewoprefix
                 )
-
-
-def test_required_by_vounit():
-    # The tests below could be replicated with all the various prefixes, but it
-    # seems unnecessary because they all come as a set.  So we only use nano for
-    # the purposes of this test.
-
-    with pytest.raises(AttributeError):
-        # nano-solar mass/rad/lum shouldn't be in the base unit namespace
-        u.nsolMass
-        u.nsolRad
-        u.nsolLum
-
-    # but they should be enabled by default via required_by_vounit, to allow
-    # the Unit constructor to accept them
-    assert u.Unit("nsolMass") == required_by_vounit.nsolMass
-    assert u.Unit("nsolRad") == required_by_vounit.nsolRad
-    assert u.Unit("nsolLum") == required_by_vounit.nsolLum
-
-    # but because they are prefixes, they shouldn't be in find_equivalent_units
-    assert required_by_vounit.nsolMass not in u.solMass.find_equivalent_units()
-    assert required_by_vounit.nsolRad not in u.solRad.find_equivalent_units()
-    assert required_by_vounit.nsolLum not in u.solLum.find_equivalent_units()

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_allclose
 from astropy import constants as c
 from astropy import units as u
 from astropy.units import utils
+from astropy.units.required_by_vounit import GsolLum, ksolMass, nsolRad
 from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT, HAS_DASK
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -1254,3 +1255,29 @@ def test_dimensionless_scale_factor_types(scale):
     # Regression test for #17355 - Unit did not accept all scale factor
     # types that CompositeUnit accepted
     assert u.Unit(scale) == u.CompositeUnit(scale, [], [])
+
+
+# No need to test everything defined in required_by_vounit, the following few are
+# representative enough.
+required_by_vounit_parametrization = pytest.mark.parametrize(
+    "unit", [GsolLum, ksolMass, nsolRad], ids=lambda x: x.name
+)
+
+
+@required_by_vounit_parametrization
+def test_required_by_vounit_not_in_main_namespace(unit):
+    with pytest.raises(
+        AttributeError,
+        match=rf"^module 'astropy\.units' has no attribute '{unit.name}'$",
+    ):
+        getattr(u, unit.name)
+
+
+@required_by_vounit_parametrization
+def test_required_by_vounit_parsing(unit):
+    assert u.Unit(unit.name) is unit
+
+
+@required_by_vounit_parametrization
+def test_required_by_vounit_not_in_find_equivalent_units(unit):
+    assert unit not in unit.represents.bases[0].find_equivalent_units()


### PR DESCRIPTION
### Description

Currently `test_deprecated.py` contains two test functions, both of which contain multiple checks. The big problem with such monolithic tests is that a failure of a check prevents the following ones from being tested. The solution is to split large monolithic tests into smaller (possibly parametrized) tests which is better because such smaller tests can be executed independently from each other.

The first commit also moves tests about `required_by_vounit` out from `test_deprecated.py` because if we ever do deprecate the `deprecated` units module then when the deprecation period ends it would be convenient to delete `tests/test_deprecated.py` together with `deprecated.py`.

The tests also contained some mistakes that I am fixing.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
