### PR TITLE
Fixed confusion about display coordinates for `WCSAxes.get_transform()`

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -705,7 +705,7 @@ class WCSAxes(Axes):
         """
         Return a transform from the specified frame to display coordinates.
 
-        This does not include the transData transformation
+        This includes the transData transformation
 
         Parameters
         ----------

--- a/docs/visualization/wcsaxes/overlays.rst
+++ b/docs/visualization/wcsaxes/overlays.rst
@@ -78,7 +78,7 @@ end up with the final pixel coordinates.
 
 The `~astropy.visualization.wcsaxes.WCSAxes` class includes a :meth:`~astropy.visualization.wcsaxes.WCSAxes.get_transform`
 method that can be used to get the appropriate transformation object to convert
-from various world coordinate systems to the final pixel coordinate system
+from various world coordinate systems to the final display coordinate system
 required by Matplotlib. The :meth:`~astropy.visualization.wcsaxes.WCSAxes.get_transform` method can
 take a number of different inputs, which are described in this and subsequent
 sections. The two simplest inputs to this method are ``'world'`` and


### PR DESCRIPTION
`WCSAxes.get_transform()` returns the matplotlib transform from the specified frame to display coordinates, but the second sentence in its docstring contradicts both the first sentence of the docstring and the one-line implementation.  This PR fixes the second sentence, as well as clarifies one spot in the docs.

(I managed to get tripped up by this docstring twice in the past week!)