### PR TITLE
Avoid stringified type annotations in `units`

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -1,22 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 
-from astropy.units.core import CompositeUnit, NamedUnit, Unit, get_current_unit_registry
+from astropy.extern.ply.lex import LexToken
+from astropy.units.core import (
+    CompositeUnit,
+    NamedUnit,
+    Unit,
+    UnitBase,
+    get_current_unit_registry,
+)
 from astropy.units.errors import UnitsWarning
+from astropy.units.typing import UnitPower, UnitScale
 from astropy.units.utils import maybe_simple_fraction
 from astropy.utils.misc import did_you_mean
-
-if TYPE_CHECKING:
-    from astropy.extern.ply.lex import LexToken
-    from astropy.units import UnitBase
-    from astropy.units.typing import UnitPower, UnitScale
 
 
 class Base:
@@ -24,7 +25,7 @@ class Base:
     The abstract base class of all unit formats.
     """
 
-    registry: ClassVar[dict[str, type[Base]]] = {}
+    registry: ClassVar[dict[str, type["Base"]]] = {}
     _space: ClassVar[str] = " "
     _scale_unit_separator: ClassVar[str] = " "
     _times: ClassVar[str] = "*"

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -12,21 +12,16 @@
 
 """Handles the CDS string format for units."""
 
-from __future__ import annotations
-
 import re
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
 
-from astropy.units.core import CompositeUnit, Unit
+from astropy.extern.ply.lex import Lexer
+from astropy.units.core import CompositeUnit, Unit, UnitBase
 from astropy.units.utils import is_effectively_unity
 from astropy.utils import classproperty, parsing
+from astropy.utils.parsing import ThreadSafeParser
 
 from .base import Base, _ParsingFormatMixin
-
-if TYPE_CHECKING:
-    from astropy.extern.ply.lex import Lexer
-    from astropy.units import UnitBase
-    from astropy.utils.parsing import ThreadSafeParser
 
 
 class CDS(Base, _ParsingFormatMixin):

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -4,14 +4,11 @@
 Handles the "Console" unit format.
 """
 
-from __future__ import annotations
+from typing import ClassVar, Literal
 
-from typing import TYPE_CHECKING, ClassVar, Literal
+from astropy.units.core import UnitBase
 
 from . import base
-
-if TYPE_CHECKING:
-    from astropy.units import UnitBase
 
 
 class Console(base.Base):

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -4,21 +4,16 @@
 Handles the "FITS" unit format.
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import numpy as np
 
-from astropy.units.core import CompositeUnit
+from astropy.units.core import CompositeUnit, UnitBase
 from astropy.units.errors import UnitScaleError
 from astropy.utils import classproperty
 
 from . import Base, utils
 from .generic import _GenericParserMixin
-
-if TYPE_CHECKING:
-    from astropy.units import UnitBase
 
 
 class FITS(Base, _GenericParserMixin):

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -14,29 +14,24 @@
 Handles a "generic" string format for units
 """
 
-from __future__ import annotations
-
 import re
 import unicodedata
 import warnings
 from fractions import Fraction
 from re import Match, Pattern
-from typing import TYPE_CHECKING, ClassVar, Final
+from typing import ClassVar, Final
 
 import numpy as np
 
-from astropy.units.core import CompositeUnit, Unit, get_current_unit_registry
+from astropy.extern.ply.lex import Lexer
+from astropy.units.core import CompositeUnit, Unit, UnitBase, get_current_unit_registry
 from astropy.units.errors import UnitsWarning
+from astropy.units.typing import UnitScale
 from astropy.utils import classproperty, parsing
 from astropy.utils.misc import did_you_mean
+from astropy.utils.parsing import ThreadSafeParser
 
 from .base import Base, _ParsingFormatMixin
-
-if TYPE_CHECKING:
-    from astropy.extern.ply.lex import Lexer
-    from astropy.units import UnitBase
-    from astropy.units.typing import UnitScale
-    from astropy.utils.parsing import ThreadSafeParser
 
 
 class _GenericParserMixin(_ParsingFormatMixin):

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -4,16 +4,13 @@
 Handles the "LaTeX" unit format.
 """
 
