### PR TITLE
MNT: ignore a `nan-comparison` (`PLW0177`) violation in `time` (unfixable)

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1197,7 +1197,7 @@ class TimeBase(MaskableShapedLikeNDArray):
             if hasattr(self, attr):
                 delattr(self, attr)
 
-        if value is np.ma.masked or value is np.nan:
+        if value is np.ma.masked or value is np.nan:  # noqa: PLW0177, RUF100
             if not isinstance(self._time.jd2, Masked):
                 self._time.jd1 = Masked(self._time.jd1, copy=False)
                 self._time.jd2 = Masked(


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/nan-comparison/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
