### PR TITLE
Initial commit for hubble parameter trait

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -41,6 +41,7 @@ from astropy.cosmology._src.traits import (
     TemperatureCMB,
     _BaryonComponent,
     _CriticalDensity,
+    _HubbleParameter,
 )
 from astropy.cosmology._src.utils import (
     aszarr,
@@ -95,7 +96,14 @@ ParameterOde0 = Parameter(
 
 
 @dataclass_decorator
-class FLRW(Cosmology, ScaleFactor, TemperatureCMB, _CriticalDensity, _BaryonComponent):
+class FLRW(
+    Cosmology,
+    ScaleFactor,
+    TemperatureCMB,
+    _CriticalDensity,
+    _BaryonComponent,
+    _HubbleParameter,
+):
     """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
     This is an abstract base class -- you cannot instantiate examples of this

--- a/astropy/cosmology/_src/traits/hubble.py
+++ b/astropy/cosmology/_src/traits/hubble.py
@@ -1,0 +1,40 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Hubble parameter trait.
+
+This is private API. See `~astropy.cosmology.traits` for public API.
+"""
+
+__all__ = ["_HubbleParameter"]
+
+from collections.abc import Callable
+from typing import Any
+
+from numpy.typing import ArrayLike, NDArray
+
+from astropy.cosmology._src.utils import deprecated_keywords
+from astropy.units import Quantity
+
+
+class _HubbleParameter:
+    """The object has attributes and methods for the Hubble parameter."""
+
+    H0: Quantity
+    """Hubble constant at redshift 0."""
+
+    efunc: Callable[[Any], NDArray[Any]]
+
+    @deprecated_keywords("z", since="7.0")
+    def hubble_parameter(self, z: Quantity | ArrayLike) -> Quantity:
+        """Hubble parameter at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+        Returns
+        -------
+        H : Quantity ['frequency']
+            Hubble parameter at each input redshift.
+        """
+        return self.H0 * self.efunc(z)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the introduction of hubble parameter as a trait in the FLRW cosmology class.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes a portion of #17150 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
