### PR TITLE
Fixing both test_convolve and test_convolve_fft to not use itertools

### DIFF
--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import itertools
 from contextlib import nullcontext
 
 import numpy as np
@@ -16,7 +15,6 @@ from astropy.convolution.convolve import convolve, convolve_fft
 from astropy.utils.exceptions import AstropyUserWarning
 
 VALID_DTYPES = (">f4", "<f4", ">f8", "<f8")
-VALID_DTYPE_MATRIX = list(itertools.product(VALID_DTYPES, VALID_DTYPES))
 
 BOUNDARY_OPTIONS = [None, "fill", "wrap"]
 NANTREATMENT_OPTIONS = ("interpolate", "fill")
@@ -35,23 +33,6 @@ Convolved with [0, 1] = [0, 1, 2, 3, 4]
 """
 
 # NOTE: use_numpy_fft is redundant if you don't have FFTW installed
-option_names = ("boundary", "nan_treatment", "normalize_kernel", "dealias")
-options = list(
-    itertools.product(
-        BOUNDARY_OPTIONS, NANTREATMENT_OPTIONS, (True, False), (True, False)
-    )
-)
-option_names_preserve_nan = (
-    "boundary",
-    "nan_treatment",
-    "normalize_kernel",
-    "preserve_nan",
-)
-options_preserve_nan = list(
-    itertools.product(
-        BOUNDARY_OPTIONS, NANTREATMENT_OPTIONS, (True, False), (True, False)
-    )
-)
 
 
 def expected_boundary_warning(boundary=None):
@@ -95,7 +76,10 @@ def assert_floatclose(x, y):
 
 
 class TestConvolve1D:
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_quantity(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that convolve_fft works correctly when input array is a Quantity
@@ -117,7 +101,10 @@ class TestConvolve1D:
 
                 assert x.unit == z.unit
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_unity_1_none(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that a unit kernel with a single element returns the same array
@@ -140,7 +127,10 @@ class TestConvolve1D:
 
                 assert_floatclose(z, x)
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_unity_3(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that a unit kernel with three elements returns the same array
@@ -164,7 +154,10 @@ class TestConvolve1D:
 
                 assert_floatclose(z, x)
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_uniform_3(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that the different modes are producing the correct results using
@@ -214,7 +207,10 @@ class TestConvolve1D:
 
                 assert_floatclose(z, result_dict[answer_key])
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_halfity_3(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that the different modes are producing the correct results using
@@ -262,7 +258,10 @@ class TestConvolve1D:
 
                 assert_floatclose(z, answer_dict[answer_key])
 
-    @pytest.mark.parametrize(option_names_preserve_nan, options_preserve_nan)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
     def test_unity_3_withnan(
         self, boundary, nan_treatment, normalize_kernel, preserve_nan
     ):
@@ -301,20 +300,13 @@ class TestConvolve1D:
         np.array([1.0, 0.0, 3.0], dtype="float64"),
         np.array([1.0, 0.0, 3.0], dtype="float64"),
     )
-    options_unity1withnan = list(
-        itertools.product(
-            BOUNDARY_OPTIONS,
-            NANTREATMENT_OPTIONS,
-            (True, False),
-            (True, False),
-            inputs,
-            outputs,
-        )
-    )
 
-    @pytest.mark.parametrize(
-        option_names_preserve_nan + ("inval", "outval"), options_unity1withnan
-    )
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
+    @pytest.mark.parametrize("inval", inputs)
+    @pytest.mark.parametrize("outval", outputs)
     def test_unity_1_withnan(
         self, boundary, nan_treatment, normalize_kernel, preserve_nan, inval, outval
     ):
@@ -345,7 +337,10 @@ class TestConvolve1D:
 
         assert_floatclose(z, outval)
 
-    @pytest.mark.parametrize(option_names_preserve_nan, options_preserve_nan)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
     def test_uniform_3_withnan(
         self, boundary, nan_treatment, normalize_kernel, preserve_nan
     ):
@@ -506,7 +501,10 @@ class TestConvolve1D:
         result = convolve_fft(array, kernel, normalize_kernel=np.max)
         assert_floatclose(result, [3, 6, 5])
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_normalization_is_respected(
         self, boundary, nan_treatment, normalize_kernel, dealias
     ):
@@ -542,7 +540,10 @@ class TestConvolve1D:
 
 
 class TestConvolve2D:
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_unity_1x1_none(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that a 1x1 unit kernel returns the same array
@@ -567,7 +568,10 @@ class TestConvolve2D:
 
                 assert_floatclose(z, x)
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_unity_3x3(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that a 3x3 unit kernel returns the same array (except when
@@ -595,7 +599,10 @@ class TestConvolve2D:
 
                 assert_floatclose(z, x)
 
-    @pytest.mark.parametrize(option_names, options)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("dealias", [True, False])
     def test_uniform_3x3(self, boundary, nan_treatment, normalize_kernel, dealias):
         """
         Test that the different modes are producing the correct results using
