### PR TITLE
Fix convolution edge behavior with fill=nan

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -329,8 +329,10 @@ def convolve(
     # computation. Since nan_treatment = 'interpolate', is the default
     # check whether it is even needed, if not, don't interpolate.
     # NB: np.isnan(array_internal.sum()) is faster than np.isnan(array_internal).any()
-    nan_interpolate = (nan_treatment == "interpolate") and np.isnan(
-        array_internal.sum()
+    # if the boundary is filled with nans, we also need interpolate (i.e.,
+    # ignore nans) enabled
+    nan_interpolate = (nan_treatment == "interpolate") and (
+        (boundary == "fill" and np.isnan(fill_value)) or np.isnan(array_internal.sum())
     )
 
     # Check if kernel is normalizable

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -1369,3 +1369,47 @@ def test_convolve_unmasked_masked_array_kernel():
     result_2d = convolve(array_2d, unmasked_kernel_2d, normalize_kernel=True)
     assert result_2d.shape == array_2d.shape
     assert not np.any(np.isnan(result_2d))
+
+
+def test_regression_16497_nan_treatment_consistency():
+    """
+    Regression test for issue #16497: convolve and convolve_fft should produce
+    consistent results when no NaN values are present in the input array.
+
+    Previously, convolve would introduce a NaN buffer of kernel_size//2 when
+    no NaN values were present, but would work correctly when NaN values were
+    present. This test ensures both functions produce consistent results
+    regardless of the presence of NaN values in the input.
+    """
+    # Create test data without NaN values
+    ar = np.ones((10, 10))
+    gaussian = Gaussian2DKernel(1, x_size=5, y_size=5)
+
+    # Test with no NaN values in input
+    result_convolve = convolve(
+        ar, gaussian, boundary="fill", fill_value=np.nan, preserve_nan=True
+    )
+    result_convolve_fft = convolve_fft(
+        ar, gaussian, boundary="fill", fill_value=np.nan, preserve_nan=True
+    )
+
+    # The results should be consistent between the two functions
+    assert_array_almost_equal(result_convolve, result_convolve_fft, decimal=10)
+
+    # Also test that the results are all finite (no NaN buffer)
+    assert np.all(np.isfinite(result_convolve))
+    assert np.all(np.isfinite(result_convolve_fft))
+
+    ar[5, 5] = np.nan
+    smoothed = convolve(
+        ar, gaussian, boundary="fill", fill_value=np.nan, preserve_nan=True
+    )
+    smoothed_fft = convolve_fft(
+        ar, gaussian, boundary="fill", fill_value=np.nan, preserve_nan=True
+    )
+    assert np.isnan(smoothed[5, 5])
+    assert np.sum(np.isnan(smoothed)) == 1
+    assert np.isnan(smoothed_fft[5, 5])
+    assert np.sum(np.isnan(smoothed_fft)) == 1
+
+    assert_array_almost_equal(smoothed, smoothed_fft, decimal=10)

--- a/docs/changes/convolution/18348.api.rst
+++ b/docs/changes/convolution/18348.api.rst
@@ -1,0 +1,2 @@
+Fixes edge treatment in ``convolve(..., boundary='fill', fill=nan)`` to be consistent with
+``convolve_fft``.

--- a/docs/changes/convolution/18348.api.rst
+++ b/docs/changes/convolution/18348.api.rst
@@ -1,2 +1,2 @@
-Fixes edge treatment in ``convolve(..., boundary='fill', fill=nan)`` to be consistent with
+Fixes edge treatment in ``convolve(..., boundary='fill', fill_value=nan)`` to be consistent with
 ``convolve_fft``.


### PR DESCRIPTION
This is work to fix issue #16497, in which it was reported that there is incorrect behavior in the treatment of edges with non-fft-based convolution.

This is a WIP - the progress so far is just implementing a regression test.  The solution is not yet clear; a workaround is to do a weighted convolution like the FFT version does, but I think that's the wrong solution as it doubles the computation time.  Part of the solution may be to remap `boundary='fill', fill=nan` to a different boundary type, but attempting that revealed that `boundary=None` is also bugged - it bleeds in zeros from the edge that should simply not happen.

Fixes #16497 
