### PR TITLE
Fix WCSAxes.get_transform() for 1D plots

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -1170,6 +1170,16 @@ def test_1d_plot_1d_wcs_format_unit(wave_wcs_1d):
     return fig
 
 
+@figure_test
+def test_1d_plot_1d_wcs_get_transform(wave_wcs_1d):
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(1, 1, 1, projection=wave_wcs_1d)
+    ax.plot([100, 200, 300], [2, 3, 2], transform=ax.get_transform("world"))
+
+    return fig
+
+
 @pytest.fixture
 def spatial_wcs_2d():
     wcs = WCS(naxis=2)

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -356,10 +356,12 @@ class WCSWorld2PixelTransform(CurvedTransform):
         # Convert to a list of arrays
         world = list(world.T)
 
-        if len(world) != self.wcs.world_n_dim:
-            raise ValueError(
-                f"Expected {self.wcs.world_n_dim} world coordinates, got {len(world)} "
-            )
+        if len(world) != 2:
+            raise ValueError(f"Expected 2 world coordinates, got {len(world)}")
+
+        if self.wcs.world_n_dim == 1:
+            world_non_wcs = world[1]
+            world = world[0:1]
 
         if len(world[0]) == 0:
             pixel = np.zeros((0, 2))
@@ -368,6 +370,9 @@ class WCSWorld2PixelTransform(CurvedTransform):
 
         if self.invert_xy:
             pixel = pixel[::-1]
+
+        if self.wcs.world_n_dim == 1:
+            pixel = [pixel, world_non_wcs]
 
         return np.array(pixel).T
 


### PR DESCRIPTION
### Description

Still a draft as need to make sure this works correctly for WCSes with one pixel coordinate but multiple world coordinates.

Fixes https://github.com/astropy/astropy/issues/16691

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
