### PR TITLE
Avoid stringified type annotations in `stats`

### DIFF
--- a/astropy/stats/info_theory.py
+++ b/astropy/stats/info_theory.py
@@ -4,8 +4,6 @@
 This module contains simple functions for model selection.
 """
 
-from __future__ import annotations
-
 import numpy as np
 
 __all__ = [

--- a/astropy/stats/setup_package.py
+++ b/astropy/stats/setup_package.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 import os
 
 from numpy import get_include as get_numpy_include


### PR DESCRIPTION
### Description

Sphinx is known to have problems resolving stringified annotations, so it's best to avoid them whenever possible. There are no longer any `if TYPE_CHECKING:` blocks in `stats` (they were all removed in #18191 and #18228), but there are still three modules where `from __future__ import annotations` statements cause annotations to be stringified. In `bayesian_blocks.py` a parameter annotation in `bayesian_blocks()` refers to `FitnessFunc` that is defined later, which means stringification is currently required to avoid a [forward reference](https://peps.python.org/pep-0484/#forward-references), but it is simple to avoid the forward reference by moving the definition of the function. I don't why the annotations are stringified in the other two modules. 

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
