### PR TITLE
MNT: Fix RET504 lint violations in astropy.nddata

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -244,9 +244,7 @@ lint.unfixable = [
     "TRY300",  # Consider `else` block
     "F811",  # see https://github.com/astropy/astropy/pull/16633
 ]
-"astropy/nddata/*" = [
-    "RET504",  # unnecessary-assign
-]
+"astropy/nddata/*" = []
 "astropy/samp/*" = [
     "PTH",      # all flake8-use-pathlib
     "RET504",  # unnecessary-assign

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -439,9 +439,7 @@ class CCDData(NDDataArray):
             hdu_psf = fits.ImageHDU(self.psf, name=hdu_psf)
             hdus.append(hdu_psf)
 
-        hdulist = fits.HDUList(hdus)
-
-        return hdulist
+        return fits.HDUList(hdus)
 
     def copy(self):
         """
@@ -725,7 +723,8 @@ def fits_ccddata_reader(
 
         use_unit = unit or fits_unit_string
         hdr, wcs = _generate_wcs_and_update_header(hdr)
-        ccd_data = CCDData(
+
+        return CCDData(
             hdus[hdu].data,
             meta=hdr,
             unit=use_unit,
@@ -734,8 +733,6 @@ def fits_ccddata_reader(
             wcs=wcs,
             psf=psf,
         )
-
-    return ccd_data
 
 
 def fits_ccddata_writer(

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -294,7 +294,8 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         else:
             new_mask = None
         # Call __class__ in case we are dealing with an inherited type
-        result = self.__class__(
+
+        return self.__class__(
             data,
             uncertainty=uncertainty,
             mask=new_mask,
@@ -302,5 +303,3 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
             meta=self.meta,
             unit=unit,
         )
-
-        return result


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Enforces RET504 (unnecessary-assign) on astropy/nddata.

Fixes part of #14818.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
