### PR TITLE
BUG,TST: fix writing to table used in all tests.

### DIFF
--- a/astropy/io/ascii/tests/test_tdat.py
+++ b/astropy/io/ascii/tests/test_tdat.py
@@ -417,12 +417,13 @@ def test_bad_delimiter():
     ):
         test_table.write(out, format="ascii.tdat", delimiter=",")
 
-    test_table.meta["keywords"]["field_delimiter"] = ","
+    check_table = test_table.copy()
+    check_table.meta["keywords"]["field_delimiter"] = ","
     with pytest.warns(
         TdatFormatWarning, match="Delimiters other than the pipe character"
     ):
         with pytest.warns(TdatFormatWarning, match="Skipping deprecated"):
-            test_table.write(out, format="ascii.tdat", delimiter=",")
+            check_table.write(out, format="ascii.tdat", delimiter=",")
 
 
 def test_bad_header_start():


### PR DESCRIPTION
Double-run failures because a common test table for the new `tdat` reader in the test file was changed in one of the tests. This makes a copy before modifying anything.

Fixes #18024

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
