### PR TITLE
Make CODATA 2022 the constants default

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -154,13 +154,14 @@ class physical_constants(base_constants_version):
     """
 
     # Maintainers: update when new constants are added
-    _value = "codata2018"
+    _value = "codata2022"
 
     _versions = dict(
         codata2022="codata2022",
         codata2018="codata2018",
         codata2014="codata2014",
         codata2010="codata2010",
+        astropyconst80="codata2022",
         astropyconst40="codata2018",
         astropyconst20="codata2014",
         astropyconst13="codata2010",
@@ -178,6 +179,7 @@ class astronomical_constants(base_constants_version):
     _versions = dict(
         iau2015="iau2015",
         iau2012="iau2012",
+        astropyconst80="iau2015",
         astropyconst40="iau2015",
         astropyconst20="iau2015",
         astropyconst13="iau2012",

--- a/astropy/constants/astropyconst80.py
+++ b/astropy/constants/astropyconst80.py
@@ -1,0 +1,70 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Astronomical and physics constants for Astropy v8.0.
+See :mod:`astropy.constants` for a complete listing of constants defined
+in Astropy.
+"""
+
+import warnings
+
+from astropy.utils import find_current_module
+
+from . import codata2022, iau2015
+from . import utils as _utils
+
+codata = codata2022
+iaudata = iau2015
+
+_utils._set_c(codata, iaudata, find_current_module())
+
+# Overwrite the following for consistency.
+# https://github.com/astropy/astropy/issues/8920
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", "Constant .*already has a definition")
+
+    # Solar mass (derived from mass parameter and gravitational constant)
+    M_sun = iau2015.IAU2015(
+        "M_sun",
+        "Solar mass",
+        iau2015.GM_sun.value / codata2022.G.value,
+        "kg",
+        (
+            (codata2022.G.uncertainty / codata2022.G.value)
+            * (iau2015.GM_sun.value / codata2022.G.value)
+        ),
+        f"IAU 2015 Resolution B 3 + {codata2022.G.reference}",
+        system="si",
+    )
+
+    # Jupiter mass (derived from mass parameter and gravitational constant)
+    M_jup = iau2015.IAU2015(
+        "M_jup",
+        "Jupiter mass",
+        iau2015.GM_jup.value / codata2022.G.value,
+        "kg",
+        (
+            (codata2022.G.uncertainty / codata2022.G.value)
+            * (iau2015.GM_jup.value / codata2022.G.value)
+        ),
+        f"IAU 2015 Resolution B 3 + {codata2022.G.reference}",
+        system="si",
+    )
+
+    # Earth mass (derived from mass parameter and gravitational constant)
+    M_earth = iau2015.IAU2015(
+        "M_earth",
+        "Earth mass",
+        iau2015.GM_earth.value / codata2022.G.value,
+        "kg",
+        (
+            (codata2022.G.uncertainty / codata2022.G.value)
+            * (iau2015.GM_earth.value / codata2022.G.value)
+        ),
+        f"IAU 2015 Resolution B 3 + {codata2022.G.reference}",
+        system="si",
+    )
+
+# Clean up namespace
+del warnings
+del find_current_module
+del _utils

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -145,7 +145,7 @@ def test_masses():
     """Ensure mass values are set up correctly.
     https://github.com/astropy/astropy/issues/8920
     """
-    from astropy.constants import astropyconst13, astropyconst20, astropyconst40
+    from astropy.constants import astropyconst13, astropyconst20, astropyconst40, astropyconst80
 
     ref_text = "Allen's Astrophysical Quantities 4th Ed."
     assert (
@@ -166,6 +166,13 @@ def test_masses():
         astropyconst40.M_sun.reference == ref_text
         and astropyconst40.M_jup.reference == ref_text
         and astropyconst40.M_earth.reference == ref_text
+    )
+
+    ref_text = "IAU 2015 Resolution B 3 + CODATA 2022"
+    assert (
+        astropyconst80.M_sun.reference == ref_text
+        and astropyconst80.M_jup.reference == ref_text
+        and astropyconst80.M_earth.reference == ref_text
     )
 
 

--- a/docs/changes/constants/18407.api.rst
+++ b/docs/changes/constants/18407.api.rst
@@ -1,0 +1,1 @@
+CODATA 2022 has replaced CODATA 2018 as default. ``astropyconst80`` is available for ``constants`` science state, combining CODATA 2022 with IAU 2015.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to follow up on #18118 and make CODATA 2022 the default.

Should only be merged when `main` is `v8.0.dev`, I think.

For reference, old PR to make CODATA 2018 default:

* https://github.com/astropy/astropy/pull/8761

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18050

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
