### PR TITLE
TST: Remove test_z_at_value_numpyvectorize

### DIFF
--- a/astropy/cosmology/_src/tests/funcs/test_funcs.py
+++ b/astropy/cosmology/_src/tests/funcs/test_funcs.py
@@ -29,9 +29,7 @@ from astropy.cosmology import (
     wpwaCDM,
     z_at_value,
 )
-from astropy.cosmology._src.funcs.optimize import _z_at_scalar_value
 from astropy.units import allclose
-from astropy.utils.compat import NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
 
@@ -171,23 +169,6 @@ class Test_ZatValue:
         assert isinstance(z, u.Quantity)
         assert z.dtype == np.float64
         assert z.shape == ()
-
-
-@pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
-@pytest.mark.xfail(
-    not NUMPY_LT_2_3, reason="TODO fix: https://github.com/astropy/astropy/issues/18045"
-)
-def test_z_at_value_numpyvectorize():
-    """Test that numpy vectorize fails on Quantities.
-
-    If this test starts failing then numpy vectorize can be used instead of
-    the home-brewed vectorization. Please submit a PR making the change.
-    """
-    z_at_value = np.vectorize(
-        _z_at_scalar_value, excluded=["func", "method", "verbose"]
-    )
-    with pytest.raises(u.UnitConversionError, match="dimensionless quantities"):
-        z_at_value(Planck15.age, 10 * u.Gyr)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to remove `test_z_at_value_numpyvectorize` because there is nothing we can do when it fails, as suggested by @mhvk and @neutrinoceros .

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Close https://github.com/astropy/astropy/issues/18045

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
