### PR TITLE
Import third party types at runtime

### DIFF
--- a/astropy/cosmology/_src/funcs/optimize.py
+++ b/astropy/cosmology/_src/funcs/optimize.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Convenience functions for `astropy.cosmology`."""
 
-from __future__ import annotations
-
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NotRequired, Protocol, TypeAlias, TypedDict
@@ -18,7 +16,7 @@ from astropy.cosmology import units as cu
 from astropy.cosmology._src.core import CosmologyError
 
 if TYPE_CHECKING:
-    from scipy.optimize import OptimizeResult
+    import scipy.optimize
 
 __all__ = ["z_at_value"]
 
@@ -34,7 +32,7 @@ class _CustomSolverCallable(Protocol):
 
     def __call__(
         self, fun: Callable[..., Any], args: tuple[Any, ...], **kwargs: Any
-    ) -> OptimizeResult: ...
+    ) -> "scipy.optimize.OptimizeResult": ...
 
 
 _BracketSingle: TypeAlias = tuple[float, float] | tuple[float, float, float]

--- a/astropy/cosmology/_src/io/builtin/yaml.py
+++ b/astropy/cosmology/_src/io/builtin/yaml.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from yaml import MappingNode
+
 import astropy.units as u
 from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 
@@ -34,8 +36,6 @@ from .mapping import from_mapping
 from .utils import FULLQUALNAME_SUBSTITUTIONS as QNS
 
 if TYPE_CHECKING:
-    from yaml import MappingNode
-
     from astropy.cosmology._src.typing import _CosmoT
 
 __all__: list[str] = []  # nothing is publicly scoped

--- a/astropy/cosmology/_src/tests/test_core.py
+++ b/astropy/cosmology/_src/tests/test_core.py
@@ -2,15 +2,13 @@
 
 """Testing :mod:`astropy.cosmology.core`."""
 
-from __future__ import annotations
-
 import abc
 import inspect
 import pickle
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 import astropy.cosmology.units as cu
 import astropy.units as u
@@ -26,9 +24,6 @@ from .parameter.test_descriptors import (
     ParametersAttributeTestMixin,
 )
 from .parameter.test_parameter import ParameterTestMixin
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
 
 ##############################################################################
 # SETUP / TEARDOWN

--- a/astropy/io/misc/pyarrow/csv.py
+++ b/astropy/io/misc/pyarrow/csv.py
@@ -10,13 +10,12 @@ from contextlib import ExitStack
 from typing import TYPE_CHECKING, BinaryIO, Literal, Union
 
 import numpy as np
-import numpy.typing
+from numpy.typing import DTypeLike, NDArray
 
 from astropy.utils.compat.optional_deps import HAS_PYARROW
 
 if TYPE_CHECKING:
-    import numpy.typing as npt
-    import pyarrow as pa
+    import pyarrow
     import pyarrow.csv
 
     from astropy.table import Table
@@ -35,7 +34,7 @@ def read_csv(
     data_start: int | None = None,
     names: list[str] | None = None,
     include_names: list[str] | None = None,
-    dtypes: dict[str, numpy.typing.DTypeLike] | None = None,
+    dtypes: dict[str, DTypeLike] | None = None,
     comment: str | None = None,
     null_values: list[str] | None = None,
     encoding: str = "utf-8",
@@ -183,9 +182,7 @@ def check_has_pyarrow():
         )
 
 
-def convert_pa_string_array_to_numpy(
-    arr: "pa.Array",
-) -> "npt.NDArray":
+def convert_pa_string_array_to_numpy(arr: "pyarrow.Array") -> NDArray:
     """
     Convert a PyArrow string array to a NumPy array.
 
