### PR TITLE
Remove two unneeded Ruff rule exceptions from global configuration

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -178,9 +178,6 @@ lint.ignore = [
     "TRY201",  # verbose-raise
     "TRY301",  # raise-within-try
 
-    # pyupgrade (UP)
-    "UP038",  # isinstance using union separators. The code is slower as of Python 3.11-3.12
-
     # flake8-quotes (Q)
     "Q000",  # use double quotes
 ]

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -1235,7 +1235,7 @@ def test_non_broadcasting_parameters():
             return
 
     # a broadcasts with both b and c, but b does not broadcast with c
-    MESSAGE = r"Mismatch is between arg \d with shape .* and arg \d with" " shape .*"
+    MESSAGE = r"Mismatch is between arg \d with shape .* and arg \d with shape .*"
     for args in itertools.permutations((a, b, c)):
         with pytest.raises(InputParameterError, match=MESSAGE):
             TestModel(*args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,10 +358,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # flake8-fixme (FIX)
     "FIX002",  # Line contains TODO | notes for improvements are OK iff the code works
 
-    # ISC001 shouldn't be used with ruff format
-    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    "ISC001",
-
     # pep8-naming (N)
     "N803",  # invalid-argument-name. Physics variables are often poor code variables
     "N806",  # non-lowercase-variable-in-function. Physics variables are often poor code variables


### PR DESCRIPTION
### Description

I found two Ruff rule exceptions in our global configuration that are not needed anymore.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
