### PR TITLE
Fix _naxis dimensionality

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -292,6 +292,22 @@ def test_slice_wcs():
         mywcs[0, ::2]
 
 
+def test_slice_nd():
+    # Regression test for a bug that caused slicing to not work correctly for
+    # WCS with more than 2 dimensions.
+
+    sub = WCS(naxis=3)[:, :, :]
+    assert isinstance(sub, WCS)
+
+
+def test_slice_ellipsis():
+    # Regression test for a bug that caused slicing with an ellipsis to not
+    # return a WCS object but a SlicedFITSWCS instead
+
+    sub = WCS(naxis=3)[...]
+    assert isinstance(sub, WCS)
+
+
 def test_slice_drop_dimensions_order():
     # Regression test for a bug that caused WCS.slice to ignore
     # ``numpy_order=False`` if dimensions were dropped.

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -583,7 +583,6 @@ reduce these to 2 dimensions using the naxis kwarg.
                     FITSFixedWarning,
                 )
 
-        self._get_naxis(header)
         WCSBase.__init__(self, sip, cpdis, wcsprm, det2im)
 
         if fix:
@@ -599,6 +598,8 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         for fd in close_fds:
             fd.close()
+
+        self._get_naxis(header)
 
         self._pixel_bounds = None
 
@@ -3085,10 +3086,10 @@ reduce these to 2 dimensions using the naxis kwarg.
                     _naxis.append(header[f"NAXIS{naxis}"])
                 except KeyError:
                     break
+
         if len(_naxis) == 0:
-            _naxis = [0, 0]
-        elif len(_naxis) == 1:
-            _naxis.append(0)
+            _naxis = self.naxis * [0]
+
         self._naxis = _naxis
 
     def printwcs(self):
@@ -3324,6 +3325,9 @@ reduce these to 2 dimensions using the naxis kwarg.
         wcs_new : `~astropy.wcs.WCS`
             A new resampled WCS axis
         """
+        if view is Ellipsis:
+            return self.deepcopy()
+
         if hasattr(view, "__len__") and len(view) > self.wcs.naxis:
             raise ValueError("Must have # of slices <= # of WCS axes")
         elif not hasattr(view, "__len__"):  # view MUST be an iterable

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -236,7 +236,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     @property
     def pixel_shape(self):
-        if self._naxis == [0, 0]:
+        if all(i == 0 for i in self._naxis):
             return None
         else:
             return tuple(self._naxis)
@@ -244,7 +244,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
     @pixel_shape.setter
     def pixel_shape(self, value):
         if value is None:
-            self._naxis = [0, 0]
+            self._naxis = self.naxis * [0]
         else:
             if len(value) != self.naxis:
                 raise ValueError(


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This PR fixes, I believe, the root-cause of issues/PRs reported in #18405 and #18417. It borrows some code from #18417 (mostly testing and ellipses stuff just so that we can test that proposed changes fix the issues reported in #18417) however, the purpose of this draft PR is to _illustrate_ what I meant in the last paragraph in https://github.com/astropy/astropy/pull/18417#issuecomment-3059589443 and if @astrofrog finds this solution acceptable, I think this fix should go into #18417 (alternatively this could deal with `_naxis` dimensionality only and #18417 with ellipses after rebasing).

Would these changes also fix #18405, @ayshih ?

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