@@ -212,7 +209,7 @@ def convert_pa_string_array_to_numpy(
     return out
 
 
-def pyarrow_zero(data_type: "pa.DataType"):
+def pyarrow_zero(data_type: "pyarrow.DataType"):
     """
     Return a "zero" value for the given PyArrow data type.
 
@@ -273,8 +270,8 @@ def pyarrow_zero(data_type: "pa.DataType"):
 
 
 def convert_pa_array_to_numpy(
-    arr: Union["pa.Array", "pa.ChunkedArray"],
-) -> "npt.NDArray":
+    arr: Union["pyarrow.Array", "pyarrow.ChunkedArray"],
+) -> NDArray:
     """
     Convert a PyArrow array to a NumPy array.
 
@@ -425,7 +422,7 @@ def strip_comment_lines(
 
 def get_convert_options(
     include_names: list[str] | None,
-    dtypes: dict[str, "npt.DTypeLike"] | None,
+    dtypes: dict[str, DTypeLike] | None,
     null_values: list[str] | None,
     timestamp_parsers: list[str] | None,
 ) -> "pyarrow.csv.ConvertOptions":

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -4,23 +4,18 @@
 This module provides utility functions for the models package.
 """
 
-from __future__ import annotations
-
 import warnings
 
 # pylint: disable=invalid-name
 from collections import UserDict
 from collections.abc import Sequence
 from inspect import signature
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TypeVar, overload
 
 import numpy as np
+from numpy.typing import NDArray
 
 from astropy import units as u
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
-
 
 __all__ = ["ellipse_extent", "poly_map_domain"]
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -50,14 +50,12 @@ from __future__ import annotations
 import warnings
 from collections.abc import KeysView
 from inspect import signature
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 from astropy.utils.exceptions import AstropyUserWarning
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
 
 # TODO: typing: use a custom-defined 'ArrayLike-but-not-a-scalar' type for `float | ArrayLike` or `ArrayLike | float` hints
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -4,18 +4,13 @@ This module contains functions for computing robust statistics using
 Tukey's biweight function.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable
-from typing import TYPE_CHECKING
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 from astropy.stats.funcs import median_absolute_deviation
 from astropy.stats.nanfunctions import nanmedian, nansum
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
 
 # TODO: typing: use a custom-defined 'ArrayLike-but-not-a-scalar' type for `float | ArrayLike` or `ArrayLike | float` hints
 

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -10,16 +10,10 @@ are based on reference [1]_, which is also the basis for the R package
 'CircStats' [2]_.
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 import numpy as np
+from numpy.typing import NDArray
 
 from astropy.units import Quantity
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
 
 __all__ = [
     "circcorrcoef",

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -9,20 +9,16 @@ This module should generally not be used directly.  Everything in
 should be used for access.
 """
 
-from __future__ import annotations
-
 import math
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal, SupportsFloat, TypeVar
+from typing import Literal, SupportsFloat, TypeVar
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_SCIPY
 
 from . import _stats
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "binned_binom_proportion",

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -6,16 +6,12 @@ Methods for selecting the bin width of histograms.
 Ported from the astroML project: https://www.astroml.org/
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 from .bayesian_blocks import bayesian_blocks
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "calculate_bin_edges",

--- a/astropy/stats/jackknife.py
+++ b/astropy/stats/jackknife.py
@@ -1,14 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TypeVar
 
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 __all__ = ["jackknife_resampling", "jackknife_stats"]
 __doctest_requires__ = {"jackknife_stats": ["scipy"]}

--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -5,21 +5,15 @@ functions using the optional bottleneck package if it is installed. If
 bottleneck is not installed, then the np.nan* functions are used.
 """
 
-from __future__ import annotations
-
 import functools
 from collections.abc import Callable
-from typing import TYPE_CHECKING
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 from astropy.stats.funcs import mad_std
 from astropy.units import Quantity
 from astropy.utils.compat.optional_deps import HAS_BOTTLENECK
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
-
 
 if HAS_BOTTLENECK:
     import bottleneck

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -1,12 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 from astropy.stats._fast_sigma_clip import _sigma_clip_fast
 from astropy.stats.biweight import biweight_location, biweight_scale
@@ -29,9 +28,6 @@ if NUMPY_LT_2_0:
     from numpy.core.multiarray import normalize_axis_index
 else:
     from numpy.lib.array_utils import normalize_axis_index
-
-if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
 
 __all__ = ["SigmaClip", "SigmaClippedStats", "sigma_clip", "sigma_clipped_stats"]
 

--- a/astropy/stats/spatial.py
+++ b/astropy/stats/spatial.py
@@ -3,15 +3,11 @@
 This module implements functions and classes for spatial statistics.
 """
 
-from __future__ import annotations
-
 import math
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 import numpy as np
-
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
+from numpy.typing import NDArray
 
 __all__ = ["RipleysKEstimator"]
 

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -6,14 +6,14 @@ import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar, Literal
 
+import numpy as np
+
 from astropy.units.core import CompositeUnit, NamedUnit, Unit, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
 from astropy.units.utils import maybe_simple_fraction
 from astropy.utils.misc import did_you_mean
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from astropy.extern.ply.lex import LexToken
     from astropy.units import UnitBase
     from astropy.units.typing import UnitPower, UnitScale

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -23,6 +23,8 @@ from fractions import Fraction
 from re import Match, Pattern
 from typing import TYPE_CHECKING, ClassVar, Final
 
+import numpy as np
+
 from astropy.units.core import CompositeUnit, Unit, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
 from astropy.utils import classproperty, parsing
@@ -31,8 +33,6 @@ from astropy.utils.misc import did_you_mean
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
     from astropy.units.typing import UnitScale

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -23,6 +23,8 @@ import warnings
 from fractions import Fraction
 from typing import TYPE_CHECKING, ClassVar, Literal
 
+import numpy as np
+
 from astropy.units.core import CompositeUnit
 from astropy.units.errors import UnitParserWarning, UnitsWarning
 from astropy.utils import classproperty, parsing
@@ -31,8 +33,6 @@ from . import utils
 from .base import Base, _ParsingFormatMixin
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from astropy.extern.ply.lex import Lexer
     from astropy.units import UnitBase
     from astropy.units.typing import UnitScale

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -10,6 +10,8 @@ import warnings
 from re import Pattern
 from typing import TYPE_CHECKING, ClassVar, Literal
 
+import numpy as np
+
 from astropy.units.core import (
     CompositeUnit,
     NamedUnit,
@@ -30,8 +32,6 @@ from . import Base, utils
 from .generic import _GenericParserMixin
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from astropy.extern.ply.lex import LexToken
     from astropy.units import UnitBase
     from astropy.units.typing import UnitScale

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -1,17 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """The ShapedLikeNDArray mixin class and shape-related functions."""
 
-from __future__ import annotations
-
 import abc
 import numbers
 from collections.abc import Sequence
 from itertools import zip_longest
 from math import prod
 from types import EllipsisType
-from typing import TYPE_CHECKING, Self, TypeVar
+from typing import Self, TypeVar
 
 import numpy as np
+from numpy.typing import NDArray
 
 from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.decorators import deprecated
@@ -32,8 +31,6 @@ __all__ = [
     "unbroadcast",
 ]
 
-if TYPE_CHECKING:
-    from numpy.typing import NDArray
 
 DT = TypeVar("DT", bound=np.generic)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,6 +389,7 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     "SLF001", # private member access
 
     # flake8-type-checking (TC)
+    "TC002",  # typing-only-third-party-import
     "TC003",  # typing-only-standard-library-import
 
     # flake8-todos (TD)


### PR DESCRIPTION
### Description

In #18191 we moved typing-only standard library imports out from `if TYPE_CHECKING:` blocks so that Sphinx bugs would be less likely to cause problems for downstream documentation builds. In this pull request I am doing the same with third party imports. In most cases our third party typing-only imports come from `numpy`, which is a required dependency, so importing types from there at runtime should not be controversial. But in a couple of cases (in `cosmology` and `io`) the typing-only third party imports come from optional dependencies. ~In those cases I thought it would be best to import the types if the dependency is available, and to define the types as aliases for `typing.Any` if it isn't.~ In those cases the `if TYPE_CHECKING:` blocks are necessary because otherwise the annotations are useless for type checkers and IDEs, but even then we can make the code less likely to cause problems downstream by only stringifying the types from optional dependencies.

#### Approvals by subpackage

- [x] `cosmology` https://github.com/astropy/astropy/pull/18228#pullrequestreview-2918381846
- [ ] `io`
- [ ] `modeling`
- [ ] `stats`
- [x] `units` https://github.com/astropy/astropy/pull/18228#pullrequestreview-2905949419
- [x] `utils` https://github.com/astropy/astropy/pull/18228#pullrequestreview-2939261644

This pull request should be backported to help prevent documentation build issues downstream packages might have.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
