### PR TITLE
Stopped the warning when importing an installation from source

### DIFF
--- a/astropy/_dev/scm_version.py
+++ b/astropy/_dev/scm_version.py
@@ -5,6 +5,6 @@ from pathlib import Path
 try:
     from setuptools_scm import get_version
 
-    version = get_version(root=Path(__file__).parents[1], relative_to=__file__)
+    version = get_version(root=Path(__file__).parents[1])
 except Exception:
     raise ImportError("setuptools_scm broken or not installed")


### PR DESCRIPTION
In `_dev/scm_version.py`, #16917 changed the `root=` argument input for `get_version()` from a relative path to an absolute path, but did not remove the `relative_to=` argument.  This results in the warning upon an import of `astropy` from a non-wheel installation (with `setuptools_scm` installed):

> \<excised\>\setuptools_scm\_config.py:68: UserWarning: absolute root path '\<excised\>\astropy\astropy' overrides relative_to '\<excised\>\astropy\astropy\_dev\scm_version.py'

This PR removes the `relative_to=` argument to stop the warning.