### PR TITLE
Deprecate function-based normalization with nan interpolation

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -11,7 +11,7 @@ from astropy.modeling.core import SPECIAL_OPERATORS, CompoundModel
 from astropy.nddata import support_nddata
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.console import human_file_size
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from ._convolve import _convolveNd_c
 from .core import MAX_NORMALIZATION, Kernel, Kernel1D, Kernel2D
@@ -773,8 +773,11 @@ def convolve_fft(
         normalized_kernel = kernel / kernel_scale
         kernel_scale = 1  # if we want to normalize it, leave it normed!
     elif normalize_kernel:
-        # try this.  If a function is not passed, the code will just crash... I
-        # think type checking would be better but PEPs say otherwise...
+        if nan_treatment == "interpolate":
+            warnings.warn(
+                "Kernel normalization with a function is deprecated if nan interpolation is set, as it produces inconsistencies between convolve_fft and convolve and no use cases are known.  If you are using this, please open an issue at https://github.com/astropy/astropy/issues.",
+                AstropyDeprecationWarning,
+            )
         kernel_scale = normalize_kernel(kernel)
         normalized_kernel = kernel / kernel_scale
     else:

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -735,7 +735,9 @@ def convolve_fft(
         kernel, dtype=complex, order="C", nan_treatment=None, mask=None, fill_value=0
     )
 
-    nan_interpolate = (nan_treatment == "interpolate") and ~np.isfinite(array.sum())
+    nan_interpolate = (nan_treatment == "interpolate") and (
+        ~np.isfinite(array.sum()) or not np.isfinite(fill_value)
+    )
 
     # Check that the number of dimensions is compatible
     if array.ndim != kernel.ndim:
@@ -782,6 +784,11 @@ def convolve_fft(
             )
         kernel_scale = normalize_kernel(kernel)
         normalized_kernel = kernel / kernel_scale
+
+        # kernel_scale has to be forced back to 1 because the "normalized" kernel now
+        # has the correct function-defined scale
+        # otherwise, the scaling would be applied twice.
+        kernel_scale = 1
     else:
         kernel_scale = kernel.sum()
         if np.abs(kernel_scale) < normalization_zero_tol:

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -1040,3 +1040,16 @@ def test_function_normalize_kernel_with_nan_interpolation_deprecation():
         )
     # If we get here, no deprecation warning was raised
     assert result_bool is not None
+
+
+def test_function_normalize_kernel_equivalence():
+    """Regression test for 8114"""
+    array = [1, 2, 3]
+    kernel = [3, 3, 3]
+
+    fill = convolve_fft(array, kernel, normalize_kernel=np.max, nan_treatment="fill")
+    interpolate = convolve_fft(
+        array, kernel, normalize_kernel=np.max, nan_treatment="interpolate"
+    )
+
+    assert_floatclose(fill, interpolate)

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 from contextlib import nullcontext
 
 import numpy as np
@@ -12,7 +13,7 @@ from numpy.testing import (
 
 from astropy import units as u
 from astropy.convolution.convolve import convolve, convolve_fft
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 VALID_DTYPES = (">f4", "<f4", ">f8", "<f8")
 
@@ -999,3 +1000,43 @@ def test_convolve_fft_boundary_extend_error():
         match=r"The 'extend' option is not implemented for fft-based convolution",
     ):
         convolve_fft(x, y, boundary="extend")
+
+
+def test_function_normalize_kernel_with_nan_interpolation_deprecation():
+    """Test that using a normalization function with nan_treatment='interpolate' raises a deprecation warning.  (PR 18365)"""
+
+    # Create test data with NaN values
+    array = np.array([1.0, np.nan, 3.0])
+    kernel = np.array([1.0, 1.0, 1.0])
+
+    # Test that the deprecation warning is raised when using a function for normalize_kernel
+    # with nan_treatment='interpolate'
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=r"Kernel normalization with a function is deprecated if nan interpolation is set",
+    ):
+        result = convolve_fft(
+            array, kernel, normalize_kernel=np.max, nan_treatment="interpolate"
+        )
+
+    # Verify the convolution still works
+    assert result is not None
+    assert result.shape == array.shape
+
+    # Test that no warning is raised when nan_treatment='fill'
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyDeprecationWarning)
+        result_fill = convolve_fft(
+            array, kernel, normalize_kernel=np.max, nan_treatment="fill"
+        )
+    # If we get here, no deprecation warning was raised
+    assert result_fill is not None
+
+    # Test that no warning is raised when normalize_kernel=True (boolean)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyDeprecationWarning)
+        result_bool = convolve_fft(
+            array, kernel, normalize_kernel=True, nan_treatment="interpolate"
+        )
+    # If we get here, no deprecation warning was raised
+    assert result_bool is not None

--- a/docs/changes/convolution/18365.api.rst
+++ b/docs/changes/convolution/18365.api.rst
@@ -1,0 +1,1 @@
+Function-based normalization with nan interpolation is deprecated.  i.e., you can no longer use a function to normalize your kernel (np.sum, np.nanmean, etc.), instead the kernel will be normalized to its sum.  This change is to improve consistency between ``convolve`` & ``convolve_fft``.


### PR DESCRIPTION
Resolves #8114.

That issue noted an inconsistency in convolve vs convolve_fft behavior.  The convolve_fft behavior is, as I now see it, allowing for unnecessary corner cases.  The proposal is to eventually raise an Exception for the circumstance highlighted here (`nan_treatment='interpolate'` with a user-specified normalization function), but start by deprecating.

I could use some hand-holding on the deprecation process - should I add a release ID to the deprecation warning here?