### PR TITLE
initial commit with all tests passing for jpegxl codec added

### DIFF
--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from astropy.io.fits.hdu.base import BITPIX2DTYPE
 
-from ._codecs import PLIO1, Gzip1, Gzip2, HCompress1, NoCompress, Rice1
+from ._codecs import PLIO1, Gzip1, Gzip2, HCompress1, NoCompress, Rice1, JPEGXL
 from ._quantization import DITHER_METHODS, QuantizationFailedException, Quantize
 from .utils import _data_shape, _iter_array_tiles, _tile_shape
 
@@ -22,6 +22,7 @@ ALGORITHMS = {
     "RICE_ONE": Rice1,
     "PLIO_1": PLIO1,
     "HCOMPRESS_1": HCompress1,
+    "JPEGXL": JPEGXL,
     "NOCOMPRESS": NoCompress,
 }
 
@@ -81,6 +82,8 @@ def _header_to_settings(header):
         settings["bytepix"] = 8
         settings["scale"] = int(_get_compression_setting(header, "SCALE", 0))
         settings["smooth"] = _get_compression_setting(header, "SMOOTH", 0)
+    elif compression_type == "JPEGXL":
+        settings["bytepix"] = _get_compression_setting(header, "BYTEPIX", 2)
 
     return settings
 

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -86,7 +86,7 @@ class CompImageHDU(ImageHDU):
         compression_type : str, optional
             Compression algorithm: one of
             ``'RICE_1'``, ``'RICE_ONE'``, ``'PLIO_1'``, ``'GZIP_1'``,
-            ``'GZIP_2'``, ``'HCOMPRESS_1'``, ``'NOCOMPRESS'``
+            ``'GZIP_2'``, ``'HCOMPRESS_1'``, ``'JPEGXL'``, ``'NOCOMPRESS'``
 
         tile_shape : tuple, optional
             Compression tile shape, which should be specified using the default
@@ -145,7 +145,7 @@ class CompImageHDU(ImageHDU):
         The astropy.io.fits package supports 3 general-purpose compression
         algorithms plus one other special-purpose compression technique that is
         designed for data masks with positive integer pixel values.  The 3
-        general purpose algorithms are GZIP, Rice, and HCOMPRESS, and the
+        general purpose algorithms are GZIP, Rice, HCOMPRESS, and JPEGXL, and the
         special-purpose technique is the IRAF pixel list compression technique
         (PLIO).  The ``compression_type`` parameter defines the compression
         algorithm to be used.
@@ -154,7 +154,8 @@ class CompImageHDU(ImageHDU):
         compression tiles.  With the GZIP, Rice, and PLIO algorithms, the
         default is to take each row of the image as a tile.  The HCOMPRESS
         algorithm is inherently 2-dimensional in nature, so the default in this
-        case is to take 16 rows of the image per tile.  In most cases, it makes
+        case is to take 16 rows of the image per tile. JPEGXL tries to use 256
+        by 256 pixel tiles when possible. In most cases, it makes
         little difference what tiling pattern is used, so the default tiles are
         usually adequate.  In the case of very small images, it could be more
         efficient to compress the whole image as a single tile.  Note that the

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -485,6 +485,24 @@ def _image_header_to_empty_bintable(
         )
         after_keyword = "ZVAL2"
         idx = 3
