### PR TITLE
refactor: replace .flat[...] with .item(...) for clearer scalar extraction

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1648,7 +1648,7 @@ class TestStreamingFunctions(FitsTestCase):
 
     def test_blank_ignore(self):
         with fits.open(self.data("blank.fits"), ignore_blank=True) as f:
-            assert f[0].data.flat[0] == 2
+            assert f[0].data.item(0) == 2
 
     def test_error_if_memmap_impossible(self):
         pth = self.data("blank.fits")

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1040,7 +1040,7 @@ class TimeAstropyTime(TimeUnique):
         Use __new__ instead of __init__ to output a class instance that
         is the same as the class of the first Time object in the list.
         """
-        val1_0 = val1.flat[0]
+        val1_0 = val1.item(0)
         if not (
             isinstance(val1_0, Time)
             and all(type(val) is type(val1_0) for val in val1.flat)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -793,7 +793,7 @@ class UnitBase:
             return CompositeUnit(1, [self], [sanitize_power(p)], _error_check=False)
         except Exception:
             arr = np.asanyarray(p)
-            p = arr.flat[0]
+            p = arr.item(0)
             if (arr != p).any():
                 raise ValueError(
                     "Quantities and Units may only be raised to a scalar power"

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1103,7 +1103,7 @@ def lexsort(keys, axis=-1):
             new_key = key.unmasked
             if new_keys and key.mask.any():
                 new_key = new_key.copy()
-                new_key[key.mask] = new_key.flat[0]
+                new_key[key.mask] = new_key.item(0)
             new_keys.extend([new_key, key.mask])
         else:
             new_keys.append(key)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Hi!

This pull request replaces uses of .flat[...] with .item(...) to make scalar extraction more explicit (and possibly faster). I'm new to the project, so if something is incorrect, please let me know. Cheers!

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Addresses #18022

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
