### PR TITLE
Restrict maximum version of array_strict_api on python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ test_all = [
     "skyfield>=1.20",
     "sgp4>=2.3",
     "array-api-strict>=1.0",
+    "array-api-strict<2.4;python_version<'3.12'",  # PYTHON_LT_3_12
 ]
 typing = [
     "pandas-stubs>=2.0",

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ deps =
     devdeps-!noscipy: skyfield>=1.20
     devdeps-!noscipy: sgp4>=2.3
     devdeps-!noscipy: array-api-strict>=1.0
+    py311-devdeps-!noscipy: array-api-strict<2.4
 
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed.
 # test_all does not work here due to upstream bug https://github.com/tox-dev/tox/issues/3433


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address recent array strict API failures on python 3.11

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18292

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
