### PR TITLE
RFC: restrict `wcs` extension modules to CPython's limited API

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -138,10 +138,6 @@ jobs:
 
   test_limited_api_build:
     # Test to make sure that we can build astropy with the limited API
-    # Currently, several extensions do not compile, so we remove them for
-    # now to make sure the remaining ones build fine. Once all the exceptions
-    # are removed, we can remove this job and instead opt in to the limited
-    # API in one of the main build+test tox jobs.
     strategy:
         fail-fast: false
         matrix:
@@ -161,11 +157,6 @@ jobs:
         name: Install Python
         with:
           python-version: "3.11"
-      - run: |
-          rm \
-            astropy/wcs/setup_package.py
-        name: Remove incompatible extensions
-        shell: bash # for windows compatibility
       - run: |
           python -m pip install build
           python -m build

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -433,7 +433,7 @@ create_parser(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
 
   fail:
     Py_XDECREF(pars_array);
-    Py_XDECREF(gufunc);
+    Py_XDECREF((PyObject*)gufunc);
     return NULL;
 }
 
@@ -513,8 +513,8 @@ PyMODINIT_FUNC PyInit__parse_times(void) {
     m = NULL;
 
   decref:
-    Py_XDECREF(dt_pars);
-    Py_XDECREF(dt_u1);
-    Py_XDECREF(dt_ymdhms);
+    Py_XDECREF((PyObject*)dt_pars);
+    Py_XDECREF((PyObject*)dt_u1);
+    Py_XDECREF((PyObject*)dt_ymdhms);
     return m;
 }

--- a/astropy/wcs/include/astropy_wcs/distortion_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/distortion_wrap.h
@@ -9,7 +9,7 @@
 #include "pyutil.h"
 #include "distortion.h"
 
