### PR TITLE
Fix interval classes for MaskedArray and MaskedNDArray

### DIFF
--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -9,6 +9,8 @@ import abc
 
 import numpy as np
 
+from astropy.utils.masked import get_data_and_mask
+
 from .transform import BaseTransform
 
 __all__ = [
@@ -64,15 +66,12 @@ class BaseInterval(BaseTransform):
         result : 1D ndarray
             The processed values.
         """
-        if isinstance(values, np.ma.MaskedArray):
-            # Get non-masked values as a 1D array
-            values = values.compressed()
-        else:
-            # Make sure values is a Numpy array
-            values = np.asarray(values)
+        data, mask = get_data_and_mask(np.asanyarray(values))
+        ok = np.isfinite(data)
+        if mask is not None:
+            ok &= ~mask
 
-        # Filter out invalid values (inf, nan)
-        return values[np.isfinite(values)]
+        return data[ok]
 
     def __call__(self, values, clip=True, out=None):
         """

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -9,8 +9,6 @@ import abc
 
 import numpy as np
 
-import astropy.units as u
-
 from .transform import BaseTransform
 
 __all__ = [
@@ -110,14 +108,6 @@ class BaseInterval(BaseTransform):
         result : ndarray
             The transformed values.
         """
-        # Drop units if present
-        if isinstance(values, u.Quantity):
-            values = values.value
-        if isinstance(values, np.ma.MaskedArray) and isinstance(
-            values.data, u.Quantity
-        ):
-            values = np.ma.MaskedArray(values.data.value, values.mask)
-
         vmin, vmax = self.get_limits(values)
 
         if out is None:

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -67,10 +67,9 @@ class BaseInterval(BaseTransform):
         if isinstance(values, np.ma.MaskedArray):
             # Get non-masked values as a 1D array
             values = values.compressed()
-
-        # Make sure values is a NumPy array; this also makes sure that
-        # units are dropped for Quantity and masked_Quantity arrays
-        values = np.asarray(values)
+        else:
+            # Make sure values is a Numpy array
+            values = np.asarray(values)
 
         # Filter out invalid values (inf, nan)
         return values[np.isfinite(values)]

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -46,6 +46,34 @@ class BaseInterval(BaseTransform):
         """
         raise NotImplementedError("Needs to be implemented in a subclass.")
 
+    @staticmethod
+    def _process_values(values):
+        """
+        Process the input values.
+
+        This function filters out masked and/or invalid values (inf,
+        nan) and returns a flattened 1D array.
+
+        Parameters
+        ----------
+        values : array-like
+            The input values.
+
+        Returns
+        -------
+        result : 1D ndarray
+            The processed values.
+        """
+        if isinstance(values, np.ma.MaskedArray):
+            # Get non-masked values as a 1D array
+            values = values.compressed()
+        else:
+            # Make sure values is a Numpy array
+            values = np.asarray(values)
+
+        # Filter out invalid values (inf, nan)
+        return values[np.isfinite(values)]
+
     def __call__(self, values, clip=True, out=None):
         """
         Transform values using this interval.
@@ -123,12 +151,7 @@ class ManualInterval(BaseInterval):
         if self.vmin is not None and self.vmax is not None:
             return self.vmin, self.vmax
 
-        # Make sure values is a Numpy array
-        values = np.asarray(values).ravel()
-
-        # Filter out invalid values (inf, nan)
-        values = values[np.isfinite(values)]
-
+        values = self._process_values(values)
         vmin = np.min(values) if self.vmin is None else self.vmin
         vmax = np.max(values) if self.vmax is None else self.vmax
 
@@ -141,11 +164,7 @@ class MinMaxInterval(BaseInterval):
     """
 
     def get_limits(self, values):
-        # Make sure values is a Numpy array
-        values = np.asarray(values).ravel()
-
-        # Filter out invalid values (inf, nan)
-        values = values[np.isfinite(values)]
+        values = self._process_values(values)
 
         return np.min(values), np.max(values)
 
@@ -179,16 +198,12 @@ class AsymmetricPercentileInterval(BaseInterval):
         self.n_samples = n_samples
 
     def get_limits(self, values):
-        # Make sure values is a Numpy array
-        values = np.asarray(values).ravel()
+        values = self._process_values(values)
 
         # If needed, limit the number of samples. We sample with replacement
         # since this is much faster.
         if self.n_samples is not None and values.size > self.n_samples:
             values = np.random.choice(values, self.n_samples)
-
-        # Filter out invalid values (inf, nan)
-        values = values[np.isfinite(values)]
 
         # Determine values at percentiles
         vmin, vmax = np.percentile(
@@ -274,9 +289,9 @@ class ZScaleInterval(BaseInterval):
         self.max_iterations = max_iterations
 
     def get_limits(self, values):
+        values = self._process_values(values)
+
         # Sample the image
-        values = np.asarray(values)
-        values = values[np.isfinite(values)]
         stride = int(max(1.0, values.size / self.n_samples))
         samples = values[::stride][: self.n_samples]
         samples.sort()

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -9,6 +9,8 @@ import abc
 
 import numpy as np
 
+import astropy.units as u
+
 from .transform import BaseTransform
 
 __all__ = [
@@ -108,6 +110,14 @@ class BaseInterval(BaseTransform):
         result : ndarray
             The transformed values.
         """
+        # Drop units if present
+        if isinstance(values, u.Quantity):
+            values = values.value
+        if isinstance(values, np.ma.MaskedArray) and isinstance(
+            values.data, u.Quantity
+        ):
+            values = np.ma.MaskedArray(values.data.value, values.mask)
+
         vmin, vmax = self.get_limits(values)
 
         if out is None:

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -67,9 +67,10 @@ class BaseInterval(BaseTransform):
         if isinstance(values, np.ma.MaskedArray):
             # Get non-masked values as a 1D array
             values = values.compressed()
-        else:
-            # Make sure values is a Numpy array
-            values = np.asarray(values)
+
+        # Make sure values is a NumPy array; this also makes sure that
+        # units are dropped for Quantity and masked_Quantity arrays
+        values = np.asarray(values)
 
         # Filter out invalid values (inf, nan)
         return values[np.isfinite(values)]

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from astropy.utils import NumpyRNGContext
 from astropy.visualization.interval import (
@@ -19,60 +20,60 @@ class TestInterval:
     def test_manual(self):
         interval = ManualInterval(-10.0, +15.0)
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -10.0)
-        np.testing.assert_allclose(vmax, +15.0)
+        assert_allclose(vmin, -10.0)
+        assert_allclose(vmax, +15.0)
 
     def test_manual_defaults(self):
         interval = ManualInterval(vmin=-10.0)
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -10.0)
-        np.testing.assert_allclose(vmax, np.max(self.data))
+        assert_allclose(vmin, -10.0)
+        assert_allclose(vmax, np.max(self.data))
 
         interval = ManualInterval(vmax=15.0)
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, np.min(self.data))
-        np.testing.assert_allclose(vmax, 15.0)
+        assert_allclose(vmin, np.min(self.data))
+        assert_allclose(vmax, 15.0)
 
     def test_manual_zero_limit(self):
         # Regression test for a bug that caused ManualInterval to compute the
         # limit (min or max) if it was set to zero.
         interval = ManualInterval(vmin=0, vmax=0)
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, 0)
-        np.testing.assert_allclose(vmax, 0)
+        assert_allclose(vmin, 0)
+        assert_allclose(vmax, 0)
 
     def test_manual_defaults_with_nan(self):
         interval = ManualInterval()
         data = np.copy(self.data)
         data[0] = np.nan
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -20)
-        np.testing.assert_allclose(vmax, +60)
+        assert_allclose(vmin, -20)
+        assert_allclose(vmax, +60)
 
     def test_minmax(self):
         interval = MinMaxInterval()
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -20.0)
-        np.testing.assert_allclose(vmax, +60.0)
+        assert_allclose(vmin, -20.0)
+        assert_allclose(vmax, +60.0)
 
     def test_percentile(self):
         interval = PercentileInterval(62.2)
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -4.88)
-        np.testing.assert_allclose(vmax, 44.88)
+        assert_allclose(vmin, -4.88)
+        assert_allclose(vmax, 44.88)
 
     def test_asymmetric_percentile(self):
         interval = AsymmetricPercentileInterval(10.5, 70.5)
         vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -11.6)
-        np.testing.assert_allclose(vmax, 36.4)
+        assert_allclose(vmin, -11.6)
+        assert_allclose(vmax, 36.4)
 
     def test_asymmetric_percentile_nsamples(self):
         with NumpyRNGContext(12345):
             interval = AsymmetricPercentileInterval(10.5, 70.5, n_samples=20)
             vmin, vmax = interval.get_limits(self.data)
-        np.testing.assert_allclose(vmin, -14.367676767676768)
-        np.testing.assert_allclose(vmax, 40.266666666666666)
+        assert_allclose(vmin, -14.367676767676768)
+        assert_allclose(vmax, 40.266666666666666)
 
 
 class TestIntervalList(TestInterval):
@@ -96,20 +97,20 @@ def test_zscale():
     data = np.random.randn(100, 100) * 5 + 10
     interval = ZScaleInterval()
     vmin, vmax = interval.get_limits(data)
-    np.testing.assert_allclose(vmin, -9.6, atol=0.1)
-    np.testing.assert_allclose(vmax, 25.4, atol=0.1)
+    assert_allclose(vmin, -9.6, atol=0.1)
+    assert_allclose(vmax, 25.4, atol=0.1)
 
     data = list(range(1000)) + [np.nan]
     interval = ZScaleInterval()
     vmin, vmax = interval.get_limits(data)
-    np.testing.assert_allclose(vmin, 0, atol=0.1)
-    np.testing.assert_allclose(vmax, 999, atol=0.1)
+    assert_allclose(vmin, 0, atol=0.1)
+    assert_allclose(vmax, 999, atol=0.1)
 
     data = list(range(100))
     interval = ZScaleInterval()
     vmin, vmax = interval.get_limits(data)
-    np.testing.assert_allclose(vmin, 0, atol=0.1)
-    np.testing.assert_allclose(vmax, 99, atol=0.1)
+    assert_allclose(vmin, 0, atol=0.1)
+    assert_allclose(vmax, 99, atol=0.1)
 
 
 def test_zscale_npoints():
@@ -130,7 +131,7 @@ def test_integers():
     # Need to make sure integers get cast to float
     interval = MinMaxInterval()
     values = interval([1, 3, 4, 5, 6])
-    np.testing.assert_allclose(values, [0.0, 0.4, 0.6, 0.8, 1.0])
+    assert_allclose(values, [0.0, 0.4, 0.6, 0.8, 1.0])
 
     # Don't accept integer array in output
     out = np.zeros(5, dtype=int)
@@ -142,7 +143,7 @@ def test_integers():
     # But integer input and floating point output is fine
     out = np.zeros(5, dtype=float)
     interval([1, 3, 4, 5, 6], out=out)
-    np.testing.assert_allclose(out, [0.0, 0.4, 0.6, 0.8, 1.0])
+    assert_allclose(out, [0.0, 0.4, 0.6, 0.8, 1.0])
 
 
 def test_constant_data():
@@ -152,5 +153,5 @@ def test_constant_data():
     interval = MinMaxInterval()
     limits = interval.get_limits(data)
     values = interval(data)
-    np.testing.assert_allclose(limits, (1.0, 1.0))
-    np.testing.assert_allclose(values, np.zeros(shape))
+    assert_allclose(limits, (1.0, 1.0))
+    assert_allclose(values, np.zeros(shape))

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-import astropy.units as u
 from astropy.utils import NumpyRNGContext
 from astropy.visualization.interval import (
     AsymmetricPercentileInterval,
@@ -28,21 +27,11 @@ class TestInterval:
         interval = ManualInterval(vmin=-10.0)
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -10.0)
-        max_data = np.max(self.data)
-        if isinstance(max_data, np.ma.MaskedArray):
-            max_data = np.asarray(max_data)
-        if isinstance(max_data, u.Quantity):
-            max_data = max_data.value
-        assert_allclose(vmax, max_data)
+        assert_allclose(vmax, np.max(self.data))
 
         interval = ManualInterval(vmax=15.0)
         vmin, vmax = interval.get_limits(self.data)
-        min_data = np.min(self.data)
-        if isinstance(min_data, np.ma.MaskedArray):
-            min_data = np.asarray(min_data)
-        if isinstance(min_data, u.Quantity):
-            min_data = min_data.value
-        assert_allclose(vmin, min_data)
+        assert_allclose(vmin, np.min(self.data))
         assert_allclose(vmax, 15.0)
 
     def test_manual_zero_limit(self):
@@ -97,21 +86,10 @@ class TestInterval2D(TestInterval):
     data = np.linspace(-20.0, 60.0, 100).reshape(100, 1)
 
 
-class TestIntervalQuantity(TestInterval):
-    # Make sure intervals work with 2d Quantity arrays
-    data = np.linspace(-20.0, 60.0, 100).reshape(100, 1) * u.nJy
-
-
 class TestIntervalMaskedArray(TestInterval):
     # Make sure intervals work with MaskedArray
     data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
     data = np.ma.MaskedArray(data, data > 1000)
-
-
-class TestIntervalMaskedQuantityArray(TestInterval):
-    # Make sure intervals work with masked_Quantity
-    data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
-    data = np.ma.MaskedArray(data * u.nJy, mask=data > 1000)
 
 
 def test_zscale():

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -23,6 +23,7 @@ class TestInterval:
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -10.0)
         assert_allclose(vmax, +15.0)
+        assert isinstance(interval(self.data), np.ndarray)
 
     def test_manual_defaults(self):
         interval = ManualInterval(vmin=-10.0)
@@ -34,6 +35,7 @@ class TestInterval:
         if isinstance(max_data, u.Quantity):
             max_data = max_data.value
         assert_allclose(vmax, max_data)
+        assert isinstance(interval(self.data), np.ndarray)
 
         interval = ManualInterval(vmax=15.0)
         vmin, vmax = interval.get_limits(self.data)
@@ -44,6 +46,7 @@ class TestInterval:
             min_data = min_data.value
         assert_allclose(vmin, min_data)
         assert_allclose(vmax, 15.0)
+        assert isinstance(interval(self.data), np.ndarray)
 
     def test_manual_zero_limit(self):
         # Regression test for a bug that caused ManualInterval to compute the
@@ -52,6 +55,7 @@ class TestInterval:
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, 0)
         assert_allclose(vmax, 0)
+        assert isinstance(interval(self.data), np.ndarray)
 
     def test_manual_defaults_with_nan(self):
         interval = ManualInterval()
@@ -60,24 +64,36 @@ class TestInterval:
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -20)
         assert_allclose(vmax, +60)
+        assert isinstance(interval(self.data), np.ndarray)
 
     def test_minmax(self):
         interval = MinMaxInterval()
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -20.0)
         assert_allclose(vmax, +60.0)
+        assert isinstance(interval(self.data), np.ndarray)
 
     def test_percentile(self):
         interval = PercentileInterval(62.2)
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -4.88)
         assert_allclose(vmax, 44.88)
+        assert isinstance(interval(self.data), np.ndarray)
+
+        if isinstance(self.data, u.Quantity):
+            assert not isinstance(interval(self.data), u.Quantity)
+
+        if isinstance(self.data, np.ma.MaskedArray) and isinstance(
+            self.data.data, u.Quantity
+        ):
+            assert not isinstance(interval(self.data).data, u.Quantity)
 
     def test_asymmetric_percentile(self):
         interval = AsymmetricPercentileInterval(10.5, 70.5)
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -11.6)
         assert_allclose(vmax, 36.4)
+        assert isinstance(interval(self.data), np.ndarray)
 
     def test_asymmetric_percentile_nsamples(self):
         with NumpyRNGContext(12345):
@@ -85,6 +101,7 @@ class TestInterval:
             vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -14.367676767676768)
         assert_allclose(vmax, 40.266666666666666)
+        assert isinstance(interval(self.data), np.ndarray)
 
 
 class TestIntervalList(TestInterval):

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -23,7 +23,6 @@ class TestInterval:
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -10.0)
         assert_allclose(vmax, +15.0)
-        assert isinstance(interval(self.data), np.ndarray)
 
     def test_manual_defaults(self):
         interval = ManualInterval(vmin=-10.0)
@@ -35,7 +34,6 @@ class TestInterval:
         if isinstance(max_data, u.Quantity):
             max_data = max_data.value
         assert_allclose(vmax, max_data)
-        assert isinstance(interval(self.data), np.ndarray)
 
         interval = ManualInterval(vmax=15.0)
         vmin, vmax = interval.get_limits(self.data)
@@ -46,7 +44,6 @@ class TestInterval:
             min_data = min_data.value
         assert_allclose(vmin, min_data)
         assert_allclose(vmax, 15.0)
-        assert isinstance(interval(self.data), np.ndarray)
 
     def test_manual_zero_limit(self):
         # Regression test for a bug that caused ManualInterval to compute the
@@ -55,7 +52,6 @@ class TestInterval:
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, 0)
         assert_allclose(vmax, 0)
-        assert isinstance(interval(self.data), np.ndarray)
 
     def test_manual_defaults_with_nan(self):
         interval = ManualInterval()
@@ -64,36 +60,24 @@ class TestInterval:
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -20)
         assert_allclose(vmax, +60)
-        assert isinstance(interval(self.data), np.ndarray)
 
     def test_minmax(self):
         interval = MinMaxInterval()
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -20.0)
         assert_allclose(vmax, +60.0)
-        assert isinstance(interval(self.data), np.ndarray)
 
     def test_percentile(self):
         interval = PercentileInterval(62.2)
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -4.88)
         assert_allclose(vmax, 44.88)
-        assert isinstance(interval(self.data), np.ndarray)
-
-        if isinstance(self.data, u.Quantity):
-            assert not isinstance(interval(self.data), u.Quantity)
-
-        if isinstance(self.data, np.ma.MaskedArray) and isinstance(
-            self.data.data, u.Quantity
-        ):
-            assert not isinstance(interval(self.data).data, u.Quantity)
 
     def test_asymmetric_percentile(self):
         interval = AsymmetricPercentileInterval(10.5, 70.5)
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -11.6)
         assert_allclose(vmax, 36.4)
-        assert isinstance(interval(self.data), np.ndarray)
 
     def test_asymmetric_percentile_nsamples(self):
         with NumpyRNGContext(12345):
@@ -101,7 +85,6 @@ class TestInterval:
             vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -14.367676767676768)
         assert_allclose(vmax, 40.266666666666666)
-        assert isinstance(interval(self.data), np.ndarray)
 
 
 class TestIntervalList(TestInterval):

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
+import astropy.units as u
 from astropy.utils import NumpyRNGContext
 from astropy.visualization.interval import (
     AsymmetricPercentileInterval,
@@ -27,11 +28,21 @@ class TestInterval:
         interval = ManualInterval(vmin=-10.0)
         vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -10.0)
-        assert_allclose(vmax, np.max(self.data))
+        max_data = np.max(self.data)
+        if isinstance(max_data, np.ma.MaskedArray):
+            max_data = np.asarray(max_data)
+        if isinstance(max_data, u.Quantity):
+            max_data = max_data.value
+        assert_allclose(vmax, max_data)
 
         interval = ManualInterval(vmax=15.0)
         vmin, vmax = interval.get_limits(self.data)
-        assert_allclose(vmin, np.min(self.data))
+        min_data = np.min(self.data)
+        if isinstance(min_data, np.ma.MaskedArray):
+            min_data = np.asarray(min_data)
+        if isinstance(min_data, u.Quantity):
+            min_data = min_data.value
+        assert_allclose(vmin, min_data)
         assert_allclose(vmax, 15.0)
 
     def test_manual_zero_limit(self):
@@ -86,10 +97,21 @@ class TestInterval2D(TestInterval):
     data = np.linspace(-20.0, 60.0, 100).reshape(100, 1)
 
 
+class TestIntervalQuantity(TestInterval):
+    # Make sure intervals work with 2d Quantity arrays
+    data = np.linspace(-20.0, 60.0, 100).reshape(100, 1) * u.nJy
+
+
 class TestIntervalMaskedArray(TestInterval):
     # Make sure intervals work with MaskedArray
     data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
     data = np.ma.MaskedArray(data, data > 1000)
+
+
+class TestIntervalMaskedQuantityArray(TestInterval):
+    # Make sure intervals work with masked_Quantity
+    data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
+    data = np.ma.MaskedArray(data * u.nJy, mask=data > 1000)
 
 
 def test_zscale():

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -5,6 +5,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from astropy.utils import NumpyRNGContext
+from astropy.utils.masked import Masked
 from astropy.visualization.interval import (
     AsymmetricPercentileInterval,
     ManualInterval,
@@ -90,6 +91,12 @@ class TestIntervalMaskedArray(TestInterval):
     # Make sure intervals work with MaskedArray
     data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
     data = np.ma.MaskedArray(data, data > 1000)
+
+
+class TestIntervalMaskedNDArray(TestInterval):
+    # Make sure intervals work with MaskedArray
+    data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
+    data = Masked(data, data > 1000)
 
 
 def test_zscale():

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -85,6 +85,12 @@ class TestInterval2D(TestInterval):
     data = np.linspace(-20.0, 60.0, 100).reshape(100, 1)
 
 
+class TestIntervalMaskedArray(TestInterval):
+    # Make sure intervals work with MaskedArray
+    data = np.concatenate((np.linspace(-20.0, 60.0, 100), np.full(100, 1e6)))
+    data = np.ma.MaskedArray(data, data > 1000)
+
+
 def test_zscale():
     np.random.seed(42)
     data = np.random.randn(100, 100) * 5 + 10

--- a/docs/changes/visualization/17927.bugfix.rst
+++ b/docs/changes/visualization/17927.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed interval classes for ``MaskedArray``, ``Quantity``, and
+``masked_Quantity`` inputs.

--- a/docs/changes/visualization/17927.bugfix.rst
+++ b/docs/changes/visualization/17927.bugfix.rst
@@ -1,2 +1,1 @@
-Fixed interval classes for ``MaskedArray``, ``Quantity``, and
-``masked_Quantity`` inputs.
+Fixed interval classes for masked input (``MaskedArray`` and ``MaskedNDArray``).


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The interval classes currently drop the mask of `MaskedArray` input, thus returning incorrect `vmin` and `vmax` values.

Simple MWE:

```python
import numpy as np
from astropy.visualization import simple_norm

rng = np.random.default_rng(seed=0)
data = rng.random((50, 50))
data[0, :] = 1.e6 
data = np.ma.masked_where(data > 1, data)
norm = simple_norm(data, 'linear', percent=100)
plt.imshow(data, norm=norm)
plt.colorbar()
```

Current main:

![main](https://github.com/user-attachments/assets/d9bb09af-ac40-4939-8cc7-6ac6ae2407ff)


With this PR:

![pr](https://github.com/user-attachments/assets/05676aef-5174-4b6e-a58d-ce0a3826ecf4)


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
