### PR TITLE
Import standard library types at runtime

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -18,12 +18,13 @@ import operator
 import os
 import pkgutil
 import warnings
+from collections.abc import Generator
 from contextlib import contextmanager, nullcontext
 from functools import reduce
 from inspect import getdoc
 from pathlib import Path
 from textwrap import TextWrapper
-from typing import TYPE_CHECKING
+from typing import Final
 from warnings import warn
 
 import numpy as np
@@ -33,10 +34,6 @@ from astropy.utils import find_current_module, silence
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .paths import get_config_dir_path
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-    from typing import Final
 
 __all__ = (
     "ConfigItem",

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -3,22 +3,15 @@
 data/cache files used by Astropy should be placed.
 """
 
-from __future__ import annotations
-
 import os
 import shutil
 import sys
+from collections.abc import Callable
 from functools import wraps
 from inspect import cleandoc
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from types import TracebackType
-    from typing import Literal, ParamSpec
-
-    P = ParamSpec("P")
+from types import TracebackType
+from typing import Literal, ParamSpec
 
 __all__ = [
     "get_cache_dir",
@@ -28,6 +21,9 @@ __all__ = [
     "set_temp_cache",
     "set_temp_config",
 ]
+
+
+P = ParamSpec("P")
 
 
 def get_config_dir_path(rootname: str = "astropy") -> Path:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -18,7 +18,7 @@ import copy
 import operator
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 import numpy as np
 
@@ -41,8 +41,6 @@ from .transformations import (
 )
 
 if TYPE_CHECKING:
-    from typing import Literal
-
     from astropy.coordinates import Latitude, Longitude, SkyCoord
     from astropy.units import Unit
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -4,7 +4,7 @@ import copy
 import operator
 import re
 import warnings
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import erfa
 import numpy as np
@@ -35,9 +35,6 @@ from .sky_coordinate_parsers import (
     _get_frame_without_data,
     _parse_coordinate_data,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 __all__ = ["SkyCoord", "SkyCoordInfo"]
 

--- a/astropy/cosmology/_src/core.py
+++ b/astropy/cosmology/_src/core.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import inspect
 from abc import ABCMeta, abstractmethod
+from collections.abc import Mapping
 from dataclasses import KW_ONLY, dataclass, replace
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Self, TypeVar
 
 import numpy as np
 
@@ -29,9 +30,6 @@ from astropy.cosmology.io import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from typing import Self
-
     from astropy.cosmology._src.funcs.comparison import _FormatType
     from astropy.cosmology._src.typing import _CosmoT
 

--- a/astropy/cosmology/_src/default.py
+++ b/astropy/cosmology/_src/default.py
@@ -1,20 +1,15 @@
 """Default Cosmology."""
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__ = ["default_cosmology"]
 
 
-from typing import TYPE_CHECKING
+from typing import ClassVar
 
 from astropy.utils.state import ScienceState
 
 # isort: split
 from astropy.cosmology._src.core import Cosmology
-
-if TYPE_CHECKING:
-    from typing import ClassVar
 
 
 class default_cosmology(ScienceState):

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -8,12 +8,13 @@ __all__ = ["FLRW", "FlatFLRWMixin"]
 import inspect
 import warnings
 from abc import abstractmethod
+from collections.abc import Mapping
 from dataclasses import field
 from functools import cached_property
 from inspect import signature
 from math import exp, floor, log, pi, sqrt
 from numbers import Number
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TYPE_CHECKING, Self, TypeVar, overload
 
 import numpy as np
 from numpy import inf, sin
@@ -48,9 +49,6 @@ from astropy.cosmology._src.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from typing import Self
-
     import astropy.units
 
 

--- a/astropy/cosmology/_src/funcs/comparison.py
+++ b/astropy/cosmology/_src/funcs/comparison.py
@@ -6,12 +6,11 @@ the top-level namespace -- :mod:`astropy.cosmology`. This module will be
 moved.
 """
 
-from __future__ import annotations
-
 import functools
 import inspect
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Any, TypeAlias
 
 import numpy as np
 from numpy import False_, True_, ndarray
@@ -20,10 +19,6 @@ from astropy import table
 
 # isort: split
 from astropy.cosmology._src.core import Cosmology
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, TypeAlias
 
 __all__: list[str] = []  # Nothing is scoped here
 

--- a/astropy/cosmology/_src/funcs/optimize.py
+++ b/astropy/cosmology/_src/funcs/optimize.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, NotRequired, Protocol, TypedDict
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, NotRequired, Protocol, TypeAlias, TypedDict
 
 import numpy as np
 import numpy.typing as npt
@@ -17,9 +18,6 @@ from astropy.cosmology import units as cu
 from astropy.cosmology._src.core import CosmologyError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import TypeAlias
-
     from scipy.optimize import OptimizeResult
 
 __all__ = ["z_at_value"]

--- a/astropy/cosmology/_src/io/builtin/ecsv.py
+++ b/astropy/cosmology/_src/io/builtin/ecsv.py
@@ -161,6 +161,7 @@ Additional keyword arguments are passed to ``QTable.read`` and ``QTable.write``.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import astropy.units as u
@@ -174,8 +175,6 @@ from astropy.cosmology._src.io.connect import readwrite_registry
 from .table import from_table, to_table
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from astropy.cosmology._src.typing import _CosmoT
     from astropy.io.typing import PathLike, ReadableFileLike, WriteableFileLike
     from astropy.table import Table

--- a/astropy/cosmology/_src/io/builtin/row.py
+++ b/astropy/cosmology/_src/io/builtin/row.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import copy
 from collections import defaultdict
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from astropy.table import QTable, Row
@@ -45,8 +46,6 @@ from astropy.cosmology._src.io.connect import convert_registry
 from .mapping import from_mapping
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from astropy.cosmology._src.typing import _CosmoT
     from astropy.table import Table
 

--- a/astropy/cosmology/_src/io/builtin/table.py
+++ b/astropy/cosmology/_src/io/builtin/table.py
@@ -152,7 +152,8 @@ not match the class' parameter names.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np
 
@@ -165,9 +166,6 @@ from .row import from_row
 from .utils import convert_parameter_to_column
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from typing import TypeVar
-
     from astropy.cosmology._src.typing import _CosmoT
 
     _TableT = TypeVar("_TableT", Table)

--- a/astropy/cosmology/_src/io/builtin/yaml.py
+++ b/astropy/cosmology/_src/io/builtin/yaml.py
@@ -19,6 +19,7 @@ require YAML serialization.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import astropy.units as u
@@ -33,8 +34,6 @@ from .mapping import from_mapping
 from .utils import FULLQUALNAME_SUBSTITUTIONS as QNS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from yaml import MappingNode
 
     from astropy.cosmology._src.typing import _CosmoT

--- a/astropy/cosmology/_src/io/connect.py
+++ b/astropy/cosmology/_src/io/connect.py
@@ -10,7 +10,8 @@ __all__ = [
     "CosmologyWrite",
 ]
 
-from typing import TYPE_CHECKING, TypeVar, overload
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from astropy.io import registry as io_registry
 from astropy.units import add_enabled_units
@@ -19,9 +20,6 @@ from astropy.units import add_enabled_units
 import astropy.cosmology._src.units as cu
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from typing import Any, Literal
-
     from astropy.cosmology import Cosmology
     from astropy.cosmology._src.io.builtin.model import _CosmologyModel
     from astropy.cosmology._src.typing import _CosmoT

--- a/astropy/cosmology/_src/parameter/core.py
+++ b/astropy/cosmology/_src/parameter/core.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 __all__ = ["MISSING", "Parameter"]
 
 import copy
+from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field, fields, is_dataclass, replace
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import astropy.units as u
 
 from .converter import _REGISTRY_FVALIDATORS, FValidateCallable, _register_validator
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
 
 
 class Sentinel(Enum):

--- a/astropy/cosmology/_src/tests/flrw/conftest.py
+++ b/astropy/cosmology/_src/tests/flrw/conftest.py
@@ -2,15 +2,11 @@
 
 """Configure the tests for :mod:`astropy.cosmology`."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, TypeVar
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TypeVar
 
 from astropy.cosmology._src.tests.helper import clean_registry  # noqa: F401
 from astropy.tests.helper import pickle_protocol  # noqa: F401
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
 
 K = TypeVar("K")
 V = TypeVar("V")

--- a/astropy/cosmology/_src/tests/flrw/test_parameters.py
+++ b/astropy/cosmology/_src/tests/flrw/test_parameters.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import copy
+from inspect import BoundArguments
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -17,8 +18,6 @@ from astropy.cosmology._src.tests.test_core import ParameterTestMixin
 from astropy.tests.helper import assert_quantity_allclose
 
 if TYPE_CHECKING:
-    from inspect import BoundArguments
-
     from astropy.cosmology import Cosmology
 
 

--- a/astropy/cosmology/_src/units_equivalencies.py
+++ b/astropy/cosmology/_src/units_equivalencies.py
@@ -15,7 +15,8 @@ __all__ = [
 ]
 
 
-from typing import TYPE_CHECKING
+import sys
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import astropy.units as u
 from astropy.units import Equivalency
@@ -26,20 +27,13 @@ from .funcs.optimize import z_at_value
 from .units import littleh, redshift
 
 if TYPE_CHECKING:
-    import sys
-    from typing import Any, Literal
-
     from astropy.cosmology import Cosmology
     from astropy.cosmology._src.funcs.optimize import _ZAtValueKWArgs
     from astropy.units import Quantity
 
     if sys.version_info < (3, 12):
-        from typing import Any
-
         _UnpackZAtValueKWArgs = Any
     else:
-        from typing import TypeAlias
-
         from typing_extensions import Unpack
 
         _UnpackZAtValueKWArgs: TypeAlias = Unpack[_ZAtValueKWArgs]

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -23,7 +23,7 @@ import warnings
 from contextlib import suppress
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import ClassVar, Final, Self, SupportsFloat, TypeGuard
 
 import numpy as np
 
@@ -33,9 +33,6 @@ from astropy.utils.exceptions import AstropyWarning
 
 from . import connect
 from .docs import READ_DOCSTRING, WRITE_DOCSTRING
-
-if TYPE_CHECKING:
-    from typing import ClassVar, Final, Self, SupportsFloat, TypeGuard
 
 # Global dictionary mapping format arg to the corresponding Reader class
 FORMAT_CLASSES: dict[str, MetaBaseReader] = {}

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -8,17 +8,12 @@ latex.py:
 :Author: Tom Aldcroft (aldcroft@head.cfa.harvard.edu)
 """
 
-from __future__ import annotations
-
 import re
-from typing import TYPE_CHECKING
+from collections.abc import Generator
+from re import Pattern
+from typing import ClassVar, Final
 
 from . import core
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-    from re import Pattern
-    from typing import ClassVar, Final
 
 latexdicts = {
     "AA": {

--- a/astropy/io/typing.py
+++ b/astropy/io/typing.py
@@ -5,15 +5,10 @@ These are type annotations for I/O-related functions and classes. Some of the ty
 objects can also be used as runtime-checkable :class:`~typing.Protocol` objects.
 """
 
-from __future__ import annotations
-
 __all__ = ["PathLike", "ReadableFileLike", "WriteableFileLike"]
 
 import os
-from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
+from typing import Protocol, TypeAlias, TypeVar, runtime_checkable
 
 _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import abc
 import copy
 import warnings
-from typing import TYPE_CHECKING, NamedTuple
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, NamedTuple, Self
 
 import numpy as np
 
@@ -17,9 +18,6 @@ from astropy.units import Quantity
 from astropy.utils.compat import COPY_IF_NEEDED
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, Self
-
     from astropy.units import UnitBase
 
 __all__ = ["CompoundBoundingBox", "ModelBoundingBox"]

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -10,20 +10,16 @@ import warnings
 
 # pylint: disable=invalid-name
 from collections import UserDict
+from collections.abc import Sequence
 from inspect import signature
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 import numpy as np
 
 from astropy import units as u
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import TypeVar
-
     from numpy.typing import NDArray
-
-    DType = TypeVar("DType", bound=np.generic)
 
 
 __all__ = ["ellipse_extent", "poly_map_domain"]
@@ -326,6 +322,9 @@ class _SpecialOperatorsDict(UserDict):
         self._set_value(key, operator)
 
         return key
+
+
+DType = TypeVar("DType", bound=np.generic)
 
 
 @overload

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -48,17 +48,15 @@ References
 from __future__ import annotations
 
 import warnings
+from collections.abc import KeysView
 from inspect import signature
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
 from astropy.utils.exceptions import AstropyUserWarning
 
 if TYPE_CHECKING:
-    from collections.abc import KeysView
-    from typing import Literal
-
     from numpy.typing import ArrayLike, NDArray
 
 # TODO: typing: use a custom-defined 'ArrayLike-but-not-a-scalar' type for `float | ArrayLike` or `ArrayLike | float` hints

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -6,6 +6,7 @@ Tukey's biweight function.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -14,8 +15,6 @@ from astropy.stats.funcs import median_absolute_deviation
 from astropy.stats.nanfunctions import nanmedian, nansum
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from numpy.typing import ArrayLike, NDArray
 
 # TODO: typing: use a custom-defined 'ArrayLike-but-not-a-scalar' type for `float | ArrayLike` or `ArrayLike | float` hints

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -12,7 +12,8 @@ should be used for access.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal, SupportsFloat, TypeVar
 
 import numpy as np
 
@@ -21,13 +22,7 @@ from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_SCIPY
 from . import _stats
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Literal, SupportsFloat, TypeVar
-
     from numpy.typing import ArrayLike, NDArray
-
-    # type for variables generated with the mpmath library
-    FloatLike = TypeVar("FloatLike", bound=SupportsFloat)
 
 __all__ = [
     "binned_binom_proportion",
@@ -54,6 +49,8 @@ __doctest_requires__ = {
     "poisson_conf_interval": ["scipy"],
 }
 
+# type for variables generated with the mpmath library
+FloatLike = TypeVar("FloatLike", bound=SupportsFloat)
 
 gaussian_sigma_to_fwhm = 2.0 * math.sqrt(2.0 * math.log(2.0))
 """

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -8,15 +8,13 @@ Ported from the astroML project: https://www.astroml.org/
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
 from .bayesian_blocks import bayesian_blocks
 
 if TYPE_CHECKING:
-    from typing import Literal
-
     from numpy.typing import ArrayLike, NDArray
 
 __all__ = [

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import TypeVar
-
     from numpy.typing import NDArray
-
-    DT = TypeVar("DT", bound=np.generic)
 
 __all__ = ["jackknife_resampling", "jackknife_stats"]
 __doctest_requires__ = {"jackknife_stats": ["scipy"]}
+
+DT = TypeVar("DT", bound=np.generic)
 
 
 def jackknife_resampling(data: NDArray[DT]) -> NDArray[DT]:

--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -8,6 +8,7 @@ bottleneck is not installed, then the np.nan* functions are used.
 from __future__ import annotations
 
 import functools
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -17,8 +18,6 @@ from astropy.units import Quantity
 from astropy.utils.compat.optional_deps import HAS_BOTTLENECK
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from numpy.typing import ArrayLike, NDArray
 
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -30,9 +31,6 @@ else:
     from numpy.lib.array_utils import normalize_axis_index
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Literal
-
     from numpy.typing import ArrayLike, NDArray
 
 __all__ = ["SigmaClip", "SigmaClippedStats", "sigma_clip", "sigma_clipped_stats"]

--- a/astropy/stats/spatial.py
+++ b/astropy/stats/spatial.py
@@ -6,19 +6,17 @@ This module implements functions and classes for spatial statistics.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 import numpy as np
 
 if TYPE_CHECKING:
-    from typing import Literal, TypeAlias
-
     from numpy.typing import NDArray
 
-    # TODO: consider replacing with `StrEnum`
-    _ModeOps: TypeAlias = Literal["none", "translation", "ohser", "var-width", "ripley"]
-
 __all__ = ["RipleysKEstimator"]
+
+# TODO: consider replacing with `StrEnum`
+_ModeOps: TypeAlias = Literal["none", "translation", "ohser", "var-width", "ripley"]
 
 
 class RipleysKEstimator:

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -11,9 +11,11 @@ import operator
 import textwrap
 import unicodedata
 import warnings
+from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
 from functools import cached_property
 from threading import RLock
-from typing import TYPE_CHECKING, NamedTuple, overload
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Self, overload
 
 import numpy as np
 
@@ -30,10 +32,6 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
-    from types import TracebackType
-    from typing import Any, Final, Literal, Self
-
     from .format import Base
     from .physical import PhysicalType
     from .quantity import Quantity

--- a/astropy/units/docgen.py
+++ b/astropy/units/docgen.py
@@ -6,17 +6,12 @@ None of the functions in the module are meant for use outside of the
 package.
 """
 
-from __future__ import annotations
-
 import io
 import re
-from typing import TYPE_CHECKING
+from collections.abc import Generator, Mapping
+from typing import Literal
 
 from .core import NamedUnit, PrefixUnit, Unit, UnitBase
-
-if TYPE_CHECKING:
-    from collections.abc import Generator, Mapping
-    from typing import Literal
 
 
 def _get_first_sentence(s: str) -> str:

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -7,10 +7,8 @@ available in (and should be used through) the `astropy.units` namespace.
 
 """
 
-from __future__ import annotations
-
 import functools
-from typing import TYPE_CHECKING
+from typing import Final
 
 # THIRD-PARTY
 import numpy as np
@@ -24,9 +22,6 @@ from .core import Unit
 from .errors import UnitsError
 from .function import units as function_units
 from .photometric import maggy
-
-if TYPE_CHECKING:
-    from typing import Final
 
 __all__ = [
     "Equivalency",

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from astropy.units.core import CompositeUnit, NamedUnit, Unit, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
@@ -11,9 +12,6 @@ from astropy.units.utils import maybe_simple_fraction
 from astropy.utils.misc import did_you_mean
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-    from typing import ClassVar, Literal
-
     import numpy as np
 
     from astropy.extern.ply.lex import LexToken

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from astropy.units.core import CompositeUnit, Unit
 from astropy.units.utils import is_effectively_unity
@@ -24,8 +24,6 @@ from astropy.utils import classproperty, parsing
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
-    from typing import ClassVar, Literal
-
     from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
     from astropy.utils.parsing import ThreadSafeParser

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -6,13 +6,11 @@ Handles the "Console" unit format.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from . import base
 
 if TYPE_CHECKING:
-    from typing import ClassVar, Literal
-
     from astropy.units import UnitBase
 
 

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -6,7 +6,7 @@ Handles the "FITS" unit format.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
@@ -18,8 +18,6 @@ from . import Base, utils
 from .generic import _GenericParserMixin
 
 if TYPE_CHECKING:
-    from typing import Literal
-
     from astropy.units import UnitBase
 
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -20,7 +20,8 @@ import re
 import unicodedata
 import warnings
 from fractions import Fraction
-from typing import TYPE_CHECKING
+from re import Match, Pattern
+from typing import TYPE_CHECKING, ClassVar, Final
 
 from astropy.units.core import CompositeUnit, Unit, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
@@ -30,9 +31,6 @@ from astropy.utils.misc import did_you_mean
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
-    from re import Match, Pattern
-    from typing import ClassVar, Final
-
     import numpy as np
 
     from astropy.extern.ply.lex import Lexer

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -7,13 +7,11 @@ Handles the "LaTeX" unit format.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from . import console
 
 if TYPE_CHECKING:
-    from typing import ClassVar, Literal
-
     from astropy.units import NamedUnit, UnitBase
     from astropy.units.typing import UnitPower
 

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import math
 import warnings
 from fractions import Fraction
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from astropy.units.core import CompositeUnit
 from astropy.units.errors import UnitParserWarning, UnitsWarning
@@ -31,8 +31,6 @@ from . import utils
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
-    from typing import ClassVar, Literal
-
     import numpy as np
 
     from astropy.extern.ply.lex import Lexer

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -6,13 +6,11 @@ Handles the "Unicode" unit format.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from . import console
 
 if TYPE_CHECKING:
-    from typing import ClassVar
-
     from astropy.units import NamedUnit
     from astropy.units.typing import UnitPower
 

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -4,13 +4,8 @@
 Utilities shared by the different formats.
 """
 
-from __future__ import annotations
-
+from collections.abc import Generator, Iterable, Sequence
 from keyword import iskeyword
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable, Sequence
 
 
 def get_non_keyword_units(

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import TYPE_CHECKING
+from re import Pattern
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from astropy.units.core import (
     CompositeUnit,
@@ -29,9 +30,6 @@ from . import Base, utils
 from .generic import _GenericParserMixin
 
 if TYPE_CHECKING:
-    from re import Pattern
-    from typing import ClassVar, Literal
-
     import numpy as np
 
     from astropy.extern.ply.lex import LexToken

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Collection
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import numpy as np
 
@@ -26,9 +27,6 @@ else:
     from numpy._core import umath as np_umath
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
-    from typing import Self
-
     from astropy.units.typing import PhysicalTypeID
 
 __all__ = ["FunctionQuantity", "FunctionUnitBase"]

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -9,16 +9,14 @@ The classes and functions defined here are also available in
 from __future__ import annotations
 
 import numbers
-from typing import TYPE_CHECKING
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Final
 
 from astropy.utils.compat import COPY_IF_NEEDED
 
 from . import astrophys, cgs, core, misc, quantity, si
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from typing import Final
-
     from .typing import PhysicalTypeID, QuantityLike, UnitPowerLike
 
 __all__: Final = ["PhysicalType", "def_physical_type", "get_physical_type"]

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -12,8 +12,9 @@ import numbers
 import operator
 import re
 import warnings
+from collections.abc import Collection
 from fractions import Fraction
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 import numpy as np
 
@@ -37,9 +38,6 @@ from .structured import StructuredUnit, _structured_unit_like_dtype
 from .utils import is_effectively_unity
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
-    from typing import Self
-
     from .typing import QuantityLike
 
 __all__ = [

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -3,20 +3,15 @@
 This module defines structured units and quantities.
 """
 
-from __future__ import annotations
-
 # Standard library
 import operator
+from collections.abc import Collection
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import Self
 
 import numpy as np
 
 from .core import UNITY, Unit, UnitBase
-
-if TYPE_CHECKING:
-    from collections.abc import Collection
-    from typing import Self
 
 __all__ = ["StructuredUnit"]
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -3,13 +3,12 @@
 Regression tests for the units.format package
 """
 
-from __future__ import annotations
-
 import re
 import warnings
+from collections.abc import Iterable
 from contextlib import nullcontext
 from fractions import Fraction
-from typing import TYPE_CHECKING, NamedTuple
+from typing import NamedTuple
 
 import numpy as np
 import pytest
@@ -29,9 +28,6 @@ from astropy.units import (
 from astropy.units import format as u_format
 from astropy.units.utils import is_effectively_unity
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 class FormatStringPair(NamedTuple):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 import inspect
 import itertools
 from io import StringIO
-from typing import TYPE_CHECKING
+from types import FunctionType, ModuleType
 
 import numpy as np
 import numpy.lib.recfunctions as rfn
@@ -24,10 +22,6 @@ from astropy.units.quantity_helper.function_helpers import (
     UNSUPPORTED_FUNCTIONS,
 )
 from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
-
-if TYPE_CHECKING:
-    from types import FunctionType, ModuleType
-
 
 VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1,12 +1,11 @@
 # The purpose of these tests are to ensure that calling ufuncs with quantities
 # returns quantities with the right units, or raises exceptions.
 
-from __future__ import annotations
-
 import concurrent.futures
 import dataclasses
 import warnings
-from typing import TYPE_CHECKING, NamedTuple
+from collections.abc import Callable
+from typing import NamedTuple
 
 import numpy as np
 import pytest
@@ -19,9 +18,6 @@ from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
 from astropy.utils.compat.numpycompat import NUMPY_LT_1_25, NUMPY_LT_2_0, NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -1,7 +1,5 @@
 """Typing module for supporting type annotations related to :mod:`~astropy.units`."""
 
-from __future__ import annotations
-
 __all__ = [
     "QuantityLike",
     "UnitLike",
@@ -13,16 +11,12 @@ __all__ = [
 
 
 from fractions import Fraction
-from typing import TYPE_CHECKING
+from typing import TypeAlias
 
 import numpy as np
 import numpy.typing as npt
 
 from astropy.units import Quantity, UnitBase
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
-
 
 UnitLike: TypeAlias = UnitBase | str | Quantity
 """Type alias for input that can be converted to a Unit.

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -9,12 +9,10 @@ celestial-to-terrestrial coordinate transformations
 (in `astropy.coordinates`).
 """
 
-from __future__ import annotations
-
 import os
 import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import Self
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -45,9 +43,6 @@ from astropy.utils.data import (
 )
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.state import ScienceState
-
-if TYPE_CHECKING:
-    from typing import Self
 
 __all__ = [
     "FROM_IERS_A",

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -1,22 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions related to Python runtime introspection."""
 
-from __future__ import annotations
-
 import inspect
 import os
 import sys
 from importlib import import_module, metadata
 from importlib.metadata import packages_distributions
-from typing import TYPE_CHECKING
+from types import FrameType, ModuleType
+from typing import Literal
 
 from packaging.version import Version
 
 from .decorators import deprecated
-
-if TYPE_CHECKING:
-    from types import FrameType, ModuleType
-    from typing import Literal
 
 __all__ = ["find_current_module", "isinstancemethod", "minversion", "resolve_name"]
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -4,8 +4,6 @@ A "grab bag" of relatively small general-purpose utilities that don't have
 a clear module/package to live in.
 """
 
-from __future__ import annotations
-
 import contextlib
 import difflib
 import inspect
@@ -18,18 +16,15 @@ import threading
 import traceback
 import unicodedata
 from collections import defaultdict
+from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
 from itertools import chain
-from typing import TYPE_CHECKING
+from types import TracebackType
+from typing import Final
 
 import numpy as np
 
 from astropy.utils import deprecated
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Generator, Iterable
-    from types import TracebackType
-    from typing import Final
 
 __all__ = [
     "JsonCustomEncoder",

--- a/astropy/utils/parsing.py
+++ b/astropy/utils/parsing.py
@@ -9,13 +9,12 @@ import contextlib
 import functools
 import re
 import threading
+from collections.abc import Generator
 from pathlib import Path
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-    from types import ModuleType
-
     from astropy.extern.ply.lex import Lexer
     from astropy.extern.ply.yacc import LRParser
 

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import abc
 import numbers
+from collections.abc import Sequence
 from itertools import zip_longest
 from math import prod
-from typing import TYPE_CHECKING
+from types import EllipsisType
+from typing import TYPE_CHECKING, Self, TypeVar
 
 import numpy as np
 
@@ -31,13 +33,9 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from types import EllipsisType
-    from typing import Self, TypeVar
-
     from numpy.typing import NDArray
 
-    DT = TypeVar("DT", bound=np.generic)
+DT = TypeVar("DT", bound=np.generic)
 
 
 class NDArrayShapeMethods:

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -87,8 +87,7 @@ py:class a shallow copy of D
 # See https://github.com/sphinx-doc/sphinx/issues/9813
 # and https://github.com/sphinx-doc/sphinx/issues/11225
 # types
-py:class EllipsisType
-py:class ModuleType
+py:class types.EllipsisType
 # numpy
 py:class np.number
 # numpy.typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -388,6 +388,9 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # flake8-self (SLF)
     "SLF001", # private member access
 
+    # flake8-type-checking (TC)
+    "TC003",  # typing-only-standard-library-import
+
     # flake8-todos (TD)
     "TD002",  # Missing author in TODO
 
@@ -431,9 +434,6 @@ mypy-init-return = true
 
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true
-
-[tool.ruff.lint.flake8-type-checking]
-exempt-modules = []
 
 [tool.ruff.lint.isort]
 known-first-party = ["astropy", "extension_helpers"]


### PR DESCRIPTION
### Description

So far imports that are needed only for type checking have been placed inside `if TYPE_CHECKING:` blocks to avoid importing them at runtime. However, because of [bugs in Sphinx](https://github.com/sphinx-doc/sphinx/issues/11991) runtime imports should be preferred.

This pull request should be backported to solve some documentation build problems downstream packages might have (such as https://github.com/astropy/astroquery/pull/3327).

#### Approvals by sub-package

- [ ] `config`
- [ ] `coordinates`
- [x] `cosmology` https://github.com/astropy/astropy/pull/18191#pullrequestreview-2879793927
- [x] `io` https://github.com/astropy/astropy/pull/18191#pullrequestreview-2897235657
- [ ] `modeling`
- [ ] `stats`
- [x] `units` https://github.com/astropy/astropy/pull/18191#pullrequestreview-2879793927
- [x] `utils` https://github.com/astropy/astropy/pull/18191#pullrequestreview-2897235657

Sub-packages that have not been approved by 2025.06.12 will be updated in separate pull requests.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
