### PR TITLE
Move the `zero_point_flux` equivalency

### DIFF
--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -23,6 +23,7 @@ from . import astrophys, cgs, dimensionless_unscaled, misc, si
 from .core import Unit
 from .errors import UnitsError
 from .function import units as function_units
+from .photometric import maggy
 
 if TYPE_CHECKING:
     from typing import Final
@@ -48,6 +49,7 @@ __all__ = [
     "temperature",
     "temperature_energy",
     "thermodynamic_temperature",
+    "zero_point_flux",
 ]
 
 km_per_s: Final = si.km / si.s
@@ -898,3 +900,16 @@ def magnetic_flux_field(mu_r=1):
         [(si.T, si.A / si.m, lambda x: x / (mu_r * mu0), lambda x: x * mu_r * mu0)],
         "magnetic_flux_field",
     )
+
+
+def zero_point_flux(flux0):
+    """
+    An equivalency for converting linear flux units ("maggys") defined relative
+    to a standard source into a standardized system.
+
+    Parameters
+    ----------
+    flux0 : `~astropy.units.Quantity`
+        The flux of a magnitude-0 object in the "maggy" system.
+    """
+    return Equivalency([(maggy, Unit(flux0))], "zero_point_flux")

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -18,10 +18,10 @@ import numpy as np
 from astropy.constants.si import L_bol0
 
 from . import astrophys, cgs, si
-from .core import Unit, UnitBase, def_unit
+from .core import UnitBase, def_unit
 from .utils import generate_unit_summary
 
-__all__ = ["zero_point_flux"]  #  Units are added at the end
+__all__ = []  #  Units are added at the end
 
 _ns = globals()
 
@@ -69,20 +69,6 @@ def_unit(
         "zero_point_flux equivalency should be used."
     ),
 )
-
-
-def zero_point_flux(flux0):
-    """
-    An equivalency for converting linear flux units ("maggys") defined relative
-    to a standard source into a standardized system.
-
-    Parameters
-    ----------
-    flux0 : `~astropy.units.Quantity`
-        The flux of a magnitude-0 object in the "maggy" system.
-    """
-    flux_unit0 = Unit(flux0)
-    return [(maggy, flux_unit0)]
 
 
 ###########################################################################


### PR DESCRIPTION
### Description

On current `main` the `zero_point_flux` equivalency is not implemented in the same module as the other equivalencies. It is instead implemented in the `photometric` units module, which should contain only dynamic unit definitions. I can't think of a good reason why `zero_point_flux` should be where it is.

The move should be invisible to users because they should be importing the equivalency from the `astropy.units` namespace both before and after this move.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
