### PR TITLE
RFC: auto-fix unique violation of lint rule `FURB166` in `io.votable`

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -884,7 +884,7 @@ class Integer(Numeric):
                 else:
                     value = self.null
             elif value.startswith("0x"):
-                value = int(value[2:], 16)
+                value = int(value, 0)
             else:
                 value = int(value, 10)
         else:


### PR DESCRIPTION
### Description
Ref #18284
[rule doc](https://docs.astral.sh/ruff/rules/int-on-sliced-str/) 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
