### PR TITLE
Fix LZMA invalid file checking in `utils`

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -384,7 +384,7 @@ def get_readable_fileobj(
             fileobj = io.BytesIO(fileobj.read())
 
     # Now read enough bytes to look at signature
-    signature = fileobj.read(4)
+    signature = fileobj.read(6)
     fileobj.seek(0)
 
     if signature[:3] == b"\x1f\x8b\x08":  # gzip
@@ -426,7 +426,7 @@ def get_readable_fileobj(
             fileobj_new.seek(0)
             close_fds.append(fileobj_new)
             fileobj = fileobj_new
-    elif signature[:3] == b"\xfd7z":  # xz
+    elif signature[:6] == b"\xfd7zXZ\x00":  # xz
         if not HAS_LZMA:
             for fd in close_fds:
                 fd.close()
@@ -438,7 +438,7 @@ def get_readable_fileobj(
         try:
             fileobj_new = lzma.LZMAFile(fileobj, mode="rb")
             fileobj_new.read(1)  # need to check that the file is really xz
-        except (OSError, EOFError):  # invalid xz file
+        except lzma.LZMAError:  # invalid xz file
             fileobj.seek(0)
             fileobj_new.close()
             # should we propagate this to the caller to signal bad content?

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -971,12 +971,13 @@ def test_local_data_obj(filename):
             assert f.read().rstrip() == b"CONTENT"
 
 
-@pytest.fixture(params=["invalid.dat.bz2", "invalid.dat.gz"])
+@pytest.fixture(params=["invalid.dat.bz2", "invalid.dat.xz", "invalid.dat.gz"])
 def bad_compressed(request, tmp_path):
     # These contents have valid headers for their respective file formats, but
     # are otherwise malformed and invalid.
     bz_content = b"BZhinvalid"
     gz_content = b"\x1f\x8b\x08invalid"
+    xz_content = b"\xfd7zXZ\x00invalid"
 
     datafile = tmp_path / request.param
     filename = str(datafile)
@@ -985,6 +986,8 @@ def bad_compressed(request, tmp_path):
         contents = bz_content
     elif filename.endswith(".gz"):
         contents = gz_content
+    elif filename.endswith(".xz"):
+        contents = xz_content
     else:
         contents = "invalid"
 

--- a/docs/changes/utils/17984.bugfix.rst
+++ b/docs/changes/utils/17984.bugfix.rst
@@ -1,0 +1,1 @@
+Properly detect invalid LZMA files in ``utils.data``.


### PR DESCRIPTION
### Description

This pull request is to address an incorrect check for invalid LZMA files. Fixes #17983.

The incorrect check is caused by a combination of factors:

1. Even though the `test_local_data_obj_invalid` test _looks_ like it's testing for the ".xz" case, it actually isn't. This is because the `invalid.dat.xz` file wasn't being created by the `bad_compressed` function, so the ".xz" was never actually triggered.
2. utils.data was capturing exceptions for OSError, EOFError; the correct exception for an invalid file is lzma.LZMAError.
3. utils.data was only comparing 3 bytes for the signature/magic; the correct signature for LZMA is 6 bytes long.