### PR TITLE
Updated list of contributors and .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,6 +21,7 @@ Amit Kumar                   <dtu.amit@gmail.com>
 Ana Posses                   <anaposses@gmail.com>
 Anany Shrey Jain             <ananyashreyjain1998@gmail.com>  <31594632+ananyashreyjain@users.noreply.github.com>
 Andreas Faisst               <afaisst@ipac.caltech.edu> <anfaisst@gmail.com>
+Andreas Michael Hermansen    <97125645+AMHermansen@users.noreply.github.com>
 Andy Casey                   <andycasey@gmail.com>
 Aniket Kulkarni              <kaniket21@gmail.com>
 Aniket Sanghi                <asanghi01@gmail.com>
@@ -28,6 +29,8 @@ Anirudh Katipally            <akatipally@abiomed.com>
 Anne Archibald               <peridot.faceted@gmail.com> <archibald@astron.nl>
 Anne Archibald               <peridot.faceted@gmail.com> <anne.archibald@ncl.ac.uk>
 Anthony Horton               <anthony.horton@aao.gov.au>
+Arthur Xavier Joao Pedro Maia <90696992+arthurxvtv@users.noreply.github.com>
+Aryan Shukla                 <88445101+Telomelonia@users.noreply.github.com>
 Asish Panda                  <asishrocks95@gmail.com>
 Asra Nizami                  <anizami@macalester.edu> <anizami@itsd-summer18.local>
 Asra Nizami                  <anizami@macalester.edu> <anizami@itsd-summer18.stsci.edu>
@@ -80,6 +83,7 @@ Daniel D'Avella              <ddavella@stsci.edu>
 Daniel D'Avella              <ddavella@stsci.edu> <drdavella@gmail.com>
 Daniel Datsev                <dan.datsev@gmail.com>
 Daniel Datsev                <dan.datsev@gmail.com> <fabled@vortex.(none)>
+Daniel Giles                 <Daniel.k.giles@gmail.com> <daniel.k.giles@gmail.com>
 Daniel Lenz                  <dlenz.bonn@gmail.com>
 Daniel Ryan <ryand5@tcd.ie> Dan Ryan <ryand5@tcd.ie>
 Daniel Ryan <ryand5@tcd.ie> DanRyanIrish <ryand5@tcd.ie>
@@ -128,6 +132,7 @@ Gabriel Perren               <gabrielperren@gmail.com> <Gabriel-p@users.noreply.
 Geert Barentsen              <geert@barentsen.be> <hello@geert.io>
 George Galvin                <george.galvin1996@gmail.com>
 Gerrit Schellenberger        <gerrit@uni-bonn.de>
+Gilles Landais               <gilles.landais@unistra.fr>
 Giorgio Calderone            <giorgio.calderone@gmail.com> <gcalderone@users.noreply.github.com>
 Graham Kanarek               <graykanarek@gmail.com>
 Guillaume Pernot             <gpernot@praksys.org>
@@ -143,6 +148,7 @@ Henry Schreiner              <HenrySchreinerIII@gmail.com> <henryschreineriii@gm
 Hélvio Peixoto               <hfcpeixoto@gmail.com> <hfcpeixoto@ds4data.com>
 Himanshu Pathak              <hpathak336@gmail.com>
 Humna Awan                   <humna.awan@rutgers.edu>
+Igor Lemos                   <j202shyf@z5.anonaddy.me>
 Ivo Busko                    <busko@stsci.edu>
 Ivo Busko                    <busko@stsci.edu> <New1trilha>
 Jaime Andrés                 <jaime-andres.alvarado-montes@students.mq.edu.au>
@@ -178,6 +184,7 @@ John Parejko                 <parejkoj@uw.edu>
 John Parejko                 <parejkoj@uw.edu> <parejkoj@gmail.com>
 Johnny Greco                 <jgreco@astro.princeton.edu>
 Johnny Greco                 <jgreco@astro.princeton.edu>  <jgreco.astro@gmail.com>
+Jon Carifio                  <carifio24@gmail.com>
 Jonathan Foster              <jonathan.bruce.foster@gmail.com>
 Jonathan Foster              <jonathan.bruce.foster@gmail.com>  <jonathan.b.foster@yale.edu>
 Jonathan Gagne               <jonathan.gagne.1@gmail.com>
@@ -195,6 +202,7 @@ Julien Woillez               <jwoillez@gmail.com> <jwoillez@gmail.org>
 Jurien Huisman               <huisman@strw.leidenuniv.nl>
 Kacper Kowalik               <xarthisius.kk@gmail.com>
 Kacper Kowalik               <xarthisius.kk@gmail.com> <xarthisius@gentoo.org>
