### PR TITLE
Fixed pathing to base directory for setuptools-scm

### DIFF
--- a/astropy/_dev/scm_version.py
+++ b/astropy/_dev/scm_version.py
@@ -5,6 +5,6 @@ from pathlib import Path
 try:
     from setuptools_scm import get_version
 
-    version = get_version(root=Path(__file__).parents[1])
+    version = get_version(root=Path(__file__).parents[2])
 except Exception:
     raise ImportError("setuptools_scm broken or not installed")


### PR DESCRIPTION
Heh, I totally should have spotted this when testing #18204, but it turned out that #16917 introduced a bug that entirely broke `setuptools-scm` version retrieval.  #16917 replaced:
```python
version = get_version(root=pth.join("..", ".."), relative_to=__file__)
```
with
```python
version = get_version(root=Path(__file__).parents[1])
```
but it actually needs to go one more directory up (`parents[2]`) because there is an internal `dirname()` call within `get_version()` when handling the `relative_to` argument.

In other words, `__file__` is `astropy/astropy/_dev/scm_version.py`, and `setuptools-scm` needs to be passed `astropy/`, not `astropy/astropy/`.