### PR TITLE
Remove length from `length`

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -427,9 +427,6 @@ class PhysicalType:
     def __hash__(self) -> int:
         return hash(self._unit._physical_type_id)
 
-    def __len__(self) -> int:
-        return len(self._physical_type)
-
     # We need to prevent operations like where a Unit instance left
     # multiplies a PhysicalType instance from returning a `Quantity`
     # instance with a PhysicalType as the value.  We can do this by


### PR DESCRIPTION
### Description

By default `length` has the same length as `acceleration`, but it is shorter than `speed`:
```python
>>> from astropy.units.physical import acceleration, length, speed
>>> len(length) == len(acceleration)
True
>>> len(length) < len(speed)
True
```
But it is possible to make `length` longer, e.g. by translating its name:
```python
>>> from astropy import units as u
>>> from astropy.units.physical import length
>>> len(length)
1
>>> u.def_physical_type(u.m, "pikkus")
>>> len(length)
2
```
The meaning of the above examples is not clear without reading the `PhysicalType` source code, so I think it's less confusing if `PhysicalType` instances didn't have a length at all.

It is not possible to deprecate `PhysicalType.__len__()` because our documentation promises that a `PhysicalType` is an iterable: https://github.com/astropy/astropy/blob/e2b2a2aa3baf96beb6f786101ad35f4efc3cfc15/docs/units/physical_types.rst?plain=1#L61-L66
which means that `list(length)` should work, but if `PhysicalType` has a deprecated `__len__()` then `list(length)` would trigger a deprecation warning that the user cannot avoid. Fortunately we don't seem to have advertised anywhere that a `PhysicalType` has length, so removing the method might not cause disruption downstream.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