+    elif compression_type == "JPEGXL":
+        bintable.header.set(
+            "ZNAME1", "BYTEPIX", "bytes per pixel (1, 2, 4, or 8)", after=after_keyword
+        )
+        if bintable.header["ZBITPIX"] == 8:
+            bytepix = 1
+        elif bintable.header["ZBITPIX"] == 16:
+            bytepix = 2
+        elif bintable.header["ZBITPIX"] == 32:
+            bytepix = 4
+        else:
+            bytepix = DEFAULT_BYTE_PIX
+
+        bintable.header.set(
+            "ZVAL1", bytepix, "bytes per pixel (1, 2, 4, or 8)", after="ZNAME1"
+        )
+        after_keyword = "ZVAL1"
+        idx = 2
 
     if image_header["BITPIX"] < 0:  # floating point image
         bintable.header.set(

--- a/astropy/io/fits/hdu/compressed/settings.py
+++ b/astropy/io/fits/hdu/compressed/settings.py
@@ -19,6 +19,7 @@ COMPRESSION_TYPES = (
     "GZIP_2",
     "PLIO_1",
     "HCOMPRESS_1",
+    "JPEGXL",
 )
 
 # Default compression parameter values

--- a/astropy/io/fits/hdu/compressed/tests/conftest.py
+++ b/astropy/io/fits/hdu/compressed/tests/conftest.py
@@ -10,6 +10,7 @@ COMPRESSION_TYPES = [
     "HCOMPRESS_1",
     "PLIO_1",
     "NOCOMPRESS",
+    "JPEGXL",
 ]
 
 
@@ -77,6 +78,14 @@ ALL_FLOAT_DTYPES = ["".join(ele) for ele in _expand([("<", ">"), ("f",), ("4", "
         ],
         [
             ["HCOMPRESS_1"],
+            (
+                {"qlevel": 20, "qmethod": 2},
+                {"qlevel": 10, "qmethod": 1},
+            ),
+            ALL_FLOAT_DTYPES,
+        ],
+        [
+            ["JPEGXL"],
             (
                 {"qlevel": 20, "qmethod": 2},
                 {"qlevel": 10, "qmethod": 1},

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -59,6 +59,7 @@ class TestCompressedImage(FitsTestCase):
             (np.zeros((2, 10, 10), dtype=np.float32), "GZIP_1", -0.01),
             (np.zeros((2, 10, 10), dtype=np.float32), "GZIP_2", -0.01),
             (np.zeros((100, 100)) + 1, "HCOMPRESS_1", 16),
+            (np.zeros((100, 100)), "JPEGXL", 16),
             (np.zeros((10, 10)), "PLIO_1", 16),
         ],
     )
@@ -83,14 +84,44 @@ class TestCompressedImage(FitsTestCase):
             assert fd[1].header["NAXIS2"] == chdu.header["NAXIS2"]
             assert fd[1].header["BITPIX"] == chdu.header["BITPIX"]
 
+    @pytest.mark.parametrize("byte_order,dtype", [
+        (bo, dt) for bo in ["<", ">"] for dt in ["uint8", "int16", "uint16", "int32", "uint32"]
+    ])
+    def test_comp_image_dtypes_jpegxl(self,byte_order, dtype):
+        """
+        Test that JPEGXL compression works with different byte orders and dtypes.
+        Make sure to sample random values from the entire dynamic range possible,
+        and ensure that lossless compression is maintained.
+        """
+        data = np.random.randint(2**32, size=(100, 100)).astype(dtype)
+        data = data.view(data.dtype.newbyteorder(byte_order))
+        primary_hdu = fits.PrimaryHDU()
+        ofd = fits.HDUList(primary_hdu)
+        chdu = fits.CompImageHDU(
+            data,
+            name="SCI",
+            compression_type="JPEGXL",
+        )
+        ofd.append(chdu)
+        ofd.writeto(self.temp("test_new.fits"), overwrite=True)
+        ofd.close()
+        with fits.open(self.temp("test_new.fits")) as fd:
+            assert (fd[1].data == data).all() # Verify lossless
+            assert fd[1].header["NAXIS"] == chdu.header["NAXIS"]
+            assert fd[1].header["NAXIS1"] == chdu.header["NAXIS1"]
+            assert fd[1].header["NAXIS2"] == chdu.header["NAXIS2"]
+            assert fd[1].header["BITPIX"] == chdu.header["BITPIX"]
+
     @pytest.mark.remote_data
-    def test_comp_image_quantize_level(self):
+    @pytest.mark.parametrize("compression_type", ["RICE_1", "JPEGXL"])
+    def test_comp_image_quantize_level(self, compression_type):
         """
         Regression test for https://github.com/astropy/astropy/issues/5969
 
         Test that quantize_level is used.
 
         """
+        import pickle
 
         np.random.seed(42)
 
@@ -106,14 +137,14 @@ class TestCompressedImage(FitsTestCase):
         fits.ImageHDU(data).writeto(self.temp("im1.fits"))
         fits.CompImageHDU(
             data,
-            compression_type="RICE_1",
+            compression_type=compression_type,
             quantize_method=1,
             quantize_level=-1,
             dither_seed=5,
         ).writeto(self.temp("im2.fits"))
         fits.CompImageHDU(
             data,
-            compression_type="RICE_1",
+            compression_type=compression_type,
             quantize_method=1,
             quantize_level=-100,
             dither_seed=5,
@@ -166,6 +197,26 @@ class TestCompressedImage(FitsTestCase):
 
         with fits.open(self.temp("test.fits")) as hdul:
             # HCOMPRESSed images are allowed to deviate from the original by
+            # about 1/quantize_level of the RMS in each tile.
+            assert np.abs(hdul["SCI"].data - cube).max() < 1.0 / 15.0
+
+    def test_comp_image_jpegxl_image_stack(self):
+        """
+        Tests that 3D data can be compressed with JPEGXL with a tile shape that is also 3D.
+        """
+
+        cube = np.arange(300, dtype=np.float32).reshape(3, 10, 10)
+        hdu = fits.CompImageHDU(
+            data=cube,
+            name="SCI",
+            compression_type="JPEGXL",
+            quantize_level=16,
+            tile_shape=(2, 5, 5),
+        )
+        hdu.writeto(self.temp("test.fits"))
+
+        with fits.open(self.temp("test.fits")) as hdul:
+            # Compressed float images are allowed to deviate from the original by
             # about 1/quantize_level of the RMS in each tile.
             assert np.abs(hdul["SCI"].data - cube).max() < 1.0 / 15.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "astropy-iers-data>=0.2025.3.31.0.36.18",
     "PyYAML>=6.0.0",
     "packaging>=22.0.0",
+    "imagecodecs>=2025.3.30",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
As shown in this [paper](https://openreview.net/forum?id=kQCHCkNk7s&nesting=2&sort=date-desc), JPEG-XL has better compression ratios than RICE and HCOMPRESS across the board. It is also fast enough for all modern computers that would be running astropy for data analysis.

The default tile size for this algorithm has been set to 256 by 256.

JPEG-XL can directly compress `uint16, uint8, and float32` data. Since `astropy` passes `int32` data to codecs (when compressing `float32` data which then gets quantized into `int32`), I decided to break this up into two `uint16` chunks for compression. The bytestring will also store the byte length of the encoded upper 16 bits, so that these two encoded sections can be separated for decoding.

New tests have been written that ensure all possible input dtypes at full dynamic range are compressed properly.

Soon-to-come commits will also add JPEG-LS, an extremely fast algorithm that is comparable to JPEG-XL at the default effort setting of 7. (JPEG-XL at the max effort setting of 9 outperforms JPEG-LS, but is quite slow).