### PR TITLE
feat: conversion between votables's coosys and astropy built in frames

### DIFF
--- a/astropy/io/votable/data/ivoa-vocalubary_refframe-v20220222.json
+++ b/astropy/io/votable/data/ivoa-vocalubary_refframe-v20220222.json
@@ -1,0 +1,182 @@
+{
+  "uri": "http://www.ivoa.net/rdf/refframe",
+  "flavour": "RDF Class",
+  "terms": {
+    "EQUATORIAL": {
+      "label": "Equatorial",
+      "description": "Umbrella term of all equatorial frames.  Only use for old, pre-FK4 equatorial coordinates.",
+      "wider": [],
+      "narrower": [
+        "geo_app",
+        "ICRS",
+        "FK4",
+        "FK5",
+        "eq_FK4",
+        "eq_FK5"
+      ]
+    },
+    "geo_app": {
+      "label": "Geocentric Apparent Positions",
+      "description": "Positions given as observed by a fictitious observer at the Earth's centre for the equator of observation.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "ICRS": {
+      "label": "ICRS",
+      "description": "International Celestial Reference System as defined by 1998AJ....116..516M.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "FK4": {
+      "label": "FK4",
+      "description": "Positions based on the 4th Fundamental Katalog. If no equinox is defined with this frame, assume B1950.0.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "FK5": {
+      "label": "FK5",
+      "description": "Positions based on the 5th Fundamental Katalog. If no equinox is defined with this frame, assume J2000.0.  Applications not requiring extremely high precision can identify FK5 at J2000 with ICRS.",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "eq_FK4": {
+      "label": "FK4",
+      "description": "Old VOTable COOSYS term for FK4.",
+      "useInstead": "FK4",
+      "deprecated": "",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "eq_FK5": {
+      "label": "FK5",
+      "description": "Old VOTable COOSYS term for FK5.",
+      "deprecated": "",
+      "useInstead": "FK5",
+      "wider": [
+        "EQUATORIAL"
+      ],
+      "narrower": []
+    },
+    "ECLIPTIC": {
+      "label": "Ecliptic",
+      "description": "Ecliptic coordinates; the ecliptic of J2000.0 is assumed.",
+      "wider": [],
+      "narrower": [
+        "ecl_FK4",
+        "ecl_FK5"
+      ]
+    },
+    "ecl_FK4": {
+      "label": "Ecliptic (FK4)",
+      "description": "Old VOTable COOSYS term ecliptic coordinates for the FK4 ecliptic (of B1950.0).",
+      "wider": [
+        "ECLIPTIC"
+      ],
+      "narrower": []
+    },
+    "ecl_FK5": {
+      "label": "Ecliptic (FK5)",
+      "description": "Old VOTable COOSYS term ecliptic coordinates for the FK5 ecliptic (of J2000.0).",
+      "useInstead": "ECLIPTIC",
+      "deprecated": "",
+      "wider": [
+        "ECLIPTIC"
+      ],
+      "narrower": []
+    },
+    "GENERIC_GALACTIC": {
+      "label": "Galactic",
+      "description": "Umbrella term for Galactic coordinates.  If at all possible, use a more specific term, as historically, many different conventions have been in use.",
+      "wider": [],
+      "narrower": [
+        "GALACTIC_I",
+        "GALACTIC",
+        "galactic"
+      ]
+    },
+    "GALACTIC_I": {
+      "label": "Old Galactic",
+      "description": "Old, pre-1958, Galactic coordinates.  See 1960MNRAS.121..123B for details.",
+      "wider": [
+        "GENERIC_GALACTIC"
+      ],
+      "narrower": []
+    },
+    "GALACTIC": {
+      "label": "Galactic",
+      "description": "Galactic coordinates, modern definition: Pole at precisely FK4 B1950 192.25, 27.4, origin at approximately FK4 B1950 265.55, -28.92.  See 1960MNRAS.121..123B for details.",
+      "wider": [
+        "GENERIC_GALACTIC"
+      ],
+      "narrower": []
+    },
+    "galactic": {
+      "label": "Galactic",
+      "description": "Old VOTable COOSYS term for GALACTIC.",
+      "useInstead": "GALACTIC",
+      "deprecated": "",
+      "wider": [
+        "GENERIC_GALACTIC"
+      ],
+      "narrower": []
+    },
+    "SUPER_GALACTIC": {
+      "label": "Supergalactic",
+      "description": "Supergalactic coordinates (pole at GALACTIC 47.37, +6.32, origin at GALACTIC 137.37, 0.",
+      "wider": [],
+      "narrower": []
+    },
+    "supergalactic": {
+      "label": "Supergalactic",
+      "description": "Old VOTable COOSYS term for SUPER_GALACTIC",
+      "deprecated": "",
+      "useInstead": "SUPER_GALACTIC",
+      "wider": [],
+      "narrower": []
+    },
+    "AZ_EL": {
+      "label": "Azimuth/elevation",
+      "description": "Local azimuth and elevation. (Ground-based observations; Azimuth from North through East.)",
+      "wider": [],
+      "narrower": []
+    },
+    "BODY": {
+      "label": "Body Coordinates",
+      "description": "Generic bodycentric coordinates. Data annotated in this way cannot be automatically combined with any other data.  Use or create more specific terms if at all possible.",
+      "wider": [],
+      "narrower": []
+    },
+    "UNKNOWN": {
+      "label": "Unknown reference frame",
+      "description": "Unknown reference frame. Only to be used as a last resort or for simulations. Data annotated in this way cannot be automatically combined with any other data.",
+      "wider": [],
+      "narrower": []
+    },
+    "xy": {
+      "label": "Unknown reference frame",
+      "description": "Old VOTable COOSYS term for UNKNOWN",
+      "deprecated": "",
+      "useInstead": "UNKNOWN",
+      "wider": [],
+      "narrower": []
+    },
+    "barycentric": {
+      "label": "ICRS/Bary",
+      "description": "Old VOTable COOSYS term indicating ICRS at BARYCENTER reference position.  In the modern VO, refpos and refframe are no longer represented together.  Do not use this any more.",
+      "useInstead": "ICRS",
+      "deprecated": "",
+      "wider": [],
+      "narrower": []
+    }
+  }
+}

--- a/astropy/io/votable/tests/test_coosys.py
+++ b/astropy/io/votable/tests/test_coosys.py
@@ -3,8 +3,10 @@ import io
 
 import pytest
 
+from astropy.coordinates import FK4, FK5, ICRS, AltAz, Galactic, Supergalactic
 from astropy.io.votable.exceptions import E16, W27, W57
 from astropy.io.votable.table import parse
+from astropy.io.votable.tree import CooSys
 from astropy.utils.data import get_pkg_data_filename
 
 COOSYS_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
@@ -55,25 +57,21 @@ def test_accept_refposition():
 
 
 def test_coosys_system():
-    """
-    Check that prior to v1.5, an error is issues for a system not in the hard-coded list.
-    With 1.5 the vocabulary is external and we're not checking that yet.
-    """
     for version, system, expected_warning in [
         ("1.4", "ICRS", None),
         ("1.4", "supergalactic", None),
         ("1.4", "InvalidSystem", E16),
         ("1.5", "ICRS", None),
         ("1.5", "supergalactic", None),
-        ("1.5", "InvalidSystem", None),
+        ("1.5", "InvalidSystem", E16),
     ]:
         xml_string = COOSYS_SYSTEM_TEMPLATE.format(version, system)
         input = io.BytesIO(bytes(xml_string, "utf-8"))
         if expected_warning is not None:
             with pytest.warns(expected_warning):
-                vot = parse(input, verify="warn")
+                parse(input, verify="warn")
         else:
-            vot = parse(input, verify="warn")
+            parse(input, verify="warn")
 
 
 def _coosys_tests(votable):
@@ -109,3 +107,33 @@ def test_coosys_roundtrip():
     bio.seek(0)
     votable = parse(bio)
     _coosys_tests(votable)
+
+
+test_to_astropy_frame = [
+    ("ICRS", None, None, ICRS()),
+    ("FK4", "B1950", "B1950", FK4(equinox="B1950")),
+    ("FK5", "J2000", None, FK5(equinox="J2000")),
+    ("eq_FK4", "B1950", "B1950", FK4(equinox="B1950")),
+    ("eq_FK5", "J2000", None, FK5(equinox="J2000")),
+    ("GALACTIC", None, None, Galactic()),
+    ("galactic", None, None, Galactic()),
+    ("SUPER_GALACTIC", None, None, Supergalactic()),
+    ("supergalactic", None, None, Supergalactic()),
+    ("AZ_EL", None, "J2020", AltAz()),
+]
+
+
+@pytest.mark.parametrize("system,equinox,epoch,expected", test_to_astropy_frame)
+def test_coosys_to_astropy_frame_and_time(system, equinox, epoch, expected):
+    coosys = CooSys(equinox=equinox, epoch=epoch, system=system)
+    assert coosys.to_astropy_frame() == expected
+
+
+def test_coosys_to_astropy_frame_error():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "There is no direct correspondence between 'BODY' and an astropy frame.*"
+        ),
+    ):
+        CooSys(system="BODY").to_astropy_frame()

