### PR TITLE
TST: avoid default values in a test function (`PT028`) in `wcs`

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -569,22 +569,15 @@ def test_crpix_maps_to_crval():
     )
 
 
-def test_all_world2pix(
-    fname=None,
-    ext=0,
-    tolerance=1.0e-4,
-    origin=0,
-    random_npts=25000,
-    adaptive=False,
-    maxiter=20,
-    detect_divergence=True,
-):
+def test_all_world2pix():
     """Test all_world2pix, iterative inverse of all_pix2world"""
 
+    tolerance = 1.0e-4
+    origin = 0
+
     # Open test FITS file:
-    if fname is None:
-        fname = get_pkg_data_filename("data/j94f05bgq_flt.fits")
-        ext = ("SCI", 1)
+    fname = get_pkg_data_filename("data/j94f05bgq_flt.fits")
+    ext = ("SCI", 1)
     if not os.path.isfile(fname):
         raise OSError(f"Input file '{fname:s}' to 'test_all_world2pix' not found.")
     h = fits.open(fname)
@@ -608,7 +601,7 @@ def test_all_world2pix(
 
     # Generate random data (in image coordinates):
     with NumpyRNGContext(123456789):
-        rnd_pix = np.random.rand(random_npts, ncoord)
+        rnd_pix = np.random.rand(25_000, ncoord)
 
     # Scale random data to cover the central part of the image
     mwidth = 2 * (crpix * 1.0 / 8)
@@ -627,9 +620,9 @@ def test_all_world2pix(
             all_world,
             origin,
             tolerance=tolerance,
-            adaptive=adaptive,
-            maxiter=maxiter,
-            detect_divergence=detect_divergence,
+            adaptive=False,
+            maxiter=20,
+            detect_divergence=True,
         )
         runtime_end = datetime.now()
     except wcs.wcs.NoConvergence as e:


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/pytest-parameter-with-default-argument/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
