### PR TITLE
Drop support for `numpy` < 1.24

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -44,7 +44,6 @@ from astropy.units.core import dimensionless_unscaled
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.utils.compat import (
     COPY_IF_NEEDED,
-    NUMPY_LT_1_24,
     NUMPY_LT_2_0,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
@@ -1079,51 +1078,6 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     )
 
 
-if NUMPY_LT_1_24:
-
-    @function_helper(helps={np.histogram})
-    def histogram_pre_1_24(
-        a, bins=10, range=None, normed=None, weights=None, density=None
-    ):
-        args, kwargs, unit, out = histogram(
-            a, bins=bins, range=range, weights=weights, density=density or normed
-        )
-        kwargs["normed"] = normed
-        kwargs["density"] = density
-        return args, kwargs, unit, out
-
-    @function_helper(helps={np.histogram2d})
-    def histogram2d_pre_1_24(
-        x, y, bins=10, range=None, normed=None, weights=None, density=None
-    ):
-        args, kwargs, unit, out = histogram2d(
-            x,
-            y,
-            bins=bins,
-            range=range,
-            weights=weights,
-            density=density or normed,
-        )
-        kwargs["normed"] = normed
-        kwargs["density"] = density
-        return args, kwargs, unit, out
-
-    @function_helper(helps={np.histogramdd})
-    def histogramdd_pre_1_24(
-        sample, bins=10, range=None, normed=None, weights=None, density=None
-    ):
-        args, kwargs, unit, out = histogramdd(
-            sample,
-            bins=bins,
-            range=range,
-            weights=weights,
-            density=density or normed,
-        )
-        kwargs["normed"] = normed
-        kwargs["density"] = density
-        return args, kwargs, unit, out
-
-
 @function_helper
 def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     a = _as_quantity(a)
@@ -1204,9 +1158,11 @@ def unique(
     return_inverse=False,
     return_counts=False,
     axis=None,
+    *,
+    equal_nan=True,
     **kwargs,
 ):
-    # having **kwargs allows to support equal_nan (for not NUMPY_LT_1_24) without
+    # having **kwargs allows to support sorted (for not NUMPY_LT_2_3) without
     # introducing it pre-maturely in older supported numpy versions
     unit = ar.unit
     n_index = sum(bool(i) for i in (return_index, return_inverse, return_counts))
