### PR TITLE
Improve formatting of degrees Rankine

### DIFF
--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -151,6 +151,7 @@ def_unit(
     5 / 9 * si.K,
     namespace=_ns,
     doc="Rankine scale: absolute scale of thermodynamic temperature",
+    format={"latex": r"{}^{\circ}R", "unicode": "°R"},
 )
 
 ###########################################################################

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1432,6 +1432,8 @@ class TestQuantityDisplay:
     @pytest.mark.parametrize(
         "q, expected",
         [
+            pytest.param(0 * u.imperial.deg_R, r"$0\mathrm{{}^{\circ}R}$", id="deg_R"),
+            pytest.param(5 * u.imperial.deg_F, r"$5\mathrm{{}^{\circ}F}$", id="deg_F"),
             pytest.param(10 * u.deg_C, r"$10\mathrm{{}^{\circ}C}$", id="deg_C"),
             pytest.param(20 * u.deg, r"$20\mathrm{{}^{\circ}}$", id="deg"),
             pytest.param(30 * u.arcmin, r"$30\mathrm{{}^{\prime}}$", id="arcmin"),

--- a/docs/changes/units/18049.bugfix.rst
+++ b/docs/changes/units/18049.bugfix.rst
@@ -1,0 +1,3 @@
+The degrees Rankine is now represented as "$\mathrm{{}^{\circ}R}$" in the
+``"latex"`` and ``"latex_inline"`` formats and as "°R" in the ``"unicode"``
+format.


### PR DESCRIPTION
### Description

Define
```python
>>> def format_demo(unit):
...     for format in ("latex", "latex_inline", "unicode"):
...         print(f"{format}: {unit.to_string(format)}")
```
On current `main`
```python
>>> from astropy import units as u
>>> format_demo(u.deg_C)
latex: $\mathrm{{}^{\circ}C}$
latex_inline: $\mathrm{{}^{\circ}C}$
unicode: °C
>>> format_demo(u.imperial.deg_F)
latex: $\mathrm{{}^{\circ}F}$
latex_inline: $\mathrm{{}^{\circ}F}$
unicode: °F
>>> format_demo(u.imperial.deg_R)
latex: $\mathrm{deg\_R}$
latex_inline: $\mathrm{deg\_R}$
unicode: deg_R
```
With this patch
```python
>>> format_demo(u.imperial.deg_R)
latex: $\mathrm{{}^{\circ}R}$
latex_inline: $\mathrm{{}^{\circ}R}$
unicode: °R
```
I couldn't find any tests for °F or °C in `"latex_inline"` or in `"unicode"`, so I didn't add a test for °R either. I did find a test for °C in the `"latex"` format, so I expanded that test to also check °F and °R.

That the symbol for degrees Rankine should be °R comes from a [NIST guideline](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8#D), which for a rather obscure non-SI unit is as authoritative as it gets.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
