### PR TITLE
Simplify imports in unit definition modules

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -13,6 +13,7 @@ from astropy.constants import si as _si
 
 from . import si
 from .core import UnitBase, def_unit, set_enabled_units
+from .utils import generate_unit_summary
 
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
@@ -222,6 +223,4 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -36,25 +36,24 @@ you have a string that uses CDS units:
 
 __all__ = ["enable"]  #  Units are added at the end
 
-from .core import UnitBase
+import numpy as np
+
+from astropy.constants import si as _si
+
+from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_prefixes
+from .utils import generate_unit_summary
 
 _ns = globals()
 
 
 def _initialize_module():
-    """Initialize CDS units module."""
-    # Local imports to avoid polluting top-level namespace
-    import numpy as np
-
+    # Having `u` in the global namespace would conflict with the atomic mass unit.
     from astropy import units as u
-    from astropy.constants import si as _si
-
-    from . import core
 
     prefixes = []
     # The CDS format also supports power-of-2 prefixes as defined here:
     # http://physics.nist.gov/cuu/Units/binary.html
-    for short, _, factor in core.si_prefixes + core.binary_prefixes:
+    for short, _, factor in si_prefixes + binary_prefixes:
         short = [s for s in short if s.isascii()]
         prefixes.append((short, short, factor))  # CDS only uses the short prefixes
 
@@ -155,7 +154,7 @@ def _initialize_module():
             excludes = []
         else:
             names, unit, doc, excludes = entry
-        core.def_unit(
+        def_unit(
             names,
             unit,
             prefixes=prefixes,
@@ -164,19 +163,19 @@ def _initialize_module():
             exclude_prefixes=excludes,
         )
 
-    core.def_unit(["µas"], u.microarcsecond, doc="microsecond of arc", namespace=_ns)
-    core.def_unit(["mas"], u.milliarcsecond, doc="millisecond of arc", namespace=_ns)
-    core.def_unit(
+    def_unit(["µas"], u.microarcsecond, doc="microsecond of arc", namespace=_ns)
+    def_unit(["mas"], u.milliarcsecond, doc="millisecond of arc", namespace=_ns)
+    def_unit(
         ["---", "-"],
         u.dimensionless_unscaled,
         doc="dimensionless and unscaled",
         namespace=_ns,
     )
-    core.def_unit(["%"], u.percent, doc="percent", namespace=_ns)
+    def_unit(["%"], u.percent, doc="percent", namespace=_ns)
     # The Vizier "standard" defines this in units of "kg s-3", but
     # that may not make a whole lot of sense, so here we just define
     # it as its own new disconnected unit.
-    core.def_unit(["Crab"], prefixes=prefixes, namespace=_ns, doc="Crab (X-ray) flux")
+    def_unit(["Crab"], prefixes=prefixes, namespace=_ns, doc="Crab (X-ray) flux")
 
 
 _initialize_module()
@@ -190,9 +189,7 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())
 
 
 def enable():
@@ -206,9 +203,4 @@ def enable():
     This may be used with the ``with`` statement to enable CDS
     units only temporarily.
     """
-    # Local imports to avoid cyclical import and polluting namespace
-    import inspect
-
-    from .core import set_enabled_units
-
-    return set_enabled_units(inspect.getmodule(enable))
+    return set_enabled_units(globals())

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from . import si
 from .core import UnitBase, def_unit
+from .utils import generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -188,6 +189,4 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -22,7 +22,8 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 __all__: list[str] = []  #  Units are added at the end
 
 from . import si
-from .core import UnitBase, def_unit
+from .core import UnitBase, add_enabled_units, def_unit
+from .utils import generate_unit_summary
 
 _ns = globals()
 
@@ -159,9 +160,7 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())
 
 
 def enable():
@@ -173,10 +172,4 @@ def enable():
     This may be used with the ``with`` statement to enable Imperial
     units only temporarily.
     """
-    # Local import to avoid cyclical import
-    # Local import to avoid polluting namespace
-    import inspect
-
-    from .core import add_enabled_units
-
-    return add_enabled_units(inspect.getmodule(enable))
+    return add_enabled_units(globals())

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -15,10 +15,11 @@ through) the `astropy.units` namespace.
 
 import numpy as np
 
-from astropy.constants import si as _si
+from astropy.constants import L_bol0
 
 from . import astrophys, cgs, si
 from .core import Unit, UnitBase, def_unit
+from .utils import generate_unit_summary
 
 __all__ = ["zero_point_flux"]  #  Units are added at the end
 
@@ -26,7 +27,7 @@ _ns = globals()
 
 def_unit(
     ["Bol", "L_bol"],
-    _si.L_bol0,
+    L_bol0,
     namespace=_ns,
     prefixes=False,
     doc=(
@@ -36,7 +37,7 @@ def_unit(
 )
 def_unit(
     ["bol", "f_bol"],
-    _si.L_bol0 / (4 * np.pi * (10.0 * astrophys.pc) ** 2),
+    L_bol0 / (4 * np.pi * (10.0 * astrophys.pc) ** 2),
     namespace=_ns,
     prefixes=False,
     doc=(
@@ -93,6 +94,4 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -9,6 +9,7 @@ This package defines the SI units.  They are also available in
 import numpy as np
 
 from .core import CompositeUnit, UnitBase, def_unit
+from .utils import generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -483,6 +484,4 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from .utils import generate_unit_summary as _generate_unit_summary
-
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += generate_unit_summary(globals())


### PR DESCRIPTION
### Description

At some time in the past the unit definition modules did not define `__all__` explicitly, which meant that anything imported had to be imported using an alias that started with an underscore, imported inside a function to stay out of module-level namespace, or cleaned up explicitly. Such tricks are no longer needed and we are better off without them.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
