### PR TITLE
Move the implementation of `online_help()`

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -61,16 +61,8 @@ def __dir__():
     return sorted(set(globals()).union(__all__))
 
 
-from .version import version as __version__
-
-# The location of the online documentation for astropy
-# This location will normally point to the current released version of astropy
-online_docs_root = "https://docs.astropy.org/en/{}/".format(
-    "latest" if "dev" in __version__ else f"v{__version__}"
-)
-
-
 from . import config as _config
+from .version import version as __version__
 
 
 class Conf(_config.ConfigNamespace):
@@ -230,28 +222,9 @@ log = _init_log()
 
 _initialize_astropy()
 
-from .utils.misc import find_api_page
-
-
-def online_help(query):
-    """
-    Search the online Astropy documentation for the given query.
-    Opens the results in the default web browser.  Requires an active
-    Internet connection.
-
-    Parameters
-    ----------
-    query : str
-        The search query.
-    """
-    import webbrowser
-    from urllib.parse import urlencode
-
-    url = online_docs_root + f"search.html?{urlencode({'q': query})}"
-    webbrowser.open(url)
-
-
 from types import ModuleType as __module_type__
+
+from .utils.misc import find_api_page, online_docs_root, online_help
 
 # Clean up top-level namespace--delete everything that isn't in __all__
 # or is a magic attribute, and that isn't a submodule of this package

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -21,10 +21,12 @@ from contextlib import contextmanager
 from itertools import chain
 from types import TracebackType
 from typing import Final
+from urllib.parse import urlencode
 
 import numpy as np
 
 from astropy.utils import deprecated
+from astropy.version import version as __version__
 
 __all__ = [
     "JsonCustomEncoder",
@@ -35,6 +37,7 @@ __all__ = [
     "indent",
     "is_path_hidden",
     "isiterable",
+    "online_help",
     "silence",
     "walk_skip_hidden",
 ]
@@ -303,6 +306,29 @@ def find_api_page(
         webbrowser.open(resurl)
 
     return resurl
+
+
+# The location of the online documentation for astropy
+# This location will normally point to the current released version of astropy
+online_docs_root: Final = "https://docs.astropy.org/en/{}/".format(
+    "latest" if "dev" in __version__ else f"v{__version__}"
+)
+
+
+def online_help(query: str) -> None:
+    """
+    Search the online Astropy documentation for the given query.
+    Opens the results in the default web browser.  Requires an active
+    Internet connection.
+
+    Parameters
+    ----------
+    query : str
+        The search query.
+    """
+    import webbrowser
+
+    webbrowser.open(online_docs_root + f"search.html?{urlencode({'q': query})}")
 
 
 # _has_hidden_attribute() can be deleted together with deprecated is_path_hidden() and


### PR DESCRIPTION
### Description

There are three reasons for moving the implementation of `online_help()` from `astropy/__init__.py` to `astropy/utils/misc.py`:

1. Based on our change log `online_help()` is supposed to be a public function: https://github.com/astropy/astropy/blob/43a6b66d0636c943ac05d489775162cb58dd99e2/CHANGES.rst#L13553
Despite that it is not exposed in our API documentation. Moving it makes visible.

2. `online_help()` is quite similar to `find_api_page()`, so it is best to define them next to each other. Moving `online_help` to `utils.misc` is backwards compatible, moving `find_api_page()` from `utils.misc` would require deprecating accessing it from the `utils` namespace.

3. The primary purpose of `__init__.py` files is to expose the public API of a package, not to contain function implementations. It might be reasonable to make exceptions for some dynamic definitions, but `online_help()` is not such a case.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