-from __future__ import annotations
-
 import re
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
+
+from astropy.units.core import NamedUnit, UnitBase
+from astropy.units.typing import UnitPower
 
 from . import console
-
-if TYPE_CHECKING:
-    from astropy.units import NamedUnit, UnitBase
-    from astropy.units.typing import UnitPower
 
 
 class Latex(console.Console):

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -16,27 +16,22 @@ FITS files
 <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`__.
 """
 
-from __future__ import annotations
-
 import math
 import warnings
 from fractions import Fraction
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 
-from astropy.units.core import CompositeUnit
+from astropy.extern.ply.lex import Lexer
+from astropy.units.core import CompositeUnit, UnitBase
 from astropy.units.errors import UnitParserWarning, UnitsWarning
+from astropy.units.typing import UnitScale
 from astropy.utils import classproperty, parsing
+from astropy.utils.parsing import ThreadSafeParser
 
 from . import utils
 from .base import Base, _ParsingFormatMixin
-
-if TYPE_CHECKING:
-    from astropy.extern.ply.lex import Lexer
-    from astropy.units import UnitBase
-    from astropy.units.typing import UnitScale
-    from astropy.utils.parsing import ThreadSafeParser
 
 
 class OGIP(Base, _ParsingFormatMixin):

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -4,15 +4,12 @@
 Handles the "Unicode" unit format.
 """
 
-from __future__ import annotations
+from typing import ClassVar
 
-from typing import TYPE_CHECKING, ClassVar
+from astropy.units.core import NamedUnit
+from astropy.units.typing import UnitPower
 
 from . import console
-
-if TYPE_CHECKING:
-    from astropy.units import NamedUnit
-    from astropy.units.typing import UnitPower
 
 
 class Unicode(console.Console):

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -3,19 +3,19 @@
 Handles the "VOUnit" unit format.
 """
 
-from __future__ import annotations
-
 import re
 import warnings
 from re import Pattern
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
 
 import numpy as np
 
+from astropy.extern.ply.lex import LexToken
 from astropy.units.core import (
     CompositeUnit,
     NamedUnit,
     PrefixUnit,
+    UnitBase,
     def_unit,
     dimensionless_unscaled,
     si_prefixes,
@@ -26,15 +26,11 @@ from astropy.units.errors import (
     UnitsError,
     UnitsWarning,
 )
+from astropy.units.typing import UnitScale
 from astropy.utils import classproperty
 
 from . import Base, utils
 from .generic import _GenericParserMixin
-
-if TYPE_CHECKING:
-    from astropy.extern.ply.lex import LexToken
-    from astropy.units import UnitBase
-    from astropy.units.typing import UnitScale
 
 
 class VOUnit(Base, _GenericParserMixin):

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Function Units and Quantities."""
 
-from __future__ import annotations
-
 from abc import ABCMeta, abstractmethod
 from collections.abc import Collection
 from functools import cached_property
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 import numpy as np
 
@@ -19,15 +17,13 @@ from astropy.units import (
     UnitTypeError,
     dimensionless_unscaled,
 )
+from astropy.units.typing import PhysicalTypeID
 from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 
 if NUMPY_LT_2_0:
     from numpy.core import umath as np_umath
 else:
     from numpy._core import umath as np_umath
-
-if TYPE_CHECKING:
-    from astropy.units.typing import PhysicalTypeID
 
 __all__ = ["FunctionQuantity", "FunctionUnitBase"]
 

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -6,20 +6,17 @@ The classes and functions defined here are also available in
 (and should be used through) the `astropy.units` namespace.
 """
 
-from __future__ import annotations
-
 import numbers
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Final
+from typing import Final, Union
 
 from astropy.utils.compat import COPY_IF_NEEDED
 
 from . import astrophys, cgs, core, misc, quantity, si
-
-if TYPE_CHECKING:
-    from .typing import PhysicalTypeID, QuantityLike, UnitPowerLike
+from .typing import PhysicalTypeID, QuantityLike, UnitPowerLike
 
 __all__: Final = ["PhysicalType", "def_physical_type", "get_physical_type"]
+
 
 _units_and_physical_types: Final[list[tuple[core.UnitBase, str | set[str]]]] = [
     (core.dimensionless_unscaled, "dimensionless"),
@@ -140,80 +137,6 @@ _units_and_physical_types: Final[list[tuple[core.UnitBase, str | set[str]]]] = [
     (si.m**-3, "number density"),
     (si.m**-2 * si.s**-1, "particle flux"),
 ]
-
-_physical_unit_mapping: Final[dict[PhysicalTypeID, PhysicalType]] = {}
-_unit_physical_mapping: Final[dict[str, PhysicalTypeID]] = {}
-_name_physical_mapping: Final[dict[str, PhysicalType]] = {}
-# mapping from attribute-accessible name (no spaces, etc.) to the actual name.
-_attrname_physical_mapping: Final[dict[str, PhysicalType]] = {}
-
-
-def _physical_type_from_str(name: str) -> PhysicalType:
-    """
-    Return the `PhysicalType` instance associated with the name of a
-    physical type.
-    """
-    if name == "unknown":
-        raise ValueError("cannot uniquely identify an 'unknown' physical type.")
-
-    elif name in _attrname_physical_mapping:
-        return _attrname_physical_mapping[name]  # convert attribute-accessible
-    elif name in _name_physical_mapping:
-        return _name_physical_mapping[name]
-    else:
-        raise ValueError(f"{name!r} is not a known physical type.")
-
-
-def _replace_temperatures_with_kelvin(unit: core.UnitBase) -> core.UnitBase:
-    """Replace °F, and °C in the bases of `unit` with K.
-
-    The Kelvin, Celsius and Fahrenheit scales have different zero points,
-    which is a problem for the unit conversion machinery (without the
-    `temperature` equivalency). Replacing °F, and °C with kelvin allows the
-    physical type to be treated consistently. The Rankine scale has the
-    same zero point as the Kelvin scale, so degrees Rankine do not have to
-    be special-cased.
-    """
-    physical_type_id = unit._physical_type_id
-
-    physical_type_id_components = []
-    substitution_was_made = False
-
-    for base, power in physical_type_id:
-        if base in ["deg_F", "deg_C"]:
-            base = "K"
-            substitution_was_made = True
-        physical_type_id_components.append((base, power))
-
-    if substitution_was_made:
-        return core.Unit._from_physical_type_id(tuple(physical_type_id_components))
-    else:
-        return unit
-
-
-def _standardize_physical_type_names(physical_type_input: str | set[str]) -> set[str]:
-    """
-    Convert a string or `set` of strings into a `set` containing
-    string representations of physical types.
-
-    The strings provided in ``physical_type_input`` can each contain
-    multiple physical types that are separated by a regular slash.
-    Underscores are treated as spaces so that variable names could
-    be identical to physical type names.
-    """
-    if isinstance(physical_type_input, str):
-        physical_type_input = {physical_type_input}
-
-    standardized_physical_types = set()
-
-    for ptype_input in physical_type_input:
-        if not isinstance(ptype_input, str):
-            raise ValueError(f"expecting a string, but got {ptype_input}")
-        input_set = set(ptype_input.split("/"))
-        processed_set = {s.strip().replace("_", " ") for s in input_set}
-        standardized_physical_types |= processed_set
-
-    return standardized_physical_types
 
 
 class PhysicalType:
@@ -370,30 +293,32 @@ class PhysicalType:
         return None
 
     def __mul__(
-        self, other: PhysicalType | core.UnitBase | numbers.Real | str
-    ) -> PhysicalType:
+        self, other: Union["PhysicalType", core.UnitBase, numbers.Real, str]
+    ) -> "PhysicalType":
         if other_unit := self._dimensionally_compatible_unit(other):
             return (self._unit * other_unit).physical_type
         return NotImplemented
 
-    def __rmul__(self, other: PhysicalType | core.UnitBase | str) -> PhysicalType:
+    def __rmul__(
+        self, other: Union["PhysicalType", core.UnitBase, str]
+    ) -> "PhysicalType":
         return self.__mul__(other)
 
     def __truediv__(
-        self, other: PhysicalType | core.UnitBase | numbers.Real | str
-    ) -> PhysicalType:
+        self, other: Union["PhysicalType", core.UnitBase, numbers.Real, str]
+    ) -> "PhysicalType":
         if other_unit := self._dimensionally_compatible_unit(other):
             return (self._unit / other_unit).physical_type
         return NotImplemented
 
     def __rtruediv__(
-        self, other: PhysicalType | core.UnitBase | numbers.Real | str
-    ) -> PhysicalType:
+        self, other: Union["PhysicalType", core.UnitBase, numbers.Real, str]
+    ) -> "PhysicalType":
         if other_unit := self._dimensionally_compatible_unit(other):
             return (other_unit / self._unit).physical_type
         return NotImplemented
 
-    def __pow__(self, power: UnitPowerLike) -> PhysicalType:
+    def __pow__(self, power: UnitPowerLike) -> "PhysicalType":
         return (self._unit**power).physical_type
 
     def __hash__(self) -> int:
@@ -408,6 +333,81 @@ class PhysicalType:
     # preventing np.array from casting a PhysicalType instance as
     # an object array.
     __array__: Final = None
+
+
+_physical_unit_mapping: Final[dict[PhysicalTypeID, PhysicalType]] = {}
+_unit_physical_mapping: Final[dict[str, PhysicalTypeID]] = {}
+_name_physical_mapping: Final[dict[str, PhysicalType]] = {}
+# mapping from attribute-accessible name (no spaces, etc.) to the actual name.
+_attrname_physical_mapping: Final[dict[str, PhysicalType]] = {}
+
+
+def _physical_type_from_str(name: str) -> PhysicalType:
+    """
+    Return the `PhysicalType` instance associated with the name of a
+    physical type.
+    """
+    if name == "unknown":
+        raise ValueError("cannot uniquely identify an 'unknown' physical type.")
+
+    elif name in _attrname_physical_mapping:
+        return _attrname_physical_mapping[name]  # convert attribute-accessible
+    elif name in _name_physical_mapping:
+        return _name_physical_mapping[name]
+    else:
+        raise ValueError(f"{name!r} is not a known physical type.")
+
+
+def _replace_temperatures_with_kelvin(unit: core.UnitBase) -> core.UnitBase:
+    """Replace °F, and °C in the bases of `unit` with K.
+
+    The Kelvin, Celsius and Fahrenheit scales have different zero points,
+    which is a problem for the unit conversion machinery (without the
+    `temperature` equivalency). Replacing °F, and °C with kelvin allows the
+    physical type to be treated consistently. The Rankine scale has the
+    same zero point as the Kelvin scale, so degrees Rankine do not have to
+    be special-cased.
+    """
+    physical_type_id = unit._physical_type_id
+
+    physical_type_id_components = []
+    substitution_was_made = False
+
+    for base, power in physical_type_id:
+        if base in ["deg_F", "deg_C"]:
+            base = "K"
+            substitution_was_made = True
+        physical_type_id_components.append((base, power))
+
+    if substitution_was_made:
+        return core.Unit._from_physical_type_id(tuple(physical_type_id_components))
+    else:
+        return unit
+
+
+def _standardize_physical_type_names(physical_type_input: str | set[str]) -> set[str]:
+    """
+    Convert a string or `set` of strings into a `set` containing
+    string representations of physical types.
+
+    The strings provided in ``physical_type_input`` can each contain
+    multiple physical types that are separated by a regular slash.
+    Underscores are treated as spaces so that variable names could
+    be identical to physical type names.
+    """
+    if isinstance(physical_type_input, str):
+        physical_type_input = {physical_type_input}
+
+    standardized_physical_types = set()
+
+    for ptype_input in physical_type_input:
+        if not isinstance(ptype_input, str):
+            raise ValueError(f"expecting a string, but got {ptype_input}")
+        input_set = set(ptype_input.split("/"))
+        processed_set = {s.strip().replace("_", " ") for s in input_set}
+        standardized_physical_types |= processed_set
+
+    return standardized_physical_types
 
 
 def def_physical_type(unit: core.UnitBase, name: str | set[str]) -> None:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -5,8 +5,6 @@ associated units. `Quantity` objects support operations like ordinary numbers,
 but will deal with unit conversions internally.
 """
 
-from __future__ import annotations
-
 import builtins
 import numbers
 import operator
@@ -14,7 +12,7 @@ import re
 import warnings
 from collections.abc import Collection
 from fractions import Fraction
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 import numpy as np
 
@@ -35,10 +33,8 @@ from .quantity_helper.function_helpers import (
     UNSUPPORTED_FUNCTIONS,
 )
 from .structured import StructuredUnit, _structured_unit_like_dtype
+from .typing import QuantityLike
 from .utils import is_effectively_unity
-
-if TYPE_CHECKING:
-    from .typing import QuantityLike
 
 __all__ = [
     "Quantity",

--- a/astropy/units/typing.py
+++ b/astropy/units/typing.py
@@ -11,14 +11,15 @@ __all__ = [
 
 
 from fractions import Fraction
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias, Union
 
 import numpy as np
 import numpy.typing as npt
 
-from astropy.units import Quantity, UnitBase
+if TYPE_CHECKING:
+    import astropy.units
 
-UnitLike: TypeAlias = UnitBase | str | Quantity
+UnitLike: TypeAlias = Union["astropy.units.UnitBase", str, "astropy.units.Quantity"]
 """Type alias for input that can be converted to a Unit.
 
 See :term:`unit-like`. Note that this includes only scalar quantities.
@@ -27,7 +28,7 @@ See :term:`unit-like`. Note that this includes only scalar quantities.
 # Note: Quantity is technically covered by npt.ArrayLike, but we want to
 # explicitly include it here so that it is clear that we are also including
 # Quantity objects in the definition of QuantityLike.
-QuantityLike: TypeAlias = Quantity | npt.ArrayLike
+QuantityLike: TypeAlias = Union["astropy.units.Quantity", npt.ArrayLike]
 """Type alias for a quantity-like object.
 
 This is an object that can be converted to a :class:`~astropy.units.Quantity` object

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -6,19 +6,14 @@ None of the functions in the module are meant for use outside of the
 package.
 """
 
-from __future__ import annotations
-
 from fractions import Fraction
-from typing import TYPE_CHECKING, SupportsFloat
+from typing import SupportsFloat
 
 import numpy as np
 from numpy import finfo
 
 from .errors import UnitScaleError
-
-if TYPE_CHECKING:
-    from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
-
+from .typing import UnitPower, UnitPowerLike, UnitScale, UnitScaleLike
 
 _float_finfo = finfo(float)
 # take float here to ensure comparison with another float is fast


### PR DESCRIPTION
### Description

Sphinx is known to have problems resolving stringified annotations, so it's best to avoid them whenever possible. In `units` it is not possible to avoid stringified annotations entirely because of circular imports, but it was nonetheless possible to remove `if TYPE_CHECKING:` blocks from all but two modules. Moving the definitions of `UnitBase` and `PhysicalType` was necessary for minimizing the number of [forward references](https://peps.python.org/pep-0484/#forward-references), but that makes the diff look huge. I recommend the reviewers first move `UnitBase` and `PhysicalType` definitions in their local repositories and then compare the resulting working tree with the branch here. That way the amount of code changes should be quite manageable.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
