### PR TITLE
Avoid stringified type annotations in `modeling`

### DIFF
--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -4,21 +4,16 @@
 This module is to contain an improved bounding box.
 """
 
-from __future__ import annotations
-
 import abc
 import copy
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, NamedTuple, Self
+from typing import Any, NamedTuple, Self
 
 import numpy as np
 
-from astropy.units import Quantity
+from astropy.units import Quantity, UnitBase
 from astropy.utils.compat import COPY_IF_NEEDED
-
-if TYPE_CHECKING:
-    from astropy.units import UnitBase
 
 __all__ = ["CompoundBoundingBox", "ModelBoundingBox"]
 


### PR DESCRIPTION
### Description

Sphinx is known to have problems resolving stringified annotations, so it's best to avoid them whenever possible. In `modeling` it is simple to get rid of stringified annotations in the one file that still has them.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