--- a/docs/changes/io.votable/17999.bugfix.rst
+++ b/docs/changes/io.votable/17999.bugfix.rst
@@ -1,0 +1,1 @@
+In ``CooSys`` elements, the system was not checked for votable version 1.5

--- a/docs/changes/io.votable/17999.feature.rst
+++ b/docs/changes/io.votable/17999.feature.rst
@@ -1,0 +1,2 @@
+``CooSys`` VOTable elements now have a method ``to_astropy_frame`` that returns the
+corresponding astropy built-in frame, when possible.

--- a/docs/io/votable/coosys_element.rst
+++ b/docs/io/votable/coosys_element.rst
@@ -1,0 +1,70 @@
+COOSYS element
+--------------
+
+The ``COOSYS`` element is allowed in the ``VOTABLE`` and ``RESOURCE`` elements. It
+describes a coordinate system and has the following attributes:
+
+- ``ID``: a label,
+- ``system``: the reference frame of the coordinates. Since VOTable version 1.5, it
+  follows the `IVOA reference frame vocabulary <http://www.ivoa.net/rdf/refframe>`_.
+- ``equinox``: fixes the equatorial or ecliptic systems
+- ``epoch``: the epoch of the positions, as Julian or Besselian years
+- ``refposition``: it exists since VOTable version 1.5 and follows the `IVOA reference
+  positions vocabulary <http://www.ivoa.net/rdf/refposition>`_.
+
+They are all optional. The `~astropy.io.votable.tree.CooSys` class represents a
+``COOSYS`` element. It can be created from scratch::
+
+    >>> from astropy.io.votable.tree import CooSys
+    >>> coosys = CooSys(system="FK4", equinox="B1950", epoch="B1980")
+
+and converted into an astropy built-in frame::
+
+    >>> coosys.to_astropy_frame()
+    <FK4 Frame (equinox=B1950.000, obstime=B1950.000)>
+
+Using the COOSYS element
+------------------------
+
+The ``COOSYS`` element is often used to describe the coordinates of a ``FIELD`` element.
+In that case, the ``FIELD`` will have a ``ref`` attribute corresponding to the
+``COOSYS``'s '``ID`` field. See for example this VOTable::
+
+    >>> from astropy.io.votable import parse as parse_votable
+    >>> from io import BytesIO
+    >>> votable = parse_votable(BytesIO(str.encode("""<?xml version="1.0" encoding="utf-8"?>
+    ...    <VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.3.xsd">
+    ...    <RESOURCE type="results">
+    ...      <COOSYS ID="coosys_c1356galcand" epoch="2016.0" system="ICRS"/>
+    ...      <TABLE ID="result_S1744377631073" name="result_S1744377631073" nrows="3">
+    ...      <FIELD ID="Source" datatype="long" name="Source" ucd="meta.id;meta.main">
+    ...        <DESCRIPTION>Unique source identifier (unique within a particular Data Release) (source_id)</DESCRIPTION></FIELD>
+    ...      <FIELD ID="RA_ICRS" datatype="double" name="RA_ICRS" ref="coosys_c1356galcand" ucd="pos.eq.ra;meta.main" unit="deg">
+    ...        <DESCRIPTION>Right ascension (ICRS) at Ep=2016.0 (ra)</DESCRIPTION></FIELD>
+    ...      <FIELD ID="DE_ICRS" datatype="double" name="DE_ICRS" ref="coosys_c1356galcand" ucd="pos.eq.dec;meta.main" unit="deg">
+    ...        <DESCRIPTION>Declination (ICRS) at Ep=2016.0 (dec)</DESCRIPTION></FIELD>
+    ...        <DATA><TABLEDATA>
+    ...        <TR><TD>3680787975936</TD><TD>45.01912373733</TD><TD>0.16323692972</TD></TR>
+    ...        <TR><TD>5570573422080</TD><TD>44.85334508786</TD><TD>0.12810861107</TD></TR>
+    ...        <TR><TD>7941395337344</TD><TD>44.97411533912</TD><TD>0.22751845955</TD></TR>
+    ...        </TABLEDATA></DATA>
+    ...      </TABLE></RESOURCE></VOTABLE>""")))
+    >>> table = votable.get_first_table()
+    >>> for field in votable.iter_fields_and_params():
+    ...     print(field)
+    <FIELD ID="Source" datatype="long" name="Source" ucd="meta.id;meta.main"/>
+    <FIELD ID="RA_ICRS" datatype="double" name="RA_ICRS" ref="coosys_c1356galcand" ucd="pos.eq.ra;meta.main" unit="deg"/>
+    <FIELD ID="DE_ICRS" datatype="double" name="DE_ICRS" ref="coosys_c1356galcand" ucd="pos.eq.dec;meta.main" unit="deg"/>
+
+We can now generate a ``SkyCoord`` object from the VOTable information::
+
+   >>> from astropy.coordinates import SkyCoord
+   >>> SkyCoord(table.array.data["RA_ICRS"],
+   ...          table.array.data["DE_ICRS"],
+   ...          frame=votable.get_coosys_by_id(
+   ...                         table.get_field_by_id("RA_ICRS").ref
+   ...                         ).to_astropy_frame(),
+   ...          unit="deg")
+   <SkyCoord (ICRS): (ra, dec) in deg
+      [(45.01912374, 0.16323693), (44.85334509, 0.12810861),
+       (44.97411534, 0.22751846)]>

