### PR TITLE
Updating test_kernel_class.py to avoid itertools

### DIFF
--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -21,15 +21,9 @@ modes = ["center", "linear_interp", "oversample"]
 test_models_1D = [Gaussian1D, Box1D, RickerWavelet1D]
 test_models_2D = [Gaussian2D, Box2D, RickerWavelet2D]
 
-models1D_modes_combo_list = [
-    (model, mode) for model in test_models_1D for mode in modes
-]
-models2D_modes_combo_list = [
-    (model, mode) for model in test_models_2D for mode in modes
-]
 
-
-@pytest.mark.parametrize(("model_class", "mode"), models1D_modes_combo_list)
+@pytest.mark.parametrize("model_class", test_models_1D)
+@pytest.mark.parametrize("mode", modes)
 def test_pixel_sum_1D(model_class, mode):
     """
     Test if the sum of all pixels corresponds nearly to the integral.
@@ -56,7 +50,8 @@ def test_gaussian_eval_1D(mode):
     assert_allclose(values, disc_values, atol=0.001)
 
 
-@pytest.mark.parametrize(("model_class", "mode"), models2D_modes_combo_list)
+@pytest.mark.parametrize("model_class", test_models_2D)
+@pytest.mark.parametrize("mode", modes)
 def test_pixel_sum_2D(model_class, mode):
     """
     Test if the sum of all pixels corresponds nearly to the integral.
@@ -76,7 +71,8 @@ def test_pixel_sum_2D(model_class, mode):
     assert_allclose(values.sum(), models_2D[model_class]["integral"], atol=0.0001)
 
 
-@pytest.mark.parametrize(("model_class", "mode"), models2D_modes_combo_list)
+@pytest.mark.parametrize("model_class", test_models_2D)
+@pytest.mark.parametrize("mode", modes)
 def test_pixel_sum_compound_2D(model_class, mode):
     """
     Test if the sum of all pixels of a compound model corresponds nearly to the integral.

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -23,10 +21,15 @@ modes = ["center", "linear_interp", "oversample"]
 test_models_1D = [Gaussian1D, Box1D, RickerWavelet1D]
 test_models_2D = [Gaussian2D, Box2D, RickerWavelet2D]
 
+models1D_modes_combo_list = [
+    (model, mode) for model in test_models_1D for mode in modes
+]
+models2D_modes_combo_list = [
+    (model, mode) for model in test_models_2D for mode in modes
+]
 
-@pytest.mark.parametrize(
-    ("model_class", "mode"), list(itertools.product(test_models_1D, modes))
-)
+
+@pytest.mark.parametrize(("model_class", "mode"), models1D_modes_combo_list)
 def test_pixel_sum_1D(model_class, mode):
     """
     Test if the sum of all pixels corresponds nearly to the integral.
@@ -53,9 +56,7 @@ def test_gaussian_eval_1D(mode):
     assert_allclose(values, disc_values, atol=0.001)
 
 
-@pytest.mark.parametrize(
-    ("model_class", "mode"), list(itertools.product(test_models_2D, modes))
-)
+@pytest.mark.parametrize(("model_class", "mode"), models2D_modes_combo_list)
 def test_pixel_sum_2D(model_class, mode):
     """
     Test if the sum of all pixels corresponds nearly to the integral.
@@ -75,9 +76,7 @@ def test_pixel_sum_2D(model_class, mode):
     assert_allclose(values.sum(), models_2D[model_class]["integral"], atol=0.0001)
 
 
-@pytest.mark.parametrize(
-    ("model_class", "mode"), list(itertools.product(test_models_2D, modes))
-)
+@pytest.mark.parametrize(("model_class", "mode"), models2D_modes_combo_list)
 def test_pixel_sum_compound_2D(model_class, mode):
     """
     Test if the sum of all pixels of a compound model corresponds nearly to the integral.

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -44,13 +44,7 @@ KERNEL_TYPES = [
     Ring2DKernel,
 ]
 
-KERNEL_WIDTH_COMBO_LIST = [
-    (kernel_type, width) for kernel_type in KERNEL_TYPES for width in WIDTHS_ODD
-]
 
