### PR TITLE
Parse `ConfigNamespace` classes recursively when generating config files

### DIFF
--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -206,6 +206,29 @@ def test_generate_config2(tmp_path):
     check_config(conf)
 
 
+def test_generate_config_subclasses(tmp_path):
+    """Test that generate_config works with subclasses of ConfigNamespace."""
+    from astropy.config.configuration import ConfigItem, ConfigNamespace
+
+    class MyPackageNamespace(ConfigNamespace):
+        pass
+
+    class RecursiveTestConf(MyPackageNamespace):
+        ti = ConfigItem(5, "this is a Description")
+
+    with set_temp_config(tmp_path):
+        from astropy.config.configuration import generate_config
+
+        generate_config("astropy")
+
+    assert os.path.exists(tmp_path / "astropy" / "astropy.cfg")
+
+    with open(tmp_path / "astropy" / "astropy.cfg") as fp:
+        conf = fp.read()
+
+    assert "# ti = 5" in conf
+
+
 def test_create_config_file(tmp_path, caplog):
     with set_temp_config(tmp_path):
         create_config_file("astropy")

--- a/docs/changes/config/18107.bugfix.rst
+++ b/docs/changes/config/18107.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where config file generation did not parse nested subclasses of ``astropy.config.ConfigNamespace``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

If you define subclasses of `astropy.config.ConfigNamespace` to set things like `rootname` for your whole package:

https://github.com/DKISTDC/dkist/blob/74921f8e1f7993e668ea9004ef9f0154b1185585/dkist/config/__init__.py#L7-L8

then any `Conf` classes derived from those subclasses do not get parsed when writing a config file.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.