### PR TITLE
Import first party types at runtime in `coordinates`

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -5,8 +5,6 @@ This module contains the fundamental classes used for representing
 coordinates in astropy.
 """
 
-from __future__ import annotations
-
 import functools
 from typing import Any, NamedTuple
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -4,8 +4,6 @@ Framework and base classes for coordinate frames/"low-level" coordinate
 classes.
 """
 
-from __future__ import annotations
-
 __all__ = [
     "BaseCoordinateFrame",
     "CoordinateFrameInfo",
@@ -19,12 +17,13 @@ import functools
 import operator
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple, Union
 
 import numpy as np
 
 from astropy import units as u
 from astropy.table import QTable
+from astropy.units import Unit
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.decorators import format_doc
@@ -32,7 +31,7 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
 from . import representation as r
-from .angles import Angle, position_angle
+from .angles import Angle, Latitude, Longitude, position_angle
 from .attributes import Attribute
 from .errors import NonRotationTransformationError, NonRotationTransformationWarning
 from .transformations import (
@@ -42,8 +41,7 @@ from .transformations import (
 )
 
 if TYPE_CHECKING:
-    from astropy.coordinates import Latitude, Longitude, SkyCoord
-    from astropy.units import Unit
+    from astropy.coordinates import SkyCoord
 
 # the graph used for all transformations between frames
 frame_transform_graph = TransformGraph()
@@ -1964,7 +1962,7 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
 
     def _prepare_unit_sphere_coords(
         self,
-        other: BaseCoordinateFrame | SkyCoord,
+        other: Union["BaseCoordinateFrame", "SkyCoord"],
         origin_mismatch: Literal["ignore", "warn", "error"],
     ) -> tuple[Longitude, Latitude, Longitude, Latitude]:
         other_frame = getattr(other, "frame", other)
@@ -1993,7 +1991,7 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
         )
         return self_sph.lon, self_sph.lat, other_sph.lon, other_sph.lat
 
-    def position_angle(self, other: BaseCoordinateFrame | SkyCoord) -> Angle:
+    def position_angle(self, other: Union["BaseCoordinateFrame", "SkyCoord"]) -> Angle:
         """Compute the on-sky position angle to another coordinate.
 
         Parameters
@@ -2028,7 +2026,7 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
 
     def separation(
         self,
-        other: BaseCoordinateFrame | SkyCoord,
+        other: Union["BaseCoordinateFrame", "SkyCoord"],
         *,
         origin_mismatch: Literal["ignore", "warn", "error"] = "warn",
     ) -> Angle:

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import annotations
-
 import copy
 from collections.abc import MappingView
 from types import MappingProxyType

--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -2,8 +2,6 @@
 
 """This module defines custom errors and exceptions used in astropy.coordinates."""
 
-from __future__ import annotations
-
 __all__ = [
     "ConvertError",
     "NonRotationTransformationError",
@@ -40,7 +38,7 @@ class NonRotationTransformationError(ValueError):
     """
 
     def __init__(
-        self, frame_to: BaseCoordinateFrame, frame_from: BaseCoordinateFrame
+        self, frame_to: "BaseCoordinateFrame", frame_from: "BaseCoordinateFrame"
     ) -> None:
         self.frame_to = frame_to
         self.frame_from = frame_from
@@ -80,7 +78,7 @@ class NonRotationTransformationWarning(AstropyUserWarning):
     """
 
     def __init__(
-        self, frame_to: BaseCoordinateFrame, frame_from: BaseCoordinateFrame
+        self, frame_to: "BaseCoordinateFrame", frame_from: "BaseCoordinateFrame"
     ) -> None:
         self.frame_to = frame_to
         self.frame_from = frame_from

--- a/astropy/coordinates/polarization.py
+++ b/astropy/coordinates/polarization.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from contextlib import contextmanager
 from typing import NamedTuple
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 import copy
 import operator
 import re
 import warnings
 from collections.abc import Callable
+from typing import Union
 
 import erfa
 import numpy as np
@@ -173,9 +172,9 @@ class SkyCoord(MaskableShapedLikeNDArray):
     info = SkyCoordInfo()
 
     # Methods implemented by the underlying frame
-    position_angle: Callable[[BaseCoordinateFrame | SkyCoord], Angle]
-    separation: Callable[[BaseCoordinateFrame | SkyCoord], Angle]
-    separation_3d: Callable[[BaseCoordinateFrame | SkyCoord], Distance]
+    position_angle: Callable[[Union[BaseCoordinateFrame, "SkyCoord"]], Angle]
+    separation: Callable[[Union[BaseCoordinateFrame, "SkyCoord"]], Angle]
+    separation_3d: Callable[[Union[BaseCoordinateFrame, "SkyCoord"]], Distance]
 
     def __init__(self, *args, copy=True, **kwargs):
         # these are frame attributes set on this SkyCoord but *not* a part of

--- a/astropy/coordinates/tests/test_exceptions.py
+++ b/astropy/coordinates/tests/test_exceptions.py
@@ -2,9 +2,7 @@
 
 """Tests for custom error and warning messages in `astropy.coordinates`."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, NamedTuple
+from typing import NamedTuple
 
 import pytest
 
@@ -12,14 +10,12 @@ from astropy import units as u
 from astropy.coordinates import (
     GCRS,
     ICRS,
+    BaseCoordinateFrame,
     Galactic,
     NonRotationTransformationError,
     NonRotationTransformationWarning,
     UnknownSiteException,
 )
-
-if TYPE_CHECKING:
-    from astropy.coordinates import BaseCoordinateFrame
 
 
 class FrameDescription(NamedTuple):


### PR DESCRIPTION
### Description

For the benefit of third-party tools (most notably Sphinx) it is best to prefer runtime imports of types. In `coordinates` not all first-party types can be imported at runtime because that would cause import loops, but it is nonetheless possible to avoid many stringified annotations.

I want to highlight that the fact that the annotations in `BaseCoordinateFrame` and `SkyCoord` refer to each other is fundamentally a design flaw, but the way I see it APE 26 is already addressing that flaw (among other things).

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
