### PR TITLE
Run more tests in `stats` without `scipy`

### DIFF
--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -440,9 +440,17 @@ def test_poisson_conf_interval_rootn():
     assert_allclose(funcs.poisson_conf_interval(16, interval="root-n"), (12, 20))
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize(
-    "interval", ["root-n-0", "pearson", "sherpagehrels", "frequentist-confidence"]
+    "interval",
+    [
+        "root-n-0",
+        "pearson",
+        "sherpagehrels",
+        pytest.param(
+            "frequentist-confidence",
+            marks=pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy"),
+        ),
+    ],
 )
 def test_poisson_conf_large(interval):
     n = 100
@@ -731,7 +739,6 @@ def test_mpmath_poisson_limit():
     _ = funcs._mpmath_kraft_burrows_nousek(1000.0, 900.0, 0.9)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_poisson_conf_value_errors():
     with pytest.raises(ValueError, match="Only sigma=1 supported"):
         funcs.poisson_conf_interval([5, 6], "root-n", sigma=2)
@@ -748,7 +755,6 @@ def test_poisson_conf_value_errors():
         funcs.poisson_conf_interval(1, "foo")
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_poisson_conf_kbn_value_errors():
     with pytest.raises(ValueError, match="number between 0 and 1"):
         funcs.poisson_conf_interval(
@@ -867,7 +873,6 @@ def test_histogram():
         assert chi2(len(h)).sf(c2) > 0.01
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 @pytest.mark.parametrize(
     "ii,rr",
     [

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -63,7 +63,6 @@ def test_sigma_clip():
         assert filtered_data.count() == 25
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="requires scipy")
 def test_axis_none():
     """
     For masked=False and axis=None, masked elements should be removed


### PR DESCRIPTION
### Description

I found a few tests in `stats` that are skipped if `scipy` is not installed even though they do not require `scipy` at all. I don't see a good reason why the tests should be skipped if they don't have to be.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
