### PR TITLE
Avoid stringified type annotations in `time`

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -6,8 +6,6 @@ UT1) and time representations (e.g. JD, MJD, ISO 8601) that are used in
 astronomy.
 """
 
-from __future__ import annotations
-
 import copy
 import enum
 import operator
@@ -17,7 +15,7 @@ from collections import defaultdict
 from datetime import UTC, date, datetime
 from itertools import pairwise
 from time import strftime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 from warnings import warn
 from weakref import WeakValueDictionary
 
@@ -57,7 +55,8 @@ from .time_helper.function_helpers import CUSTOM_FUNCTIONS, UNSUPPORTED_FUNCTION
 from .utils import day_frac
 
 if TYPE_CHECKING:
-    from astropy.coordinates import EarthLocation
+    import astropy.coordinates
+
 __all__ = [
     "STANDARD_TIME_SCALES",
     "TIME_DELTA_SCALES",
@@ -758,7 +757,7 @@ class TimeBase(MaskableShapedLikeNDArray):
             raise TypeError(f"unhashable type: '{self.__class__.__name__}' {reason}")
 
     @property
-    def location(self) -> EarthLocation | None:
+    def location(self) -> Union["astropy.coordinates.EarthLocation", None]:
         return self._location
 
     @location.setter


### PR DESCRIPTION
### Description

Although stringified annotations cannot be avoided entirely because of runtime import loops, they should be avoided as much as possible to prevent causing problems with some third-party tools, most notably Sphinx.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
