### PR TITLE
ci(ruff): change to from select-all+ignore to select+ignore list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -80,6 +80,8 @@ lint.ignore = [
     "FIX001",  # Line contains FIXME.  this should be fixed or at least FIXME replaced with TODO
     "FIX004",  # Line contains HACK. replace HACK with NOTE.
 
+    "FURB166",  # int-on-sliced-str
+
     # pep8-naming (N)
     # NOTE: some of these can/should be fixed, but this changes the API.
     "N801",  # invalid-class-name
@@ -109,6 +111,7 @@ lint.ignore = [
     "PLR2004",  # MagicValueComparison
     "PLR5501",  # collapsible-else-if
     "PLW0603",  # global-statement
+    "PLW1641",  # Object does not implement `__hash__` method
     "PLW2901",  # redefined-loop-name
 
     # flake8-pytest-style (PT)
@@ -119,6 +122,8 @@ lint.ignore = [
     "PT012",   # pytest-raises-with-multiple-statements
     "PT017",   # pytest-assert-in-exceptinstead
     "PT018",   # pytest-composite-assertion
+    "PT028",   # pytest-parameter-with-default-argument
+    "PT030",   # pytest.warns({warning}) is too broad
 
     # flake8-return (RET)
     "RET501",  # unnecessary-return-none

--- a/astropy/table/soco.py
+++ b/astropy/table/soco.py
@@ -6,7 +6,6 @@ Index engine for Tables.
 """
 
 from collections import OrderedDict
-from itertools import starmap
 
 from astropy.utils.compat.optional_deps import HAS_SORTEDCONTAINERS
 
@@ -78,7 +77,7 @@ class SCEngine:
             raise ImportError("sortedcontainers is needed for using SCEngine")
 
         node_keys = map(tuple, data)
-        self._nodes = SortedList(starmap(Node, zip(node_keys, row_index)))
+        self._nodes = SortedList(map(Node, node_keys, row_index))
         self._unique = unique
 
     def add(self, key, value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,7 +328,64 @@ archs = ["auto", "aarch64"]
         ]
 
 [tool.ruff]
-lint.select = ["ALL"]
+lint.extend-select = [
+    "A",     # flake8-builtins
+    "AIR",   # Airflow
+    "ANN",   # flake8-annotations
+    "ARG",   # flake8-unused-arguments
+    "ASYNC", # flake8-async
+    "B",     # flake8-bugbear
+    "BLE",   # flake8-blind-except
+    "C4",    # flake8-comprehensions
+    "C90",   # mccabe
+    "COM",   # flake8-commas
+    # "CPY",   # flake8-copyright  # TODO: enable when out of preview
+    "D",     # pydocstyle
+    "DJ",    # flake8-django
+    # "DOC",   # pydocstyle  # TODO: enable when out of preview
+    "DTZ",   # flake8-datetimez
+    "E",     # pycodestyle
+    "EM",    # flake8-errmsg
+    "ERA",   # Eradicate
+    "EXE",   # flake8-executable
+    "F",     # Pyflakes
+    "FA",    # flake8-future-annotations
+    "FBT",   # flake8-boolean-trap
+    "FIX",   # flake8-fixme
+    "FLY",   # flynt
+    "FURB",  # refurb
+    "G",     # flake8-logging-format
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INP",   # flake8-no-pep420
+    "INT",   # flake8-gettext
+    "ISC",   # flake8-implicit-str-concat
+    "LOG",   # flake8-logging
+    "N",     # pep8-naming
+    "NPY",   # NumPy-specific rules
+    "PERF",  # Perflint
+    "PGH",   # pygrep-hooks
+    "PIE",   # flake8-pie
+    "PL",    # Pylint
+    "PT",    # flake8-pytest-style
+    "PTH",   # flake8-use-pathlib
+    "PYI",   # flake8-pyi
+    "Q",     # flake8-quotes
+    "RET",   # flake8-return
+    "RSE",   # flake8-raise
+    "RUF",   # Ruff-specific rules
+    "S",     # flake8-bandit
+    "SIM",   # flake8-simplify
+    "SLOT",  # flake8-slots
+    "T10",   # flake8-debugger
+    "T20",   # flake8-print
+    "TD",    # flake8-todos
+    "TID",   # flake8-tidy-imports
+    "TRY",   # tryceratops
+    "UP",    # pyupgrade
+    "W",     # pycodestyle
+    "YTT",   # flake8-2020
+]
 exclude=[
     "astropy/extern/*",
     "*_parsetab.py",
@@ -383,19 +440,6 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
     # flake8-quotes (Q)
     "Q000",  # use double quotes, conflicts with Ruff formatter
 
-    # flake8-simplify (SIM)
-    "SIM103", # needless-bool (cannot be safely applied in all contexts (np.True_ is not True))
-
-    # flake8-self (SLF)
-    "SLF001", # private member access
-
-    # flake8-type-checking (TC)
-    "TC002",  # typing-only-third-party-import
-    "TC003",  # typing-only-standard-library-import
-
-    # flake8-todos (TD)
-    "TD002",  # Missing author in TODO
-
     # flake8-return (RET)
     # RET can sometimes help find places where refactoring is very helpful,
     # but enforcing it everywhere might create undesirable churn
@@ -404,6 +448,18 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 
     # Ruff-specific rules (RUF)
     "RUF005",  # unpack-instead-of-concatenating-to-collection-literal -- it's not clearly faster.
+
+    # flake8-simplify (SIM)
+    "SIM103", # needless-bool (cannot be safely applied in all contexts (np.True_ is not True))
+
+    # flake8-self (SLF)
+    "SLF001", # private member access
+
+    # flake8-todos (TD)
+    "TD002",  # Missing author in TODO
+
+    # PyUpgrade (UP)
+    "UP038",  # non-pep604-isinstance  # NOTE: this rule is deprecated
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
This PR does:

1. Update ruff in pre-commit so as to make sure we're capturing the full set of enforced rules.
2. Replace `select=["ALL"]` with `extend-select=[...]`.
     Note that we cannot use `select=[...]` if we want ruff to pay attention to stuff in the ignore lists as currently written. 
     Note that this is essentially a no-op change in what is being enforced. Let's have followup discussions about *changing* the current set of enforced rules in separate issues / PRs. This PR is to address the very narrow and well-defined action plan from the Coordination Meeting.
4. Fix a very few lines of code (see step 1 as for why this is happening). Sorry @neutrinoceros this will cause a rebase for some of your PRs.


