### PR TITLE
Avoid cluttering documentation build log with deprecation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -628,3 +628,6 @@ def setup(app):
     # docs astropy: targets will go to the local docs instead of the
     # intersphinx mapping
     app.connect("missing-reference", resolve_astropy_reference, priority=400)
+
+
+warnings.filterwarnings("ignore", module="astropy.units.deprecated")


### PR DESCRIPTION
### Description

Accessing the units defined in `astropy.units.deprecated` causes deprecation warnings. All the units are accessed when the documentation is built, so the documentation build log is getting cluttered with these warnings. The simplest solution is to set up a warning filter in `docs/conf.py` to ignore all warnings from `astropy.units.deprecated`.

Fixes #17938

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
