### PR TITLE
Deprecate hashing scalar `Quantity` instances

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,7 +20,7 @@ import numpy as np
 from astropy import config as _config
 from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .core import Unit, UnitBase, dimensionless_unscaled, get_current_unit_registry
 from .errors import UnitConversionError, UnitsError, UnitTypeError
@@ -1256,7 +1256,15 @@ class Quantity(np.ndarray):
 
     # other overrides of special functions
     def __hash__(self):
-        return hash(self.value) ^ hash(self.unit)
+        hash_value = hash(self.value) ^ hash(self.unit)
+        # Emit the warning only if hashing does not raise an error anyways.
+        warnings.warn(
+            AstropyDeprecationWarning(  # since=7.2
+                f"Hashing {type(self).__name__} instances is deprecated and may be "
+                "removed in a future version."
+            )
+        )
+        return hash_value
 
     def __iter__(self):
         if self.isscalar:

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -16,6 +16,7 @@ from astropy.coordinates import Longitude
 from astropy.units import Quantity
 from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_2, NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_PLT
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.masked import Masked, MaskedNDArray
 
 
@@ -1380,11 +1381,76 @@ class TestMaskedArrayMethods(MaskedArraySetup):
 
 
 class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):
-    pass
+    def test_sum_hash(self):
+        ma_sum = self.ma.sum()
+        assert ma_sum.mask
+        # Masked scalars cannot be hashed.
+        with pytest.raises(TypeError, match="^unhashable type: 'numpy.ndarray'$"):
+            hash(ma_sum)
+        # But an unmasked scalar can, for now.
+        with pytest.warns(
+            AstropyDeprecationWarning,
+            match="^Hashing MaskedQuantity instances is deprecated",
+        ):
+            masked_hash = hash(Masked(self.a).sum())
+        with pytest.warns(
+            AstropyDeprecationWarning, match="^Hashing Quantity instances is deprecated"
+        ):
+            plain_hash = hash(self.a.sum())
+        assert masked_hash == plain_hash
+
+    def test_mean_hash(self):
+        ma_mean = self.ma.mean()
+        with pytest.warns(
+            AstropyDeprecationWarning,
+            match="^Hashing MaskedQuantity instances is deprecated",
+        ):
+            ma_mean_hash = hash(ma_mean)
+
+        a_mean = ma_mean.unmasked[()]
+        with pytest.warns(
+            AstropyDeprecationWarning, match="^Hashing Quantity instances is deprecated"
+        ):
+            a_mean_hash = hash(a_mean)
+
+        assert ma_mean_hash == a_mean_hash
 
 
 class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
