### PR TITLE
Allow importing `constants` before `units`

### DIFF
--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -14,13 +14,7 @@ import astropy
 
 @pytest.mark.parametrize(
     "subpkg",
-    [
-        pytest.param(
-            subpkg.name, marks=pytest.mark.xfail() if subpkg.name == "constants" else []
-        )
-        for subpkg in pkgutil.walk_packages(astropy.__path__)
-        if subpkg.ispkg
-    ],
+    [subpkg.name for subpkg in pkgutil.walk_packages(astropy.__path__) if subpkg.ispkg],
 )
 def test_imports(subpkg):
     """

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -12,25 +12,22 @@ import pytest
 import astropy
 
 
-def test_imports():
+@pytest.mark.parametrize(
+    "subpkg",
+    [
+        pytest.param(
+            subpkg.name, marks=pytest.mark.xfail() if subpkg.name == "constants" else []
+        )
+        for subpkg in pkgutil.walk_packages(astropy.__path__)
+        if subpkg.ispkg
+    ],
+)
+def test_imports(subpkg):
     """
-    This just imports all modules in astropy, making sure they don't have any
+    This just imports all top-level sub-packages in astropy, making sure they don't have any
     dependencies that sneak through
     """
-
-    def onerror(name):
-        # We should raise any legitimate error that occurred, but not
-        # any warnings which happen to be caught because of our pytest
-        # settings (e.g., DeprecationWarning).
-        try:
-            raise  # noqa: PLE0704
-        except Warning:
-            pass
-
-    for imper, nm, _ispkg in pkgutil.walk_packages(
-        ["astropy"], "astropy.", onerror=onerror
-    ):
-        imper.find_spec(nm)
+    subprocess.run([sys.executable, "-c", f"from astropy import {subpkg}"], check=True)
 
 
 def test_toplevel_namespace():

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -15,7 +15,7 @@ through) the `astropy.units` namespace.
 
 import numpy as np
 
-from astropy.constants import L_bol0
+from astropy.constants.si import L_bol0
 
 from . import astrophys, cgs, si
 from .core import Unit, UnitBase, def_unit

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import locale
 import os
+import pkgutil
 import platform
 import urllib.request
 
@@ -9,14 +10,15 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from astropy.tests.tests.test_imports import test_imports
+import astropy
 from astropy.time import Time, TimeDelta
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.iers import iers
 
-# Import every top-level astropy module as a test that the ERFA leap second
+# Import every astropy module as a test that the ERFA leap second
 # table is not updated for normal imports.
-test_imports()
+for finder, name, _ in pkgutil.walk_packages(astropy.__path__, prefix="astropy."):
+    finder.find_spec(name)
 
 # Now test that the erfa leap_seconds table has not been updated. This must be
 # done at the module level, which unfortunately will abort the entire test run


### PR DESCRIPTION
### Description

An unintended consequence of bb18a1b2556d41b0cc98e3c1bbdbb0c2030708eb is that importing `constants` before `units` causes an import loop. The fact that our tests didn't catch this must mean that in tests `units` do get imported before `constants`.

UPDATE: although the bug in question is very simple to understand and very simple to fix, investigating why `astropy.tests.tests.test_imports()` did not catch this bug in CI revealed problems that affect more than one sub-package.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
