### PR TITLE
Add LZMA file support to `io.fits`

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -453,10 +453,10 @@ def writeto(
 
     Notes
     -----
-    gzip, zip and bzip2 compression algorithms are natively supported.
+    gzip, zip, bzip2 and lzma compression algorithms are natively supported.
     Compression mode is determined from the filename extension
-    ('.gz', '.zip' or '.bz2' respectively).  It is also possible to pass a
-    compressed file object, e.g. `gzip.GzipFile`.
+    ('.gz', '.zip', '.bz2' or '.xz' respectively).  It is also possible to pass
+    a compressed file object, e.g. `gzip.GzipFile`.
     """
     hdu = _makehdu(data, header)
     if hdu.is_image and not isinstance(hdu, PrimaryHDU):

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -238,7 +238,8 @@ class _File:
             self.compression = "zip"
         elif _is_bz2file(fileobj):
             self.compression = "bzip2"
-
+        elif _is_lzmafile(fileobj):
+            self.compression = "lzma"
         if (
             self.compression is not None
             and decompress_in_memory
@@ -677,7 +678,10 @@ class _File:
         # Make certain we're back at the beginning of the file
         # BZ2File does not support seek when the file is open for writing, but
         # when opening a file for write, bz2.BZ2File always truncates anyway.
-        if not (_is_bz2file(self._file) and mode == "ostream"):
+        if not (
+            (_is_bz2file(self._file) or (_is_lzmafile(self._file)))
+            and mode == "ostream"
+        ):
             self._file.seek(0)
 
     @classproperty(lazy=True)

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -17,7 +17,7 @@ from functools import reduce
 import numpy as np
 
 # NOTE: Python can be built without bz2.
-from astropy.utils.compat.optional_deps import HAS_BZ2
+from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA
 from astropy.utils.data import (
     _is_url,
     _requires_fsspec,
@@ -44,6 +44,8 @@ from .util import (
 if HAS_BZ2:
     import bz2
 
+if HAS_LZMA:
+    import lzma
 
 # Maps astropy.io.fits-specific file mode names to the appropriate file
 # modes to use for the underlying raw files.
@@ -98,11 +100,19 @@ MEMMAP_MODES = {
 GZIP_MAGIC = b"\x1f\x8b\x08"
 PKZIP_MAGIC = b"\x50\x4b\x03\x04"
 BZIP2_MAGIC = b"\x42\x5a"
+LZMA_MAGIC = b"\xfd7zXZ\x00"
 
 
 def _is_bz2file(fileobj):
     if HAS_BZ2:
         return isinstance(fileobj, bz2.BZ2File)
+    else:
+        return False
+
+
+def _is_lzmafile(fileobj):
+    if HAS_LZMA:
+        return isinstance(fileobj, lzma.LZMAFile)
     else:
         return False
 
@@ -557,6 +567,19 @@ class _File:
             bzip2_mode = "w" if is_ostream else "r"
             self._file = bz2.BZ2File(obj_or_name, mode=bzip2_mode)
             self.compression = "bzip2"
+        elif (is_ostream and ext == ".xz") or magic.startswith(LZMA_MAGIC):
+            # Handle lzma files
+            if mode in ["update", "append"]:
+                raise OSError(
+                    "update and append modes are not supported with lzma files"
+                )
+            if not HAS_LZMA:
+                raise ModuleNotFoundError(
+                    "This Python installation does not provide the lzma module."
+                )
+            lzma_mode = "w" if is_ostream else "r"
+            self._file = lzma.LZMAFile(obj_or_name, mode=lzma_mode)
+            self.compression = "lzma"
         return self.compression is not None
 
     def _open_fileobj(self, fileobj, mode, overwrite):
@@ -581,7 +604,7 @@ class _File:
             # means that the current file position is at the end of the file.
             if mode in ["ostream", "append"]:
                 self._file.seek(0)
-            magic = self._file.read(4)
+            magic = self._file.read(6)
             # No matter whether the underlying file was opened with 'ab' or
             # 'ab+', we need to return to the beginning of the file in order
             # to properly process the FITS header (and handle the possibility
@@ -641,7 +664,7 @@ class _File:
 
         if os.path.exists(self.name):
             with open(self.name, "rb") as f:
-                magic = f.read(4)
+                magic = f.read(6)
         else:
             magic = b""
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -395,10 +395,10 @@ class _BaseHDU:
 
         Notes
         -----
-        gzip, zip and bzip2 compression algorithms are natively supported.
+        gzip, zip, bzip2 and lzma compression algorithms are natively supported.
         Compression mode is determined from the filename extension
-        ('.gz', '.zip' or '.bz2' respectively).  It is also possible to pass a
-        compressed file object, e.g. `gzip.GzipFile`.
+        ('.gz', '.zip', '.bz2' or '.xz' respectively).  It is also possible to
+        pass a compressed file object, e.g. `gzip.GzipFile`.
         """
         from .hdulist import HDUList
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1002,10 +1002,10 @@ class HDUList(list, _Verify):
 
         Notes
         -----
-        gzip, zip and bzip2 compression algorithms are natively supported.
+        gzip, zip, bzip2 and lzma compression algorithms are natively supported.
         Compression mode is determined from the filename extension
-        ('.gz', '.zip' or '.bz2' respectively).  It is also possible to pass a
-        compressed file object, e.g. `gzip.GzipFile`.
+        ('.gz', '.zip', '.bz2' or '.xz' respectively).  It is also possible to
+        pass a compressed file object, e.g. `gzip.GzipFile`.
         """
         if len(self) == 0:
             warnings.warn("There is nothing to write.", AstropyUserWarning)

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -27,7 +27,7 @@ from astropy.utils import indent
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 # NOTE: Python can be built without bz2.
-from astropy.utils.compat.optional_deps import HAS_BZ2
+from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .base import ExtensionHDU, _BaseHDU, _NonstandardHDU, _ValidHDU
@@ -38,6 +38,9 @@ from .table import BinTableHDU
 
 if HAS_BZ2:
     import bz2
+
+if HAS_LZMA:
+    import lzma
 
 __all__ = ["HDUList", "fitsopen"]
 
@@ -1468,6 +1471,12 @@ class HDUList(list, _Verify):
                         "This Python installation does not provide the bz2 module."
                     )
                 new_file = bz2.BZ2File(name, mode="w")
+            elif self._file.compression == "lzma":
+                if not HAS_LZMA:
+                    raise ModuleNotFoundError(
+                        "This Python installation does not provide the lzma module."
+                    )
+                new_file = lzma.LZMAFile(name, mode="w")
             else:
                 new_file = name
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1010,7 +1010,7 @@ class TestFileFunctions(FitsTestCase):
         with fits.open(self.temp("test.fits.gz")) as hdul:
             assert np.all(hdul[0].data == data)
 
-    @pytest.mark.parametrize("ext", ["gz", "bz2", "zip"])
+    @pytest.mark.parametrize("ext", ["gz", "bz2", "zip", "xz"])
     def test_compressed_ext_but_not_compressed(self, ext):
         testfile = self.temp(f"test0.fits.{ext}")
         shutil.copy(self.data("test0.fits"), testfile)

--- a/docs/changes/io.fits/17968.feature.rst
+++ b/docs/changes/io.fits/17968.feature.rst
@@ -1,0 +1,3 @@
+``io.fits`` now supports on-the-fly decompression of LZMA-compressed files
+(typically ".xz" extension) if the lzma module is provided by the Python
+installation.

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -205,7 +205,7 @@ talking about a FITS file that has been compressed with one of these utilities
 
 There are some limitations when working with compressed files. For example,
 with Zip files that contain multiple compressed files, only the first file will
-be accessible. Also bzip2 and lzma does not support the append or update access
+be accessible. Also bzip2 and lzma do not support the append or update access
 modes.
 
 When writing a file (e.g., with the :func:`writeto` function), compression will

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -199,13 +199,14 @@ Working with compressed files
 
 
 The :func:`open` function will seamlessly open FITS files that have been
-compressed with gzip, bzip2 or pkzip. Note that in this context we are talking
-about a FITS file that has been compressed with one of these utilities (e.g., a
-.fits.gz file).
+compressed with gzip, bzip2, pkzip or lzma. Note that in this context we are
+talking about a FITS file that has been compressed with one of these utilities
+(e.g., a .fits.gz file).
 
 There are some limitations when working with compressed files. For example,
 with Zip files that contain multiple compressed files, only the first file will
-be accessible. Also bzip2 does not support the append or update access modes.
+be accessible. Also bzip2 and lzma does not support the append or update access
+modes.
 
 When writing a file (e.g., with the :func:`writeto` function), compression will
 be determined based on the filename extension given, or the compression used in


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the lack of LZMA support in  `io.fits`. Fixes #9714

Header magic needs to be expanded to 6 bytes because that's the size of LZMA's (at least according to both [The Tukaani Project](https://tukaani.org/xz/xz-file-format.txt) and [Wikipedia](https://en.wikipedia.org/wiki/List_of_file_signatures)). The existing code was already doing `magic.startswith`, so this should not conflict with the other detections.

The code added is a near copy-paste of the code for bz2, but it seems to work fine. I'll add tests later.