### PR TITLE
Fix parameter bound for PowerDistStretch and InvertedPowerDistStretch

### DIFF
--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -281,14 +281,13 @@ class PowerDistStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be
-        greater than or equal to 0, but cannot be set to 1.  Default is
-        1000.
+        The ``a`` parameter used in the above formula. ``a`` must be
+        greater than 0, but cannot be set to 1. Default is 1000.
     """
 
     def __init__(self, a=1000.0):
-        if a < 0 or a == 1:  # singularity
-            raise ValueError("a must be >= 0, but cannot be set to 1")
+        if a <= 0 or a == 1:  # singularity
+            raise ValueError("a must be > 0, but cannot be set to 1")
         super().__init__()
         self.a = a
 
@@ -318,14 +317,13 @@ class InvertedPowerDistStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be
-        greater than or equal to 0, but cannot be set to 1.  Default is
-        1000.
+        The ``a`` parameter used in the above formula. ``a`` must be
+        greater than 0, but cannot be set to 1. Default is 1000.
     """
 
     def __init__(self, a=1000.0):
-        if a < 0 or a == 1:  # singularity
-            raise ValueError("a must be >= 0, but cannot be set to 1")
+        if a <= 0 or a == 1:  # singularity
+            raise ValueError("a must be > 0, but cannot be set to 1")
         super().__init__()
         self.a = a
 

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -118,9 +118,9 @@ def test_clip_invalid():
     np.testing.assert_allclose(values, [np.nan, 0.0, 0.70710678, 1.0, 1.2247448])
 
 
-@pytest.mark.parametrize("a", [-2.0, -1, 1.0])
+@pytest.mark.parametrize("a", [-2.0, -1, 0.0, 1.0])
 def test_invalid_powerdist_a(a):
-    match = "a must be >= 0, but cannot be set to 1"
+    match = "a must be > 0, but cannot be set to 1"
     with pytest.raises(ValueError, match=match):
         PowerDistStretch(a=a)
     with pytest.raises(ValueError, match=match):

--- a/docs/changes/visualization/17941.bugfix.rst
+++ b/docs/changes/visualization/17941.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed the limits of ``a`` parameter in the ``PowerDistStretch``
+and ``InvertedPowerDistStretch`` classes so that a value of
+0 in no longer allowed. That value gives infinity values in
+``InvertedPowerDistStretch`` and it makes the ``PowerDistStretch``
+results independent of the input data.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The ``a`` parameter in `PowerDistStretch `and `InvertedPowerDistStretch` cannot be equal to 0.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
