### PR TITLE
Remove itertools.product parameterization from test_convolve_kernals.py

### DIFF
--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -99,7 +99,6 @@ class Test2DConvolutions:
 
     @pytest.mark.parametrize("shape", SHAPES_ODD)
     @pytest.mark.parametrize("width", WIDTHS)
-
     def test_uniform_smallkernel(self, shape, width):
         """
         Test smoothing of an image with a single positive pixel
@@ -124,7 +123,6 @@ class Test2DConvolutions:
 
     @pytest.mark.parametrize("shape", SHAPES_ODD)
     @pytest.mark.parametrize("width", [1, 3, 5])
-
     def test_smallkernel_Box2DKernel(self, shape, width):
         """
         Test smoothing of an image with a single positive pixel

--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import itertools
-
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
@@ -99,9 +97,9 @@ class Test2DConvolutions:
         # not clear why, but these differ by a couple ulps...
         assert_almost_equal(c1, c2, decimal=12)
 
-    @pytest.mark.parametrize(
-        ("shape", "width"), list(itertools.product(SHAPES_ODD, WIDTHS))
-    )
+    @pytest.mark.parametrize("shape", SHAPES_ODD)
+    @pytest.mark.parametrize("width", WIDTHS)
+
     def test_uniform_smallkernel(self, shape, width):
         """
         Test smoothing of an image with a single positive pixel
@@ -124,9 +122,9 @@ class Test2DConvolutions:
 
         assert_almost_equal(c1, c2, decimal=12)
 
-    @pytest.mark.parametrize(
-        ("shape", "width"), list(itertools.product(SHAPES_ODD, [1, 3, 5]))
-    )
+    @pytest.mark.parametrize("shape", SHAPES_ODD)
+    @pytest.mark.parametrize("width", [1, 3, 5])
+
     def test_smallkernel_Box2DKernel(self, shape, width):
         """
         Test smoothing of an image with a single positive pixel


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of itertools.product parameterization from test_convolve_kernals.py based on Issue #18110.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes part of #18110

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
