### PR TITLE
Add type annotations to `astropy.utils.misc`

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -22,10 +22,14 @@ from contextlib import contextmanager
 from itertools import chain
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from astropy.utils import deprecated
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Generator, Iterable
+    from types import TracebackType
+    from typing import Final
 
 __all__ = [
     "JsonCustomEncoder",
@@ -40,12 +44,12 @@ __all__ = [
     "walk_skip_hidden",
 ]
 
-NOT_OVERWRITING_MSG = (
+NOT_OVERWRITING_MSG: Final = (
     "File {} already exists. If you mean to replace it "
     'then use the argument "overwrite=True".'
 )
 # A useful regex for tests.
-_NOT_OVERWRITING_MSG_MATCH = (
+_NOT_OVERWRITING_MSG_MATCH: Final = (
     r"File .* already exists\. If you mean to "
     r"replace it then use the argument "
     r'"overwrite=True"\.'
@@ -75,12 +79,12 @@ def indent(s, shift=1, width=4):
 class _DummyFile:
     """A noop writeable object."""
 
-    def write(self, s):
+    def write(self, s: str) -> None:
         pass
 
 
 @contextlib.contextmanager
-def silence():
+def silence() -> Generator[None, None, None]:
     """A context manager that silences sys.stdout and sys.stderr."""
     old_stdout = sys.stdout
     old_stderr = sys.stderr
@@ -159,22 +163,28 @@ class NumpyRNGContext:
 
     """
 
-    def __init__(self, seed):
+    def __init__(self, seed: int) -> None:
         self.seed = seed
 
-    def __enter__(self):
-        from numpy import random
+    def __enter__(self) -> None:
+        self.startstate = np.random.get_state()
+        np.random.seed(self.seed)
 
-        self.startstate = random.get_state()
-        random.seed(self.seed)
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        np.random.set_state(self.startstate)
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        from numpy import random
 
-        random.set_state(self.startstate)
-
-
-def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
+def find_api_page(
+    obj: object,
+    version: str | None = None,
+    openinbrowser: bool = True,
+    timeout: float | None = None,
+) -> str:
     """
     Determines the URL of the API page for the specified object, and
     optionally open that page in a web browser.
@@ -395,9 +405,7 @@ class JsonCustomEncoder(json.JSONEncoder):
 
     """
 
-    def default(self, obj):
-        import numpy as np
-
+    def default(self, obj: object) -> object:
         from astropy import units as u
 
         if isinstance(obj, u.Quantity):
@@ -498,11 +506,11 @@ def did_you_mean(
     return f"Did you mean {suggestion}?"
 
 
-LOCALE_LOCK = threading.Lock()
+LOCALE_LOCK: Final = threading.Lock()
 
 
 @contextmanager
-def _set_locale(name):
+def _set_locale(name: str) -> Generator[None, None, None]:
     """
     Context manager to temporarily set the locale to ``name``.
 
@@ -535,7 +543,7 @@ def _set_locale(name):
                 locale.setlocale(locale.LC_ALL, saved)
 
 
-def dtype_bytes_or_chars(dtype):
+def dtype_bytes_or_chars(dtype: np.dtype) -> int | None:
     """
     Parse the number out of a dtype.str value like '<U5' or '<f8'.
 


### PR DESCRIPTION
### Description

The module was already partially annotated, so added annotations to the remaining functions that are not deprecated, except `_hungry_for()`, `pizza()` and `coffee()` because even I don't see any point in annotating those three.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
