### PR TITLE
Remove a useless constant from `modeling` tests

### DIFF
--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -14,11 +14,8 @@ from numpy.testing import assert_allclose
 from astropy.modeling import fitting, models
 from astropy.modeling.core import Fittable1DModel
 from astropy.modeling.parameters import Parameter
-from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
-
-SCIPY_LT_1_11_2 = not minversion("scipy", "1.11.2") if HAS_SCIPY else True
 
 fitters = [
     fitting.LevMarLSQFitter,


### PR DESCRIPTION
### Description

The constant has not been used anywhere since b6deb07fbfed9310a4be9394255f92536ff46d96.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
