### PR TITLE
Update `jplephem` requirement to >=2.15

### DIFF
--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -2,7 +2,6 @@
 """Accuracy tests for GCRS coordinate transformations, primarily to/from AltAz."""
 
 import warnings
-from importlib import metadata
 
 import erfa
 import numpy as np
@@ -1035,19 +1034,8 @@ def test_itrs_straight_overhead():
     assert_allclose(hd.dec, 52 * u.deg, atol=1 * u.uas, rtol=0)
 
 
-def jplephem_ge(minversion):
-    """Check if jplephem is installed and has version >= minversion."""
-    # This is a separate routine since somehow with pyinstaller the stanza
-    # not HAS_JPLEPHEM or metadata.version('jplephem') < '2.15'
-    # leads to a module not found error.
-    try:
-        return HAS_JPLEPHEM and metadata.version("jplephem") >= minversion
-    except Exception:
-        return False
-
-
 @pytest.mark.remote_data
-@pytest.mark.skipif(not jplephem_ge("2.15"), reason="requires jplephem >= 2.15")
+@pytest.mark.skipif(not HAS_JPLEPHEM, reason="requires jplephem")
 def test_aa_hd_high_precision():
     """These tests are provided by @mkbrewer - see issue #10356.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ all = [
     "pandas>=2.0",
     "sortedcontainers>=1.5.7", # (older versions may work)
     "pytz>=2016.10", # (older versions may work)
-    "jplephem>=2.6", # (older versions may work)
+    "jplephem>=2.15",
     "mpmath>=1.2.1",
     "asdf>=2.8.3", # via asdf-astropy==0.3.*
     "asdf-astropy>=0.3",


### PR DESCRIPTION
### Description

A test in `coordinates` is incompatible with older versions of `jplephem`, but given that [2.15 was released back in 2020](https://pypi.org/project/jplephem/#history), support for older versions can be dropped and the test setup simplified.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
