### PR TITLE
TST: globally filter out a harmless deprecation warning from a private, builtin class (`_UnionGenericAlias`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,8 @@ log_cli_level = "info"
 xfail_strict = true
 filterwarnings = [
     "error",
+    # https://github.com/astropy/astropy/issues/18126
+    "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
### Description
Fixes #18126

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
