### PR TITLE
Fix bug not setting null_values=[""] by default in pyarrow.csv reader

### DIFF
--- a/astropy/io/misc/pyarrow/csv.py
+++ b/astropy/io/misc/pyarrow/csv.py
@@ -118,7 +118,8 @@ def read_csv(
     ----------------
     null_values : list, optional (default None)
         List of strings to interpret as null values. By default, only empty strings are
-        considered as null values. Set to ``[]`` to disable null value handling.
+        considered as null values (equivalent to ``null_values=[""]``). Set to ``[]`` to
+        disable null value handling.
     encoding: str, optional (default 'utf-8')
         Encoding of the input data.
     newlines_in_values: bool, optional (default False)
@@ -462,11 +463,10 @@ def get_convert_options(
 
     convert_options = csv.ConvertOptions()
     convert_options.strings_can_be_null = True
+    convert_options.null_values = [""] if null_values is None else null_values
 
     if include_names is not None:
         convert_options.include_columns = include_names
-    if null_values is not None:
-        convert_options.null_values = null_values
     if dtypes is not None:
         convert_options.column_types = {
             colname: (

--- a/astropy/io/misc/pyarrow/tests/test_csv.py
+++ b/astropy/io/misc/pyarrow/tests/test_csv.py
@@ -586,6 +586,27 @@ def test_read_null_values():
     check_tables_equal(exp, out)
 
 
+def test_read_null_values_default():
+    """Test that the default null value is [""].
+
+    PyArrow by default includes other null values like "NaN" or "nan".
+    """
+    tbl_text = textwrap.dedent("""\
+    a,b,c
+    ,nan,NaN
+    4,,#N/A
+    """)
+    out = table_read_csv(tbl_text)
+    exp = [
+        "  a      b     c  ",
+        "int64 float64 str4",
+        "----- ------- ----",
+        "   --     nan  NaN",
+        "    4      -- #N/A",
+    ]
+    assert out.pformat(show_dtype=True) == exp
+
+
 def test_read_newlines_in_values():
     """Test reading a simple CSV file with newlines in values.
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes a mistake in #17706 where the default for `null_values` was delegated to `PyArrow`, whereas the `read_csv()` documentation states that (by default) only empty strings are considered null. It turns out `PyArrow` includes various spellings of `NaN` and `#N/A` in the default null list and this is not desired in the astropy interface.

This PR sets the default `null_values` to `[""]` if it is not specified, and adds a test of null value handling in that case.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
