### PR TITLE
Redefine degrees Rankine as a scaled version of the kelvin

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -766,11 +766,10 @@ def thermodynamic_temperature(frequency, T_cmb=None):
 
 @functools.cache
 def temperature():
-    """Convert between Kelvin, Celsius, Rankine and Fahrenheit here because
+    """Convert degrees Celsius and degrees Fahrenheit here because
     Unit and CompositeUnit cannot do addition or subtraction properly.
     """
     from .imperial import deg_F as F
-    from .imperial import deg_R as R
 
     K = si.K
     C = si.deg_C
@@ -780,9 +779,6 @@ def temperature():
             (K, C, lambda x: x - 273.15, lambda x: x + 273.15),
             (C, F, lambda x: x * 1.8 + 32.0, lambda x: (x - 32.0) / 1.8),
             (K, F, lambda x: x * 1.8 - 459.67, lambda x: (x + 459.67) / 1.8),
-            (R, F, lambda x: x - 459.67, lambda x: x + 459.67),
-            (R, C, lambda x: (x - 491.67) * (5 / 9), lambda x: x * 1.8 + 491.67),
-            (R, K, lambda x: x * (5 / 9), lambda x: x * 1.8),
         ],
         "temperature",
     )

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -148,6 +148,7 @@ def_unit(
 )
 def_unit(
     ["deg_R", "Rankine"],
+    5 / 9 * si.K,
     namespace=_ns,
     doc="Rankine scale: absolute scale of thermodynamic temperature",
 )

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -167,15 +167,14 @@ def _physical_type_from_str(name: str) -> PhysicalType:
 
 
 def _replace_temperatures_with_kelvin(unit: core.UnitBase) -> core.UnitBase:
-    """
-    If a unit contains a temperature unit besides kelvin, then replace
-    that unit with kelvin.
+    """Replace °F, and °C in the bases of `unit` with K.
 
-    Temperatures cannot be converted directly between K, °F, °C, and
-    °Ra, in particular since there would be different conversions for
-    T and ΔT.  However, each of these temperatures each represents the
-    physical type.  Replacing the different temperature units with
-    kelvin allows the physical type to be treated consistently.
+    The Kelvin, Celsius and Fahrenheit scales have different zero points,
+    which is a problem for the unit conversion machinery (without the
+    `temperature` equivalency). Replacing °F, and °C with kelvin allows the
+    physical type to be treated consistently. The Rankine scale has the
+    same zero point as the Kelvin scale, so degrees Rankine do not have to
+    be special-cased.
     """
     physical_type_id = unit._physical_type_id
 
@@ -183,7 +182,7 @@ def _replace_temperatures_with_kelvin(unit: core.UnitBase) -> core.UnitBase:
     substitution_was_made = False
 
     for base, power in physical_type_id:
-        if base in ["deg_F", "deg_C", "deg_R"]:
+        if base in ["deg_F", "deg_C"]:
             base = "K"
             substitution_was_made = True
         physical_type_id_components.append((base, power))

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -842,10 +842,6 @@ def test_temperature():
     t_k = 0 * u.K
     assert_allclose(t_k.to_value(u.deg_C, u.temperature()), -273.15)
     assert_allclose(t_k.to_value(deg_F, u.temperature()), -459.67)
-    t_k = 20 * u.K
-    assert_allclose(t_k.to_value(deg_R, u.temperature()), 36.0)
-    t_k = 20 * deg_R
-    assert_allclose(t_k.to_value(u.K, u.temperature()), 11.11, atol=0.01)
     t_k = 20 * deg_F
     assert_allclose(t_k.to_value(deg_R, u.temperature()), 479.67)
     t_k = 20 * deg_R

--- a/docs/changes/units/17985.feature.rst
+++ b/docs/changes/units/17985.feature.rst
@@ -1,0 +1,2 @@
+Unit conversions between kelvins and degrees Rankine no longer require the
+``temperature`` equivalency.

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -463,15 +463,22 @@ point of 3631.1 Jy::
 Temperature Equivalency
 -----------------------
 
-The :func:`~astropy.units.temperature` equivalency allows conversion
-between the Celsius, Fahrenheit, Rankine and Kelvin.
+Conversions between kelvins and degrees Rankine do not require using any
+equivalencies because the Kelvin scale and the Rankine scale have the same zero
+point::
 
-Example
-^^^^^^^
+   >>> temp_K = 100 * u.K
+   >>> temp_R = temp_K.to(u.imperial.deg_R)
+   >>> temp_R
+   <Quantity 180. deg_R>
+   >>> temp_R.to(u.K)
+   <Quantity 100. K>
 
 .. EXAMPLE START: Using the Temperature Equivalency
 
-To convert between temperature scales::
+The Celsius and Fahrenheit scales have different zero points, which
+neccessitates the use of the :func:`~astropy.units.temperature` equivalency for
+unit conversions involving degrees Celsius or degrees Fahrenheit::
 
     >>> temp_C = 0 * u.Celsius
     >>> temp_Kelvin = temp_C.to(u.K, equivalencies=u.temperature())


### PR DESCRIPTION
### Description

The Kelvin, Celsius and Fahrenheit temperature scales all have different zero-points, which means the normal unit conversion machinery (i.e. multiplying by a conversion factor) cannot handle them. `astropy` has to provide the [`temperature` equivalency](https://docs.astropy.org/en/v7.0.1/units/equivalencies.html#temperature-equivalency) for these conversions. But the Rankine scale has the same zero-point as the Kelvin scale, so redefining degrees Rankine as a scaled version of the kelvin removes the need for using the equivalency for conversions between the two.

This change also simplifies our physical types machinery, but that is invisible for users.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
