### PR TITLE
Fix bug in Wcs.wcs.print_contents() related to stdout buffer not bein…

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1706,6 +1706,7 @@ PyWcsprm_print_contents(
   wcsprm_c2python(&self->x);
 
   printf("%s", wcsprintf_buf());
+  fflush(stdout);
 
   Py_INCREF(Py_None);
   return Py_None;

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -694,7 +694,6 @@ def test_str():
 
 
 def test_print_contents(capfd):
-
     # This is both a check that print_contents() runs and outputs something,
     # and also a regression test for a bug in print_contents() which caused the
     # stdout buffer to not be fully flushed, which could lead to the output of
@@ -702,8 +701,7 @@ def test_print_contents(capfd):
     # print_contents() calls in both wcsprm and other print_contents() methods in
     # astropy.wcs (e.g. Wcs.wcs.wtb[0].print_contents())
 
-    for iter in range(5):
-
+    for _ in range(5):
         w = _wcs.Wcsprm()
         w.print_contents()
 
@@ -718,7 +716,7 @@ def test_print_contents(capfd):
 
         assert len(stdout.splitlines()) == 210
 
-        assert 'crval:' in stdout and 'restfrq' in stdout
+        assert "crval:" in stdout and "restfrq" in stdout
 
 
 def test_radesys():

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -686,11 +686,38 @@ def test_piximg_matrix2():
         w.piximg_matrix = None
 
 
-def test_print_contents():
+def test_str():
     # In general, this is human-consumable, so we don't care if the
     # content changes, just check the type
     w = _wcs.Wcsprm()
     assert isinstance(str(w), str)
+
+
+def test_print_contents(capfd):
+
+    # This is both a check that print_contents() runs and outputs something,
+    # and also a regression test for a bug in print_contents() which caused the
+    # stdout buffer to not be fully flushed, which could lead to the output of
+    # print_contents() being truncated and pollution of subsequent
+    # print_contents() calls in both wcsprm and other print_contents() methods in
+    # astropy.wcs (e.g. Wcs.wcs.wtb[0].print_contents())
+
+    for iter in range(10):
+
+        w = _wcs.Wcsprm()
+        w.print_contents()
+
+        captured = capfd.readouterr()
+
+        # The details of the output don't matter too much, but check that it
+        # outputs the correct number of lines and contains some strings we
+        # expect
+
+        stdout = captured.out
+
+        assert len(stdout.splitlines()) == 210
+
+        assert 'crval:' in stdout and 'restfrq' in stdout
 
 
 def test_radesys():

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -702,7 +702,7 @@ def test_print_contents(capfd):
     # print_contents() calls in both wcsprm and other print_contents() methods in
     # astropy.wcs (e.g. Wcs.wcs.wtb[0].print_contents())
 
-    for iter in range(10):
+    for iter in range(5):
 
         w = _wcs.Wcsprm()
         w.print_contents()
@@ -711,7 +711,8 @@ def test_print_contents(capfd):
 
         # The details of the output don't matter too much, but check that it
         # outputs the correct number of lines and contains some strings we
-        # expect
+        # expect. Before the ``print_contents()`` bug was fixed, the number of
+        # lines from call to call was different and truncated.
 
         stdout = captured.out
 

--- a/docs/changes/wcs/18350.bugfix.rst
+++ b/docs/changes/wcs/18350.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug that caused the output of ``WCS.wcs.print_contents()`` to be truncated
+and to then cause the output of subsequent ``print_contents()`` calls (on
+``WCS.wcs`` or other wcs objects such as ``WCS.wcs.wtb``) to be corrupted.


### PR DESCRIPTION
### Description

I ran into this when working on https://github.com/astropy/astropy/pull/18338 but it is a bug that exists in main - the short version is that ``WCS.wcs.print_contents()`` was not flushing ``stdout``, which was causing the output of ``print_contents()`` to be truncated and to then pollute subsequent tests using ``print_contents``. When I added the ``print_contents()`` test here, it caused another test to fail:

```
_______________________________________________________________________________ test_wtbarr_print ________________________________________________________________________________

tab_wcs_2di = WCS Keywords

Number of WCS axes: 2
CTYPE : 'RA---TAB' 'DEC--TAB' 
CRVAL : 1.0 1.0 
CRPIX : 1.0 1.0 
PC1_1 PC1_2  : 1.0 0.0 
PC2_1 PC2_2  : 0.0 1.0 
CDELT : 1.0 1.0 
NAXIS : 150  200
capfd = <_pytest.capture.CaptureFixture object at 0x7fa127e7b690>

    def test_wtbarr_print(tab_wcs_2di, capfd):
        tab_wcs_2di.wcs.wtb[0].print_contents()
        captured = capfd.readouterr()
        s = str(tab_wcs_2di.wcs.wtb[0])
        lines = s.split("\n")
>       assert captured.out == s
E       assert 'g: 0\n       code: "   "\n         r0:  0.000000\n         pv: (not used)\n       phi0: UNDEFINED\n     theta0: UNDEFINED\n     bounds: 7\n\n       name: "undefined"\n   category: 0 (undefined)\n    pvrange: 0\n  simplezen: 0\n  equiareal: 0\n  conformal: 0\n     global: 0\n  divergent: 0\n         x0: 0.000000\n         y0: 0.000000\n        err: 0x0\n        w[]:   0.0000       0.0000       0.0000       0.0000       0.0000    \n               0.0000       0.0000       0.0000       0.0000       0.0000    \n          m: 0\n          n: 0\n     prjx2s: 0x0\n     prjs2x: 0x0\n\n   spc.*\n       flag: 0\n       type: "    "\n       code: "   "\n      crval: UNDEFINED\n    restfrq: 0.000000\n    restwav: 0.000000\n         pv: (not used)\n          w:   0.0000       0.0000       0.0000      (remainder unused)\n    isGrism: 0\n        err: 0x0\n     spxX2P: 0x0\n     spxP2S: 0x0\n     spxS2P: 0x0\n     spxP2X: 0x0\n     i: 1\n     m: 1\n  kind: c\nextnam: WCS-TABLE\nextver: 1\nextlev: 1\n ttype: wavelength\n   row: 1\n  ndim: 3\ndimlen: 0x2d7057c0\n        0:   4\n        1:   2\narrayp: 0x2dc8a8c8\n' == '     i: 1\n     m: 1\n  kind: c\nextnam: WCS-TABLE\nextver: 1\nextlev: 1\n ttype: wavelength\n   row: 1\n  ndim: 3\ndimlen: 0x2d7057c0\n        0:   4\n        1:   2\narrayp: 0x2dc8a8c8\n'
E         
E         + g: 0
E         +        code: "   "
E         +          r0:  0.000000
E         +          pv: (not used)
E         +        phi0: UNDEFINED
E         +      theta0: UNDEFINED
E         +      bounds: 7
E         + 
E         +        name: "undefined"
E         +    category: 0 (undefined)
E         +     pvrange: 0
E         +   simplezen: 0
E         +   equiareal: 0
E         +   conformal: 0
E         +      global: 0
E         +   divergent: 0
E         +          x0: 0.000000
E         +          y0: 0.000000
E         +         err: 0x0
E         +         w[]:   0.0000       0.0000       0.0000       0.0000       0.0000    
E         +                0.0000       0.0000       0.0000       0.0000       0.0000    
E         +           m: 0
E         +           n: 0
E         +      prjx2s: 0x0
E         +      prjs2x: 0x0
E         + 
E         +    spc.*
E         +        flag: 0
E         +        type: "    "
E         +        code: "   "
E         +       crval: UNDEFINED
E         +     restfrq: 0.000000
E         +     restwav: 0.000000
E         +          pv: (not used)
E         +           w:   0.0000       0.0000       0.0000      (remainder unused)
E         +     isGrism: 0
E         +         err: 0x0
E         +      spxX2P: 0x0
E         +      spxP2S: 0x0
E         +      spxS2P: 0x0
E         +      spxP2X: 0x0
E                i: 1
E                m: 1
E             kind: c
E           extnam: WCS-TABLE
E           extver: 1
E           extlev: 1
E            ttype: wavelength
E              row: 1
E             ndim: 3
E           dimlen: 0x2d7057c0
E                   0:   4
E                   1:   2
E           arrayp: 0x2dc8a8c8

astropy/wcs/tests/test_wtbarr.py:45: AssertionError
```

because the ``print_contents()`` output of ``wtb[0]`` contained leftover output from the top-level ``print_contents``.
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
