### PR TITLE
Update Unicode guidelines

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -87,43 +87,19 @@ def assert_follows_unicode_guidelines(x, roundtrip=None):
     from astropy import conf
 
     with conf.set_temp("unicode_output", False):
-        bytes_x = bytes(x)
-        unicode_x = str(x)
+        assert format(x, "").isascii()
+        str_x = str(x)
+        assert str_x.isascii()
         repr_x = repr(x)
-
-        assert isinstance(bytes_x, bytes)
-        bytes_x.decode("ascii")
-        assert isinstance(unicode_x, str)
-        unicode_x.encode("ascii")
-        assert isinstance(repr_x, str)
-        if isinstance(repr_x, bytes):
-            repr_x.decode("ascii")
-        else:
-            repr_x.encode("ascii")
-
+        assert repr_x.isascii()
         if roundtrip is not None:
-            assert x.__class__(bytes_x) == x
-            assert x.__class__(unicode_x) == x
+            assert type(x)(str_x) == x
             assert eval(repr_x, roundtrip) == x
 
     with conf.set_temp("unicode_output", True):
-        bytes_x = bytes(x)
-        unicode_x = str(x)
-        repr_x = repr(x)
-
-        assert isinstance(bytes_x, bytes)
-        bytes_x.decode("ascii")
-        assert isinstance(unicode_x, str)
-        assert isinstance(repr_x, str)
-        if isinstance(repr_x, bytes):
-            repr_x.decode("ascii")
-        else:
-            repr_x.encode("ascii")
-
+        assert repr(x) == repr_x
         if roundtrip is not None:
-            assert x.__class__(bytes_x) == x
-            assert x.__class__(unicode_x) == x
-            assert eval(repr_x, roundtrip) == x
+            assert type(x)(str(x)) == x
 
 
 @pytest.fixture(params=[0, 1, 4, -1])


### PR DESCRIPTION
### Description

It looks to me like our Unicode guidelines were quite reasonable for Python 2, but the text hasn't been properly updated for Python 3. There is no reason anymore why Unicode guidelines should specify anything about `__bytes__()`, and there is little reason Unicode guidelines should specify anything about `__format__()` if the `format_spec` argument is not an empty string. Note that our `"unicode"` unit formatter is contradicting the current guidelines for `__format__()`, so some sort of an update is unavoidable.

I also updated the `assert_follows_unicode_guidelines()` test helper to match the updated guidelines.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
