### PR TITLE
Added check for the first element of array-like t parameter in `LombScargle` class constructor

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -125,9 +125,11 @@ class LombScargle(BasePeriodogram):
 
         self.t = t
 
-        if isinstance(self.t, Time):
+        if isinstance(self.t, Time) or isinstance(self.t[0], Time):
             self._tstart = self.t[0]
-            trel = (self.t - self._tstart).to(u.day)
+            # Casting self.t into a Time object. If it is already a Time
+            # object, nothing happens, if not, it is turned into a Time object.
+            trel = (Time(self.t) - self._tstart).to(u.day)
         else:
             self._tstart = None
             trel = self.t


### PR DESCRIPTION
Commit Message:
Added check for the first element of array-like t parameter in LombScargle
class constructor.  Additionally, a casting to Time was added for the
array-like t object, when it contains Time objects.  This fixes issue
[https://github.com/astropy/astropy/issues/18212](https://github.com/astropy/astropy/issues/18212), where t inputs with
array-like objects are deemed 'unitless', but cause issues when calculating the
power spectrum.

Tests `pytest astropy/timeseries` pass.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