--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -23,14 +23,10 @@ from ``numpy`` record arrays.
 Getting Started
 ===============
 
-This section provides a quick introduction of using :mod:`astropy.io.votable`. The
-goal is to demonstrate the package's basic features without getting into too
-much detail.
-
 Reading a VOTable File
 ----------------------
 
-To read in a VOTable file, pass a file path to
+To read a VOTable file, pass a file path to
 `~astropy.io.votable.parse`::
 
     from astropy.io.votable import parse
@@ -40,170 +36,8 @@ To read in a VOTable file, pass a file path to
 can be used to retrieve and manipulate the data and save it back out
 to disk.
 
-VOTable files are made up of nested ``RESOURCE`` elements, each of
-which may contain one or more ``TABLE`` elements. The ``TABLE``
-elements contain the arrays of data.
-
-To get at the ``TABLE`` elements, you can write a loop over the
-resources in the ``VOTABLE`` file::
-
-    for resource in votable.resources:
-        for table in resource.tables:
-            # ... do something with the table ...
-            pass
-
-However, if the nested structure of the resources is not important,
-you can use `~astropy.io.votable.tree.VOTableFile.iter_tables` to
-return a flat list of all tables::
-
-    for table in votable.iter_tables():
-        # ... do something with the table ...
-        pass
-
-Finally, if you expect only one table in the file, it might be most convenient
-to use `~astropy.io.votable.tree.VOTableFile.get_first_table`::
-
-  table = votable.get_first_table()
-
-Alternatively, there is a convenience method to parse a VOTable file and
-return the first table all in one step::
-
-  from astropy.io.votable import parse_single_table
-  table = parse_single_table("votable.xml")
-
-From a `~astropy.io.votable.tree.TableElement` object, you can get the data itself
-in the ``array`` member variable::
-
-  data = table.array
-
-This data is a ``numpy`` record array.
-
-The columns get their names from both the ``ID`` and ``name``
-attributes of the ``FIELD`` elements in the ``VOTABLE`` file.
-
-Examples
-^^^^^^^^
-
-..
-  EXAMPLE START
-  Reading a VOTable File with astropy.io.votable
-
-Suppose we had a ``FIELD`` specified as follows:
-
-.. code-block:: xml
-
-   <FIELD ID="Dec" name="dec_targ" datatype="char" ucd="POS_EQ_DEC_MAIN"
-          unit="deg">
-    <DESCRIPTION>
-     representing the ICRS declination of the center of the image.
-    </DESCRIPTION>
-   </FIELD>
-
-.. note::
-
-    The mapping from VOTable ``name`` and ``ID`` attributes to ``numpy``
-    dtype ``names`` and ``titles`` is highly confusing.
-
-    In VOTable, ``ID`` is guaranteed to be unique, but is not
-    required. ``name`` is not guaranteed to be unique, but is
-    required.
-
-    In ``numpy`` record dtypes, ``names`` are required to be unique and
-    are required. ``titles`` are not required, and are not required
-    to be unique.
-
-    Therefore, VOTable's ``ID`` most closely maps to ``numpy``'s
-    ``names``, and VOTable's ``name`` most closely maps to ``numpy``'s
-    ``titles``. However, in some cases where a VOTable ``ID`` is not
-    provided, a ``numpy`` ``name`` will be generated based on the VOTable
-    ``name``. Unfortunately, VOTable fields do not have an attribute
-    that is both unique and required, which would be the most
-    convenient mechanism to uniquely identify a column.
-
-    When converting from an `astropy.io.votable.tree.TableElement` object to
-    an `astropy.table.Table` object, you can specify whether to give
-    preference to ``name`` or ``ID`` attributes when naming the
-    columns. By default, ``ID`` is given preference. To give
-    ``name`` preference, pass the keyword argument
-    ``use_names_over_ids=True``::
-
-      >>> votable.get_first_table().to_table(use_names_over_ids=True)
-
-This column of data can be extracted from the record array using::
-
-  >>> table.array['dec_targ']
-  array([17.15153360566, 17.15153360566, 17.15153360566, 17.1516686826,
-         17.1516686826, 17.1516686826, 17.1536197136, 17.1536197136,
-         17.1536197136, 17.15375479055, 17.15375479055, 17.15375479055,
-         17.1553884541, 17.15539736932, 17.15539752176,
-         17.25736014763,
-         # ...
-         17.2765703], dtype=object)
-
-or equivalently::
-
-  >>> table.array['Dec']
-  array([17.15153360566, 17.15153360566, 17.15153360566, 17.1516686826,
-         17.1516686826, 17.1516686826, 17.1536197136, 17.1536197136,
-         17.1536197136, 17.15375479055, 17.15375479055, 17.15375479055,
-         17.1553884541, 17.15539736932, 17.15539752176,
-         17.25736014763,
-         # ...
-         17.2765703], dtype=object)
-
-..
-  EXAMPLE END
-
-Building a New Table from Scratch
----------------------------------
-
-It is also possible to build a new table, define some field datatypes,
-and populate it with data.
-
-Example
-^^^^^^^
-
-..
-  EXAMPLE START
-  Building a New Table from a VOTable File
-
-To build a new table from a VOTable file::
-
-  from astropy.io.votable.tree import VOTableFile, Resource, TableElement, Field
-
-  # Create a new VOTable file...
-  votable = VOTableFile()
-
-  # ...with one resource...
-  resource = Resource()
-  votable.resources.append(resource)
-
-  # ... with one table
-  table = TableElement(votable)
-  resource.tables.append(table)
-
-  # Define some fields
-  table.fields.extend([
-          Field(votable, name="filename", datatype="char", arraysize="*"),
-          Field(votable, name="matrix", datatype="double", arraysize="2x2")])
-
-  # Now, use those field definitions to create the numpy record arrays, with
-  # the given number of rows
-  table.create_arrays(2)
-
-  # Now table.array can be filled with data
-  table.array[0] = ('test1.xml', [[1, 0], [0, 1]])
-  table.array[1] = ('test2.xml', [[0.5, 0.3], [0.2, 0.1]])
-
-  # Now write the whole thing to a file.
-  # Note, we have to use the top-level votable file object
-  votable.to_xml("new_votable.xml")
-
-..
-  EXAMPLE END
-
-Outputting a VOTable File
--------------------------
+Writing a VOTable File
+----------------------
 
 This section describes writing table data in the VOTable format using the
 `~astropy.io.votable` package directly. For some cases, however, the high-level
