### PR TITLE
Deprecate `find_api_page()`

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -177,6 +177,7 @@ class NumpyRNGContext:
         np.random.set_state(self.startstate)
 
 
+@deprecated(since="7.2", alternative="online_help")
 def find_api_page(
     obj: object,
     version: str | None = None,

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -35,8 +35,10 @@ def test_isiterable(obj, expectation):
 @pytest.mark.remote_data
 def test_api_lookup():
     try:
-        strurl = misc.find_api_page("astropy.utils.misc", "dev", False, timeout=5)
-        objurl = misc.find_api_page(misc, "dev", False, timeout=5)
+        with pytest.warns(AstropyDeprecationWarning, match="Use online_help instead.$"):
+            strurl = misc.find_api_page("astropy.utils.misc", "dev", False, timeout=5)
+        with pytest.warns(AstropyDeprecationWarning, match="Use online_help instead.$"):
+            objurl = misc.find_api_page(misc, "dev", False, timeout=5)
     except (urllib.error.URLError, TimeoutError):
         if CI:
             pytest.xfail("Timed out in CI")
@@ -50,7 +52,8 @@ def test_api_lookup():
     )
 
     # Try a non-dev version
-    objurl = misc.find_api_page(misc, "stable", False, timeout=3)
+    with pytest.warns(AstropyDeprecationWarning, match="Use online_help instead.$"):
+        objurl = misc.find_api_page(misc, "stable", False, timeout=3)
     assert (
         objurl
         == "https://docs.astropy.org/en/stable/utils/ref_api.html#module-astropy.utils.misc"

--- a/docs/changes/utils/18448.api.rst
+++ b/docs/changes/utils/18448.api.rst
@@ -1,0 +1,2 @@
+The ``find_api_page()`` function is deprecated.
+The similar ``online_help()`` function can be used instead.

--- a/docs/importing_astropy.rst
+++ b/docs/importing_astropy.rst
@@ -57,13 +57,12 @@ Because different sub-packages have very different functionalities, each
 sub-package has its own getting started guide. These can be found by browsing
 the sections listed in the :ref:`user-docs`.
 
-You can also look at docstrings for a particular package or object, or access
-their documentation using the `~astropy.utils.misc.find_api_page` function. For
-example, ::
+You can also search the ``astropy`` documentation using
+:func:`~astropy.utils.misc.online_help`.
+For example, ::
 
-    >>> from astropy import find_api_page
-    >>> from astropy.units import Quantity
-    >>> find_api_page(Quantity)  # doctest: +SKIP
+    >>> from astropy import online_help
+    >>> online_help("Quantity")  # doctest: +SKIP
 
-will bring up the documentation for the `~astropy.units.Quantity` class
-in your browser.
+will open your browser on a page with search results for
+:class:`~astropy.units.Quantity`.


### PR DESCRIPTION
### Description

There are many ways of accessing `astropy` documentation, including the `find_api_page()` and `online_help()` functions. I doubt these functions are commonly used and in any case having two so similar functions is not good. I don't see why we should keep `find_api_page()`, so I am deprecating it. I'm not sure we need `online_help()` either, but the implementation of that function is so simple that I don't mind keeping it.

Closes #18092, closes #18098

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
