### PR TITLE
Update Ruff configuration regarding lint rules that can conflict with Ruff formatter

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -38,7 +38,6 @@ lint.ignore = [
     "D104",  # undocumented-public-package
     "D205",  # blank-line-after-summary
     # Quotes Issues
-    "D300",  # triple-single-quotes
     "D301",  # escape-sequence-in-docstring
     # Docstring Content Issues
     "D403",  # first-line-capitalized
@@ -176,9 +175,6 @@ lint.ignore = [
     "TRY004",  # prefer-type-error
     "TRY201",  # verbose-raise
     "TRY301",  # raise-within-try
-
-    # flake8-quotes (Q)
-    "Q000",  # use double quotes
 ]
 lint.unfixable = [
     "E711"  # NoneComparison. Hard to fix b/c numpy has it's own None.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,8 +341,8 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "B008",  # FunctionCallArgumentDefault
 
     # flake8-commas (COM)
-    "COM812",  # TrailingCommaMissing
-    "COM819",  # TrailingCommaProhibited
+    "COM812",  # TrailingCommaMissing, conflicts with Ruff formatter
+    "COM819",  # TrailingCommaProhibited, conflicts with Ruff formatter
 
     # pydocstyle (D)
     # Missing Docstrings
@@ -350,6 +350,8 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "D105",  # Missing docstring in magic method. Don't check b/c class docstring.
     # Whitespace Issues
     "D200",  # FitsOnOneLine
+    # Quotes Issues
+    "D300",  # triple-single-quotes, conflicts with Ruff formatter
     # Docstring Content Issues
     "D410",  # BlankLineAfterSection. Using D412 instead.
     "D400",  # EndsInPeriod.  NOTE: might want to revisit this.
@@ -374,6 +376,9 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 
     # flake8-use-pathlib (PTH)
     "PTH123", # builtin-open (not worth creating a Path object, builtin open is fine)
+
+    # flake8-quotes (Q)
+    "Q000",  # use double quotes, conflicts with Ruff formatter
 
     # flake8-simplify (SIM)
     "SIM103", # needless-bool (cannot be safely applied in all contexts (np.True_ is not True))


### PR DESCRIPTION
### Description

[Ruff has a few lint rules that can conflict with the Ruff formatter.](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules) Two such rules are currently configured to be ignored in `.ruff.toml`, but that file is supposed to be temporary and the rules listed there should either be addressed or moved to the permanent configuration in `pyproject.toml`. Two rules are already configured in `pyproject.toml`, but without an explanation.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
