### PR TITLE
DEP: redefine `dev[_all]` extras as PEP 735 Dependency Groups

### DIFF
--- a/docs/changes/18342.other.rst
+++ b/docs/changes/18342.other.rst
@@ -1,0 +1,3 @@
+Development-only dependencies, previously defined as user-visible
+extras ``dev`` and ``dev_all``, were moved to PEP 735 dependency groups, and
+are thus only accessible when building astropy from source.

--- a/docs/development/git_edit_workflow_examples.rst
+++ b/docs/development/git_edit_workflow_examples.rst
@@ -50,7 +50,7 @@ Set up an isolated workspace
 + Install our branch of ``astropy`` along with all development dependencies in this
   environment with::
 
-    python -m pip install --editable ".[dev_all]"
+    python -m pip install --editable . --group dev_all
 
 If installation fails, try to upgrade ``pip`` using ``python -m pip install pip
 --upgrade`` command. It is also a good practice to occasionally keep your ``conda``

--- a/docs/development/maintainers/testhelpers.rst
+++ b/docs/development/maintainers/testhelpers.rst
@@ -19,7 +19,9 @@ Astropy, and will also be of general use to other packages.
 Since the testing dependencies are not actually required to install or use
 Astropy, in the ``pyproject.toml`` file they are not included under the
 ``[project]`` section in ``dependencies``. Instead, they are listed under the
-``[project.optional-dependences]`` in named sections such as ``test`` or ``dev_all``.
+``[project.optional-dependences]`` in named sections such as ``test``.
+Furthermore, dev-only dependencies are listed under ``[dependency-groups]``, which for
+instance defines a ``dev`` and a ``dev_all`` group.
 
 In particular the ``test`` dependencies are the minimal set of dependencies for running
 astropy tests and you would use this primarily to check that tests pass *without* the

--- a/docs/development/quickstart.rst
+++ b/docs/development/quickstart.rst
@@ -141,7 +141,7 @@ Now you can install the development version of astropy into your new environment
 will install the latest version of astropy from your local git repo, along with
 all the dependencies needed to build and fully test astropy::
 
-   python -m pip install --editable '.[dev_all]'
+   python -m pip install --editable . --group dev_all
 
 **Checking the build**
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -18,7 +18,7 @@ Testing Dependencies
 Most commonly, you should install the full suite of testing and development
 dependencies::
 
-    python -m pip install --editable '.[dev_all]'
+    python -m pip install --editable . --group dev_all
 
 This will provide all dependencies for running the full test suite using `tox <https://tox.wiki/>`__
 and |pytest|. It will also allow running tests via any IDE which
@@ -94,7 +94,7 @@ in an :ref:`isolated development environment<create-isolated-env>`.
 In the uncommon situation that one or more compiled extensions have changed, you will
 need to rebuild them by re-running the usual editable install command::
 
-    python -m pip install --editable '.[dev_all]'
+    python -m pip install --editable . --group dev_all
 
 It is possible to run only the tests for a particular subpackage or set of
 subpackages.  For example, to run only the ``wcs`` and ``utils`` tests from the

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -86,7 +86,6 @@ one of the following commands::
     python -m pip install astropy                # Minimum required dependencies
     python -m pip install "astropy[recommended]" # Recommended dependencies
     python -m pip install "astropy[all]"         # All optional dependencies
-    python -m pip install "astropy[dev_all]"     # All optional and test dependencies
 
 In most cases, this will install a pre-compiled version of ``astropy`` (called a
 *wheel*). However, if you are installing astropy on an uncommon platform, astropy will be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,18 +146,6 @@ docs = [
     "dask[dataframe]>=2024.8.0", # keep in sync with dependency-groups.dataframe
     "fsspec[http,s3]>=2023.4.0",  # keep in sync with dependency-groups.dataframe
 ]
