### PR TITLE
Implement option in WCS class to preserve the original units

### DIFF
--- a/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
@@ -10,8 +10,24 @@
 extern PyTypeObject PyWcsprmType;
 
 typedef struct {
+
   PyObject_HEAD
   struct wcsprm x;
+
+  // WCSLIB converts units to SI (for example nanometers for a specrtal axis to
+  // meters, or arcseconds for a celestial frame to degrees). There is no easy
+  // way to turn off this behavior in WCSLIB itself, but since we expose WCSLIB
+  // through a wrapper layer, we can optionally do conversions on-the-fly to
+  // make it look to the user as if the units are the original ones. This is
+  // controlled via the preserve_units option which can be 0 (default WCSLIB
+  // behavior) or 1 (preserve original units). The original_cunit array is used
+  // to store the original CUNIT values, while the unit_scaling array contains
+  // the multiplicative scaling required to convert the units from the original
+  // units (e.g. arcsec) to the internal WCSLIB units (e.g. deg)
+  int    preserve_units;
+  char   (*original_cunit)[72];
+  double *unit_scaling;
+
 } PyWcsprm;
 
 int _setup_wcsprm_type(PyObject* m);

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -207,6 +207,8 @@ Wcs_all_pix2world(
     PyObject* kwds) {
 
   int            naxis      = 2;
+  npy_intp       ncoord     = 0;
+  npy_intp       nelem      = 0;
   PyObject*      pixcrd_obj = NULL;
   int            origin     = 1;
   PyArrayObject* pixcrd     = NULL;
@@ -228,7 +230,10 @@ Wcs_all_pix2world(
     return NULL;
   }
 
-  if (PyArray_DIM(pixcrd, 1) < naxis) {
+  ncoord = PyArray_DIM(pixcrd, 0);
+  nelem = PyArray_DIM(pixcrd, 1);
+
+  if (nelem < naxis) {
     PyErr_Format(
       PyExc_RuntimeError,
       "Input array must be 2-dimensional, where the second dimension >= %d",
@@ -246,8 +251,8 @@ Wcs_all_pix2world(
   preoffset_array(pixcrd, origin);
   wcsprm_python2c(self->x.wcs);
   status = pipeline_all_pixel2world(&self->x,
-                                    (unsigned int)PyArray_DIM(pixcrd, 0),
-                                    (unsigned int)PyArray_DIM(pixcrd, 1),
+                                    (unsigned int)ncoord,
+                                    (unsigned int)nelem,
                                     (double*)PyArray_DATA(pixcrd),
                                     (double*)PyArray_DATA(world));
   wcsprm_c2python(self->x.wcs);
@@ -259,6 +264,17 @@ Wcs_all_pix2world(
   Py_XDECREF(pixcrd);
 
   if (status == 0 || status == 8) {
+    // Since the conversion succeeded, if user has requested to preserve units,
+    // we convert the world coordinates to the original units
+    if (((PyWcsprm*)(self->py_wcsprm))->preserve_units == 1) {
+      double *world_data = (double *)PyArray_DATA(world);
+      double *unit_scaling = ((PyWcsprm*)(self->py_wcsprm))->unit_scaling;
+      for (npy_intp i = 0; i < nelem; ++i) {
+        for (npy_intp j = 0; j < ncoord; ++j) {
+            world_data[j * nelem + i] /= unit_scaling[i];
+        }
+      }
+    }
     return (PyObject*)world;
   } else {
     Py_XDECREF(world);

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -164,6 +164,31 @@ convert_rejections_to_warnings() {
   return status;
 }
 
+PyObject* get_scaled_double_1d_array(
+    /*@unused@*/ const char* propname,
+    double* value,
+    double *scale,
+    const npy_intp dim,
+    /*@shared@*/ PyObject* owner) {
+
+  PyArrayObject* array;
+
+  array = (PyArrayObject*)PyArray_SimpleNew(1, &dim, NPY_DOUBLE);
+  if (array == NULL) {
+    return NULL;
+  }
+
+  double *array_data = (double *)PyArray_DATA(array);
+
+  for (npy_intp i = 0; i < dim; ++i) {
+    array_data[i] = value[i] / scale[i];
+  }
+
+  return (PyObject*)array;
+
+}
+
+
 
 /***************************************************************************
  * wtbarr-related global variables and functions                           *
@@ -355,15 +380,20 @@ PyWcsprm_init(
   int            nwcs          = 0;
   struct wcsprm* wcs           = NULL;
   int            i, j;
+  int            preserve_units = 0;
   const char*    keywords[]    = {"header", "key", "relax", "naxis", "keysel",
-                                  "colsel", "warnings", "hdulist", NULL};
+                                  "colsel", "warnings", "hdulist", "preserve_units", NULL};
 
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwds, "|OsOiiOiO:WCSBase.__init__",
+          args, kwds, "|OsOiiOiOp:WCSBase.__init__",
           (char **)keywords, &header_obj, &key, &relax_obj, &naxis, &keysel,
-          &colsel, &warnings, &hdulist)) {
+          &colsel, &warnings, &hdulist, &preserve_units)) {
     return -1;
   }
+
+  // The user can optionally choose to preserve the original units rather
+  // than use the units WCSLIB converts to (e.g. arcsec -> deg)
+  self->preserve_units = preserve_units;
 
   if (header_obj == NULL || header_obj == Py_None) {
     if (keysel > 0) {
@@ -975,6 +1005,8 @@ PyWcsprm_fix(
   int            i               = 0;
   int            msg_index       = 0;
   const char*    message;
+  double         scale, offset, power;
+  int            status;
 
   struct message_map_entry {
     const char* name;
@@ -1025,9 +1057,57 @@ PyWcsprm_fix(
 
   memset(err, 0, sizeof(struct wcserr) * NWCSFIX);
 
+  // If the user has requested to preserve units, we keep track of what CUNIT
+  // was before and after fixing so that we can store the scaling factor if
+  // needed.
+  if (self->preserve_units == 1) {
+
+    if (self->original_cunit == NULL) {
+      self->original_cunit = malloc(self->x.naxis * sizeof(*self->original_cunit));
+      if (self->original_cunit == NULL) {
+          PyErr_NoMemory();
+          return NULL;
+      }
+      for (int i = 0; i < self->x.naxis; ++i) {
+          strncpy(self->original_cunit[i], self->x.cunit[i], 72);
+      }
+    }
+
+    if (self->unit_scaling == NULL) {
+      self->unit_scaling = malloc(self->x.naxis * sizeof(double));
+      if (self->unit_scaling == NULL) {
+          PyErr_NoMemory();
+          return NULL;
+      }
+      for (int i = 0; i < self->x.naxis; ++i) {
+          self->unit_scaling[i] = 1.0;
+      }
+    }
+  }
+
   wcsprm_python2c(&self->x);
   wcsfixi(ctrl, naxis, &self->x, stat, err);
   wcsprm_c2python(&self->x);
+
+  // Check which units have changed, and store scaling if changed.
+  if (self->preserve_units == 1) {
+    for (int i = 0; i < self->x.naxis; ++i) {
+      if (!strcmp(self->original_cunit[i], self->x.cunit[i]) == 0) {
+        status = wcsunits(self->original_cunit[i], self->x.cunit[i], &scale, &offset, &power);
+        if (status == 0) {
+          // We don't support offset and power currently because it should not be needed,
+          // and would introduce additional complexity. However, if needed this can be
+          // supported in future.
+          if (offset != 0 || power != 1)
+                PyErr_Format(
+                  PyExc_ValueError,
+                 "Preserving original units with non-trivial offset and power is not supported "
+                );
+          self->unit_scaling[i] = scale;
+        }
+      }
+    }
+  }
 
   /* We're done with this already, so deref now so we don't have to remember
      later */
@@ -1068,6 +1148,7 @@ PyWcsprm_get_cdelt_func(
     /*@unused@*/ PyObject* kwds) {
 
   Py_ssize_t naxis = 0;
+  PyObject *result;
 
   if (is_null(self->x.cdelt)) {
     return NULL;
@@ -1079,7 +1160,13 @@ PyWcsprm_get_cdelt_func(
 
   naxis = self->x.naxis;
 
-  return get_double_array_readonly("cdelt", self->x.cdelt, 1, &naxis, (PyObject*)self);
+  if (self->preserve_units == 1) {
+    result = get_scaled_double_1d_array("cdelt", self->x.cdelt, self->unit_scaling, naxis, (PyObject*)self);
+  } else {
+    result = get_double_array_readonly("cdelt", self->x.cdelt, 1, &naxis, (PyObject*)self);
+  }
+
+  return result;
 }
 
 /*@null@*/ static PyObject*
@@ -1366,7 +1453,10 @@ PyWcsprm_p2s(
     return NULL;
   }
 
-  if (PyArray_DIM(pixcrd, 1) < naxis) {
+  ncoord = PyArray_DIM(pixcrd, 0);
+  nelem = PyArray_DIM(pixcrd, 1);
+
+  if (nelem < naxis) {
     PyErr_Format(
       PyExc_RuntimeError,
       "Input array must be 2-dimensional, where the second dimension >= %d",
@@ -1408,8 +1498,6 @@ PyWcsprm_p2s(
 
   /* Make the call */
   Py_BEGIN_ALLOW_THREADS
-  ncoord = PyArray_DIM(pixcrd, 0);
-  nelem = PyArray_DIM(pixcrd, 1);
   preoffset_array(pixcrd, origin);
   wcsprm_python2c(&self->x);
   status = wcsp2s(
@@ -1439,6 +1527,16 @@ PyWcsprm_p2s(
   Py_END_ALLOW_THREADS
 
   if (status == 0 || status == 8) {
+    // Since the conversion succeeded, if user has requested to preserve units,
+    // we convert the world coordinates to the original units
+    if (self->preserve_units == 1) {
+      double *world_data = (double *)PyArray_DATA(world);
+      for (npy_intp i = 0; i < nelem; ++i) {
+        for (npy_intp j = 0; j < ncoord; ++j) {
+            world_data[j * nelem + i] /= self->unit_scaling[i];
+        }
+      }
+    }
     result = PyDict_New();
     if (result == NULL ||
         PyDict_SetItemString(result, "imgcrd", (PyObject*)imgcrd) ||
@@ -1508,12 +1606,25 @@ PyWcsprm_s2p(
     return NULL;
   }
 
-  if (PyArray_DIM(world, 1) < naxis) {
+  ncoord = (int)PyArray_DIM(world, 0);
+  nelem = (int)PyArray_DIM(world, 1);
+
+  if (nelem < naxis) {
     PyErr_Format(
       PyExc_RuntimeError,
       "Input array must be 2-dimensional, where the second dimension >= %d",
       naxis);
     goto exit;
+  }
+
+  // Convert world units to native WCSLIB units if needed
+  if (self->preserve_units == 1) {
+    double *world_data = (double *)PyArray_DATA(world);
+    for (npy_intp i = 0; i < nelem; ++i) {
+      for (npy_intp j = 0; j < ncoord; ++j) {
+          world_data[j * nelem + i] *= self->unit_scaling[i];
+      }
+    }
   }
 
   /* Now we allocate a bunch of numpy arrays to store the
@@ -1551,8 +1662,6 @@ PyWcsprm_s2p(
 
   /* Make the call */
   Py_BEGIN_ALLOW_THREADS
-  ncoord = (int)PyArray_DIM(world, 0);
-  nelem = (int)PyArray_DIM(world, 1);
   /* preoffset_array(world, origin); */
   wcsprm_python2c(&self->x);
   status = wcss2p(
@@ -2013,6 +2122,8 @@ PyWcsprm_to_header(
   int       status       = -1;
   PyObject* result       = NULL;
   const char* keywords[] = {"relax", NULL};
+  PyWcsprm*     copy = NULL;
+  int       original_flag = 0;
 
   if (!PyArg_ParseTupleAndKeywords(
           args, kwds, "|O:to_header",
@@ -2034,13 +2145,67 @@ PyWcsprm_to_header(
     }
   }
 
-  wcsprm_python2c(&self->x);
-  status = wcshdo(relax, &self->x, &nkeyrec, &header);
-  wcsprm_c2python(&self->x);
+  // If the user has requested to preserve the original units, then we
+  // could try and edit the header returned by wcshdo - however, this
+  // might be tricky and not robust to future WCSLIB changes. Instead,
+  // we make a copy of the Wcsprm object, change the units on that and
+  // prevent WCSLIB fixing the units, then convert to a header.
+  if (self->preserve_units == 1) {
+    copy = PyWcsprm_cnew();
+    if (copy == NULL) {
+      return NULL;
+    }
 
-  if (status != 0) {
-    wcs_to_python_exc(&(self->x));
-    goto exit;
+    wcsini(0, self->x.naxis, &copy->x);
+
+    wcsprm_python2c(&self->x);
+    status = wcscopy(1, &self->x, &copy->x);
+    wcsprm_c2python(&self->x);
+
+    if (status != 0) {
+        // Handle error (e.g., allocation failure)
+        PyErr_SetString(PyExc_RuntimeError, "wcscopy failed");
+        return NULL;
+    }
+
+    // We make sure wcsset is happy
+    wcsset(&copy->x);
+
+    // We preserve the value of the flag which indicates that wcsset
+    // has been called and there have been no further modifications
+    original_flag = copy->x.flag;
+
+    // We now override the unit, cdelt and crval values
+    for (int i = 0; i < copy->x.naxis; ++i) {
+      strncpy(copy->x.cunit[i], self->original_cunit[i], 72);
+      copy->x.cdelt[i] /= self->unit_scaling[i];
+      copy->x.crval[i] /= self->unit_scaling[i];
+    }
+
+    // We restore the flag to trick WCSLIB into thinking it no longer
+    // needs to change the units.
+    copy->x.flag = original_flag;
+
+    wcsprm_python2c(&copy->x);
+    status = wcshdo(relax, &copy->x, &nkeyrec, &header);
+
+    if (status != 0) {
+      wcs_to_python_exc(&(copy->x));
+      wcsfree(&copy->x);
+      goto exit;
+    }
+
+    wcsfree(&copy->x);
+
+  } else {
+
+    status = wcshdo(relax, &self->x, &nkeyrec, &header);
+
+    if (status != 0) {
+      wcs_to_python_exc(&(self->x));
+      goto exit;
+    }
+
   }
 
   /* Just return the raw header string.  astropy.io.fits on the Python side will
@@ -2239,6 +2404,7 @@ PyWcsprm_get_cdelt(
     /*@unused@*/ void* closure) {
 
   Py_ssize_t naxis = 0;
+  PyObject* result;
 
   if (is_null(self->x.cdelt)) {
     return NULL;
@@ -2250,7 +2416,15 @@ PyWcsprm_get_cdelt(
     PyErr_WarnEx(NULL, "cdelt will be ignored since cd is present", 1);
   }
 
-  return get_double_array("cdelt", self->x.cdelt, 1, &naxis, (PyObject*)self);
+  if (self->preserve_units == 1) {
+    result = get_scaled_double_1d_array("cdelt", self->x.cdelt, self->unit_scaling, naxis, (PyObject*)self);
+  } else {
+    result = get_double_array_readonly("cdelt", self->x.cdelt, 1, &naxis, (PyObject*)self);
+  }
+
+  return result;
+
+
 }
 
 /*@null@*/ static int
@@ -2496,6 +2670,7 @@ PyWcsprm_get_crval(
     /*@unused@*/ void* closure) {
 
   Py_ssize_t naxis = 0;
+  PyObject* result;
 
   if (is_null(self->x.crval)) {
     return NULL;
@@ -2503,7 +2678,14 @@ PyWcsprm_get_crval(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return get_double_array("crval", self->x.crval, 1, &naxis, (PyObject*)self);
+  if (self->preserve_units == 1) {
+    result = get_scaled_double_1d_array("cdelt", self->x.crval, self->unit_scaling, naxis, (PyObject*)self);
+  } else {
+    result = get_double_array("crval", self->x.crval, 1, &naxis, (PyObject*)self);
+  }
+
+  return result;
+
 }
 
 static int
@@ -2613,8 +2795,13 @@ PyWcsprm_get_cunit(
     return NULL;
   }
 
-  return get_unit_list(
-    "cunit", self->x.cunit, (Py_ssize_t)self->x.naxis, (PyObject*)self);
+  if (self->preserve_units == 1) {
+    return get_unit_list(
+      "cunit", self->original_cunit, (Py_ssize_t)self->x.naxis, (PyObject*)self);
+  } else {
+    return get_unit_list(
+      "cunit", self->x.cunit, (Py_ssize_t)self->x.naxis, (PyObject*)self);
+  }
 }
 
 static int

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -2199,7 +2199,9 @@ PyWcsprm_to_header(
 
   } else {
 
+    wcsprm_python2c(&self->x);
     status = wcshdo(relax, &self->x, &nkeyrec, &header);
+    wcsprm_c2python(&self->x);
 
     if (status != 0) {
       wcs_to_python_exc(&(self->x));

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -2421,7 +2421,7 @@ PyWcsprm_get_cdelt(
   if (self->preserve_units == 1) {
     result = get_scaled_double_1d_array("cdelt", self->x.cdelt, self->unit_scaling, naxis, (PyObject*)self);
   } else {
-    result = get_double_array_readonly("cdelt", self->x.cdelt, 1, &naxis, (PyObject*)self);
+    result = get_double_array("cdelt", self->x.cdelt, 1, &naxis, (PyObject*)self);
   }
 
   return result;

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1915,3 +1915,104 @@ def test_DistortionLookupTable():
             img_world_wcs.pixel_to_world_values(12 + dx * 3, 22 + dy * 3),
             [12 + dx * 3, 22 + dy * 3],
         )
+
+
+HEADER_WITH_NON_SI_UNITS = """
+WCSAXES = 5
+CTYPE1  = 'RA---TAN'
+CTYPE2  = 'FREQ'
+CTYPE3  = 'DEC--TAN'
+CTYPE4  = 'WAVE'
+CTYPE5  = 'OFFSET'
+CUNIT1  = 'arcsec'
+CUNIT2  = 'GHz'
+CUNIT3  = 'arcsec'
+CUNIT4  = 'nm'
+CUNIT5  = 'arcmin'
+CRVAL1  = 4
+CRVAL2  = 5
+CRVAL3  = 6
+CRVAL4  = 7
+CRVAL5  = 8
+CRPIX1  = 1
+CRPIX2  = 2
+CRPIX3  = 3
+CRPIX4  = 4
+CRPIX5  = 5
+CDELT1  = 4
+CDELT2  = 3
+CDELT3  = 2
+CDELT4  = 1
+CDELT5  = 6
+""".strip()
+
+
+class TestPreserveUnits:
+    def setup_method(self, method):
+        header = fits.Header.fromstring(HEADER_WITH_NON_SI_UNITS, sep="\n")
+        self.wcs_default = wcs.WCS(header)
+        self.wcs_preserve = wcs.WCS(header, preserve_units=True)
+        self.ones = np.ones((3, 5))
+        self.scale = np.array([1 / 3600, 1e9, 1 / 3600, 1e-9, 1])
+
+    def test_cunit(self):
+        assert list(self.wcs_default.wcs.cunit) == ["deg", "Hz", "deg", "m", "arcmin"]
+        assert list(self.wcs_preserve.wcs.cunit) == [
+            "arcsec",
+            "GHz",
+            "arcsec",
+            "nm",
+            "arcmin",
+        ]
+
+    def test_cdelt(self):
+        assert_allclose(self.wcs_default.wcs.cdelt, [4 / 3600, 3e9, 2 / 3600, 1e-9, 6])
+        assert_allclose(self.wcs_preserve.wcs.cdelt, [4, 3, 2, 1, 6])
+
+    def test_get_cdelt(self):
+        assert_allclose(
+            self.wcs_default.wcs.get_cdelt(), [4 / 3600, 3e9, 2 / 3600, 1e-9, 6]
+        )
+        assert_allclose(self.wcs_preserve.wcs.get_cdelt(), [4, 3, 2, 1, 6])
+
+    def test_crval(self):
+        assert_allclose(self.wcs_default.wcs.crval, [4 / 3600, 5e9, 6 / 3600, 7e-9, 8])
+        assert_allclose(self.wcs_preserve.wcs.crval, [4, 5, 6, 7, 8])
+
+    def test_p2s(self):
+        result_default = self.wcs_default.wcs.p2s(self.ones, 0)
+        result_preserve = self.wcs_preserve.wcs.p2s(self.ones, 0)
+        for key in result_default:
+            if key == "world":
+                assert_allclose(result_default[key], result_preserve[key] * self.scale)
+            else:
+                assert_allclose(result_default[key], result_preserve[key])
+
+    def test_s2p(self):
+        result_default = self.wcs_default.wcs.s2p(self.ones * self.scale, 0)
+        result_preserve = self.wcs_preserve.wcs.s2p(self.ones, 0)
+        for key in result_default:
+            assert_allclose(result_default[key], result_preserve[key])
+
+    def test_wcs_pix2world(self):
+        result_default = self.wcs_default.wcs_pix2world(self.ones, 0)
+        result_preserve = self.wcs_preserve.wcs_pix2world(self.ones, 0)
+        assert_allclose(result_default, result_preserve * self.scale)
+
+    def test_wcs_world2pix(self):
+        result_default = self.wcs_default.wcs_world2pix(self.ones * self.scale, 0)
+        result_preserve = self.wcs_preserve.wcs_world2pix(self.ones, 0)
+        assert_allclose(result_default, result_preserve)
+
+    def test_all_pix2world(self):
+        result_default = self.wcs_default.all_pix2world(self.ones, 0)
+        result_preserve = self.wcs_preserve.all_pix2world(self.ones, 0)
+        assert_allclose(result_default, result_preserve * self.scale)
+
+    def test_all_world2pix(self):
+        result_default = self.wcs_default.all_world2pix(self.ones * self.scale, 0)
+        result_preserve = self.wcs_preserve.all_world2pix(self.ones, 0)
+        assert_allclose(result_default, result_preserve)
+
+
+# TODO: add test for CD matrix

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -347,6 +347,12 @@ class WCS(FITSWCSAPIMixin, WCSBase):
         `WCS.fix` for more information about this parameter.  Only
         effective when ``fix`` is `True`.
 
+    preserve_units : str, optional
+        By default, some units are converted to SI, for example spectral
+        axes in units of nm might be converted to m, and celestial axes
+        in units of arcsec might be converted to deg. If ``preserve_units``
+        is set to `True`, the original units will be preserved.
+
     Raises
     ------
     MemoryError
@@ -418,6 +424,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
         fix=True,
         translate_units="",
         _do_set=True,
+        preserve_units=False,
     ):
         close_fds = []
 
@@ -430,7 +437,13 @@ class WCS(FITSWCSAPIMixin, WCSBase):
         if header is None:
             if naxis is None:
                 naxis = 2
-            wcsprm = _wcs.Wcsprm(header=None, key=key, relax=relax, naxis=naxis)
+            wcsprm = _wcs.Wcsprm(
+                header=None,
+                key=key,
+                relax=relax,
+                naxis=naxis,
+                preserve_units=preserve_units,
+            )
             self.naxis = wcsprm.naxis
             # Set some reasonable defaults.
             det2im = (None, None)
@@ -502,6 +515,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                     colsel=colsel,
                     warnings=False,
                     hdulist=fobj,
+                    preserve_units=preserve_units,
                 )
                 if naxis is not None:
                     try:
@@ -541,6 +555,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                     keysel=keysel_flags,
                     colsel=colsel,
                     hdulist=fobj,
+                    preserve_units=preserve_units,
                 )
             except _wcs.NoWcsKeywordsFoundError:
                 # The header may have SIP or distortions, but no core
@@ -554,6 +569,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                         keysel=keysel_flags,
                         colsel=colsel,
                         hdulist=fobj,
+                        preserve_units=preserve_units,
                     )
                 else:
                     raise


### PR DESCRIPTION
### Description

A common issue users run into when using the ``astropy.wcs`` class is that WCSLIB will convert units to SI. For instance, celestial WCS in arcseconds will be converted to degrees, and spectral axes in GHz and nm will be converted to m. There isn't much we can do to stop WCSLIB from doing this - however I have realized that since we never expose the WCSLIB objects directly, but instead have our own C wrapper class, we can make that wrapper class remember any initial units and do on-the-fly conversions for all appropriate methods/properties.

As an example:

```python
In [1]: from astropy.io import fits
   ...: 

In [2]: header = fits.Header()
   ...: header['CTYPE1'] = 'RA---TAN'
   ...: header['CTYPE2'] = 'DEC--TAN'
   ...: header['CUNIT1'] = 'arcsec'
   ...: header['CUNIT2'] = 'arcsec'
   ...: header['CRVAL1'] = 20
   ...: header['CRVAL2'] = 20
   ...: header['CRPIX1'] = 1
   ...: header['CRPIX2'] = 1
   ...: header['CDELT1'] = -1
   ...: header['CDELT2'] = 1
   ...: 

In [3]: from astropy.wcs import WCS
   ...: 

In [4]: wcs = WCS(header)

In [5]: wcs.wcs.cunit
Out[5]: ['deg', 'deg']

In [6]: wcs.wcs.crval
Out[6]: array([0.00555556, 0.00555556])

In [8]: wcs.all_pix2world(1, 1, 0)
Out[8]: [array(0.00527778), array(0.00583333)]

In [9]: wcs2 = WCS(header, preserve_units=True)

In [10]: wcs2.wcs.cunit
Out[10]: ['arcsec', 'arcsec']

In [11]: wcs2.wcs.crval
Out[11]: array([20., 20.])

In [13]: wcs2.all_pix2world(1, 1, 0)
Out[13]: [array(18.99999999), array(21.)]

```

This is not yet complete but I am putting it up already so that people who are interested can try it out.

Remaining TODOs:

```
* [ ] Extend support to headers with CD matrices
* [ ] Fix/check support for printing the WCS
* [ ] Check that we can dynamically change the units on the WCS and that things behave correctly
* [ ] Expand test suite
* [ ] Write documentation
* [ ] Add news fragment

This will need to be rebased once https://github.com/astropy/astropy/pull/18231 is merged

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
