### PR TITLE
TST: Add Sersic2D to NON_FINITE_LM_MODELS

### DIFF
--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -612,6 +612,7 @@ NON_FINITE_TRF_MODELS = [
 # These models will fail the LMLSQFitter fitting test due to non-finite
 NON_FINITE_LM_MODELS = [
     Sersic1D,
+    Sersic2D,
     ArcSine1D,
     ArcCosine1D,
     PowerLaw1D,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
 # Recommended run-time dependencies to enable a lot of functionality within Astropy.
 recommended = [
     "scipy>=1.9.2",
-    "scipy<1.16 ; platform_system=='Windows'", # temp, https://github.com/astropy/astropy/issues/18333
     "matplotlib>=3.8.0",
 ]
 # Optional IPython-related behavior is in many places in Astropy. IPython is a complex


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to add `Sersic2D` to `NON_FINITE_LM_MODELS` in modeling tests and undo `scipy` max pin for Windows.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

* Works around https://github.com/astropy/astropy/issues/18333
* Revert the Windows pin introduced in https://github.com/astropy/astropy/pull/18331

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
