### PR TITLE
ENH: enable color and suggestion-on-typos in all `argparse` CLIs with CPython >= 3.14

### DIFF
--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -69,6 +69,9 @@ def handle_options(args):
     parser = argparse.ArgumentParser(
         description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
 
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -98,6 +98,9 @@ def handle_options(argv=None):
         epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
 
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -404,6 +404,9 @@ def main(args=None):
     parser = argparse.ArgumentParser(
         description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
 
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"

--- a/astropy/io/fits/scripts/fitsinfo.py
+++ b/astropy/io/fits/scripts/fitsinfo.py
@@ -57,6 +57,10 @@ def main(args=None):
     parser = argparse.ArgumentParser(
         description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
+
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )

--- a/astropy/io/votable/volint.py
+++ b/astropy/io/votable/volint.py
@@ -12,6 +12,10 @@ def main(args=None):
     parser = argparse.ArgumentParser(
         description="Check a VOTable file for compliance to the VOTable specification"
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
+
     parser.add_argument("filename", nargs=1, help="Path to VOTable file to check")
     args = parser.parse_args(args)
 

--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -19,6 +19,9 @@ def hub_script(timeout=0):
     This main function is executed by the ``samp_hub`` command line tool.
     """
     parser = argparse.ArgumentParser(prog="samp_hub " + __version__)
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
 
     parser.add_argument(
         "-k", "--secret", dest="secret", metavar="CODE", help="custom secret code."

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -111,6 +111,9 @@ def main(args=None):
         """
         )
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
 
     addarg = parser.add_argument
     addarg("filename", nargs="+", help="path to one or more files")

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -136,6 +136,10 @@ def main(args=None):
     parser = argparse.ArgumentParser(
         description="Create a bitmap file from a FITS image."
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
+
     # the mutually exclusive groups can be removed when the deprecated
     # min_cut and max_cut are removed
     vmin_group = parser.add_mutually_exclusive_group()

--- a/astropy/wcs/wcslint.py
+++ b/astropy/wcs/wcslint.py
@@ -14,6 +14,10 @@ def main(args=None):
             "Check the WCS keywords in a FITS file for compliance against the standards"
         )
     )
+    # TODO: pass color and suggest_on_error as kwargs when PYTHON_LT_14 is dropped
+    parser.color = True
+    parser.suggest_on_error = True
+
     parser.add_argument("filename", nargs=1, help="Path to FITS file to check")
     args = parser.parse_args(args)
 

--- a/docs/changes/io.fits/18151.feature.rst
+++ b/docs/changes/io.fits/18151.feature.rst
@@ -1,0 +1,2 @@
+Enable color and suggestion-on-typos in all ``argparse`` CLIs for Python 3.14
+(``fitscheck``, ``fitsdiff``, ``fitsheader`` and ``fitsinfo``).

--- a/docs/changes/io.votable/18151.feature.rst
+++ b/docs/changes/io.votable/18151.feature.rst
@@ -1,0 +1,1 @@
+Enable color and suggestion-on-typos in ``volint`` CLI for Python 3.14

--- a/docs/changes/samp/18151.feature.rst
+++ b/docs/changes/samp/18151.feature.rst
@@ -1,0 +1,1 @@
+Enable color and suggestion-on-typos in ``samp_hub`` CLI for Python 3.14

--- a/docs/changes/table/18151.feature.rst
+++ b/docs/changes/table/18151.feature.rst
@@ -1,0 +1,1 @@
+Enable color and suggestion-on-typos in ``showtable`` CLI for Python 3.14

--- a/docs/changes/visualization/18151.feature.rst
+++ b/docs/changes/visualization/18151.feature.rst
@@ -1,0 +1,1 @@
+Enable color and suggestion-on-typos in ``fits2bitmap`` CLI for Python 3.14

--- a/docs/changes/wcs/18151.feature.rst
+++ b/docs/changes/wcs/18151.feature.rst
@@ -1,0 +1,1 @@
+Enable color and suggestion-on-typos in all ``wcslint`` CLI for Python 3.14


### PR DESCRIPTION
### Description

Leverage upcoming `argparse.ArgumentParser` features from Python 3.14 in a backward-compatible (noop) fashion. Setting non-existing attributes may look like a hack, but it's much simpler than wrapping the class initialization into ``if sys.version_info >= (3, 14): ...`` blocks, *and* it's actually the recommended style from the documentation:

see https://docs.python.org/3.14/library/argparse.html#color
and https://docs.python.org/3.14/library/argparse.html#suggest-on-error

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
