### PR TITLE
CLN: cleanup an unused parameter in a test function (fix `PT028` for `timeseries`)

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/tests/test_statistics.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_statistics.py
@@ -121,7 +121,7 @@ def test_inverse_bootstrap(normalization, use_errs, units):
 @pytest.mark.parametrize("use_errs", [True, False])
 @pytest.mark.parametrize("N", [10, 100, 1000])
 @pytest.mark.parametrize("units", [False, True])
-def test_inverses(method, normalization, use_errs, N, units, T=5):
+def test_inverses(method, normalization, use_errs, N, units):
     if not HAS_SCIPY and method in ["baluev", "davies"]:
         pytest.skip("SciPy required")
 


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/pytest-parameter-with-default-argument/)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
