### PR TITLE
TST: adapt a test to Python 3.14

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -708,7 +708,11 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdul[0].header == orig_header[:-1]
             assert (hdul[0].data == data).all()
 
-        if sys.platform.startswith("win") and not NUMPY_LT_2_0:
+        if (
+            sys.platform.startswith("win")
+            and sys.version_info < (3, 14)
+            and not NUMPY_LT_2_0
+        ):
             ctx = pytest.warns(
                 UserWarning,
                 match="Memory map object was closed but appears to still be referenced",


### PR DESCRIPTION
### Description
Resolves a compatibility issue discovered in #18336 ([example logs](https://github.com/astropy/astropy/actions/runs/15848052187/job/44675103499))
Follow up to #16778

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