+Kang Wang                    <kangqiwang@outlook.com>
 Karan Grover                 <karan@karan-HP-Pavilion-dm4-Notebook-PC.(none)>
 Karl Gordon                  <kgordon@stsci.edu> Karl D. Gordon <kgordon@stsci.edu>
 Karl Vyhmeister              <kvyh@users.noreply.github.com>
@@ -210,8 +218,10 @@ Larry Bradley                <larry.bradley@gmail.com>
 Larry Bradley                <larry.bradley@gmail.com> <larrybradley@users.noreply.github.com>
 Laura Watkins                <lauralwatkins@gmail.com>
 Lauren Glattly               <laurenglattly@gmail.com> <44421608+lglattly@users.noreply.github.com>
+Laurent Michel               <laurent.michel@astro.unistra.fr>
 Lennard Kiehl                <luzuku@gmail.com>
 Leo Singer                   <leo.singer@ligo.org> <leo.singer@nasa.gov>
+Leo Singer                   <leo.singer@ligo.org> <leo.p.singer@nasa.gov>
 Leonardo Ferreira            <leonardo.ferreira.furg@gmail.com> <[leonardo.ferreira.furg@gmail.com]>
 Lia Corrales                 <liac@umich.edu>
 Lingyi Hu                    <hulingyi1995@yahoo.com.sg>
@@ -222,6 +232,7 @@ Luke G. Bouma                <lgbouma@users.noreply.github.com>
 Luke Kelley                  <lkelley@cfa.harvard.edu>
 Luz Paz                      <luzpaz@users.noreply.github.com> luz paz <luzpaz@users.noreply.github.com>
 Maximilian Linhoff           <maximilian.linhoff@tu-dortmund.de> Maximilian Nöthe <maximilian.noethe@tu-dortmund.de>
+Maximilian Linhoff           <maximilian.linhoff@tu-dortmund.de> <maximilian.linhoff@posteo.de>
 Madhura Parikh               <madhuraparikh@gmail.com>
 Magali Mebsout               <magalimebsout@gmail.com>
 Magnus Persson               <vilhelmp@gmail.com>
@@ -235,6 +246,7 @@ Marten van Kerkwijk          <mhvk@astro.utoronto.ca> Marten Henric van Kerkwijk
 Matt Davis                   <jiffyclub.programatic@gmail.com>
 Matteo Bachetti              <matteo@matteobachetti.it> <matteo.bachetti@irap.omp.eu>
 Matthew Craig                <mattwcraig@gmail.com>
+Matthias Stein               <matthias.stein@ptb.de>
 Matthieu Baumann             <baumannmatthieu0@gmail.com> <matthieu.baumann@astro.unistra.fr>
 Mavani Bhautik               <mavanibhautik@gmail.com>
 Michael Brewer               <brewer@astro.umass.edu>
@@ -260,6 +272,7 @@ Nadia Dencheva               <nadia.astropy@gmail.com> <nadia.dencheva@gmail.com
 Nathaniel Starkman           <nstarkman@protonmail.com>
 Nathaniel Starkman           <nstarkman@protonmail.com> <nstarman@users.noreply.github.com>
 Nathaniel Starkman           <nstarkman@protonmail.com> <nathanielstarkman@gmail.com>
+Naveen Selvadurai            <172697+naveensrinivasan@users.noreply.github.com>
 Neil Crighton                <neilcrighton@gmail.com>
 Neal McBurnett               <neal@mcburnett.org> <nealmcb@gmail.com>
 Nicholas Earl                <contact@nicholasearl.me>
@@ -279,6 +292,7 @@ Porter Averett               <porter@averett.net> <46609497+paverett@users.norep
 Prajwel Joseph               <prajwel.pj@gmail.com>
 Pratik Patel                 <pratikpatel15133@gmail.com>
 Pritish Chakraborty          <chakrabortypritish@gmail.com>
+Rachel Guo                   <rachelg2273@gmail.com>
 Ricardo Fonseca              <ricardopfonseca95@gmail.com>
 Ricardo Fonseca              <ricardopfonseca95@gmail.com> <ricardopfonseca@tecnico.ulisboa.pt>
 Richard R <rrjbca@users.noreply.github.com>
@@ -294,19 +308,21 @@ Rohit Patil                  <rohit4change@yahoo.in>
 Rohit Patil                  <rohit4change@yahoo.in> <Quan@Aries.(none)>
 Roman Tolesnikov             <rtolesnikov@yahoo.com>
 Ryan Cooke                   <ryancooke86@gmail.com>
