### PR TITLE
Fix handling of bounded variable-length char arrays in BINARY2 format

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -406,7 +406,6 @@ class Char(Converter):
 
         if self.arraysize != "*" and len(value) > self.arraysize:
             vo_warn(W46, ("char", self.arraysize), None, None)
-            value = value[: self.arraysize]
 
         return self._write_length(len(value)) + value
 

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -323,14 +323,25 @@ class Char(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
-            field.arraysize = field.arraysize.removesuffix("*")
+            # Check if this is a bounded variable-length field
+            is_variable = field.arraysize.endswith("*")
+
+            numeric_part = field.arraysize.removesuffix("*")
             try:
-                self.arraysize = int(field.arraysize)
+                self.arraysize = int(numeric_part)
             except ValueError:
-                vo_raise(E01, (field.arraysize, "char", field.ID), config)
+                vo_raise(E01, (numeric_part, "char", field.ID), config)
+
             self.format = f"U{self.arraysize:d}"
-            self.binparse = self._binparse_fixed
-            self.binoutput = self._binoutput_fixed
+
+            # For bounded variable-length fields use the variable methods
+            if is_variable:
+                self.binparse = self._binparse_var
+                self.binoutput = self._binoutput_var
+            else:
+                self.binparse = self._binparse_fixed
+                self.binoutput = self._binoutput_fixed
+
             self._struct_format = f">{self.arraysize:d}s"
 
     def supports_empty_values(self, config):
@@ -371,6 +382,10 @@ class Char(Converter):
 
     def _binparse_var(self, read):
         length = self._parse_length(read)
+
+        if self.arraysize != "*" and length > self.arraysize:
+            vo_warn(W46, ("char", self.arraysize), None, None)
+
         return read(length).decode("ascii"), False
 
     def _binparse_fixed(self, read):
@@ -389,6 +404,11 @@ class Char(Converter):
                 value = value.encode("ascii")
             except ValueError:
                 vo_raise(E24, (value, self.field_name))
+
+        if self.arraysize != "*" and len(value) > self.arraysize:
+            vo_warn(W46, ("char", self.arraysize), None, None)
+            value = value[: self.arraysize]
+
         return self._write_length(len(value)) + value
 
     def _binoutput_fixed(self, value, mask):
@@ -424,14 +444,24 @@ class UnicodeChar(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
-            field.arraysize = field.arraysize.removesuffix("*")
+            is_variable = field.arraysize.endswith("*")
+
+            # Get numeric part without modifying field.arraysize
+            numeric_part = field.arraysize.removesuffix("*")
             try:
-                self.arraysize = int(field.arraysize)
+                self.arraysize = int(numeric_part)
             except ValueError:
-                vo_raise(E01, (field.arraysize, "unicode", field.ID), config)
+                vo_raise(E01, (numeric_part, "unicode", field.ID), config)
+
             self.format = f"U{self.arraysize:d}"
-            self.binparse = self._binparse_fixed
-            self.binoutput = self._binoutput_fixed
+
+            if is_variable:
+                self.binparse = self._binparse_var
+                self.binoutput = self._binoutput_var
+            else:
+                self.binparse = self._binparse_fixed
+                self.binoutput = self._binoutput_fixed
+
             self._struct_format = f">{self.arraysize * 2:d}s"
 
     def parse(self, value, config=None, pos=None):
@@ -446,6 +476,10 @@ class UnicodeChar(Converter):
 
     def _binparse_var(self, read):
         length = self._parse_length(read)
+
+        if self.arraysize != "*" and length > self.arraysize:
+            vo_warn(W46, ("unicodeChar", self.arraysize), None, None)
+
         return read(length * 2).decode("utf_16_be"), False
 
     def _binparse_fixed(self, read):
@@ -459,8 +493,15 @@ class UnicodeChar(Converter):
     def _binoutput_var(self, value, mask):
         if mask or value is None or value == "":
             return _zero_int
+
         encoded = value.encode("utf_16_be")
-        return self._write_length(len(encoded) / 2) + encoded
+
+        if self.arraysize != "*" and len(value) > self.arraysize:
+            vo_warn(W46, ("unicodeChar", self.arraysize), None, None)
+            value = value[: self.arraysize]
+            encoded = value.encode("utf_16_be")
+
+        return self._write_length(len(encoded) // 2) + encoded
 
     def _binoutput_fixed(self, value, mask):
         if mask:
@@ -1441,28 +1482,52 @@ def table_column_to_votable_datatype(column):
         set on a VOTable FIELD element.
     """
     votable_string_dtype = None
+    max_length = None
+    original_arraysize = None
+
     if column.info.meta is not None:
         votable_string_dtype = column.info.meta.get("_votable_string_dtype")
+        # Check if we have stored the original arraysize with bounds
+        # If so, extract the max length
+        original_arraysize = column.info.meta.get("_votable_arraysize")
+        if (
+            original_arraysize is not None
+            and original_arraysize.endswith("*")
+            and not original_arraysize == "*"
+        ):
+            max_length = original_arraysize[:-1]
+
     if column.dtype.char == "O":
+        arraysize = "*"
+
+        # If max length is stored use it to create a bounded var-length array
+        if max_length is not None:
+            arraysize = f"{max_length}*"
+
         if votable_string_dtype is not None:
-            return {"datatype": votable_string_dtype, "arraysize": "*"}
+            return {"datatype": votable_string_dtype, "arraysize": arraysize}
         elif isinstance(column[0], np.ndarray):
             dtype, shape = _all_matching_dtype(column)
             if dtype is not False:
                 result = numpy_to_votable_dtype(dtype, shape)
                 if "arraysize" not in result:
-                    result["arraysize"] = "*"
+                    result["arraysize"] = arraysize
                 else:
                     result["arraysize"] += "*"
                 return result
 
         # All bets are off, do the most generic thing
-        return {"datatype": "unicodeChar", "arraysize": "*"}
+        return {"datatype": "unicodeChar", "arraysize": arraysize}
 
     # For fixed size string columns, datatype here will be unicodeChar,
     # but honor the original FIELD datatype if present.
     result = numpy_to_votable_dtype(column.dtype, column.shape[1:])
     if result["datatype"] == "unicodeChar" and votable_string_dtype == "char":
         result["datatype"] = "char"
+
+    # If we stored the original arraysize, use it instead of what
+    # numpy_to_votable_dtype derives
+    if original_arraysize is not None:
+        result["arraysize"] = original_arraysize
 
     return result

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -325,7 +325,6 @@ class Char(Converter):
         else:
             # Check if this is a bounded variable-length field
             is_variable = field.arraysize.endswith("*")
-
             numeric_part = field.arraysize.removesuffix("*")
             try:
                 self.arraysize = int(numeric_part)
@@ -444,9 +443,8 @@ class UnicodeChar(Converter):
             self.binoutput = self._binoutput_var
             self.arraysize = "*"
         else:
+            # Check if this is a bounded variable-length field
             is_variable = field.arraysize.endswith("*")
-
-            # Get numeric part without modifying field.arraysize
             numeric_part = field.arraysize.removesuffix("*")
             try:
                 self.arraysize = int(numeric_part)
@@ -494,12 +492,11 @@ class UnicodeChar(Converter):
         if mask or value is None or value == "":
             return _zero_int
 
-        encoded = value.encode("utf_16_be")
-
         if self.arraysize != "*" and len(value) > self.arraysize:
             vo_warn(W46, ("unicodeChar", self.arraysize), None, None)
             value = value[: self.arraysize]
-            encoded = value.encode("utf_16_be")
+
+        encoded = value.encode("utf_16_be")
 
         return self._write_length(len(encoded) // 2) + encoded
 

--- a/astropy/io/votable/tests/data/binary2_variable_length_char.xml
+++ b/astropy/io/votable/tests/data/binary2_variable_length_char.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.4">
+  <RESOURCE type="results">
+    <INFO name="QUERY_STATUS" value="OK" />
+    <INFO name="QUERY" value="SELECT TOP 1 access_format FROM ivoa.ObsCore" />
+    <TABLE>
+      <FIELD name="access_format" datatype="char" arraysize="128*" ucd="meta.code.mime" utype="Access.format">
+        <DESCRIPTION>Content format of the dataset</DESCRIPTION>
+      </FIELD>
+      <DATA>
+      <BINARY2>
+        <STREAM encoding='base64'>
+AAAAACphcHBsaWNhdGlvbi94LXZvdGFibGUreG1sO2NvbnRlbnQ9ZGF0YWxpbms=
+        </STREAM>
+      </BINARY2>
+    </DATA>
+</TABLE>
+  </RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.1.xml
@@ -41,7 +41,7 @@
    <FIELD ID="string_test_2" arraysize="10" datatype="char" name="fixed string test"/>
    <FIELD ID="unicode_test" arraysize="*" datatype="unicodeChar" name="unicode_test"/>
    <FIELD ID="fixed_unicode_test" arraysize="10" datatype="unicodeChar" name="unicode test"/>
-   <FIELD ID="string_array_test" arraysize="4" datatype="char" name="string array test"/>
+   <FIELD ID="string_array_test" arraysize="4*" datatype="char" name="string array test"/>
    <FIELD ID="unsignedByte" datatype="unsignedByte" name="unsignedByte"/>
    <FIELD ID="short" datatype="short" name="short">
     <VALUES null="-32768"/>

--- a/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
+++ b/astropy/io/votable/tests/data/regression.bin.tabledata.truth.1.3.xml
@@ -41,7 +41,7 @@
    <FIELD ID="string_test_2" arraysize="10" datatype="char" name="fixed string test"/>
    <FIELD ID="unicode_test" arraysize="*" datatype="unicodeChar" name="unicode_test"/>
    <FIELD ID="fixed_unicode_test" arraysize="10" datatype="unicodeChar" name="unicode test"/>
-   <FIELD ID="string_array_test" arraysize="4" datatype="char" name="string array test"/>
+   <FIELD ID="string_array_test" arraysize="4*" datatype="char" name="string array test"/>
    <FIELD ID="unsignedByte" datatype="unsignedByte" name="unsignedByte"/>
    <FIELD ID="short" datatype="short" name="short">
     <VALUES null="-32768"/>

--- a/astropy/io/votable/tests/data/vizier_b2_votable.xml
+++ b/astropy/io/votable/tests/data/vizier_b2_votable.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE version="1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+  xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+<!-- VOTable description at http://www.ivoa.net/Documents/latest/VOT.html -->
+<INFO name="service_protocol" value="ASU">  IVOID of the protocol through which the data was retrieved</INFO>
+<INFO name="request_date" value="2025-05-08T00:06:04">  Query execution date</INFO>
+<INFO name="request" value="https://vizier.u-strasbg.fr/viz-bin/votable/-b64?-source=V/127A/mash1&amp;-out.max=20&amp;-out.meta=hu2D">  Full request URL</INFO>
+<INFO name="contact" value="cds-question@unistra.fr">  Email or URL to contact publisher</INFO>
+<INFO name="server_software" value="7.4.6">  Software version</INFO>
+<INFO name="publisher" value="CDS">  Data centre that produced the VOTable</INFO>
+
+<!--
+Execution Reports
+ -->
+
+<RESOURCE ID="yCat_5127" name="V/127A" type="results">
+  <DESCRIPTION>MASH Catalogues of Planetary Nebulae (Parker+ 2006-2008)</DESCRIPTION>  <INFO name="ivoid" value="ivo://cds.vizier/v/127a">    IVOID of underlying data collection  </INFO>
+  <INFO name="creator" value="Parker Q.A.">    First author or institution  </INFO>
+  <INFO name="cites" value="bibcode:2006MNRAS.373...79P">    Article or Data origin sources  </INFO>
+  <INFO name="original_date" value="2006">    Year of the article publication  </INFO>
+  <INFO name="reference_url" value="https://cdsarc.cds.unistra.fr/viz-bin/cat/V/127A">    Dataset landing page  </INFO>
+  <INFO name="publication_date" value="2018-10-17">    Date of first publication in the data centre  </INFO>
+  <INFO name="rights_uri" value="https://cds.unistra.fr/vizier-org/licences_vizier.html">    Licence URI  </INFO>
+
+  <COOSYS ID="J2000" system="eq_FK5" equinox="J2000"/>
+  <TABLE ID="V_127A_mash1" name="V/127A/mash1">
+    <DESCRIPTION>The MASH Catalog of Planetary Nebulae (paper I)</DESCRIPTION>
+    <!-- Definitions of GROUPs and FIELDs -->
+    <FIELD name="n_PNG" ucd="meta.note" datatype="char" arraysize="1"><!-- ucd="NOTE" -->
+      <DESCRIPTION>[TLP] True, Likely or Possible PN nature</DESCRIPTION>
+    </FIELD>
+    <FIELD name="PNG" ucd="meta.id;meta.main" datatype="char" arraysize="12"><!-- ucd="DATA_LINK" -->
+      <DESCRIPTION>Name of PN, based on Galactic position (1)</DESCRIPTION>
+    </FIELD>
+    <FIELD name="Name" ucd="meta.id" datatype="char" arraysize="13"><!-- ucd="?" -->
+      <DESCRIPTION>Usual name of the PN (2)</DESCRIPTION>
+    </FIELD>
+    <FIELD name="RAJ2000" ucd="pos.eq.ra;meta.main" ref="J2000" datatype="double" width="10" precision="4" unit=""><!-- ucd="POS_EQ_RA_MAIN" -->
+      <DESCRIPTION>Right Ascension J2000</DESCRIPTION>
+    </FIELD>
+    <FIELD name="DEJ2000" ucd="pos.eq.dec;meta.main" ref="J2000" datatype="double" width="9" precision="4" unit=""><!-- ucd="POS_EQ_DEC_MAIN" -->
+      <DESCRIPTION>Declination J2000</DESCRIPTION>
+    </FIELD>
+    <FIELD name="MajDiam" ucd="phys.angSize" datatype="float" width="6" precision="1" unit="arcsec"><!-- ucd="?" -->
+      <DESCRIPTION>? Major diameter of the PN from H{alpha} image</DESCRIPTION>
+      <VALUES null="NaN" />
+    </FIELD>
+    <FIELD name="MinDiam" ucd="phys.angSize" datatype="float" width="6" precision="1" unit="arcsec"><!-- ucd="?" -->
+      <DESCRIPTION>? Minor diameter of the PN from H{alpha} image</DESCRIPTION>
+      <VALUES null="NaN" />
+    </FIELD>
+    <FIELD name="CS" ucd="meta.note" datatype="char" arraysize="7*"><!-- ucd="?" -->
+      <DESCRIPTION>Type of central star (4)</DESCRIPTION>
+    </FIELD>
+    <FIELD name="Morph" ucd="src.morph" datatype="char" arraysize="7*"><!-- ucd="?" -->
+      <DESCRIPTION>Morphology of the nebula</DESCRIPTION>
+    </FIELD>
+    <FIELD name="ObsDate" ucd="time.epoch" datatype="int" width="10" unit="'Y:M:D'"><!-- ucd="?" -->
+      <DESCRIPTION>? Date of first spectroscopic observation</DESCRIPTION>
+      <VALUES null="-2147483648" />
+    </FIELD>
+    <FIELD name="img" ucd="meta.note" datatype="char" arraysize="5"><!-- ucd="DATA_LINK" -->
+      <DESCRIPTION>View images and spectra</DESCRIPTION>
+    </FIELD>
+    <FIELD name="AssocData" ucd="meta.bib.page" datatype="char" arraysize="4"><!-- ucd="DATA_LINK" -->
+      <DESCRIPTION>Associated Data web page</DESCRIPTION>
+    </FIELD>
+<DATA><BINARY><STREAM encoding="base64">
+VEcyMDkuMS0wOC4yIFBIUjA2MTUtMDAyNSBAV3Vwo9cKPb/biavN8BIzQsgAAELIAAAAAAAA
+AAAAAVIAJW+BMTAwMSBmaXRzUEcyMjcuMy0xMi4wIFBIUjA2MzMtMTgwOCBAWJaj1wo9cMAy
+I8TV5vgIQYgAAEFwAAAAAAAAAAAAAkVhACVswDEwMDIgZml0c1RHMjEyLjItMDQuNyBQSFIw
+NjMzLTAxMzUgQFiSeuFHrhS/+WL8li/JYkJgAABCSAAAAAAAAAAAAAJFYQAlbjsxMDAzIGZp
+dHNQRzIxNC4yLTAyLjQgUEhSMDY0NS0wMjE3IEBZUO7u7u7uwAJh2VDIP7dCXgAAQjgAAAAA
+AAAAAAACRXMAJWy8MTAwNCBmaXRzTEcyMjMuNi0wNi44IFBIUjA2NDYtMTIzNSBAWWbF+Sxf
+ksApMqGQf25cQiAAAEIUAAAAAAAAAAAAAUUAJXEcMTAwNSBmaXRzTEcyMTkuMS0wMy45IFBI
+UjA2NDgtMDcxOSBAWYuuFHrhR8AdUsX5LF+SQgwAAEIEAAAAAAAAAAAAAkVhACVofjEwMDYg
+Zml0c1RHMjEyLjYtMDAuMCBQSFIwNjUwKzAwMTMgQFmqzMzMzMw/zSfSfSfSfEKIAABB0AAA
+AAAAAAAAAAFCACVuODEwMDcgZml0c1RHMjE1LjUtMDEuNCBQSFIwNjUxLTAyNTcgQFmx64Ue
+uFHAB52VDIP7ckEIAABBCAAAAAAAAAAAAAFSACVm9zEwMDggZml0c1BHMjIxLjgtMDQuMiBQ
+SFIwNjUyLTA5NTEgQFnFLF+SxfjAI7hR64UeuEJwAABCOAAAAAAAAAAAAAJFYQAlbL0xMDA5
+IGZpdHNQRzIyNC4zLTA1LjUgUEhSMDY1Mi0xMjQwIEBZxWnQNp0CwClaKzxNXm9DOwAAQzQA
+AAAAAAAAAAABSQAlbL4xMDEwIGZpdHNURzIyMi44LTA0LjIgUEhSMDY1NC0xMDQ1IEBZ45LF
++SxfwCWFZ4mrze9B2AAAQYAAAAAAAAAAAAABRQAlbLsxMDExIGZpdHNURzIyNC4zLTAzLjQg
+UEhSMDcwMC0xMTQzIEBaQYvyWL8lwCd2L8li/JVCRAAAQjwAAAAAAAAAAAACRWEAJWy8MTAx
+MiBmaXRzTEcyMjEuMC0wMS40IFBIUjA3MDEtMDc0OSBAWlJ64UeuFMAfSj1wo9cJQoYAAEKE
+AAAAAAAAAAAAAkVhACVsuzEwMTMgZml0c1RHMjE3LjIrMDAuOSBQSFIwNzAyLTAzMjQgQFpp
+HrhR64TAC0cccccccUJQAABCMgAAAAAAAAAAAAJFYQAlZvcxMDE0IGZpdHNURzIxNC42KzAy
+LjkgUEhSMDcwNC0wMDExIEBajxfksX5Kv8f///////9BYAAAQWAAAAAAAAAAAAABUgAlbjgx
+MDE1IGZpdHNURzIyNy4yLTAzLjQgUEhSMDcwNS0xNDE5IEBamkRERERDwCyi2C2C2CxBcAAA
+QXAAAAAAAAAAAAABRQAlbLwxMDE2IGZpdHNURzIyMi45LTAxLjEgUEhSMDcwNS0wOTI0IEBa
+nbToG06BwCLOXUw7KhhCqgAAQqAAAAAAAAAAAAABQgAlbLsxMDE3IGZpdHNQRzIzNy45LTA3
+LjIgRlAwNzExLTI1MzEgIEBa+IiIiIiIwDmF+SxfksVEJQAARBYAAAAAAAAAAAACRWEAJW45
+MTAxOCBmaXRzVEcyMjYuNC0wMS4zIFBIUjA3MTEtMTIzOCBAWvuL8li/JcApRLF+SxfkQmIA
+AEJcAAAAAAAAAAAAAlJhACVsvDEwMTkgZml0c0xHMjI1LjIrMDAuMSBQSFIwNzE0LTEwNTEg
+QFsnrhR64UfAJbl1MOyoY0DgAABAoAAAAAAAAAAAAAFFACVvgTEwMjAgZml0 cw==
+</STREAM></BINARY></DATA>
+</TABLE>
+<INFO name="matches" value="20">matching records</INFO>
+
+<INFO name="Warning" value="truncated result (maxtup=20)"/><INFO name="QUERY_STATUS" value="OVERFLOW"> value="truncated result (maxtup=20)"</INFO>
+
+</RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1718,8 +1718,12 @@ class Field(
             column.format = self.converter.output_format
         elif isinstance(self.converter, converters.Char):
             column.info.meta["_votable_string_dtype"] = "char"
+            if self.arraysize is not None and self.arraysize.endswith("*"):
+                column.info.meta["_votable_arraysize"] = self.arraysize
         elif isinstance(self.converter, converters.UnicodeChar):
             column.info.meta["_votable_string_dtype"] = "unicodeChar"
+            if self.arraysize is not None and self.arraysize.endswith("*"):
+                column.info.meta["_votable_arraysize"] = self.arraysize
 
     @classmethod
     def from_table_column(cls, votable, column):

--- a/docs/changes/io.votable/18105.bugfix.rst
+++ b/docs/changes/io.votable/18105.bugfix.rst
@@ -1,1 +1,1 @@
-Fix handling of bounded variable-length char arrays in BINARY2 format which were previously treated as fixed length
+Fix handling of bounded variable-length char arrays in BINARY2 format which were previously treated as fixed length.

--- a/docs/changes/io.votable/18105.bugfix.rst
+++ b/docs/changes/io.votable/18105.bugfix.rst
@@ -1,0 +1,1 @@
+Fix handling of bounded variable-length char arrays in BINARY2 format which were previously treated as fixed length


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address issue #18099 with VOTable BINARY2 serialization where fields with bounded variable length char arrays (e.g., arraysize="128*") were being handled as fixed length. 

Specifically, the parser was removing the asterisk from the arraysize attribute and treating these fields as fixed-length arrays, which caused them to be incorrectly encoded/decoded in BINARY2 format.

The issue resulted in either empty tables or exceptions when parsing VOTable results containing these field types.

### Changes

- Modified the Char converter class's `__init__` method to detect bounded variable length arrays (e.g. arraysize="128*") and use the appropriate var parsing methods
- Preserved the original arraysize format with the asterisk to ensure it's correctly written back during serialization
- Added bounds checking in variable length array handlers to properly validate against the max lengths
- Added unit tests to verify correct handling of bounded variable length char arrays
- Changed existing unit tests to ensure these field type metadata is properly propagated through the roundtrips. 

### Technical Details

The issue was caused by this code in the Char converter's `__init__` method:
`field.arraysize = field.arraysize.removesuffix("*")`

This was removing the asterisk and therefore losing the information that this should be handled as a variable length field with an upper bound, which later in the `__init__` method lead to the fixed length binary parsing methods being used. The changes should address this by recognizing that the field is a variable length field with an upper bound and assigning the converted the appropriate binary parsing methods. The changes also address the round-tripping of this information between astropy/votable tables.

### Testing
Added following new tests:

- `test_binary2_single_bounded_char_array`:     Test that variable length char arrays with a max length arraysize="128*") are read correctly in BINARY2 format.
- `test_binary2_bounded_variable_length_char`: Tests round-trip serialization of bounded variable length char arrays across all formats
- `test_binary2_bounded_variable_length_char_edge_cases`: Tests edge cases
- `test_binary2_char_fields_vizier_data`: Test parsing a VOTable from a Vizier query which includes bounded variable-length char arrays (e.g., arraysize="7*"). Related issue: https://github.com/astropy/astropy/issues/8737


This fix is particularly important for interoperability with IVOA services that commonly use this field type in their response formats.

### Related Issues
Fixes #18099 
Fixes #8737

### Notes: 
Let me know if I've misinterpreted the issue or if there are better ways to address it and I'd be happy to make any changes accordingly.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
