### PR TITLE
Fix typo in FLRW Ode method docstring

### DIFF
--- a/astropy/cosmology/_src/traits/darkenergy.py
+++ b/astropy/cosmology/_src/traits/darkenergy.py
@@ -139,8 +139,8 @@ class DarkEnergyComponent:
         Returns
         -------
         Ode : ndarray or float
-            The density of non-relativistic matter relative to the critical
-            density at each redshift.
+            The density of dark energy relative to the critical density at each
+            redshift.
             Returns `float` if the input is scalar.
         """
         z = aszarr(z)


### PR DESCRIPTION
### Description
This pull request is to address a typo in the FLRW Ode method, saying it returned non-relativistic matter density instead of dark energy.