@@ -653,7 +660,10 @@ class TestConvolve2D:
                 a = answer_dict[answer_key]
                 assert_floatclose(z, a)
 
-    @pytest.mark.parametrize(option_names_preserve_nan, options_preserve_nan)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
     def test_unity_3x3_withnan(
         self, boundary, nan_treatment, normalize_kernel, preserve_nan
     ):
@@ -689,7 +699,10 @@ class TestConvolve2D:
 
         assert_floatclose(z, x)
 
-    @pytest.mark.parametrize(option_names_preserve_nan, options_preserve_nan)
+    @pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+    @pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+    @pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+    @pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
     def test_uniform_3x3_withnan(
         self, boundary, nan_treatment, normalize_kernel, preserve_nan
     ):
@@ -883,16 +896,11 @@ def test_asymmetric_kernel(boundary):
         assert_array_almost_equal_nulp(z, np.array([9.0, 10.0, 5.0], dtype="float"), 10)
 
 
-@pytest.mark.parametrize(
-    ("boundary", "nan_treatment", "normalize_kernel", "preserve_nan", "dtype"),
-    itertools.product(
-        BOUNDARY_OPTIONS,
-        NANTREATMENT_OPTIONS,
-        NORMALIZE_OPTIONS,
-        PRESERVE_NAN_OPTIONS,
-        VALID_DTYPES,
-    ),
-)
+@pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+@pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+@pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+@pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
+@pytest.mark.parametrize("dtype", VALID_DTYPES)
 def test_input_unmodified(
     boundary, nan_treatment, normalize_kernel, preserve_nan, dtype
 ):
@@ -923,16 +931,11 @@ def test_input_unmodified(
     assert np.all(np.array(kernel, dtype=dtype) == y)
 
 
-@pytest.mark.parametrize(
-    ("boundary", "nan_treatment", "normalize_kernel", "preserve_nan", "dtype"),
-    itertools.product(
-        BOUNDARY_OPTIONS,
-        NANTREATMENT_OPTIONS,
-        NORMALIZE_OPTIONS,
-        PRESERVE_NAN_OPTIONS,
-        VALID_DTYPES,
-    ),
-)
+@pytest.mark.parametrize("boundary", BOUNDARY_OPTIONS)
+@pytest.mark.parametrize("nan_treatment", NANTREATMENT_OPTIONS)
+@pytest.mark.parametrize("normalize_kernel", NORMALIZE_OPTIONS)
+@pytest.mark.parametrize("preserve_nan", PRESERVE_NAN_OPTIONS)
+@pytest.mark.parametrize("dtype", VALID_DTYPES)
 def test_input_unmodified_with_nan(
     boundary, nan_treatment, normalize_kernel, preserve_nan, dtype
 ):


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the removal of itertools from the two tests [astropy/convolution/tests/test_convolve_fft.py](https://github.com/astropy/astropy/blob/main/astropy/convolution/tests/test_convolve_fft.py) and [astropy/convolution/tests/test_convolve.py](https://github.com/astropy/astropy/blob/main/astropy/convolution/tests/test_convolve.py)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes a part of #18110 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
