### PR TITLE
TST: hotfix for running test suite in parallel via `pytest-xdist`

### DIFF
--- a/astropy/constants/tests/test_sciencestate.py
+++ b/astropy/constants/tests/test_sciencestate.py
@@ -26,7 +26,7 @@ def test_previously_imported():
         astronomical_constants.set("iau2015")
 
 
-@pytest.mark.parametrize("version", set(physical_constants._versions.values()))
+@pytest.mark.parametrize("version", sorted(set(physical_constants._versions.values())))
 def test_physical_constants_versions(version):
     """Spot check that setting the different physical constants actually works.
 


### PR DESCRIPTION
### Description
Hotfix for a crash I'm seeing when running, e.g., `pytest -n 5`, where test collection differs from one runner to another, preventing execution altogether. This is a [known limitation](https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#order-and-amount-of-test-must-be-consistent) of using `set`s in `@pytest.mark.parametrize`, and easily fixed.

Follow up to #18118

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
