### PR TITLE
Fix: Issue#17054 - Preserve bzero for uint32 columns in ColDefs.add_col 

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1678,6 +1678,9 @@ class ColDefs(NotifierMixin):
                 # tables yet
                 new_column.disp = None
 
+        # Explicitly preserve bzero and bscale
+        new_column.bzero = column.bzero
+        new_column.bscale = column.bscale
         return new_column
 
     def __getattr__(self, name):
@@ -1829,6 +1832,21 @@ class ColDefs(NotifierMixin):
 
         # Ask the HDU object to load the data before we modify our columns
         self._notify("load_data")
+
+        # Restore default bzero for unsigned integer column formats
+        if column.bzero is None and column.format in ("I", "J", "K"):
+            if column.array is not None and np.issubdtype(
+                column.array.dtype, np.unsignedinteger
+            ):
+                if column.format == "I":
+                    column.bzero = 2**15
+                elif column.format == "J":
+                    column.bzero = 2**31
+                elif column.format == "K":
+                    column.bzero = 2**63
+
+        if column.bscale is None:
+            column.bscale = 1
 
         self._arrays.append(column.array)
         # Obliterate caches of certain things


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
This PR addresses #17054 where FITS tables containing unsigned integer (uint32) columns lose correct interpretation when modified via ColDefs.add_col
The fix ensures that if a column uses the FITS convention (TFORM = 'J', TZERO = 2^31) to represent unsigned 32-bit integers, that metadata is preserved when adding or copying columns

Changes:
- Preserves bzero and bscale in _copy_column
- Updates ColDefs.add_col() to restore bzero when array is present and is an unsigned int
- Adds regression tests to ensure:
- uint32 columns retain correct values
- bzero is preserved
- Signed columns remain unchanged

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17054 
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
