### PR TITLE
Fix a bug that caused ``get_transform`` to not correctly handle differences in units between WCSes

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -749,7 +749,6 @@ class WCSAxes(Axes):
             )
             transform_world2pixel = transform.inverted()
 
-
             if (
                 self._transform_pixel2world.frame_out == transform_world2pixel.frame_in
                 and self._transform_pixel2world.units_out
@@ -784,7 +783,7 @@ class WCSAxes(Axes):
                     self._transform_pixel2world.frame_out,
                     self._transform_pixel2world.units_out,
                     frame,
-                    ['deg', 'deg'],
+                    ["deg", "deg"],
                 )
 
                 if coordinate_transform.same_frames:

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -729,8 +729,10 @@ class WCSAxes(Axes):
                   world-to-pixel transformation used to instantiate the
                   ``WCSAxes`` instance).
                 * ``'fk5'`` or ``'galactic'``: return a transformation from
-                  the specified frame to the pixel/data coordinates.
+                  the specified frame to the pixel/data coordinates. In this
+                  case, the values are assumed to be in degrees.
                 * :class:`~astropy.coordinates.BaseCoordinateFrame` instance.
+                  In this case, the values are assumed to be in degrees.
         """
         return self._get_transform_no_transdata(frame).inverted() + self.transData
 
@@ -747,7 +749,12 @@ class WCSAxes(Axes):
             )
             transform_world2pixel = transform.inverted()
 
-            if self._transform_pixel2world.frame_out == transform_world2pixel.frame_in:
+
+            if (
+                self._transform_pixel2world.frame_out == transform_world2pixel.frame_in
+                and self._transform_pixel2world.units_out
+                == transform_world2pixel.units_in
+            ):
                 return self._transform_pixel2world + transform_world2pixel
 
             else:
@@ -755,7 +762,9 @@ class WCSAxes(Axes):
                     self._transform_pixel2world
                     + CoordinateTransform(
                         self._transform_pixel2world.frame_out,
+                        self._transform_pixel2world.units_out,
                         transform_world2pixel.frame_in,
+                        transform_world2pixel.units_in,
                     )
                     + transform_world2pixel
                 )
@@ -772,7 +781,10 @@ class WCSAxes(Axes):
 
             else:
                 coordinate_transform = CoordinateTransform(
-                    self._transform_pixel2world.frame_out, frame
+                    self._transform_pixel2world.frame_out,
+                    self._transform_pixel2world.units_out,
+                    frame,
+                    ['deg', 'deg'],
                 )
 
                 if coordinate_transform.same_frames:

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -8,6 +8,7 @@ import pytest
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.contour import QuadContourSet
 from matplotlib.figure import Figure
+from numpy.testing import assert_allclose
 from packaging.version import Version
 
 from astropy import units as u
@@ -787,3 +788,39 @@ def test_simplify_cases(before, after):
 
     ticklabels.simplify_labels()
     assert ticklabels.text["axis"] == after
+
+
+def test_get_transform_unit_mismatch():
+    """
+    Regression test for a bug that caused get_transform to ignore differences
+    in WCS units.
+
+    https://github.com/astropy/astropy/issues/18246
+    """
+
+    wcs_deg = WCS(naxis=2, preserve_units=True)
+    wcs_deg.wcs.ctype = "RA---TAN", "DEC--TAN"
+    wcs_deg.wcs.crval = 20, 30
+    wcs_deg.wcs.cunit = "deg", "deg"
+    wcs_deg.wcs.crpix = 1, 1
+    wcs_deg.wcs.cdelt = 1 / 60, 1 / 60
+
+    wcs_arcmin = WCS(naxis=2, preserve_units=True)
+    wcs_arcmin.wcs.ctype = "RA---TAN", "DEC--TAN"
+    wcs_arcmin.wcs.crval = 1200, 1800
+    wcs_arcmin.wcs.cunit = "arcmin", "arcmin"
+    wcs_arcmin.wcs.crpix = 1, 1
+    wcs_arcmin.wcs.cdelt = 1, 1
+
+    fig = Figure(figsize=(6, 6))
+    ax = fig.add_subplot(projection=wcs_arcmin)
+    transform1 = ax.get_transform(wcs_arcmin)
+    transform2 = ax.get_transform(wcs_deg)
+
+    # Since the two WCS are equivalent, the returned transforms should also
+    # be equivalent
+
+    rng = np.random.default_rng(12345)
+    pixels = rng.uniform(0, 100, (2, 100))
+
+    assert_allclose(transform1.transform(pixels), transform2.transform(pixels))

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -65,10 +65,13 @@ class CurvedTransform(Transform, metaclass=abc.ABCMeta):
 class CoordinateTransform(CurvedTransform):
     has_inverse = True
 
-    def __init__(self, input_system, output_system):
+    def __init__(self, input_system, input_units, output_system, output_units):
         super().__init__()
         self._input_system_name = input_system
         self._output_system_name = output_system
+        self._input_units = [u.Unit(unit) for unit in input_units]
+        self._output_units = [u.Unit(unit) for unit in output_units]
+        self.same_units = input_units == output_units
 
         if isinstance(self._input_system_name, str):
             frame_cls = frame_transform_graph.lookup_name(self._input_system_name)
@@ -116,24 +119,32 @@ class CoordinateTransform(CurvedTransform):
         """
         Transform one set of coordinates to another.
         """
-        if self.same_frames:
+
+        if self.same_frames and self.same_units:
             return input_coords
 
-        input_coords = input_coords * u.deg
-        x_in, y_in = input_coords[:, 0], input_coords[:, 1]
+        x_in = input_coords[:, 0] * u.Unit(self._input_units[0])
+        y_in = input_coords[:, 1] * u.Unit(self._input_units[1])
 
-        c_in = SkyCoord(
-            UnitSphericalRepresentation(x_in, y_in), frame=self.input_system
-        )
+        if self.same_frames:
+            lon = x_in
+            lat = y_in
+        else:
+            c_in = SkyCoord(
+                UnitSphericalRepresentation(x_in, y_in), frame=self.input_system
+            )
 
-        # We often need to transform arrays that contain NaN values, and filtering
-        # out the NaN values would have a performance hit, so instead we just pass
-        # on all values and just ignore Numpy warnings
-        with np.errstate(all="ignore"):
-            c_out = c_in.transform_to(self.output_system)
+            # We often need to transform arrays that contain NaN values, and filtering
+            # out the NaN values would have a performance hit, so instead we just pass
+            # on all values and just ignore Numpy warnings
+            with np.errstate(all="ignore"):
+                c_out = c_in.transform_to(self.output_system)
 
-        lon = c_out.spherical.lon.deg
-        lat = c_out.spherical.lat.deg
+            lon = c_out.spherical.lon
+            lat = c_out.spherical.lat
+
+        lon = lon.to_value(self._output_units[0])
+        lat = lat.to_value(self._output_units[1])
 
         return np.concatenate((lon[:, np.newaxis], lat[:, np.newaxis]), axis=1)
 
@@ -143,7 +154,12 @@ class CoordinateTransform(CurvedTransform):
         """
         Return the inverse of the transform.
         """
-        return CoordinateTransform(self._output_system_name, self._input_system_name)
+        return CoordinateTransform(
+            self._output_system_name,
+            self._output_units,
+            self._input_system_name,
+            self._input_units,
+        )
 
 
 class World2PixelTransform(CurvedTransform, metaclass=abc.ABCMeta):

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -119,7 +119,6 @@ class CoordinateTransform(CurvedTransform):
         """
         Transform one set of coordinates to another.
         """
-
         if self.same_frames and self.same_units:
             return input_coords
 

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -334,6 +334,7 @@ class WCSWorld2PixelTransform(CurvedTransform):
 
     has_inverse = True
     frame_in = None
+    units_in = None
 
     def __init__(self, wcs, invert_xy=False):
         super().__init__()
@@ -345,6 +346,7 @@ class WCSWorld2PixelTransform(CurvedTransform):
         self.invert_xy = invert_xy
 
         self.frame_in = wcsapi_to_celestial_frame(wcs)
+        self.units_in = wcs.world_axis_units
 
     def __eq__(self, other):
         return (
@@ -407,6 +409,7 @@ class WCSPixel2WorldTransform(CurvedTransform):
         self.invert_xy = invert_xy
 
         self.frame_out = wcsapi_to_celestial_frame(wcs)
+        self.units_out = wcs.world_axis_units
 
     def __eq__(self, other):
         return (

--- a/docs/changes/visualization/18311.bugfix.rst
+++ b/docs/changes/visualization/18311.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug that caused ``WCSAxes.get_transform`` to not return the correct
+transform when using WCS instances with celestial axes that were not in
+degrees.


### PR DESCRIPTION
### Description

This fixes a bug which occurred for non-FITS WCSes with mismatching celestial coordinate units. We now keep track of input/output units in the transforms and convert accordingly.

This still needs a regression test, but I want to check first whether this fixes the issues @ayshih was seeing.

Fixes https://github.com/astropy/astropy/issues/18246

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
