### PR TITLE
Include a limited API build in CI, disabling incompatible extensions

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -134,3 +134,39 @@ jobs:
       test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --pyargs astropy
       targets: |
         - cp311-manylinux_x86_64
+
+
+  test_limited_api_build:
+
+    # Test to make sure that we can build astropy with the limited API
+    # Currently, several extensions do not compile, so we remove them for
+    # now to make sure the remaining ones build fine. Once all the exceptions
+    # are removed, we can remove this job and instead opt in to the limited
+    # API in one of the main build+test tox jobs.
+
+    runs-on: ubuntu-latest
+    name: Python 3.11 (build only) with limited API
+    needs: [initial_checks]
+    env:
+      EXTENSION_HELPERS_PY_LIMITED_API: cp311
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        name: Install Python
+        with:
+          python-version: "3.11"
+      - run: |
+          rm \
+            astropy/cosmology/_src/setup_package.py \
+            astropy/table/_column_mixins.pyx \
+            astropy/table/setup_package.py \
+            astropy/utils/xml/setup_package.py \
+            astropy/wcs/setup_package.py
+        name: Remove incompatible extensions
+      - run: pip install build
+        name: Install build package
+      - run: python -m build
+        name: Run build

--- a/astropy/io/fits/hdu/compressed/src/compression.c
+++ b/astropy/io/fits/hdu/compressed/src/compression.c
@@ -8,7 +8,7 @@
 #include <quantize.h>
 #include <unquantize.h>
 #include <ricecomp.h>
-
+#include <stdlib.h>
 
 /* Define docstrings */
 static char module_docstring[] = "Core compression/decompression functions wrapped from cfitsio.";

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -220,7 +220,7 @@ write_tabledata(PyObject* self, PyObject *args, PyObject *kwds)
     if (!supports_empty_values) goto exit;
     for (i = 0; i < ncols; ++i) {
         supports_empty_values[i] = PyObject_IsTrue(
-                PyList_GET_ITEM(py_supports_empty_values, i));
+                PyList_GetItem(py_supports_empty_values, i));
     }
 
     if ((buf = PyMem_Malloc((size_t)buf_size * sizeof(CHAR))) == NULL) goto exit;
@@ -234,7 +234,7 @@ write_tabledata(PyObject* self, PyObject *args, PyObject *kwds)
         if (_write_cstring(&buf, &buf_size, &x, " <TR>\n", 6)) goto exit;
 
         for (j = 0; j < ncols; ++j) {
-            if ((converter = PyList_GET_ITEM(converters, j)) == NULL) goto exit;
+            if ((converter = PyList_GetItem(converters, j)) == NULL) goto exit;
             if ((array_val = PySequence_GetItem(array_row, j)) == NULL) goto exit;
             if ((mask_val = PySequence_GetItem(mask_row, j)) == NULL) goto exit;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ requires = ["setuptools>=77.0.0",
             "setuptools_scm>=8.0.0",
             "cython>=3.0.0, <4",
             "numpy>=2.0.0, <3",
-            "extension-helpers>=1,<2"]
+            "extension-helpers>=1.4,<2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This adds a simple CI job which checks whether building against the limited API works. This is a very fast job that does not run the tests, so I have included it in the main CI. This is to avoid having to enable all the time consuming CI anytime someone wants to fix something related to the limited API.

Here I make use of the newly released extension-helpers 1.4.0 which includes the ability to opt in to limited API builds via an environment variable.

The idea is that @neutrinoceros could in his PRs remove the removal of the extensions he is fixing.

This PR is a much simple alternative to https://github.com/astropy/astropy/pull/18211

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
