### PR TITLE
Fix "<U" in dtype check breaking TDAT writer on big-endian systems

### DIFF
--- a/astropy/io/ascii/tdat.py
+++ b/astropy/io/ascii/tdat.py
@@ -515,19 +515,18 @@ class TdatHeader(basic.BasicHeader):
         lines.append("# Table Parameters")
         lines.append("#")
         for col in self.cols:
-            if str(col.info.dtype) in self._dtype_dict_out:
-                ctype = self._dtype_dict_out[str(col.info.dtype)]
-            elif "int" in str(col.info.dtype):
+            if str(col_type := col.info.dtype) in self._dtype_dict_out:
+                ctype = self._dtype_dict_out[str(col_type)]
+            elif col_type.kind == "i":
                 ctype = "int4"
-            elif "float" in str(col.info.dtype):
+            elif col_type.kind == "f":
                 ctype = "float8"
-            elif "<U" in str(col.info.dtype):
-                ctype = f"char{str(col.info.dtype).rsplit('<U', maxsplit=1)[-1]}"
+            elif col_type.kind == "U":
+                ctype = f"char{col_type.itemsize // 4}"
             else:
                 raise TdatFormatError(
-                    f'Unrecognized data type `{col.info.dtype}` for column "{col.info.name}".'
+                    f'Unrecognized data type `{col_type}` for column "{col.info.name}".'
                 )
-                # ctype = f"{col.info.dtype}"
             col_name = col.info.name
             if len(col_name) >= 24:
                 warn(

--- a/astropy/io/ascii/tests/test_tdat.py
+++ b/astropy/io/ascii/tests/test_tdat.py
@@ -188,7 +188,7 @@ def test_read_tdat():
         "Declination",
         "Empty",
     ]
-    dtypes = [np.int32, np.int32, "<U3", float, float, float]
+    dtypes = [np.int32, np.int32, np.dtype("U3"), float, float, float]
     units = [None, None, None, "deg", "deg", None]
     meta = [
         {"ucd": "meta.id", "index": "key"},
@@ -245,7 +245,7 @@ def test_full_table_content():
         ),
     }
     assert len(test_table) == 7
-    dtypes = [np.int32, np.int32, "<U3", float, float, float]
+    dtypes = [np.int32, np.int32, np.dtype("U3"), float, float, float]
     descriptions = [
         "Unique Identifier for Entry",
         "Source ID Number",


### PR DESCRIPTION
### Description
Fixes #17997 – the column formatter for the `tdat` writer specifically checking for little-endian `<U` dtype was [breaking](https://github.com/astropy/astropy/pull/16780#discussion_r2037603927) extra CI on big-endian systems (the s390).
Replaced with `dtype.kind` checks here.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