+Sam Bianco                   <sbianco@stsci.edu> <70121323+snbianco@users.noreply.github.com>
 Sam Lee                      <orionlee@yahoo.com> <orionlee@users.noreply.github.com>
 Sam Van Kooten               <vankooten.sam@gmail.com> <svank@users.noreply.github.com>
 Sam Verstocken               <sam.verstocken@gmail.com>
 Sanjeev Dubey                <getsanjeevdubey@gmail.com>
 Sara Ogaz                    <ogaz@stsci.edu>
 Sarah Graves                 <s.graves@eaobservatory.org>
-Sashank Mishra               <sashankmishra27@gmail.com> sashmish <sashankmishra27@gmail.com>
+Sashank Mishra               <sashankmishra27@gmail.com>
 Sebastian Meßlinger          <sebastian.messlinger@posteo.de> <39328484+krachyon@users.noreply.github.com>
 Sebastian Meßlinger          <sebastian.messlinger@posteo.de> Sebastian <sebastian.messlinger@posteo.de>
 Sergio Pascual               <sergio.pasra@gmail.com> <sergiopr@fis.ucm.es>
 Shane Maloney                <shane.maloney@dias.ie> <maloneys@tcd.ie>
 Shane Maloney                <shane.maloney@dias.ie> <sm@dhcp-115.wireless.ap.dias.ie>
 Shantanu Srivastava          <shan_mbic@rediffmail.com>
+Sharath Ramkumar             <29162020+tnfssc@users.noreply.github.com>
 Shilpi Jain                  <shilpi1958@gmail.com>
 Shivansh Mishra              <dHoneysh@gmail.com>
 Shivansh Mishra              <dHoneysh@gmail.com> <shivanshmishra@shivanshs-MacBook-Pro.local>

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -6,21 +6,22 @@ Core Package Contributors
 =========================
 
 * Aaron Meisner
+* aarsh1a
 * Aarya Patil
 * Abdu Zoghbi
 * Abhinuv Nitin Pitale
 * Abigail Stevens
 * Adam Broussard
 * Adam Ginsburg
+* Adam Turner
 * Adele Plunkett
 * Aditya Sharma
 * Adrian Price-Whelan
 * Akash Deshpande
 * Akeem
 * Akshat Dixit
-* Akshat1Nar
 * Al Niessner
-* Albert Y. Shih
+* Albert Y\. Shih
 * Albert Zhang
 * Aleh Khvalko
 * Alex Conley
@@ -30,19 +31,20 @@ Core Package Contributors
 * Alex Rudy
 * Alexander Bakanov
 * Alexandre Beelen
-* Alexandre R. Bomfim Junior
+* Alexandre R\. Bomfim Junior
 * Alfio Puglisi
 * Alpha-Ursae-Minoris
 * Amit Kumar
-* AMHermansen
 * Ana Posses
 * Anany Shrey Jain
 * Anchit Jain
 * Andreas Baumbach
 * Andreas Faisst
+* Andreas Michael Hermansen
 * Andrej Rode
 * Andrew Hearin
 * Andrii Oriekhov
+* Andy Casey
 * Aniket Kulkarni
 * Aniket Sanghi
 * Anirudh Katipally
@@ -54,9 +56,10 @@ Core Package Contributors
 * Arie Kurniawan
 * Arne de Laat
 * Arthur Eigenbrot
+* Arthur Xavier Joao Pedro Maia
+* Aryan Shukla
 * Asish Panda
 * Asra Nizami
-* arthurxvtv
 * athul
 * Austen Groener
 * Axel Donath
@@ -68,8 +71,8 @@ Core Package Contributors
 * Benjamin Winkel
 * Bernardo Sulzbach
 * Bernie Simon
+* Bharath Saiguhan
 * Bhavya Khandelwal
-* Bharath Saiguha
 * Bili Dong
 * Bill Cleveland
 * Bogdan Nicula
@@ -106,12 +109,14 @@ Core Package Contributors
 * Conor MacBride
 * Cristian Ardelean
 * Curtis McCully
+* Damien LaRocque
 * Dan Foreman-Mackey
-* Dan P. Cunningham
+* Dan P\. Cunningham
 * Dan Taranu
 * Daniel Bell
 * Daniel D'Avella
 * Daniel Datsev
+* Daniel Giles
 * Daniel Lenz
 * Daniel Ruschel Dutra
 * Daniel Ryan
@@ -119,7 +124,7 @@ Core Package Contributors
 * Dany Vohl
 * Daria Cara
 * David Kirkby
-* David M. Palmer
+* David M\. Palmer
 * David Paz
 * David Pérez-Suárez
 * David Shiga
