### PR TITLE
Fix possible int overflow in io.fits compression

### DIFF
--- a/astropy/io/fits/hdu/compressed/src/compression.c
+++ b/astropy/io/fits/hdu/compressed/src/compression.c
@@ -320,7 +320,7 @@ static PyObject *compress_hcompress_1_c(PyObject *self, PyObject *args) {
     return (PyObject *)NULL;
   }
 
-  if (count != nx * ny * bytepix) {
+  if (count != (Py_ssize_t) nx * ny * bytepix) {
     PyErr_SetString(PyExc_ValueError,
                     "The tile dimensions and dtype do not match the number of bytes provided.");
     return (PyObject *)NULL;
@@ -395,7 +395,7 @@ static PyObject *decompress_hcompress_1_c(PyObject *self, PyObject *args) {
 
   compressed_values = (unsigned char *)str;
 
-  dbytes = malloc(nx * ny * bytepix);
+  dbytes = malloc((size_t) nx * ny * bytepix);
 
   if (bytepix == 4) {
     decompressed_values_int = (int *)dbytes;
@@ -421,7 +421,7 @@ static PyObject *decompress_hcompress_1_c(PyObject *self, PyObject *args) {
   }
 
   // fits_hdecompress[64] always returns 4 byte integers
-  result = Py_BuildValue("y#", dbytes, nx * ny * 4);
+  result = Py_BuildValue("y#", dbytes, (Py_ssize_t) nx * ny * 4);
   free(dbytes);
   return result;
 }

--- a/docs/changes/io.fits/17995.bugfix.rst
+++ b/docs/changes/io.fits/17995.bugfix.rst
@@ -1,0 +1,1 @@
+Fix possible int overflow in the tile compression C code.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
