### PR TITLE
BUG: ensure velocity attributes check the unit.

### DIFF
--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -471,6 +471,7 @@ class Galactocentric(BaseCoordinateFrame):
 
     galcen_v_sun = DifferentialAttribute(
         allowed_classes=[r.CartesianDifferential],
+        unit=u.km / u.s,
         doc="The velocity of the Sun in the Galactocentric frame",
     )
 

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -152,6 +152,7 @@ class GalacticLSR(BaseCoordinateFrame):
     # frame attributes:
     v_bary = DifferentialAttribute(
         default=v_bary_Schoenrich2010,
+        allowed_classes=[r.CartesianDifferential],
         doc="The relative velocity of the solar-system barycenter",
     )
 

--- a/docs/changes/coordinates/18218.api.rst
+++ b/docs/changes/coordinates/18218.api.rst
@@ -1,0 +1,2 @@
+``DifferentialAttribute`` now can take a ``unit`` attribute (or infer it from
+the ``default``), and will check whether input has units equivalent to that.

--- a/docs/changes/coordinates/18218.bugfix.rst
+++ b/docs/changes/coordinates/18218.bugfix.rst
@@ -1,0 +1,2 @@
+``Galactocentric`` and ``LSR`` now raise an error if their velocities are
+initialized with something that does not have velocity units.


### PR DESCRIPTION
This pull request ensures any `DifferentialAttribute` can check the unit of input. It is uesd to ensure `Galactocentric` and `LSR` check that input for the velocity attributes actually has the correct units.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17969

Note: this introduces somewhat of an API change, so am not backporting. Still, feel bugfix is more appropriate than API change.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