@@ -141,7 +146,7 @@ Core Package Contributors
 * Dylan Gregersen
 * E\. Madison Bray
 * E\. Rykoff
-* E.C. Herenz
+* E\.C\. Herenz
 * Eduardo Olinto
 * Edward Betts
 * Edward Slavich
@@ -150,7 +155,7 @@ Core Package Contributors
 * Elijah Bernstein-Cooper
 * Eloy Salinas
 * Emily Deibert
-* Emir
+* Emir Karamehmetoglu
 * Emma Hogan
 * Eric Depagne
 * Eric Jeschke
@@ -171,7 +176,6 @@ Core Package Contributors
 * Frazer McLean
 * Frédéric Chapoton
 * Frédéric Grollier
-* Gabe Brammer
 * Gabriel Brammer
 * Gabriel Perren
 * Geert Barentsen
@@ -179,6 +183,7 @@ Core Package Contributors
 * Georgiana Ogrean
 * Gerrit Schellenberger
 * Giang Nguyen
+* Gilles Landais
 * Giorgio Calderone
 * Gordon Gibb
 * Graham Kanarek
@@ -192,10 +197,10 @@ Core Package Contributors
 * Hans Moritz Günther
 * Harry Ferguson
 * Heinz-Alexander Fuetterer
-* Henrike F
-* Henry Schreiner
 * Helen Sherwood-Taylor
 * Hélvio Peixoto
+* Henrike F
+* Henry Schreiner
 * Himanshu Pathak
 * homeboy445
 * Hood Chatham
@@ -203,6 +208,7 @@ Core Package Contributors
 * Hugo Buddelmeijer
 * Humna Awan
 * iamsoto
+* Igor Lemos
 * ikkamens
 * Inada Naoki
 * J\. Goutin
@@ -237,6 +243,8 @@ Core Package Contributors
 * John Fisher
 * John Parejko
 * Johnny Greco
+* johnny1up
+* Jon Carifio
 * Jonas Große Sundrup
 * Jonas Kemmer
 * Jonathan Eisenhamer
@@ -245,11 +253,11 @@ Core Package Contributors
 * Jonathan Whitmore
 * Jörg Dietrich
 * Jose Sabater
+* José Sabater Montes
 * Joseph Jon Booker
 * Joseph Long
 * Joseph Ryan
 * Joseph Schlitz
-* José Sabater Montes
 * Jost Migenda
 * JP Maia
 * Juan Luis Cano Rodríguez
@@ -257,6 +265,7 @@ Core Package Contributors
 * Julien Woillez
 * Jurien Huisman
 * Kacper Kowalik
+* Kang Wang
 * Karan Grover
 * Karl Gordon
 * Karl Vyhmeister
@@ -274,7 +283,7 @@ Core Package Contributors
 * Kyle Barbary
 * Kyle Conroy
 * Kyle Oman
-* kYwzor
+* Kyle Westfall
 * Larry Bradley
 * Laura Hayes
 * Laura Watkins
@@ -282,8 +291,10 @@ Core Package Contributors
 * Laurent Michel
 * Laurie Stephey
 * Leah Fulmer
+* Lee Kelvin
 * Lee Spitler
 * Lehman Garrison
+* Léni Gauffier
 * Lennard Kiehl
 * Leo Singer
 * Leonardo Ferreira
@@ -295,10 +306,9 @@ Core Package Contributors
 * Lu Xu
 * Ludwig Schwardt
 * Luigi Paioro
-* Luke G. Bouma
+* Luke G\. Bouma
 * Luke Kelley
-* luz paz
-* Léni Gauffier
+* Luz Paz
 * M Atakan Gürkan
 * M S R Dinesh
 * Mabry Cervin
@@ -320,6 +330,7 @@ Core Package Contributors
 * Marten van Kerkwijk
 * Martin Dyer
 * Martin Glatzle
+* MatCat776
 * Matej Stuchlik
 * Mathieu Servillat
 * Matt Davis
@@ -331,6 +342,8 @@ Core Package Contributors
 * Matthew Pitkin
 * Matthew Turk
 * Matthias Bussonnier
+* Matthias Stein
+* Matthieu Bec
 * Mavani Bhautik
 * Max Mahlke
 * Max Silbiger
@@ -366,16 +379,18 @@ Core Package Contributors
 * Molly Peeples
 * Mridul Seth
 * Mubin Manasia
+* myanm
 * mzhengxi
 * Nabil Freij
 * Nadia Dencheva
 * Nathanial Hendler
 * Nathaniel Starkman
+* Naveen Selvadurai
 * Neal McBurnett
 * Neil Crighton
 * Neil Parley
 * Nicholas Earl
