### PR TITLE
DOC: add missing changelog entry for manylinux update

### DIFF
--- a/docs/changes/18374.other.rst
+++ b/docs/changes/18374.other.rst
@@ -1,0 +1,2 @@
+Pre-built binaries (wheels) for Linux are now built using the ``manylinux_2_28``
+image (previously, ``manylinux2014`` was used).


### PR DESCRIPTION
### Update

Now a change log for #18374

### Description
cibuildwheel's next version is set for some breaking changes. Even though I don't think anything on the changelog affects us, I want to try the beta out, out of an excess of caution. 

labeling with "Python 3.14" because this upgrade will be necessary to enable `cp314` wheels.
xref: https://github.com/OpenAstronomy/github-actions-workflows/pull/278
changelog: https://cibuildwheel.pypa.io/en/latest/changelog/#v300b1


ref #18187

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
