### PR TITLE
Fix bugs in Table indices related to list/ndarray item in .loc/.loc_indices

### DIFF
--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -624,6 +624,7 @@ def simple_table():
         (slice(0, 0), 0, Table),
         ([], 0, Table),
         ([1], 1, Table),
+        ([1, 3], 3, Table),
         (np.array([]), 0, Table),
         (np.array([1]), 1, Table),
         (3, 2, Table),  # scalar index with multiple rows

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -607,6 +607,47 @@ def test_index_slice_exception():
         SlicedIndex(None, None)
 
 
+@pytest.fixture(scope="module")
+def simple_table():
+    """Simple table with an index on column 'a'."""
+    t = Table()
+    t["a"] = [3, 1, 2, 3]
+    t["b"] = ["x", "y", "z", "w"]
+    t.add_index("a")
+    return t
+
+
+@pytest.mark.parametrize("key", [None, "a"])
+@pytest.mark.parametrize(
+    "item,length,cls",
+    [
+        (slice(0, 0), 0, Table),
+        ([], 0, Table),
+        ([1], 1, Table),
+        (np.array([]), 0, Table),
+        (np.array([1]), 1, Table),
+        (3, 2, Table),  # scalar index with multiple rows
+        (1, None, Row),  # scalar index with single row
+    ],
+)
+def test_index_zero_slice_or_sequence_or_scalar(simple_table, key, item, length, cls):
+    """Test that indexing with various types gives the expected result.
+
+    Tests fix for #18037.
+    """
+    if key is not None:
+        item = (key, item)
+
+    tloc = simple_table.loc[item]
+    assert isinstance(tloc, cls)
+    assert tloc.colnames == simple_table.colnames
+
+    rows = simple_table.loc_indices[item]
+    if cls is Table:
+        assert len(tloc) == length
+        assert len(rows) == length
+
+
 @pytest.mark.parametrize(
     "masked",
     [pytest.param(False, id="raw-array"), pytest.param(True, id="masked array")],

--- a/docs/changes/table/18051.api.rst
+++ b/docs/changes/table/18051.api.rst
@@ -1,0 +1,14 @@
+Fix issues in the handling of a call like ``tbl.loc[item]`` or ``tbl.loc_indices[item]``
+and make the behavior consistent with pandas. Here ``tbl`` is a ``Table`` or ``QTable``
+with an index defined.
+
+If ``item`` is an empty list or zero-length ``np.ndarray`` or an empty slice, then
+previously ``tbl.loc[item]`` would raise a ``KeyError`` exception. Now it returns the
+zero-length table ``tbl[[]]``.
+
+If ``item`` is a one-element list like ``["foo"]``, then previously
+``tbl.loc[item]`` would return either a ``Row`` or a ``Table`` with multiple row,
+depending on whether the index was unique. Now it always returns a ``Table``, consistent
+with behavior for ``tbl.loc[[]]`` and ``tbl.loc[["foo", "bar"]]``.
+
+See https://github.com/astropy/astropy/pull/18051 for more details.

--- a/docs/changes/table/18051.bugfix.rst
+++ b/docs/changes/table/18051.bugfix.rst
@@ -1,0 +1,14 @@
+Fix issues in the handling of a call like ``tbl.loc[item]`` or ``tbl.loc_indices[item]``
+and make the behavior consistent with pandas. Here ``tbl`` is a ``Table`` or ``QTable``
+with an index defined.
+
+If ``item`` is an empty list or zero-length ``np.ndarray`` or an empty slice, then
+previously ``tbl.loc[item]`` would raise a ``KeyError`` exception. Now it returns the
+zero-length table ``tbl[[]]``.
+
+If ``item`` is a one-element list like ``["foo"]``, then previously
+``tbl.loc[item]`` would return either a ``Row`` or a ``Table`` with multiple row,
+depending on whether the index was unique. Now it always returns a ``Table``, consistent
+with behavior for ``tbl.loc[[]]`` and ``tbl.loc[["foo", "bar"]]``.
+
+See https://github.com/astropy/astropy/pull/18051 for more details.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix issues in the handling of a list or ndarray `item` when calling `tbl.loc[item]` where `tbl` is a `Table` or `QTable` with an index. These are discussed in more detail in #18037. The changes described here apply to both the `.loc` and `.loc_indices` properties.

The issues arise because the code was applying the following output rules at the end of row selection, **regardless** of the type of the input `item`:
- If no rows selected, raise a `KeyError` exception.
- If one row selected, return a scalar `Row` instead of a `Table`

However, it is reasonable expectation, and *consistent with pandas*, that all these should result in a `Table` as follows:
```
tbl.loc[[]]  # zero length Table. Current release raises a KeyError exception.
tbl.loc[0:0]  # zero length Table. Current release raises a KeyError exception.
tbl.loc[[key1]]  # Table with row(s) matching key1. Current returns a Row for one matching row.
tbl.loc[[key1, key2]]  # Table with rows matching key1 or key2. Current returns a Table
```
This PR adds logic to consider the input `item` type in handling how to cast the output rows.

#### API change

This PR changes the output of `tbl.loc[[key1]]` (where one row matches) from a `Row` to a `Table`. This can be considered a bug in the original implementation, but since it has been the behavior since the introduction of indexing, it is possible some code relies on this.

There is no obvious/nice way to make this change as a deprecation or with some back-compatible workaround. With this PR, I am recommending to just make the change but document it as both a bug fix and an API change. Code that is currently using list inputs to `.loc` are likely already handling the possibility of either `Table` or `Row` output, so the risk of code breakage is likely to be low.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18037

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
