### PR TITLE
Fixed the reporting of the shape of a 1D WCS

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1417,6 +1417,25 @@ def test_naxis():
     assert w.pixel_bounds is None
 
 
+def test_naxis_1d():
+    w = wcs.WCS(
+        {
+            "naxis1": 100,
+            "crval1": 1,
+            "cdelt1": 0.1,
+            "crpix1": 1,
+        }
+    )
+    assert w.pixel_shape == (100,)
+    assert w.array_shape == (100,)
+
+    w.pixel_shape = (99,)
+    assert w._naxis == [99]
+
+    w.pixel_shape = None
+    assert w.pixel_bounds is None
+
+
 def test_sip_with_altkey():
     """
     Test that when creating a WCS object using a key, CTYPE with

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3122,7 +3122,8 @@ reduce these to 2 dimensions using the naxis kwarg.
                 s += sfmt
                 description.append(s.format(*self.wcs.cd[i]))
 
-        description.append(f"NAXIS : {'  '.join(map(str, self._naxis))}")
+        if self._naxis != [0, 0]:
+            description.append(f"NAXIS : {'  '.join(map(str, self._naxis))}")
         return "\n".join(description)
 
     def get_axis_types(self):

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3087,8 +3087,6 @@ reduce these to 2 dimensions using the naxis kwarg.
                     break
         if len(_naxis) == 0:
             _naxis = [0, 0]
-        elif len(_naxis) == 1:
-            _naxis.append(0)
         self._naxis = _naxis
 
     def printwcs(self):

--- a/docs/changes/wcs/18405.bugfix.rst
+++ b/docs/changes/wcs/18405.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the reporting of the shape of a 1D WCS so there does not appear to be a
+second dimension of size zero.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes the reporting of shape of a 1D WCS.  The shape of a 1D WCS when read from a header is set to a 2D shape with the second pixel dimension (NAXIS2) being zero.  This appears to be vestigial: this approach was originally to support a `_naxis2` property (#5411 from 2016), but that property has long since been removed (#9465 from 2019).

Before this PR:
```python
>>> from astropy.wcs import WCS
>>> wcs = WCS({
...     'naxis1': 10,
...     'crval1': 1,
...     'cdelt1': 0.1,
...     'crpix1': 1,
... })
>>> wcs
WCS Keywords

Number of WCS axes: 1
CTYPE : ''
CRVAL : 1.0
CRPIX : 1.0
PC1_1  : 1.0
CDELT : 0.1
NAXIS : 10  0
>>> wcs.pixel_shape
(10, 0)
```

After this PR:
```python
>>> from astropy.wcs import WCS
>>> wcs = WCS({
...     'naxis1': 10,
...     'crval1': 1,
...     'cdelt1': 0.1,
...     'crpix1': 1,
... })
>>> wcs
WCS Keywords

Number of WCS axes: 1
CTYPE : ''
CRVAL : 1.0
CRPIX : 1.0
PC1_1  : 1.0
CDELT : 0.1
NAXIS : 10
>>> wcs.pixel_shape
(10,)
```

This PR also makes a change to the repr of the WCS instance.  When the shape is undefined in the header or is cleared, the private attribute (`WCS._naxis`) gets set to the sentinel value of `[0, 0]` (irrespective of the number of pixel dimensions).  Public API like `WCS.pixel_shape` check for the sentinel value, but the repr directly accesses `self._naxis`, so the puzzling line `NAXIS : 0  0` appears in the repr.  I think changing the sentinel-value approach could break code in the wild, so this PR takes the simple approach of checking for the sentinel value before printing out the `NAXIS: ...`  line.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
