### PR TITLE
Dark Energy Component Trait Class

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -4,12 +4,11 @@ __all__ = ["FLRW", "FlatFLRWMixin"]
 
 import inspect
 import warnings
-from abc import abstractmethod
 from collections.abc import Mapping
 from dataclasses import field
 from functools import cached_property
 from inspect import signature
-from math import exp, floor, log, pi, sqrt
+from math import floor, pi, sqrt
 from numbers import Number
 from typing import Self, TypeVar, overload
 
@@ -34,6 +33,7 @@ from astropy.cosmology._src.parameter import (
     validate_with_unit,
 )
 from astropy.cosmology._src.traits import (
+    DarkEnergyComponent,
     HubbleParameter,
     ScaleFactor,
     TemperatureCMB,
@@ -93,10 +93,11 @@ class FLRW(
     Cosmology,
     HubbleParameter,
     ScaleFactor,
-    TemperatureCMB,
     _CriticalDensity,
     _BaryonComponent,
     _MatterComponent,
+    DarkEnergyComponent,
+    TemperatureCMB,
 ):
     """An isotropic and homogeneous (Friedmann-Lemaitre-Robertson-Walker) cosmology.
 
@@ -163,7 +164,10 @@ class FLRW(
         doc="Omega matter; matter density/critical density at z=0.",
         fvalidate="non-negative",
     )
-    Ode0: Parameter = ParameterOde0.clone()
+    Ode0: Parameter = Parameter(
+        doc="Omega dark energy; dark energy density/critical density at z=0.",
+        fvalidate="float",
+    )
     Tcmb0: Parameter = Parameter(
         default=0.0 * u.K,
         doc="Temperature of the CMB at z=0.",
@@ -357,36 +361,6 @@ class FLRW(
 
     # ---------------------------------------------------------------
 
-    @abstractmethod
-    @deprecated_keywords("z", since="7.0")
-    def w(self, z):
-        r"""The dark energy equation of state.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        w : ndarray or float
-            The dark energy equation of state.
-            `float` if scalar input.
-
-        Notes
-        -----
-        The dark energy equation of state is defined as
-        :math:`w(z) = P(z)/\rho(z)`, where :math:`P(z)` is the pressure at
-        redshift z and :math:`\rho(z)` is the density at redshift z, both in
-        units where c=1.
-
-        This must be overridden by subclasses.
-        """
-        raise NotImplementedError("w(z) is not implemented")
-
     @deprecated_keywords("z", since="7.0")
     def Otot(self, z):
         """The total density parameter at redshift ``z``.
@@ -456,30 +430,6 @@ class FLRW(
         if self.Ok0 == 0:  # Common enough to be worth checking explicitly
             return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
         return self.Ok0 * (z + 1.0) ** 2 * self.inv_efunc(z) ** 2
-
-    @deprecated_keywords("z", since="7.0")
-    def Ode(self, z):
-        """Return the density parameter for dark energy at redshift ``z``.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        Ode : ndarray or float
-            The density of non-relativistic matter relative to the critical
-            density at each redshift.
-            Returns `float` if the input is scalar.
-        """
-        z = aszarr(z)
-        if self.Ode0 == 0:  # Common enough to be worth checking explicitly
-            return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
-        return self.Ode0 * self.de_density_scale(z) * self.inv_efunc(z) ** 2
 
     @deprecated_keywords("z", since="7.0")
     def Ogamma(self, z):
@@ -620,80 +570,6 @@ class FLRW(
         rel_mass = rel_mass_per.sum(-1) + self._nmasslessnu
 
         return prefac * self._neff_per_nu * rel_mass
-
-    def _w_integrand(self, ln1pz, /):
-        """Internal convenience function for w(z) integral (eq. 5 of [1]_).
-
-        Parameters
-        ----------
-        ln1pz : `~numbers.Number` or scalar ndarray, positional-only
-            Assumes scalar input, since this should only be called inside an
-            integral.
-
-            .. versionchanged:: 7.0
-                The argument is positional-only.
-
-        References
-        ----------
-        .. [1] Linder, E. (2003). Exploring the Expansion History of the
-               Universe. Phys. Rev. Lett., 90, 091301.
-        """
-        return 1.0 + self.w(exp(ln1pz) - 1.0)
-
-    @deprecated_keywords("z", since="7.0")
-    def de_density_scale(self, z):
-        r"""Evaluates the redshift dependence of the dark energy density.
-
-        Parameters
-        ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
-
-            .. versionchanged:: 7.0
-                Passing z as a keyword argument is deprecated.
-
-        Returns
-        -------
-        I : ndarray or float
-            The scaling of the energy density of dark energy with redshift.
-            Returns `float` if the input is scalar.
-
-        Notes
-        -----
-        The scaling factor, I, is defined by :math:`\rho(z) = \rho_0 I`,
-        and is given by
-
-        .. math::
-
-           I = \exp \left( 3 \int_{a}^1 \frac{ da^{\prime} }{ a^{\prime} }
-                          \left[ 1 + w\left( a^{\prime} \right) \right] \right)
-
-        The actual integral used is rewritten from [1]_ to be in terms of z.
-
-        It will generally helpful for subclasses to overload this method if
-        the integral can be done analytically for the particular dark
-        energy equation of state that they implement.
-
-        References
-        ----------
-        .. [1] Linder, E. (2003). Exploring the Expansion History of the
-               Universe. Phys. Rev. Lett., 90, 091301.
-        """
-        # This allows for an arbitrary w(z) following eq (5) of
-        # Linder 2003, PRL 90, 91301.  The code here evaluates
-        # the integral numerically.  However, most popular
-        # forms of w(z) are designed to make this integral analytic,
-        # so it is probably a good idea for subclasses to overload this
-        # method if an analytic form is available.
-        z = aszarr(z)
-        if not isinstance(z, (Number, np.generic)):  # array/Quantity
-            ival = np.array(
-                [quad(self._w_integrand, 0, log(1 + redshift))[0] for redshift in z]
-            )
-            return np.exp(3 * ival)
-        else:  # scalar
-            ival = quad(self._w_integrand, 0, log(z + 1.0))[0]
-            return exp(3 * ival)
 
     @deprecated_keywords("z", since="7.0")
     def efunc(self, z):

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -164,10 +164,7 @@ class FLRW(
         doc="Omega matter; matter density/critical density at z=0.",
         fvalidate="non-negative",
     )
-    Ode0: Parameter = Parameter(
-        doc="Omega dark energy; dark energy density/critical density at z=0.",
-        fvalidate="float",
-    )
+    Ode0: Parameter = ParameterOde0.clone()
     Tcmb0: Parameter = Parameter(
         default=0.0 * u.K,
         doc="Temperature of the CMB at z=0.",

--- a/astropy/cosmology/_src/traits/__init__.py
+++ b/astropy/cosmology/_src/traits/__init__.py
@@ -5,6 +5,7 @@ The public API is provided by `astropy.cosmology.traits`.
 """
 
 __all__ = [
+    "DarkEnergyComponent",
     "HubbleParameter",
     "ScaleFactor",
     "TemperatureCMB",
@@ -15,6 +16,7 @@ __all__ = [
 
 from ._matter_density import _MatterComponent
 from .baryons import _BaryonComponent
+from .darkenergy import DarkEnergyComponent
 from .hubble import HubbleParameter
 from .rhocrit import _CriticalDensity
 from .scale_factor import ScaleFactor

--- a/astropy/cosmology/_src/traits/darkenergy.py
+++ b/astropy/cosmology/_src/traits/darkenergy.py
@@ -16,7 +16,9 @@ else:
 
 
 class DarkEnergyComponent:
-    # Ode0 should be defined as a Parameter in concrete cosmology classes
+    # Subclasses should use `Parameter` to make this a parameter of the cosmology.
+    Ode0: float
+    """Omega dark energy; dark energy density/critical density at z=0."""
 
     @abstractmethod
     @deprecated_keywords("z", since="7.0")

--- a/astropy/cosmology/_src/traits/darkenergy.py
+++ b/astropy/cosmology/_src/traits/darkenergy.py
@@ -4,7 +4,6 @@ from numbers import Number
 
 import numpy as np
 
-from astropy.cosmology._src.parameter import Parameter
 from astropy.cosmology._src.utils import aszarr, deprecated_keywords
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
@@ -17,10 +16,7 @@ else:
 
 
 class DarkEnergyComponent:
-    Ode0: Parameter = Parameter(
-        doc="Omega dark energy; dark energy density/critical density at z=0.",
-        fvalidate="float",
-    )
+    # Ode0 should be defined as a Parameter in concrete cosmology classes
 
     @abstractmethod
     @deprecated_keywords("z", since="7.0")

--- a/astropy/cosmology/_src/traits/darkenergy.py
+++ b/astropy/cosmology/_src/traits/darkenergy.py
@@ -1,0 +1,156 @@
+from abc import abstractmethod
+from math import exp, log
+from numbers import Number
+
+import numpy as np
+
+from astropy.cosmology._src.parameter import Parameter
+from astropy.cosmology._src.utils import aszarr, deprecated_keywords
+from astropy.utils.compat.optional_deps import HAS_SCIPY
+
+if HAS_SCIPY:
+    from scipy.integrate import quad
+else:
+
+    def quad(*args, **kwargs):
+        raise ModuleNotFoundError("No module named 'scipy.integrate'")
+
+
+class DarkEnergyComponent:
+    Ode0: Parameter = Parameter(
+        doc="Omega dark energy; dark energy density/critical density at z=0.",
+        fvalidate="float",
+    )
+
+    @abstractmethod
+    @deprecated_keywords("z", since="7.0")
+    def w(self, z):
+        r"""The dark energy equation of state.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        w : ndarray or float
+            The dark energy equation of state.
+            `float` if scalar input.
+
+        Notes
+        -----
+        The dark energy equation of state is defined as
+        :math:`w(z) = P(z)/\rho(z)`, where :math:`P(z)` is the pressure at
+        redshift z and :math:`\rho(z)` is the density at redshift z, both in
+        units where c=1.
+
+        This must be overridden by subclasses.
+        """
+        raise NotImplementedError("w(z) is not implemented")
+
+    def _w_integrand(self, ln1pz, /):
+        """Internal convenience function for w(z) integral (eq. 5 of [1]_).
+
+        Parameters
+        ----------
+        ln1pz : `~numbers.Number` or scalar ndarray, positional-only
+            Assumes scalar input, since this should only be called inside an
+            integral.
+
+            .. versionchanged:: 7.0
+                The argument is positional-only.
+
+        References
+        ----------
+        .. [1] Linder, E. (2003). Exploring the Expansion History of the
+               Universe. Phys. Rev. Lett., 90, 091301.
+        """
+        return 1.0 + self.w(exp(ln1pz) - 1.0)
+
+    @deprecated_keywords("z", since="7.0")
+    def de_density_scale(self, z):
+        r"""Evaluates the redshift dependence of the dark energy density.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        I : ndarray or float
+            The scaling of the energy density of dark energy with redshift.
+            Returns `float` if the input is scalar.
+
+        Notes
+        -----
+        The scaling factor, I, is defined by :math:`\rho(z) = \rho_0 I`,
+        and is given by
+
+        .. math::
+
+           I = \exp \left( 3 \int_{a}^1 \frac{ da^{\prime} }{ a^{\prime} }
+                          \left[ 1 + w\left( a^{\prime} \right) \right] \right)
+
+        The actual integral used is rewritten from [1]_ to be in terms of z.
+
+        It will generally helpful for subclasses to overload this method if
+        the integral can be done analytically for the particular dark
+        energy equation of state that they implement.
+
+        References
+        ----------
+        .. [1] Linder, E. (2003). Exploring the Expansion History of the
+               Universe. Phys. Rev. Lett., 90, 091301.
+        """
+        # This allows for an arbitrary w(z) following eq (5) of
+        # Linder 2003, PRL 90, 91301.  The code here evaluates
+        # the integral numerically.  However, most popular
+        # forms of w(z) are designed to make this integral analytic,
+        # so it is probably a good idea for subclasses to overload this
+        # method if an analytic form is available.
+        z = aszarr(z)
+        if not isinstance(z, (Number, np.generic)):  # array/Quantity
+            ival = np.array(
+                [quad(self._w_integrand, 0, log(1 + redshift))[0] for redshift in z]
+            )
+            return np.exp(3 * ival)
+        else:  # scalar
+            ival = quad(self._w_integrand, 0, log(z + 1.0))[0]
+            return exp(3 * ival)
+
+    @deprecated_keywords("z", since="7.0")
+    def Ode(self, z):
+        """Return the density parameter for dark energy at redshift ``z``.
+
+        Parameters
+        ----------
+        z : Quantity-like ['redshift'], array-like
+            Input redshift.
+
+            .. versionchanged:: 7.0
+                Passing z as a keyword argument is deprecated.
+
+        Returns
+        -------
+        Ode : ndarray or float
+            The density of non-relativistic matter relative to the critical
+            density at each redshift.
+            Returns `float` if the input is scalar.
+        """
+        z = aszarr(z)
+        if self.Ode0 == 0:  # Common enough to be worth checking explicitly
+            return np.zeros(z.shape) if hasattr(z, "shape") else 0.0
+        # Ensure self.inv_efunc is implemented by the main class
+        if not hasattr(self, "inv_efunc") or not callable(self.inv_efunc):
+            raise NotImplementedError(
+                "The main class must implement an 'inv_efunc(z)' method."
+            )
+        return self.Ode0 * self.de_density_scale(z) * self.inv_efunc(z) ** 2

--- a/astropy/cosmology/traits.py
+++ b/astropy/cosmology/traits.py
@@ -2,9 +2,15 @@
 """Traits for building ``astropy`` :class:`~astropy.cosmology.Cosmology` classes."""
 
 __all__ = [
+    "DarkEnergyComponent",
     "HubbleParameter",
     "ScaleFactor",
     "TemperatureCMB",
 ]
 
-from ._src.traits import HubbleParameter, ScaleFactor, TemperatureCMB
+from ._src.traits import (
+    DarkEnergyComponent,
+    HubbleParameter,
+    ScaleFactor,
+    TemperatureCMB,
+)

--- a/docs/changes/cosmology/18447.feature.rst
+++ b/docs/changes/cosmology/18447.feature.rst
@@ -1,0 +1,1 @@
+The trait ``astropy.cosmology.traits.DarkEnergyComponent`` has been added to work with objects that have attributes and methods related to the Dark Energy component.

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -38,11 +38,11 @@ Here is an example of how to use the
 ...         self.Tcmb0 = u.Quantity(Tcmb0, "K")
 ...         super().__init__()
 ...
-...     is_flat = False
-
 ...     def w(self, z):
 ...         # Example: equation of state varies with redshift
 ...         return -1 + 0.1 * np.sin(z)
+...
+...     is_flat = False
 
 >>> cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
 >>> cosmo.H0

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -54,7 +54,7 @@ Here is an example of how to use the
 >>> cosmo.hubble_time
 <Quantity 13.96846031 Gyr>
 >>> cosmo.w(0.5)
--0.9520574461395797
+np.float64(-0.9520574461395797)
 
 Reference/API
 *************

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -28,6 +28,7 @@ Here is an example of how to use the
 >>> import astropy.units as u
 >>> from astropy.cosmology.traits import HubbleParameter, ScaleFactor, TemperatureCMB, DarkEnergyComponent
 >>> from astropy.cosmology import Cosmology
+>>> import numpy as np
 >>>
 >>> class CustomCosmology(Cosmology, HubbleParameter, ScaleFactor, TemperatureCMB, DarkEnergyComponent):
 ...     def __init__(self, Om0, Ode0, H0=70, Tcmb0=2.725):

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -38,7 +38,10 @@ Here is an example of how to use the
 ...         super().__init__()
 ...
 ...     is_flat = False
-...     # Additional custom methods and properties can be added here
+
+...     def w(self, z):
+...         # Example: equation of state varies with redshift
+...         return -1 + 0.1 * np.sin(z)
 
 >>> cosmo = CustomCosmology(H0=70, Om0=0.3, Ode0=0.7)
 >>> cosmo.H0
@@ -49,6 +52,8 @@ Here is an example of how to use the
 <Quantity 5.45 K>
 >>> cosmo.hubble_time
 <Quantity 13.96846031 Gyr>
+>>> cosmo.w(0.5)
+-0.9520574461395797
 
 Reference/API
 *************

--- a/docs/cosmology/traits.rst
+++ b/docs/cosmology/traits.rst
@@ -10,9 +10,10 @@ The :mod:`~astropy.cosmology.traits` module provides reusable components, called
 :term:`traits <trait type>`, that encapsulate specific cosmological properties or
 behaviors. For example, the :class:`~astropy.cosmology.traits.HubbleParameter` trait
 provides the Hubble constant (``H0``) and related methods, while
-:class:`~astropy.cosmology.traits.ScaleFactor` and
-:class:`~astropy.cosmology.traits.TemperatureCMB` provide the scale factor and the
-temperature or the CMB, respectively.
+:class:`~astropy.cosmology.traits.ScaleFactor`,
+:class:`~astropy.cosmology.traits.TemperatureCMB` and
+:class:`~astropy.cosmology.traits.DarkEnergyComponent` provide the scale factor, the
+temperature or the CMB, and the Dark Energy component, respectively.
 
 By combining these traits, you can easily construct custom cosmology classes with
 precisely the features you need, without having to reimplement common functionality.
@@ -20,14 +21,15 @@ precisely the features you need, without having to reimplement common functional
 
 Here is an example of how to use the
 :class:`~astropy.cosmology.traits.HubbleParameter`,
-:class:`~astropy.cosmology.traits.ScaleFactor`, and
-:class:`~astropy.cosmology.traits.TemperatureCMB` traits in a custom cosmology class:
+:class:`~astropy.cosmology.traits.ScaleFactor`,
+:class:`~astropy.cosmology.traits.TemperatureCMB` and
+:class:`~astropy.cosmology.traits.DarkEnergyComponent` traits in a custom cosmology class:
 
 >>> import astropy.units as u
->>> from astropy.cosmology.traits import HubbleParameter, ScaleFactor, TemperatureCMB
+>>> from astropy.cosmology.traits import HubbleParameter, ScaleFactor, TemperatureCMB, DarkEnergyComponent
 >>> from astropy.cosmology import Cosmology
 >>>
->>> class CustomCosmology(Cosmology, HubbleParameter, ScaleFactor, TemperatureCMB):
+>>> class CustomCosmology(Cosmology, HubbleParameter, ScaleFactor, TemperatureCMB, DarkEnergyComponent):
 ...     def __init__(self, Om0, Ode0, H0=70, Tcmb0=2.725):
 ...         self.H0 = H0 << (u.km / u.s / u.Mpc)
 ...         self.Om0 = Om0

--- a/docs/whatsnew/7.2.rst
+++ b/docs/whatsnew/7.2.rst
@@ -37,19 +37,21 @@ The :mod:`~astropy.cosmology.traits` module provides reusable components, called
 :term:`traits <trait type>`, that encapsulate specific cosmological properties or
 behaviors. For example, the :class:`~astropy.cosmology.traits.HubbleParameter` trait
 provides the Hubble constant (``H0``) and related methods, while
-:class:`~astropy.cosmology.traits.ScaleFactor` and
-:class:`~astropy.cosmology.traits.TemperatureCMB` provide the scale factor and the
-temperature or the CMB, respectively.
+:class:`~astropy.cosmology.traits.ScaleFactor`,
+:class:`~astropy.cosmology.traits.TemperatureCMB`, and
+:class:`~astropy.cosmology.traits.DarkEnergyComponent` provide the scale factor, the
+temperature or the CMB, and the Dark Energy component, respectively.
 Here is an example of how to use the
 :class:`~astropy.cosmology.traits.HubbleParameter`,
-:class:`~astropy.cosmology.traits.ScaleFactor`, and
-:class:`~astropy.cosmology.traits.TemperatureCMB` traits in a custom cosmology class:
+:class:`~astropy.cosmology.traits.ScaleFactor`,
+:class:`~astropy.cosmology.traits.TemperatureCMB`, and
+:class:`~astropy.cosmology.traits.DarkEnergyComponent` traits in a custom cosmology class:
 
 >>> import astropy.units as u
->>> from astropy.cosmology.traits import HubbleParameter, ScaleFactor, TemperatureCMB
+>>> from astropy.cosmology.traits import HubbleParameter, ScaleFactor, TemperatureCMB, DarkEnergyComponent
 >>> from astropy.cosmology import Cosmology
 >>>
->>> class CustomCosmology(Cosmology, HubbleParameter, ScaleFactor, TemperatureCMB):
+>>> class CustomCosmology(Cosmology, HubbleParameter, ScaleFactor, TemperatureCMB, DarkEnergyComponent):
 ...     def __init__(self, Om0, Ode0, H0=70, Tcmb0=2.725):
 ...         self.H0 = H0 << (u.km / u.s / u.Mpc)
 ...         self.Om0 = Om0


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to introduce a trait class for dark energy as planned in the issue #17150 . The goal here is allow for users to create custom cosmologies using these traits.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes a portion of #17150 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
