### PR TITLE
Make `astropy.units.imperial` properly available

### DIFF
--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -16,6 +16,7 @@ from . import (
     core,
     decorators,
     errors,
+    imperial,
     misc,
     photometric,
     physical,

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -13,15 +13,7 @@ from typing import TYPE_CHECKING
 
 from astropy.utils.compat import COPY_IF_NEEDED
 
-from . import (
-    astrophys,
-    cgs,
-    core,
-    imperial,  # for bkwd compat #11975 and #11977  # noqa: F401
-    misc,
-    quantity,
-    si,
-)
+from . import astrophys, cgs, core, misc, quantity, si
 
 if TYPE_CHECKING:
     from collections.abc import Iterator


### PR DESCRIPTION
### Description

Currently the `imperial` module is available in the `units` namespace because of a side-effect of it being imported by the `physical` module, but `physical` has no need for `imperial` and there is no reason `imperial` can't be imported in `units/__init__.py`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