@@ -231,6 +65,38 @@ attribute, or globally using the
   votable.set_all_tables_format('binary')
   votable.to_xml('binary.xml')
 
+The VOTable elements
+====================
+
+VOTables are built from nested elements. Let's for example build a
+votable containing an ``INFO`` elements::
+
+  >>> from astropy.io.votable.tree import VOTableFile, Info
+  >>> vot = VOTableFile()
+  >>> vot.infos.append(Info(name="date_obs", value="2025-01-01"))
+
+These elements can be:
+
+- `~astropy.io.votable.tree.CooSys`
+- `~astropy.io.votable.tree.TimeSys`
+- `~astropy.io.votable.tree.Info`
+- `~astropy.io.votable.tree.Param`
+- `~astropy.io.votable.tree.Group`
+- `~astropy.io.votable.tree.Resource`
+- `~astropy.io.votable.tree.Link`
+- `~astropy.io.votable.tree.TableElement`
+- `~astropy.io.votable.tree.Field`
+- `~astropy.io.votable.tree.Values`
+- `~astropy.io.votable.tree.MivotBlock`
+
+Here are some detailed explanations on some of these elements:
+
+.. toctree::
+   :maxdepth: 1
+
+   table_element
+   mivot_blocks
+
 Using `astropy.io.votable`
 ==========================
 
@@ -244,8 +110,10 @@ Version 1.1
 <https://www.ivoa.net/documents/VOTable/20091130/REC-VOTable-1.2.html>`_,
 `Version 1.3
 <https://www.ivoa.net/documents/VOTable/20130920/REC-VOTable-1.3-20130920.html>`_,
-and `Version 1.4
-<https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html>`_.
+`Version 1.4
+<https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html>`_,
+and `Version 1.5
+<https://ivoa.net/documents/VOTable/20250116/REC-VOTable-1.5.html>`_,
 Some flexibility is provided to support the 1.0 draft version and
 other nonstandard usage in the wild, see :ref:`verifying-votables` for more
 details.
@@ -256,13 +124,13 @@ details.
   is documented in more detail in :ref:`warnings` and
   :ref:`exceptions`.
 
-Output always conforms to the 1.1, 1.2, 1.3, or 1.4 spec, depending on the
+Output always conforms to the 1.1, 1.2, 1.3, 1.4, 1.5 spec, depending on the
 input.
 
 .. _verifying-votables:
 
 Verifying VOTables
-^^^^^^^^^^^^^^^^^^
+------------------
 
 Many VOTable files in the wild do not conform to the VOTable specification. You
 can set what should happen when a violation is encountered with the ``verify``
@@ -295,94 +163,6 @@ cannot be guaranteed.
 It is good practice to report any errors to the author of the application that
 generated the VOTable file to bring the file into compliance with the
 specification.
