### PR TITLE
TST: narrow a warning catch in `units`' test suite (fix `PT030`)

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2026,7 +2026,7 @@ class TestSortFunctions(InvariantUnitTestSetup):
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
     def test_msort(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning, match="^msort is deprecated"):
             self.check(np.msort)
 
     @needs_array_function


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/pytest-warns-too-broad/)

I would normally avoid matching a message we do not control, but transitionning from ruff 0.11 to 0.12 would require add `# noqa: PT030, RUF100` and then removing `, RUF100`, which is simply not worth the effort for a warning that's *very* unlikely to be updated in the future, as numpy 1.x isn't maintained any longer.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
