### PR TITLE
Replace `lazyproperty` with `functools.cached_property` in `nddata`

### DIFF
--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -3,6 +3,7 @@
 This module includes helper functions for array operations.
 """
 
+import functools
 from copy import deepcopy
 
 import numpy as np
@@ -11,7 +12,6 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io.fits.hdu.compressed import CompImageSection
 from astropy.io.fits.hdu.image import Section
-from astropy.utils import lazyproperty
 from astropy.wcs import Sip
 from astropy.wcs.utils import proj_plane_pixel_scales, skycoord_to_pixel
 
@@ -815,7 +815,7 @@ class Cutout2D:
             (slices[1].start, slices[1].stop - 1),
         )
 
-    @lazyproperty
+    @functools.cached_property
     def origin_original(self):
         """
         The ``(x, y)`` index of the origin pixel of the cutout with
@@ -825,7 +825,7 @@ class Cutout2D:
         """
         return (self.slices_original[1].start, self.slices_original[0].start)
 
-    @lazyproperty
+    @functools.cached_property
     def origin_cutout(self):
         """
         The ``(x, y)`` index of the origin pixel of the cutout with
@@ -845,7 +845,7 @@ class Cutout2D:
         """
         return int(np.floor(a + 0.5))
 
-    @lazyproperty
+    @functools.cached_property
     def position_original(self):
         """
         The ``(x, y)`` position index (rounded to the nearest pixel) in
@@ -856,7 +856,7 @@ class Cutout2D:
             self._round(self.input_position_original[1]),
         )
 
-    @lazyproperty
+    @functools.cached_property
     def position_cutout(self):
         """
         The ``(x, y)`` position index (rounded to the nearest pixel) in
@@ -867,7 +867,7 @@ class Cutout2D:
             self._round(self.input_position_cutout[1]),
         )
 
-    @lazyproperty
+    @functools.cached_property
     def center_original(self):
         """
         The central ``(x, y)`` position of the cutout array with respect
@@ -876,7 +876,7 @@ class Cutout2D:
         """
         return self._calc_center(self.slices_original)
 
-    @lazyproperty
+    @functools.cached_property
     def center_cutout(self):
         """
         The central ``(x, y)`` position of the cutout array with respect
@@ -885,7 +885,7 @@ class Cutout2D:
         """
         return self._calc_center(self.slices_cutout)
 
-    @lazyproperty
+    @functools.cached_property
     def bbox_original(self):
         """
         The bounding box ``((ymin, ymax), (xmin, xmax))`` of the minimal
@@ -895,7 +895,7 @@ class Cutout2D:
         """
         return self._calc_bbox(self.slices_original)
 
-    @lazyproperty
+    @functools.cached_property
     def bbox_cutout(self):
         """
         The bounding box ``((ymin, ymax), (xmin, xmax))`` of the minimal


### PR DESCRIPTION
### Description

Utilities from the standard library should be preferred over our own utilities whenever possible. For example, importing from the standard library cannot cause import loops, but importing from our own utilities might. In `nddata` [`lazyproperty`](https://docs.astropy.org/en/v7.1.0/api/astropy.utils.decorators.lazyproperty.html) can be easily replaced with [`functools.cached_property`](https://docs.python.org/3.11/library/functools.html#functools.cached_property), so there's no reason not to.

Contributes towards #9036

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.