### PR TITLE
Update `pytest` `norecursedirs` setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,11 +206,11 @@ testpaths = [
     "docs",
 ]
 norecursedirs = [
+    ".*",
     "docs[\\/]_build",
     "docs[\\/]generated",
     "astropy[\\/]extern",
     "astropy[\\/]_dev",
-    "astropy[\\/]units[\\/]tests[\\/]data",
 ]
 astropy_header = true
 doctest_plus = "enabled"


### PR DESCRIPTION
### Description

Running `pytest` can fail if the repository contains a `.hypothesis/` directory. [By default `pytest` would ignore any hidden directories](https://docs.pytest.org/en/8.0.x/reference/reference.html#confval-norecursedirs), so it is a good idea to configure `pytest` to do that with a custom `norecursedirs` setting too.
Fixes #18062, closes #18074

`astropy/units/tests/data/` should not be ignored anymore because it was deleted in 71a5752dcf64321d30aec2126704cea58d19723c.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
