### PR TITLE
Removing three skips in docs/time/index.rst

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -84,7 +84,7 @@ The full power of output representation is available via the
 `subformat`_. For instance, using ``numpy.longdouble`` as the output type
 for higher precision::
 
-  >>> t.to_value('mjd', 'long')  # doctest: +SKIP
+  >>> t.to_value('mjd', 'long')  
   array([51179.00000143, 55197.        ], dtype=float128)
 
 The default representation can be changed by setting the ``format`` attribute::
@@ -294,7 +294,7 @@ can have higher precision than the standard 64-bit float::
   >>> tm = Time('51544.000000000000001', format='mjd')  # String input
   >>> tm.mjd  # float64 output loses last digit but Decimal gets it
   np.float64(51544.0)
-  >>> tm.to_value('mjd', subfmt='decimal')  # doctest: +SKIP
+  >>> tm.to_value('mjd', subfmt='decimal')  
   Decimal('51544.00000000000000099920072216264')
   >>> tm.to_value('mjd', subfmt='str')
   '51544.000000000000001'
@@ -664,7 +664,7 @@ You can explicitly specify ``in_subfmt`` in order to strictly require a
 certain subformat::
 
   >>> t = Time('2000:002:03:04', in_subfmt='date_hm')
-  >>> t = Time('2000:002', in_subfmt='date_hm')  # doctest: +SKIP
+  >>> t = Time('2000:002', in_subfmt='date_hm')  
   Traceback (most recent call last):
     ...
   ValueError: Input values did not match any of the formats where the


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
Removed three `#doctest: +SKIP` that seems to be safe in `docs/time/index.rst`.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address Issue #17454 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->