@@ -1215,7 +1171,7 @@ def unique(
 
     return (
         (ar.value, return_index, return_inverse, return_counts, axis),
-        kwargs,
+        kwargs | {"equal_nan": equal_nan},
         unit,
         None,
     )

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -12,8 +12,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_24
-
 from .core import UNITY, Unit, UnitBase
 
 if TYPE_CHECKING:
@@ -246,11 +244,7 @@ class StructuredUnit:
             If given, should be a subclass of `~numpy.void`. By default,
             will return a new `~astropy.units.StructuredUnit` instance.
         """
-        applied = tuple(func(part) for part in self.values())
-        if NUMPY_LT_1_24:
-            results = np.array(applied, self._units.dtype)[()]
-        else:
-            results = np.void(applied, self._units.dtype)
+        results = np.void(tuple(map(func, self.values())), self._units.dtype)
         if cls is not None:
             return results.view((cls, results.dtype))
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -23,13 +23,7 @@ from astropy.units.quantity_helper.function_helpers import (
     TBD_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
-from astropy.utils.compat import (
-    NUMPY_LT_1_24,
-    NUMPY_LT_1_25,
-    NUMPY_LT_2_0,
-    NUMPY_LT_2_1,
-    NUMPY_LT_2_2,
-)
+from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
 
 if TYPE_CHECKING:
     from types import FunctionType, ModuleType
@@ -2036,9 +2030,10 @@ class TestSortFunctions(InvariantUnitTestSetup):
     def test_sort_axis(self):
         self.check(np.sort, axis=0)
 
-    @pytest.mark.skipif(not NUMPY_LT_1_24, reason="np.msort is deprecated")
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
     def test_msort(self):
-        self.check(np.msort)
+        with pytest.warns(DeprecationWarning):
+            self.check(np.msort)
 
     @needs_array_function
     def test_sort_complex(self):

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,6 @@ from astropy.utils import minversion
 
 __all__ = [
     "COPY_IF_NEEDED",
-    "NUMPY_LT_1_24",
     "NUMPY_LT_1_25",
     "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
@@ -22,7 +21,6 @@ __all__ = [
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_24 = not minversion(np, "1.24")
 NUMPY_LT_1_25 = not minversion(np, "1.25")
 NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0")

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -15,7 +15,7 @@ import warnings
 import numpy as np
 
 from astropy.units.quantity_helper.function_helpers import FunctionAssigner
-from astropy.utils.compat import NUMPY_LT_1_24, NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
+from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
 
 if NUMPY_LT_2_0:
     import numpy.core as np_core
@@ -571,11 +571,9 @@ if NUMPY_LT_2_0:
 
     @dispatched_function
     def msort(a):
-        if not NUMPY_LT_1_24:
-            warnings.warn(
-                "msort is deprecated, use np.sort(a, axis=0) instead",
-                DeprecationWarning,
-            )
+        warnings.warn(
+            "msort is deprecated, use np.sort(a, axis=0) instead", DeprecationWarning
+        )
         result = a.copy()
         result.sort(axis=0)
         return result, None, None
@@ -749,27 +747,14 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     if out is not None and not isinstance(out, Masked):
         raise NotImplementedError
 
-    a = Masked(a)
-
-    if NUMPY_LT_1_24:
-        r, k = _ureduce(
-            a,
-            func=_masked_median,
-            axis=axis,
-            out=out,
-            overwrite_input=overwrite_input,
-        )
-        result = (r.reshape(k) if keepdims else r) if out is None else out
-
-    else:
-        result = _ureduce(
-            a,
-            func=_masked_median,
-            axis=axis,
-            out=out,
-            overwrite_input=overwrite_input,
-            keepdims=keepdims,
-        )
+    result = _ureduce(
+        Masked(a),
+        func=_masked_median,
+        axis=axis,
+        out=out,
+        overwrite_input=overwrite_input,
+        keepdims=keepdims,
+    )
     return result, None, None
 
 
@@ -832,36 +817,7 @@ def _preprocess_quantile(a, q, axis=None, out=None, **kwargs):
     return a, q, axis, out, kwargs
 
 
-if NUMPY_LT_1_24:
-
-    @dispatched_function
-    def quantile(
-        a,
-        q,
-        axis=None,
-        out=None,
-        overwrite_input=False,
-        method="linear",
-        keepdims=False,
-        *,
-        interpolation=None,
-    ):
-        a, q, axis, out, kwargs = _preprocess_quantile(
-            a,
-            q,
-            axis,
-            out,
-            overwrite_input=overwrite_input,
-            method=method,
-            keepdims=keepdims,
-            interpolation=interpolation,
-        )
-        keepdims = kwargs.pop("keepdims", False)
-        r, k = _ureduce(a, func=_masked_quantile, q=q, axis=axis, out=out, **kwargs)
-        result = (r.reshape(q.shape + k) if keepdims else r) if out is None else out
-        return result, None, None
-
-elif NUMPY_LT_2_0:
+if NUMPY_LT_2_0:
 
     @dispatched_function
     def quantile(
@@ -1446,33 +1402,18 @@ def _copy_of_mask(a):
     return mask.copy() if mask is not None else False
 
 
-if NUMPY_LT_1_24:  # "kind" argument introduced in 1.24.
+@dispatched_function
+def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
+    mask = _copy_of_mask(ar1).ravel()
+    return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
 
-    @dispatched_function
-    def in1d(ar1, ar2, assume_unique=False, invert=False):
-        mask = _copy_of_mask(ar1).ravel()
-        return _in1d(ar1, ar2, assume_unique, invert), mask, None
 
-    @dispatched_function
-    def isin(element, test_elements, assume_unique=False, invert=False):
-        element = np.asanyarray(element)
-        result = _in1d(element, test_elements, assume_unique, invert)
-        result.shape = element.shape
-        return result, _copy_of_mask(element), None
-
-else:
-
-    @dispatched_function
-    def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
-        mask = _copy_of_mask(ar1).ravel()
-        return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
-
-    @dispatched_function
-    def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
-        element = np.asanyarray(element)
-        result = _in1d(element, test_elements, assume_unique, invert, kind=kind)
-        result.shape = element.shape
-        return result, _copy_of_mask(element), None
+@dispatched_function
+def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
+    element = np.asanyarray(element)
+    result = _in1d(element, test_elements, assume_unique, invert, kind=kind)
+    result.shape = element.shape
+    return result, _copy_of_mask(element), None
 
 
 @dispatched_function

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -11,7 +11,6 @@ TODO: finish full coverage (see also `~astropy.utils.masked.function_helpers`)
 
 """
 
-import contextlib
 import itertools
 
 import numpy as np
@@ -24,13 +23,7 @@ from astropy.units.tests.test_quantity_non_ufuncs import (
     get_covered_functions,
     get_wrapped_functions,
 )
-from astropy.utils.compat import (
-    NUMPY_LT_1_24,
-    NUMPY_LT_1_25,
-    NUMPY_LT_2_0,
-    NUMPY_LT_2_1,
-    NUMPY_LT_2_2,
-)
+from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
     APPLY_TO_BOTH_FUNCTIONS,
@@ -1272,11 +1265,7 @@ class TestSortFunctions(MaskedArraySetup):
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
     def test_msort(self):
-        with (
-            contextlib.nullcontext()
-            if NUMPY_LT_1_24
-            else pytest.warns(DeprecationWarning, match="msort is deprecated")
-        ):
+        with pytest.warns(DeprecationWarning, match="msort is deprecated"):
             o = np.msort(self.ma)
         expected = np.sort(self.ma, axis=0)
         assert_masked_equal(o, expected)
@@ -1708,7 +1697,6 @@ class TestArraySetOps:
         assert_masked_equal(np.in1d(Masked([]), []), Masked([]))  # noqa: NPY201
         assert_masked_equal(np.in1d(Masked([]), [], invert=True), Masked([]))  # noqa: NPY201
 
-    @pytest.mark.skipif(NUMPY_LT_1_24, reason="kind introduced in numpy 1.24")
     def test_in1d_kind_table_error(self):
         with pytest.raises(ValueError, match="'table' method is not supported"):
             np.in1d(Masked([1, 2, 3]), [4, 5], kind="table")  # noqa: NPY201

--- a/docs/changes/18160.other.rst
+++ b/docs/changes/18160.other.rst
@@ -1,0 +1,1 @@
+The minimum required NumPy version is now 1.24.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=1.23.2",
+    "numpy>=1.24",
     "pyerfa>=2.0.1.1",
     "astropy-iers-data>=0.2025.4.28.0.37.27",
     "PyYAML>=6.0.0",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ ext_modules = get_extensions()
 # Specify the minimum version for the Numpy C-API
 for ext in ext_modules:
     if ext.include_dirs and "numpy" in ext.include_dirs[0]:
-        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_23_API_VERSION"))
+        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_24_API_VERSION"))
         ext.define_macros.append(("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"))
 
 setup(ext_modules=ext_modules)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy124,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -50,7 +50,6 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of direct dependencies
     cov: and test coverage
-    numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
     image: with image tests
@@ -60,7 +59,6 @@ description =
     noscipy: without scipy-dev
 
 deps =
-    numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
 


### PR DESCRIPTION
### Description

According to [SPEC 0](https://scientific-python.org/specs/spec-0000/) we do not have to support `numpy` 1.23 or 1.24 anymore. Removing compatibility code for those versions simplifies our codebase.

SPEC 0 also recommends dropping support for `numpy` 1.25 starting from June 2025. It's not June yet, but `astropy` 7.2 will not be released in May, so we could drop support for `numpy` 1.25 on `main` already. I haven't done that here yet, but if reviewers would like that then it would be simple enough to add one more commit.

EDIT: I ended up dropping support only for `numpy` 1.23 here.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
