### PR TITLE
Import first party types at runtime in `utils`

### DIFF
--- a/astropy/utils/parsing.py
+++ b/astropy/utils/parsing.py
@@ -3,8 +3,6 @@
 Wrappers for PLY to provide thread safety.
 """
 
-from __future__ import annotations
-
 import contextlib
 import functools
 import re
@@ -12,11 +10,9 @@ import threading
 from collections.abc import Generator
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from astropy.extern.ply.lex import Lexer
-    from astropy.extern.ply.yacc import LRParser
+from astropy.extern.ply.lex import Lexer
+from astropy.extern.ply.yacc import LRParser
 
 __all__ = ["ThreadSafeParser", "lex", "yacc"]
 


### PR DESCRIPTION
### Description

Because Sphinx is known to have trouble resolving stringified annotations, it is best to import as many types as possible at runtime (see also #18191 and #18228). However, with first party imports some `if TYPE_CHECKING:` blocks might be necessary to avoid runtime import loops.

At the moment it seems to me that attempting to import first party types at runtime in all of `astropy` in a single pull request is not a good idea. It should be better to do this one sub-package at a time so that the more complicated sub-packages would not hold back the simpler ones. In this pull request I am only updating `utils`. This is a simple sub-package to update because there are only two first party type imports, they are both in the same file and the imports are from `astropy.extern`, which means they are really third party imports in disguise.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
