### PR TITLE
Deprecate deprecated units

### DIFF
--- a/astropy/units/deprecated.py
+++ b/astropy/units/deprecated.py
@@ -17,27 +17,46 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 
 """
 
+import warnings
+
+from astropy.utils.decorators import deprecated
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
 from . import astrophys, cgs
 from .core import UnitBase, _add_prefixes, add_enabled_units, def_unit
 from .utils import generate_prefixonly_unit_summary, generate_unit_summary
 
-def_unit(["emu"], cgs.Bi, namespace=globals(), doc="Biot: CGS (EMU) unit of current")
-# Add only some *prefixes* as deprecated units.
-_add_prefixes(astrophys.jupiterMass, namespace=globals(), prefixes=True)
-_add_prefixes(astrophys.earthMass, namespace=globals(), prefixes=True)
-_add_prefixes(astrophys.jupiterRad, namespace=globals(), prefixes=True)
-_add_prefixes(astrophys.earthRad, namespace=globals(), prefixes=True)
+local_units = {}
 
-__all__ = [name for (name, member) in globals().items() if isinstance(member, UnitBase)]
+def_unit(["emu"], cgs.Bi, namespace=local_units, doc="Biot: CGS (EMU) unit of current")
+# Add only some *prefixes* as deprecated units.
+_add_prefixes(astrophys.jupiterMass, namespace=local_units, prefixes=True)
+_add_prefixes(astrophys.earthMass, namespace=local_units, prefixes=True)
+_add_prefixes(astrophys.jupiterRad, namespace=local_units, prefixes=True)
+_add_prefixes(astrophys.earthRad, namespace=local_units, prefixes=True)
+
+__all__ = [
+    name for (name, member) in local_units.items() if isinstance(member, UnitBase)
+]
 __all__ += ["enable"]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    __doc__ += generate_unit_summary(globals())
-    __doc__ += generate_prefixonly_unit_summary(globals())
+    __doc__ += generate_unit_summary(local_units)
+    __doc__ += generate_prefixonly_unit_summary(local_units)
 
 
+def __getattr__(name):
+    if unit := local_units.get(name):
+        warnings.warn(
+            f"{name!r} is deprecated since version 7.1", AstropyDeprecationWarning
+        )
+        return unit
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+@deprecated(since="7.1")
 def enable():
     """
     Enable deprecated units so they appear in results of
@@ -47,4 +66,4 @@ def enable():
     This may be used with the ``with`` statement to enable deprecated
     units only temporarily.
     """
-    return add_enabled_units(globals())
+    return add_enabled_units(local_units)

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -2,9 +2,7 @@
 """
 This package defines SI prefixed units that are required by the VOUnit standard
 but that are rarely used in practice and liable to lead to confusion (such as
-``msolMass`` for milli-solar mass). They are in a separate module from
-`astropy.units.deprecated` because they need to be enabled by default for
-`astropy.units` to parse compliant VOUnit strings. As a result, e.g.,
+``msolMass`` for milli-solar mass). The units here are enabled so, e.g.,
 ``Unit('msolMass')`` will just work, but to access the unit directly, use
 ``astropy.units.required_by_vounit.msolMass`` instead of the more typical idiom
 possible for the non-prefixed unit, ``astropy.units.solMass``.

--- a/astropy/units/tests/test_deprecated.py
+++ b/astropy/units/tests/test_deprecated.py
@@ -1,23 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 
 import pytest
 
 from astropy import units as u
 from astropy.units import deprecated
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
-emu = deprecated.emu
-GearthRad = deprecated.GearthRad
-MjupiterMass = deprecated.MjupiterMass
-mjupiterRad = deprecated.MjupiterRad
-nearthMass = deprecated.nearthMass
+with warnings.catch_warnings(action="ignore", category=AstropyDeprecationWarning):
+    emu = deprecated.emu
+    GearthRad = deprecated.GearthRad
+    MjupiterMass = deprecated.MjupiterMass
+    mjupiterRad = deprecated.MjupiterRad
+    nearthMass = deprecated.nearthMass
 
 
 def test_enable():
-    with deprecated.enable():
-        # `unit in u.Bi.compose()` would use `==` for comparison, but we really
-        # do want to check identity, not just equality.
-        assert any(unit is emu for unit in u.Bi.compose())
+    with pytest.warns(AstropyDeprecationWarning, match="enable function is deprecated"):
+        with deprecated.enable():
+            # `unit in u.Bi.compose()` would use `==` for comparison, but we really
+            # do want to check identity, not just equality.
+            assert any(unit is emu for unit in u.Bi.compose())
 
 
 def test_emu():
@@ -48,3 +52,19 @@ def test_deprecated_unit_not_in_main_namespace(unit):
 )
 def test_deprecated_unit_definition(prefixed_unit, base_unit):
     assert prefixed_unit.represents.bases[0] is base_unit
+
+
+def test_deprecated_units_are_deprecated():
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"^'gigaM_jupiter' is deprecated since version 7\.1$",
+    ):
+        deprecated.gigaM_jupiter
+
+
+def test_invalid_name_raises_attribute_error():
+    with pytest.raises(
+        AttributeError,
+        match=r"^module 'astropy\.units\.deprecated' has no attribute 'fifaRearth'$",
+    ):
+        deprecated.fifaRearth

--- a/docs/changes/units/17929.api.rst
+++ b/docs/changes/units/17929.api.rst
@@ -1,0 +1,3 @@
+Accessing the contents of the ``deprecated`` module now emits deprecation
+warnings.
+The module may be removed in a future version.


### PR DESCRIPTION
### Description

For many years `units` has had a `deprecated` module that isn't. Having a permanent module with such a name is not good. It should be deprecated properly and eventually removed, or renamed. But there isn't much value in keeping this module around. If anyone needs the units it defines then they can define them themselves.

My understanding is that when the module was created there was no good way of deprecating its contents, but Python 3.7 introduced the module-level `__getattr__()` ([PEP 562](https://peps.python.org/pep-0562/)) which is just what we need.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
