### PR TITLE
Ensure SI unit names start with a lowercase letter

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -167,7 +167,7 @@ class FLRW(Cosmology, ScaleFactor, TemperatureCMB, _CriticalDensity, _BaryonComp
     Tcmb0: Parameter = Parameter(
         default=0.0 * u.K,
         doc="Temperature of the CMB at z=0.",
-        unit="Kelvin",
+        unit="K",
         fvalidate="scalar",
     )
     Neff: Parameter = Parameter(

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -225,13 +225,7 @@ def_unit(
 ###########################################################################
 # FREQUENCY
 
-def_unit(
-    ["Hz", "Hertz", "hertz"],
-    1 / s,
-    namespace=_ns,
-    prefixes=True,
-    doc="Frequency",
-)
+def_unit(["Hz", "hertz"], 1 / s, namespace=_ns, prefixes=True, doc="Frequency")
 
 
 ###########################################################################
@@ -279,7 +273,7 @@ def_unit(
 # TEMPERATURE
 
 def_unit(
-    ["K", "Kelvin"],
+    ["K", "kelvin"],
     namespace=_ns,
     prefixes=True,
     doc="Kelvin: temperature with a null point at absolute zero.",
@@ -296,48 +290,28 @@ def_unit(
 # FORCE
 
 def_unit(
-    ["N", "Newton", "newton"],
-    kg * m * s**-2,
-    namespace=_ns,
-    prefixes=True,
-    doc="Newton: force",
+    ["N", "newton"], kg * m * s**-2, namespace=_ns, prefixes=True, doc="Newton: force"
 )
 
 
 ##########################################################################
 # ENERGY
 
-def_unit(
-    ["J", "Joule", "joule"],
-    N * m,
-    namespace=_ns,
-    prefixes=True,
-    doc="Joule: energy",
-)
+def_unit(["J", "joule"], N * m, namespace=_ns, prefixes=True, doc="Joule: energy")
 
 
 ##########################################################################
 # PRESSURE
 
 def_unit(
-    ["Pa", "Pascal", "pascal"],
-    J * m**-3,
-    namespace=_ns,
-    prefixes=True,
-    doc="Pascal: pressure",
+    ["Pa", "pascal"], J * m**-3, namespace=_ns, prefixes=True, doc="Pascal: pressure"
 )
 
 
 ###########################################################################
 # POWER
 
-def_unit(
-    ["W", "Watt", "watt"],
-    J / s,
-    namespace=_ns,
-    prefixes=True,
-    doc="Watt: power",
-)
+def_unit(["W", "watt"], J / s, namespace=_ns, prefixes=True, doc="Watt: power")
 
 
 ###########################################################################
@@ -357,7 +331,7 @@ def_unit(
     doc="coulomb: electric charge",
 )
 def_unit(
-    ["V", "Volt", "volt"],
+    ["V", "volt"],
     J * C**-1,
     namespace=_ns,
     prefixes=True,
@@ -372,14 +346,14 @@ def_unit(
     format={"latex": r"\Omega", "ogip": "ohm", "unicode": "Ω"},
 )
 def_unit(
-    ["S", "Siemens", "siemens"],
+    ["S", "siemens"],
     A * V**-1,
     namespace=_ns,
     prefixes=True,
     doc="Siemens: electrical conductance",
 )
 def_unit(
-    ["F", "Farad", "farad"],
+    ["F", "farad"],
     C * V**-1,
     namespace=_ns,
     prefixes=True,
@@ -391,25 +365,17 @@ def_unit(
 # MAGNETIC
 
 def_unit(
-    ["Wb", "Weber", "weber"],
-    V * s,
-    namespace=_ns,
-    prefixes=True,
-    doc="Weber: magnetic flux",
+    ["Wb", "weber"], V * s, namespace=_ns, prefixes=True, doc="Weber: magnetic flux"
 )
 def_unit(
-    ["T", "Tesla", "tesla"],
+    ["T", "tesla"],
     Wb * m**-2,
     namespace=_ns,
     prefixes=True,
     doc="Tesla: magnetic flux density",
 )
 def_unit(
-    ["H", "Henry", "henry"],
-    Wb * A**-1,
-    namespace=_ns,
-    prefixes=True,
-    doc="Henry: inductance",
+    ["H", "henry"], Wb * A**-1, namespace=_ns, prefixes=True, doc="Henry: inductance"
 )
 
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -980,11 +980,11 @@ def test_pprint():
     pprint_class = u.UnitBase.EquivalentUnitsList
     equiv_units_to_Hz = u.Hz.find_equivalent_units()
     assert pprint_class.__repr__(equiv_units_to_Hz).splitlines() == [
-        "  Primary name | Unit definition | Aliases     ",
+        "  Primary name | Unit definition | Aliases  ",
         "[",
-        "  Bq           | 1 / s           | becquerel    ,",
-        "  Ci           | 3.7e+10 / s     | curie        ,",
-        "  Hz           | 1 / s           | Hertz, hertz ,",
+        "  Bq           | 1 / s           | becquerel ,",
+        "  Ci           | 3.7e+10 / s     | curie     ,",
+        "  Hz           | 1 / s           | hertz     ,",
         "]",
     ]
     assert (
@@ -993,7 +993,7 @@ def test_pprint():
         "<th>Aliases</th></tr>"
         "<tr><td>Bq</td><td>1 / s</td><td>becquerel</td></tr>"
         "<tr><td>Ci</td><td>3.7e+10 / s</td><td>curie</td></tr>"
-        "<tr><td>Hz</td><td>1 / s</td><td>Hertz, hertz</td></tr></table>"
+        "<tr><td>Hz</td><td>1 / s</td><td>hertz</td></tr></table>"
     )
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -775,7 +775,7 @@ def test_vounit_unknown():
 
 
 def test_vounit_details():
-    assert u.Unit("Pa", format="vounit") is u.Pascal
+    assert u.Unit("Pa", format="vounit") is u.pascal
     assert u.Unit("ka", format="vounit") == u.Unit("1000 yr")
     assert u.Unit("pix", format="vounit") == u.Unit("pixel", format="vounit")
 

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -92,7 +92,7 @@ def test_wrong_unit(x_input, y_input):
             f"convertible to '{str(y_target)}'."
         ),
     ):
-        x, y = myfunc_args(1 * x_unit, 100 * u.Joule)  # has to be an unspecified unit
+        x, y = myfunc_args(1 * x_unit, 100 * u.joule)  # has to be an unspecified unit
 
 
 def test_wrong_unit_annotated(x_input, y_input):
@@ -104,7 +104,7 @@ def test_wrong_unit_annotated(x_input, y_input):
         return x, y
 
     with pytest.raises(u.UnitsError, match="Argument 'y' to function 'myfunc_args'"):
-        x, y = myfunc_args(1 * x_unit, 100 * u.Joule)  # has to be an unspecified unit
+        x, y = myfunc_args(1 * x_unit, 100 * u.joule)  # has to be an unspecified unit
 
 
 def test_not_quantity(x_input, y_input):
@@ -194,7 +194,7 @@ def test_kwarg_wrong_unit(x_input, y_input):
             f"convertible to '{str(y_target)}'."
         ),
     ):
-        x, y = myfunc_args(1 * x_unit, y=100 * u.Joule)
+        x, y = myfunc_args(1 * x_unit, y=100 * u.joule)
 
 
 def test_kwarg_not_quantity(x_input, y_input):

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -663,9 +663,9 @@ the standard set::
   >>> u.Hz.find_equivalent_units()
     Primary name | Unit definition | Aliases
   [
-    Bq           | 1 / s           | becquerel    ,
-    Ci           | 3.7e+10 / s    | curie        ,
-    Hz           | 1 / s           | Hertz, hertz ,
+    Bq           | 1 / s           | becquerel ,
+    Ci           | 3.7e+10 / s     | curie     ,
+    Hz           | 1 / s           | hertz     ,
   ]
 
 However, when passing the spectral equivalency, you can see there are
@@ -678,8 +678,8 @@ all kinds of things that ``Hz`` can be converted to::
     Angstrom     | 1e-10 m                | AA, angstrom, Å                  ,
     Bq           | 1 / s                  | becquerel                        ,
     Ci           | 3.7e+10 / s            | curie                            ,
-    Hz           | 1 / s                  | Hertz, hertz                     ,
-    J            | m2 kg / s2             | Joule, joule                     ,
+    Hz           | 1 / s                  | hertz                            ,
+    J            | m2 kg / s2             | joule                            ,
     Ry           | 2.17987e-18 m2 kg / s2 | rydberg                          ,
     cm           | 0.01 m                 | centimeter                       ,
     eV           | 1.60218e-19 m2 kg / s2 | electronvolt                     ,


### PR DESCRIPTION
### Description

Section 5.3 of the official [SI brochure](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf) says:

> In English, the names of units start with a lower-case letter (even when the symbol for the unit begins with a capital letter), ...

`astropy.units.si` is already following that guideline for some units (e.g. the coulomb or the curie), but for others it has defined names with both lowercase and uppercase first letters. Here I am removing the names of the SI units with uppercase first letters with three exceptions:
- `Angstrom` is not an SI unit at all, so it would be best to move its definition to a different file entirely,
- `Celsius` should really be named `degrees_Celsius`, the name `celsius` is not recommended anywhere (this is explicitly discussed in the aforementioned SI brochure Section 5.3),
- the SI symbol for the ohm is Ω, so Ohm is often used as an ASCII-compatible symbol instead. Keeping it as an alternative name for the unit might therefore be justified.

With the changes here `len(si.__all__)` is 2197, whereas on the current `main` it is 2483.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
