### PR TITLE
DOC: get rid of excessive warnings in doc build / alternative

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,6 +295,12 @@ def _custom_edit_url(
         if module := getattr(item, "__module__", None):
             mod_dir, _, mod_file = module.rpartition(".")
             new_file_name = mod_file + ".py"
+            # Remove wrappings, such as functools.cache in astropy.units.equivalencies.
+            # This also avoids "could not find source" warnings.  But don't remove
+            # a correct one for sharedmethod.
+            if module != "astropy.utils.decorators":
+                while wrapped := getattr(item, "__wrapped__", None):
+                    item = wrapped
             try:
                 line_no = inspect.findsource(item)[1]
             except Exception:

--- a/docs/units/ref_api.rst
+++ b/docs/units/ref_api.rst
@@ -1,6 +1,11 @@
 Reference/API
 *************
 
+.. note::
+
+    `astropy.units.deprecated <https://docs.astropy.org/en/v7.0.0/units/ref_api.html#module-astropy.units.deprecated>`_
+    was deprecated in v7.1 and will be removed in a future version.
+
 .. automodapi:: astropy.units
 
 .. automodapi:: astropy.units.si

--- a/docs/units/ref_api.rst
+++ b/docs/units/ref_api.rst
@@ -23,6 +23,4 @@ Reference/API
 
 .. automodapi:: astropy.units.format
 
-.. automodapi:: astropy.units.deprecated
-
 .. automodapi:: astropy.units.required_by_vounit


### PR DESCRIPTION
This is an alternative to #18016 that changes the last commit to simply unwrap any wrapped code. Locally, this seems to work, but we should definitely check the readthedocs build before merging.