### PR TITLE
CLN: drop unused `noqa: RUF009` in `cosmology`

### DIFF
--- a/astropy/cosmology/_src/core.py
+++ b/astropy/cosmology/_src/core.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: RUF009
 
 from __future__ import annotations
 

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: RUF009
 
 from __future__ import annotations
 

--- a/astropy/cosmology/_src/flrw/w0cdm.py
+++ b/astropy/cosmology/_src/flrw/w0cdm.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: RUF009
 
 
 import numpy as np

--- a/astropy/cosmology/_src/flrw/w0wacdm.py
+++ b/astropy/cosmology/_src/flrw/w0wacdm.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: RUF009
 
 
 from numpy import exp

--- a/astropy/cosmology/_src/flrw/w0wzcdm.py
+++ b/astropy/cosmology/_src/flrw/w0wzcdm.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: RUF009
 
 
 from numpy import exp

--- a/astropy/cosmology/_src/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/_src/flrw/wpwazpcdm.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: RUF009
 
 
 from numpy import exp


### PR DESCRIPTION
### Description
Ref #18284
This one should be trivial

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