-
-Missing Values
---------------
-
-Any value in the table may be "missing". `astropy.io.votable` stores
-a  ``numpy`` masked array in each `~astropy.io.votable.tree.TableElement`
-instance. This behaves like an ordinary ``numpy`` masked array, except
-for variable-length fields. For those fields, the datatype of the
-column is "object" and another ``numpy`` masked array is stored there.
-Therefore, operations on variable-length columns will not work — this
-is because variable-length columns are not directly supported
-by ``numpy`` masked arrays.
-
-Datatype Mappings
------------------
-
-The datatype specified by a ``FIELD`` element is mapped to a ``numpy``
-type according to the following table:
-
-  ================================ =========================
-  VOTABLE type                     NumPy type
-  ================================ =========================
-  boolean                          b1
-  -------------------------------- -------------------------
-  bit                              b1
-  -------------------------------- -------------------------
-  unsignedByte                     u1
-  -------------------------------- -------------------------
-  char (*variable length*)         O - A ``bytes()`` object.
-  -------------------------------- -------------------------
-  char (*fixed length*)            S
-  -------------------------------- -------------------------
-  unicodeChar (*variable length*)  O - A `str` object
-  -------------------------------- -------------------------
-  unicodeChar (*fixed length*)     U
-  -------------------------------- -------------------------
-  short                            i2
-  -------------------------------- -------------------------
-  int                              i4
-  -------------------------------- -------------------------
-  long                             i8
-  -------------------------------- -------------------------
-  float                            f4
-  -------------------------------- -------------------------
-  double                           f8
-  -------------------------------- -------------------------
-  floatComplex                     c8
-  -------------------------------- -------------------------
-  doubleComplex                    c16
-  ================================ =========================
-
-If the field is a fixed-size array, the data is stored as a ``numpy``
-fixed-size array.
-
-If the field is a variable-size array (that is, ``arraysize`` contains
-a '*'), the cell will contain a Python list of ``numpy`` values. Each
-value may be either an array or scalar depending on the ``arraysize``
-specifier.
-
-Examining Field Types
----------------------
-
-To look up more information about a field in a table, you can use the
-`~astropy.io.votable.tree.TableElement.get_field_by_id` method, which returns
-the `~astropy.io.votable.tree.Field` object with the given ID.
-
-Example
-^^^^^^^
-
-..
-  EXAMPLE START
-  Examining Field Types in VOTables with astropy.io.votable
-
-To look up more information about a field::
-
-  >>> field = table.get_field_by_id('Dec')
-  >>> field.datatype
-  'char'
-  >>> field.unit
-  'deg'
-
-.. note::
-   Field descriptors should not be mutated. To change the set of
-   columns, convert the Table to an `astropy.table.Table`, make the
-   changes, and then convert it back.
-
-..
-  EXAMPLE END
 
 .. _votable-serialization:
 
@@ -472,134 +252,6 @@ record array must be resized repeatedly during load.
 
 .. _nrows: http://www.ivoa.net/documents/REC/VOTable/VOTable-20040811.html#ToC10
 
-.. _votable_mivot:
-
-Reading and writing VO model annotations
-========================================
-
-Introduction
-------------
-Model Instances in VOTables (`MIVOT <https://ivoa.net/documents/MIVOT/20230620/REC-mivot-1.0.pdf>`_)
-defines a syntax to map VOTable data to any model serialised in VO-DML (Virtual Observatory Data Modeling Language).
-This annotation schema operates as a bridge between data and the models. It associates both column/param metadata and data
-from the VOTable to the data model elements (class, attributes, types, etc.). It also brings up VOTable data or
-metadata that were possibly missing in the table, e.g., coordinate system description, or curation tracing.
-The data model elements are grouped in an independent annotation block complying with the MIVOT XML schema which
-is added as an extra resource above the table element.
-The MIVOT syntax allows to describe a data structure as a hierarchy of classes.
-It is also able to represent relations and compositions between them. It can moreover build up data model objects by
-aggregating instances from different tables of the VOTable.
-
-Astropy implementation
-----------------------
-The purpose of Astropy is not to process VO annotations.
-It is just to allow related packages to get and set MIVOT blocks from/into VOTables.
-For this reason, in this implementation MIVOT annotations are both imported and exported as strings.
-The current implementation prevents client code from injecting into VOTables strings
-that are not MIVOT serializations.
-
-MivotBlock implementation:
-
-- MIVOT blocks are handled by the :class:`astropy.io.votable.tree.MivotBlock` class.
-- A MivotBlock instance can only be carried by a resource with "type=meta".
-- This instance holds the XML mapping block as a string.
-- MivotBlock objects are instanced by the Resource parser.
-- The MivotBlock class has its own logic that operates both parsing and IO functionalities.
-
-Example
-^^^^^^^
-
-.. code-block:: xml
-
-       <VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3">
-         <RESOURCE>
-           <RESOURCE type="meta">
-             <VODML xmlns="http://www.ivoa.net/xml/mivot">
-              ...
-             </VODML>
-           </RESOURCE>
-           <TABLE name="myDataTable">
-            ....
-           </TABLE>
-         </RESOURCE>
-    </VOTABLE>
-
-Reading a VOTable containing a MIVOT block
-------------------------------------------
-
-To read in a VOTable file containing or not a MIVOT Resource, pass a file path to`~astropy.io.votable.parse`:
-
-.. code-block:: python
-
-   >>> from astropy.io.votable import parse
-   >>> from astropy.utils.data import get_pkg_data_filename
-   >>> votable = parse(get_pkg_data_filename("data/test.order.xml", package="astropy.io.votable.tests"))
-   <VODML xmlns="http://www.ivoa.net/xml/mivot">
-   </VODML>
-
-   <VODML xmlns="http://www.ivoa.net/xml/mivot">
-   </VODML>
-
-The parse function will call the MIVOT parser if it detects a MIVOT block.
-
-Building a Resource containing a MIVOT block
---------------------------------------------
-
-Construct the MIVOT block by passing the XML block as a parameter:
-
-.. code-block:: python
-
-   >>> from astropy.io.votable import tree
-   >>> from astropy.io.votable.tree import MivotBlock, Resource, VOTableFile
-   >>> mivot_block = MivotBlock("""
-   <VODML xmlns="http://www.ivoa.net/xml/mivot" >
-      <REPORT status="OK">Unit test mapping block</REPORT>
-      <GLOBALS>  </GLOBALS>
-   </VODML>
-   """)
-
-Build a new resource:
-
-.. code-block:: python
-
-   >>> mivot_resource = Resource()
-
-Give it the type meta:
-
-.. code-block:: python
-
-   >>> mivot_resource.type = "meta"
-
-Then add it the MIVOT block:
-
-.. code-block:: python
-
-   >>> mivot_resource.mivot_block = mivot_block
-
-Now you have a MIVOT resource that you can add to an object Resource creating a new Resource:
-
-.. code-block:: python
-
-   >>> votable = VOTableFile()
-   >>> r1 = Resource()
-   >>> r1.type = "results"
-   >>> r1.resources.append(mivot_resource)
-
-You can add an `astropy.io.votable.tree.TableElement` to the resource:
-
-.. code-block:: python
-
-   >>> table = tree.TableElement(votable)
-   >>> r1.tables.append(t1)
-   >>> votable.resources.append(r1)
-   >>> for resource in votable.resources:
-   ...     print(resource.mivot_block.content)
-   <VODML xmlns="http://www.ivoa.net/xml/mivot" >
-      <REPORT status="OK">Unit test mapping block</REPORT>
-      <GLOBALS>  </GLOBALS>
-   </VODML>
-
 
 See Also
 ========
