### PR TITLE
Deprecate the `isiterable()` utility function

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -24,8 +24,10 @@ from textwrap import TextWrapper
 from typing import TYPE_CHECKING
 from warnings import warn
 
+import numpy as np
+
 from astropy.extern.configobj import configobj, validate
-from astropy.utils import find_current_module, isiterable, silence
+from astropy.utils import find_current_module, silence
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .paths import get_config_dir_path
@@ -297,7 +299,7 @@ class ConfigItem:
 
         # now determine cfgtype if it is not given
         if cfgtype is None:
-            if isiterable(defaultvalue) and not isinstance(defaultvalue, str):
+            if np.iterable(defaultvalue) and not isinstance(defaultvalue, str):
                 # it is an options list
                 dvstr = [str(v) for v in defaultvalue]
                 cfgtype = "option(" + ", ".join(dvstr) + ")"

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import SpecificTypeQuantity
-from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 
 from . import formats
@@ -189,7 +188,7 @@ class Angle(SpecificTypeQuantity):
             ):
                 angle = np.asarray(angle)
 
-            elif isiterable(angle):
+            elif np.iterable(angle):
                 angle = [cls(x, unit, copy=COPY_IF_NEEDED) for x in angle]
 
         return super().__new__(cls, angle, unit, dtype=dtype, copy=copy, **kwargs)

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -17,7 +17,7 @@ import numpy as np
 from astropy import units as u
 from astropy.constants import c
 from astropy.io import ascii
-from astropy.utils import data, isiterable
+from astropy.utils import data
 
 from .builtin_frames import GCRS, PrecessedGeocentric
 from .builtin_frames.utils import get_jd12
