### PR TITLE
Allow passing fsspec kwargs to Table's FITS reader

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -126,6 +126,7 @@ def read_table_fits(
     unit_parse_strict="warn",
     mask_invalid=True,
     strip_spaces=False,
+    fsspec_kwargs=None,
 ):
     """
     Read a Table object from an FITS file.
@@ -184,6 +185,13 @@ def read_table_fits(
         Strip trailing whitespace in string columns, default is False and will be
         changed to True in the next major release. This is deactivated when
         using ``memmap=True`` (see above).
+    fsspec_kwargs : dict, optional
+        Keyword arguments passed on to `fsspec.open`. This can be used to
+        configure cloud storage credentials and caching behavior.
+        For example, pass ``fsspec_kwargs={"anon": True}`` to enable
+        anonymous access to Amazon S3 open data buckets.
+        See ``fsspec``'s documentation for available parameters.
+
 
     """
     if isinstance(input, HDUList):
@@ -247,7 +255,12 @@ def read_table_fits(
             mask_invalid = False
             strip_spaces = False
 
-        hdulist = fits_open(input, character_as_bytes=character_as_bytes, memmap=memmap)
+        hdulist = fits_open(
+            input,
+            character_as_bytes=character_as_bytes,
+            memmap=memmap,
+            fsspec_kwargs=fsspec_kwargs,
+        )
 
         try:
             return read_table_fits(
@@ -257,6 +270,7 @@ def read_table_fits(
                 unit_parse_strict=unit_parse_strict,
                 mask_invalid=mask_invalid,
                 strip_spaces=strip_spaces,
+                fsspec_kwargs=fsspec_kwargs,
             )
         finally:
             hdulist.close()

--- a/docs/changes/io.fits/18379.bugfix.rst
+++ b/docs/changes/io.fits/18379.bugfix.rst
@@ -1,0 +1,1 @@
+Allow passing fsspec parameters to the FITS Table reader.


### PR DESCRIPTION
Partially fix #18372 : 

Reading remote table is now possible with fsspec with:
```
Table.read(url, fsspec_kwargs={"anon": True}, format="fits")
```

But when not specifying `format="fits"` it will still crash when trying the different readers, with the votable reader triggering the `NoCredentialsError` exception. Not sure what to do about it, @taldcroft ?

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
