### PR TITLE
Move `units` documentation utilities to a separate module

### DIFF
--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
 
 __all__ = [
     # redshift equivalencies

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -13,7 +13,7 @@ from astropy.constants import si as _si
 
 from . import si
 from .core import UnitBase, def_unit, set_enabled_units
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -41,7 +41,7 @@ import numpy as np
 from astropy.constants import si as _si
 
 from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_prefixes
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 _ns = globals()
 

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from . import si
 from .core import UnitBase, def_unit
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 

--- a/astropy/units/deprecated.py
+++ b/astropy/units/deprecated.py
@@ -24,7 +24,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import astrophys, cgs
 from .core import UnitBase, _add_prefixes, add_enabled_units, def_unit
-from .utils import generate_prefixonly_unit_summary, generate_unit_summary
+from .docgen import generate_prefixonly_unit_summary, generate_unit_summary
 
 local_units = {}
 

--- a/astropy/units/docgen.py
+++ b/astropy/units/docgen.py
@@ -1,0 +1,160 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Utilities for generating documentation for unit definition modules.
+
+None of the functions in the module are meant for use outside of the
+package.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from typing import TYPE_CHECKING
+
+from .core import NamedUnit, PrefixUnit, Unit, UnitBase
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Mapping
+    from typing import Literal
+
+
+def _get_first_sentence(s: str) -> str:
+    """
+    Get the first sentence from a string and remove any carriage
+    returns.
+    """
+    x = re.match(r".*?\S\.\s", s)
+    if x is not None:
+        s = x.group(0)
+    return s.replace("\n", " ")
+
+
+def _iter_unit_summary(
+    namespace: Mapping[str, object],
+) -> Generator[tuple[NamedUnit, str, str, str, Literal["Yes", "No"]], None, None]:
+    """
+    Generates the ``(unit, doc, represents, aliases, prefixes)``
+    tuple used to format the unit summary docs in `generate_unit_summary`.
+    """
+    # Get all of the units, and keep track of which ones have SI
+    # prefixes
+    units = []
+    has_prefixes = set()
+    for key, val in namespace.items():
+        # Skip non-unit items
+        if not isinstance(val, UnitBase):
+            continue
+
+        if not isinstance(val, NamedUnit):
+            raise TypeError(f"{key!r} must be defined with 'def_unit()'")
+
+        # Skip aliases
+        if key != val.name:
+            continue
+
+        if isinstance(val, PrefixUnit):
+            # This will return the root unit that is scaled by the prefix
+            # attached to it
+            has_prefixes.add(val._represents.bases[0].name)
+        else:
+            units.append(val)
+
+    # Sort alphabetically, case insensitive
+    units.sort(key=lambda x: x.name.lower())
+
+    for unit in units:
+        doc = _get_first_sentence(unit.__doc__).strip()
+        represents = ""
+        if isinstance(unit, Unit):
+            represents = f":math:`{unit._represents.to_string('latex')[1:-1]}`"
+        aliases = ", ".join(f"``{x}``" for x in unit.aliases)
+
+        yield (
+            unit,
+            doc,
+            represents,
+            aliases,
+            "Yes" if unit.name in has_prefixes else "No",
+        )
+
+
+def generate_unit_summary(namespace: Mapping[str, object]) -> str:
+    """
+    Generates a summary of units from a given namespace.  This is used
+    to generate the docstring for the modules that define the actual
+    units.
+
+    Parameters
+    ----------
+    namespace : dict
+        A namespace containing units.
+
+    Returns
+    -------
+    docstring : str
+        A docstring containing a summary table of the units.
+    """
+    docstring = io.StringIO()
+
+    docstring.write(
+        """
+.. list-table:: Available Units
+   :header-rows: 1
+   :widths: 10 20 20 20 1
+
+   * - Unit
+     - Description
+     - Represents
+     - Aliases
+     - SI Prefixes
+"""
+    )
+    template = """
+   * - ``{}``
+     - {}
+     - {}
+     - {}
+     - {}
+"""
+    for unit_summary in _iter_unit_summary(namespace):
+        docstring.write(template.format(*unit_summary))
+
+    return docstring.getvalue()
+
+
+def generate_prefixonly_unit_summary(namespace: Mapping[str, object]) -> str:
+    """
+    Generates table entries for units in a namespace that are just prefixes
+    without the base unit.  Note that this is intended to be used *after*
+    `generate_unit_summary` and therefore does not include the table header.
+
+    Parameters
+    ----------
+    namespace : dict
+        A namespace containing units that are prefixes but do *not* have the
+        base unit in their namespace.
+
+    Returns
+    -------
+    docstring : str
+        A docstring containing a summary table of the units.
+    """
+    faux_namespace = {}
+    for unit in namespace.values():
+        if isinstance(unit, PrefixUnit):
+            base_unit = unit.represents.bases[0]
+            faux_namespace[base_unit.name] = base_unit
+
+    docstring = io.StringIO()
+    template = """
+   * - Prefixes for ``{}``
+     - {} prefixes
+     - {}
+     - {}
+     - Only
+"""
+    for unit_summary in _iter_unit_summary(faux_namespace):
+        docstring.write(template.format(*unit_summary))
+
+    return docstring.getvalue()

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -75,7 +75,7 @@ __all__ += [n for n, v in _ns.items() if isinstance(v, (UnitBase, MagUnit))]
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the
     # standard units defined here.
-    from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+    from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
 
     def _description(unit):
         pu = unit.physical_unit.represents

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -23,7 +23,7 @@ __all__: list[str] = []  #  Units are added at the end
 
 from . import si
 from .core import UnitBase, add_enabled_units, def_unit
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 _ns = globals()
 

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -13,7 +13,7 @@ from astropy.constants import si as _si
 
 from . import si
 from .core import UnitBase, binary_prefixes, def_unit, si_prefixes
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -19,7 +19,7 @@ from astropy.constants.si import L_bol0
 
 from . import astrophys, cgs, si
 from .core import UnitBase, def_unit
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 __all__ = []  #  Units are added at the end
 

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -10,7 +10,7 @@ possible for the non-prefixed unit, ``astropy.units.solMass``.
 
 from . import astrophys
 from .core import UnitBase, _add_prefixes
-from .utils import generate_prefixonly_unit_summary, generate_unit_summary
+from .docgen import generate_prefixonly_unit_summary, generate_unit_summary
 
 _add_prefixes(astrophys.solMass, namespace=globals(), prefixes=True)
 _add_prefixes(astrophys.solRad, namespace=globals(), prefixes=True)

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -9,7 +9,7 @@ This package defines the SI units.  They are also available in
 import numpy as np
 
 from .core import CompositeUnit, UnitBase, def_unit
-from .utils import generate_unit_summary
+from .docgen import generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 

--- a/astropy/units/tests/test_docgen.py
+++ b/astropy/units/tests/test_docgen.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Test utilities for `astropy.units`.
-"""
 
 # ruff: noqa: FLY002
 
@@ -19,7 +16,7 @@ def test_composite_unit_definition(tmp_path):
     module_path.write_text(
         textwrap.dedent("""
         from astropy import units as u
-        from astropy.units.utils import generate_unit_summary
+        from astropy.units.docgen import generate_unit_summary
 
         km_per_h = u.km / u.h
 

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -8,8 +8,6 @@ package.
 
 from __future__ import annotations
 
-import io
-import re
 from fractions import Fraction
 from typing import TYPE_CHECKING, SupportsFloat
 
@@ -19,10 +17,6 @@ from numpy import finfo
 from .errors import UnitScaleError
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
-    from typing import Literal
-
-    from .core import NamedUnit
     from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
 
 
@@ -31,151 +25,6 @@ _float_finfo = finfo(float)
 # give a little margin since often multiple calculations happened
 _JUST_BELOW_UNITY = float(1.0 - 4.0 * _float_finfo.epsneg)
 _JUST_ABOVE_UNITY = float(1.0 + 4.0 * _float_finfo.eps)
-
-
-def _get_first_sentence(s: str) -> str:
-    """
-    Get the first sentence from a string and remove any carriage
-    returns.
-    """
-    x = re.match(r".*?\S\.\s", s)
-    if x is not None:
-        s = x.group(0)
-    return s.replace("\n", " ")
-
-
-def _iter_unit_summary(
-    namespace: Mapping[str, object],
-) -> Generator[tuple[NamedUnit, str, str, str, Literal["Yes", "No"]], None, None]:
-    """
-    Generates the ``(unit, doc, represents, aliases, prefixes)``
-    tuple used to format the unit summary docs in `generate_unit_summary`.
-    """
-    from . import core
-
-    # Get all of the units, and keep track of which ones have SI
-    # prefixes
-    units = []
-    has_prefixes = set()
-    for key, val in namespace.items():
-        # Skip non-unit items
-        if not isinstance(val, core.UnitBase):
-            continue
-
-        if not isinstance(val, core.NamedUnit):
-            raise TypeError(f"{key!r} must be defined with 'def_unit()'")
-
-        # Skip aliases
-        if key != val.name:
-            continue
-
-        if isinstance(val, core.PrefixUnit):
-            # This will return the root unit that is scaled by the prefix
-            # attached to it
-            has_prefixes.add(val._represents.bases[0].name)
-        else:
-            units.append(val)
-
-    # Sort alphabetically, case insensitive
-    units.sort(key=lambda x: x.name.lower())
-
-    for unit in units:
-        doc = _get_first_sentence(unit.__doc__).strip()
-        represents = ""
-        if isinstance(unit, core.Unit):
-            represents = f":math:`{unit._represents.to_string('latex')[1:-1]}`"
-        aliases = ", ".join(f"``{x}``" for x in unit.aliases)
-
-        yield (
-            unit,
-            doc,
-            represents,
-            aliases,
-            "Yes" if unit.name in has_prefixes else "No",
-        )
-
-
-def generate_unit_summary(namespace: Mapping[str, object]) -> str:
-    """
-    Generates a summary of units from a given namespace.  This is used
-    to generate the docstring for the modules that define the actual
-    units.
-
-    Parameters
-    ----------
-    namespace : dict
-        A namespace containing units.
-
-    Returns
-    -------
-    docstring : str
-        A docstring containing a summary table of the units.
-    """
-    docstring = io.StringIO()
-
-    docstring.write(
-        """
-.. list-table:: Available Units
-   :header-rows: 1
-   :widths: 10 20 20 20 1
-
-   * - Unit
-     - Description
-     - Represents
-     - Aliases
-     - SI Prefixes
-"""
-    )
-    template = """
-   * - ``{}``
-     - {}
-     - {}
-     - {}
-     - {}
-"""
-    for unit_summary in _iter_unit_summary(namespace):
-        docstring.write(template.format(*unit_summary))
-
-    return docstring.getvalue()
-
-
-def generate_prefixonly_unit_summary(namespace: Mapping[str, object]) -> str:
-    """
-    Generates table entries for units in a namespace that are just prefixes
-    without the base unit.  Note that this is intended to be used *after*
-    `generate_unit_summary` and therefore does not include the table header.
-
-    Parameters
-    ----------
-    namespace : dict
-        A namespace containing units that are prefixes but do *not* have the
-        base unit in their namespace.
-
-    Returns
-    -------
-    docstring : str
-        A docstring containing a summary table of the units.
-    """
-    from .core import PrefixUnit
-
-    faux_namespace = {}
-    for unit in namespace.values():
-        if isinstance(unit, PrefixUnit):
-            base_unit = unit.represents.bases[0]
-            faux_namespace[base_unit.name] = base_unit
-
-    docstring = io.StringIO()
-    template = """
-   * - Prefixes for ``{}``
-     - {} prefixes
-     - {}
-     - {}
-     - Only
-"""
-    for unit_summary in _iter_unit_summary(faux_namespace):
-        docstring.write(template.format(*unit_summary))
-
-    return docstring.getvalue()
 
 
 def is_effectively_unity(value: UnitScaleLike) -> bool | np.bool_:


### PR DESCRIPTION
### Description

`units.utils` contains utilities for the internals of the units machinery, but it also contains utilities for dynamically generating documentation for unit definition modules. The documentation utilities require importing unit classes so that they could decide how to document unit instances, but the unit classes need to import the utilities. This import loop has so far been suppressed by importing unit classes inside the documentation utility functions, not at module level. But by moving the documentation utilities to a separate module, that import loop can be avoided entirely. These two sets of utilities are also conceptually different enough that placing them in separate modules is not confusing.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
