### PR TITLE
Backport PR #17642: Add back bzero and bscale keywords when `do_not_s…

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -620,12 +620,7 @@ class _BaseHDU:
                 )
 
     def _postwriteto(self):
-        # If data is unsigned integer 16, 32 or 64, remove the
-        # BSCALE/BZERO cards
-        if self._has_data and self._standard and _is_pseudo_integer(self.data.dtype):
-            for keyword in ("BSCALE", "BZERO"):
-                with suppress(KeyError):
-                    del self._header[keyword]
+        pass
 
     def _writeheader(self, fileobj):
         offset = 0

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -178,6 +178,32 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(ValueError):
             hdul.append(hdu)
 
+    @pytest.mark.parametrize(
+        "image", ["scale.fits", "o4sp040b0_raw.fits", "fixed-1890.fits"]
+    )
+    @pytest.mark.parametrize("do_not_scale", [True, False])
+    def test_append_scaled_image_with_do_not_scale_image_data(
+        self, image, do_not_scale
+    ):
+        """Tests appending a scaled ImageHDU to a HDUList."""
+
+        with fits.open(
+            self.data(image), do_not_scale_image_data=do_not_scale
+        ) as source:
+            # create the file
+            dest = fits.HDUList()
+            dest.append(source[0])
+            # append a second hdu
+            dest.append(source[0])
+            assert dest[-1].header.get("BZERO") == source[0].header.get("BZERO")
+            assert dest[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
+            dest.writeto(self.temp("test-append.fits"))
+        with fits.open(
+            self.temp("test-append.fits"), do_not_scale_image_data=do_not_scale
+        ) as tmphdu:
+            assert tmphdu[-1].header.get("BZERO") == source[0].header.get("BZERO")
+            assert tmphdu[-1].header.get("BSCALE") == source[0].header.get("BSCALE")
+
     def test_insert_primary_to_empty_list(self):
         """Tests inserting a Simple PrimaryHDU to an empty HDUList."""
         hdul = fits.HDUList()

--- a/docs/changes/io.fits/17642.bugfix.rst
+++ b/docs/changes/io.fits/17642.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug so that now the scaling state from the source HDU to the new appended HDU is copied on the
+destination file, when the HDU is read with ``do_not_scale_image_data=True``.


### PR DESCRIPTION
…cale_image_data` is true for the appended hdu

(cherry picked from commit 0aa40c5126c7c4f88e9291eb6fb81eb3b880fe59)

Ref  #17642

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
