### PR TITLE
Speed up `utils.diff.diff_values()`

### DIFF
--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -1,5 +1,6 @@
 import difflib
 import functools
+import math
 import sys
 from textwrap import indent
 
@@ -33,11 +34,11 @@ def diff_values(a, b, rtol=0.0, atol=0.0):
 
     """
     if isinstance(a, float) and isinstance(b, float):
-        if np.isnan(a) and np.isnan(b):
+        if math.isfinite(b):
+            return not abs(a - b) <= atol + rtol * abs(b)
+        if math.isnan(a) and math.isnan(b):
             return False
-        return not np.allclose(a, b, rtol=rtol, atol=atol)
-    else:
-        return a != b
+    return a != b
 
 
 def _ignore_astropy_terminal_size(func):

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -18,7 +18,8 @@ def test_diff_values_false(a):
 
 
 @pytest.mark.parametrize(
-    ("a", "b"), [(np.inf, np.nan), (1.11, 1.1), (1, 2), (1, "a"), ("a", "b")]
+    ("a", "b"),
+    [(np.inf, np.nan), (1.11, 1.1), (1, 2), (1, "a"), ("a", "b"), (np.nan, 1.1)],
 )
 def test_diff_values_true(a, b):
     assert diff_values(a, b)


### PR DESCRIPTION
### Description

If both arguments of `diff_values()` are floats then it is needlessly slow because it calls `numpy` functions on scalar values. Avoiding `numpy` speeds it up by two orders of magnitude. The function is used in `io.fits`, but I have not investigated how much the code there is sped up by this.

#### Timing on current `main`

```
$ ipython -i -c 'import numpy as np; from astropy.utils.diff import diff_values'
Python 3.12.3 (main, Jun 18 2025, 17:59:45) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.2.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Put a ';' at the end of a line to suppress the printing of output.

In [1]: %timeit diff_values(1.11, 1.1)
10.2 μs ± 39 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit diff_values(np.inf, np.nan)
10.4 μs ± 9.58 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

#### Timing with this patch

```
In [1]: %timeit diff_values(1.11, 1.1)
83.6 ns ± 0.119 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [2]: %timeit diff_values(np.inf, np.nan)
94.2 ns ± 0.06 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
