### PR TITLE
Stop hiding `numpy.msort()` deprecation warnings with `Masked` arrays

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -571,6 +571,11 @@ if NUMPY_LT_2_0:
 
     @dispatched_function
     def msort(a):
+        if not NUMPY_LT_1_24:
+            warnings.warn(
+                "msort is deprecated, use np.sort(a, axis=0) instead",
+                DeprecationWarning,
+            )
         result = a.copy()
         result.sort(axis=0)
         return result, None, None

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1271,10 +1271,6 @@ class TestSortFunctions(MaskedArraySetup):
         assert_masked_equal(o, expected)
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
-    @pytest.mark.xfail(
-        condition=not NUMPY_LT_1_24,
-        reason="astropy erroneously hides an upstream deprecation message",
-    )
     def test_msort(self):
         with (
             contextlib.nullcontext()

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -11,6 +11,7 @@ TODO: finish full coverage (see also `~astropy.utils.masked.function_helpers`)
 
 """
 
+import contextlib
 import itertools
 
 import numpy as np
@@ -1269,9 +1270,18 @@ class TestSortFunctions(MaskedArraySetup):
         expected = ma[np.lexsort((ma.unmasked.imag, ma.unmasked.real, ma.mask))]
         assert_masked_equal(o, expected)
 
-    @pytest.mark.skipif(not NUMPY_LT_1_24, reason="np.msort is deprecated")
+    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
+    @pytest.mark.xfail(
+        condition=not NUMPY_LT_1_24,
+        reason="astropy erroneously hides an upstream deprecation message",
+    )
     def test_msort(self):
-        o = np.msort(self.ma)
+        with (
+            contextlib.nullcontext()
+            if NUMPY_LT_1_24
+            else pytest.warns(DeprecationWarning, match="msort is deprecated")
+        ):
+            o = np.msort(self.ma)
         expected = np.sort(self.ma, axis=0)
         assert_masked_equal(o, expected)
 

--- a/docs/changes/utils/18173.bugfix.rst
+++ b/docs/changes/utils/18173.bugfix.rst
@@ -1,0 +1,3 @@
+If ``numpy.msort()`` is called with a ``Masked`` array then ``astropy`` no
+longer erroneously hides the deprecation warning (with ``numpy`` versions
+1.24-1.26).


### PR DESCRIPTION
### Description

`numpy.msort()` was [deprecated in 1.24](https://numpy.org/doc/1.24/release/1.24.0-notes.html#deprecate-msort) and [removed in 2.0](https://numpy.org/doc/2.0/release/2.0.0-notes.html#expired-deprecations), but despite that no warnings are emitted if the function is called with a `Masked` array. The first commit here reveals the bug, the second fixes it.

The reason this went unnoticed was that the function that checks `np.msort()` with a `Masked` array is skipped entirely unless the installed `numpy` version is <1.24, where the function was not deprecated. We do have machinery that tries to check for the completeness of relevant tests, but that machinery only checks that an appropriate test function exists, not that it is called (which also has the charming consequence that removing a test that is always skipped can cause other tests to fail).

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
