### PR TITLE
Fix incorrect default format_unit for a WCS with RA/Dec and arcsecond units

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -25,6 +25,7 @@ from astropy.visualization.wcsaxes import WCSAxes, add_beam, add_scalebar
 from astropy.visualization.wcsaxes.frame import EllipticalFrame
 from astropy.visualization.wcsaxes.patches import Quadrangle, SphericalCircle
 from astropy.wcs import WCS
+from astropy.wcs.wcsapi import BaseLowLevelWCS
 
 
 class BaseImageTests:
@@ -1491,4 +1492,62 @@ def test_custom_formatter(spatial_wcs_2d_small_angle):
     ax.coords[0].set_major_formatter(double_format)
     ax.coords[1].set_major_formatter(fruit_format)
     canvas.draw()
+    return fig
+
+
+class EquatorialArcsecWCS(BaseLowLevelWCS):
+    @property
+    def pixel_n_dim(self):
+        return 2
+
+    @property
+    def world_n_dim(self):
+        return 2
+
+    @property
+    def world_axis_physical_types(self):
+        return [
+            "pos.eq.ra",
+            "pos.eq.dec",
+        ]
+
+    @property
+    def world_axis_units(self):
+        return ["arcsec", "arcsec"]
+
+    @property
+    def world_axis_names(self):
+        return ["RA", "DEC"]
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        return pixel_arrays
+
+    def world_to_pixel_values(self, *world_arrays):
+        return world_arrays
+
+    @property
+    def world_axis_object_components(self):
+        return [
+            ("celestial", 0, "spherical.lon.degree"),
+            ("celestial", 1, "spherical.lat.degree"),
+        ]
+
+    @property
+    def world_axis_object_classes(self):
+        return {
+            "celestial": (SkyCoord, (), {"unit": "deg"}),
+        }
+
+
+@figure_test
+def test_equatorial_arcsec():
+    wcs = EquatorialArcsecWCS()
+
+    fig = Figure()
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(projection=wcs)
+
+    ax.set_xlim(-0.5, 20 - 0.5)
+    ax.set_ylim(-0.5, 30 - 0.5)
+
     return fig

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -29,7 +29,7 @@ IDENTITY.wcs.cdelt = [1.0, 1.0]
 UCD_COORD_META_MAPPING = {
     "lon": {"coord_type": "longitude"},
     "lat": {"coord_type": "latitude"},
-    "ra": {"coord_type": "longitude", "format_unit": u.hourangle},
+    "ra": {"coord_type": "longitude"},
     "dec": {"coord_type": "latitude"},
     "alt": {"coord_type": "longitude"},
     "az": {"coord_type": "latitude"},
@@ -177,6 +177,11 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
                 for ucd, meta in UCD_COORD_META_MAPPING.items():
                     if ucd == axis_type_split[-1]:
                         dim_meta.update(meta)
+                        # We only do the following if the original unit was
+                        # degrees. If the unit was e.g. arcsec, it seems
+                        # reasonable to stick to the WCS unit.
+                        if ucd == "ra" and axis_unit is u.deg:
+                            dim_meta['format_unit'] = u.hourangle
                         break
 
         coord_meta["type"].append(dim_meta["coord_type"])


### PR DESCRIPTION
### Description

This is a bit of a corner case, but if a WCS is in RA/Dec and the world units are e.g. arcseconds, we shouldn't use hour angles. I've changed it so that we only use hour angles by default if the world units are degrees (most regular WCSes).

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