@@ -369,7 +369,7 @@ def concatenate(coords):
         A single sky coordinate with its data set to the concatenation of all
         the elements in ``coords``
     """
-    if getattr(coords, "isscalar", False) or not isiterable(coords):
+    if getattr(coords, "isscalar", False) or not np.iterable(coords):
         raise TypeError("The argument to concatenate must be iterable")
 
     scs = [SkyCoord(coord, copy=False) for coord in coords]

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -31,7 +31,6 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose_quantity
-from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 
@@ -308,7 +307,7 @@ class TestSphericalRepresentation:
         assert_allclose_quantity(s_slc.distance, [1, 1, 1] * u.kpc)
 
         assert len(s) == 10
-        assert isiterable(s)
+        assert np.iterable(s)
 
     def test_getitem_len_iterable_scalar(self):
         s = SphericalRepresentation(lon=1 * u.deg, lat=-2 * u.deg, distance=3 * u.kpc)
@@ -317,7 +316,7 @@ class TestSphericalRepresentation:
             s_slc = s[0]
         with pytest.raises(TypeError):
             len(s)
-        assert not isiterable(s)
+        assert not np.iterable(s)
 
     def test_setitem(self):
         s = SphericalRepresentation(

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -43,7 +43,6 @@ from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
-from astropy.utils import isiterable
 from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.wcs import WCS
@@ -820,9 +819,9 @@ def test_ops():
 
     with pytest.raises(TypeError):
         iter(sc)
-    assert not isiterable(sc)
-    assert isiterable(sc_arr)
-    assert isiterable(sc_empty)
+    assert not np.iterable(sc)
+    assert np.iterable(sc_arr)
+    assert np.iterable(sc_empty)
     it = iter(sc_arr)
     assert next(it).dec == sc_arr[0].dec
     assert next(it).dec == sc_arr[1].dec

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -16,7 +16,7 @@ from textwrap import indent
 import numpy as np
 from numpy import char as chararray
 
-from astropy.utils import isiterable, lazyproperty
+from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .card import CARD_LENGTH, Card
@@ -1493,7 +1493,7 @@ class ColDefs(NotifierMixin):
         elif isinstance(input, np.ndarray) and input.dtype.fields is not None:
             # Construct columns from the fields of a record array
             self._init_from_array(input)
-        elif isiterable(input):
+        elif np.iterable(input):
             # if the input is a list of Columns
             self._init_from_sequence(input)
         elif isinstance(input, _TableBaseHDU):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -14,7 +14,7 @@ from astropy.io.fits.util import (
     _pseudo_zero,
 )
 from astropy.io.fits.verify import VerifyWarning
-from astropy.utils import isiterable, lazyproperty
+from astropy.utils import lazyproperty
 
 from .base import BITPIX2DTYPE, DELAYED, DTYPE2BITPIX, ExtensionHDU, _ValidHDU
 
@@ -1055,7 +1055,7 @@ class Section:
                 ks = range(*key.indices(axis))
                 break
 
-            if isiterable(key):
+            if np.iterable(key):
                 # Handle both integer and boolean arrays.
                 ks = np.arange(axis, dtype=int)[key]
                 break
@@ -1063,7 +1063,7 @@ class Section:
 
         data = [self[keys[:idx] + (k,) + keys[idx + 1 :]] for k in ks]
 
-        if any(isinstance(key, slice) or isiterable(key) for key in keys[idx + 1 :]):
+        if any(isinstance(key, slice) or np.iterable(key) for key in keys[idx + 1 :]):
             # data contains multidimensional arrays; combine them.
             return np.array(data)
         else:
@@ -1288,7 +1288,7 @@ class _IndexInfo:
             self.npts = (stop - start) // step
             self.offset = start
             self.contiguous = step == 1
-        elif isiterable(index):
+        elif np.iterable(index):
             self.npts = len(index)
             self.offset = 0
             self.contiguous = False

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -8,7 +8,8 @@ import os
 import re
 import warnings
 
-from astropy.utils import isiterable
+import numpy as np
+
 from astropy.utils.exceptions import AstropyUserWarning
 
 from ._utils import parse_header
@@ -1862,7 +1863,7 @@ class Header:
             else:
                 indices = self._wildcardmatch(key)
 
-            if isinstance(value, str) or not isiterable(value):
+            if isinstance(value, str) or not np.iterable(value):
                 value = itertools.repeat(value, len(indices))
 
             for idx, val in zip(indices, value):
@@ -2080,7 +2081,7 @@ class _CardAccessor:
     def __eq__(self, other):
         # If the `other` item is a scalar we will still treat it as equal if
         # this _CardAccessor only contains one item
-        if not isiterable(other) or isinstance(other, str):
+        if not np.iterable(other) or isinstance(other, str):
             if len(self) == 1:
                 other = [other]
             else:
@@ -2108,7 +2109,7 @@ class _CardAccessor:
                 indices = range(*item.indices(len(self)))
             else:
                 indices = self._header._wildcardmatch(item)
-            if isinstance(value, str) or not isiterable(value):
+            if isinstance(value, str) or not np.iterable(value):
                 value = itertools.repeat(value, len(indices))
             for idx, val in zip(indices, value):
                 self[idx] = val

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 
 from astropy.units import Quantity
-from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED
 
 if TYPE_CHECKING:
@@ -85,7 +84,7 @@ class _Interval(_BaseInterval):
                 and all(isinstance(b, np.ndarray) for b in interval)
             )
 
-        if not isiterable(interval) or not valid_shape:
+        if not np.iterable(interval) or not valid_shape:
             raise ValueError(MESSAGE)
 
     @classmethod
@@ -1022,7 +1021,7 @@ class _SelectorArgument(_BaseSelectorArgument):
             All the processed model evaluation inputs.
         """
         _selector = inputs[self.index]
-        if isiterable(_selector):
+        if np.iterable(_selector):
             if len(_selector) == 1:
                 return _selector[0]
             else:
@@ -1427,7 +1426,7 @@ class CompoundBoundingBox(_BoundingDomain):
 
     @staticmethod
     def _get_selector_key(key):
