### PR TITLE
DOC: document runtime environment variables in a dedicated page

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -34,15 +34,9 @@ The exact location of this file can be obtained with
     >>> from astropy.config import get_config_dir
     >>> get_config_dir()  # doctest: +SKIP
 
-And you should see the location of your configuration directory. The standard
-scheme generally puts your configuration directory in
-``$HOME/.astropy/config``. It can be customized with the environment variable
-``XDG_CONFIG_HOME`` in which case the ``$XDG_CONFIG_HOME/astropy`` directory
-must exist. Note that ``XDG_CONFIG_HOME`` comes from a Linux-centric
-specification (see `here
-<https://wiki.archlinux.org/index.php/XDG_Base_Directory_support>`_ for more
-details), but ``astropy`` will use this on any OS as a more general means to
-know where user-specific configurations should be written.
+And you should see the location of your configuration directory. The default
+configuration directory is ``$HOME/.astropy/config``, but this can be
+customized with :ref:`environment_variables`.
 
 .. note::
     See :ref:`astropy_config_file` for the content of this configuration file.
@@ -60,12 +54,8 @@ changes immediately in your current ``astropy`` session::
 .. note::
     If for whatever reason your ``$HOME/.astropy`` directory is not accessible
     (i.e., you have ``astropy`` running somehow as root but you are not the root
-    user), the best solution is to set the ``XDG_CONFIG_HOME`` and
-    ``XDG_CACHE_HOME`` environment variables pointing to directories, and create
-    an ``astropy`` directory inside each of those. Both the configuration and
-    data download systems will then use those directories and never try to
-    access the ``$HOME/.astropy`` directory.
-
+    user), the best solution is to set :ref:`environment_variables` pointing to
+    directories you control.
 
 Using `astropy.config`
 ======================

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -341,8 +341,7 @@ location, or as a *decorator* that takes effect for an entire test function
 (not including setup or teardown, which would have to be decorated separately).
 
 Furthermore, it is possible to change the location of the cache directory
-for the duration of the test run by setting the ``XDG_CACHE_HOME``
-environment variable.
+for the duration of the test run via :ref:`environment_variables`.
 
 
 Tests that create files

--- a/docs/environment_variables.rst
+++ b/docs/environment_variables.rst
@@ -1,0 +1,35 @@
+.. currentmodule:: astropy
+
+.. _environment_variables:
+
+*********************
+Environment variables
+*********************
+
+
+.. glossary::
+
+    ``XDG_CONFIG_HOME``
+        This environment variables control where configuration files are read
+        and written. Astropy will look for configuration files in
+        ``$XDG_CONFIG_HOME/astropy``.
+        If not set, or if ``$XDG_CONFIG_HOME/astropy`` does not exist,
+        astropy will default to ``$HOME/.astropy/config``.
+        See :ref:`astropy_config` for how to programmatically set or get the
+        location of the corresponding directory at runtime.
+
+    ``XDG_CACHE_HOME``
+        These environment variables control where data files are cached.
+        Astropy will cache files in ``$XDG_CACHE_HOME/astropy``.
+        If not set, or if ``$XDG_CACHE_HOME/astropy`` does not exist,
+        astropy will default to ``$HOME/.astropy/cache``.
+        See :ref:`utils-data` for how to programmatically set or get the
+        location of the corresponding directory at runtime.
+
+
+.. note::
+    ``XDG_CONFIG_HOME`` and ``XDG_CACHE_HOME`` come from a Linux-centric
+    specification
+    (see `here <https://wiki.archlinux.org/index.php/XDG_Base_Directory_support>`_
+    for more details), but ``astropy`` will use them on any OS as a more
+    general means to know where user-specific configurations should be written.

--- a/docs/index_user_docs.rst
+++ b/docs/index_user_docs.rst
@@ -55,4 +55,5 @@ User Guide
    logging
    warnings
    utils/index
+   environment_variables
    glossary

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -22,9 +22,9 @@ cache) the data will only be downloaded if it is not already present in the
 cache. The tools can be instructed to obtain a new copy of data
 that is in the cache but has been updated online.
 
-The ``astropy`` cache is stored in a centralized place (on Linux machines by
-default it is ``$HOME/.astropy/cache``; see :ref:`astropy_config` for
-more details).  You can check its location on your machine::
+The ``astropy`` cache is stored in a centralized place (see
+:ref:`environment_variables` for more details).  You can check its location
+on your machine::
 
    >>> import astropy.config.paths
    >>> astropy.config.paths.get_cache_dir()  # doctest: +SKIP


### PR DESCRIPTION
### Description
This is split from #17640 [at @eerovaher's request](https://github.com/astropy/astropy/pull/17640#issuecomment-2752015834).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
