### PR TITLE
Fix pickling tests with spurious xfails in `convolution`

### DIFF
--- a/astropy/convolution/tests/test_pickle.py
+++ b/astropy/convolution/tests/test_pickle.py
@@ -8,16 +8,14 @@ from astropy.tests.helper import check_pickling_recovery, pickle_protocol  # noq
 
 
 @pytest.mark.parametrize(
-    ("name", "args", "kwargs", "xfail"),
+    "original",
     [
-        (conv.CustomKernel, [], {"array": np.random.rand(15)}, False),
-        (conv.Gaussian1DKernel, [1.0], {"x_size": 5}, True),
-        (conv.Gaussian2DKernel, [1.0], {"x_size": 5, "y_size": 5}, True),
+        conv.CustomKernel(array=np.random.rand(15)),
+        conv.Gaussian1DKernel(1.0, x_size=5),
+        conv.Gaussian2DKernel(1.0, x_size=5, y_size=5),
     ],
+    ids=lambda x: type(x).__name__,
 )
-def test_simple_object(pickle_protocol, name, args, kwargs, xfail):  # noqa: F811
+def test_simple_object(pickle_protocol, original):  # noqa: F811
     # Tests easily instantiated objects
-    if xfail:
-        pytest.xfail()
-    original = name(*args, **kwargs)
     check_pickling_recovery(original, pickle_protocol)


### PR DESCRIPTION
### Description

The pickling tests in `convolution` are overly complicated and they also cause 8 xfails even though pickling works just fine.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
