### PR TITLE
build(deps): typing-extensions as a dependency

### DIFF
--- a/docs/changes/18360.other.rst
+++ b/docs/changes/18360.other.rst
@@ -1,0 +1,1 @@
+Added ``typing-extensions`` as a dependency.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,10 @@ intersphinx_mapping.update(
         "fsspec": ("https://filesystem-spec.readthedocs.io/en/latest/", None),
         "cycler": ("https://matplotlib.org/cycler/", None),
         "dask": ("https://docs.dask.org/en/stable/", None),
+        "typing_extensions": (
+            "https://typing-extensions.readthedocs.io/en/latest/",
+            None,
+        ),
     }
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -513,6 +513,12 @@ mypy-init-return = true
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing_extensions.TypeForm".msg = "`TypeForm` is from draft PEP 747."
+"typing_extensions.disjoint_base".msg = "`disjoint_base` is from draft PEP 800."
+"typing_extensions.Doc".msg = "`Doc` is from withdrawn PEP 727."
+"typing_extensions.Sentinel".msg = "`Sentinel` is from deferred PEP 661."
+
 [tool.ruff.lint.isort]
 known-first-party = ["astropy", "extension_helpers"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "astropy-iers-data>=0.2025.9.29.0.35.48",
     "PyYAML>=6.0.0",
     "packaging>=22.0.0",
+    "typing-extensions>=4.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
It's made by the core Python devs and we've had this as an on-again-off-again dependency.
4.6 goes back to 2023.

### Why we should do this

#### 1. Bug fixes:

- **TypedDict** — backports Python 3.12 behavior ensuring `__orig_bases__` is consistently populated.
- **get_type_hints** — backports Python 3.12 fix that strips `ReadOnly` when `include_extras=false`.
- **is_typeddict** — backports Python 3.12 fix making `is_typeddict(TypedDict)` correctly return `False`.
- **Protocol** — backports Python 3.12 runtime-checkable fixes.

#### 2. Performance Backports:

- **SupportsIndex** — backports the optimized Python 3.12 implementation.
- **runtime_checkable** — backports Python 3.12 performance improvements for runtime-checkable protocols.
- **Protocol** — backports Python 3.12 performance improvements

#### 3. Supports uniform typing across python versions

It back ports functionality across python versions, so that the same type annotations can be used regardless of python version. This prevents the need for any `if sys.version` checks in your code just to be able to use the correct type annotation.

```python
if sys.version_info >= (3, 12):
    from typing import Thing


if sys.version_info >= (3, 12):
    def func(x: Thing): ...
```

becomes

```python
from typing_extensions import Thing

def func(x: Thing): ...
```

Here's a full  list

Python 3.12 features (and backports)

- `TypeAliasType`: Backport of `typing.TypeAliasType` (PEP 695).
- `Buffer`: Backport of `collections.abc.Buffer`.
- `get_original_bases`: Backport of `types.get_original_bases()`.  
- `override`: Backport of `typing.override()` (PEP 698).
- `TypeVar` enhancements: `default=` (PEP 696) and `infer_variance=` (PEP 695).
- `TypeVarTuple` enhancements: `default=` (PEP 696) support and implementation.
- `ParamSpec` enhancements: `default=` (PEP 696) support and implementation.
- `Protocol` runtime behaviour: Backports performance improvements for runtime-checkable protocols.  
- `runtime_checkable`: Backports performance improvements for `typing.runtime_checkable()`.
- `Unpack`: Backports the `repr()` change introduced by PEP 692.  
- `SupportsIndex`: Backports performance improvements for `typing.SupportsIndex`.  
- `NamedTuple`: Backports addition of the `__orig_bases__` attribute on `NamedTuple` classes.  
- `TypedDict`: Backports consistent `__orig_bases__` support and related behaviour.  


Python 3.13 features (and backports)

- `NoDefault`: Backport of `typing.NoDefault`.  
- `ReadOnly`: Backport of `typing.ReadOnly` (PEP 705).  
- `TypeIs`: Backport of `typing.TypeIs` (PEP 742).  
- `get_protocol_members`: Backport of `typing.get_protocol_members()`.  
- `is_protocol`: Backport of `typing.is_protocol()`.  
- `deprecated`: Backport of `warnings.deprecated()` (PEP 702).
- `TypeVar.has_default`, `TypeVarTuple.has_default`, `ParamSpec.has_default`:


Python 3.14 features (and backports)

- `Reader`: Backport of `io.Reader`.
- `Writer`: Backport of `io.Writer`. 
- `type_repr`: Backport of `annotationlib.type_repr()` used with PEP 649-style formats.


Python 3.15 features (and backports / pre-standardisation)

- `NoExtraItems`: Sentinel used when the `extra_items` class argument to `TypedDict` is not provided.  
- `TypedDict` `closed` / `extra_items` / `__closed__` / `__extra_items__`: Backports PEP 728 features (`closed` and `extra_items`) from `typing.TypedDict`.  


#### 4. `typing_extensions` is officially supported by `ruff`

It's `ruff`'s [`pyupgrade` rule UP035](https://docs.astral.sh/ruff/rules/deprecated-import/#deprecated-import-up035) so it automatically handles...

Current Astropy with Python 3.10+:

```python
from typing_extensions import Thing  # Thing is in Python 3.12+
```

Future Astropy with Python 3.12+:

```bash
pre-commit run -a
```

```python
from typing import Thing 
```


### How do we prevent use of deferred/rejected PEP imports?

Very easily!

```
[tool.ruff.lint.flake8-tidy-imports.banned-api]
"typing_extensions.Doc".msg = "Doc is from withdrawn PEP 727; don't use it."
"typing_extensions.Sentinel".msg = "PEP661 is deferred."
"typing_extensions.Reader".msg = "Internal only; do not use in library API."
# etc.
```

The one small thing is that this list does need to be maintained.
Thankfully the rate of PEPs and changes to `typing` / `typing_extensions` is relatively low.


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
