### PR TITLE
Potential fix for memory leak in Table indices

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -713,6 +713,30 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         if "info" in getattr(obj, "__dict__", {}):
             self.info = obj.info
 
+    def _cleanup_indices(self):
+        """
+        Clean up indices to prevent circular references.
+        
+        This method breaks any circular references between the column and its indices
+        by clearing the indices list. This helps prevent memory leaks when the column
+        is no longer needed.
+        """
+        if hasattr(self, 'indices') and self.indices:
+            # Clear the indices list to break circular references
+            self.indices.clear()
+            
+    def __del__(self):
+        """
+        Clean up resources when the column is being destroyed.
+        
+        This ensures that circular references are broken to prevent memory leaks.
+        """
+        try:
+            self._cleanup_indices()
+        except (AttributeError, TypeError):
+            # Ignore errors during cleanup as the object may be partially destroyed
+            pass
+
     def __array_wrap__(self, out_arr, context=None, return_scalar=False):
         """
         __array_wrap__ is called at the end of every ufunc.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a memory leak in Table indices. This was reported in #16089.

*Note*: I don't know enough about the Astropy code to know whether this is the most appropriate fix for this issues, but it does seem to fix the issue. 

Without these changes memory in the example below climbs to around 2816MiB, but with these changes it seems to stabilise at around 580MiB.

```python
import numpy as np

from astropy.table import MaskedColumn
from astropy.table.table_helpers import simple_table
from astropy.time import Time


def go() -> None:
    size = 250000
    t = simple_table(size=size, cols=26)
    idxs = Time(np.random.randint(0, size // 20, size=size), format="cxcsec").isot
    t["idx"] = MaskedColumn(idxs)  # THIS IS THE PROBLEM
    t.add_index(["idx"])

    idxs = np.random.choice(t["idx"], size=100, replace=False)
    for idx in idxs:
        _do_thing(idx, t)

def _do_thing(idx, t) -> None:
    _ = t[t["idx"] == idx]


if __name__ == "__main__":
    go()

```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #16089

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