@@ -615,6 +267,9 @@ See Also
 
 - `VOTable Format Definition Version 1.4
   <https://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html>`_
+
+- `VOTable Format Definition Version 1.5
+  <https://ivoa.net/documents/VOTable/20250116/REC-VOTable-1.5.html>`_
 
 - `MIVOT Recommendation Version 1.0
   <https://ivoa.net/documents/MIVOT/20230620/REC-mivot-1.0.pdf>`_

--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -69,7 +69,7 @@ The VOTable elements
 ====================
 
 VOTables are built from nested elements. Let's for example build a
-votable containing an ``INFO`` elements::
+votable containing an ``INFO`` element::
 
   >>> from astropy.io.votable.tree import VOTableFile, Info
   >>> vot = VOTableFile()
@@ -95,6 +95,7 @@ Here are some detailed explanations on some of these elements:
    :maxdepth: 1
 
    table_element
+   coosys_element
    mivot_blocks
 
 Using `astropy.io.votable`

--- a/docs/io/votable/mivot_blocks.rst
+++ b/docs/io/votable/mivot_blocks.rst
@@ -1,0 +1,129 @@
+.. doctest-skip-all
+
+Reading and writing VO model annotations (MIVOT)
+------------------------------------------------
+
+A ``RESOURCE`` element can be a ``MIVOT`` block since VOTable version 1.5.
+
+Introduction
+^^^^^^^^^^^^
+Model Instances in VOTables (`MIVOT <https://ivoa.net/documents/MIVOT/20230620/REC-mivot-1.0.pdf>`_)
+defines a syntax to map VOTable data to any model serialised in VO-DML (Virtual Observatory Data Modeling Language).
+This annotation schema operates as a bridge between data and the models. It associates both column/param metadata and data
+from the VOTable to the data model elements (class, attributes, types, etc.). It also brings up VOTable data or
+metadata that were possibly missing in the table, e.g., coordinate system description, or curation tracing.
+The data model elements are grouped in an independent annotation block complying with the MIVOT XML schema which
+is added as an extra resource above the table element.
+The MIVOT syntax allows to describe a data structure as a hierarchy of classes.
+It is also able to represent relations and compositions between them. It can moreover build up data model objects by
+aggregating instances from different tables of the VOTable.
+
+Astropy implementation
+^^^^^^^^^^^^^^^^^^^^^^
+The purpose of Astropy is not to process VO annotations.
+It is just to allow related packages to get and set MIVOT blocks from/into VOTables.
+For this reason, in this implementation MIVOT annotations are both imported and exported as strings.
+The current implementation prevents client code from injecting into VOTables strings
+that are not MIVOT serializations.
+
+MivotBlock implementation:
+
+- MIVOT blocks are handled by the :class:`astropy.io.votable.tree.MivotBlock` class.
+- A MivotBlock instance can only be carried by a resource with "type=meta".
+- This instance holds the XML mapping block as a string.
+- MivotBlock objects are instanced by the Resource parser.
+- The MivotBlock class has its own logic that operates both parsing and IO functionalities.
+
+Example
+"""""""
+
+.. code-block:: xml
+
+       <VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3">
+         <RESOURCE>
+           <RESOURCE type="meta">
+             <VODML xmlns="http://www.ivoa.net/xml/mivot">
+              ...
+             </VODML>
+           </RESOURCE>
+           <TABLE name="myDataTable">
+            ....
+           </TABLE>
+         </RESOURCE>
+    </VOTABLE>
+
+Reading a VOTable containing a MIVOT block
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To read in a VOTable file containing or not a MIVOT Resource, pass a file path to`~astropy.io.votable.parse`:
+
+.. code-block:: python
+
+   >>> from astropy.io.votable import parse
+   >>> from astropy.utils.data import get_pkg_data_filename
+   >>> votable = parse(get_pkg_data_filename("data/test.order.xml", package="astropy.io.votable.tests"))
+   <VODML xmlns="http://www.ivoa.net/xml/mivot">
+   </VODML>
+
+   <VODML xmlns="http://www.ivoa.net/xml/mivot">
+   </VODML>
+
+The parse function will call the MIVOT parser if it detects a MIVOT block.
+
+Building a Resource containing a MIVOT block
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Construct the MIVOT block by passing the XML block as a parameter:
+
+.. code-block:: python
+
+   >>> from astropy.io.votable import tree
+   >>> from astropy.io.votable.tree import MivotBlock, Resource, VOTableFile
+   >>> mivot_block = MivotBlock("""
+   <VODML xmlns="http://www.ivoa.net/xml/mivot" >
+      <REPORT status="OK">Unit test mapping block</REPORT>
+      <GLOBALS>  </GLOBALS>
+   </VODML>
+   """)
+
+Build a new resource:
+
+.. code-block:: python
+
+   >>> mivot_resource = Resource()
+
+Give it the type meta:
+
+.. code-block:: python
+
+   >>> mivot_resource.type = "meta"
+
+Then add it the MIVOT block:
+
+.. code-block:: python
+
+   >>> mivot_resource.mivot_block = mivot_block
+
+Now you have a MIVOT resource that you can add to an object Resource creating a new Resource:
+
+.. code-block:: python
+
+   >>> votable = VOTableFile()
+   >>> r1 = Resource()
+   >>> r1.type = "results"
+   >>> r1.resources.append(mivot_resource)
+
+You can add an `astropy.io.votable.tree.TableElement` to the resource:
+
+.. code-block:: python
+
+   >>> table = tree.TableElement(votable)
+   >>> r1.tables.append(t1)
+   >>> votable.resources.append(r1)
+   >>> for resource in votable.resources:
+   ...     print(resource.mivot_block.content)
+   <VODML xmlns="http://www.ivoa.net/xml/mivot" >
+      <REPORT status="OK">Unit test mapping block</REPORT>
+      <GLOBALS>  </GLOBALS>
+   </VODML>

