### PR TITLE
TST: simplify `jplephem` test case for newer versions

### DIFF
--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -24,6 +24,7 @@ from astropy.coordinates.solar_system import (
 from astropy.tests.helper import CI, assert_quantity_allclose
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
+from astropy.utils import minversion
 from astropy.utils.compat.optional_deps import HAS_JPLEPHEM, HAS_SKYFIELD
 from astropy.utils.data import download_file, get_pkg_data_filename
 
@@ -395,12 +396,13 @@ def test_ephemeris_wrong_input(ephemeris, expected_error):
         get_body("earth", Time("1960-01-12 00:00"), ephemeris=ephemeris)
 
 
+# jplephem<2.23 leaves the file open (a ResourceWarning is emitted)
+@pytest.mark.filterwarnings(
+    "error" if minversion("jplephem", "2.23") else "ignore", category=ResourceWarning
+)
 @pytest.mark.skipif(not HAS_JPLEPHEM, reason="requires jplephem")
 def test_ephemeris_local_file_not_ephemeris():
-    # NOTE: This test currently leaves the file open (ResourceWarning).
-    # To fix this issue, an upstream fix is required in jplephem
-    # package.
-    with pytest.warns(ResourceWarning), pytest.raises(ValueError, match="^file starts"):
+    with pytest.raises(ValueError, match="^file starts"):
         get_body("earth", Time("1960-01-12 00:00"), ephemeris=__file__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 # Recommended run-time dependencies to enable a lot of functionality within Astropy.
 recommended = [
     "scipy>=1.9.2",
+    "scipy<1.16 ; platform_system=='Windows'", # temp, https://github.com/astropy/astropy/issues/18333
     "matplotlib>=3.8.0",
 ]
 # Optional IPython-related behavior is in many places in Astropy. IPython is a complex


### PR DESCRIPTION
### Description
This test failed on weekly cron, presumably because `jplephem` 0.23 just came out (hard to be certain without a changelog)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
