### PR TITLE
Replace `lazyproperty` with `functools.cached_property` in `coordinates`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -15,6 +15,7 @@ __all__ = [
 ]
 
 import copy
+import functools
 import operator
 import warnings
 from collections import defaultdict
@@ -26,7 +27,7 @@ from astropy import units as u
 from astropy.table import QTable
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.data_info import MixinInfo
-from astropy.utils.decorators import format_doc, lazyproperty
+from astropy.utils.decorators import format_doc
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
@@ -886,7 +887,7 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
         setattr(cls, private_attr, value)
         setattr(cls, attr_name, property(getter, doc=doc))
 
-    @lazyproperty
+    @functools.cached_property
     def cache(self):
         """Cache for this frame, a dict.
 
@@ -1117,7 +1118,7 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
             cls._frame_class_cache["last_reprdiff_hash"] = r.get_reprdiff_cls_hash()
         return cls._frame_class_cache["representation_info"]
 
-    @lazyproperty
+    @functools.cached_property
     def representation_info(self):
         """
         A dictionary with the information of what attribute names for this frame

--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -7,6 +7,7 @@ and transitions from one node to another are defined as functions (or methods)
 wrapped in transformation objects.
 """
 
+import functools
 import heapq
 import subprocess
 from collections import defaultdict
@@ -23,7 +24,6 @@ from astropy.coordinates.transformations.function import (
     FunctionTransform,
     FunctionTransformWithFiniteDifference,
 )
-from astropy.utils import lazyproperty
 
 __all__ = ["TransformGraph"]
 
@@ -81,7 +81,7 @@ class TransformGraph:
         self._graph = defaultdict(dict)
         self.invalidate_cache()  # generates cache entries
 
-    @lazyproperty
+    @functools.cached_property
     def _cached_names(self):
         dct = {}
         for c in self.frame_set:
@@ -103,7 +103,7 @@ class TransformGraph:
 
         return self._cached_frame_set.copy()
 
-    @lazyproperty
+    @functools.cached_property
     def frame_attributes(self):
         """
         A `dict` of all the attributes of all frame classes in this TransformGraph.
@@ -125,9 +125,9 @@ class TransformGraph:
         are added or removed, but will need to be called manually if
         weights on transforms are modified inplace.
         """
-        del self._cached_names
+        vars(self).pop("_cached_names", None)
         self._cached_frame_set = None
-        del self.frame_attributes
+        vars(self).pop("frame_attributes", None)
         self._shortestpaths = {}
         self._composite_cache = {}
 


### PR DESCRIPTION
### Description

Utilities from the standard library should be preferred over our own utilities whenever possible. For example, importing from the standard library cannot cause import loops, but importing from our own utilities might. In `coordinates` [`lazyproperty`](https://docs.astropy.org/en/v7.1.0/api/astropy.utils.decorators.lazyproperty.html) can be easily replaced with [`functools.cached_property`](https://docs.python.org/3.11/library/functools.html#functools.cached_property), so there's no reason not to.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
