### PR TITLE
Emit warning if axes given to set_*_position are invalid

### DIFF
--- a/astropy/visualization/wcsaxes/_auto.py
+++ b/astropy/visualization/wcsaxes/_auto.py
@@ -114,9 +114,10 @@ def auto_assign_coord_positions(ax):
 
     # Finalize assignments
     for coord, spine in zip(auto_coords, best_option):
+        position = [spine, "#"] if spine != " " else "#"
         if "#" in coord.get_ticks_position():
-            coord.set_ticks_position([spine, "#"])
+            coord.set_ticks_position(position)
         if "#" in coord.get_ticklabel_position():
-            coord.set_ticklabel_position([spine, "#"])
+            coord.set_ticklabel_position(position)
         if "#" in coord.get_axislabel_position():
-            coord.set_axislabel_position([spine, "#"])
+            coord.set_axislabel_position(position)

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -1,13 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
 
 import matplotlib.transforms as mtransforms
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.text import Text
-
-from astropy.utils.exceptions import AstropyUserWarning
 
 from .frame import RectangularFrame
 
@@ -38,15 +35,7 @@ class AxisLabels(Text):
             return self._minpad
 
     def set_visible_axes(self, visible_axes):
-        if visible_axes != "all":
-            for axis in visible_axes:
-                if axis not in self._frame and axis != "#":
-                    warnings.warn(
-                        f"Ignoring invalid axis '{axis}' "
-                        "(should be one of: " + "/".join(self._frame.keys()) + ")",
-                        AstropyUserWarning,
-                    )
-        self._visible_axes = visible_axes
+        self._visible_axes = self._frame._validate_positions(visible_axes)
 
     def get_visible_axes(self):
         if self._visible_axes == "all":

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 
 import matplotlib.transforms as mtransforms
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.text import Text
+
+from astropy.utils.exceptions import AstropyUserWarning
 
 from .frame import RectangularFrame
 
@@ -35,6 +38,14 @@ class AxisLabels(Text):
             return self._minpad
 
     def set_visible_axes(self, visible_axes):
+        if visible_axes != "all":
+            for axis in visible_axes:
+                if axis not in self._frame and axis != "#":
+                    warnings.warn(
+                        f"Ignoring invalid axis '{axis}' "
+                        "(should be one of: " + "/".join(self._frame.keys()) + ")",
+                        AstropyUserWarning,
+                    )
         self._visible_axes = visible_axes
 
     def get_visible_axes(self):

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -273,6 +273,42 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
             if spine.data_func:
                 spine.data = spine.data_func(spine)
 
