### PR TITLE
Fix WCSAxes.plot_coord slice issue

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -299,16 +299,22 @@ class WCSAxes(Axes):
             frame0 = frame0.transform_to(native_frame)
 
             plot_data = []
-            for coord in self.coords:
-                if coord.coord_type == "longitude":
-                    plot_data.append(frame0.spherical.lon.to_value(coord.coord_unit))
-                elif coord.coord_type == "latitude":
-                    plot_data.append(frame0.spherical.lat.to_value(coord.coord_unit))
-                else:
-                    raise NotImplementedError(
-                        "Coordinates cannot be plotted with this "
-                        "method because the WCS does not represent longitude/latitude."
-                    )
+            coord_types = {coord.coord_type for coord in self.coords}
+            if "longitude" in coord_types and "latitude" in coord_types:
+                for coord in self.coords:
+                    if coord.coord_type == "longitude":
+                        plot_data.append(
+                            frame0.spherical.lon.to_value(coord.coord_unit)
+                        )
+                    elif coord.coord_type == "latitude":
+                        plot_data.append(
+                            frame0.spherical.lat.to_value(coord.coord_unit)
+                        )
+            else:
+                raise NotImplementedError(
+                    "Coordinates cannot be plotted with this "
+                    "method because the WCS does not represent longitude/latitude."
+                )
 
             if "transform" in kwargs.keys():
                 raise TypeError(

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -714,3 +714,17 @@ def test_get_axislabel_default():
     ax.coords[1].set_axislabel("")
     assert ax.coords[0].get_axislabel() == "Right Ascension"
     assert ax.coords[1].get_axislabel() == ""
+
+
+def test_plot_coord_slicing(ignore_matplotlibrc):
+    # Regression test to ensure plot_coord does not raise a NotImplementedError
+    # after slicing coordinates (issue #10254).
+
+    cube_header = get_pkg_data_filename("data/cube_header")
+    cube_header = fits.Header.fromtextfile(cube_header)
+
+    fig = Figure(figsize=(6, 6))
+    ax = fig.add_subplot(projection=WCS(cube_header), slices=("x", "y", 0))
+
+    c = SkyCoord(52 * u.deg, 30.5 * u.deg)
+    ax.plot_coord(c, "o")

--- a/docs/changes/visualization/18005.bugfix.rst
+++ b/docs/changes/visualization/18005.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue when using ``plot_coord`` after slicing the ``WCS`` object coordinates.


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address issue #10254. It checks that the WCSAxes has both latitude and longitude coordinates before processing. This prevents a NotImplementedError being raised after using the slices keyword. 

I also added a test in astropy/visualization/wcsaxes/tests/test_misc.py because that's where I saw other plot_coord tests, but let me know if it should be moved somewhere else.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10254

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
