### PR TITLE
Revert "TST: xfail test_z_at_value_numpyvectorize for numpy 2.3.dev and later"

### DIFF
--- a/astropy/cosmology/_src/tests/funcs/test_funcs.py
+++ b/astropy/cosmology/_src/tests/funcs/test_funcs.py
@@ -31,7 +31,6 @@ from astropy.cosmology import (
 )
 from astropy.cosmology._src.funcs.optimize import _z_at_scalar_value
 from astropy.units import allclose
-from astropy.utils.compat import NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -174,9 +173,6 @@ class Test_ZatValue:
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
-@pytest.mark.xfail(
-    not NUMPY_LT_2_3, reason="TODO fix: https://github.com/astropy/astropy/issues/18045"
-)
 def test_z_at_value_numpyvectorize():
     """Test that numpy vectorize fails on Quantities.
 


### PR DESCRIPTION
Reverts astropy/astropy#18093

Close #18045