### PR TITLE
DOC: adding votable.parquet and parquet.votable to the formats table

### DIFF
--- a/docs/io/unified_table.rst
+++ b/docs/io/unified_table.rst
@@ -134,8 +134,10 @@ ascii.fixed_width_no_header    Yes          :class:`~astropy.io.ascii.FixedWidth
                 pandas.html    Yes          :func:`pandas.read_html` and :meth:`pandas.DataFrame.to_html`
                 pandas.json    Yes          :func:`pandas.read_json` and :meth:`pandas.DataFrame.to_json`
                     parquet    Yes    auto  |Parquet|: Apache Parquet binary file
+            parquet.votable    Yes          Parquet file(s) with VOTable metadata
                 pyarrow.csv     No          :func:`~astropy.io.misc.pyarrow.csv.read_csv`: Performant CSV reader
                     votable    Yes    auto  :mod:`~astropy.io.votable`: Table format used by Virtual Observatory (VO) initiative
+            votable.parquet    Yes          Parquet serialization of VOTables. Specify this format for writing, reading is automatic.
 ===========================  =====  ======  ============================================================================================
 
 Details


### PR DESCRIPTION
I've noticed that these are missing from the big available format listing table. Milestoning to 7.1 as the docs got refactored significantly so I doubt that out of box backport would work, and it doesn't really matter if this doesn't end up in the bugfix branch's docs build.