### PR TITLE
TST: Relax param_cov_array check in parallel_fit_dask

### DIFF
--- a/astropy/modeling/tests/test_fitting_parallel.py
+++ b/astropy/modeling/tests/test_fitting_parallel.py
@@ -1153,7 +1153,7 @@ class TestFitInfo:
         assert param_cov_array.shape == (3, 3, 3)
         assert_allclose(param_cov_array[0], 0)
         assert_allclose(param_cov_array[1], param_cov_array[2])
-        assert np.all(np.abs(param_cov_array[1]) > 0)
+        assert np.any(np.abs(param_cov_array[1]) > 0)
 
         # Test slicing that returns an array
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to relax `param_cov_array` check in `parallel_fit_dask` because it is okay to have some zeroes.

Fix #18137

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