+    def _validate_positions(self, positions):
+        """
+        Given a string with single character positions or an iterable with
+        single or multi-character positions, emit a warning for any
+        unrecognized positions and return a list of valid positions.
+        """
+        if positions == "all":
+            return positions
+
+        valid_positions = []
+        invalid_positions = []
+        for position in positions:
+            if position in self or position == "#":
+                valid_positions.append(position)
+            else:
+                invalid_positions.append(position)
+
+        if invalid_positions:
+            if isinstance(positions, str) and positions in self:
+                hint = (
+                    f"It looks like '{positions}' matches the name of a single "
+                    f"axis. If you are trying to specify a multi-character axis "
+                    f"name, use a list or a tuple, e.g. ('{positions}',)."
+                )
+            else:
+                hint = ""
+
+            warnings.warn(
+                f"Ignoring unrecognized position(s): {invalid_positions}, should "
+                f"be one of {'/'.join(self.keys())}. In future this will "
+                f"raise an error. {hint}",
+                AstropyDeprecationWarning,
+            )
+
+        return valid_positions
+
 
 class RectangularFrame1D(BaseFrame):
     """

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -216,7 +216,7 @@ def test_set_position_invalid():
     with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'x'"):
         ax.coords[0].set_ticks_position("xl")
     with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'o'"):
-        ax.coords[1].set_ticklabel_position("ot")
+        ax.coords[1].set_ticklabel_position("to")
     with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'q'"):
         ax.coords[1].set_axislabel_position("qb")
 

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import matplotlib.transforms as transforms
 import pytest
@@ -125,7 +125,7 @@ def test_grid_variations(ignore_matplotlibrc, draw_grid, expected_visibility):
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     fig.add_axes(ax)
     transform = transforms.Affine2D().scale(2.0)
-    coord_helper = CoordinateHelper(parent_axes=ax, transform=transform)
+    coord_helper = CoordinateHelper(parent_axes=ax, transform=transform, frame=MagicMock(),)
     coord_helper.grid(draw_grid=draw_grid)
     assert coord_helper._grid_lines_kwargs["visible"] == expected_visibility
 
@@ -173,7 +173,7 @@ def test_deprecated_getters():
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     fig.add_axes(ax)
 
-    helper = CoordinateHelper(parent_axes=ax)
+    helper = CoordinateHelper(parent_axes=ax, frame=MagicMock(),)
 
     with pytest.warns(AstropyDeprecationWarning):
         ticks = helper.ticks

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -10,7 +10,7 @@ from matplotlib.figure import Figure
 from astropy import units as u
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.wcsaxes.coordinate_helpers import CoordinateHelper
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.wcs import WCS
@@ -213,13 +213,43 @@ def test_set_position_invalid():
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     fig.add_axes(ax)
 
-    with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'x'"):
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"Ignoring unrecognized position\(s\): \['x'\], should be one of b/r/t/l",
+    ):
         ax.coords[0].set_ticks_position("xl")
-    with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'o'"):
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"Ignoring unrecognized position\(s\): \['o'\], should be one of b/r/t/l",
+    ):
         ax.coords[1].set_ticklabel_position("to")
-    with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'q'"):
-        ax.coords[1].set_axislabel_position("qb")
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"Ignoring unrecognized position\(s\): \['q', 'p'\], should be one of b/r/t/l",
+    ):
+        ax.coords[1].set_axislabel_position("qbp")
 
     assert ax.coords[0].get_ticks_position() == ["l"]
     assert ax.coords[1].get_ticklabel_position() == ["t"]
     assert ax.coords[1].get_axislabel_position() == ["b"]
+
+
+def test_set_position_invalid_gridline():
+    fig = Figure()
+    _canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
+    fig.add_axes(ax)
+
+    ax.coords[0].add_tickable_gridline("my-grid-line", -30 * u.one)
+
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"Ignoring unrecognized position\(s\): \['my-parrot-line'\]",
+    ):
+        ax.coords[1].set_ticks_position(["my-grid-line", "my-parrot-line"])
+
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"It looks like 'my-grid-line' matches the name of a single axis",
+    ):
+        ax.coords[1].set_ticks_position("my-grid-line")

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import matplotlib.transforms as transforms
 import pytest
@@ -125,7 +125,11 @@ def test_grid_variations(ignore_matplotlibrc, draw_grid, expected_visibility):
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     fig.add_axes(ax)
     transform = transforms.Affine2D().scale(2.0)
-    coord_helper = CoordinateHelper(parent_axes=ax, transform=transform, frame=MagicMock(),)
+    coord_helper = CoordinateHelper(
+        parent_axes=ax,
+        transform=transform,
+        frame=MagicMock(),
+    )
     coord_helper.grid(draw_grid=draw_grid)
     assert coord_helper._grid_lines_kwargs["visible"] == expected_visibility
 
@@ -173,7 +177,10 @@ def test_deprecated_getters():
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     fig.add_axes(ax)
 
-    helper = CoordinateHelper(parent_axes=ax, frame=MagicMock(),)
+    helper = CoordinateHelper(
+        parent_axes=ax,
+        frame=MagicMock(),
+    )
 
     with pytest.warns(AstropyDeprecationWarning):
         ticks = helper.ticks
@@ -250,6 +257,8 @@ def test_set_position_invalid_gridline():
 
     with pytest.warns(
         AstropyDeprecationWarning,
-        match=r"It looks like 'my-grid-line' matches the name of a single axis",
+        match=r"It looks like 'my-grid-line' matches the name of a single axis. If "
+        r"you are trying to specify a multi-character axis name, use a list "
+        r"or a tuple, e.g. \('my-grid-line',\).",
     ):
         ax.coords[1].set_ticks_position("my-grid-line")

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -10,7 +10,7 @@ from matplotlib.figure import Figure
 from astropy import units as u
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.visualization.wcsaxes.coordinate_helpers import CoordinateHelper
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.wcs import WCS
@@ -205,3 +205,21 @@ def test_set_major_formatter():
 
     ax.coords[1].set_major_formatter("dd:mm:ss.s", show_decimal_unit=False)
     assert ax.coords[1].format_coord(4) == "4\xb000'00.0\""
+
+
+def test_set_position_invalid():
+    fig = Figure()
+    _canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
+    fig.add_axes(ax)
+
+    with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'x'"):
+        ax.coords[0].set_ticks_position("xl")
+    with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'o'"):
+        ax.coords[1].set_ticklabel_position("ot")
+    with pytest.warns(AstropyUserWarning, match="Ignoring invalid axis 'q'"):
+        ax.coords[1].set_axislabel_position("qb")
+
+    assert ax.coords[0].get_ticks_position() == ["l"]
+    assert ax.coords[1].get_ticklabel_position() == ["t"]
+    assert ax.coords[1].get_axislabel_position() == ["b"]

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import warnings
+from unittest.mock import MagicMock
 
 import matplotlib as mpl
 import numpy as np
@@ -520,7 +521,7 @@ def test_simplify_labels_minus_sign(
     if usetex and TEX_UNAVAILABLE:
         pytest.skip("TeX is unavailable")
 
-    ticklabels = TickLabels(None)
+    ticklabels = TickLabels(frame=MagicMock())
     expected_labels = []
     for i in range(1, 6):
         label = label_str.format(i)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -8,7 +8,7 @@ from matplotlib.artist import allow_rasterization
 from matplotlib.text import Text
 
 from astropy.utils.decorators import deprecated_renamed_argument
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .frame import RectangularFrame
 
@@ -169,15 +169,7 @@ class TickLabels(Text):
         return self._pad
 
     def set_visible_axes(self, visible_axes):
-        if visible_axes != "all":
-            for axis in visible_axes:
-                if axis not in self._frame and axis != "#":
-                    warnings.warn(
-                        f"Ignoring invalid axis '{axis}' "
-                        "(should be one of: " + "/".join(self._frame.keys()) + ")",
-                        AstropyUserWarning,
-                    )
-        self._visible_axes = visible_axes
+        self._visible_axes = self._frame._validate_positions(visible_axes)
         self._stale = True
 
     def get_visible_axes(self):

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -8,7 +8,7 @@ from matplotlib.artist import allow_rasterization
 from matplotlib.text import Text
 
 from astropy.utils.decorators import deprecated_renamed_argument
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from .frame import RectangularFrame
 
@@ -169,6 +169,14 @@ class TickLabels(Text):
         return self._pad
 
     def set_visible_axes(self, visible_axes):
+        if visible_axes != "all":
+            for axis in visible_axes:
+                if axis not in self._frame and axis != "#":
+                    warnings.warn(
+                        f"Ignoring invalid axis '{axis}' "
+                        "(should be one of: " + "/".join(self._frame.keys()) + ")",
+                        AstropyUserWarning,
+                    )
         self._visible_axes = visible_axes
         self._stale = True
 

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -1,14 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
 from collections import defaultdict
 
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.lines import Line2D, Path
 from matplotlib.transforms import Affine2D
-
-from astropy.utils.exceptions import AstropyUserWarning
 
 
 class Ticks(Line2D):
@@ -108,15 +105,7 @@ class Ticks(Line2D):
             return 0.0
 
     def set_visible_axes(self, visible_axes):
-        if visible_axes != "all":
-            for axis in visible_axes:
-                if axis not in self._frame and axis != "#":
-                    warnings.warn(
-                        f"Ignoring invalid axis '{axis}' "
-                        "(should be one of: " + "/".join(self._frame.keys()) + ")",
-                        AstropyUserWarning,
-                    )
-        self._visible_axes = visible_axes
+        self._visible_axes = self._frame._validate_positions(visible_axes)
 
     def get_visible_axes(self):
         if self._visible_axes == "all":

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -1,11 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 from collections import defaultdict
 
 import numpy as np
 from matplotlib import rcParams
 from matplotlib.lines import Line2D, Path
 from matplotlib.transforms import Affine2D
+
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 class Ticks(Line2D):
@@ -105,6 +108,14 @@ class Ticks(Line2D):
             return 0.0
 
     def set_visible_axes(self, visible_axes):
+        if visible_axes != "all":
+            for axis in visible_axes:
+                if axis not in self._frame and axis != "#":
+                    warnings.warn(
+                        f"Ignoring invalid axis '{axis}' "
+                        "(should be one of: " + "/".join(self._frame.keys()) + ")",
+                        AstropyUserWarning,
+                    )
         self._visible_axes = visible_axes
 
     def get_visible_axes(self):

--- a/docs/changes/visualization/18324.api.rst
+++ b/docs/changes/visualization/18324.api.rst
@@ -1,4 +1,3 @@
 A warning is now emitted for each axis name which is
 invalid in ``set_ticklabel_position``, ``set_axislabel_position``,
 and ``set_ticks_position``
-

--- a/docs/changes/visualization/18324.api.rst
+++ b/docs/changes/visualization/18324.api.rst
@@ -1,3 +1,4 @@
 A warning is now emitted for each axis name which is
 invalid in ``set_ticklabel_position``, ``set_axislabel_position``,
-and ``set_ticks_position``
+and ``set_ticks_position``. This is a deprecation warning,
+and in future invalid axis names will result in an error.

--- a/docs/changes/visualization/18324.api.rst
+++ b/docs/changes/visualization/18324.api.rst
@@ -1,0 +1,4 @@
+A warning is now emitted for each axis name which is
+invalid in ``set_ticklabel_position``, ``set_axislabel_position``,
+and ``set_ticks_position``
+


### PR DESCRIPTION
### Description

This now checks if any of the axes names passed to ``set_*_position`` are invalid, and emits a warning if so. This will avoid user mistakes if they do e.g.:

```
ax.coords['lat'].set_axislabel_position('right')
```

and will get the following warnings:

```
WARNING: Ignoring invalid axis 'i' (should be one of: b/r/t/l) [astropy.visualization.wcsaxes.axislabels]
WARNING: Ignoring invalid axis 'g' (should be one of: b/r/t/l) [astropy.visualization.wcsaxes.axislabels]
WARNING: Ignoring invalid axis 'h' (should be one of: b/r/t/l) [astropy.visualization.wcsaxes.axislabels]
```

I still need to add a news fragment.

See also [#11929](https://github.com/astropy/astropy/issues/11929)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
