### PR TITLE
Avoid importing `itertools` just for test parametrization in `units`

### DIFF
--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -3,7 +3,6 @@
 Test the Logarithmic Units and Quantities
 """
 
-import itertools
 import pickle
 
 import numpy as np
@@ -43,9 +42,8 @@ class TestLogUnitCreation:
         assert lu == lu._default_function_unit  # eg, MagUnit() == u.mag
         assert lu._default_function_unit == lu  # and u.mag == MagUnit()
 
-    @pytest.mark.parametrize(
-        "lu_unit, physical_unit", itertools.product(lu_units, pu_sample)
-    )
+    @pytest.mark.parametrize("physical_unit", pu_sample)
+    @pytest.mark.parametrize("lu_unit", lu_units)
     def test_call_units(self, lu_unit, physical_unit):
         """Create a LogUnit subclass using the callable unit and physical unit,
         and do basic check that output is right."""
@@ -59,10 +57,8 @@ class TestLogUnitCreation:
         with pytest.raises(ValueError):
             u.mag(u.mag())
 
-    @pytest.mark.parametrize(
-        "lu_cls, physical_unit",
-        itertools.product(lu_subclasses + [u.LogUnit], pu_sample),
-    )
+    @pytest.mark.parametrize("physical_unit", pu_sample)
+    @pytest.mark.parametrize("lu_cls", lu_subclasses + [u.LogUnit])
     def test_subclass_creation(self, lu_cls, physical_unit):
         """Create a LogUnit subclass object for given physical unit,
         and do basic check that output is right."""
@@ -214,9 +210,8 @@ class TestLogUnitStrings:
 
 
 class TestLogUnitConversion:
-    @pytest.mark.parametrize(
-        "lu_unit, physical_unit", itertools.product(lu_units, pu_sample)
-    )
+    @pytest.mark.parametrize("physical_unit", pu_sample)
+    @pytest.mark.parametrize("lu_unit", lu_units)
     def test_physical_unit_conversion(self, lu_unit, physical_unit):
         """Check various LogUnit subclasses are equivalent and convertible
         to their non-log counterparts."""
@@ -261,10 +256,9 @@ class TestLogUnitConversion:
         with pytest.raises(u.UnitsError):
             lu2.to(lu2.function_unit, values)
 
-    @pytest.mark.parametrize(
-        "flu_unit, tlu_unit, physical_unit",
-        itertools.product(lu_units, lu_units, pu_sample),
-    )
+    @pytest.mark.parametrize("physical_unit", pu_sample)
+    @pytest.mark.parametrize("tlu_unit", lu_units)
+    @pytest.mark.parametrize("flu_unit", lu_units)
     def test_subclass_conversion(self, flu_unit, tlu_unit, physical_unit):
         """Check various LogUnit subclasses are equivalent and convertible
         to each other if they correspond to equivalent physical units."""
@@ -511,9 +505,8 @@ class TestLogQuantityCreation:
         assert lq._unit_class == lu
         assert type(lu()._quantity_class(1.0)) is lq
 
-    @pytest.mark.parametrize(
-        "lq_cls, physical_unit", itertools.product(lq_subclasses, pu_sample)
-    )
+    @pytest.mark.parametrize("physical_unit", pu_sample)
+    @pytest.mark.parametrize("lq_cls", lq_subclasses)
     def test_subclass_creation(self, lq_cls, physical_unit):
         """Create LogQuantity subclass objects for some physical units,
         and basic check on transformations"""


### PR DESCRIPTION
### Description

A test module in `units` sets up parametrized tests using `itertools.product()`, but using stacked `@pytest.mark.parametrize` decorators reduces line count and avoids having to import `itertools`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
