### PR TITLE
Fix bug in ``WCS.pixel_to_world`` for spectral WCS where ``restwav`` or ``restfrq`` was not defined

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -668,9 +668,14 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
                 if restfrq > 0 or restwav > 0:
                     if restwav == 0:
-                        restwav = u.Quantity(restfrq, u.Hz).to(u.m, u.spectral())
+                        restfrq = u.Quantity(restfrq, u.Hz)
+                        restwav = restfrq.to(u.m, u.spectral())
                     elif restfrq == 0:
-                        restfrq = u.Quantity(restwav, u.m).to(u.Hz, u.spectral())
+                        restwav = u.Quantity(restwav, u.m)
+                        restfrq = restwav.to(u.Hz, u.spectral())
+                    else:
+                        restfrq = u.Quantity(restfrq, u.Hz)
+                        restwav = u.Quantity(restwav, u.m)
 
                     if ctype == "VELO":
                         kwargs["doppler_convention"] = "relativistic"

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -14,6 +14,7 @@ from astropy.coordinates.spectral_coordinate import (
     attach_zero_velocities,
     update_differentials_to_match,
 )
+from astropy.units import allclose as quantity_allclose
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .high_level_api import HighLevelWCSMixin
@@ -676,6 +677,11 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     else:
                         restfrq = u.Quantity(restfrq, u.Hz)
                         restwav = u.Quantity(restwav, u.m)
+                        restfrq_derived = restwav.to(u.Hz, u.spectral())
+                        if not quantity_allclose(restfrq, restfrq_derived, rtol=1e-4):
+                            raise ValueError(
+                                f"restfrq={restfrq} and restwav={restwav}={restfrq_derived} are not consistent to 10^-4 or better precision"
+                            )
 
                     if ctype == "VELO":
                         kwargs["doppler_convention"] = "relativistic"

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -2,6 +2,7 @@
 # the mix-in class on its own (since it's not functional without being used as
 # a mix-in)
 
+import re
 import warnings
 
 import numpy as np
@@ -28,7 +29,7 @@ from astropy.time import Time
 from astropy.units import Quantity, UnitsWarning
 from astropy.utils import iers
 from astropy.utils.data import get_pkg_data_filename
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.wcs._wcs import __version__ as wcsver
 from astropy.wcs.wcs import WCS, FITSFixedWarning, NoConvergence, Sip
 from astropy.wcs.wcsapi.fitswcs import VELOCITY_FRAMES, custom_ctype_to_ucd_mapping
@@ -1098,7 +1099,7 @@ def test_different_ctypes(header_spectral_frames, ctype3, observer):
     else:
         header["CUNIT3"] = ""
 
-    header["RESTWAV"] = 1.420405752e09
+    header["RESTWAV"] = 0.21106114
     header["MJD-OBS"] = 55197
 
     if observer:
@@ -1185,7 +1186,7 @@ def test_spectral_1d(header_spectral_1d, ctype1, observer):
     else:
         header["CUNIT1"] = ""
 
-    header["RESTWAV"] = 1.420405752e09
+    header["RESTWAV"] = 0.21106114
     header["MJD-OBS"] = 55197
 
     if observer:
@@ -1567,8 +1568,12 @@ def test_restfrq_restwav():
         }
     )
 
-    with pytest.raises(
-        ValueError,
-        match="restfrq=295000000.0 Hz and restwav=1.0 m=299792458.0 Hz are not consistent to 10^-4 or better precision",
+    # Once we switch from a deprecation warning to an exception, convert the
+    # following to pytest.raises
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=re.escape(
+            "restfrq=295000000.0 Hz and restwav=1.0 m=299792458.0 Hz are not consistent to rtol=1e-4"
+        ),
     ):
         scoord3 = wcs.pixel_to_world(5)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1554,3 +1554,21 @@ def test_restfrq_restwav():
 
     assert scoord2.doppler_convention == "radio"
     assert_quantity_allclose(scoord2.doppler_rest, (1 * u.um).to(u.Hz, u.spectral()))
+
+    wcs = WCS(
+        header={
+            "CRVAL1": 100,
+            "CTYPE1": "VRAD",
+            "CDELT1": 1.0,
+            "CUNIT1": "m/s",
+            "CRPIX1": 1,
+            "RESTWAV": 1,
+            "RESTFRQ": 295000000.0,
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="restfrq=295000000.0 Hz and restwav=1.0 m=299792458.0 Hz are not consistent to 10^-4 or better precision",
+    ):
+        scoord3 = wcs.pixel_to_world(5)

--- a/docs/changes/wcs/18352.bugfix.rst
+++ b/docs/changes/wcs/18352.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug in ``WCS.pixel_to_world`` for spectral WCS where ``restfrq`` was
+defined but CTYPE was ``VOPT``, and likewise where ``restwav`` was defined but
+CTYPE was ``VRAD``.


### PR DESCRIPTION
### Description

Fixes https://github.com/astropy/astropy/issues/13774

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