--- a/docs/io/votable/table_element.rst
+++ b/docs/io/votable/table_element.rst
@@ -1,0 +1,245 @@
+.. doctest-skip-all
+
+Table element
+-------------
+
+VOTable files can contain ``RESOURCE`` elements, each of
+which may contain one or more ``TABLE`` elements. The ``TABLE``
+elements contain the arrays of data.
+
+To get at the ``TABLE`` elements, you can write a loop over the
+resources in the ``VOTABLE`` file::
+
+    for resource in votable.resources:
+        for table in resource.tables:
+            # ... do something with the table ...
+            pass
+
+However, if the nested structure of the resources is not important,
+you can use `~astropy.io.votable.tree.VOTableFile.iter_tables` to
+return a flat list of all tables::
+
+    for table in votable.iter_tables():
+        # ... do something with the table ...
+        pass
+
+Finally, if you expect only one table in the file, it might be most convenient
+to use `~astropy.io.votable.tree.VOTableFile.get_first_table`::
+
+  table = votable.get_first_table()
+
+Alternatively, there is a convenience method to parse a VOTable file and
+return the first table all in one step::
+
+  from astropy.io.votable import parse_single_table
+  table = parse_single_table("votable.xml")
+
+From a `~astropy.io.votable.tree.TableElement` object, you can get the data itself
+in the ``array`` member variable::
+
+  data = table.array
+
+This data is a ``numpy`` record array.
+
+The columns get their names from both the ``ID`` and ``name``
+attributes of the ``FIELD`` elements in the ``VOTABLE`` file.
+
+..
+  EXAMPLE START
+  Reading a VOTable File with astropy.io.votable
+
+Suppose we had a ``FIELD`` specified as follows:
+
+.. code-block:: xml
+
+   <FIELD ID="Dec" name="dec_targ" datatype="char" ucd="POS_EQ_DEC_MAIN"
+          unit="deg">
+    <DESCRIPTION>
+     representing the ICRS declination of the center of the image.
+    </DESCRIPTION>
+   </FIELD>
+
+.. note::
+
+    The mapping from VOTable ``name`` and ``ID`` attributes to ``numpy``
+    dtype ``names`` and ``titles`` is highly confusing.
+
+    In VOTable, ``ID`` is guaranteed to be unique, but is not
+    required. ``name`` is not guaranteed to be unique, but is
+    required.
+
+    In ``numpy`` record dtypes, ``names`` are required to be unique and
+    are required. ``titles`` are not required, and are not required
+    to be unique.
+
+    Therefore, VOTable's ``ID`` most closely maps to ``numpy``'s
+    ``names``, and VOTable's ``name`` most closely maps to ``numpy``'s
+    ``titles``. However, in some cases where a VOTable ``ID`` is not
+    provided, a ``numpy`` ``name`` will be generated based on the VOTable
+    ``name``. Unfortunately, VOTable fields do not have an attribute
+    that is both unique and required, which would be the most
+    convenient mechanism to uniquely identify a column.
+
+    When converting from an `astropy.io.votable.tree.TableElement` object to
+    an `astropy.table.Table` object, you can specify whether to give
+    preference to ``name`` or ``ID`` attributes when naming the
+    columns. By default, ``ID`` is given preference. To give
+    ``name`` preference, pass the keyword argument
+    ``use_names_over_ids=True``::
+
+      >>> votable.get_first_table().to_table(use_names_over_ids=True)
+
+This column of data can be extracted from the record array using::
+
+  >>> table.array['dec_targ']
+  array([17.15153360566, 17.15153360566, 17.15153360566, 17.1516686826,
+         17.1516686826, 17.1516686826, 17.1536197136, 17.1536197136,
+         17.1536197136, 17.15375479055, 17.15375479055, 17.15375479055,
+         17.1553884541, 17.15539736932, 17.15539752176,
+         17.25736014763,
+         # ...
+         17.2765703], dtype=object)
+
+or equivalently::
+
+  >>> table.array['Dec']
+  array([17.15153360566, 17.15153360566, 17.15153360566, 17.1516686826,
+         17.1516686826, 17.1516686826, 17.1536197136, 17.1536197136,
+         17.1536197136, 17.15375479055, 17.15375479055, 17.15375479055,
+         17.1553884541, 17.15539736932, 17.15539752176,
+         17.25736014763,
+         # ...
+         17.2765703], dtype=object)
+
+..
+  EXAMPLE END
+
+Datatype Mappings
+^^^^^^^^^^^^^^^^^
+
+The datatype specified by a ``FIELD`` element is mapped to a ``numpy``
+type according to the following table:
+
+  ================================ =========================
+  VOTABLE type                     NumPy type
+  ================================ =========================
+  boolean                          b1
+  -------------------------------- -------------------------
+  bit                              b1
+  -------------------------------- -------------------------
+  unsignedByte                     u1
+  -------------------------------- -------------------------
+  char (*variable length*)         O - A ``bytes()`` object.
+  -------------------------------- -------------------------
+  char (*fixed length*)            S
+  -------------------------------- -------------------------
+  unicodeChar (*variable length*)  O - A `str` object
+  -------------------------------- -------------------------
+  unicodeChar (*fixed length*)     U
+  -------------------------------- -------------------------
+  short                            i2
+  -------------------------------- -------------------------
+  int                              i4
+  -------------------------------- -------------------------
+  long                             i8
+  -------------------------------- -------------------------
+  float                            f4
+  -------------------------------- -------------------------
+  double                           f8
+  -------------------------------- -------------------------
+  floatComplex                     c8
+  -------------------------------- -------------------------
+  doubleComplex                    c16
+  ================================ =========================
+
+If the field is a fixed-size array, the data is stored as a ``numpy``
+fixed-size array.
+
+If the field is a variable-size array (that is, ``arraysize`` contains
+a '*'), the cell will contain a Python list of ``numpy`` values. Each
+value may be either an array or scalar depending on the ``arraysize``
+specifier.
+
+Examining Field Types
+^^^^^^^^^^^^^^^^^^^^^
+
+To look up more information about a field in a table, you can use the
+`~astropy.io.votable.tree.TableElement.get_field_by_id` method, which returns
+the `~astropy.io.votable.tree.Field` object with the given ID.
+
+..
+  EXAMPLE START
+  Examining Field Types in VOTables with astropy.io.votable
+
+To look up more information about a field::
+
+  >>> field = table.get_field_by_id('Dec')
+  >>> field.datatype
+  'char'
+  >>> field.unit
+  'deg'
+
+.. note::
+   Field descriptors should not be mutated. To change the set of
+   columns, convert the Table to an `astropy.table.Table`, make the
+   changes, and then convert it back.
+
+..
+  EXAMPLE END
+
+Building a New Table from Scratch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is also possible to build a new table, define some field datatypes,
+and populate it with data.
+
+..
+  EXAMPLE START
+  Building a New Table from a VOTable File
+
+To build a new table from a VOTable file::
+
+  from astropy.io.votable.tree import VOTableFile, Resource, TableElement, Field
+
+  # Create a new VOTable file...
+  votable = VOTableFile()
+
+  # ...with one resource...
+  resource = Resource()
+  votable.resources.append(resource)
+
+  # ... with one table
+  table = TableElement(votable)
+  resource.tables.append(table)
+
+  # Define some fields
+  table.fields.extend([
+          Field(votable, name="filename", datatype="char", arraysize="*"),
+          Field(votable, name="matrix", datatype="double", arraysize="2x2")])
+
+  # Now, use those field definitions to create the numpy record arrays, with
+  # the given number of rows
+  table.create_arrays(2)
+
+  # Now table.array can be filled with data
+  table.array[0] = ('test1.xml', [[1, 0], [0, 1]])
+  table.array[1] = ('test2.xml', [[0.5, 0.3], [0.2, 0.1]])
+
+  # Now write the whole thing to a file.
+  # Note, we have to use the top-level votable file object
+  votable.to_xml("new_votable.xml")
+
+..
+  EXAMPLE END
+
+Missing Values
+^^^^^^^^^^^^^^
+
+Any value in the table may be "missing". `astropy.io.votable` stores
+a  ``numpy`` masked array in each `~astropy.io.votable.tree.TableElement`
+instance. This behaves like an ordinary ``numpy`` masked array, except
+for variable-length fields. For those fields, the datatype of the
+column is "object" and another ``numpy`` masked array is stored there.
+Therefore, operations on variable-length columns will not work — this
+is because variable-length columns are not directly supported
+by ``numpy`` masked arrays.