-        if isiterable(key):
+        if np.iterable(key):
             return tuple(key)
         else:
             return (key,)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -28,12 +28,7 @@ import numpy as np
 from astropy.nddata.utils import add_array, extract_array
 from astropy.table import Table
 from astropy.units import Quantity, UnitsError, dimensionless_unscaled
-from astropy.utils import (
-    find_current_module,
-    isiterable,
-    metadata,
-    sharedmethod,
-)
+from astropy.utils import find_current_module, metadata, sharedmethod
 from astropy.utils.codegen import make_function_with_signature
 from astropy.utils.compat import COPY_IF_NEEDED
 
@@ -2224,7 +2219,7 @@ class Model(metaclass=_ModelMeta):
         inputs_are_quantity = any(isinstance(i, Quantity) for i in inputs)
         if self.return_units and inputs_are_quantity:
             # We allow a non-iterable unit only if there is one output
-            if self.n_outputs == 1 and not isiterable(self.return_units):
+            if self.n_outputs == 1 and not np.iterable(self.return_units):
                 return_units = {self.outputs[0]: self.return_units}
             else:
                 return_units = self.return_units

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -15,7 +15,6 @@ import operator
 import numpy as np
 
 from astropy.units import MagUnit, Quantity, dimensionless_unscaled
-from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED
 
 from .utils import array_repr_oneline, get_inputs_and_params
@@ -37,7 +36,7 @@ class ParameterDefinitionError(ParameterError):
 
 def _tofloat(value):
     """Convert a parameter to float or float array."""
-    if isiterable(value):
+    if np.iterable(value):
         try:
             value = np.asanyarray(value, dtype=float)
         except (TypeError, ValueError):

--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -9,7 +9,6 @@ import warnings
 
 import numpy as np
 
-from astropy.utils import isiterable
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .core import FittableModel, ModelDefinitionError
@@ -483,7 +482,7 @@ class Spline1D(_Spline):
     def _init_knots(self, knots, has_bounds, lower, upper):
         if np.issubdtype(type(knots), np.integer):
             self._t = np.concatenate((lower, np.zeros(knots), upper))
-        elif isiterable(knots):
+        elif np.iterable(knots):
             self._user_knots = True
             if has_bounds:
                 self._t = np.concatenate((lower, np.array(knots), upper))

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -3,8 +3,6 @@
 
 import numpy as np
 
-from astropy.utils.misc import isiterable
-
 __all__ = ["FlagCollection"]
 
 
@@ -24,7 +22,7 @@ class FlagCollection(dict):
     def __init__(self, *args, **kwargs):
         if "shape" in kwargs:
             self.shape = kwargs.pop("shape")
