### PR TITLE
SAMPHubServer._call_and_wait raises a new SAMPProxyTimeout (derived f…

### DIFF
--- a/astropy/samp/errors.py
+++ b/astropy/samp/errors.py
@@ -32,3 +32,9 @@ class SAMPProxyError(xmlrpc.Fault):
     """
     SAMP Proxy Hub exception.
     """
+
+
+class SAMPProxyTimeoutError(SAMPProxyError):
+    """
+    SAMP Proxy Hub timeout exception.
+    """

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -16,7 +16,7 @@ from urllib.parse import urlunparse
 from astropy import log
 
 from .constants import SAMP_STATUS_OK, __profile_version__
-from .errors import SAMPHubError, SAMPProxyError, SAMPWarning
+from .errors import SAMPHubError, SAMPProxyError, SAMPProxyTimeoutError, SAMPWarning
 from .lockfile_helpers import create_lock_file, read_lockfile
 from .standard_profile import ThreadingXMLRPCServer
 from .utils import ServerProxyPool, _HubAsClient, internet_on
@@ -1207,7 +1207,7 @@ class SAMPHubServer:
             while self._is_running:
                 if 0 < timeout <= time.time() - now:
                     del self._sync_msg_ids_heap[msg_id]
-                    raise SAMPProxyError(1, "Timeout expired!")
+                    raise SAMPProxyTimeoutError(1, "Timeout expired!")
 
                 if self._sync_msg_ids_heap[msg_id] is not None:
                     response = copy.deepcopy(self._sync_msg_ids_heap[msg_id])

--- a/docs/changes/samp/18169.bugfix.rst
+++ b/docs/changes/samp/18169.bugfix.rst
@@ -1,3 +1,2 @@
 ``SAMPHubServer._call_and_wait`` raises a new ``SAMPProxyTimeoutError`` (derived from ``SAMPProxyError``) exception on timeout.
 This allows client code to more easily distinguish timeouts from other kind of exceptions.
-

--- a/docs/changes/samp/18169.bugfix.rst
+++ b/docs/changes/samp/18169.bugfix.rst
@@ -1,0 +1,3 @@
+``SAMPHubServer._call_and_wait`` raises a new ``SAMPProxyTimeoutError`` (derived from ``SAMPProxyError``) exception on timeout.
+This allows client code to more easily distinguish timeouts from other kind of exceptions.
+


### PR DESCRIPTION
SAMPHubServer._call_and_wait raises a new SAMPProxyTimeout (derived from SAMPProxyError) exception on timeout.

This allows client code to more easily distinguish timeouts from other kind of exceptions.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/astropy/astropy/issues/18154

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
