### PR TITLE
Fixed bugs with WCS slicing, 

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -292,6 +292,26 @@ def test_slice_wcs():
         mywcs[0, ::2]
 
 
+def test_slice_nd():
+
+    # Regression test for a bug that caused slicing to not work correctly for
+    # WCS with more than 2 dimensions.
+
+    sub = WCS(naxis=3)[:, :, :]
+    assert isinstance(sub, WCS)
+
+
+def test_slice_ellipsis():
+
+    # Regression test for a bug that caused slicing with an ellipsis to not
+    # return a WCS object but a SlicedFITSWCS instead
+
+    sub = WCS(naxis=3)[...]
+    assert isinstance(sub, WCS)
+
+
+
+
 def test_slice_drop_dimensions_order():
     # Regression test for a bug that caused WCS.slice to ignore
     # ``numpy_order=False`` if dimensions were dropped.

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -293,7 +293,6 @@ def test_slice_wcs():
 
 
 def test_slice_nd():
-
     # Regression test for a bug that caused slicing to not work correctly for
     # WCS with more than 2 dimensions.
 
@@ -302,14 +301,11 @@ def test_slice_nd():
 
 
 def test_slice_ellipsis():
-
     # Regression test for a bug that caused slicing with an ellipsis to not
     # return a WCS object but a SlicedFITSWCS instead
 
     sub = WCS(naxis=3)[...]
     assert isinstance(sub, WCS)
-
-
 
 
 def test_slice_drop_dimensions_order():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3325,6 +3325,10 @@ reduce these to 2 dimensions using the naxis kwarg.
         wcs_new : `~astropy.wcs.WCS`
             A new resampled WCS axis
         """
+
+        if view is Ellipsis:
+            return self.deepcopy()
+
         if hasattr(view, "__len__") and len(view) > self.wcs.naxis:
             raise ValueError("Must have # of slices <= # of WCS axes")
         elif not hasattr(view, "__len__"):  # view MUST be an iterable
@@ -3409,20 +3413,21 @@ reduce these to 2 dimensions using the naxis kwarg.
                     for table in distortion_tables:
                         table.crval[wcs_index] -= iview.start
 
-            try:
-                # range requires integers but the other attributes can also
-                # handle arbitrary values, so this needs to be in a try/except.
-                nitems = len(builtins.range(self._naxis[wcs_index])[iview])
-            except TypeError as exc:
-                if "indices must be integers" not in str(exc):
-                    raise
-                warnings.warn(
-                    f"NAXIS{wcs_index} attribute is not updated because at "
-                    f"least one index ('{iview}') is no integer.",
-                    AstropyUserWarning,
-                )
-            else:
-                wcs_new._naxis[wcs_index] = nitems
+            if self._naxis != [0, 0]:
+                try:
+                    # range requires integers but the other attributes can also
+                    # handle arbitrary values, so this needs to be in a try/except.
+                    nitems = len(builtins.range(self._naxis[wcs_index])[iview])
+                except TypeError as exc:
+                    if "indices must be integers" not in str(exc):
+                        raise
+                    warnings.warn(
+                        f"NAXIS{wcs_index} attribute is not updated because at "
+                        f"least one index ('{iview}') is no integer.",
+                        AstropyUserWarning,
+                    )
+                else:
+                    wcs_new._naxis[wcs_index] = nitems
 
         if wcs_new.sip is not None:
             wcs_new.sip = Sip(

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3325,7 +3325,6 @@ reduce these to 2 dimensions using the naxis kwarg.
         wcs_new : `~astropy.wcs.WCS`
             A new resampled WCS axis
         """
-
         if view is Ellipsis:
             return self.deepcopy()
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3412,21 +3412,20 @@ reduce these to 2 dimensions using the naxis kwarg.
                     for table in distortion_tables:
                         table.crval[wcs_index] -= iview.start
 
-            if self._naxis != [0, 0]:
-                try:
-                    # range requires integers but the other attributes can also
-                    # handle arbitrary values, so this needs to be in a try/except.
-                    nitems = len(builtins.range(self._naxis[wcs_index])[iview])
-                except TypeError as exc:
-                    if "indices must be integers" not in str(exc):
-                        raise
-                    warnings.warn(
-                        f"NAXIS{wcs_index} attribute is not updated because at "
-                        f"least one index ('{iview}') is no integer.",
-                        AstropyUserWarning,
-                    )
-                else:
-                    wcs_new._naxis[wcs_index] = nitems
+            try:
+                # range requires integers but the other attributes can also
+                # handle arbitrary values, so this needs to be in a try/except.
+                nitems = len(builtins.range(self._naxis[wcs_index])[iview])
+            except TypeError as exc:
+                if "indices must be integers" not in str(exc):
+                    raise
+                warnings.warn(
+                    f"NAXIS{wcs_index} attribute is not updated because at "
+                    f"least one index ('{iview}') is no integer.",
+                    AstropyUserWarning,
+                )
+            else:
+                wcs_new._naxis[wcs_index] = nitems
 
         if wcs_new.sip is not None:
             wcs_new.sip = Sip(

--- a/docs/changes/wcs/18417.bugfix.rst
+++ b/docs/changes/wcs/18417.bugfix.rst
@@ -1,3 +1,3 @@
 Fixed a bug that caused slicing of WCS objects with more than two dimensions and no
-data shape set to fail, and fixed a bug which caused slicing of WCS objects with 
+data shape set to fail, and fixed a bug which caused slicing of WCS objects with
 an Ellipsis ([...]) to not return a WCS object.

--- a/docs/changes/wcs/18417.bugfix.rst
+++ b/docs/changes/wcs/18417.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug that caused slicing of WCS objects with more than two dimensions and no
+data shape set to fail, and fixed a bug which caused slicing of WCS objects with 
+an Ellipsis ([...]) to not return a WCS object.

--- a/docs/changes/wcs/18417.bugfix.rst
+++ b/docs/changes/wcs/18417.bugfix.rst
@@ -1,3 +1,2 @@
-Fixed a bug that caused slicing of WCS objects with more than two dimensions and no
-data shape set to fail, and fixed a bug which caused slicing of WCS objects with
-an Ellipsis ([...]) to not return a WCS object.
+Fixed a bug that caused slicing of WCS objects with an ellipsis to not return a WCS
+object but instead a SlicedLowLevelWCS object.


### PR DESCRIPTION
Specifically slicing WCS objects wi…th more than 2 dimensions but with _naxis not set would fail, and that slicing a WCS with an ellipsis would not return a WCS object but a SlicedFITSWCS instead

Fixes https://github.com/astropy/astropy/issues/18410



- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
