### PR TITLE
Removes unnecessary deepcopy of unit in NDUncertainty

### DIFF
--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -143,11 +143,7 @@ class NDUncertainty(metaclass=ABCMeta):
         else:
             self._unit = Unit(unit)
 
-        if copy:
-            array = deepcopy(array)
-            unit = deepcopy(unit)
-
-        self.array = array
+        self.array = deepcopy(array) if copy else array
         self.parent_nddata = None  # no associated NDData - until it is set!
 
     @property


### PR DESCRIPTION
As titled.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
