### PR TITLE
Backport PR #17936: Fix unit bug in Table creation, fixes #17930

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -194,15 +194,11 @@ def _convert_sequence_data_to_array(data, dtype=None):
     """
     np_ma_masked = np.ma.masked  # Avoid repeated lookups of this object
 
+    has_len_gt0 = hasattr(data, "__len__") and len(data) > 0
     # Special case of an homogeneous list of MaskedArray elements (see #8977).
     # np.ma.masked is an instance of MaskedArray, so exclude those values.
-    if (
-        hasattr(data, "__len__")
-        and len(data) > 0
-        and all(
-            isinstance(val, np.ma.MaskedArray) and val is not np_ma_masked
-            for val in data
-        )
+    if has_len_gt0 and all(
+        isinstance(val, np.ma.MaskedArray) and val is not np_ma_masked for val in data
     ):
         np_data = np.ma.array(data, dtype=dtype)
         return np_data
@@ -222,21 +218,19 @@ def _convert_sequence_data_to_array(data, dtype=None):
             category=FutureWarning,
             message=".*Promotion of numbers and bools to strings.*",
         )
+
+        has_unit = has_len_gt0 and any(hasattr(v, "unit") for v in data)
+
         try:
-            np_data = np.array(data, dtype=dtype)
+            cls = Quantity if has_unit else np.array
+            np_data = cls(data, dtype=dtype)
         except np.ma.MaskError:
             # Catches case of dtype=int with masked values, instead let it
             # convert to float
             np_data = np.array(data)
         except Exception:
-            # Conversion failed for some reason, e.g. [2, 1*u.m] gives TypeError in Quantity.
-            # First try to interpret the data as Quantity. If that still fails then fall
-            # through to object
-            try:
-                np_data = Quantity(data, dtype)
-            except Exception:
-                dtype = object
-                np_data = np.array(data, dtype=dtype)
+            dtype = object
+            np_data = np.array(data, dtype=dtype)
 
     if np_data.ndim == 0 or (np_data.ndim > 0 and len(np_data) == 0):
         # Implies input was a scalar or an empty list (e.g. initializing an

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -3601,3 +3601,16 @@ def test_table_replace_column_with_scalar(empty_table):
     # Direct replacement should never work.
     with pytest.raises(ValueError, match="cannot replace.*with a scalar"):
         t.replace_column("a", 2)
+
+
+def test_table_from_records_nd_quantity():
+    """Regression test for #17930"""
+
+    data = [
+        {"q0d": 5 * u.m, "q1d": [1, 2, 3] * u.s, "q2d": [[0, 1, 2], [3, 4, 5]] * u.TeV},
+    ]
+
+    t = Table(data)
+    assert t["q0d"].unit == u.m
+    assert t["q1d"].unit == u.s
+    assert t["q2d"].unit == u.TeV

--- a/docs/changes/table/17936.bugfix.rst
+++ b/docs/changes/table/17936.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a bug in creating a ``Table`` from a list of rows that dropped the units
+of non-scalar Quantity, e.g., ``Table(rows=[([1] * u.m,), ([2] * u.m,)])``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to backport #17936 on v7.0.x

The conflict was only in added / removed tests at the bottom of the test file. No actual changes in the code from the original PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
