### PR TITLE
Speed up `astropy.stats.histogram_intervals()`

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1674,12 +1674,11 @@ def histogram_intervals(
 
     """
     h = np.zeros(n)
-    start = breaks[0]
-    for i in range(len(totals)):
-        end = breaks[i + 1]
-        for j in range(n):
-            ol = interval_overlap_length((float(j) / n, float(j + 1) / n), (start, end))
-            h[j] += ol / (1.0 / n) * totals[i]
+    start = n * breaks[0]
+    for i, total in enumerate(totals):
+        end = n * breaks[i + 1]
+        for j in range(math.floor(start), math.ceil(end)):
+            h[j] += total * interval_overlap_length((j, j + 1), (start, end))
         start = end
 
     return h


### PR DESCRIPTION
### Description

#### Setup

The timing measurements can be set up with a script:
```
$ cat timing_setup.py 
import numpy as np

from astropy.stats import histogram_intervals

n_totals = 200
breaks = np.linspace(0, 1, n_totals + 1)
totals = np.random.default_rng(486).random(n_totals)
```

In the following I will also use the test case from https://github.com/astropy/astropy/blob/cc87b2284a815449f274c0a5a22e91fe28f4d0a1/astropy/stats/tests/test_funcs.py#L883 but that is simple enough that it does not have to be set up in the script.

#### Performance on current `main` (3e11bbf79be18356b6c19c40ab97228124a53a07)

```
$ ipython -i timing_setup.py 
Python 3.12.3 (main, Jun 18 2025, 17:59:45) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.2.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Use `F2` or %edit with no arguments to open an empty editor with a temporary file.

In [1]: %timeit histogram_intervals(3, (0, 0.5, 1), (1, 2))
2.56 μs ± 34.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit histogram_intervals(200, breaks, totals)
15.8 ms ± 48 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

#### Performance with this patch

```
In [1]: %timeit histogram_intervals(3, (0, 0.5, 1), (1, 2))
1.7 μs ± 3.87 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit histogram_intervals(200, breaks, totals)
132 μs ± 2.4 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

#### Backwards compatibility

The docstring states 
https://github.com/astropy/astropy/blob/cc87b2284a815449f274c0a5a22e91fe28f4d0a1/astropy/stats/funcs.py#L1665-L1666
meaning the values in `breaks` should be in $[0, 1]$. Additionally, the function assumes that `breaks` is sorted. However, these assumptions are not validated at runtime, so if invalid `breaks` are passed in the function silently produces garbage. The changes I am making are backwards compatible (up to floating point rounding) if `breaks` is valid, but `breaks` is invalid then the updated function will produce different garbage and elements in `breaks` larger than 1 now cause an `IndexError`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
