### PR TITLE
RFC: avoid 14 violations of lint rule `PLR01733` with a simpler, manual refactor

### DIFF
--- a/astropy/utils/metadata/merge.py
+++ b/astropy/utils/metadata/merge.py
@@ -259,10 +259,10 @@ def merge(
 
     out = deepcopy(left)
 
-    for key, val in right.items():
+    for key in right.keys():
         # If no conflict then insert val into out dict and continue
         if key not in out:
-            out[key] = deepcopy(val)
+            out[key] = deepcopy(right[key])
             continue
 
         # There is a conflict that must be resolved


### PR DESCRIPTION
### Description

Ref #18284

This rule is auto-fixable but in this case I think this manual refactor is both simpler and more in line with the intended symmetry between left and right dicts.
For reference, here's how ruff would auto-fix these 14 violations:
```patch
--- astropy/utils/metadata/merge.py
+++ astropy/utils/metadata/merge.py
@@ -266,9 +266,9 @@
             continue
 
         # There is a conflict that must be resolved
-        if _both_isinstance(left[key], right[key], dict):
+        if _both_isinstance(left[key], val, dict):
             out[key] = merge(
-                left[key], right[key], merge_func, metadata_conflicts=metadata_conflicts
+                left[key], val, merge_func, metadata_conflicts=metadata_conflicts
             )
 
         else:
@@ -278,14 +278,14 @@
                         if not merge_cls.enabled:
                             continue
                         if isinstance(left[key], left_type) and isinstance(
-                            right[key], right_type
+                            val, right_type
                         ):
-                            out[key] = merge_cls.merge(left[key], right[key])
+                            out[key] = merge_cls.merge(left[key], val)
                             break
                     else:
                         raise MergeConflictError
                 else:
-                    out[key] = merge_func(left[key], right[key])
+                    out[key] = merge_func(left[key], val)
             except MergeConflictError:
                 # Pick the metadata item that is not None, or they are both not
                 # None, then if they are equal, there is no conflict, and if
@@ -296,26 +296,26 @@
                     # This may not seem necessary since out[key] gets set to
                     # right[key], but not all objects support != which is
                     # needed for one of the if clauses.
-                    out[key] = right[key]
-                elif right[key] is None:
+                    out[key] = val
+                elif val is None:
                     out[key] = left[key]
-                elif _not_equal(left[key], right[key]):
+                elif _not_equal(left[key], val):
                     if metadata_conflicts == "warn":
                         warnings.warn(
-                            warn_str_func(key, left[key], right[key]),
+                            warn_str_func(key, left[key], val),
                             MergeConflictWarning,
                         )
                     elif metadata_conflicts == "error":
                         raise MergeConflictError(
-                            error_str_func(key, left[key], right[key])
+                            error_str_func(key, left[key], val)
                         )
                     elif metadata_conflicts != "silent":
                         raise ValueError(
                             "metadata_conflicts argument must be one "
                             'of "silent", "warn", or "error"'
                         )
-                    out[key] = right[key]
+                    out[key] = val
                 else:
-                    out[key] = right[key]
+                    out[key] = val
 
     return out

Would fix 14 errors.
```


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
