### PR TITLE
DOC: Avoid remote data calls in coordinates plots

### DIFF
--- a/docs/coordinates/example_gallery_plot_obs_planning.rst
+++ b/docs/coordinates/example_gallery_plot_obs_planning.rst
@@ -40,12 +40,8 @@ Astropy can answer that.
 
     Get the coordinates of M33:
 
-    >>> m33 = SkyCoord.from_name("M33")  # doctest: +SKIP
-
-    .. testsetup:: sphx_glr_generated_examples_coordinates_plot_obs-planning
-
-        >>> m33 = SkyCoord(23.46206906, 30.66017511, unit="deg")
-
+    >>> # m33 = SkyCoord.from_name("M33")
+    >>> m33 = SkyCoord(23.46206906, 30.66017511, unit="deg")
     Use `astropy.coordinates.EarthLocation` to provide the location of Bear
     Mountain and set the time to 11pm Eastern Daylight Time (EDT) on 2012 July 12:
 

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -209,18 +209,17 @@ for ``time_resolution`` compared to the non-interpolating, default approach.
     )
 
     # A celestial object in ICRS
-    crab = SkyCoord.from_name("Crab Nebula")
+    # crab = SkyCoord.from_name("Crab Nebula")
+    crab = SkyCoord(83.6287, 22.0147, unit="deg")
 
     # target horizontal coordinate frame
     altaz = AltAz(obstime=t, location=location)
-
 
     # the reference transform using no interpolation
     t0 = perf_counter()
     no_interp = crab.transform_to(altaz)
     reference = perf_counter() - t0
     print(f'No Interpolation took {reference:.4f} s')
-
 
     # now the interpolating approach for different time resolutions
     resolutions = 10.0**np.arange(-1, 5) * u.s


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to avoid remote data calls in coordinates plots because I do not think plot directive respects doctest skip and will run them anyway, causing warning when the calls fail and then fails RTD build.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