-# These group together all the dependencies needed for developing in Astropy.
-dev = [
-    "astropy[recommended]",  # installs the most common optional dependencies
-    "astropy[test]",
-    "astropy[docs]",
-    "astropy[typing]",
-]
-dev_all = [
-    "tox>=4.33.0", # keep in sync with tox.minversion in tox.ini
-    "astropy[dev]",
-    "astropy[test_all]",
-]
 
 [project.urls]
 homepage = "https://www.astropy.org/"
@@ -198,6 +186,21 @@ dataframe = [
     "polars>=1.18.0",
     "duckdb>=1.1.0",
     "dask[dataframe]>=2024.8.0", # keep in sync with other declarations
+]
+# re-define historical optional dependencies (a.k.a. 'extras') as
+# user-invisible, PEP 735 dependency groups
+# These group together all the dependencies needed for developing in Astropy.
+dev = [
+    "astropy[recommended]",  # installs the most common optional dependencies
+    "astropy[test]",
+    "astropy[docs]",
+    "astropy[typing]",
+]
+dev_all = [
+    {include-group = "dev"},
+    {include-group = "dataframe"},
+    "astropy[test_all]",
+    "tox>=4.33.0", # keep in sync with tox.minversion in tox.ini
 ]
 
 [tool.setuptools]
@@ -531,7 +534,6 @@ ignore = [
     "PC140", # ignore using `mypy` in pre-commit
     "PC180", # ignore using `prettier` in pre-commit
     "PC901", # ignore using custom update message (we have many of the default ones in our history already)
-    "PP006", # ignore defining dev dependency group
     "PP308", # ignore requiring `-ra` flag for pytest, astropy's test suite is too large for this to be useful
     "PY005", # ignore requiring a root level "test*" directory
 ]
@@ -862,3 +864,7 @@ constraint-dependencies = [
     # see https://github.com/astropy/astropy/issues/18292
     "array-api-strict<2.4 ; python_version<'3.12'",
 ]
+
+# uv sync's default behavior includes the 'dev' group.
+# Disable this so we get lightweight envs by default.
+default-groups = []

--- a/scripts/lowest-resolved-tree.txt
+++ b/scripts/lowest-resolved-tree.txt
@@ -218,55 +218,18 @@ astropy
 │   └── numpy v2.0.0
 ├── sortedcontainers v2.1.0 (extra: all)
 ├── uncompresspy v0.4.0 (extra: all)
-├── coverage v7.2.0 (extra: dev)
-├── dask[dataframe] v2024.8.0 (extra: dev) (*)
-├── fsspec[http, s3] v2023.4.0 (extra: dev) (*)
-├── hypothesis v6.84.0 (extra: dev)
-│   ├── attrs v20.1.0
-│   └── sortedcontainers v2.1.0
-├── jinja2 v3.1.3 (extra: dev) (*)
-├── matplotlib v3.9.1.post1 (extra: dev) (*)
-├── narwhals v1.42.0 (extra: dev)
-├── pandas-stubs v2.0.2.230605 (extra: dev)
-│   ├── numpy v2.0.0
-│   └── types-pytz v2022.1.1
-├── pytest v8.0.1 (extra: dev)
+├── dask[dataframe] v2024.8.0 (extra: docs) (*)
+├── fsspec[http, s3] v2023.4.0 (extra: docs) (*)
+├── jinja2 v3.1.3 (extra: docs) (*)
+├── matplotlib v3.9.1.post1 (extra: docs) (*)
+├── narwhals v1.42.0 (extra: docs)
+├── pytest v8.0.1 (extra: docs)
 │   ├── colorama v0.4.6
 │   ├── iniconfig v1.0.1
 │   ├── packaging v25.0
 │   └── pluggy v1.6.0
