### PR TITLE
Fixes test_fitting_with_initial_values[DogBoxLSQFitter] convergence failure on arm64

### DIFF
--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -116,7 +116,7 @@ def test_fitting_with_initial_values(fitter):
     x, y = _fake_gaussian_data()
 
     # Fit the data using a Gaussian with units
-    g_init = models.Gaussian1D(amplitude=1.0 * u.mJy, mean=3 * u.cm, stddev=2 * u.mm)
+    g_init = models.Gaussian1D(amplitude=1.0 * u.mJy, mean=4 * u.cm, stddev=3 * u.mm)
     g = fitter(g_init, x, y)
 
     # TODO: update actual numerical results once implemented, but these should


### PR DESCRIPTION

### Description
On ARM64, when using an optimized OpenBLAS (i.e. configured with -march=native), the unit test `test_fitting_with_initial_values[DogBoxLSQFitter]` fails to converge. This is because due to the optimization, numerical behavior may alter ever-so-slightly, and apparently the initial starting conditions for this fit we're poorly conditioned. See https://github.com/astropy/astropy/issues/15650 for a more extensive description of the issue.

After doing an extensive search for various initial conditions [here](https://github.com/astropy/astropy/issues/15650#issuecomment-2699109142), this PR changes the initial conditions to values that appear to be more robust. I myself have build this on a wide range of CPU architectures (zen2, zen3, zen4, skylake, haswell, sapphire_rapids, x86_64/generic, aarch64/generic, neoverse_v1, neoverse_n1) to check if the test now passes on all of them. For each of those builds, the underlying OpenBLAS was optimized with `-march=native` (with the exception of the 'generic' builds), build natively on a machine of one of those architectures. This makes me as sure as I can be that the change in initial condition doesn't fix things for ARM, while reintroducing similar problems elsewhere.

Fixes #15650

