### PR TITLE
fix: unicodechar fields can have bounded variable size

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -424,6 +424,7 @@ class UnicodeChar(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
+            field.arraysize = field.arraysize.removesuffix("*")
             try:
                 self.arraysize = int(field.arraysize)
             except ValueError:

--- a/astropy/io/votable/tests/test_converter.py
+++ b/astropy/io/votable/tests/test_converter.py
@@ -49,6 +49,13 @@ def test_oversize_unicode():
     assert len(w) == 1
 
 
+def test_bounded_variable_size_unicode():
+    # regression test for #18075
+    field = tree.Field(None, name="unicode", datatype="unicodeChar", arraysize="20*")
+    unicode_converter = converters.get_converter(field)
+    assert unicode_converter.parse("XXX") == ("XXX", False)
+
+
 def test_unicode_mask():
     config = {"verify": "exception"}
     field = tree.Field(

--- a/docs/changes/io.votable/18075.bugfix.rst
+++ b/docs/changes/io.votable/18075.bugfix.rst
@@ -1,0 +1,1 @@
+``unicodeChar`` fields can now be of bounded variable size (``arraysize="10*``).


### PR DESCRIPTION
Hi astropy maintainers :slightly_smiling_face: 

### Description

This PR is a fix for `unicodeChar` fields in VOTables. Currently, their arraysize can only be fixed (arraysize is an int) or variable (`araysize="*"`). But it should also be allowed to be of bounded variable size (`arraysize="20*"` means a string with 0 to 20 characters). 

This is already working for `char` fields, so I just coppied the class above. 

I checked the standard, and other VOTable linters to be sure that this is indeed a bug from astropy.

### Before the fix

```python
from astropy.io.votable import tree
field = tree.Field(None, name="unicode", datatype="unicodeChar", arraysize="20*")
```

```
astropy.io.votable.exceptions.E01: ?:?:?: E01: Invalid size specifier '20*' for a unicode field (in field 'unicode')
```

And there's no error raised anymore after the fix. 

---

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
