### PR TITLE
Fix testing guidelines for running Pytest on installed astropy, regarding error: "found no collectors"

### DIFF
--- a/docs/changes/18074.other.rst
+++ b/docs/changes/18074.other.rst
@@ -1,0 +1,3 @@
+Changed `docs/development/testguide.rst` to offer advice when `pytest` returns
+the error "found no collectors", specific to testing changes to 
+astropy installations. More details in https://github.com/astropy/astropy/issues/18062.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -106,13 +106,18 @@ You can also specify a single directory, a file (``.py`` python or ``.rst``
 doc file), or a specific test to check, rerun only tests that failed in
 the previous run, or require remote data::
 
-    pytest astropy/modeling
-    pytest astropy/wcs/tests/test_wcs.py
-    pytest astropy/units -k float_dtype_promotion
-    pytest astropy/units/tests/test_quantity.py::TestQuantityCreation::test_float_dtype_promotion
-    pytest astropy/wcs/index.rst
+    pytest --pyargs astropy.modeling
+    pytest --pyargs astropy.wcs.tests.test_wcs
+    pytest --pyargs astropy.units -k float_dtype_promotion
+    pytest --pyargs astropy.units.tests.test_quantity.py::TestQuantityCreation::test_float_dtype_promotion
+    pytest --pyargs astropy.wcs/index.rst
     pytest --last-failed
     pytest --remote-data=any
+
+If you are having issues with running `pytest` after editing files, try running the same command with the `--pyargs` flag and writing file paths as Python modules. For example, 
+- `pytest astropy/units/tests/test_quantity.py::TestQuantityCreation::test_float_dtype_promotion` 
+would turn into 
+- `pytest --pyargs astropy.units.tests.test_quantity::TestQuantityCreation::test_float_dtype_promotion`
 
 For more details, see the `pytest invocation guide
 <https://docs.pytest.org/en/stable/how-to/usage.html>`_ and the

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -106,11 +106,11 @@ You can also specify a single directory, a file (``.py`` python or ``.rst``
 doc file), or a specific test to check, rerun only tests that failed in
 the previous run, or require remote data::
 
-    pytest --pyargs astropy.modeling
-    pytest --pyargs astropy.wcs.tests.test_wcs
-    pytest --pyargs astropy.units -k float_dtype_promotion
-    pytest --pyargs astropy.units.tests.test_quantity.py::TestQuantityCreation::test_float_dtype_promotion
-    pytest --pyargs astropy.wcs/index.rst
+    pytest astropy/modeling
+    pytest astropy/wcs/tests/test_wcs.py
+    pytest astropy/units -k float_dtype_promotion
+    pytest astropy/units/tests/test_quantity.py::TestQuantityCreation::test_float_dtype_promotion
+    pytest astropy/wcs/index.rst
     pytest --last-failed
     pytest --remote-data=any
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -114,10 +114,14 @@ the previous run, or require remote data::
     pytest --last-failed
     pytest --remote-data=any
 
-If you are having issues with running `pytest` after editing files, try running the same command with the `--pyargs` flag and writing file paths as Python modules. For example, 
+If you are having issues with running `pytest` after editing files, 
+try running the same command with the `--pyargs` flag and writing file 
+paths as Python modules. For example, 
 - `pytest astropy/units/tests/test_quantity.py::TestQuantityCreation::test_float_dtype_promotion` 
+- `pytest astropy/io -k compressed`
 would turn into 
 - `pytest --pyargs astropy.units.tests.test_quantity::TestQuantityCreation::test_float_dtype_promotion`
+- `pytest --pyargs astropy.io -k compressed`
 
 For more details, see the `pytest invocation guide
 <https://docs.pytest.org/en/stable/how-to/usage.html>`_ and the


### PR DESCRIPTION
Adds simple advice to Testing Guidelines docs to address this astropy issue:

https://github.com/astropy/astropy/issues/18062