### PR TITLE
Fix table repr when column has scaling factors

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -478,8 +478,16 @@ class FITS_rec(np.recarray):
         return data
 
     def __repr__(self):
+        # recarray.__repr__ hard-codes the name of the class, so we overwrite.
+        # The following is mostly a straight copy except for the name change
+        # and for treating using str to typeset integer -- the latter to fix
+        # the case where the integer columns are scaled (see gh-17583). Also,
+        # removed a branch for "if the user is playing strange game with dtypes".
+        #
+        # FIXME: recarray removes the "numpy.record" mention in the dtype repr,
+        # we could do the same in a future version
+
         repr_dtype = self.dtype
-        # FIXME: remove numpy.record in the dtype repr, as recarray?
         # if repr_dtype.type is np.record:
         #     repr_dtype = np.dtype((np.void, repr_dtype))
         prefix = "FITS_rec("

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -478,9 +478,22 @@ class FITS_rec(np.recarray):
         return data
 
     def __repr__(self):
-        # Force use of the normal ndarray repr (rather than the new
-        # one added for recarray in Numpy 1.10) for backwards compat
-        return np.ndarray.__repr__(self)
+        repr_dtype = self.dtype
+        # FIXME: remove numpy.record in the dtype repr, as recarray?
+        # if repr_dtype.type is np.record:
+        #     repr_dtype = np.dtype((np.void, repr_dtype))
+        prefix = "FITS_rec("
+        fmt = "FITS_rec(%s,%sdtype=%s)"
+        # get data/shape string. logic taken from numeric.array_repr
+        if self.size > 0 or self.shape == (0,):
+            lst = np.array2string(
+                self, separator=", ", prefix=prefix, suffix=",", formatter=dict(int=str)
+            )
+        else:
+            # show zero-length shape unless it is (0,)
+            lst = "[], shape=%s" % (repr(self.shape),)  # noqa: UP031
+        lf = "\n" + " " * len(prefix)
+        return fmt % (lst, lf, repr_dtype)
 
     def __getattribute__(self, attr):
         # First, see if ndarray has this attr, and return it if so. Note that

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3934,3 +3934,20 @@ def test_invalid_table_array():
         ),
     ):
         fits.BinTableHDU(data, name="DATA")
+
+
+def test_repr_scaling(tmp_path):
+    cols = [
+        fits.Column(name="a", array=np.array([1, 2]), format="I"),
+        fits.Column(name="b", array=np.array([1, 2]), format="I"),
+    ]
+    hdu = fits.BinTableHDU.from_columns(cols)
+    hdu.header["TSCAL2"] = 0.1
+    hdu.header["TZERO2"] = 10
+    hdu.writeto(tmp_path / "test.fits")
+
+    data = fits.getdata(tmp_path / "test.fits")
+    assert repr(data) == (
+        "FITS_rec([(1, 10.1), (2, 10.2)],\n"
+        "         dtype=(numpy.record, [('a', '>i2'), ('b', '>i2')]))"
+    )

--- a/docs/changes/io.fits/17933.bugfix.rst
+++ b/docs/changes/io.fits/17933.bugfix.rst
@@ -1,2 +1,2 @@
 Fix FITS_rec repr when a column has scaling factors, leading to a crash with
-with numpy>=2.0.
+numpy>=2.0.

--- a/docs/changes/io.fits/17933.bugfix.rst
+++ b/docs/changes/io.fits/17933.bugfix.rst
@@ -1,0 +1,2 @@
+Fix FITS_rec repr when a column has scaling factors, leading to a crash with
+with numpy>=2.0.


### PR DESCRIPTION
Fix #17583

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
