### PR TITLE
TST: add a job for free-threading CPython 3.13 to weekly cron

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -68,6 +68,11 @@ jobs:
             python: '3.13'
             toxenv: py313-test-alldeps
 
+          - name: Python 3.13t (free-threading) with minimum dependencies
+            os: ubuntu-latest
+            python: '3.13t'
+            toxenv: py313t-test
+
           - name: Documentation link check
             os: ubuntu-latest
             python: '3.x'

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -68,10 +68,10 @@ jobs:
             python: '3.13'
             toxenv: py313-test-alldeps
 
-          - name: Python 3.13t (free-threading) with minimum dependencies
+          - name: Python 3.13t (free-threading) with recommended dependencies
             os: ubuntu-latest
             python: '3.13t'
-            toxenv: py313t-test
+            toxenv: py313t-test-recdeps
 
           - name: Documentation link check
             os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ setenv =
     py312: COVERAGE_CORE=sysmon
     py313: COVERAGE_CORE=sysmon
     py313t: COVERAGE_CORE=sysmon
+    py313t: PYTHON_GIL=0
     image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy124,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy124,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -21,6 +21,7 @@ setenv =
     # opt-in faster coverage when available (requires Python >= 3.12)
     py312: COVERAGE_CORE=sysmon
     py313: COVERAGE_CORE=sysmon
+    py313t: COVERAGE_CORE=sysmon
     image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii


### PR DESCRIPTION
### Description
As requested from https://github.com/astropy/astropy/pull/18211

I'm adding this to weekly cron for now because we do not claim to support this build yet, so it shouldn't be blocking ever, and testing it is also rarely needed at this point.

I expect I'll need to set `PYTHON_GIL=0` for this to be relevant, but I'm starting with the most basic job possible to see if anything breaks already.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