-extern PyTypeObject PyDistLookupType;
+extern PyObject* PyDistLookupType;
 
 typedef struct {
   PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/sip_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/sip_wrap.h
@@ -9,7 +9,7 @@
 #include "pyutil.h"
 #include "sip.h"
 
-extern PyTypeObject PySipType;
+extern PyObject* PySipType;
 
 typedef struct {
   PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/wcslib_auxprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_auxprm_wrap.h
@@ -4,7 +4,7 @@
 #include "pyutil.h"
 #include "wcs.h"
 
-extern PyTypeObject PyAuxprmType;
+extern PyObject* PyAuxprmType;
 
 typedef struct {
   PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/wcslib_celprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_celprm_wrap.h
@@ -4,7 +4,7 @@
 #include "pyutil.h"
 #include "wcs.h"
 
-extern PyTypeObject PyCelprmType;
+extern PyObject* PyCelprmType;
 
 typedef struct {
     PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/wcslib_prjprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_prjprm_wrap.h
@@ -4,7 +4,7 @@
 #include "pyutil.h"
 #include "wcs.h"
 
-extern PyTypeObject PyPrjprmType;
+extern PyObject* PyPrjprmType;
 
 typedef struct {
     PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/wcslib_tabprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_tabprm_wrap.h
@@ -9,7 +9,7 @@
 #include "pyutil.h"
 #include "wcs.h"
 
-extern PyTypeObject PyTabprmType;
+extern PyObject* PyTabprmType;
 
 typedef struct {
   PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
@@ -7,7 +7,7 @@
 
 #include "pyutil.h"
 
-extern PyTypeObject PyWcsprmType;
+extern PyObject* PyWcsprmType;
 
 typedef struct {
   PyObject_HEAD

--- a/astropy/wcs/include/astropy_wcs/wcslib_wtbarr_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_wtbarr_wrap.h
@@ -9,7 +9,7 @@
 #include "pyutil.h"
 #include "wcs.h"
 
-extern PyTypeObject PyWtbarrType;
+extern PyObject* PyWtbarrType;
 
 typedef struct {
   PyObject_HEAD

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -29,8 +29,6 @@
  * Wcs type
  ***************************************************************************/
 
-static PyTypeObject WcsType;
-
 static int _setup_wcs_type(PyObject* m);
 
 
@@ -66,6 +64,7 @@ Wcs_traverse(
   Py_VISIT(self->py_distortion_lookup[0]);
   Py_VISIT(self->py_distortion_lookup[1]);
   Py_VISIT(self->py_wcsprm);
+  Py_VISIT((PyObject*)Py_TYPE(self));
 
   return 0;
 }
@@ -91,7 +90,10 @@ Wcs_dealloc(
   PyObject_GC_UnTrack(self);
   Wcs_clear(self);
   pipeline_free(&self->x);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  PyTypeObject *tp = Py_TYPE((PyObject*)self);
+  freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+  free_func((PyObject*)self);
+  Py_DECREF(tp);
 }
 
 /*@null@*/ static PyObject *
@@ -101,7 +103,8 @@ Wcs_new(
     /*@unused@*/ PyObject* kwds) {
 
   Wcs* self;
-  self = (Wcs*)type->tp_alloc(type, 0);
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (Wcs*)alloc_func(type, 0);
   if (self != NULL) {
     pipeline_clear(&self->x);
     self->py_det2im[0]            = NULL;
@@ -140,7 +143,7 @@ Wcs_init(
   /* Check and set Distortion lookup tables */
   for (i = 0; i < 2; ++i) {
     if (py_det2im[i] != NULL && py_det2im[i] != Py_None) {
-      if (!PyObject_TypeCheck(py_det2im[i], &PyDistLookupType)) {
+      if (!PyObject_TypeCheck(py_det2im[i], (PyTypeObject*)PyDistLookupType)) {
         PyErr_SetString(PyExc_TypeError,
                         "Arg 4 must be a pair of DistortionLookupTable or None objects");
         return -1;
@@ -155,7 +158,7 @@ Wcs_init(
 
   /* Check and set SIP */
   if (py_sip != NULL && py_sip != Py_None) {
-    if (!PyObject_TypeCheck(py_sip, &PySipType)) {
+    if (!PyObject_TypeCheck(py_sip, (PyTypeObject*)PySipType)) {
       PyErr_SetString(PyExc_TypeError,
                       "Arg 1 must be Sip object");
       return -1;
@@ -170,7 +173,7 @@ Wcs_init(
   /* Check and set Distortion lookup tables */
   for (i = 0; i < 2; ++i) {
     if (py_distortion_lookup[i] != NULL && py_distortion_lookup[i] != Py_None) {
-      if (!PyObject_TypeCheck(py_distortion_lookup[i], &PyDistLookupType)) {
+      if (!PyObject_TypeCheck(py_distortion_lookup[i], (PyTypeObject*)PyDistLookupType)) {
         PyErr_SetString(PyExc_TypeError,
                         "Arg 2 must be a pair of DistortionLookupTable or None objects");
         return -1;
@@ -185,7 +188,7 @@ Wcs_init(
 
   /* Set and lookup Wcsprm object */
   if (py_wcsprm != NULL && py_wcsprm != Py_None) {
-    if (!PyObject_TypeCheck(py_wcsprm, &PyWcsprmType)) {
+    if (!PyObject_TypeCheck(py_wcsprm, (PyTypeObject*)PyWcsprmType)) {
       PyErr_SetString(PyExc_TypeError,
                       "Arg 3 must be Wcsprm object");
       return -1;
@@ -256,12 +259,12 @@ Wcs_all_pix2world(
   /* unoffset_array(world, origin); */
 
  exit:
-  Py_XDECREF(pixcrd);
+  Py_XDECREF((PyObject*)pixcrd);
 
   if (status == 0 || status == 8) {
     return (PyObject*)world;
   } else {
-    Py_XDECREF(world);
+    Py_XDECREF((PyObject*)world);
     if (status == -1) {
       PyErr_SetString(
         PyExc_ValueError,
@@ -331,12 +334,12 @@ Wcs_p4_pix2foc(
 
  exit:
 
-  Py_XDECREF(pixcrd);
+  Py_XDECREF((PyObject*)pixcrd);
 
   if (status == 0) {
     return (PyObject*)foccrd;
   } else {
-    Py_XDECREF(foccrd);
+    Py_XDECREF((PyObject*)foccrd);
     if (status == -1) {
       /* Exception already set */
       return NULL;
@@ -399,12 +402,12 @@ Wcs_det2im(
 
  exit:
 
-  Py_XDECREF(detcrd);
+  Py_XDECREF((PyObject*)detcrd);
 
   if (status == 0) {
     return (PyObject*)imcrd;
   } else {
-    Py_XDECREF(imcrd);
+    Py_XDECREF((PyObject*)imcrd);
     if (status == -1) {
       /* Exception already set */
       return NULL;
@@ -462,12 +465,12 @@ Wcs_pix2foc(
 
  _exit:
 
-  Py_XDECREF(pixcrd);
+  Py_XDECREF((PyObject*)pixcrd);
 
   if (status == 0) {
     return (PyObject*)foccrd;
   } else {
-    Py_XDECREF(foccrd);
+    Py_XDECREF((PyObject*)foccrd);
     if (status == -1) {
       /* Exception already set */
       return NULL;
@@ -502,7 +505,7 @@ Wcs_set_wcs(
   self->x.wcs = NULL;
 
   if (value != NULL && value != Py_None) {
-    if (!PyObject_TypeCheck(value, &PyWcsprmType)) {
+    if (!PyObject_TypeCheck(value, (PyTypeObject*)PyWcsprmType)) {
       PyErr_SetString(PyExc_TypeError,
                       "wcs must be Wcsprm object");
       return -1;
@@ -540,7 +543,7 @@ Wcs_set_cpdis1(
   self->x.cpdis[0] = NULL;
 
   if (value != NULL && value != Py_None) {
-    if (!PyObject_TypeCheck(value, &PyDistLookupType)) {
+    if (!PyObject_TypeCheck(value, (PyTypeObject*)PyDistLookupType)) {
       PyErr_SetString(PyExc_TypeError,
                       "cpdis1 must be DistortionLookupTable object");
       return -1;
@@ -578,7 +581,7 @@ Wcs_set_cpdis2(
   self->x.cpdis[1] = NULL;
 
   if (value != NULL && value != Py_None) {
-    if (!PyObject_TypeCheck(value, &PyDistLookupType)) {
+    if (!PyObject_TypeCheck(value, (PyTypeObject*)PyDistLookupType)) {
       PyErr_SetString(PyExc_TypeError,
                       "cpdis2 must be DistortionLookupTable object");
       return -1;
@@ -616,7 +619,7 @@ Wcs_set_det2im1(
   self->x.det2im[0] = NULL;
 
   if (value != NULL && value != Py_None) {
-    if (!PyObject_TypeCheck(value, &PyDistLookupType)) {
+    if (!PyObject_TypeCheck(value, (PyTypeObject*)PyDistLookupType)) {
       PyErr_SetString(PyExc_TypeError,
                       "det2im1 must be DistortionLookupTable object");
       return -1;
@@ -654,7 +657,7 @@ Wcs_set_det2im2(
   self->x.det2im[1] = NULL;
 
   if (value != NULL && value != Py_None) {
-    if (!PyObject_TypeCheck(value, &PyDistLookupType)) {
+    if (!PyObject_TypeCheck(value, (PyTypeObject*)PyDistLookupType)) {
       PyErr_SetString(PyExc_TypeError,
                       "det2im2 must be DistortionLookupTable object");
       return -1;
@@ -692,7 +695,7 @@ Wcs_set_sip(
   self->x.sip = NULL;
 
   if (value != NULL && value != Py_None) {
-    if (!PyObject_TypeCheck(value, &PySipType)) {
+    if (!PyObject_TypeCheck(value, (PyTypeObject*)PySipType)) {
       PyErr_SetString(PyExc_TypeError,
                       "sip must be Sip object");
       return -1;
@@ -750,47 +753,25 @@ static PyMethodDef module_methods[] = {
   {NULL}  /* Sentinel */
 };
 
-static PyTypeObject WcsType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "astropy.wcs.WCSBase",                 /*tp_name*/
-  sizeof(Wcs),                /*tp_basicsize*/
-  0,                            /*tp_itemsize*/
-  (destructor)Wcs_dealloc,    /*tp_dealloc*/
-  0,                            /*tp_print*/
-  0,                            /*tp_getattr*/
-  0,                            /*tp_setattr*/
-  0,                            /*tp_compare*/
-  0,                            /*tp_repr*/
-  0,                            /*tp_as_number*/
-  0,                            /*tp_as_sequence*/
-  0,                            /*tp_as_mapping*/
-  0,                            /*tp_hash */
-  0,                            /*tp_call*/
-  0,                            /*tp_str*/
-  0,                            /*tp_getattro*/
-  0,                            /*tp_setattro*/
-  0,                            /*tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-  doc_Wcs,                      /* tp_doc */
-  (traverseproc)Wcs_traverse, /* tp_traverse */
-  (inquiry)Wcs_clear,         /* tp_clear */
-  0,                            /* tp_richcompare */
-  0,                            /* tp_weaklistoffset */
-  0,                            /* tp_iter */
-  0,                            /* tp_iternext */
-  Wcs_methods,                /* tp_methods */
-  0,                            /* tp_members */
-  Wcs_getset,                 /* tp_getset */
-  0,                            /* tp_base */
-  0,                            /* tp_dict */
-  0,                            /* tp_descr_get */
-  0,                            /* tp_descr_set */
-  0,                            /* tp_dictoffset */
-  (initproc)Wcs_init,         /* tp_init */
-  0,                            /* tp_alloc */
-  Wcs_new,                    /* tp_new */
+static PyType_Spec WcsType_spec = {
+  .name = "astropy.wcs.WCSBase",
+  .basicsize = sizeof(Wcs),
+  .itemsize = 0,
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE,
+  .slots = (PyType_Slot[]){
+    {Py_tp_dealloc, (destructor)Wcs_dealloc},
+    {Py_tp_doc, doc_Wcs},
+    {Py_tp_traverse, (traverseproc)Wcs_traverse},
+    {Py_tp_clear, (inquiry)Wcs_clear},
+    {Py_tp_methods, Wcs_methods},
+    {Py_tp_getset, Wcs_getset},
+    {Py_tp_init, (initproc)Wcs_init},
+    {Py_tp_new, Wcs_new},
+    {0, NULL},
+  },
 };
 
+static PyObject* WcsType = NULL;
 
 /***************************************************************************
  * Module-level
@@ -799,11 +780,11 @@ static PyTypeObject WcsType = {
 int _setup_wcs_type(
     PyObject* m) {
 
-  if (PyType_Ready(&WcsType) < 0)
+  WcsType = PyType_FromSpec(&WcsType_spec);
+  if (WcsType == NULL)
     return -1;
 
-  Py_INCREF(&WcsType);
-  return PyModule_AddObject(m, "_Wcs", (PyObject *)&WcsType);
+  return PyModule_AddObject(m, "_Wcs", WcsType);
 }
 
 struct module_state {

--- a/astropy/wcs/src/distortion_wrap.c
+++ b/astropy/wcs/src/distortion_wrap.c
@@ -17,6 +17,7 @@ PyDistLookup_traverse(
     void* arg) {
 
   Py_VISIT(self->py_data);
+  Py_VISIT((PyObject*)Py_TYPE(self));
 
   return 0;
 }
@@ -36,8 +37,11 @@ PyDistLookup_dealloc(
 
   PyObject_GC_UnTrack(self);
   distortion_lookup_t_free(&self->x);
-  Py_XDECREF(self->py_data);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  Py_XDECREF((PyObject*)self->py_data);
+  PyTypeObject *tp = Py_TYPE((PyObject*)self);
+  freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+  free_func((PyObject*)self);
+  Py_DECREF(tp);
 }
 
 /*@null@*/ static PyObject *
@@ -48,7 +52,8 @@ PyDistLookup_new(
 
   PyDistLookup* self;
 
-  self = (PyDistLookup*)type->tp_alloc(type, 0);
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyDistLookup*)alloc_func(type, 0);
   if (self != NULL) {
     if (distortion_lookup_t_init(&self->x)) {
       return NULL;
@@ -160,7 +165,7 @@ PyDistLookup_get_data(
     Py_INCREF(Py_None);
     return Py_None;
   } else {
-    Py_INCREF(self->py_data);
+    Py_INCREF((PyObject*)self->py_data);
     return (PyObject*)self->py_data;
   }
 }
@@ -185,7 +190,7 @@ PyDistLookup_set_data(
     return -1;
   }
 
-  Py_XDECREF(self->py_data);
+  Py_XDECREF((PyObject*)self->py_data);
 
   self->py_data = value_array;
   self->x.naxis[0] = (unsigned int)PyArray_DIM(value_array, 1);
@@ -227,7 +232,7 @@ PyDistLookup___copy__(
   PyDistLookup* copy = NULL;
   int           i    = 0;
 
-  copy = (PyDistLookup*)PyDistLookup_new(&PyDistLookupType, NULL, NULL);
+  copy = (PyDistLookup*)PyDistLookup_new((PyTypeObject*)PyDistLookupType, NULL, NULL);
   if (copy == NULL) {
     return NULL;
   }
@@ -256,7 +261,7 @@ PyDistLookup___deepcopy__(
   PyObject*     obj_copy;
   int           i = 0;
 
-  copy = (PyDistLookup*)PyDistLookup_new(&PyDistLookupType, NULL, NULL);
+  copy = (PyDistLookup*)PyDistLookup_new((PyTypeObject*)PyDistLookupType, NULL, NULL);
   if (copy == NULL) {
     return NULL;
   }
@@ -297,54 +302,33 @@ static PyMethodDef PyDistLookup_methods[] = {
   {NULL}
 };
 
-PyTypeObject PyDistLookupType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "astropy.wcs.DistortionLookupTable",  /*tp_name*/
-  sizeof(PyDistLookup),         /*tp_basicsize*/
-  0,                            /*tp_itemsize*/
-  (destructor)PyDistLookup_dealloc, /*tp_dealloc*/
-  0,                            /*tp_print*/
-  0,                            /*tp_getattr*/
-  0,                            /*tp_setattr*/
-  0,                            /*tp_compare*/
-  0,                            /*tp_repr*/
-  0,                            /*tp_as_number*/
-  0,                            /*tp_as_sequence*/
-  0,                            /*tp_as_mapping*/
-  0,                            /*tp_hash */
-  0,                            /*tp_call*/
-  0,                            /*tp_str*/
-  0,                            /*tp_getattro*/
-  0,                            /*tp_setattro*/
-  0,                            /*tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-  doc_DistortionLookupTable,    /* tp_doc */
-  (traverseproc)PyDistLookup_traverse, /* tp_traverse */
-  (inquiry)PyDistLookup_clear,  /* tp_clear */
-  0,                            /* tp_richcompare */
-  0,                            /* tp_weaklistoffset */
-  0,                            /* tp_iter */
-  0,                            /* tp_iternext */
-  PyDistLookup_methods,         /* tp_methods */
-  0,                            /* tp_members */
-  PyDistLookup_getset,          /* tp_getset */
-  0,                            /* tp_base */
-  0,                            /* tp_dict */
-  0,                            /* tp_descr_get */
-  0,                            /* tp_descr_set */
-  0,                            /* tp_dictoffset */
-  (initproc)PyDistLookup_init,  /* tp_init */
-  0,                            /* tp_alloc */
-  PyDistLookup_new,             /* tp_new */
+static PyType_Spec PyDistLookupType_spec = {
+  .name = "astropy.wcs.DistortionLookupTable",
+  .basicsize = sizeof(PyDistLookup),
+  .itemsize = 0,
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE,
+  .slots = (PyType_Slot[]){
+    {Py_tp_dealloc, (destructor)PyDistLookup_dealloc},
+    {Py_tp_doc, doc_DistortionLookupTable},
+    {Py_tp_traverse, (traverseproc)PyDistLookup_traverse},
+    {Py_tp_clear, (inquiry)PyDistLookup_clear},
+    {Py_tp_methods, PyDistLookup_methods},
+    {Py_tp_getset, PyDistLookup_getset},
+    {Py_tp_init, (initproc)PyDistLookup_init},
+    {Py_tp_new, PyDistLookup_new},
+    {0, NULL},
+  },
 };
+
+PyObject* PyDistLookupType = NULL;
 
 int _setup_distortion_type(
     PyObject* m) {
 
-  if (PyType_Ready(&PyDistLookupType) < 0) {
+  PyDistLookupType = PyType_FromSpec(&PyDistLookupType_spec);
+  if (PyDistLookupType == NULL) {
     return -1;
   }
 
-  Py_INCREF(&PyDistLookupType);
-  return PyModule_AddObject(m, "DistortionLookupTable", (PyObject *)&PyDistLookupType);
+  return PyModule_AddObject(m, "DistortionLookupTable", PyDistLookupType);
 }

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -5,6 +5,9 @@
 
 #define NO_IMPORT_ARRAY
 
+#include <stdlib.h> // malloc, free
+#include <string.h> // memcpy
+
 /* util.h must be imported first */
 #include "astropy_wcs/pyutil.h"
 
@@ -871,7 +874,7 @@ set_pvcards(
   if (!fastseq)
     goto done;
 
-  size = PySequence_Fast_GET_SIZE(value);
+  size = PySequence_Size(value);
   newmem = malloc(sizeof(struct pvcard) * size);
 
   /* Raise exception if size is nonzero but newmem
@@ -881,11 +884,13 @@ set_pvcards(
     return -1;
   }
 
+  PyObject* item = NULL;
   for (i = 0; i < size; ++i)
   {
-    if (!PyArg_ParseTuple(PySequence_Fast_GET_ITEM(value, i), "iid",
+    if (!PyArg_ParseTuple((item = PySequence_GetItem(value, i)), "iid",
         &newmem[i].i, &newmem[i].m, &newmem[i].value))
     {
+      Py_DECREF(item);
       goto done;
     }
   }

--- a/astropy/wcs/src/str_list_proxy.c
+++ b/astropy/wcs/src/str_list_proxy.c
@@ -5,13 +5,14 @@
 
 #define NO_IMPORT_ARRAY
 
+#include <stdlib.h> // malloc, free
 #include "astropy_wcs/pyutil.h"
 
 /***************************************************************************
  * List-of-strings proxy object
  ***************************************************************************/
 
-static PyTypeObject PyStrListProxyType;
+static PyObject* PyStrListProxyType;
 
 typedef struct {
   PyObject_HEAD
@@ -27,7 +28,10 @@ PyStrListProxy_dealloc(
 
   PyObject_GC_UnTrack(self);
   Py_XDECREF(self->pyobject);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  PyTypeObject *tp = Py_TYPE((PyObject*)self);
+  freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+  free_func((PyObject*)self);
+  Py_DECREF(tp);
 }
 
 /*@null@*/ static PyObject *
@@ -38,7 +42,8 @@ PyStrListProxy_new(
 
   PyStrListProxy* self = NULL;
 
-  self = (PyStrListProxy*)type->tp_alloc(type, 0);
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyStrListProxy*)alloc_func(type, 0);
   if (self != NULL) {
     self->pyobject = NULL;
   }
@@ -52,6 +57,7 @@ PyStrListProxy_traverse(
     void *arg) {
 
   Py_VISIT(self->pyobject);
+  Py_VISIT((PyObject*)Py_TYPE(self));
   return 0;
 }
 
@@ -77,7 +83,9 @@ PyStrListProxy_New(
     maxsize = 68;
   }
 
-  self = (PyStrListProxy*)PyStrListProxyType.tp_alloc(&PyStrListProxyType, 0);
+  PyTypeObject* tp = (PyTypeObject*)PyStrListProxyType;
+  allocfunc alloc_func = PyType_GetSlot(tp, Py_tp_alloc);
+  self = (PyStrListProxy*)alloc_func(tp, 0);
   if (self == NULL) {
     return NULL;
   }
@@ -197,65 +205,33 @@ PyStrListProxy_repr(
   return str_list_proxy_repr(self->array, self->size, self->maxsize);
 }
 
-static PySequenceMethods PyStrListProxy_sequence_methods = {
-  (lenfunc)PyStrListProxy_len,
-  NULL,
-  NULL,
-  (ssizeargfunc)PyStrListProxy_getitem,
-  NULL,
-  (ssizeobjargproc)PyStrListProxy_setitem,
-  NULL,
-  NULL,
-  NULL,
-  NULL
+static PyType_Spec PyStrListProxyType_spec = {
+  .name = "astropy.wcs.StrListProxy",
+  .basicsize = sizeof(PyStrListProxy),
+  .itemsize = 0,
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+  .slots = (PyType_Slot[]){
+    {Py_tp_dealloc, (destructor)PyStrListProxy_dealloc},
+    {Py_tp_repr, (reprfunc)PyStrListProxy_repr},
+    {Py_sq_length, (lenfunc)PyStrListProxy_len},
+    {Py_sq_item, (ssizeargfunc)PyStrListProxy_getitem},
+    {Py_sq_ass_item, (ssizeobjargproc)PyStrListProxy_setitem},
+    {Py_tp_str, (reprfunc)PyStrListProxy_repr},
+    {Py_tp_traverse, (traverseproc)PyStrListProxy_traverse},
+    {Py_tp_clear, (inquiry)PyStrListProxy_clear},
+    {Py_tp_new, (newfunc)PyStrListProxy_new},
+    {0, NULL},
+  },
 };
 
-static PyTypeObject PyStrListProxyType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "astropy.wcs.StrListProxy", /*tp_name*/
-  sizeof(PyStrListProxy),  /*tp_basicsize*/
-  0,                          /*tp_itemsize*/
-  (destructor)PyStrListProxy_dealloc, /*tp_dealloc*/
-  0,                          /*tp_print*/
-  0,                          /*tp_getattr*/
-  0,                          /*tp_setattr*/
-  0,                          /*tp_compare*/
-  (reprfunc)PyStrListProxy_repr, /*tp_repr*/
-  0,                          /*tp_as_number*/
-  &PyStrListProxy_sequence_methods, /*tp_as_sequence*/
-  0,                          /*tp_as_mapping*/
-  0,                          /*tp_hash */
-  0,                          /*tp_call*/
-  (reprfunc)PyStrListProxy_repr, /*tp_str*/
-  0,                          /*tp_getattro*/
-  0,                          /*tp_setattro*/
-  0,                          /*tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-  0,                          /* tp_doc */
-  (traverseproc)PyStrListProxy_traverse, /* tp_traverse */
-  (inquiry)PyStrListProxy_clear, /* tp_clear */
-  0,                          /* tp_richcompare */
-  0,                          /* tp_weaklistoffset */
-  0,                          /* tp_iter */
-  0,                          /* tp_iternext */
-  0,                          /* tp_methods */
-  0,                          /* tp_members */
-  0,                          /* tp_getset */
-  0,                          /* tp_base */
-  0,                          /* tp_dict */
-  0,                          /* tp_descr_get */
-  0,                          /* tp_descr_set */
-  0,                          /* tp_dictoffset */
-  0,                          /* tp_init */
-  0,                          /* tp_alloc */
-  PyStrListProxy_new,      /* tp_new */
-};
+static PyObject* PyStrListProxyType = NULL;
 
 int
 _setup_str_list_proxy_type(
     /*@unused@*/ PyObject* m) {
 
-  if (PyType_Ready(&PyStrListProxyType) < 0) {
+  PyStrListProxyType = PyType_FromSpec(&PyStrListProxyType_spec);
+  if (PyStrListProxyType == NULL) {
     return 1;
   }
 

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -5,6 +5,7 @@
 
 #define NO_IMPORT_ARRAY
 
+#include <string.h> // strncmp
 #include "astropy_wcs/pyutil.h"
 #include "astropy_wcs/str_list_proxy.h"
 
@@ -15,7 +16,7 @@
 #define MAXSIZE 68
 #define ARRAYSIZE 72
 
-static PyTypeObject PyUnitListProxyType;
+static PyObject* PyUnitListProxyType;
 
 typedef struct {
   PyObject_HEAD
@@ -31,7 +32,10 @@ PyUnitListProxy_dealloc(
 
   PyObject_GC_UnTrack(self);
   Py_XDECREF(self->pyobject);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  PyTypeObject *tp = Py_TYPE((PyObject*)self);
+  freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+  free_func((PyObject*)self);
+  Py_DECREF(tp);
 }
 
 /*@null@*/ static PyObject *
@@ -42,7 +46,8 @@ PyUnitListProxy_new(
 
   PyUnitListProxy* self = NULL;
 
-  self = (PyUnitListProxy*)type->tp_alloc(type, 0);
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyUnitListProxy*)alloc_func(type, 0);
   if (self != NULL) {
     self->pyobject = NULL;
     self->unit_class = NULL;
@@ -58,6 +63,7 @@ PyUnitListProxy_traverse(
 
   Py_VISIT(self->pyobject);
   Py_VISIT(self->unit_class);
+  Py_VISIT((PyObject*)Py_TYPE(self));
   return 0;
 }
 
@@ -100,8 +106,9 @@ PyUnitListProxy_New(
 
   Py_INCREF(unit_class);
 
-  self = (PyUnitListProxy*)PyUnitListProxyType.tp_alloc(
-      &PyUnitListProxyType, 0);
+  PyTypeObject* type = (PyTypeObject*)PyUnitListProxyType;
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyUnitListProxy*)alloc_func(type, 0);
   if (self == NULL) {
     return NULL;
   }
@@ -180,8 +187,8 @@ PyUnitListProxy_richcmp(
   Py_ssize_t idx;
   int equal = 1;
   assert(a != NULL && b != NULL);
-  if (!PyObject_TypeCheck(a, &PyUnitListProxyType) ||
-      !PyObject_TypeCheck(b, &PyUnitListProxyType)) {
+  if (!PyObject_TypeCheck(a, (PyTypeObject*)PyUnitListProxyType) ||
+      !PyObject_TypeCheck(b, (PyTypeObject*)PyUnitListProxyType)) {
     Py_RETURN_NOTIMPLEMENTED;
   }
   if (op != Py_EQ && op != Py_NE) {
@@ -260,60 +267,27 @@ PyUnitListProxy_repr(
   return str_list_proxy_repr(self->array, self->size, MAXSIZE);
 }
 
-static PySequenceMethods PyUnitListProxy_sequence_methods = {
-  (lenfunc)PyUnitListProxy_len,
-  NULL,
-  NULL,
-  (ssizeargfunc)PyUnitListProxy_getitem,
-  NULL,
-  (ssizeobjargproc)PyUnitListProxy_setitem,
-  NULL,
-  NULL,
-  NULL,
-  NULL
+static PyType_Spec PyUnitListProxyType_spec = {
+  .name = "astropy.wcs.UnitListProxy",
+  .basicsize = sizeof(PyUnitListProxy),
+  .itemsize = 0,
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE,
+  .slots = (PyType_Slot[]){
+    {Py_tp_dealloc, (destructor)PyUnitListProxy_dealloc},
+    {Py_tp_repr, (reprfunc)PyUnitListProxy_repr},
+    {Py_tp_str, (reprfunc)PyUnitListProxy_repr},
+    {Py_tp_traverse, (traverseproc)PyUnitListProxy_traverse},
+    {Py_tp_clear, (inquiry)PyUnitListProxy_clear},
+    {Py_tp_richcompare, (richcmpfunc)PyUnitListProxy_richcmp},
+    {Py_tp_new, (newfunc)PyUnitListProxy_new},
+    {Py_sq_length, (lenfunc)PyUnitListProxy_len},
+    {Py_sq_item, (ssizeargfunc)PyUnitListProxy_getitem},
+    {Py_sq_ass_item, (ssizeobjargproc)PyUnitListProxy_setitem},
+    {0, NULL},
+  },
 };
 
-static PyTypeObject PyUnitListProxyType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "astropy.wcs.UnitListProxy", /*tp_name*/
-  sizeof(PyUnitListProxy),  /*tp_basicsize*/
-  0,                          /*tp_itemsize*/
-  (destructor)PyUnitListProxy_dealloc, /*tp_dealloc*/
-  0,                          /*tp_print*/
-  0,                          /*tp_getattr*/
-  0,                          /*tp_setattr*/
-  0,                          /*tp_compare*/
-  (reprfunc)PyUnitListProxy_repr, /*tp_repr*/
-  0,                          /*tp_as_number*/
-  &PyUnitListProxy_sequence_methods, /*tp_as_sequence*/
-  0,                          /*tp_as_mapping*/
-  0,                          /*tp_hash */
-  0,                          /*tp_call*/
-  (reprfunc)PyUnitListProxy_repr, /*tp_str*/
-  0,                          /*tp_getattro*/
-  0,                          /*tp_setattro*/
-  0,                          /*tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-  0,                          /* tp_doc */
-  (traverseproc)PyUnitListProxy_traverse, /* tp_traverse */
-  (inquiry)PyUnitListProxy_clear, /* tp_clear */
-  (richcmpfunc)PyUnitListProxy_richcmp, /* tp_richcompare */
-  0,                          /* tp_weaklistoffset */
-  0,                          /* tp_iter */
-  0,                          /* tp_iternext */
-  0,                          /* tp_methods */
-  0,                          /* tp_members */
-  0,                          /* tp_getset */
-  0,                          /* tp_base */
-  0,                          /* tp_dict */
-  0,                          /* tp_descr_get */
-  0,                          /* tp_descr_set */
-  0,                          /* tp_dictoffset */
-  0,                          /* tp_init */
-  0,                          /* tp_alloc */
-  PyUnitListProxy_new,      /* tp_new */
-};
-
+static PyObject* PyUnitListProxyType = NULL;
 
 int
 set_unit_list(
@@ -379,7 +353,8 @@ int
 _setup_unit_list_proxy_type(
     /*@unused@*/ PyObject* m) {
 
-  if (PyType_Ready(&PyUnitListProxyType) < 0) {
+  PyUnitListProxyType = PyType_FromSpec(&PyUnitListProxyType_spec);
+  if (PyUnitListProxyType == NULL) {
     return 1;
   }
 

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -22,7 +22,9 @@
 static PyObject*
 PyAuxprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
   PyAuxprm* self;
-  self = (PyAuxprm*)type->tp_alloc(type, 0);
+
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyAuxprm*)alloc_func(type, 0);
   return (PyObject*)self;
 }
 
@@ -30,6 +32,7 @@ PyAuxprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
 static int
 PyAuxprm_traverse(PyAuxprm* self, visitproc visit, void *arg) {
   Py_VISIT(self->owner);
+  Py_VISIT((PyObject*)Py_TYPE(self));
   return 0;
 }
 
@@ -43,13 +46,18 @@ PyAuxprm_clear(PyAuxprm* self) {
 
 static void PyAuxprm_dealloc(PyAuxprm* self) {
   PyAuxprm_clear(self);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  PyTypeObject *tp = Py_TYPE((PyObject*)self);
+  freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+  free_func((PyObject*)self);
+  Py_DECREF(tp);
 }
 
 
 PyAuxprm* PyAuxprm_cnew(PyObject* wcsprm, struct auxprm* x) {
   PyAuxprm* self;
-  self = (PyAuxprm*)(&PyAuxprmType)->tp_alloc(&PyAuxprmType, 0);
+  PyTypeObject* type = (PyTypeObject*)PyAuxprmType;
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyAuxprm*)alloc_func(type, 0);
   if (self == NULL) return NULL;
   self->x = x;
   Py_INCREF(wcsprm);
@@ -330,57 +338,35 @@ static PyGetSetDef PyAuxprm_getset[] = {
   {NULL}
 };
 
-PyTypeObject PyAuxprmType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "astropy.wcs.Auxprm",         /*tp_name*/
-  sizeof(PyAuxprm),             /*tp_basicsize*/
-  0,                            /*tp_itemsize*/
-  (destructor)PyAuxprm_dealloc, /*tp_dealloc*/
-  0,                            /*tp_print*/
-  0,                            /*tp_getattr*/
-  0,                            /*tp_setattr*/
-  0,                            /*tp_compare*/
-  0,                            /*tp_repr*/
-  0,                            /*tp_as_number*/
-  0,                            /*tp_as_sequence*/
-  0,                            /*tp_as_mapping*/
-  0,                            /*tp_hash */
-  0,                            /*tp_call*/
-  (reprfunc)PyAuxprm___str__,   /*tp_str*/
-  0,                            /*tp_getattro*/
-  0,                            /*tp_setattro*/
-  0,                            /*tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  doc_Auxprm,                   /* tp_doc */
-  (traverseproc)PyAuxprm_traverse, /* tp_traverse */
-  (inquiry)PyAuxprm_clear,      /* tp_clear */
-  0,                            /* tp_richcompare */
-  0,                            /* tp_weaklistoffset */
-  0,                            /* tp_iter */
-  0,                            /* tp_iternext */
-  0,                            /* tp_methods */
-  0,                            /* tp_members */
-  PyAuxprm_getset,              /* tp_getset */
-  0,                            /* tp_base */
-  0,                            /* tp_dict */
-  0,                            /* tp_descr_get */
-  0,                            /* tp_descr_set */
-  0,                            /* tp_dictoffset */
-  0,                            /* tp_init */
-  0,                            /* tp_alloc */
-  0,                            /* tp_new */
+PyType_Spec PyAuxprmType_spec = {
+  .name = "astropy.wcs.Auxprm",
+  .basicsize = sizeof(PyAuxprm),
+  .itemsize = 0,
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+  .slots = (PyType_Slot[]) {
+    {Py_tp_dealloc, (destructor)PyAuxprm_dealloc},
+    {Py_tp_str, (reprfunc)PyAuxprm___str__},
+    {Py_tp_doc, doc_Auxprm},
+    {Py_tp_traverse, (traverseproc)PyAuxprm_traverse},
+    {Py_tp_clear, (inquiry)PyAuxprm_clear},
+    {Py_tp_getset, PyAuxprm_getset},
+    // FIXME: this seems logical but this slot wasn't previously set
+    // maybe a mistake from https://github.com/astropy/astropy/pull/10333 ?
+    // {Py_tp_new, (void*)PyAuxprm_new},
+    {0, NULL}
+  },
 };
 
+PyObject* PyAuxprmType = NULL;
 
 int
 _setup_auxprm_type(PyObject* m) {
-  if (PyType_Ready(&PyAuxprmType) < 0) {
+  PyAuxprmType = PyType_FromSpec(&PyAuxprmType_spec);
+  if (PyAuxprmType == NULL) {
     return -1;
   }
 
-  Py_INCREF(&PyAuxprmType);
-
-  PyModule_AddObject(m, "Auxprm", (PyObject *)&PyAuxprmType);
+  PyModule_AddObject(m, "Auxprm", PyAuxprmType);
 
   return 0;
 }

--- a/astropy/wcs/src/wcslib_celprm_wrap.c
+++ b/astropy/wcs/src/wcslib_celprm_wrap.c
@@ -1,5 +1,8 @@
 #define NO_IMPORT_ARRAY
 
+#include <stdlib.h> // calloc, malloc, free
+#include <string.h> // memcpy
+
 #include "astropy_wcs/wcslib_celprm_wrap.h"
 #include "astropy_wcs/wcslib_prjprm_wrap.h"
 
@@ -71,7 +74,8 @@ static int is_cel_null(PyCelprm* self)
 static PyObject* PyCelprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
     PyCelprm* self;
-    self = (PyCelprm*)type->tp_alloc(type, 0);
+    allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+    self = (PyCelprm*)alloc_func(type, 0);
     if (self == NULL) return NULL;
     self->owner = NULL;
     self->prefcount = NULL;
@@ -100,6 +104,7 @@ static PyObject* PyCelprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds
 static int PyCelprm_traverse(PyCelprm* self, visitproc visit, void *arg)
 {
     Py_VISIT(self->owner);
+    Py_VISIT((PyObject*)Py_TYPE(self));
     return 0;
 }
 
@@ -119,7 +124,10 @@ static void PyCelprm_dealloc(PyCelprm* self)
         free(self->x);
         free(self->prefcount);
     }
-    Py_TYPE(self)->tp_free((PyObject*)self);
+    PyTypeObject *tp = Py_TYPE((PyObject*)self);
+    freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+    free_func((PyObject*)self);
+    Py_DECREF(tp);
 }
 
 
@@ -142,7 +150,9 @@ static PyObject* PyCelprm_set(PyCelprm* self)
 PyCelprm* PyCelprm_cnew(PyObject* wcsprm_obj, struct celprm* x, int* prefcount)
 {
     PyCelprm* self;
-    self = (PyCelprm*)(&PyCelprmType)->tp_alloc(&PyCelprmType, 0);
+    PyTypeObject* type = (PyTypeObject*)PyCelprmType;
+    allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+    self = (PyCelprm*)alloc_func(type, 0);
     if (self == NULL) return NULL;
     self->x = x;
     Py_XINCREF(wcsprm_obj);
@@ -164,7 +174,7 @@ static PyObject* PyCelprm_copy(PyCelprm* self)
 
 static PyObject* PyCelprm_deepcopy(PyCelprm* self)
 {
-    PyCelprm* copy = (PyCelprm*) PyCelprm_new(&PyCelprmType, NULL, NULL);
+    PyCelprm* copy = (PyCelprm*) PyCelprm_new((PyTypeObject*)PyCelprmType, NULL, NULL);
     if (copy == NULL) return NULL;
 
     memcpy(copy->x, self->x, sizeof(struct celprm));
@@ -422,54 +432,31 @@ static PyMethodDef PyCelprm_methods[] = {
     {NULL}
 };
 
-
-PyTypeObject PyCelprmType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "astropy.wcs.Celprm",         /*tp_name*/
-    sizeof(PyCelprm),             /*tp_basicsize*/
-    0,                            /*tp_itemsize*/
-    (destructor)PyCelprm_dealloc, /*tp_dealloc*/
-    0,                            /*tp_print*/
-    0,                            /*tp_getattr*/
-    0,                            /*tp_setattr*/
-    0,                            /*tp_compare*/
-    0,                            /*tp_repr*/
-    0,                            /*tp_as_number*/
-    0,                            /*tp_as_sequence*/
-    0,                            /*tp_as_mapping*/
-    0,                            /*tp_hash */
-    0,                            /*tp_call*/
-    (reprfunc)PyCelprm___str__,   /*tp_str*/
-    0,                            /*tp_getattro*/
-    0,                            /*tp_setattro*/
-    0,                            /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    doc_Celprm,                   /* tp_doc */
-    (traverseproc)PyCelprm_traverse, /* tp_traverse */
-    (inquiry)PyCelprm_clear,      /* tp_clear */
-    0,                            /* tp_richcompare */
-    0,                            /* tp_weaklistoffset */
-    0,                            /* tp_iter */
-    0,                            /* tp_iternext */
-    PyCelprm_methods,             /* tp_methods */
-    0,                            /* tp_members */
-    PyCelprm_getset,              /* tp_getset */
-    0,                            /* tp_base */
-    0,                            /* tp_dict */
-    0,                            /* tp_descr_get */
-    0,                            /* tp_descr_set */
-    0,                            /* tp_dictoffset */
-    0,                            /* tp_init */
-    0,                            /* tp_alloc */
-    PyCelprm_new,                 /* tp_new */
+static PyType_Spec PyCelprmType_spec = {
+    .name = "astropy.wcs.Celprm",
+    .basicsize = sizeof(PyCelprm),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = (PyType_Slot[]){
+        {Py_tp_dealloc, (destructor)PyCelprm_dealloc},
+        {Py_tp_str, (reprfunc)PyCelprm___str__},
+        {Py_tp_doc, doc_Celprm},
+        {Py_tp_traverse, (traverseproc)PyCelprm_traverse},
+        {Py_tp_clear, (inquiry)PyCelprm_clear},
+        {Py_tp_methods, PyCelprm_methods},
+        {Py_tp_getset, PyCelprm_getset},
+        {Py_tp_new, PyCelprm_new},
+        {0, NULL},
+    },
 };
 
+PyObject* PyCelprmType = NULL;
 
 int _setup_celprm_type(PyObject* m)
 {
-    if (PyType_Ready(&PyCelprmType) < 0) return -1;
-    Py_INCREF(&PyCelprmType);
-    PyModule_AddObject(m, "Celprm", (PyObject *)&PyCelprmType);
+    PyCelprmType = PyType_FromSpec(&PyCelprmType_spec);
+    if (PyCelprmType == NULL) return -1;
+    PyModule_AddObject(m, "Celprm", PyCelprmType);
 
     cel_errexc[0] = NULL;                         /* Success */
     cel_errexc[1] = &PyExc_MemoryError;           /* Null celprm pointer passed */

--- a/astropy/wcs/src/wcslib_prjprm_wrap.c
+++ b/astropy/wcs/src/wcslib_prjprm_wrap.c
@@ -1,6 +1,8 @@
 #define NO_IMPORT_ARRAY
 #include <math.h>
 #include <float.h>
+#include <stdlib.h> // calloc, malloc, free
+#include <string.h> // memcpy, strlen, strncpy
 
 #include "astropy_wcs/wcslib_celprm_wrap.h"
 #include "astropy_wcs/wcslib_prjprm_wrap.h"
@@ -70,7 +72,8 @@ static int is_prj_null(PyPrjprm* self)
 static PyObject* PyPrjprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
     PyPrjprm* self;
-    self = (PyPrjprm*)type->tp_alloc(type, 0);
+    allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+    self = (PyPrjprm*)alloc_func(type, 0);
     if (self == NULL) return NULL;
     self->owner = NULL;
     self->x = NULL;
@@ -98,6 +101,7 @@ static PyObject* PyPrjprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds
 static int PyPrjprm_traverse(PyPrjprm* self, visitproc visit, void *arg)
 {
     Py_VISIT(self->owner);
+    Py_VISIT((PyObject*)Py_TYPE(self));
     return 0;
 }
 
@@ -117,14 +121,19 @@ static void PyPrjprm_dealloc(PyPrjprm* self)
         free(self->x);
         free(self->prefcount);
     }
-    Py_TYPE(self)->tp_free((PyObject*)self);
+    PyTypeObject *tp = Py_TYPE((PyObject*)self);
+    freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+    free_func((PyObject*)self);
+    Py_DECREF(tp);
 }
 
 
 PyPrjprm* PyPrjprm_cnew(PyObject* celprm_obj, struct prjprm* x, int* prefcount)
 {
     PyPrjprm* self;
-    self = (PyPrjprm*)(&PyPrjprmType)->tp_alloc(&PyPrjprmType, 0);
+    PyTypeObject* type = (PyTypeObject*)PyPrjprmType;
+    allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+    self = (PyPrjprm*)alloc_func(type, 0);
     if (self == NULL) return NULL;
     self->x = x;
     Py_XINCREF(celprm_obj);
@@ -146,7 +155,7 @@ static PyObject* PyPrjprm_copy(PyPrjprm* self)
 
 static PyObject* PyPrjprm_deepcopy(PyPrjprm* self)
 {
-    PyPrjprm* copy = (PyPrjprm*) PyPrjprm_new(&PyPrjprmType, NULL, NULL);
+    PyPrjprm* copy = (PyPrjprm*) PyPrjprm_new((PyTypeObject*)PyPrjprmType, NULL, NULL);
     if (copy == NULL) return NULL;
 
     memcpy(copy->x, self->x, sizeof(struct prjprm));
@@ -268,11 +277,11 @@ static PyObject* _prj_eval(PyPrjprm* self, int (*prjfn)(PRJX2S_ARGS),
     }
 
     exit:
-        Py_XDECREF(x1);
-        Py_XDECREF(x2);
-        Py_XDECREF(prj_x1);
-        Py_XDECREF(prj_x2);
-        Py_XDECREF(stat);
+        Py_XDECREF((PyObject*)x1);
+        Py_XDECREF((PyObject*)x2);
+        Py_XDECREF((PyObject*)prj_x1);
+        Py_XDECREF((PyObject*)prj_x2);
+        Py_XDECREF((PyObject*)stat);
 
     return result;
 }
@@ -613,7 +622,6 @@ static PyObject* PyPrjprm_get_pvi(PyPrjprm* self, PyObject* args, PyObject* kwds
 {
     int idx;
     PyObject* index = NULL;
-    PyObject* value = NULL;
     const char* keywords[] = { "index", NULL };
 
     if (is_prj_null(self)) return NULL;
@@ -954,54 +962,31 @@ static PyMethodDef PyPrjprm_methods[] = {
     {NULL}
 };
 
-
-PyTypeObject PyPrjprmType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "astropy.wcs.Prjprm",         /*tp_name*/
-    sizeof(PyPrjprm),             /*tp_basicsize*/
-    0,                            /*tp_itemsize*/
-    (destructor)PyPrjprm_dealloc, /*tp_dealloc*/
-    0,                            /*tp_print*/
-    0,                            /*tp_getattr*/
-    0,                            /*tp_setattr*/
-    0,                            /*tp_compare*/
-    0,                            /*tp_repr*/
-    0,                            /*tp_as_number*/
-    0,                            /*tp_as_sequence*/
-    0,                            /*tp_as_mapping*/
-    0,                            /*tp_hash */
-    0,                            /*tp_call*/
-    (reprfunc)PyPrjprm___str__,   /*tp_str*/
-    0,                            /*tp_getattro*/
-    0,                            /*tp_setattro*/
-    0,                            /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    doc_Prjprm,                   /* tp_doc */
-    (traverseproc)PyPrjprm_traverse, /* tp_traverse */
-    (inquiry)PyPrjprm_clear,      /* tp_clear */
-    0,                            /* tp_richcompare */
-    0,                            /* tp_weaklistoffset */
-    0,                            /* tp_iter */
-    0,                            /* tp_iternext */
-    PyPrjprm_methods,             /* tp_methods */
-    0,                            /* tp_members */
-    PyPrjprm_getset,              /* tp_getset */
-    0,                            /* tp_base */
-    0,                            /* tp_dict */
-    0,                            /* tp_descr_get */
-    0,                            /* tp_descr_set */
-    0,                            /* tp_dictoffset */
-    0,                            /* tp_init */
-    0,                            /* tp_alloc */
-    PyPrjprm_new,                 /* tp_new */
+static PyType_Spec PyPrjprm_spec = {
+    .name = "astropy.wcs.Prjprm",
+    .basicsize = sizeof(PyPrjprm),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+    .slots = (PyType_Slot[]) {
+        {Py_tp_dealloc, (destructor)PyPrjprm_dealloc},
+        {Py_tp_str, (reprfunc)PyPrjprm___str__},
+        {Py_tp_doc, doc_Prjprm},
+        {Py_tp_traverse, (traverseproc)PyPrjprm_traverse},
+        {Py_tp_clear, (inquiry)PyPrjprm_clear},
+        {Py_tp_methods, PyPrjprm_methods},
+        {Py_tp_getset, PyPrjprm_getset},
+        {Py_tp_new, PyPrjprm_new},
+        {0, NULL},
+    },
 };
 
+PyObject* PyPrjprmType = NULL;
 
 int _setup_prjprm_type(PyObject* m)
 {
-    if (PyType_Ready(&PyPrjprmType) < 0) return -1;
-    Py_INCREF(&PyPrjprmType);
-    PyModule_AddObject(m, "Prjprm", (PyObject *)&PyPrjprmType);
+    PyPrjprmType = PyType_FromSpec(&PyPrjprm_spec);
+    if (PyPrjprmType == NULL) return -1;
+    PyModule_AddObject(m, "Prjprm", PyPrjprmType);
 
     prj_errexc[0] = NULL;                         /* Success */
     prj_errexc[1] = &PyExc_MemoryError;           /* Null prjprm pointer passed */

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -5,6 +5,9 @@
 
 #define NO_IMPORT_ARRAY
 
+#include <stdlib.h> // calloc, malloc, free
+#include <string.h> // memset, strlen, strncpy
+
 #include "astropy_wcs/wcslib_wrap.h"
 #include "astropy_wcs/wcslib_auxprm_wrap.h"
 #include "astropy_wcs/wcslib_prjprm_wrap.h"
@@ -215,7 +218,7 @@ int _update_wtbarr_from_hdulist(PyObject *hdulist, struct wtbarr *wtb) {
     return 0;
   }
 
-  if (!PyArray_Check(arrayp)) {
+  if (!PyArray_Check((PyObject*)arrayp)) {
     PyErr_SetString(PyExc_TypeError,
                     "wtbarr callback must return a numpy.ndarray type "
                     "coordinate or index array.");
@@ -308,13 +311,18 @@ PyWcsprm_dealloc(
     PyWcsprm* self) {
 
   wcsfree(&self->x);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  PyTypeObject *tp = Py_TYPE((PyObject*)self);
+  freefunc free_func = PyType_GetSlot(tp, Py_tp_free);
+  free_func((PyObject*)self);
+  Py_DECREF(tp);
 }
 
 static PyWcsprm*
 PyWcsprm_cnew(void) {
   PyWcsprm* self;
-  self = (PyWcsprm*)(&PyWcsprmType)->tp_alloc(&PyWcsprmType, 0);
+  PyTypeObject* type = (PyTypeObject*)PyWcsprmType;
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyWcsprm*)alloc_func(type, 0);
   return self;
 }
 
@@ -325,7 +333,8 @@ PyWcsprm_new(
     /*@unused@*/ PyObject* kwds) {
 
   PyWcsprm* self;
-  self = (PyWcsprm*)type->tp_alloc(type, 0);
+  allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
+  self = (PyWcsprm*)alloc_func(type, 0);
   return (PyObject*)self;
 }
 
@@ -645,14 +654,14 @@ PyWcsprm_copy(
 
   if (status == 0) {
     if (PyWcsprm_cset(copy, 0)) {
-      Py_XDECREF(copy);
+      Py_XDECREF((PyObject*)copy);
       return NULL;
     }
 
     wcsprm_c2python(&copy->x);
     return (PyObject*)copy;
   } else {
-    Py_XDECREF(copy);
+    Py_XDECREF((PyObject*)copy);
     wcs_to_python_exc(&(self->x));
     return NULL;
   }
@@ -866,7 +875,7 @@ PyWcsprm_compare(
 
   if (!PyArg_ParseTupleAndKeywords(
           args, kwds, "O!|id:compare", (char **)keywords,
-          &PyWcsprmType, &other, &cmp, &tolerance)) {
+          (PyTypeObject*)PyWcsprmType, &other, &cmp, &tolerance)) {
     return NULL;
   }
 
@@ -929,7 +938,7 @@ PyWcsprm_cylfix(
   status = cylfix(naxis, &self->x);
   wcsprm_c2python(&self->x);
 
-  Py_XDECREF(naxis_array);
+  Py_XDECREF((PyObject*)naxis_array);
 
   if (status == -1 || status == 0) {
     return PyLong_FromLong((long)status);
@@ -1031,7 +1040,7 @@ PyWcsprm_fix(
 
   /* We're done with this already, so deref now so we don't have to remember
      later */
-  Py_XDECREF(naxis_array);
+  Py_XDECREF((PyObject*)naxis_array);
 
   result = PyDict_New();
   if (result == NULL) {
@@ -1310,11 +1319,11 @@ PyWcsprm_mix(
   }
 
  exit:
-  Py_XDECREF(world);
-  Py_XDECREF(phi);
-  Py_XDECREF(theta);
-  Py_XDECREF(imgcrd);
-  Py_XDECREF(pixcrd);
+  Py_XDECREF((PyObject*)world);
+  Py_XDECREF((PyObject*)phi);
+  Py_XDECREF((PyObject*)theta);
+  Py_XDECREF((PyObject*)imgcrd);
+  Py_XDECREF((PyObject*)pixcrd);
 
   if (status == 0) {
     return result;
@@ -1451,12 +1460,12 @@ PyWcsprm_p2s(
   }
 
  exit:
-  Py_XDECREF(pixcrd);
-  Py_XDECREF(imgcrd);
-  Py_XDECREF(phi);
-  Py_XDECREF(theta);
-  Py_XDECREF(world);
-  Py_XDECREF(stat);
+  Py_XDECREF((PyObject*)pixcrd);
+  Py_XDECREF((PyObject*)imgcrd);
+  Py_XDECREF((PyObject*)phi);
+  Py_XDECREF((PyObject*)theta);
+  Py_XDECREF((PyObject*)world);
+  Py_XDECREF((PyObject*)stat);
 
   if (status == 0 || status == 8) {
     return result;
@@ -1594,12 +1603,12 @@ PyWcsprm_s2p(
   }
 
  exit:
-  Py_XDECREF(pixcrd);
-  Py_XDECREF(imgcrd);
-  Py_XDECREF(phi);
-  Py_XDECREF(theta);
-  Py_XDECREF(world);
-  Py_XDECREF(stat);
+  Py_XDECREF((PyObject*)pixcrd);
+  Py_XDECREF((PyObject*)imgcrd);
+  Py_XDECREF((PyObject*)phi);
+  Py_XDECREF((PyObject*)theta);
+  Py_XDECREF((PyObject*)world);
+  Py_XDECREF((PyObject*)stat);
 
   if (status == 0 || status == 9) {
     return result;
@@ -1795,7 +1804,7 @@ PyObject *PyWcsprm_richcompare(PyObject *a, PyObject *b, int op) {
   struct wcsprm *bx;
 
   if ((op == Py_EQ || op == Py_NE) &&
-      PyObject_TypeCheck(b, &PyWcsprmType)) {
+      PyObject_TypeCheck(b, (PyTypeObject*)PyWcsprmType)) {
     ax = &((PyWcsprm *)a)->x;
     bx = &((PyWcsprm *)b)->x;
 
@@ -1990,12 +1999,12 @@ PyWcsprm_sub(
   if (status == 0) {
     return (PyObject*)py_dest_wcs;
   } else if (status == -1) {
-    Py_XDECREF(py_dest_wcs);
+    Py_XDECREF((PyObject*)py_dest_wcs);
     /* Exception already set */
     return NULL;
   } else {
     wcs_to_python_exc(&(py_dest_wcs->x));
-    Py_XDECREF(py_dest_wcs);
+    Py_XDECREF((PyObject*)py_dest_wcs);
     return NULL;
   }
 }
@@ -3957,7 +3966,7 @@ static PyObject* PyWcsprm_get_wtb(PyWcsprm* self, void* closure) {
       return NULL;
     }
 
-    PyList_SET_ITEM(list, i, elem);
+    PyList_SetItem(list, i, elem);
   }
 
   return list;
@@ -4134,46 +4143,26 @@ static PyMethodDef PyWcsprm_methods[] = {
   {NULL}
 };
 
-PyTypeObject PyWcsprmType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-  "astropy.wcs.Wcsprm",              /*tp_name*/
-  sizeof(PyWcsprm),             /*tp_basicsize*/
-  0,                            /*tp_itemsize*/
-  (destructor)PyWcsprm_dealloc, /*tp_dealloc*/
-  0,                            /*tp_print*/
-  0,                            /*tp_getattr*/
-  0,                            /*tp_setattr*/
-  0,                            /*tp_compare*/
-  (reprfunc)PyWcsprm___str__,   /*tp_repr*/
-  0,                            /*tp_as_number*/
-  0,                            /*tp_as_sequence*/
-  0,                            /*tp_as_mapping*/
-  0,                            /*tp_hash */
-  0,                            /*tp_call*/
-  (reprfunc)PyWcsprm___str__,   /*tp_str*/
-  0,                            /*tp_getattro*/
-  0,                            /*tp_setattro*/
-  0,                            /*tp_as_buffer*/
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  doc_Wcsprm,                   /* tp_doc */
-  0,                            /* tp_traverse */
-  0,                            /* tp_clear */
-  PyWcsprm_richcompare,         /* tp_richcompare */
-  0,                            /* tp_weaklistoffset */
-  0,                            /* tp_iter */
-  0,                            /* tp_iternext */
-  PyWcsprm_methods,             /* tp_methods */
-  0,                            /* tp_members */
-  PyWcsprm_getset,              /* tp_getset */
-  0,                            /* tp_base */
-  0,                            /* tp_dict */
-  0,                            /* tp_descr_get */
-  0,                            /* tp_descr_set */
-  0,                            /* tp_dictoffset */
-  (initproc)PyWcsprm_init,      /* tp_init */
-  0,                            /* tp_alloc */
-  PyWcsprm_new,                 /* tp_new */
+static PyType_Spec PyWcsprm_spec = {
+  .name = "astropy.wcs.Wcsprm",
+  .basicsize = sizeof(PyWcsprm),
+  .itemsize = 0,
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_IMMUTABLETYPE,
+  .slots = (PyType_Slot[]) {
+    {Py_tp_dealloc, (destructor)PyWcsprm_dealloc},
+    {Py_tp_repr, (reprfunc)PyWcsprm___str__},
+    {Py_tp_str, (reprfunc)PyWcsprm___str__},
+    {Py_tp_doc, doc_Wcsprm},
+    {Py_tp_richcompare, PyWcsprm_richcompare},
+    {Py_tp_methods, PyWcsprm_methods},
+    {Py_tp_getset, PyWcsprm_getset},
+    {Py_tp_init, (initproc)PyWcsprm_init},
+    {Py_tp_new, PyWcsprm_new},
+    {0, NULL},
+  },
 };
+
+PyObject* PyWcsprmType = NULL;
 
 #define CONSTANT(a) PyModule_AddIntConstant(m, #a, a)
 #define CONSTANT2(n, v) PyModule_AddIntConstant(m, n, v)
@@ -4209,18 +4198,17 @@ int add_prj_codes(PyObject* module)
 int
 _setup_wcsprm_type(
     PyObject* m) {
+  PyWcsprmType = PyType_FromSpec(&PyWcsprm_spec);
 
-  if (PyType_Ready(&PyWcsprmType) < 0) {
+  if (PyWcsprmType == NULL) {
     return -1;
   }
-
-  Py_INCREF(&PyWcsprmType);
 
   wcsprintf_set(NULL);
   wcserr_enable(1);
 
   return (
-    PyModule_AddObject(m, "Wcsprm", (PyObject *)&PyWcsprmType) ||
+    PyModule_AddObject(m, "Wcsprm", PyWcsprmType) ||
     CONSTANT(WCSSUB_LONGITUDE) ||
     CONSTANT(WCSSUB_LATITUDE)  ||
     CONSTANT(WCSSUB_CUBEFACE)  ||


### PR DESCRIPTION
### Description
Following [@da-woods' advice](https://github.com/astropy/astropy/issues/18163#issuecomment-2949904220), I think I got *most* of this right, but I'm still struggling to resolve the last compilation-error I'm getting, namely:

```
astropy/wcs/src/astropy_wcs.c:774:28: error: initializer element is not a compile-time constant
  774 | static PyObject* WcsType = PyType_FromSpec(&WCSBaseClass_spec);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

At this point, I'd like to ask @astrofrog and @da-woods for a hand solving this last bit.
Partially address #18163


update: notes to reviewers

- in a couple places I added `FIXME` comments indicating what I believe are bug-for-bug refactors, where I found some methods defined but not included in their natural parent structs
- a couple of functions were simply replaced with a slower equivalent (e.g. `Py_List_GET_ITEM` -> `Py_List_GetItem`). It should be possible to instead select the version we want at compile time using `#ifdef ...` pre-proc directives (if we keep LIMITED_API as a opt-in build option). Let me know if this (small) additional complexity is desired.
- because my primary source of information when working on this were compilation errors and warnings, I ended up fixing many unrelated but noisy warning about mismatched pointer types (i.e. `PY_XDECREF` expects a `PyObject*` pointer)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
