### PR TITLE
CLN: drop unused `noqa` comments in `units`

### DIFF
--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -10,8 +10,6 @@ Both the units and magnitudes are available in (and should be used
 through) the `astropy.units` namespace.
 
 """
-# avoid ruff complaints about undefined names defined by def_unit
-# ruff: noqa: F821
 
 import numpy as np
 

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# ruff: noqa: FA100, FA102
 
 import pytest
 


### PR DESCRIPTION
### Description
Ref #18284

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