-├── pytest-astropy v0.11.0 (extra: dev)
-│   ├── attrs v20.1.0
-│   ├── hypothesis v6.84.0 (*)
-│   ├── pytest v8.0.1 (*)
-│   ├── pytest-arraydiff v0.5.0
-│   │   ├── numpy v2.0.0
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-astropy-header v0.2.2
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-cov v2.3.1
-│   │   ├── coverage v7.2.0
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-doctestplus v1.4.0
-│   │   ├── packaging v25.0
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-filter-subpackage v0.1.2
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-mock v2.0.0
-│   │   └── pytest v8.0.1 (*)
-│   └── pytest-remotedata v0.4.1
-│       ├── packaging v25.0
-│       └── pytest v8.0.1 (*)
-├── pytest-astropy-header v0.2.2 (extra: dev) (*)
-├── pytest-doctestplus v1.4.0 (extra: dev) (*)
-├── pytest-xdist v3.6.1 (extra: dev)
-│   ├── execnet v2.1.0
-│   └── pytest v8.0.1 (*)
-├── scipy v1.13.0 (extra: dev) (*)
-├── scipy-stubs v1.14.1.6 (extra: dev)
-│   └── optype v0.7.3
-│       └── typing-extensions v4.10.0
-├── sphinx v8.2.0 (extra: dev)
+├── scipy v1.13.0 (extra: docs) (*)
+├── sphinx v8.2.0 (extra: docs)
 │   ├── alabaster v0.7.14
 │   ├── babel v2.13.0
 │   ├── colorama v0.4.6
@@ -287,7 +250,7 @@ astropy
 │   │   └── sphinx v8.2.0 (*)
 │   └── sphinxcontrib-serializinghtml v1.1.9
 │       └── sphinx v8.2.0 (*)
-├── sphinx-astropy[confv2] v1.9.1 (extra: dev)
+├── sphinx-astropy[confv2] v1.9.1 (extra: docs)
 │   ├── astropy-sphinx-theme v1.0
 │   │   └── setuptools v18.5
 │   ├── numpydoc v1.0.0
@@ -295,7 +258,9 @@ astropy
 │   │   └── sphinx v8.2.0 (*)
 │   ├── packaging v25.0
 │   ├── pillow v9.2.0
-│   ├── pytest-doctestplus v1.4.0 (*)
+│   ├── pytest-doctestplus v1.4.0
+│   │   ├── packaging v25.0
+│   │   └── pytest v8.0.1 (*)
 │   ├── sphinx v8.2.0 (*)
 │   ├── sphinx-automodapi v0.1
 │   ├── sphinx-gallery v0.0.4
@@ -308,7 +273,7 @@ astropy
 │   ├── pydata-sphinx-theme v0.1.0 (extra: confv2)
 │   │   └── sphinx v8.2.0 (*)
 │   └── sphinx-copybutton v0.1 (extra: confv2)
-├── sphinx-changelog v1.2.0 (extra: dev)
+├── sphinx-changelog v1.2.0 (extra: docs)
 │   ├── sphinx v8.2.0 (*)
 │   └── towncrier v22.8.0
 │       ├── click v8.1.0 (*)
@@ -318,90 +283,10 @@ astropy
 │       ├── jinja2 v3.1.3 (*)
 │       ├── setuptools v18.5
 │       └── tomli v1.1.0
-├── sphinx-design v0.6.1 (extra: dev)
+├── sphinx-design v0.6.1 (extra: docs)
 │   └── sphinx v8.2.0 (*)
-├── sphinxcontrib-globalsubs v0.1.1 (extra: dev)
+├── sphinxcontrib-globalsubs v0.1.1 (extra: docs)
 │   └── sphinx v8.2.0 (*)
