### PR TITLE
Rewrite `Quantity` multiplication and division helpers to be faster

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -234,11 +234,25 @@ def helper_frexp(f, unit):
 
 
 def helper_multiplication(f, unit1, unit2):
-    return [None, None], _d(unit1) * _d(unit2)
+    match unit1, unit2:
+        case None, None:
+            return [None, None], dimensionless_unscaled
+        case (unit, None) | (None, unit):
+            return [None, None], unit
+        case _:
+            return [None, None], unit1 * unit2
 
 
 def helper_division(f, unit1, unit2):
-    return [None, None], _d(unit1) / _d(unit2)
+    if unit1 is unit2:
+        unit = dimensionless_unscaled
+    elif unit1 is None:
+        unit = unit2**-1
+    elif unit2 is None:
+        unit = unit1
+    else:
+        unit = unit1 / unit2
+    return [None, None], unit
 
 
 def helper_power(f, unit1, unit2):


### PR DESCRIPTION
### Description

The rewritten helpers are faster. Setup:
```python
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.2.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can use `%hist` to view history, see the options with `%history?`

In [1]: from astropy import units as u

In [2]: q = 5 * u.m
```
On current `main`:
```python
In [3]: %timeit 3 * q
5.34 μs ± 11.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: %timeit q * 3
5.3 μs ± 27.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [5]: %timeit q * q
9.07 μs ± 81.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [6]: %timeit 3 / q
8.62 μs ± 33.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [7]: %timeit q / 3
5.26 μs ± 19.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [8]: %timeit q / q
8.55 μs ± 31.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
With my patch:
```python
In [3]: %timeit 3 * q
4.69 μs ± 21.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: %timeit q * 3
4.62 μs ± 37.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [5]: %timeit q * q
8.94 μs ± 91.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [6]: %timeit 3 / q
8.28 μs ± 45 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [7]: %timeit q / 3
4.55 μs ± 10.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [8]: %timeit q / q
5.07 μs ± 26 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Note that dividing two `Quantity` instances seems to be much faster now, but that is only the case if they have the same unit. If the units are not the same then there is no significant change in performance (even if the units are equal). 

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
