### PR TITLE
MNT: Fix ruff RET504 linting violations in astropy/cosmology

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -204,7 +204,6 @@ lint.unfixable = [
 ]
 "astropy/cosmology/*" = [
     "PT019",   # pytest-fixture-param-without-value
-    "RET504",  # unnecessary-assign
 ]
 "astropy/io/*" = [
     "G001",  # logging-string-format

--- a/astropy/cosmology/_src/core.py
+++ b/astropy/cosmology/_src/core.py
@@ -416,7 +416,7 @@ class Cosmology(metaclass=ABCMeta):
         if other.__class__ is not self.__class__:
             return NotImplemented  # allows other.__eq__
 
-        eq = (
+        return (
             # non-Parameter checks: name
             self.name == other.name
             # check all parameters in 'other' match those in 'self' and 'other'
@@ -430,8 +430,6 @@ class Cosmology(metaclass=ABCMeta):
                 for k in self._parameters_all
             )
         )
-
-        return eq
 
     # ---------------------------------------------------------------
 
@@ -645,7 +643,7 @@ class FlatCosmologyMixin(metaclass=ABCMeta):
 
         # Check if have equivalent parameters and all parameters in `other`
         # match those in `self`` and `other`` has no extra parameters.
-        params_eq = (
+        return (
             # no extra parameters
             self._parameters_all == other._parameters_all
             # equal
@@ -655,5 +653,3 @@ class FlatCosmologyMixin(metaclass=ABCMeta):
             # flatness check
             and other.is_flat
         )
-
-        return params_eq

--- a/astropy/cosmology/_src/funcs/comparison.py
+++ b/astropy/cosmology/_src/funcs/comparison.py
@@ -197,9 +197,8 @@ def _comparison_decorator(pyfunc: Callable[..., Any]) -> Callable[..., Any]:
         # Parse cosmologies to format. Only do specified number.
         cosmos = _parse_formats(*cosmos, format=format)
         # Evaluate pyfunc, erroring if didn't match specified number.
-        result = wrapper.__wrapped__(*cosmos, **kwargs)
         # Return, casting to correct type casting is possible.
-        return result
+        return wrapper.__wrapped__(*cosmos, **kwargs)
 
     return wrapper
 
@@ -366,8 +365,6 @@ def _cosmology_not_equal(
     astropy.cosmology.cosmology_equal
         Element-wise equality check, with argument conversion to Cosmology.
     """
-    neq = not cosmology_equal(cosmo1, cosmo2, allow_equivalent=allow_equivalent)
     # TODO! it might eventually be worth the speed boost to implement some of
     #       the internals of cosmology_equal here, but for now it's a hassle.
-
-    return neq
+    return not cosmology_equal(cosmo1, cosmo2, allow_equivalent=allow_equivalent)

--- a/astropy/cosmology/_src/io/builtin/model.py
+++ b/astropy/cosmology/_src/io/builtin/model.py
@@ -97,14 +97,13 @@ class _CosmologyModel(FittableModel, Generic[_CosmoT]):
     @property
     def cosmology(self) -> _CosmoT:
         """Return |Cosmology| using `~astropy.modeling.Parameter` values."""
-        cosmo = self._cosmology_class(
+        return self._cosmology_class(
             name=self.name,
             **{
                 k: (v.value if not (v := getattr(self, k)).unit else v.quantity)
                 for k in self.param_names
             },
         )
-        return cosmo
 
     @classproperty
     def method_name(self) -> str:
@@ -161,9 +160,7 @@ class _CosmologyModel(FittableModel, Generic[_CosmoT]):
         # make instance of cosmology
         cosmo = self._cosmology_class(**ba.arguments)
         # evaluate method
-        result = getattr(cosmo, self._method_name)(*args[: self.n_inputs])
-
-        return result
+        return getattr(cosmo, self._method_name)(*args[: self.n_inputs])
 
 
 ##############################################################################
@@ -275,11 +272,9 @@ def to_model(cosmology: _CosmoT, *_: object, method: str) -> _CosmologyModel[_Co
         )
 
     # instantiate class using default values
-    model = CosmoModel(
+    return CosmoModel(
         **cosmology.parameters, name=cosmology.name, meta=copy.deepcopy(cosmology.meta)
     )
-
-    return model
 
 
 def model_identify(

--- a/astropy/cosmology/_src/io/builtin/utils.py
+++ b/astropy/cosmology/_src/io/builtin/utils.py
@@ -49,7 +49,7 @@ def convert_parameter_to_column(parameter, value, meta=None):
     """
     shape = (1,) + np.shape(value)  # minimum of 1d
 
-    col = Column(
+    return Column(
         data=np.reshape(value, shape),
         name=parameter.name,
         dtype=None,  # inferred from the data
@@ -57,8 +57,6 @@ def convert_parameter_to_column(parameter, value, meta=None):
         format=None,
         meta=meta,
     )
-
-    return col
 
 
 def convert_parameter_to_model_parameter(parameter, value, meta=None):

--- a/astropy/cosmology/_src/io/connect.py
+++ b/astropy/cosmology/_src/io/connect.py
@@ -104,9 +104,7 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
                 )
 
         with add_enabled_units(cu):
-            cosmo = self.registry.read(self._cls, *args, **kwargs)
-
-        return cosmo
+            return self.registry.read(self._cls, *args, **kwargs)
 
 
 class CosmologyWrite(io_registry.UnifiedReadWrite):
@@ -277,9 +275,7 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
                 )
 
         with add_enabled_units(cu):
-            cosmo = self.registry.read(self._cls, obj, *args, format=format, **kwargs)
-
-        return cosmo
+            return self.registry.read(self._cls, obj, *args, format=format, **kwargs)
 
 
 class CosmologyToFormat(io_registry.UnifiedReadWrite):

--- a/astropy/cosmology/_src/tests/funcs/test_comparison.py
+++ b/astropy/cosmology/_src/tests/funcs/test_comparison.py
@@ -70,10 +70,9 @@ class ComparisonFunctionTestBase(ToFromTestMixinBase):
     def pert_cosmo(self, cosmo):
         # change one parameter
         p, v = next(iter(cosmo.parameters.items()))
-        cosmo2 = cosmo.clone(
+        return cosmo.clone(
             **{p: v * 1.0001 if v != 0 else 0.001 * getattr(v, "unit", 1)}
         )
-        return cosmo2
 
     @pytest.fixture(scope="class")
     def pert_cosmo_eqvxflat(self, pert_cosmo):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Enforces RET504 (unnecessary-assign) on astropy/cosmology.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes part of #14818

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
