### PR TITLE
Drop support for `matplotlib` < 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ workflows:
           matrix:
             parameters:
               jobname:
-                - "py311-test-image-mpl360-cov"
+                - "py311-test-image-mpl380-cov"
                 - "py311-test-image-mpldev-cov"
 
       - deploy-reference-images:
@@ -94,7 +94,7 @@ workflows:
           matrix:
             parameters:
               jobname:
-                - "py311-test-image-mpl360-cov"
+                - "py311-test-image-mpl380-cov"
                 - "py311-test-image-mpldev-cov"
           requires:
             - << matrix.jobname >>

--- a/astropy/tests/figures/py311-test-image-mpl380-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpl380-cov.json
@@ -9,7 +9,7 @@
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axisbelow[True]": "5364e39cab14f28b08073b31cce3dae8501c0431b1a49985810b764902747c8e",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axisbelow[False]": "ee1e46856a19ba472ae9ea4588c614fbbd1b3a4a0787ef40e33f991a8f79d6c0",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_axisbelow[line]": "516c3882bbaa31a0d241eec2c70aca45b27b44929662371718b10025735db772",
-  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contour_overlay": "44fd1a202f8baa894a289bac150b3b0eda9b069a06fc8f49ce14d77e743481e0",
+  "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contour_overlay": "8679305e8a8b5b3f5b896343f4e16dfc65e9289c31505e3b35ef773d7837c8ea",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_contourf_overlay": "fa928ab57291e8a128009320323ffb8955cd75d28b2a589074defb7b0889b3eb",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_overlay_features_image": "30d5562cb7a2484db0b898bc886253829de884fbf92bc0e6575f091438ec5f32",
   "astropy.visualization.wcsaxes.tests.test_images.TestBasic.test_curvilinear_grid_patches_image": "ad0a985a324a73b5bea839a231f7537075306c874c279c6a6ea2cfe16529d815",

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1601,11 +1601,6 @@ class TestMaskedQuantityInteractionWithNumpyMA(
 
 @pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib.pyplot")
 def test_plt_scatter_masked():
-    from astropy.visualization.wcsaxes.utils import MATPLOTLIB_LT_3_8
-
-    if MATPLOTLIB_LT_3_8:
-        pytest.skip("never worked before matplotlib 3.8")
-
     # check that plotting Masked data doesn't raise an exception
     # see https://github.com/astropy/astropy/issues/12481
     import matplotlib.pyplot as plt

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -22,7 +22,6 @@ from .frame import EllipticalFrame, RectangularFrame1D
 from .grid_paths import get_gridline_path, get_lon_lat_path
 from .ticklabels import TickLabels
 from .ticks import Ticks
-from .utils import MATPLOTLIB_LT_3_8
 
 __all__ = ["CoordinateHelper"]
 
@@ -859,13 +858,8 @@ class CoordinateHelper:
                     p.draw(renderer)
 
             elif self._grid is not None:
-                if MATPLOTLIB_LT_3_8:
-                    for line in self._grid.collections:
-                        line.set(**self._grid_lines_kwargs)
-                        line.draw(renderer)
-                else:
-                    self._grid.set(**self._grid_lines_kwargs)
-                    self._grid.draw(renderer)
+                self._grid.set(**self._grid_lines_kwargs)
+                self._grid.draw(renderer)
 
         renderer.close_group("grid lines")
 
@@ -1372,11 +1366,7 @@ class CoordinateHelper:
 
     def _clear_grid_contour(self):
         if hasattr(self, "_grid") and self._grid:
-            if MATPLOTLIB_LT_3_8:
-                for line in self._grid.collections:
-                    line.remove()
-            else:
-                self._grid.remove()
+            self._grid.remove()
 
     def _update_grid_contour(self):
         if self.coord_index is None:

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import warnings
-from contextlib import nullcontext
 
 import matplotlib as mpl
 import numpy as np
@@ -32,8 +31,6 @@ FREETYPE_261 = ft_version == Version("2.6.1")
 # We cannot use matplotlib.checkdep_usetex() anymore, see
 # https://github.com/matplotlib/matplotlib/issues/23244
 TEX_UNAVAILABLE = True
-
-MATPLOTLIB_LT_3_7 = Version(mpl.__version__) < Version("3.7")
 
 
 def test_grid_regression(ignore_matplotlibrc):
@@ -341,16 +338,7 @@ def test_contour_empty():
     fig = Figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
-
-    if MATPLOTLIB_LT_3_7:
-        ctx = pytest.warns(
-            UserWarning, match="No contour levels were found within the data range"
-        )
-    else:
-        ctx = nullcontext()
-
-    with ctx:
-        ax.contour(np.zeros((4, 4)), transform=ax.get_transform("world"))
+    ax.contour(np.zeros((4, 4)), transform=ax.get_transform("world"))
 
 
 def test_iterate_coords(ignore_matplotlibrc):

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -1,10 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import matplotlib as mpl
 import numpy as np
 
 from astropy import units as u
 from astropy.coordinates import BaseCoordinateFrame, UnitSphericalRepresentation
-from astropy.utils.introspection import minversion
 
 __all__ = [
     "select_step_degree",
@@ -12,8 +10,6 @@ __all__ = [
     "select_step_scalar",
     "transform_contour_set_inplace",
 ]
-
-MATPLOTLIB_LT_3_8 = not minversion(mpl, "3.8")
 
 
 def select_step_degree(dv):
@@ -138,29 +134,15 @@ def transform_contour_set_inplace(cset, transform):
     all_paths = []
     pos_level = []
     pos_segments = []
-
-    if MATPLOTLIB_LT_3_8:
-        for collection in cset.collections:
-            paths = collection.get_paths()
-            if len(paths) == 0:
-                continue
-            all_paths.append(paths)
-            # The last item in pos isn't needed for np.split and in fact causes
-            # issues if we keep it because it will cause an extra empty array to be
-            # returned.
-            pos = np.cumsum([len(x) for x in paths])
-            pos_segments.append(pos[:-1])
-            pos_level.append(pos[-1])
-    else:
-        paths = cset.get_paths()
-        if len(paths) > 0:
-            all_paths.append(paths)
-            # The last item in pos isn't needed for np.split and in fact causes
-            # issues if we keep it because it will cause an extra empty array to be
-            # returned.
-            pos = np.cumsum([len(x) for x in paths])
-            pos_segments.append(pos[:-1])
-            pos_level.append(pos[-1])
+    paths = cset.get_paths()
+    if len(paths) > 0:
+        all_paths.append(paths)
+        # The last item in pos isn't needed for np.split and in fact causes
+        # issues if we keep it because it will cause an extra empty array to be
+        # returned.
+        pos = np.cumsum([len(x) for x in paths])
+        pos_segments.append(pos[:-1])
+        pos_level.append(pos[-1])
 
     # As above the last item isn't needed
     pos_level = np.cumsum(pos_level)[:-1]

--- a/docs/changes/18164.other.rst
+++ b/docs/changes/18164.other.rst
@@ -1,0 +1,1 @@
+The minimum required Matplotlib version is now 3.8.0.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -680,7 +680,7 @@ hashes and images.
 
 To run the Astropy tests with the image comparison, use e.g.::
 
-    tox -e py311-test-image-mpl360-cov
+    tox -e py311-test-image-mpl380-cov
 
 However, note that the output can be sensitive to the operating system and
 specific version of libraries such as freetype. In general, using tox will
@@ -745,7 +745,7 @@ generate it, you should run the tests the first time with::
 
 for example::
 
-    tox -e py311-test-image-mpl360-cov -- --mpl-generate-hash-library=astropy/tests/figures/py311-test-image-mpl360-cov.json
+    tox -e py311-test-image-mpl380-cov -- --mpl-generate-hash-library=astropy/tests/figures/py311-test-image-mpl380-cov.json
 
 Then add and commit the new JSON file and try running the tests again. The tests
 may fail in the continuous integration if e.g. the freetype version does not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 # Recommended run-time dependencies to enable a lot of functionality within Astropy.
 recommended = [
     "scipy>=1.9.2",
-    "matplotlib>=3.6.0",
+    "matplotlib>=3.8.0",
 ]
 # Optional IPython-related behavior is in many places in Astropy. IPython is a complex
 # dependency that occasionally requires pinning one of it's upstream dependencies. If
@@ -599,9 +599,9 @@ ignore = [
         type_incorrect_long = "The changelog file you added is not one of the allowed types. Please use one of the types described in the changelog [README](https://github.com/astropy/astropy/blob/main/docs/changes/README.rst)"
         number_incorrect_long = "The number in the changelog file you added does not match the number of this pull request. Please rename the file."
 
-    [tool.gilesbot.circleci_artifacts.py311-test-image-mpl360]
-        url = ".tmp/py311-test-image-mpl360/results/fig_comparison.html"
-        message = "Click details to see the figure test comparisons, for py311-test-image-mpl360."
+    [tool.gilesbot.circleci_artifacts.py311-test-image-mpl380]
+        url = ".tmp/py311-test-image-mpl380/results/fig_comparison.html"
+        message = "Click details to see the figure test comparisons, for py311-test-image-mpl380."
         report_on_fail = true
 
     [tool.gilesbot.circleci_artifacts.py311-test-image-mpldev]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{311,312,313,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl360}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy123,-numpy124,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
-    py311-test-image-mpl360-cov
+    py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
     build_docs
     linkcheck
@@ -54,7 +54,7 @@ description =
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
     image: with image tests
-    mpl360: with matplotlib 3.6.0
+    mpl380: with matplotlib 3.8.0
     mpldev: with the latest developer version of matplotlib
     double: twice in a row to check for global state changes
     noscipy: without scipy-dev
@@ -64,9 +64,7 @@ deps =
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
 
-    mpl360: matplotlib==3.6.0
-    # mpl 3.6.0 isn't compatible with numpy 2.0 but didn't include a pin
-    mpl360: numpy<2.0
+    mpl380: matplotlib==3.8.0
 
     image: latex
     image, devinfra: scipy


### PR DESCRIPTION
### Description

[SPEC 0](https://scientific-python.org/specs/spec-0000/) allows us to drop support for `matplotlib` < 3.8. Doing so lets us remove some compatibility code. Furthermore, this will simplify updating our `numpy` requirement, which will allow us to remove even more compatibility code.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
