### PR TITLE
TST: fix Limited-API test job's Python version (pin 3.11)

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -164,7 +164,9 @@ jobs:
             astropy/utils/xml/setup_package.py \
             astropy/wcs/setup_package.py
         name: Remove incompatible extensions
-      - run: pipx run build
+      - run: |
+          python -m pip install build
+          python -m build
         name: Run build
         env:
           EXTENSION_HELPERS_PY_LIMITED_API: 'cp311'


### PR DESCRIPTION
### Description
Hotfix for a mistake I introduced via suggestion in #18236: apparently `pipx` runs its own version of Python (namely, in logs I've read, 3.12) instead of the one we *want* to use in this job (3.11).
Sorry about not noticing this earlier ! ping @astrofrog


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
