### PR TITLE
Deprecate isiterable in 7.2 rather than 7.1

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -52,7 +52,7 @@ _NOT_OVERWRITING_MSG_MATCH = (
 )
 
 
-@deprecated(since="7.1", alternative="numpy.iterable()")
+@deprecated(since="7.2", alternative="numpy.iterable()")
 def isiterable(obj):
     """Returns `True` if the given object is iterable."""
     try:


### PR DESCRIPTION
As this is definitely used in downstream packages, deprecating immediately before feature freeze did not really give enough time for downstream packages to adapt to the new deprecation warning ahead of the astropy 7.1.0 release.

This is a companion to https://github.com/astropy/astropy/pull/18063

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
