### PR TITLE
style(cosmo): unstringify annotations

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__ = ["FLRW", "FlatFLRWMixin"]
 
 import inspect
@@ -13,7 +11,7 @@ from functools import cached_property
 from inspect import signature
 from math import exp, floor, log, pi, sqrt
 from numbers import Number
-from typing import TYPE_CHECKING, Self, TypeVar, overload
+from typing import Self, TypeVar, overload
 
 import numpy as np
 from numpy import inf, sin
@@ -48,10 +46,6 @@ from astropy.cosmology._src.utils import (
     deprecated_keywords,
     vectorize_redshift_method,
 )
-
-if TYPE_CHECKING:
-    import astropy.units
-
 
 # isort: split
 if HAS_SCIPY:
@@ -1025,16 +1019,14 @@ class FLRW(
     # Comoving distance
 
     @overload
-    def comoving_distance(self, z: _InputT) -> astropy.units.Quantity: ...
+    def comoving_distance(self, z: _InputT) -> u.Quantity: ...
 
     @overload
-    def comoving_distance(self, z: _InputT, z2: _InputT) -> astropy.units.Quantity: ...
+    def comoving_distance(self, z: _InputT, z2: _InputT) -> u.Quantity: ...
 
     @deprecated_keywords("z2", since="7.1")
     @deprecated_keywords("z", since="7.0")
-    def comoving_distance(
-        self, z: _InputT, z2: _InputT | None = None
-    ) -> astropy.units.Quantity:
+    def comoving_distance(self, z: _InputT, z2: _InputT | None = None) -> u.Quantity:
         r"""Comoving line-of-sight distance :math:`d_c(z1, z2)` in Mpc.
 
         The comoving distance along the line-of-sight between two objects

--- a/astropy/cosmology/_src/io/builtin/cosmology.py
+++ b/astropy/cosmology/_src/io/builtin/cosmology.py
@@ -13,15 +13,9 @@ are present mainly for completeness and testing.
     True
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from astropy.cosmology._src.core import _COSMOLOGY_CLASSES, Cosmology
+from astropy.cosmology._src.typing import _CosmoT
 from astropy.cosmology.io import convert_registry
-
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
 
 __all__: list[str] = []  # nothing is publicly scoped
 

--- a/astropy/cosmology/_src/io/builtin/ecsv.py
+++ b/astropy/cosmology/_src/io/builtin/ecsv.py
@@ -159,27 +159,22 @@ Additional keyword arguments are passed to ``QTable.read`` and ``QTable.write``.
     >>> temp_dir.cleanup()
 """
 
-from __future__ import annotations
-
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 import astropy.units as u
-from astropy.table import QTable
+from astropy.table import QTable, Table
 
 # isort: split
 import astropy.cosmology.units as cu
 from astropy.cosmology._src.core import Cosmology
 from astropy.cosmology._src.io.connect import readwrite_registry
+from astropy.cosmology._src.typing import _CosmoT
+from astropy.io.typing import PathLike, ReadableFileLike, WriteableFileLike
 
 from .table import from_table, to_table
 
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
-    from astropy.io.typing import PathLike, ReadableFileLike, WriteableFileLike
-    from astropy.table import Table
-
-    _TableT = TypeVar("_TableT", "Table")
+_TableT = TypeVar("_TableT", bound=Table)
 
 
 def read_ecsv(

--- a/astropy/cosmology/_src/io/builtin/html.py
+++ b/astropy/cosmology/_src/io/builtin/html.py
@@ -85,27 +85,22 @@ enable this, set ``latex_names=True``.
     >>> temp_dir.cleanup()
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 import astropy.units as u
-from astropy.table import QTable
+from astropy.table import QTable, Table
 
 # isort: split
 import astropy.cosmology.units as cu
 from astropy.cosmology._src.core import Cosmology
 from astropy.cosmology._src.io.connect import readwrite_registry
 from astropy.cosmology._src.parameter import Parameter
+from astropy.cosmology._src.typing import _CosmoT
+from astropy.io.typing import PathLike, ReadableFileLike, WriteableFileLike
 
 from .table import from_table, to_table
 
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
-    from astropy.io.typing import PathLike, ReadableFileLike, WriteableFileLike
-    from astropy.table import Table
-
-    _TableT = TypeVar("_TableT", "Table")
+_TableT = TypeVar("_TableT", bound=Table)
 
 # Format look-up for conversion, {original_name: new_name}
 # TODO! move this information into the Parameters themselves

--- a/astropy/cosmology/_src/io/builtin/latex.py
+++ b/astropy/cosmology/_src/io/builtin/latex.py
@@ -54,25 +54,18 @@ By default the parameter names are converted to LaTeX format. To disable this, s
     >>> temp_dir.cleanup()
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 import astropy.units as u
-from astropy.table import QTable
-
-# isort: split
 from astropy.cosmology._src.core import Cosmology
 from astropy.cosmology._src.io.connect import readwrite_registry
 from astropy.cosmology._src.parameter import Parameter
+from astropy.io.typing import PathLike, WriteableFileLike
+from astropy.table import QTable, Table
 
 from .table import to_table
 
-if TYPE_CHECKING:
-    from astropy.io.typing import PathLike, WriteableFileLike
-    from astropy.table import Table
-
-    _TableT = TypeVar("_TableT", Table)
+_TableT = TypeVar("_TableT", bound=Table)
 
 _FORMAT_TABLE = {
     "H0": "$H_0$",

--- a/astropy/cosmology/_src/io/builtin/mapping.py
+++ b/astropy/cosmology/_src/io/builtin/mapping.py
@@ -126,22 +126,18 @@ Lastly, the keys in the mapping may be renamed with the ``rename`` keyword.
      'cosmo_name': 'Planck18', ...
 """
 
-from __future__ import annotations
-
 __all__: list[str] = []  # nothing is publicly scoped
 
 import copy
 import inspect
 from collections.abc import Mapping, MutableMapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 from astropy.cosmology._src.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology._src.io.connect import convert_registry
+from astropy.cosmology._src.typing import _CosmoT
 
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
-
-    _MapT = TypeVar("_MapT", MutableMapping[str, Any])
+_MapT = TypeVar("_MapT", bound=MutableMapping[str, Any])
 
 
 def _rename_map(

--- a/astropy/cosmology/_src/io/builtin/model.py
+++ b/astropy/cosmology/_src/io/builtin/model.py
@@ -27,8 +27,6 @@ The |Planck18| cosmology can be recovered with |Cosmology.from_format|.
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 """
 
-from __future__ import annotations
-
 import abc
 import copy
 import inspect

--- a/astropy/cosmology/_src/io/builtin/row.py
+++ b/astropy/cosmology/_src/io/builtin/row.py
@@ -30,24 +30,18 @@ to the ``Planck18`` cosmology from which it was generated.
 For more information on the argument options, see :ref:`cosmology_io_builtin-table`.
 """
 
-from __future__ import annotations
-
 import copy
 from collections import defaultdict
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
 
-from astropy.table import QTable, Row
+from astropy.table import QTable, Row, Table
 
 # isort: split
 from astropy.cosmology._src.core import Cosmology
 from astropy.cosmology._src.io.connect import convert_registry
+from astropy.cosmology._src.typing import _CosmoT
 
 from .mapping import from_mapping
-
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
-    from astropy.table import Table
 
 
 def from_row(

--- a/astropy/cosmology/_src/io/builtin/table.py
+++ b/astropy/cosmology/_src/io/builtin/table.py
@@ -150,25 +150,21 @@ not match the class' parameter names.
     True
 """
 
-from __future__ import annotations
-
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, TypeVar
+from typing import TypeVar
 
 import numpy as np
 
 from astropy.cosmology._src.core import Cosmology
 from astropy.cosmology._src.io.connect import convert_registry
+from astropy.cosmology._src.typing import _CosmoT
 from astropy.table import Column, QTable, Table
 
 from .mapping import to_mapping
 from .row import from_row
 from .utils import convert_parameter_to_column
 
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
-
-    _TableT = TypeVar("_TableT", Table)
+_TableT = TypeVar("_TableT", bound=Table)
 
 
 def from_table(

--- a/astropy/cosmology/_src/io/builtin/yaml.py
+++ b/astropy/cosmology/_src/io/builtin/yaml.py
@@ -17,10 +17,7 @@ require YAML serialization.
                   Tcmb0=2.7255 K, Neff=3.046, m_nu=[0. 0. 0.06] eV, Ob0=0.04897)
 """  # this is shown in the docs.
 
-from __future__ import annotations
-
 from collections.abc import Callable
-from typing import TYPE_CHECKING
 
 from yaml import MappingNode
 
@@ -31,12 +28,10 @@ from astropy.io.misc.yaml import AstropyDumper, AstropyLoader, dump, load
 import astropy.cosmology.units as cu
 from astropy.cosmology._src.core import _COSMOLOGY_CLASSES, Cosmology
 from astropy.cosmology._src.io.connect import convert_registry
+from astropy.cosmology._src.typing import _CosmoT
 
 from .mapping import from_mapping
 from .utils import FULLQUALNAME_SUBSTITUTIONS as QNS
-
-if TYPE_CHECKING:
-    from astropy.cosmology._src.typing import _CosmoT
 
 __all__: list[str] = []  # nothing is publicly scoped
 

--- a/astropy/cosmology/_src/io/connect.py
+++ b/astropy/cosmology/_src/io/connect.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__ = [
     # classes
     "CosmologyFromFormat",
@@ -13,23 +11,23 @@ __all__ = [
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
+from astropy.cosmology._src.typing import _CosmoT
 from astropy.io import registry as io_registry
+from astropy.table import Row, Table
 from astropy.units import add_enabled_units
 
 # isort: split
 import astropy.cosmology._src.units as cu
 
 if TYPE_CHECKING:
-    from astropy.cosmology import Cosmology
-    from astropy.cosmology._src.io.builtin.model import _CosmologyModel
-    from astropy.cosmology._src.typing import _CosmoT
-    from astropy.table import Row, Table
+    import astropy.cosmology
+
 
 __doctest_skip__ = __all__
 
 
 # NOTE: private b/c RTD error
-_MT = TypeVar("_MT", bound="Mapping")  # type: ignore[type-arg]
+_MT = TypeVar("_MT", bound=Mapping)  # type: ignore[type-arg]
 
 
 # ==============================================================================
@@ -81,10 +79,14 @@ class CosmologyRead(io_registry.UnifiedReadWrite):
     -----
     """
 
-    def __init__(self, instance: Cosmology, cosmo_cls: type[Cosmology]) -> None:
+    def __init__(
+        self,
+        instance: "astropy.cosmology.Cosmology",
+        cosmo_cls: type["astropy.cosmology.Cosmology"],
+    ) -> None:
         super().__init__(instance, cosmo_cls, "read", registry=readwrite_registry)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Cosmology:
+    def __call__(self, *args: Any, **kwargs: Any) -> "astropy.cosmology.Cosmology":
         from astropy.cosmology._src.core import Cosmology
 
         # so subclasses can override, also pass the class as a kwarg.
@@ -136,7 +138,11 @@ class CosmologyWrite(io_registry.UnifiedReadWrite):
     -----
     """
 
-    def __init__(self, instance: Cosmology, cls: type[Cosmology]) -> None:
+    def __init__(
+        self,
+        instance: "astropy.cosmology.Cosmology",
+        cls: type["astropy.cosmology.Cosmology"],
+    ) -> None:
         super().__init__(instance, cls, "write", registry=readwrite_registry)
 
     def __call__(self, *args: Any, **kwargs: Any) -> None:
@@ -195,7 +201,11 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
         `~astropy.cosmology.Cosmology` corresponding to ``obj`` contents.
     """
 
-    def __init__(self, instance: Cosmology, cosmo_cls: type[Cosmology]) -> None:
+    def __init__(
+        self,
+        instance: "astropy.cosmology.Cosmology",
+        cosmo_cls: type["astropy.cosmology.Cosmology"],
+    ) -> None:
         super().__init__(instance, cosmo_cls, "read", registry=convert_registry)
 
     # ===============================================================
@@ -214,16 +224,16 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
     @overload
     def __call__(
         self,
-        obj: _CosmologyModel,
+        obj: "astropy.cosmology._src.io.builtin.model._CosmologyModel",
         *args: Any,
         format: Literal["astropy.model"] | None,
         **kwargs: Any,
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     @overload
     def __call__(
         self, obj: Row, *args: Any, format: Literal["astropy.row"] | None, **kwargs: Any
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     @overload
     def __call__(
@@ -232,7 +242,7 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
         *args: Any,
         format: Literal["astropy.table"] | None,
         **kwargs: Any,
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     @overload
     def __call__(
@@ -241,21 +251,21 @@ class CosmologyFromFormat(io_registry.UnifiedReadWrite):
         *args: Any,
         format: Literal["mapping"] | None,
         **kwargs: Any,
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     @overload
     def __call__(
         self, obj: str, *args: Any, format: Literal["yaml"], **kwargs: Any
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     @overload
     def __call__(
         self, obj: Any, *args: Any, format: str | None = None, **kwargs: Any
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     def __call__(
         self, obj: Any, *args: Any, format: str | None = None, **kwargs: Any
-    ) -> Cosmology:
+    ) -> "astropy.cosmology.Cosmology":
         from astropy.cosmology._src.core import Cosmology
 
         # so subclasses can override, also pass the class as a kwarg.
@@ -309,7 +319,11 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
         Keyword arguments passed through to data writer.
     """
 
-    def __init__(self, instance: Cosmology, cls: type[Cosmology]) -> None:
+    def __init__(
+        self,
+        instance: "astropy.cosmology.Cosmology",
+        cls: type["astropy.cosmology.Cosmology"],
+    ) -> None:
         super().__init__(instance, cls, "write", registry=convert_registry)
 
     # ===============================================================
@@ -318,12 +332,12 @@ class CosmologyToFormat(io_registry.UnifiedReadWrite):
     @overload
     def __call__(
         self, format: Literal["astropy.cosmology"], *args: Any, **kwargs: Any
-    ) -> Cosmology: ...
+    ) -> "astropy.cosmology.Cosmology": ...
 
     @overload
     def __call__(
         self, format: Literal["astropy.model"], *args: Any, **kwargs: Any
-    ) -> _CosmologyModel: ...
+    ) -> "astropy.cosmology._src.io.builtin.model._CosmologyModel": ...
 
     @overload
     def __call__(

--- a/astropy/cosmology/_src/parameter/converter.py
+++ b/astropy/cosmology/_src/parameter/converter.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__ = [
     "validate_non_negative",
     "validate_to_float",

--- a/astropy/cosmology/_src/parameter/core.py
+++ b/astropy/cosmology/_src/parameter/core.py
@@ -1,14 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__ = ["MISSING", "Parameter"]
 
 import copy
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field, fields, is_dataclass, replace
 from enum import Enum, auto
-from typing import Any
+from typing import Any, Union
 
 import astropy.units as u
 
@@ -33,13 +31,13 @@ class _UnitField:
     # TODO: rm this class when py3.13+ allows for `field(converter=...)`
 
     def __get__(
-        self, obj: Parameter | None, objcls: type[Parameter] | None
+        self, obj: Union["Parameter", None], objcls: type["Parameter"] | None
     ) -> u.Unit | None:
         if obj is None:  # calling `Parameter.unit` from the class
             return None
         return getattr(obj, "_unit", None)
 
-    def __set__(self, obj: Parameter, value: Any) -> None:
+    def __set__(self, obj: "Parameter", value: Any) -> None:
         object.__setattr__(obj, "_unit", u.Unit(value) if value is not None else None)
 
 
@@ -48,13 +46,13 @@ class _FValidateField:
     default: FValidateCallable | str = "default"
 
     def __get__(
-        self, obj: Parameter | None, objcls: type[Parameter] | None
+        self, obj: Union["Parameter", None], objcls: type["Parameter"] | None
     ) -> FValidateCallable | str:
         if obj is None:  # calling `Parameter.fvalidate` from the class
             return self.default
         return obj._fvalidate  # calling `Parameter.fvalidate` from an instance
 
-    def __set__(self, obj: Parameter, value: Any) -> None:
+    def __set__(self, obj: "Parameter", value: Any) -> None:
         # Always store input fvalidate.
         object.__setattr__(obj, "_fvalidate_in", value)
 

--- a/astropy/cosmology/_src/parameter/dataclass_utils.py
+++ b/astropy/cosmology/_src/parameter/dataclass_utils.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__: list[str] = []  # nothing is publicly scoped
 
 from dataclasses import Field

--- a/astropy/cosmology/_src/parameter/descriptors.py
+++ b/astropy/cosmology/_src/parameter/descriptors.py
@@ -1,15 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__: list[str] = ["ParametersAttribute"]
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn, Union
 
 if TYPE_CHECKING:
-    from astropy.cosmology import Cosmology
+    import astropy.cosmology
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,7 +52,9 @@ class ParametersAttribute:
         object.__setattr__(self, "_name", name)
 
     def __get__(
-        self, instance: Cosmology | None, owner: type[Cosmology] | None
+        self,
+        instance: Union["astropy.cosmology.Cosmology", None],
+        owner: type["astropy.cosmology.Cosmology"] | None,
     ) -> MappingProxyType[str, Any]:
         # Called from the class
         if instance is None:

--- a/astropy/cosmology/_src/tests/flrw/test_parameters.py
+++ b/astropy/cosmology/_src/tests/flrw/test_parameters.py
@@ -2,23 +2,17 @@
 
 """Parameter test mixin classes."""
 
-from __future__ import annotations
-
 import copy
 from inspect import BoundArguments
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.cosmology import FlatFLRWMixin, Parameter
+from astropy.cosmology import Cosmology, FlatFLRWMixin, Parameter
 from astropy.cosmology._src.parameter import MISSING
 from astropy.cosmology._src.tests.test_core import ParameterTestMixin
 from astropy.tests.helper import assert_quantity_allclose
-
-if TYPE_CHECKING:
-    from astropy.cosmology import Cosmology
 
 
 class ParameterH0TestMixin(ParameterTestMixin):

--- a/astropy/cosmology/_src/tests/parameter/test_descriptors.py
+++ b/astropy/cosmology/_src/tests/parameter/test_descriptors.py
@@ -2,19 +2,14 @@
 
 """Testing :mod:`astropy.cosmology._src.parameter.descriptor`."""
 
-from __future__ import annotations
-
 from types import MappingProxyType
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 import pytest
 
-from astropy.cosmology._src.parameter import Parameter
+from astropy.cosmology import Cosmology, Parameter
 from astropy.cosmology._src.parameter.descriptors import ParametersAttribute
 from astropy.cosmology._src.utils import all_cls_vars
-
-if TYPE_CHECKING:
-    from astropy.cosmology._src.core import Cosmology
 
 
 class Obj:

--- a/astropy/cosmology/_src/typing.py
+++ b/astropy/cosmology/_src/typing.py
@@ -1,14 +1,12 @@
 """Static typing for :mod:`astropy.cosmology`. PRIVATE API."""
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__ = ["_CosmoT"]
 
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
-    from astropy.cosmology import Cosmology
+    import astropy.cosmology
 
-_CosmoT = TypeVar("_CosmoT", bound="Cosmology")
+_CosmoT = TypeVar("_CosmoT", bound="astropy.cosmology.Cosmology")
 """Type variable for :class:`~astropy.cosmology.Cosmology` and subclasses."""

--- a/astropy/cosmology/_src/utils.py
+++ b/astropy/cosmology/_src/utils.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 __all__: list[str] = []  # nothing is publicly scoped
 
 import functools

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cosmological units and equivalencies."""
 
-from __future__ import annotations
-
 from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
 
 __all__ = [


### PR DESCRIPTION
This PR unstringifies most annotations and makes them parseable at runtime.
This has 2 benefits:
1. Avoiding some Sphinx shenanigans
2. Better support for IDEs and runtime type checkers.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