-├── threadpoolctl v3.0.0 (extra: dev)
-├── array-api-strict v1.0 (extra: dev-all)
-│   └── numpy v2.0.0
-├── asdf-astropy v0.7.0 (extra: dev-all) (*)
-├── beautifulsoup4 v4.11.2 (extra: dev-all) (*)
-├── bleach v3.2.1 (extra: dev-all) (*)
-├── bottleneck v1.4.0 (extra: dev-all) (*)
-├── certifi v2022.6.15.1 (extra: dev-all)
-├── coverage v7.2.0 (extra: dev-all)
-├── dask[dataframe] v2024.8.0 (extra: dev-all) (*)
-├── fsspec[http, s3] v2023.4.0 (extra: dev-all) (*)
-├── h5py v3.11.0 (extra: dev-all) (*)
-├── html5lib v1.1 (extra: dev-all) (*)
-├── hypothesis v6.84.0 (extra: dev-all) (*)
-├── ipydatagrid v1.1.13 (extra: dev-all) (*)
-├── ipykernel v6.16.0 (extra: dev-all) (*)
-├── ipython v8.0.0 (extra: dev-all) (*)
-├── ipywidgets v7.7.3 (extra: dev-all) (*)
-├── jinja2 v3.1.3 (extra: dev-all) (*)
-├── jplephem v2.17 (extra: dev-all) (*)
-├── jupyter-core v4.11.2 (extra: dev-all) (*)
-├── matplotlib v3.9.1.post1 (extra: dev-all) (*)
-├── mpmath v1.2.1 (extra: dev-all)
-├── narwhals v1.42.0 (extra: dev-all)
-├── numpy-quaddtype v0.2.2 (extra: dev-all)
-│   └── numpy v2.0.0
-├── objgraph v3.1.2 (extra: dev-all)
-│   └── graphviz v0.1
-├── pandas v2.2.2 (extra: dev-all) (*)
-├── pandas-stubs v2.0.2.230605 (extra: dev-all) (*)
-├── pyarrow v16.0.0 (extra: dev-all) (*)
-├── pytest v8.0.1 (extra: dev-all) (*)
-├── pytest-astropy v0.11.0 (extra: dev-all) (*)
-├── pytest-astropy-header v0.2.2 (extra: dev-all) (*)
-├── pytest-doctestplus v1.4.0 (extra: dev-all) (*)
-├── pytest-xdist v3.6.1 (extra: dev-all) (*)
-├── pytz v2020.1 (extra: dev-all)
-├── s3fs v2023.4.0 (extra: dev-all) (*)
-├── scipy v1.13.0 (extra: dev-all) (*)
-├── scipy-stubs v1.14.1.6 (extra: dev-all) (*)
-├── sgp4 v2.22 (extra: dev-all)
-├── skyfield v1.42 (extra: dev-all)
-│   ├── certifi v2022.6.15.1
-│   ├── jplephem v2.17 (*)
-│   ├── numpy v2.0.0
-│   └── sgp4 v2.22
-├── sortedcontainers v2.1.0 (extra: dev-all)
-├── sphinx v8.2.0 (extra: dev-all) (*)
-├── sphinx-astropy[confv2] v1.9.1 (extra: dev-all) (*)
-├── sphinx-changelog v1.2.0 (extra: dev-all) (*)
-├── sphinx-design v0.6.1 (extra: dev-all) (*)
-├── sphinxcontrib-globalsubs v0.1.1 (extra: dev-all) (*)
-├── threadpoolctl v3.0.0 (extra: dev-all)
-├── tox v4.33.0 (extra: dev-all)
-│   ├── cachetools v6.2.4
-│   ├── chardet v5.2.0
-│   ├── colorama v0.4.6
-│   ├── filelock v3.20.2
-│   ├── packaging v25.0
-│   ├── platformdirs v4.5.1
-│   ├── pluggy v1.6.0
-│   ├── pyproject-api v1.10.0
-│   │   └── packaging v25.0
-│   └── virtualenv v20.35.4
-│       ├── distlib v0.3.7
-│       ├── filelock v3.20.2
-│       └── platformdirs v4.5.1
-├── uncompresspy v0.4.0 (extra: dev-all)
-├── dask[dataframe] v2024.8.0 (extra: docs) (*)
-├── fsspec[http, s3] v2023.4.0 (extra: docs) (*)
-├── jinja2 v3.1.3 (extra: docs) (*)
-├── matplotlib v3.9.1.post1 (extra: docs) (*)
-├── narwhals v1.42.0 (extra: docs)
-├── pytest v8.0.1 (extra: docs) (*)
-├── scipy v1.13.0 (extra: docs) (*)
-├── sphinx v8.2.0 (extra: docs) (*)
-├── sphinx-astropy[confv2] v1.9.1 (extra: docs) (*)
-├── sphinx-changelog v1.2.0 (extra: docs) (*)
-├── sphinx-design v0.6.1 (extra: docs) (*)
-├── sphinxcontrib-globalsubs v0.1.1 (extra: docs) (*)
 ├── ipython v8.0.0 (extra: ipython) (*)
 ├── ipydatagrid v1.1.13 (extra: jupyter) (*)
 ├── ipykernel v6.16.0 (extra: jupyter) (*)
