### PR TITLE
Removing itertools from test_fits compressed

### DIFF
--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -26,10 +26,6 @@ from astropy.io.fits.verify import VerifyWarning
 from astropy.utils.data import download_file
 from astropy.utils.misc import NumpyRNGContext
 
-DATA_TYPE_COMPRESSION_COMBO_LIST = [
-    (dtype, comp_type) for dtype in ("f", "i4") for comp_type in COMPRESSION_TYPES
-]
-
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):
@@ -867,9 +863,8 @@ class TestCompressedImage(FitsTestCase):
         new = fits.getdata(testfile)
         np.testing.assert_array_equal(data, new)
 
-    @pytest.mark.parametrize(
-        ("dtype", "compression_type"), DATA_TYPE_COMPRESSION_COMBO_LIST
-    )
+    @pytest.mark.parametrize("dtype", ["f", "i4"])
+    @pytest.mark.parametrize("compression_type", COMPRESSION_TYPES)
     def test_write_non_contiguous_data(self, dtype, compression_type):
         """
         Regression test for https://github.com/astropy/astropy/issues/2150

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -26,6 +26,10 @@ from astropy.io.fits.verify import VerifyWarning
 from astropy.utils.data import download_file
 from astropy.utils.misc import NumpyRNGContext
 
+DATA_TYPE_COMPRESSION_COMBO_LIST = [
+    (dtype, comp_type) for dtype in ("f", "i4") for comp_type in COMPRESSION_TYPES
+]
+
 
 class TestCompressedImage(FitsTestCase):
     def test_empty(self):
@@ -863,12 +867,8 @@ class TestCompressedImage(FitsTestCase):
         new = fits.getdata(testfile)
         np.testing.assert_array_equal(data, new)
 
-    DATA_TYPE_COMPRESSION_COMBOS = [
-        (dtype, comp_type) for dtype in ("f", "i4") for comp_type in COMPRESSION_TYPES
-    ]
-
     @pytest.mark.parametrize(
-        ("dtype", "compression_type"), DATA_TYPE_COMPRESSION_COMBOS
+        ("dtype", "compression_type"), DATA_TYPE_COMPRESSION_COMBO_LIST
     )
     def test_write_non_contiguous_data(self, dtype, compression_type):
         """

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -7,7 +7,6 @@ import pickle
 import re
 import time
 from io import BytesIO
-from itertools import product
 
 import numpy as np
 import pytest
@@ -864,8 +863,12 @@ class TestCompressedImage(FitsTestCase):
         new = fits.getdata(testfile)
         np.testing.assert_array_equal(data, new)
 
+    DATA_TYPE_COMPRESSION_COMBOS = [
+        (dtype, comp_type) for dtype in ("f", "i4") for comp_type in COMPRESSION_TYPES
+    ]
+
     @pytest.mark.parametrize(
-        ("dtype", "compression_type"), product(("f", "i4"), COMPRESSION_TYPES)
+        ("dtype", "compression_type"), DATA_TYPE_COMPRESSION_COMBOS
     )
     def test_write_non_contiguous_data(self, dtype, compression_type):
         """


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of itertools from [astropy/io/fits/hdu/compressed/tests/test_compressed.py](https://github.com/astropy/astropy/blob/main/astropy/io/fits/hdu/compressed/tests/test_compressed.py)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes a portion of #18110

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
