### PR TITLE
Remove some duplicated and outdated documentation from testing guidelines

### DIFF
--- a/docs/development/maintainers/testhelpers.rst
+++ b/docs/development/maintainers/testhelpers.rst
@@ -11,7 +11,7 @@ overview of running or writing the tests.
 Details
 =======
 The dependencies used by the Astropy test runner are provided by a separate
-package called |pytest-astropy| (see :ref:`pytest-plugins`). This package provides the ``pytest``
+package called |pytest-astropy|. This package provides the ``pytest``
 dependency itself, in addition to several ``pytest`` plugins that are used by
 Astropy, and will also be of general use to other packages.
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -791,7 +791,7 @@ running framework. For example doctests and detailed documentation on how to
 write them, see the full :mod:`doctest` documentation.
 
 For more information on the ``pytest-doctestplus`` plugin used by Astropy, see
-:ref:`doctestplus-plugin`.
+|pytest-doctestplus|.
 
 .. _skipping-doctests:
 
@@ -1023,27 +1023,3 @@ test functions with ``@pytest.mark.remote_data(source='astropy')``. Tests
 marked with ``internet_off`` will also be skipped in this case.
 
 Also see :ref:`data-files`.
-
-.. _doctestplus-plugin:
-
-pytest-doctestplus
-==================
-
-The |pytest-doctestplus| plugin provides advanced doctest features, including:
-
-* handling doctests that use remote data in conjunction with the
-  ``pytest-remotedata`` plugin above (see :ref:`data-files`)
-* approximate floating point comparison for doctests that produce floating
-  point results (see :ref:`handling-float-output`)
-* skipping particular classes, methods, and functions when running doctests
-  (see :ref:`skipping-doctests`)
-* optional inclusion of ``*.rst`` files for doctests
-
-This plugin provides two command line options: ``--doctest-plus`` for enabling
-the advanced features mentioned above, and ``--doctest-rst`` for including
-``*.rst`` files in doctest collection.
-
-The Astropy test runner enables both of these options by default. When running
-the test suite directly from ``pytest`` (instead of through the Astropy test
-runner), it is necessary to explicitly provide these options when they are
-needed.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -586,15 +586,6 @@ tables to HDF5 format), and in ``test_all`` for dependencies only used in tests
 (e.g., ``skyfield``, which is used to cross-check the accuracy of coordinate
 transforms).
 
-Using pytest helper functions
-=============================
-
-If your tests need to use `pytest helper functions
-<https://docs.pytest.org/en/latest/reference/reference.html#functions>`_, such as
-``pytest.raises``, import ``pytest`` into your test module like so::
-
-    import pytest
-
 Testing warnings
 ================
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -290,7 +290,7 @@ enable just these tests, you can run the
 tests with ``pytest --remote-data=astropy``.
 
 For more information on the ``pytest-remotedata`` plugin, see
-:ref:`remotedata-plugin`.
+|pytest-remotedata|.
 
 Examples
 --------
@@ -977,49 +977,3 @@ from `astropy-benchmarks <https://github.com/astropy/astropy-benchmarks/>`_.
 It is important to note that these benchmarks can be flaky as they run on
 virtual machines (and thus shared hardware) but they should give a general
 idea of the performance impact of a pull request.
-
-.. _pytest-plugins:
-
-Pytest Plugins
-**************
-
-The following ``pytest`` plugins are maintained and used by Astropy. They are
-included as dependencies to the ``pytest-astropy`` package, which is now
-required for testing Astropy. More information on all of the  plugins provided
-by the ``pytest-astropy`` package (including dependencies not maintained by
-Astropy) can be found `here <https://github.com/astropy/pytest-astropy>`__.
-
-.. _remotedata-plugin:
-
-pytest-remotedata
-=================
-
-The |pytest-remotedata| plugin allows developers to control whether to run
-tests that access data from the internet. The plugin provides two decorators
-that can be used to mark individual test functions or entire test classes:
-
-* ``@pytest.mark.remote_data`` for tests that require data from the internet
-* ``@pytest.mark.internet_off`` for tests that should run only when there is no
-  internet access. This is useful for testing local data caches or fallbacks
-  for when no network access is available.
-
-The plugin also adds the ``--remote-data`` option to the ``pytest`` command
-(which is also made available through the Astropy test runner).
-
-If the ``--remote-data`` option is not provided when running the test suite, or
-if ``--remote-data=none`` is provided, all tests that are marked with
-``remote_data`` will be skipped. All tests that are marked with
-``internet_off`` will be executed. Any test that attempts to access the
-internet but is not marked with ``remote_data`` will result in a failure.
-
-Providing either the ``--remote-data`` option, or ``--remote-data=any``, will
-cause all tests marked with ``remote_data`` to be executed. Any tests that are
-marked with ``internet_off`` will be skipped.
-
-Running the tests with ``--remote-data=astropy`` will cause only tests that
-receive remote data from Astropy data sources to be run. Tests with any other
-data sources will be skipped. This is indicated in the test code by marking
-test functions with ``@pytest.mark.remote_data(source='astropy')``. Tests
-marked with ``internet_off`` will also be skipped in this case.
-
-Also see :ref:`data-files`.


### PR DESCRIPTION
### Description

I think our testing guidelines are not very well written. For example, a large fraction of our guidelines is a worse version of `pytest` documentation. But addressing that properly would be a large undertaking. In this pull request I am only removing a few sub-sections for which it is clear that they provide no value.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