-* Nicholas S. Kern
+* Nicholas S\. Kern
 * Nicholas Saunders
 * Nick Lloyd
 * Nick Murphy
@@ -387,11 +402,13 @@ Core Package Contributors
 * Nora Luetzgendorf
 * odidev
 * Ole Streicher
-* Orion Poplawski
 * omahs
+* Orion Poplawski
 * orionlee
+* P\. L\. Lim
 * Param Patidar
 * Parikshit Sakurikar
+* Parkerwise
 * Patricio Rojo
 * Patti Carroll
 * Paul Barrett
@@ -404,7 +421,6 @@ Core Package Contributors
 * Peter Cock
 * Peter Teuben
 * Peter Yoachim
-* Pey Lian Lim
 * Piyush Sharma
 * Porter Averett
 * Prajwel Joseph
@@ -412,10 +428,12 @@ Core Package Contributors
 * Pratik Patel
 * Pritish Chakraborty
 * Pushkar Kopparla
+* Rachel Guo
 * Raghuram Devarakonda
 * Ralf Gommers
 * Rashid Khan
 * Rasmus Handberg
+* Ravi Kumar
 * Ray Plante
 * Régis Terrier
 * Ricardo Fonseca
@@ -441,7 +459,9 @@ Core Package Contributors
 * Ryan Cooke
 * Ryan Fox
 * Sadie Bartholomew
+* Sam Bianco
 * Sam Holt
+* Sam Lee
 * Sam Van Kooten
 * Sam Verstocken
 * Samruddhi Khandale
@@ -454,11 +474,10 @@ Core Package Contributors
 * Sarah Weissman
 * Saransh Chopra
 * Sashank Mishra
-* sashmish
 * Saurav Sachidanand
 * Scott Thomas
-* Sébastien Maret
 * Sebastian Meßlinger
+* Sébastien Maret
 * Sedona Price
 * Semyeong Oh
 * Serge Montagnac
@@ -468,6 +487,7 @@ Core Package Contributors
 * Shane Maloney
 * Shankar Kulumani
 * Shantanu Srivastava
+* Sharath Ramkumar
 * Shilpi Jain
 * Shivan Sornarajah
 * Shivansh Mishra
@@ -501,18 +521,19 @@ Core Package Contributors
 * Tanuj Rastogi
 * Tanvi Pooranmal Meena
 * Thais Borges
-* Thomas J. Fan
 * Thomas Erben
+* Thomas J\. Fan
 * Thomas Robitaille
 * Thomas Vandal
 * Thompson Le Blanc
+* thuiop
 * Tiago Gomes
 * Tiago Ribeiro
 * Tiffany Jansen
 * Tim Gates
 * Tim Jenness
 * Tim Plummer
-* Timothy P. Ellsworth Bowers
+* Timothy P\. Ellsworth Bowers
 * Tito Dal Canton
 * Tom Aldcroft
 * Tom Donaldson
@@ -520,18 +541,20 @@ Core Package Contributors
 * Tom Kooij
 * Tomas Babej
 * Tyler Finethy
+* Varun Nikam
 * Vatsala Swaroop
+* Víctor Terrón
+* Víctor Zabalza
 * Victoria Dye
 * Vinayak Mehta
 * Vishnunarayan K I
 * Vital Fernández
 * Volodymyr Savchenko
 * VSN Reddy Janga
-* Víctor Terrón
-* Víctor Zabalza
 * Wilfred Tyler Gee
 * William Jamieson
 * Wolfgang Kerzendorf
+* xuewc
 * Yannick Copin
 * Yash Kumar
 * Yash Nandwana
@@ -541,11 +564,11 @@ Core Package Contributors
 * Zach Burnett
 * Zach Edwards
 * Zachary Kurtz
+* Zé Vinicius
 * Zeljko Ivezic
 * Zhen-Kai Gao
 * Zhiyuan Ma
 * Zlatan Vasović
-* Zé Vinicius
 
 Other Credits
 =============


### PR DESCRIPTION
By far the most time consuming part of a minor release is updating credits and cleaning up the mailmap etc.

This PR adds a script that will automatically update the ``credits.rst`` file and starts adding entries to ``.mailmap`` to clean up the author list.

Once this is done, by plan is to add a cron job that will periodically run this and open a PR so that we can fix issues as we go along rather than have to deal with a mountain of issues just at release time. I'll also make it so that we can run this with a workflow dispatch so we can trigger it manually at release time.

I haven't finished going through the credits to clean up incorrectly formatted/duplicate/missing names, but will try and finish this evening.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
