### PR TITLE
Rewrite `golden_spiral_grid()` unit test

### DIFF
--- a/astropy/coordinates/tests/test_angle_generators.py
+++ b/astropy/coordinates/tests/test_angle_generators.py
@@ -1,6 +1,7 @@
 """Unit tests for the :mod:`astropy.coordinates.angles.utils` module."""
 
 import pytest
+from numpy.testing import assert_allclose
 
 import astropy.units as u
 from astropy.coordinates import (
@@ -11,9 +12,21 @@ from astropy.coordinates import (
 from astropy.utils import NumpyRNGContext
 
 
-def test_golden_spiral_grid_input():
-    usph = golden_spiral_grid(size=100)
-    assert len(usph) == 100
+@pytest.mark.parametrize(
+    "size,lon,lat",
+    [
+        (3, [1.94161104, 5.82483312, 3.42486989], [0.72972766, 0.0, -0.72972766]),
+        (
+            6,
+            [1.94161104, 5.82483312, 3.4248699, 1.0249067, 4.908129, 2.5081655],
+            [0.9851108, 0.5235988, 0.16744808, -0.16744808, -0.5235988, -0.9851108],
+        ),
+    ],
+)
+def test_golden_spiral_grid_input(size, lon, lat):
+    grid = golden_spiral_grid(size)
+    assert_allclose(grid.lon.to_value(u.rad), lon)
+    assert_allclose(grid.lat.to_value(u.rad), lat)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

b692654845006151df6465043201046cf79cc4b6 added what the commit message calls "some very embarassing unit tests". I have rewritten one of them. It would not be complicated to rewrite the others in a similar manner, but the functions they test rely on random number generation, so it would be best to decide whether we continue forcing downstream to use the [legacy `RandomState`](https://numpy.org/doc/stable/reference/random/legacy.html) or we allow them to use the [currently recommended `Generator`](https://numpy.org/doc/stable/reference/random/index.html#quick-start). I don't expect us to make a final decision in this pull request, but it would be good to think about it.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
