### PR TITLE
BUG: ensure time parser works with numpy 2.3.0

### DIFF
--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -367,8 +367,10 @@ parser_loop(char **args, const npy_intp *dimensions, const npy_intp *steps, void
     return;
 
   error:
+    PyGILState_STATE state = PyGILState_Ensure();
     PyErr_Format(PyExc_ValueError,
                  "fast C time string parser failed: %s", msgs[status-1]);
+    PyGILState_Release(state);
     return;
 }
 

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -366,7 +366,7 @@ parser_loop(char **args, const npy_intp *dimensions, const npy_intp *steps, void
     }
     return;
 
-  error:
+  error:;
     PyGILState_STATE state = PyGILState_Ensure();
     PyErr_Format(PyExc_ValueError,
                  "fast C time string parser failed: %s", msgs[status-1]);

--- a/astropy/time/tests/test_fast_parser.py
+++ b/astropy/time/tests/test_fast_parser.py
@@ -142,3 +142,14 @@ def test_fast_subclass():
                 Time("2000:0601", format="yday_subclass")
     finally:
         del TimeYearDayTimeSubClass._registry["yday_subclass"]
+
+
+def test_fast_large_arrays():
+    """Test that we do not segfault on large arrays with wrong formats.
+
+    See gh-18254, where this turned out to happen with numpy 2.3.0.
+    """
+    t = Time(["J2000.0"] * 501)
+    assert t.size == 501
+    with pytest.raises(ValueError, match="Input values did not match any"):
+        Time(["parrot"] * 1000)

--- a/docs/changes/time/18265.bugfix.rst
+++ b/docs/changes/time/18265.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that the fast C parser for ``Time`` works also with numpy 2.3.0, fixing
+a bug in our implementation which had no effect in previous numpy versions.


### PR DESCRIPTION
Ensure that the fast C parser for ``Time`` works also with numpy 2.3.0, fixing a bug in our implementation which had no effect in previous numpy versions.

Fixes #18254

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
