### PR TITLE
Remove an obsolete private API test from `units`

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1013,33 +1013,6 @@ def test_enable_unit_groupings():
         assert imperial.inch in u.m.find_equivalent_units()
 
 
-def test_unit_summary_prefixes():
-    """
-    Test for a few units that the unit summary table correctly reports
-    whether or not that unit supports prefixes.
-
-    Regression test for https://github.com/astropy/astropy/issues/3835
-    """
-
-    from astropy.units import astrophys
-
-    for summary in utils._iter_unit_summary(astrophys.__dict__):
-        unit, _, _, _, prefixes = summary
-
-        if unit.name == "lyr":
-            assert prefixes
-        elif unit.name == "pc":
-            assert prefixes
-        elif unit.name == "barn":
-            assert prefixes
-        elif unit.name == "cycle":
-            assert prefixes == "No"
-        elif unit.name == "spat":
-            assert prefixes == "No"
-        elif unit.name == "vox":
-            assert prefixes == "Yes"
-
-
 def test_raise_to_negative_power():
     """Test that order of bases is changed when raising to negative power.
 


### PR DESCRIPTION
### Description

I found a test that is explicitly testing private API. Such tests cause needless problems for refactoring (would you like to guess how I found this one?). Testing public API is much more valuable. If some piece of code cannot be triggered through the public API then it is dead code that can be safely removed. In this particular case rewriting the test to make use of public API would essentially duplicate tests added in af437e9e0a98ba6b7e2bfce2c068ba91a180399f, so it's best to remove the test entirely.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
