### PR TITLE
Fixed broken world->pixel on a sliced 1D WCS

### DIFF
--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -268,7 +268,10 @@ class SlicedLowLevelWCS(BaseWCSWrapper):
                 world_arrays_new.append(sliced_out_world_coords[iworld])
 
         world_arrays_new = np.broadcast_arrays(*world_arrays_new)
-        pixel_arrays = list(self._wcs.world_to_pixel_values(*world_arrays_new))
+        pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays_new)
+        pixel_arrays = (
+            list(pixel_arrays) if self._wcs.pixel_n_dim > 1 else [pixel_arrays]
+        )
 
         for ipixel in range(self._wcs.pixel_n_dim):
             if (
@@ -281,7 +284,7 @@ class SlicedLowLevelWCS(BaseWCSWrapper):
         if isinstance(pixel_arrays, np.ndarray) and not pixel_arrays.shape:
             return pixel_arrays
         pixel = tuple(pixel_arrays[ip] for ip in self._pixel_keep)
-        if self.pixel_n_dim == 1 and self._wcs.pixel_n_dim > 1:
+        if self.pixel_n_dim == 1:
             pixel = pixel[0]
         return pixel
 

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -876,6 +876,10 @@ def test_1d_sliced_low_level(time_1d_wcs):
     assert isinstance(world, np.ndarray)
     assert np.allclose(world, [27, 29])
 
+    pixel = sll.world_to_pixel_values(world)
+    assert isinstance(pixel, np.ndarray)
+    assert np.allclose(pixel, [1, 2])
+
 
 def validate_info_dict(result, expected):
     result_value = result.pop("value")

--- a/docs/changes/wcs/18394.bugfix.rst
+++ b/docs/changes/wcs/18394.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where world->pixel conversions did not work correctly on a 1D WCS
+sliced via ``SlicedLowLevelWCS``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes a bug where the world->pixel conversion is broken on a 1D WCS sliced via `SlicedLowLevelWCS`.  The bug is that the code does not account for the fact `world_to_pixel_values()` for a 1D WCS does not return a tuple of results (because there is only one axis).

Before this PR:
```python
>>> from astropy.wcs import WCS
>>> from astropy.wcs.wcsapi import SlicedLowLevelWCS
>>> wcs = WCS({
...     'naxis1': 10,
...     'ctype1': 'WAVE',
...     'cunit1': 'm',
...     'cdelt1': 4,
...     'crpix1': 1,
...     'crval1': 3,
... })
>>> sliced_wcs = SlicedLowLevelWCS(wcs, slices=slice(None))

>>> wcs.world_to_pixel_values(15)
array(3.)
>>> sliced_wcs.world_to_pixel_values(15)
...
TypeError: iteration over a 0-d array

>>> wcs.world_to_pixel_values([15, 21])
array([3. , 4.5])
>>> sliced_wcs.world_to_pixel_values([15, 21])
(np.float64(3.0),)
```

After this PR:
```python
>>> wcs.world_to_pixel_values(15)
array(3.)
>>> sliced_wcs.world_to_pixel_values(15)
array(3.)

>>> wcs.world_to_pixel_values([15, 21])
array([3. , 4.5])
>>> sliced_wcs.world_to_pixel_values([15, 21])
array([3. , 4.5])
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
