### PR TITLE
Revert PR 17461 (Optimize getting config item values)

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -295,8 +295,6 @@ class ConfigItem:
     def __init__(
         self, defaultvalue="", description=None, cfgtype=None, module=None, aliases=None
     ):
-        from astropy.utils import isiterable
-
         if module is None:
             module = find_current_module(2)
             if module is None:

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -76,7 +76,17 @@ class ConfigurationChangedWarning(AstropyWarning):
     """
 
 
-class ConfigNamespace:
+class _ConfigNamespaceMeta(type):
+    def __init__(cls, name, bases, dict):
+        if cls.__bases__[0] is object:
+            return
+
+        for key, val in dict.items():
+            if isinstance(val, ConfigItem):
+                val.name = key
+
+
+class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
     """
     A namespace of configuration items.  Each subpackage with
     configuration items should define a subclass of this class,
@@ -285,13 +295,14 @@ class ConfigItem:
     def __init__(
         self, defaultvalue="", description=None, cfgtype=None, module=None, aliases=None
     ):
+        from astropy.utils import isiterable
+
         if module is None:
             module = find_current_module(2)
             if module is None:
-                raise RuntimeError(
-                    "Cannot automatically determine get_config module, "
-                    "because it is not called from inside a valid module"
-                )
+                msg1 = "Cannot automatically determine get_config module, "
+                msg2 = "because it is not called from inside a valid module"
+                raise RuntimeError(msg1 + msg2)
             else:
                 module = module.__name__
 
@@ -328,22 +339,13 @@ class ConfigItem:
         else:
             self.aliases = aliases
 
-    def __set_name__(self, owner, name):
-        self.name = name
-
     def __set__(self, obj, value):
         return self.set(value)
 
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
-        # cache value on the descriptor itself, to avoid repeated accesses
-        # to the ConfigObj object which is much slower
-        try:
-            return self.value
-        except AttributeError:
-            val = self.value = self()
-            return val
+        return self()
 
     def set(self, value):
         """
@@ -370,11 +372,9 @@ class ConfigItem:
                 f" {e.args[0]}"
             )
 
-        # store value on the ConfigObj instance...
         sec = get_config(self.module, rootname=self.rootname)
+
         sec[self.name] = value
-        # and on the descriptor
-        self.value = value
 
     @contextmanager
     def set_temp(self, value):
@@ -398,8 +398,8 @@ class ConfigItem:
 
         """
         initval = self()
+        self.set(value)
         try:
-            self.set(value)
             yield
         finally:
             self.set(initval)
@@ -414,11 +414,7 @@ class ConfigItem:
             The new value loaded from the configuration file.
 
         """
-        try:
-            del self.value
-        except AttributeError:
-            pass
-
+        self.set(self.defaultvalue)
         baseobj = get_config(self.module, True, rootname=self.rootname)
         secname = baseobj.name
 

--- a/docs/changes/config/17461.perf.rst
+++ b/docs/changes/config/17461.perf.rst
@@ -1,1 +1,0 @@
-Optimize getting config item values.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to close #18138 to unblock astropy v7.1 release. This reverts commit 49765f493c16405ef523762781d3c2972d86ce3b.

* #17461

- [ ] Reopen https://github.com/astropy/astropy/issues/12504

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