@@ -413,14 +298,38 @@ astropy
 ├── narwhals v1.42.0 (extra: recommended)
 ├── scipy v1.13.0 (extra: recommended) (*)
 ├── coverage v7.2.0 (extra: test)
-├── hypothesis v6.84.0 (extra: test) (*)
+├── hypothesis v6.84.0 (extra: test)
+│   ├── attrs v20.1.0
+│   └── sortedcontainers v2.1.0
 ├── pytest v8.0.1 (extra: test) (*)
-├── pytest-astropy v0.11.0 (extra: test) (*)
+├── pytest-astropy v0.11.0 (extra: test)
+│   ├── attrs v20.1.0
+│   ├── hypothesis v6.84.0 (*)
+│   ├── pytest v8.0.1 (*)
+│   ├── pytest-arraydiff v0.5.0
+│   │   ├── numpy v2.0.0
+│   │   └── pytest v8.0.1 (*)
+│   ├── pytest-astropy-header v0.2.2
+│   │   └── pytest v8.0.1 (*)
+│   ├── pytest-cov v2.3.1
+│   │   ├── coverage v7.2.0
+│   │   └── pytest v8.0.1 (*)
+│   ├── pytest-doctestplus v1.4.0 (*)
+│   ├── pytest-filter-subpackage v0.1.2
+│   │   └── pytest v8.0.1 (*)
+│   ├── pytest-mock v2.0.0
+│   │   └── pytest v8.0.1 (*)
+│   └── pytest-remotedata v0.4.1
+│       ├── packaging v25.0
+│       └── pytest v8.0.1 (*)
 ├── pytest-astropy-header v0.2.2 (extra: test) (*)
 ├── pytest-doctestplus v1.4.0 (extra: test) (*)
-├── pytest-xdist v3.6.1 (extra: test) (*)
+├── pytest-xdist v3.6.1 (extra: test)
+│   ├── execnet v2.1.0
+│   └── pytest v8.0.1 (*)
 ├── threadpoolctl v3.0.0 (extra: test)
-├── array-api-strict v1.0 (extra: test-all) (*)
+├── array-api-strict v1.0 (extra: test-all)
+│   └── numpy v2.0.0
 ├── asdf-astropy v0.7.0 (extra: test-all) (*)
 ├── beautifulsoup4 v4.11.2 (extra: test-all) (*)
 ├── bleach v3.2.1 (extra: test-all) (*)
@@ -441,8 +350,10 @@ astropy
 ├── matplotlib v3.9.1.post1 (extra: test-all) (*)
 ├── mpmath v1.2.1 (extra: test-all)
 ├── narwhals v1.42.0 (extra: test-all)
