### PR TITLE
Compute maximum absolute and relative differences reported by ImageDataDiff on the full arrays

### DIFF
--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -51,12 +51,6 @@ _COL_ATTRS = [
 ]
 
 
-def _get_differences(a, b):
-    relative = abs(b - a) / abs(b)
-    absolute = float(abs(b - a))
-    return relative, absolute
-
-
 class _BaseDiff:
     """
     Base class for all FITS diff objects.
@@ -1051,6 +1045,8 @@ class ImageDataDiff(_BaseDiff):
         self.diff_dimensions = ()
         self.diff_pixels = []
         self.diff_ratio = 0
+        self.max_absolute = 0
+        self.max_relative = 0
 
         # self.diff_pixels only holds up to numdiffs differing pixels, but this
         # self.diff_total stores the total count of differences between
@@ -1080,7 +1076,9 @@ class ImageDataDiff(_BaseDiff):
             rtol = self.rtol
             atol = self.atol
 
-        diffs = where_not_allclose(self.a, self.b, atol=atol, rtol=rtol)
+        diffs, self.max_absolute, self.max_relative = where_not_allclose(
+            self.a, self.b, atol=atol, rtol=rtol, return_maxdiff=True
+        )
 
         self.diff_total = len(diffs[0])
 
@@ -1115,9 +1113,6 @@ class ImageDataDiff(_BaseDiff):
         if not self.diff_pixels:
             return
 
-        max_relative = 0
-        max_absolute = 0
-
         for index, values in self.diff_pixels:
             # Convert to int to avoid np.int64 in list repr.
             index = [int(x + 1) for x in reversed(index)]
@@ -1130,9 +1125,6 @@ class ImageDataDiff(_BaseDiff):
                 rtol=self.rtol,
                 atol=self.atol,
             )
-            rdiff, adiff = _get_differences(values[0], values[1])
-            max_relative = max(max_relative, rdiff)
-            max_absolute = max(max_absolute, adiff)
 
         if self.diff_total > self.numdiffs:
             self._writeln(" ...")
@@ -1140,8 +1132,8 @@ class ImageDataDiff(_BaseDiff):
             f" {self.diff_total} different pixels found "
             f"({self.diff_ratio:.2%} different)."
         )
-        self._writeln(f" Maximum relative difference: {max_relative}")
-        self._writeln(f" Maximum absolute difference: {max_absolute}")
+        self._writeln(f" Maximum relative difference: {self.max_relative}")
+        self._writeln(f" Maximum absolute difference: {self.max_absolute}")
 
 
 class RawDataDiff(ImageDataDiff):

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -198,6 +198,7 @@ def where_not_allclose(a, b, rtol=1e-5, atol=1e-8, return_maxdiff=False):
     indices = np.where(invalid | (absolute.filled(0) > thresh))
 
     if return_maxdiff:
+        absolute[invalid] = np.ma.masked
         finites = ~absolute.mask
         absolute = absolute.compressed()
         if len(indices[0]) == 0 or absolute.size == 0:

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -192,10 +192,13 @@ def where_not_allclose(a, b, rtol=1e-5, atol=1e-8, return_maxdiff=False):
         indices = np.where(absolute > (atol + rtol * np.abs(b)))
 
     if return_maxdiff:
-        with np.errstate(invalid="ignore", divide="ignore"):
-            relative = absolute / np.abs(b)
-        max_absolute = float(np.max(absolute))
-        max_relative = np.max(relative)
+        if len(indices[0]) == 0:
+            max_absolute = max_relative = 0
+        else:
+            with np.errstate(invalid="ignore", divide="ignore"):
+                relative = absolute / np.abs(b)
+            max_absolute = float(np.max(absolute[indices]))
+            max_relative = np.max(relative[indices])
         return indices, max_absolute, max_relative
     else:
         return indices

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -174,6 +174,10 @@ def where_not_allclose(a, b, rtol=1e-5, atol=1e-8, return_maxdiff=False):
     -------
     idx : tuple of array
         Indices where the two arrays differ.
+    max_absolute : float
+        Maximum of absolute difference, returned if ``return_maxdiff=True``.
+    max_relative : float
+        Maximum of relative difference, returned if ``return_maxdiff=True``.
 
     """
     # Create fixed mask arrays to handle INF and NaN; currently INF and NaN

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -169,3 +169,19 @@ def test_where_not_allclose(kwargs):
     diff, maxabs, maxrel = where_not_allclose(a, b, return_maxdiff=True, **kwargs)
     assert np.isclose(maxabs, 0.1)
     assert np.isclose(maxrel, 0.1 / 4.6)
+
+    a = np.array([np.nan, np.inf, 0, 4.5])
+    b = np.array([1, np.inf, np.nan, 4.6])
+
+    diff, maxabs, maxrel = where_not_allclose(a, b, return_maxdiff=True, **kwargs)
+    assert list(diff[0]) == [0, 2, 3]
+    assert np.isclose(maxabs, 0.1)
+    assert np.isclose(maxrel, 0.1 / 4.6)
+
+    a = np.array([np.nan, np.inf, 0])
+    b = np.array([1, np.inf, np.nan])
+
+    diff, maxabs, maxrel = where_not_allclose(a, b, return_maxdiff=True, **kwargs)
+    assert list(diff[0]) == [0, 2]
+    assert maxabs == 0
+    assert maxrel == 0

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -165,3 +165,7 @@ def test_where_not_allclose(kwargs):
 
     assert where_not_allclose(a, b, **kwargs) == ([3],)
     assert len(where_not_allclose(a, a, **kwargs)[0]) == 0
+
+    diff, maxabs, maxrel = where_not_allclose(a, b, return_maxdiff=True, **kwargs)
+    assert np.isclose(maxabs, 0.1)
+    assert np.isclose(maxrel, 0.1 / 4.6)

--- a/docs/changes/io.fits/18451.bugfix.rst
+++ b/docs/changes/io.fits/18451.bugfix.rst
@@ -1,0 +1,2 @@
+Compute maximum absolute and relative differences reported by ``ImageDataDiff``
+on the full arrays instead of only a few values.


### PR DESCRIPTION
Fix #18413

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
