### PR TITLE
Ensure THEAP, ZBLANK, ZSCALE, and ZZERO are stripped during decompression

### DIFF
--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -32,7 +32,12 @@ __all__ = [
 ]
 
 ZDEF_RE = re.compile(r"(?P<label>^[Zz][a-zA-Z]*)(?P<num>[1-9][0-9 ]*$)?")
-INDEXED_COMPRESSION_KEYWORDS = {"ZNAXIS", "ZTILE", "ZNAME", "ZVAL"}
+INDEXED_COMPRESSION_KEYWORDS = {
+    "ZNAXIS",
+    "ZTILE",
+    "ZNAME",
+    "ZVAL",
+}
 REMAPPED_KEYWORDS = {
     "SIMPLE": "ZSIMPLE",
     "XTENSION": "ZTENSION",
@@ -46,7 +51,16 @@ REMAPPED_KEYWORDS = {
     "DATASUM": "ZDATASUM",
 }
 COMPRESSION_KEYWORDS = set(REMAPPED_KEYWORDS.values()).union(
-    {"ZIMAGE", "ZCMPTYPE", "ZMASKCMP", "ZQUANTIZ", "ZDITHER0"}
+    {
+        "ZIMAGE",
+        "ZCMPTYPE",
+        "ZMASKCMP",
+        "ZQUANTIZ",
+        "ZDITHER0",
+        "ZBLANK",
+        "ZSCALE",
+        "ZZERO",
+    }
 )
 
 
@@ -61,7 +75,7 @@ class CompImageHeader(Header):
 
 def _is_reserved_table_keyword(keyword):
     m = TDEF_RE.match(keyword)
-    return keyword == "TFIELDS" or (
+    return keyword in ("TFIELDS", "THEAP") or (
         m and m.group("label").upper() in TABLE_KEYWORD_NAMES
     )
 

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1436,7 +1436,7 @@ def test_reserved_keywords_stripped(tmp_path):
     #
     # See also https://github.com/astropy/astropy/issues/18067
 
-    data = np.random.randint(0, 100, (256, 256))
+    data = np.arange(6).reshape((2, 3))
 
     hdu = fits.CompImageHDU(data)
     hdu.writeto(tmp_path / "compressed.fits")

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1441,7 +1441,9 @@ def test_reserved_keywords_stripped(tmp_path):
     hdu = fits.CompImageHDU(data)
     hdu.writeto(tmp_path / "compressed.fits")
 
-    with fits.open(tmp_path / "compressed.fits", disable_image_compression=True) as hduc:
+    with fits.open(
+        tmp_path / "compressed.fits", disable_image_compression=True
+    ) as hduc:
         hduc[1].header["THEAP"] = hduc[1].header["NAXIS1"] * hduc[1].header["NAXIS2"]
         hduc[1].header["ZBLANK"] = 1231212
         hduc[1].header["ZSCALE"] = 2

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -507,13 +507,16 @@ class TestCompressedImage(FitsTestCase):
         with fits.open(self.data("comp.fits")) as hdul:
             hdr = hdul[1].header
             hdr["TFIELDS"] = 8
+            hdr["THEAP"] = 1000
             hdr["TTYPE1"] = "Foo"
             hdr["ZCMPTYPE"] = "ASDF"
             hdr["ZVAL1"] = "Foo"
             with pytest.warns() as record:
                 hdul.writeto(tmp_path / "test.fits")
-            assert len(record) == 4
-            for i, keyword in enumerate(("TFIELDS", "TTYPE1", "ZCMPTYPE", "ZVAL1")):
+            assert len(record) == 5
+            for i, keyword in enumerate(
+                ("TFIELDS", "THEAP", "TTYPE1", "ZCMPTYPE", "ZVAL1")
+            ):
                 assert f"Keyword {keyword!r} is reserved" in record[i].message.args[0]
 
     def test_compression_header_append(self, tmp_path):
@@ -1425,3 +1428,28 @@ def test_compression_options_with_mutated_data(
 
     zflags = {k: hdr[k] for k in expected_zflags}
     assert zflags == expected_zflags
+
+
+def test_reserved_keywords_stripped(tmp_path):
+    # Regression test for a bug that caused THEAP, ZBLANK, ZSCALE and ZZERO to
+    # not be correctly stripped from the compressed header when decompressing
+    #
+    # See also https://github.com/astropy/astropy/issues/18067
+
+    data = np.random.randint(0, 100, (256, 256))
+
+    hdu = fits.CompImageHDU(data)
+    hdu.writeto(tmp_path / "compressed.fits")
+
+    hduc = fits.open(tmp_path / "compressed.fits", disable_image_compression=True)
+    hduc[1].header["THEAP"] = hduc[1].header["NAXIS1"] * hduc[1].header["NAXIS2"]
+    hduc[1].header["ZBLANK"] = 1231212
+    hduc[1].header["ZSCALE"] = 2
+    hduc[1].header["ZZERO"] = 10
+    hduc[1].writeto(tmp_path / "compressed_with_extra.fits")
+
+    hdud = fits.open(tmp_path / "compressed_with_extra.fits")
+    assert "THEAP" not in hdud[1].header
+    assert "ZBLANK" not in hdud[1].header
+    assert "ZSCALE" not in hdud[1].header
+    assert "ZZERO" not in hdud[1].header

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1441,15 +1441,15 @@ def test_reserved_keywords_stripped(tmp_path):
     hdu = fits.CompImageHDU(data)
     hdu.writeto(tmp_path / "compressed.fits")
 
-    hduc = fits.open(tmp_path / "compressed.fits", disable_image_compression=True)
-    hduc[1].header["THEAP"] = hduc[1].header["NAXIS1"] * hduc[1].header["NAXIS2"]
-    hduc[1].header["ZBLANK"] = 1231212
-    hduc[1].header["ZSCALE"] = 2
-    hduc[1].header["ZZERO"] = 10
-    hduc[1].writeto(tmp_path / "compressed_with_extra.fits")
+    with fits.open(tmp_path / "compressed.fits", disable_image_compression=True) as hduc:
+        hduc[1].header["THEAP"] = hduc[1].header["NAXIS1"] * hduc[1].header["NAXIS2"]
+        hduc[1].header["ZBLANK"] = 1231212
+        hduc[1].header["ZSCALE"] = 2
+        hduc[1].header["ZZERO"] = 10
+        hduc[1].writeto(tmp_path / "compressed_with_extra.fits")
 
-    hdud = fits.open(tmp_path / "compressed_with_extra.fits")
-    assert "THEAP" not in hdud[1].header
-    assert "ZBLANK" not in hdud[1].header
-    assert "ZSCALE" not in hdud[1].header
-    assert "ZZERO" not in hdud[1].header
+    with fits.open(tmp_path / "compressed_with_extra.fits") as hdud:
+        assert "THEAP" not in hdud[1].header
+        assert "ZBLANK" not in hdud[1].header
+        assert "ZSCALE" not in hdud[1].header
+        assert "ZZERO" not in hdud[1].header

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -42,9 +42,15 @@ def test_canonical_data(original_int_hdu, canonical_int_hdus):
 
 
 def test_zblank_support(canonical_data_base_path, tmp_path):
+
     # This uses a test 12x12 image which contains a NaN value in the [1, 1]
     # pixel - it was compressed using fpack which automatically added a ZBLANK
     # header keyword
+
+    # First, check that the ZBLANK keyword is indeed present in the original
+    # compressed FITS file
+    with fits.open(canonical_data_base_path / "compressed_with_nan.fits", disable_image_compression=True) as hduc:
+        assert hduc[1].header['ZBLANK'] == -2147483647
 
     reference = np.arange(144).reshape((12, 12)).astype(float)
     reference[1, 1] = np.nan
@@ -61,8 +67,12 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
 
     hdu.writeto(tmp_path / "test_zblank.fits")
 
+    with fits.open(tmp_path / "test_zblank.fits", disable_image_compression=True) as hduc:
+        # The ZBLANK value is different from before as we don't preserve it,
+        # instead we always write out with the default ZBLANK
+        assert hduc[1].header['ZBLANK'] == -2147483648
+
     with fits.open(tmp_path / "test_zblank.fits") as hdul:
-        assert "ZBLANK" in hdul[1].header
         assert_equal(np.round(hdul[1].data), reference)
 
 

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -42,15 +42,17 @@ def test_canonical_data(original_int_hdu, canonical_int_hdus):
 
 
 def test_zblank_support(canonical_data_base_path, tmp_path):
-
     # This uses a test 12x12 image which contains a NaN value in the [1, 1]
     # pixel - it was compressed using fpack which automatically added a ZBLANK
     # header keyword
 
     # First, check that the ZBLANK keyword is indeed present in the original
     # compressed FITS file
-    with fits.open(canonical_data_base_path / "compressed_with_nan.fits", disable_image_compression=True) as hduc:
-        assert hduc[1].header['ZBLANK'] == -2147483647
+    with fits.open(
+        canonical_data_base_path / "compressed_with_nan.fits",
+        disable_image_compression=True,
+    ) as hduc:
+        assert hduc[1].header["ZBLANK"] == -2147483647
 
     reference = np.arange(144).reshape((12, 12)).astype(float)
     reference[1, 1] = np.nan
@@ -67,10 +69,12 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
 
     hdu.writeto(tmp_path / "test_zblank.fits")
 
-    with fits.open(tmp_path / "test_zblank.fits", disable_image_compression=True) as hduc:
+    with fits.open(
+        tmp_path / "test_zblank.fits", disable_image_compression=True
+    ) as hduc:
         # The ZBLANK value is different from before as we don't preserve it,
         # instead we always write out with the default ZBLANK
-        assert hduc[1].header['ZBLANK'] == -2147483648
+        assert hduc[1].header["ZBLANK"] == -2147483648
 
     with fits.open(tmp_path / "test_zblank.fits") as hdul:
         assert_equal(np.round(hdul[1].data), reference)

--- a/docs/changes/io.fits/18072.bugfix.rst
+++ b/docs/changes/io.fits/18072.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug that caused THEAP, ZBLANK, ZSCALE, and ZZERO to not be correctly
+removed during decompression of tile-compressed FITS files.


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/18067

Labeling as requiring backport to v7.0.x and v7.1.x just in the event that v7.1.0 ends up being delayed a lot

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
