### PR TITLE
Speed up `Quantity.__iter__()`

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1264,13 +1264,7 @@ class Quantity(np.ndarray):
                 f"'{self.__class__.__name__}' object with a scalar value is not"
                 " iterable"
             )
-
-        # Otherwise return a generator
-        def quantity_iter():
-            for val in self.value:
-                yield self._new_view(val)
-
-        return quantity_iter()
+        return map(self._new_view, self.value)
 
     def __getitem__(self, key):
         if isinstance(key, str) and isinstance(self.unit, StructuredUnit):


### PR DESCRIPTION
### Description

The speedup is not large (maybe 6-7%), but it is achieved by simplifying the code.

Setup:
```python
Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.2.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Use `ipython --help-all | less` to view all the IPython configuration options.

In [1]: import numpy as np

In [2]: from astropy import units as u

In [3]: q_small = np.arange(3) * u.m

In [4]: q_med = np.arange(300) * u.m

In [5]: q_large = np.arange(3_000_000) * u.m
```
Timing on current `main`:
```python
In [6]: %timeit list(q_small)
4.85 μs ± 23.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [7]: %timeit list(q_med)
321 μs ± 3.37 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [8]: %timeit list(q_large)
3.87 s ± 30.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
Timing with this patch:
```python
In [6]: %timeit list(q_small)
4.52 μs ± 15.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [7]: %timeit list(q_med)
301 μs ± 1.09 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [8]: %timeit list(q_large)
3.64 s ± 15.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