-            if not isiterable(self.shape):
+            if not np.iterable(self.shape):
                 raise ValueError("FlagCollection shape should be an iterable object")
         else:
             raise Exception(

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -21,7 +21,6 @@ from astropy.stats.nanfunctions import (
     nanvar,
 )
 from astropy.units import Quantity
-from astropy.utils import isiterable
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -300,7 +299,7 @@ class SigmaClip:
         if axis is None:
             axis = -1 if data.ndim == 1 else tuple(range(data.ndim))
 
-        if not isiterable(axis):
+        if not np.iterable(axis):
             axis = normalize_axis_index(axis, data.ndim)
             data_reshaped = data
             transposed_shape = None
@@ -481,7 +480,7 @@ class SigmaClip:
 
         if axis is not None:
             # convert negative axis/axes
-            if not isiterable(axis):
+            if not np.iterable(axis):
                 axis = (axis,)
             axis = tuple(filtered_data.ndim + n if n < 0 else n for n in axis)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -15,11 +15,7 @@ from numpy import ma
 from astropy import log
 from astropy.io.registry import UnifiedReadWriteMethod
 from astropy.units import Quantity, QuantityInfo
-from astropy.utils import (
-    ShapedLikeNDArray,
-    deprecated,
-    isiterable,
-)
+from astropy.utils import ShapedLikeNDArray, deprecated
 from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_25
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, DataInfo, MixinInfo
@@ -1203,7 +1199,7 @@ class Table:
         the same length as data.
         """
         for inp_list, inp_str in ((dtype, "dtype"), (names, "names")):
-            if not isiterable(inp_list):
+            if not np.iterable(inp_list):
                 raise ValueError(f"{inp_str} must be a list or None")
 
         if len(names) != n_cols or len(dtype) != n_cols:
@@ -3297,8 +3293,10 @@ class Table:
             vals = vals_list
             mask = mask_list
 
-        if isiterable(vals):
-            if mask is not None and (not isiterable(mask) or isinstance(mask, Mapping)):
+        if np.iterable(vals):
+            if mask is not None and (
+                not np.iterable(mask) or isinstance(mask, Mapping)
+            ):
                 raise TypeError("Mismatch between type of vals and mask")
 
             if len(self.columns) != len(vals):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -29,7 +29,7 @@ from astropy.time import (
     TimezoneInfo,
     conf,
 )
-from astropy.utils import iers, isiterable
+from astropy.utils import iers
 from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_PYTZ
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -1740,20 +1740,20 @@ def test_remove_astropy_time():
 def test_isiterable():
     """
     Ensure that scalar `Time` instances are not reported as iterable by the
-    `isiterable` utility.
+    `np.iterable()` utility.
 
     Regression test for https://github.com/astropy/astropy/issues/4048
     """
 
     t1 = Time.now()
-    assert not isiterable(t1)
+    assert not np.iterable(t1)
 
     t2 = Time(
         ["1999-01-01 00:00:00.123456789", "2010-01-01 00:00:00"],
         format="iso",
         scale="utc",
     )
-    assert isiterable(t2)
+    assert np.iterable(t2)
 
 
 def test_to_datetime():

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -20,7 +20,6 @@ import numpy as np
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import deprecated, lazyproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from astropy.utils.misc import isiterable
 
 from .errors import UnitConversionError, UnitParserWarning, UnitsError, UnitsWarning
 from .utils import (
@@ -95,7 +94,7 @@ def _flatten_units_collection(items: object) -> set[UnitBase]:
                 units = item.values()
             elif inspect.ismodule(item):
                 units = vars(item).values()
-            elif isiterable(item):
+            elif np.iterable(item):
                 units = item
             else:
                 continue

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -18,7 +18,6 @@ import numpy as np
 # LOCAL
 from astropy.constants import si as _si
 from astropy.utils import deprecated_renamed_argument
-from astropy.utils.misc import isiterable
 
 from . import astrophys, cgs, dimensionless_unscaled, misc, si
 from .core import Unit
@@ -123,7 +122,7 @@ def parallax():
         x = np.asanyarray(x)
         d = 1 / x
 
-        if isiterable(d):
+        if np.iterable(d):
             d[d < 0] = np.nan
             return d
 

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -42,7 +42,6 @@ from numpy.lib import recfunctions as rfn
 
 from astropy.units.core import dimensionless_unscaled
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
-from astropy.utils import isiterable
 from astropy.utils.compat import (
     COPY_IF_NEEDED,
     NUMPY_LT_1_24,
@@ -204,7 +203,7 @@ class FunctionAssigner:
         if f is not None:
             if helps is None:
                 helps = getattr(module, f.__name__)
-            if not isiterable(helps):
+            if not np.iterable(helps):
                 helps = (helps,)
             for h in helps:
                 self.assignments[h] = f

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_allclose, assert_array_almost_equal, assert_arr
 
 from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
-from astropy.utils import isiterable
 from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
@@ -1677,11 +1676,11 @@ def test_quantity_iterability():
     """
 
     q1 = [15.0, 17.0] * u.m
-    assert isiterable(q1)
+    assert np.iterable(q1)
 
     q2 = next(iter(q1))
     assert q2 == 15.0 * u.m
-    assert not isiterable(q2)
+    assert not np.iterable(q2)
     pytest.raises(TypeError, iter, q2)
 
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     _CAN_RESIZE_TERMINAL = False
 
+import numpy as np
+
 from astropy import conf
 from astropy.utils.compat.optional_deps import (
     HAS_IPYKERNEL,
@@ -34,7 +36,6 @@ from astropy.utils.compat.optional_deps import (
 )
 
 from .decorators import classproperty, deprecated
-from .misc import isiterable
 
 __all__ = [
     "ProgressBar",
@@ -436,7 +437,7 @@ class ProgressBar:
         else:
             self._silent = False
 
-        if isiterable(total_or_items):
+        if np.iterable(total_or_items):
             self._items = iter(total_or_items)
             self._total = len(total_or_items)
         else:

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -52,6 +52,7 @@ _NOT_OVERWRITING_MSG_MATCH = (
 )
 
 
+@deprecated(since="7.1", alternative="numpy.iterable()")
 def isiterable(obj):
     """Returns `True` if the given object is iterable."""
     try:

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -15,12 +15,21 @@ from astropy.utils import data, misc
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
-def test_isiterable():
-    assert misc.isiterable(2) is False
-    assert misc.isiterable([2]) is True
-    assert misc.isiterable([1, 2, 3]) is True
-    assert misc.isiterable(np.array(2)) is False
-    assert misc.isiterable(np.array([1, 2, 3])) is True
+@pytest.mark.parametrize(
+    "obj,expectation",
+    [
+        (2, False),
+        ([2], True),
+        ([1, 2, 3], True),
+        (np.array(2), False),
+        (np.array([1, 2, 3]), True),
+    ],
+)
+def test_isiterable(obj, expectation):
+    with pytest.warns(
+        AstropyDeprecationWarning, match=r"Use numpy.iterable\(\) instead\.$"
+    ):
+        assert misc.isiterable(obj) is expectation
 
 
 @pytest.mark.remote_data

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -19,7 +19,6 @@ from astropy.coordinates import (
 )
 from astropy.io import fits
 from astropy.tests.figures import figure_test
-from astropy.utils import isiterable
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.visualization.wcsaxes import WCSAxes, add_beam, add_scalebar
@@ -1464,14 +1463,14 @@ def test_nosimplify():
 @figure_test
 def test_custom_formatter(spatial_wcs_2d_small_angle):
     def double_format(value, **kwargs):
-        if isiterable(value):
+        if np.iterable(value):
             return [f"{(v * 2):.4f}" for v in value]
         else:
             return f"{(value * 2):.2f}"
 
     def fruit_format(value, **kwargs):
         fruits = ["apple", "pear", "banana", "orange", "kiwi", "grape"]
-        if isiterable(value):
+        if np.iterable(value):
             return (fruits * 10)[: len(value)]
         else:
             return "apple"

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 import numpy as np
 
-from astropy.utils import isiterable
 from astropy.utils.decorators import lazyproperty
 
 from .base import BaseWCSWrapper
@@ -26,7 +25,7 @@ def sanitize_slices(slices, ndim):
             f"than the dimensionality ({ndim}) of the wcs."
         )
 
-    if any(isiterable(s) for s in slices):
+    if any(np.iterable(s) for s in slices):
         raise IndexError(
             "This slice is invalid, only integer or range slices are supported."
         )

--- a/docs/changes/utils/18053.api.rst
+++ b/docs/changes/utils/18053.api.rst
@@ -1,0 +1,2 @@
+The ``isiterable()`` utility is deprecated.
+``numpy.iterable()`` can be used as a drop-in replacement.


### PR DESCRIPTION
### Description

[`numpy.iterable()`](https://numpy.org/doc/1.23/reference/generated/numpy.iterable.html) can be used as a drop-in replacement.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