-├── numpy-quaddtype v0.2.2 (extra: test-all) (*)
-├── objgraph v3.1.2 (extra: test-all) (*)
+├── numpy-quaddtype v0.2.2 (extra: test-all)
+│   └── numpy v2.0.0
+├── objgraph v3.1.2 (extra: test-all)
+│   └── graphviz v0.1
 ├── pandas v2.2.2 (extra: test-all) (*)
 ├── pyarrow v16.0.0 (extra: test-all) (*)
 ├── pytest v8.0.1 (extra: test-all) (*)
@@ -454,17 +365,47 @@ astropy
 ├── s3fs v2023.4.0 (extra: test-all) (*)
 ├── scipy v1.13.0 (extra: test-all) (*)
 ├── sgp4 v2.22 (extra: test-all)
-├── skyfield v1.42 (extra: test-all) (*)
+├── skyfield v1.42 (extra: test-all)
+│   ├── certifi v2022.6.15.1
+│   ├── jplephem v2.17 (*)
+│   ├── numpy v2.0.0
+│   └── sgp4 v2.22
 ├── sortedcontainers v2.1.0 (extra: test-all)
 ├── threadpoolctl v3.0.0 (extra: test-all)
 ├── uncompresspy v0.4.0 (extra: test-all)
 ├── narwhals v1.42.0 (extra: typing)
-├── pandas-stubs v2.0.2.230605 (extra: typing) (*)
-├── scipy-stubs v1.14.1.6 (extra: typing) (*)
+├── pandas-stubs v2.0.2.230605 (extra: typing)
+│   ├── numpy v2.0.0
+│   └── types-pytz v2022.1.1
+├── scipy-stubs v1.14.1.6 (extra: typing)
+│   └── optype v0.7.3
+│       └── typing-extensions v4.10.0
 ├── dask[dataframe] v2024.8.0 (group: dataframe) (*)
 ├── duckdb v1.1.0 (group: dataframe)
 ├── narwhals v1.42.0 (group: dataframe)
 ├── pandas v2.2.2 (group: dataframe) (*)
 ├── polars v1.18.0 (group: dataframe)
-└── pyarrow v16.0.0 (group: dataframe) (*)
+├── pyarrow v16.0.0 (group: dataframe) (*)
+├── astropy[docs, recommended, test, typing] (group: dev) (*)
+├── astropy[docs, recommended, test, test-all, typing] (group: dev-all) (*)
+├── dask[dataframe] v2024.8.0 (group: dev-all) (*)
+├── duckdb v1.1.0 (group: dev-all)
+├── narwhals v1.42.0 (group: dev-all)
+├── pandas v2.2.2 (group: dev-all) (*)
+├── polars v1.18.0 (group: dev-all)
+├── pyarrow v16.0.0 (group: dev-all) (*)
+└── tox v4.33.0 (group: dev-all)
+    ├── cachetools v6.2.4
+    ├── chardet v5.2.0
+    ├── colorama v0.4.6
+    ├── filelock v3.20.2
+    ├── packaging v25.0
+    ├── platformdirs v4.5.1
+    ├── pluggy v1.6.0
+    ├── pyproject-api v1.10.0
+    │   └── packaging v25.0
+    └── virtualenv v20.35.4
+        ├── distlib v0.3.7
+        ├── filelock v3.20.2
+        └── platformdirs v4.5.1
 (*) Package tree already displayed


### PR DESCRIPTION
- [x] Un-ignore PP006. The ignore was added in https://github.com/astropy/astropy/pull/19259

### Description
This is a first stab at #17623, implementing dependency groups to eventually (but not yet) replace our dev-only extra sets of optional dependencies, and use them internally where it makes sense.
This PR is 100% backwards compatible, since it doesn't remove any `extras` (which are user visible), and instead defines (user-invisible) dependency groups as mirrors.
Not every extra I'm mirrorin here is intended to be fully dropped in the future (for instance, we may still want to deliberatly expose `astropy[test]` as an install target), but I expect at least part of them would be uncontroversial (I don't know who needs `astropy[docs]` or `astropy[typing]` downstream).


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
