### PR TITLE
Backport PR #18107: Parse `ConfigNamespace` classes recursively when generating config files

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -12,10 +12,12 @@ configuration files for Astropy and affiliated packages.
 import contextlib
 import importlib
 import io
+import operator
 import os
 import pkgutil
 import warnings
 from contextlib import contextmanager, nullcontext
+from functools import reduce
 from pathlib import Path
 from textwrap import TextWrapper
 from warnings import warn
@@ -632,6 +634,17 @@ def get_config(packageormod=None, reload=False, rootname=None):
         return cobj
 
 
+def _recursive_subclasses(class_):
+    """
+    Return all subclasses of all subclasses.
+    """
+    subclasses = class_.__subclasses__()
+    if not subclasses:
+        return []
+    next = reduce(operator.concat, [_recursive_subclasses(cls) for cls in subclasses])
+    return [*next, *subclasses]
+
+
 def generate_config(pkgname="astropy", filename=None, verbose=False):
     """Generates a configuration file, from the list of `ConfigItem`
     objects for each subpackage.
@@ -683,8 +696,7 @@ def generate_config(pkgname="astropy", filename=None, verbose=False):
             # assume it's a file object, or io.StringIO
             fp = filename
 
-        # Parse the subclasses, ordered by their module name
-        subclasses = ConfigNamespace.__subclasses__()
+        subclasses = _recursive_subclasses(ConfigNamespace)
         processed = set()
 
         for conf in sorted(subclasses, key=lambda x: x.__module__):

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -206,6 +206,29 @@ def test_generate_config2(tmp_path):
     check_config(conf)
 
 
+def test_generate_config_subclasses(tmp_path):
+    """Test that generate_config works with subclasses of ConfigNamespace."""
+    from astropy.config.configuration import ConfigItem, ConfigNamespace
+
+    class MyPackageNamespace(ConfigNamespace):
+        pass
+
+    class RecursiveTestConf(MyPackageNamespace):
+        ti = ConfigItem(5, "this is a Description")
+
+    with set_temp_config(tmp_path):
+        from astropy.config.configuration import generate_config
+
+        generate_config("astropy")
+
+    assert os.path.exists(tmp_path / "astropy" / "astropy.cfg")
+
+    with open(tmp_path / "astropy" / "astropy.cfg") as fp:
+        conf = fp.read()
+
+    assert "# ti = 5" in conf
+
+
 def test_create_config_file(tmp_path, caplog):
     with set_temp_config(tmp_path):
         create_config_file("astropy")

--- a/docs/changes/config/18107.bugfix.rst
+++ b/docs/changes/config/18107.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where config file generation did not parse nested subclasses of ``astropy.config.ConfigNamespace``.


### PR DESCRIPTION
Backport of #18107 