### PR TITLE
TST: narrow a warning catch in `io.ascii`'s test suite (fix `PT030`)

### DIFF
--- a/astropy/io/ascii/tests/test_qdp.py
+++ b/astropy/io/ascii/tests/test_qdp.py
@@ -219,7 +219,10 @@ def test_read_write_simple(tmp_path):
         )
     )
     t1.write(test_file, format="ascii.qdp")
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(
+        AstropyUserWarning,
+        match=r"^table_id not specified\. Reading the first available table$",
+    ) as record:
         t2 = Table.read(test_file, format="ascii.qdp")
     assert np.any(
         [


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/pytest-warns-too-broad/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