-KERNEL_MODE_COMBO_LIST = [
-    (kernel_type, mode) for kernel_type in KERNEL_TYPES for mode in MODES
-]
 NUMS = [1, 1.0, np.float32(1.0), np.float64(1.0)]
 
 
@@ -130,7 +124,8 @@ class TestKernels:
         assert_almost_equal(astropy_1D, scipy_1D, decimal=5)
         assert_almost_equal(astropy_2D, scipy_2D, decimal=5)
 
-    @pytest.mark.parametrize(("kernel_type", "width"), KERNEL_WIDTH_COMBO_LIST)
+    @pytest.mark.parametrize("kernel_type", KERNEL_TYPES)
+    @pytest.mark.parametrize("width", WIDTHS_ODD)
     def test_delta_data(self, kernel_type, width):
         """
         Test smoothing of an image with a single positive pixel
@@ -159,7 +154,8 @@ class TestKernels:
             )
             assert_almost_equal(c1, c2, decimal=12)
 
-    @pytest.mark.parametrize(("kernel_type", "width"), KERNEL_WIDTH_COMBO_LIST)
+    @pytest.mark.parametrize("kernel_type", KERNEL_TYPES)
+    @pytest.mark.parametrize("width", WIDTHS_ODD)
     def test_random_data(self, kernel_type, width):
         """
         Test smoothing of an image made of random noise
@@ -514,7 +510,8 @@ class TestKernels:
         # Check separability
         assert box.separable
 
-    @pytest.mark.parametrize(("kernel_type", "mode"), KERNEL_MODE_COMBO_LIST)
+    @pytest.mark.parametrize("kernel_type", KERNEL_TYPES)
+    @pytest.mark.parametrize("mode", MODES)
     def test_discretize_modes(self, kernel_type, mode):
         """
         Check if the different modes result in kernels that work with convolve.

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
@@ -46,7 +44,13 @@ KERNEL_TYPES = [
     Ring2DKernel,
 ]
 
+KERNEL_WIDTH_COMBO_LIST = [
+    (kernel_type, width) for kernel_type in KERNEL_TYPES for width in WIDTHS_ODD
+]
 
+KERNEL_MODE_COMBO_LIST = [
+    (kernel_type, mode) for kernel_type in KERNEL_TYPES for mode in MODES
+]
 NUMS = [1, 1.0, np.float32(1.0), np.float64(1.0)]
 
 
@@ -126,9 +130,7 @@ class TestKernels:
         assert_almost_equal(astropy_1D, scipy_1D, decimal=5)
         assert_almost_equal(astropy_2D, scipy_2D, decimal=5)
 
-    @pytest.mark.parametrize(
-        ("kernel_type", "width"), list(itertools.product(KERNEL_TYPES, WIDTHS_ODD))
-    )
+    @pytest.mark.parametrize(("kernel_type", "width"), KERNEL_WIDTH_COMBO_LIST)
     def test_delta_data(self, kernel_type, width):
         """
         Test smoothing of an image with a single positive pixel
@@ -157,9 +159,7 @@ class TestKernels:
             )
             assert_almost_equal(c1, c2, decimal=12)
 
-    @pytest.mark.parametrize(
-        ("kernel_type", "width"), list(itertools.product(KERNEL_TYPES, WIDTHS_ODD))
-    )
+    @pytest.mark.parametrize(("kernel_type", "width"), KERNEL_WIDTH_COMBO_LIST)
     def test_random_data(self, kernel_type, width):
         """
         Test smoothing of an image made of random noise
@@ -514,9 +514,7 @@ class TestKernels:
         # Check separability
         assert box.separable
 
-    @pytest.mark.parametrize(
-        ("kernel_type", "mode"), list(itertools.product(KERNEL_TYPES, MODES))
-    )
+    @pytest.mark.parametrize(("kernel_type", "mode"), KERNEL_MODE_COMBO_LIST)
     def test_discretize_modes(self, kernel_type, mode):
         """
         Check if the different modes result in kernels that work with convolve.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of itertools as a dependency from [astropy/convolution/tests/test_kernel_class.py](https://github.com/astropy/astropy/blob/main/astropy/convolution/tests/test_kernel_class.py). The fixes are minor and I have created an explicit list to avoid using `itertools.product`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18110 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