--- a/docs/whatsnew/7.1.rst
+++ b/docs/whatsnew/7.1.rst
@@ -15,6 +15,8 @@ In particular, this release includes:
 * :ref:`whatsnew-7.1-table-spaces`
 * :ref:`whatsnew-7.1-tdat-reader`
 * :ref:`whatsnew-7.1-covariance`
+* :ref:`whatsnew-7.1-cosmology`
+* :ref:`whatsnew-7.1-votable-coosys-to-astropy-frame`
 
 In addition to these major changes, Astropy v7.1 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -99,6 +101,19 @@ Here is an example of how to use the :class:`~astropy.cosmology.traits.ScaleFact
 
 By combining different traits, you can create fully-featured cosmology classes with
 minimal effort.
+
+.. _whatsnew-7.1-votable-coosys-to-astropy-frame:
+
+Get an astropy built-in frame out of a VOTable's coosys element
+===============================================================
+
+``CooSys`` VOTable elements now have a method ``to_astropy_frame`` that returns the
+corresponding astropy built-in frame, when possible::
+
+    >>> from astropy.io.votable.tree import CooSys
+    >>> coosys = CooSys(system="ICRS", epoch="J2020")
+    >>> coosys.to_astropy_frame()
+    <ICRS Frame>
 
 
 Full change log


### PR DESCRIPTION
Hi astropy maintainers!

### Description

This PR does:

- add a check for coosys systems according to http://www.ivoa.net/rdf/refframe (was a TODO in the comments)
- add a method to convert a CooSys object into an astropy built in frame

This is of particular interest when reading VOTables, see for example this workflow:

```python
from io import BytesIO
from astropy.io.votable import parse as parse_votable
import requests

url = "https://vizier.cds.unistra.fr/viz-bin/votable?-source=J/MNRAS/413/3059/clusters\nout=RAJ2000,DEJ2OOO,Cluster,z,r80"
cat = requests.post(url=url)
votable = parse_votable(BytesIO(str.encode(cat.text)))
coosys = votable.iter_coosys()
coosys = next(coosys)
```

Before this PR, I'd have to manually get the correct frame in the astropy's API, compare it to the IVOA documentation, and create the object manually from the `CooSys`'s properties.
Now, I can do it automatically:

```python
frame = coosys.to_astropy_frame()
```

### Limitations

Some frames don't have an obvious equivalent in the IVOA's vocabulary. In that case, I raise a `ValueError` and the users will have to read the CooSys's properties and interpret them manually like before. Maybe this should only warn and return `None`?


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

EDIT: On the CI failure, `ImportError: cannot import name 'FK4' from partially initialized module 'astropy.coordinates' (most likely due to a circular import)`. How should I import the frames? I'm confused.