-    pass
+    def test_sum_hash(self):
+        ma_sum = self.ma.sum()
+        assert ma_sum.mask
+        # Masked scalars cannot be hashed.
+        with pytest.raises(TypeError, match="^unhashable type: 'numpy.ndarray'$"):
+            hash(ma_sum)
+        # But an unmasked scalar can, for now.
+        with pytest.warns(
+            AstropyDeprecationWarning,
+            match="^Hashing MaskedAngle instances is deprecated",
+        ):
+            masked_hash = hash(Masked(self.a).sum())
+        with pytest.warns(
+            AstropyDeprecationWarning, match="^Hashing Angle instances is deprecated"
+        ):
+            plain_hash = hash(self.a.sum())
+        assert masked_hash == plain_hash
+
+    def test_mean_hash(self):
+        ma_mean = self.ma.mean()
+        with pytest.warns(
+            AstropyDeprecationWarning,
+            match="^Hashing MaskedLongitude instances is deprecated",
+        ):
+            ma_mean_hash = hash(ma_mean)
+
+        a_mean = ma_mean.unmasked[()]
+        with pytest.warns(
+            AstropyDeprecationWarning,
+            match="^Hashing Longitude instances is deprecated",
+        ):
+            a_mean_hash = hash(a_mean)
+
+        assert ma_mean_hash == a_mean_hash
 
 
 class TestMaskedArrayProductMethods(MaskedArraySetup):

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -67,7 +67,7 @@ def solar_system_body_representation_type(
     return type(
         f"{object_name}{baserepresentation.__name__[4:]}",
         (baserepresentation,),
-        dict(_equatorial_radius=equatorial_radius, _flattening=flattening),
+        dict(_equatorial_radius=equatorial_radius * u.m, _flattening=flattening),
     )
 
 
@@ -174,10 +174,7 @@ def _wcs_to_celestial_frame_builtin(wcs):
                 baserepresentation = BaseGeodeticRepresentation
                 representation_type_name = "GeodeticRepresentation"
 
-            if a_radius == b_radius:
-                equatorial_radius = a_radius * u.m
-                flattening = (a_radius - c_radius) / a_radius
-            else:
+            if a_radius != b_radius:
                 raise NotImplementedError(
                     "triaxial systems are not supported at this time."
                 )
@@ -186,8 +183,8 @@ def _wcs_to_celestial_frame_builtin(wcs):
             representation_type = solar_system_body_representation_type(
                 SOLAR_SYSTEM_OBJ_DICT.get(xcoord[:2]),
                 baserepresentation,
-                equatorial_radius,
-                flattening,
+                equatorial_radius=a_radius,
+                flattening=(a_radius - c_radius) / a_radius,
             )
 
             # create a new frame class

--- a/docs/changes/units/18208.api.rst
+++ b/docs/changes/units/18208.api.rst
@@ -1,0 +1,9 @@
+Hashing scalar ``Quantity`` instances (including instances of subclasses) is
+error-prone because equal quantities can nonetheless have different hash
+values, which contradicts important assumptions Python makes about hashable
+objects.
+Furthermore, the hash value of a ``Quantity`` can change during its lifetime,
+which allows repeated insertions into a ``set`` or a ``dict``.
+Because the behavior is fundamentally broken then it is now deprecated, and the
+functionality may be removed in a future version.
+Hashing non-scalar ``Quantity`` instances is already impossible.


### PR DESCRIPTION
### Description

[Python documentation for `object.__hash__()`](https://docs.python.org/3.11/reference/datamodel.html#object.__hash__) states:

> The only required property is that objects which compare equal have the same hash value;

Currently `astropy` allows hashing scalar `Quantity` instances:
```python
>>> from astropy import units as u
>>> hash(5 * u.m)
1626539361576894276  # The hash can change in different sessions
```
But equal quantities can have different hashes:
```python
>>> q1 = 5000 * u.m
>>> q2 = 5 * u.km
>>> q1 == q2
True
>>> hash(q1) == hash(q2)
False
```
Even worse, the hash of a single `Quantity` can change during its lifetime, which allows inserting it into a `set` more than once:
```python
>>> q_set = {q1}
>>> q1 <<= u.km
>>> q_set.add(q1)
>>> len(q_set)
2
>>> list(map(id, q_set))
[137087694577360, 137087694577360]
>>> from collections import Counter
>>> Counter(q_set)
Counter({<Quantity 5. km>: 2})
```
A similar example of creating a `dict` that has a `Quantity` as key more than once is left as an exercise to the reader.

The above proves that hashing a scalar `Quantity` is completely broken, so it should be either deprecated and eventually removed, or fixed. However, hashing a non-scalar `Quantity` is already impossible:
```python
>>> hash([5] * u.m)
Traceback (most recent call last):
  ...
TypeError: unhashable type: 'numpy.ndarray'
```
And hashing a scalar `np.ndarray()` is also impossible:
```python
>>> import numpy as np
>>> hash(np.array(5))
  ...
TypeError: unhashable type: 'numpy.ndarray'
```
It is therefore better to make hashing scalar `Quantity` instances impossible instead of trying to fix the behavior.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
