### PR TITLE
TST: narrow a warning catch in `coordinates`' test suite (fix `PT030`)

### DIFF
--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -9,6 +9,7 @@ from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 @pytest.fixture(scope="module")
@@ -290,7 +291,7 @@ def test_warning_no_obstime_on_skycoord():
         distance=50 * u.pc,
         frame="galactic",
     )
-    with pytest.warns(Warning):
+    with pytest.warns(AstropyUserWarning, match=r"^SkyCoord has space motion"):
         c.radial_velocity_correction("barycentric", test_input_time, test_input_loc)
 
 


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/pytest-warns-too-broad/)


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
