### PR TITLE
Deprecate `constellation_list` parameter of `get_constellation()`

### DIFF
--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -18,6 +18,7 @@ from astropy import units as u
 from astropy.constants import c
 from astropy.io import ascii
 from astropy.utils import data
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from .builtin_frames import GCRS, PrecessedGeocentric
 from .builtin_frames.utils import get_jd12
@@ -182,6 +183,7 @@ def get_sun(time):
 _constellation_data = {}
 
 
+@deprecated_renamed_argument("constellation_list", new_name=None, since="7.2")
 def get_constellation(coord, short_name=False, constellation_list="iau"):
     """
     Determines the constellation(s) a given coordinate object contains.

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -18,6 +18,7 @@ from astropy.coordinates.funcs import (
     get_sun,
 )
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 CARTESIAN_POS = r.CartesianRepresentation([1, 2, 3] * u.kpc)
 CARTESIAN_VEL = r.CartesianDifferential([8, 9, 10] * u.km / u.s)
@@ -119,6 +120,11 @@ def test_constellation_edge_cases():
 
     # TODO: When that's fixed, add other tests with coords that are in different constellations
     # depending on equinox
+
+
+def test_constellation_list_deprecation():
+    with pytest.warns(AstropyDeprecationWarning):
+        get_constellation(SkyCoord(0 * u.deg, 0 * u.deg), constellation_list="iau")
 
 
 def test_concatenate():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -45,6 +45,7 @@ from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
 from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_SCIPY
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.wcs import WCS
 
 RA = 1.0 * u.deg
@@ -1673,6 +1674,11 @@ def test_constellations_with_nameresolve():
     )
     assert SkyCoord.from_name("Orion Nebula").get_constellation() == "Orion"
     assert SkyCoord.from_name("Triangulum Galaxy").get_constellation() == "Triangulum"
+
+
+def test_constellation_list_deprecation():
+    with pytest.warns(AstropyDeprecationWarning):
+        SkyCoord(0 * u.deg, 0 * u.deg).get_constellation(constellation_list="iau")
 
 
 def test_getitem_representation():

--- a/docs/changes/coordinates/18422.api.rst
+++ b/docs/changes/coordinates/18422.api.rst
@@ -1,0 +1,4 @@
+The ``constellation_list`` parameter of the ``SkyCoord.get_constellation()``
+method and the ``get_constellation()`` function is deprecated.
+Any value different from ``"iau"`` has always caused a ``ValueError`` so in
+practice it has not been possible to use the parameter anyways.


### PR DESCRIPTION
### Description

The `get_constellation()` function and `SkyCoord.get_constellation()` method have a `constellation_list` parameter, which cannot be used in practice because any value different from `"iau"` causes a `ValueError`:
https://github.com/astropy/astropy/blob/91fc8bc8c18c8d4912322ff51d7afdf9bcfef513/astropy/coordinates/funcs.py#L214-L215

 I don't understand why the parameter was introduced at all.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
