### PR TITLE
Enable ruff B007 (unused control loop variable) in time

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -302,7 +302,6 @@ lint.unfixable = [
     "PTH",      # all flake8-use-pathlib
 ]
 "astropy/time/*" = [
-    "B007",  # UnusedLoopControlVariable
     "FIX003",  # Line contains XXX.  replace XXX with TODO
     "PIE794",  # duplicate-class-field-definition
     "PLC0415",  # import-outside-top-level

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -547,7 +547,7 @@ class TimeNumeric(TimeFormat):
             val1.dtype if orig_val2_is_none else np.result_type(val1.dtype, val2.dtype)
         )
         subfmts = self._select_subfmts(self.in_subfmt)
-        for subfmt, dtype, convert, _ in subfmts:
+        for _, dtype, convert, _ in subfmts:  # noqa: B007
             if np.issubdtype(val_dtype, dtype):
                 break
         else:

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -29,7 +29,10 @@ class TestTimeComparisons:
             (operator.le, "<="),
             (operator.lt, "<"),
         ):
-            with pytest.raises(TypeError):
+            with pytest.raises(
+                TypeError,
+                match=f"'{op_str}' not supported between instances of 'Time' and 'NoneType'",
+            ):
                 op(t1, None)
         # Keep == and != as they are specifically meant to test Time.__eq__
         # and Time.__ne__


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to enable ruff check B007 (unusual control loop variable) in the time subpackage.

As part of that, a test was enhanced to check the exception message.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This supersedes #17915 and fixes partially #14818.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
