### PR TITLE
ENH: support hashing immutable objects that are already comparable via `__eq__` (`PLW1641`)

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1967,6 +1967,10 @@ class UnrecognizedUnit(IrreducibleUnit):
     __pow__ = __truediv__ = __rtruediv__ = __mul__ = __rmul__ = _unrecognized_operator
     __lt__ = __gt__ = __le__ = __ge__ = __neg__ = _unrecognized_operator
 
+    def __hash__(self):
+        # __hash__ isn't inherited in classes with a custom __eq__ method
+        return self._hash
+
     def __eq__(self, other):
         try:
             other = Unit(other, parse_strict="silent")

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -494,6 +494,9 @@ class StructuredUnit:
     def __repr__(self):
         return f'Unit("{self.to_string()}")'
 
+    def __hash__(self):
+        return hash(self.values())
+
     def __eq__(self, other):
         try:
             other = StructuredUnit(other)

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -286,6 +286,9 @@ class TestStructuredUnitAsMapping(StructuredTestBaseWithUnits):
         with pytest.raises(TypeError, match="item assignment"):
             self.pv_t_unit["t"] = u.Gyr
 
+    def test_hashing(self):
+        assert hash(self.pv_unit) != hash(self.pv_t_unit)
+
 
 class TestStructuredUnitMethods(StructuredTestBaseWithUnits):
     def test_physical_type_id(self):

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -20,6 +20,7 @@ from astropy.units import Quantity
 from astropy.utils.data import get_pkg_data_filename
 from astropy.visualization.wcsaxes.frame import RectangularFrame, RectangularFrame1D
 from astropy.visualization.wcsaxes.wcsapi import (
+    WCSPixel2WorldTransform,
     WCSWorld2PixelTransform,
     apply_slices,
     custom_ucd_coord_meta_mapping,
@@ -130,6 +131,16 @@ def test_shorthand_inversion():
     assert t1 - t2 == t1 + t2.inverted()
     assert t1 - t2 != t2.inverted() + t1
     assert t1 - t1 == IdentityTransform()
+
+
+@pytest.mark.parametrize(
+    "wcs_factory", [WCSPixel2WorldTransform, WCSWorld2PixelTransform]
+)
+def test_hashing(wcs_factory):
+    w1 = wcs_factory(WCS2D)
+    w2 = w1.inverted()
+    assert hash(w1) != hash(w2)
+    assert hash(w1) == hash(w2.inverted())
 
 
 # We add Affine2D to catch the fact that in Matplotlib, having a Composite

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -346,6 +346,9 @@ class WCSWorld2PixelTransform(CurvedTransform):
 
         self.frame_in = wcsapi_to_celestial_frame(wcs)
 
+    def __hash__(self):
+        return hash((type(self), self.wcs, self.invert_xy))
+
     def __eq__(self, other):
         return (
             isinstance(other, type(self))
@@ -407,6 +410,9 @@ class WCSPixel2WorldTransform(CurvedTransform):
         self.invert_xy = invert_xy
 
         self.frame_out = wcsapi_to_celestial_frame(wcs)
+
+    def __hash__(self):
+        return hash((type(self), self.wcs, self.invert_xy))
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
### Description
Ref #18284
[rule docs](https://docs.astral.sh/ruff/rules/eq-without-hash/?query=PLW1641)

Exceptionally, I'm doing this one in a package-wise style, so it's easier to see the pattern in how I chose to implement `__hash__` methods (based on `__eq__` implementations).

As mentionned in #18284, I'd rather fix this lint, albeit non urgent by any mean, because it adds systematic detection for a problem that *did* already bite us recently (#18126).
I'm also specifically focussing on classes that have a *clear* `__eq__` implementation (some have more refined logic that is not easily transposed to a `__hash__`), and avoid array comparisons (because `np.ndarray` isn't hashable).

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
