### PR TITLE
DOC: remove deprecated units from documentation.

### DIFF
--- a/docs/units/ref_api.rst
+++ b/docs/units/ref_api.rst
@@ -23,6 +23,4 @@ Reference/API
 
 .. automodapi:: astropy.units.format
 
-.. automodapi:: astropy.units.deprecated
-
 .. automodapi:: astropy.units.required_by_vounit


### PR DESCRIPTION
In #17929, the units defined in `astropy.units.deprecated` were properly deprecated, i.e., accessing them raises a deprecation warning. As noted in #17938, this leads to a lot of noise in the documentation build, since these units are included in the documentation. This PR fixes this in a crude way, by no longer documenting those units. This would actually seem correct, though: if these units are deprecated, why help users find them? Especially given that they will remain in old versions of the documentation. 

Fixes #<17938

p.s.  I actually tried to fix it "nicely" but it was non-trivial, and then I realized that, really, there is no reason to document deprecated stuff.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
