### PR TITLE
Add Cython implementation for VOTable binary converters

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -832,7 +832,9 @@ class Double(FloatingPoint):
         data = read(8)
         if len(data) != 8:
             raise EOFError("Unexpected end of file")
-        return fast_binparse_double(data)
+        value, _ = fast_binparse_double(data)
+        is_null = self.is_null(value)
+        return value, is_null
 
 
 class Float(FloatingPoint):
@@ -971,7 +973,9 @@ class Int(Integer):
         data = read(4)
         if len(data) != 4:
             raise EOFError("Unexpected end of file")
-        return fast_binparse_int(data)
+        value, _ = fast_binparse_int(data)
+        is_null = self.is_null(value)
+        return value, is_null
 
 
 class Long(Integer):
@@ -987,7 +991,9 @@ class Long(Integer):
         data = read(8)
         if len(data) != 8:
             raise EOFError("Unexpected end of file")
-        return fast_binparse_long(data)
+        value, _ = fast_binparse_long(data)
+        is_null = self.is_null(value)
+        return value, is_null
 
 
 class ComplexArrayVarArray(VarArray):
@@ -1173,7 +1179,6 @@ class BitArray(NumericArray):
     def binoutput(self, value, mask):
         if np.any(mask):
             vo_warn(W39)
-
         return bool_to_bitarray(value)
 
 

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -48,8 +48,6 @@ from .fast_converters import (
     fast_binparse_long,
     fast_binparse_short,
     fast_binparse_ubyte,
-    fast_bitarray_to_bool,
-    fast_bool_to_bitarray,
 )
 
 __all__ = ["Converter", "get_converter", "table_column_to_votable_datatype"]
@@ -116,7 +114,9 @@ def bitarray_to_bool(data, length):
     -------
     array : numpy bool array
     """
-    return fast_bitarray_to_bool(data, length)
+    return np.unpackbits(
+        np.frombuffer(data, dtype=np.uint8), count=length if length >= 0 else None
+    ).astype(bool, copy=False)
 
 
 def bool_to_bitarray(value):
@@ -135,7 +135,8 @@ def bool_to_bitarray(value):
         significant bit in the result.  The length will be `floor((N +
         7) / 8)` where `N` is the length of `value`.
     """
-    return fast_bool_to_bitarray(value)
+    bytes = np.packbits(np.ma.filled(value, fill_value=False).flat).tobytes()
+    return struct.pack(f"{len(bytes)}B", *bytes)
 
 
 class Converter:

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -39,6 +39,18 @@ from .exceptions import (
     vo_warn,
     warn_or_raise,
 )
+from .fast_converters import (
+    fast_binparse_bit,
+    fast_binparse_bool,
+    fast_binparse_double,
+    fast_binparse_float,
+    fast_binparse_int,
+    fast_binparse_long,
+    fast_binparse_short,
+    fast_binparse_ubyte,
+    fast_bitarray_to_bool,
+    fast_bool_to_bitarray,
+)
 
 __all__ = ["Converter", "get_converter", "table_column_to_votable_datatype"]
 
@@ -104,9 +116,7 @@ def bitarray_to_bool(data, length):
     -------
     array : numpy bool array
     """
-    return np.unpackbits(
-        np.frombuffer(data, dtype=np.uint8), count=length if length >= 0 else None
-    ).astype(bool, copy=False)
+    return fast_bitarray_to_bool(data, length)
 
 
 def bool_to_bitarray(value):
@@ -125,8 +135,7 @@ def bool_to_bitarray(value):
         significant bit in the result.  The length will be `floor((N +
         7) / 8)` where `N` is the length of `value`.
     """
-    bytes = np.packbits(np.ma.filled(value, fill_value=False).flat).tobytes()
-    return struct.pack(f"{len(bytes)}B", *bytes)
+    return fast_bool_to_bitarray(value)
 
 
 class Converter:
@@ -469,6 +478,7 @@ class UnicodeChar(Converter):
 
         if self.arraysize != "*" and len(value) > self.arraysize:
             vo_warn(W46, ("unicodeChar", self.arraysize), None, None)
+            value = value[: self.arraysize]
 
         encoded = value.encode("utf_16_be")
 
@@ -818,6 +828,12 @@ class Double(FloatingPoint):
 
     format = "f8"
 
+    def binparse(self, read):
+        data = read(8)
+        if len(data) != 8:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_double(data)
+
 
 class Float(FloatingPoint):
     """
@@ -825,6 +841,12 @@ class Float(FloatingPoint):
     """
 
     format = "f4"
+
+    def binparse(self, read):
+        data = read(4)
+        if len(data) != 4:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_float(data)
 
 
 class Integer(Numeric):
@@ -913,6 +935,12 @@ class UnsignedByte(Integer):
     val_range = (0, 255)
     bit_size = "8-bit unsigned"
 
+    def binparse(self, read):
+        data = read(1)
+        if len(data) != 1:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_ubyte(data)
+
 
 class Short(Integer):
     """
@@ -922,6 +950,12 @@ class Short(Integer):
     format = "i2"
     val_range = (-32768, 32767)
     bit_size = "16-bit"
+
+    def binparse(self, read):
+        data = read(2)
+        if len(data) != 2:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_short(data)
 
 
 class Int(Integer):
@@ -933,6 +967,12 @@ class Int(Integer):
     val_range = (-2147483648, 2147483647)
     bit_size = "32-bit"
 
+    def binparse(self, read):
+        data = read(4)
+        if len(data) != 4:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_int(data)
+
 
 class Long(Integer):
     """
@@ -942,6 +982,12 @@ class Long(Integer):
     format = "i8"
     val_range = (-9223372036854775808, 9223372036854775807)
     bit_size = "64-bit"
+
+    def binparse(self, read):
+        data = read(8)
+        if len(data) != 8:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_long(data)
 
 
 class ComplexArrayVarArray(VarArray):
@@ -1168,7 +1214,9 @@ class Bit(Converter):
 
     def binparse(self, read):
         data = read(1)
-        return (ord(data) & 0x8) != 0, False
+        if len(data) != 1:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_bit(data)
 
     def binoutput(self, value, mask):
         if mask:
@@ -1250,8 +1298,10 @@ class Boolean(Converter):
         return "F"
 
     def binparse(self, read):
-        value = ord(read(1))
-        return self.binparse_value(value)
+        data = read(1)
+        if len(data) != 1:
+            raise EOFError("Unexpected end of file")
+        return fast_binparse_bool(data)
 
     _binparse_mapping = {
         ord("T"): (True, False),

--- a/astropy/io/votable/setup_package.py
+++ b/astropy/io/votable/setup_package.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+
 from os.path import join
 
+import numpy as np
 from setuptools import Extension
 
 
@@ -13,5 +15,10 @@ def get_extensions(build_type="release"):
             "astropy.io.votable.tablewriter",
             [join(VO_DIR, "tablewriter.c")],
             include_dirs=[VO_DIR],
-        )
+        ),
+        Extension(
+            "astropy.io.votable.fast_converters",
+            [join(VO_DIR, "fast_converters.pyx")],
+            include_dirs=[np.get_include(), VO_DIR],
+        ),
     ]

--- a/astropy/io/votable/src/fast_converters.pyx
+++ b/astropy/io/votable/src/fast_converters.pyx
@@ -1,0 +1,221 @@
+# cython: language_level=3
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+
+"""
+Fast binary converters for VOTable Binary2 parsing.
+
+This module replaces the slow python binary parsing in astropy's VOTable
+implementation with more performant Cython code.
+"""
+
+import numpy as np
+import sys
+cimport numpy as cnp
+cimport cython
+from libc.string cimport memcpy
+from libc.stdlib cimport malloc, free
+
+cnp.import_array()
+
+ctypedef cnp.float64_t float64_t
+ctypedef cnp.float32_t float32_t
+ctypedef cnp.int64_t int64_t
+ctypedef cnp.int32_t int32_t
+ctypedef cnp.int16_t int16_t
+ctypedef cnp.uint8_t uint8_t
+ctypedef cnp.uint8_t bool_t
+
+cdef bint NEED_BYTESWAP = sys.byteorder == 'little'
+
+def fast_bitarray_to_bool(const unsigned char[::1] data, int length):
+    """Convert packed bits to bool array"""
+    cdef cnp.ndarray[bool_t, ndim=1] results = np.empty(length, dtype=np.bool_)
+    cdef int i = 0
+    cdef int byte_idx = 0
+    cdef int bit_no
+    cdef unsigned char byte_val
+    cdef bool_t bit_val
+
+    while i < length and byte_idx < data.shape[0]:
+        byte_val = data[byte_idx]
+        for bit_no in range(7, -1, -1):
+            if i >= length:
+                break
+            bit_val = (byte_val & (1 << bit_no)) != 0
+            results[i] = bit_val
+            i += 1
+        byte_idx += 1
+
+    return results
+
+def fast_bool_to_bitarray(const bool_t[::1] value):
+    """Pack bools into bit array - reverse of above."""
+    cdef int length = value.shape[0]
+    cdef int num_bytes = (length + 7) // 8
+    cdef cnp.ndarray[unsigned char, ndim=1] result = np.zeros(num_bytes, dtype=np.uint8)
+
+    cdef int i
+    cdef int byte_idx
+    cdef int bit_no
+    cdef unsigned char byte_val
+
+    for i in range(length):
+        byte_idx = i // 8
+        bit_no = 7 - (i % 8)
+        if value[i]:
+            result[byte_idx] |= (1 << bit_no)
+
+    return result.tobytes()
+
+cdef inline void swap_bytes_64(unsigned char* data) noexcept nogil:
+    """64-bit byte swap."""
+    cdef unsigned char temp
+    temp = data[0]; data[0] = data[7]; data[7] = temp
+    temp = data[1]; data[1] = data[6]; data[6] = temp
+    temp = data[2]; data[2] = data[5]; data[5] = temp
+    temp = data[3]; data[3] = data[4]; data[4] = temp
+
+cdef inline void swap_bytes_32(unsigned char* data) noexcept nogil:
+    """32-bit byte swap."""
+    cdef unsigned char t
+    t = data[0]; data[0] = data[3]; data[3] = t
+    t = data[1]; data[1] = data[2]; data[2] = t
+
+cdef inline void swap_bytes_16(unsigned char* data) noexcept nogil:
+    """16-bit byte swap."""
+    cdef unsigned char temp
+    temp = data[0]; data[0] = data[1]; data[1] = temp
+
+
+def fast_binparse_double(const unsigned char[::1] data, int offset=0):
+    """Parse 8-byte double from big-endian VOTable data."""
+    cdef float64_t value
+    cdef unsigned char temp_data[8]
+    cdef int i
+
+    for i in range(8):
+        temp_data[i] = data[offset + i]
+
+    if NEED_BYTESWAP:
+        swap_bytes_64(temp_data)
+
+    value = (<float64_t*>temp_data)[0]
+
+    cdef bint is_null = value != value
+
+    return value, is_null
+
+
+def fast_binparse_float(const unsigned char[::1] data, int offset=0):
+    """Parse 4-byte float."""
+    cdef float32_t value
+    cdef unsigned char temp_data[4]
+    cdef int i
+
+    for i in range(4):
+        temp_data[i] = data[offset + i]
+
+    if NEED_BYTESWAP:
+        swap_bytes_32(temp_data)
+
+    value = (<float32_t*>temp_data)[0]
+
+    cdef bint is_null = value != value
+
+    return value, is_null
+
+def fast_binparse_long(const unsigned char[::1] data, int offset=0):
+    """Parse 8-byte signed integer."""
+    cdef int64_t value
+    cdef unsigned char temp_data[8]
+    cdef int i
+
+    for i in range(8):
+        temp_data[i] = data[offset + i]
+
+    if NEED_BYTESWAP:
+        swap_bytes_64(temp_data)
+
+    value = (<int64_t*>temp_data)[0]
+
+    return value, False
+
+def fast_binparse_int(const unsigned char[::1] data, int offset=0):
+    """Parse 4-byte signed int."""
+    cdef int32_t value
+    cdef unsigned char temp_data[4]
+    cdef int i
+
+    for i in range(4):
+        temp_data[i] = data[offset + i]
+
+    if NEED_BYTESWAP:
+        swap_bytes_32(temp_data)
+
+    value = (<int32_t*>temp_data)[0]
+
+    return value, False
+
+def fast_binparse_short(const unsigned char[::1] data, int offset=0):
+    """Parse 2-byte signed short."""
+    cdef int16_t value
+    cdef unsigned char temp_data[2]
+    cdef int i
+
+    for i in range(2):
+        temp_data[i] = data[offset + i]
+
+    if NEED_BYTESWAP:
+        swap_bytes_16(temp_data)
+
+    value = (<int16_t*>temp_data)[0]
+
+    return value, False
+
+def fast_binparse_ubyte(const unsigned char[::1] data, int offset=0):
+    """Parse unsigned byte. """
+    cdef uint8_t value = data[offset]
+    return value, False
+
+def fast_binparse_bool(const unsigned char[::1] data, int offset=0):
+    """Parse boolean from character representation."""
+    cdef unsigned char byte_val = data[offset]
+    cdef bint value = False
+    cdef bint is_null = False
+
+    if byte_val == ord(b'T') or byte_val == ord(b't') or byte_val == ord(b'1'):
+        value = True
+    elif byte_val == ord(b'F') or byte_val == ord(b'f') or byte_val == ord(b'0'):
+        value = False
+    elif byte_val == 0 or byte_val == ord(b' ') or byte_val == ord(b'?'):
+        value = False
+        is_null = True
+    else:
+        value = False
+        is_null = True
+
+    return value, is_null
+
+def fast_binparse_bit(const unsigned char[::1] data, int offset=0):
+    """Parse single bit from VOTable bit field"""
+    cdef unsigned char byte_val = data[offset]
+    cdef bint value = (byte_val & 0x8) != 0
+    return value, False
+
+# Mapping of datatype strings to according parsing function
+cdef dict FAST_BINPARSE_MAP = {
+    'double': fast_binparse_double,
+    'float': fast_binparse_float,
+    'long': fast_binparse_long,
+    'int': fast_binparse_int,
+    'short': fast_binparse_short,
+    'unsignedByte': fast_binparse_ubyte,
+    'boolean': fast_binparse_bool,
+    'bit': fast_binparse_bit,
+}
+
+def get_fast_binparse_func(datatype):
+    """Get the binparse function for a given datatype."""
+    return FAST_BINPARSE_MAP.get(datatype)

--- a/astropy/io/votable/src/fast_converters.pyx
+++ b/astropy/io/votable/src/fast_converters.pyx
@@ -104,8 +104,8 @@ cdef inline void swap_bytes_16(unsigned char* data) noexcept nogil:
     cdef unsigned char temp
     temp = data[0]; data[0] = data[1]; data[1] = temp
 
-
-def fast_binparse_double(const unsigned char[::1] data, int offset=0):
+def fast_binparse_double(const unsigned char[::1] data,
+        int offset=0, double null_value=0.0, bint has_custom_null=False):
     """Parse 8-byte double from big-endian VOTable data."""
     cdef float64_t value
     cdef unsigned char temp_data[8]
@@ -119,12 +119,16 @@ def fast_binparse_double(const unsigned char[::1] data, int offset=0):
 
     value = (<float64_t*>temp_data)[0]
 
-    cdef bint is_null = value != value
+    cdef bint is_null
+    if has_custom_null:
+        is_null = (value == null_value)
+    else:
+        is_null = (value != value)
 
     return value, is_null
 
-
-def fast_binparse_float(const unsigned char[::1] data, int offset=0):
+def fast_binparse_float(const unsigned char[::1] data,
+        int offset=0, float null_value=0.0, bint has_custom_null=False):
     """Parse 4-byte float."""
     cdef float32_t value
     cdef unsigned char temp_data[4]
@@ -138,11 +142,16 @@ def fast_binparse_float(const unsigned char[::1] data, int offset=0):
 
     value = (<float32_t*>temp_data)[0]
 
-    cdef bint is_null = value != value
+    cdef bint is_null
+    if has_custom_null:
+        is_null = (value == null_value)
+    else:
+        is_null = (value != value)
 
     return value, is_null
 
-def fast_binparse_long(const unsigned char[::1] data, int offset=0):
+def fast_binparse_long(const unsigned char[::1] data,
+        int offset=0, long null_value=0, bint has_custom_null=False):
     """Parse 8-byte signed integer."""
     cdef int64_t value
     cdef unsigned char temp_data[8]
@@ -156,9 +165,14 @@ def fast_binparse_long(const unsigned char[::1] data, int offset=0):
 
     value = (<int64_t*>temp_data)[0]
 
-    return value, False
+    cdef bint is_null = False
+    if has_custom_null:
+        is_null = (value == null_value)
 
-def fast_binparse_int(const unsigned char[::1] data, int offset=0):
+    return value, is_null
+
+def fast_binparse_int(const unsigned char[::1] data,
+        int offset=0, int null_value=0, bint has_custom_null=False):
     """Parse 4-byte signed int."""
     cdef int32_t value
     cdef unsigned char temp_data[4]
@@ -172,9 +186,14 @@ def fast_binparse_int(const unsigned char[::1] data, int offset=0):
 
     value = (<int32_t*>temp_data)[0]
 
-    return value, False
+    cdef bint is_null = False
+    if has_custom_null:
+        is_null = (value == null_value)
 
-def fast_binparse_short(const unsigned char[::1] data, int offset=0):
+    return value, is_null
+
+def fast_binparse_short(const unsigned char[::1] data, int offset=0,
+        short null_value=0, bint has_custom_null=False):
     """Parse 2-byte signed short."""
     cdef int16_t value
     cdef unsigned char temp_data[2]
@@ -188,12 +207,22 @@ def fast_binparse_short(const unsigned char[::1] data, int offset=0):
 
     value = (<int16_t*>temp_data)[0]
 
-    return value, False
+    cdef bint is_null = False
+    if has_custom_null:
+        is_null = (value == null_value)
 
-def fast_binparse_ubyte(const unsigned char[::1] data, int offset=0):
-    """Parse unsigned byte. """
+    return value, is_null
+
+def fast_binparse_ubyte(const unsigned char[::1] data, int offset=0,
+        unsigned char null_value=0, bint has_custom_null=False):
+    """Parse unsigned byte."""
     cdef uint8_t value = data[offset]
-    return value, False
+
+    cdef bint is_null = False
+    if has_custom_null:
+        is_null = (value == null_value)
+
+    return value, is_null
 
 def fast_binparse_bool(const unsigned char[::1] data, int offset=0):
     """Parse boolean from character representation."""

--- a/docs/changes/io.votable/18454.perf.rst
+++ b/docs/changes/io.votable/18454.perf.rst
@@ -1,1 +1,10 @@
 Improve performance of Binary parsing by moving converters to Cython
+
+* **Numeric operations**: 47-57% faster
+* **Mixed data types**: 37-45% faster
+* **String operations**: 24-35% faster
+* **Boolean fields**: 10-20% faster
+* **Small overhead operations**: 29-43% faster
+
+Performance gains are consistent across dataset sizes from 200k to 1M rows.
+The most substantial improvements are seen in numeric types with up to 50-60% reduction in processing time.

--- a/docs/changes/io.votable/18454.perf.rst
+++ b/docs/changes/io.votable/18454.perf.rst
@@ -1,0 +1,1 @@
+Improve performance of Binary parsing by moving converters to Cython


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

This pull request attempts to improve the performance of VOTable binary parsing by implementing optimized Cython converters.

Initial benchmarks have shown performance improvements of the order:
- 53% speedup on numeric-heavy tables 
- 43-47% speedup on mixed data type tables
- 30-35% speedup on string-heavy tables
- Consistent improvements across BINARY and BINARY2 formats

**Problem:**
We’re seeing relatively slow performance when parsing large VOTables using the BINARY2 serialization format. 
 Profiling results from py-spy show a significant portion of time is spent in astropy.io.votable.converters.binparse. Here’s an excerpt of the profiler output:

```
py-spy top -- python test.py
Collecting samples from 'python test.py' (python v3.12.7)
Total Samples 1600
GIL: 100.00%, Active: 100.00%, Threads: 1
  %Own   %Total  OwnTime  TotalTime  Function (filename)                                                                                                                                                           
 54.00%  57.00%    7.69s     8.26s   binparse (astropy/io/votable/converters.py)
 24.00% 100.00%    3.68s    14.66s   parsebinary (astropy/io/votable/tree.py)
  4.00%   4.00%   0.940s    0.940s   bitarray_to_bool (astropy/io/votable/converters.py)
  8.00%   8.00%   0.890s    0.910s   setitem (numpy/ma/core.py)
  0.00%   0.00%   0.470s    0.670s   getbinary_data_stream (astropy/io/votable/tree.py)
  2.00%   2.00%   0.450s    0.450s   careful_read (astropy/io/votable/tree.py)
  0.00%   0.00%   0.430s    0.430s   new (numpy/_core/records.py)
  
```
As shown, the hot path is dominated by the binparse function in converters.py.


**Solution:**
- Added "Fast" Cython converters for all numeric types (`double`, `float`, `int`, `long`, `short`, `unsignedByte`, `boolean`, `bit`)

**Compatibility:**
Should be 100% backward compatible since the API has not been modified

**Testing:**
Added comprehensive benchmarks to astropy-benchmarks showing consistent 30-50% performance improvements across different table types and data patterns. https://github.com/astropy/astropy-benchmarks/pull/141

Astropy:main

```
[ 0.00%] · For astropy commit 8599d499 <main>:
[ 0.00%] ·· Benchmarking virtualenv-py3.11
[ 3.85%] ··· votable.TimeVOTableBooleanFields.time_booleans_binary                                                                                                                                         2.19±0s
[ 7.69%] ··· votable.TimeVOTableBooleanFields.time_booleans_binary2                                                                                                                                        3.16±0s
[11.54%] ··· votable.TimeVOTableLongStrings.time_long_strings_binary                                                                                                                                       2.45±0s
[15.38%] ··· votable.TimeVOTableLongStrings.time_long_strings_binary2                                                                                                                                      3.31±0s
[19.23%] ··· votable.TimeVOTableMixed.time_mixed_binary                                                                                                                                                    4.37±0s
[23.08%] ··· votable.TimeVOTableMixed.time_mixed_binary2                                                                                                                                                   5.77±0s
[26.92%] ··· votable.TimeVOTableNumeric.time_numeric_binary                                                                                                                                                3.37±0s
[30.77%] ··· votable.TimeVOTableNumeric.time_numeric_binary2                                                                                                                                               4.24±0s
[34.62%] ··· votable.TimeVOTableShortStrings.time_short_strings_binary                                                                                                                                     2.98±0s
[38.46%] ··· votable.TimeVOTableShortStrings.time_short_strings_binary2                                                                                                                                    3.82±0s
[42.31%] ··· votable.TimeVOTableSmallOverhead.time_small_binary                                                                                                                                           10.5±0ms
[46.15%] ··· votable.TimeVOTableSmallOverhead.time_small_binary2                                                                                                                                          13.9±0ms
[50.00%] ··· votable.TimeVOTableStringIntensive.time_string_intensive_binary2                                                                                                                              4.42±0s
```
u/stvoutsin/binary2-cython 

```
[ 0.00%] · For astropy commit 82cd430e <u/stvoutsin/binary2-cython>:
[ 0.00%] ·· Benchmarking virtualenv-py3.11
[ 3.85%] ··· votable.TimeVOTableBooleanFields.time_booleans_binary                                                                                                                                         1.82±0s
[ 7.69%] ··· votable.TimeVOTableBooleanFields.time_booleans_binary2                                                                                                                                        2.38±0s
[11.54%] ··· votable.TimeVOTableLongStrings.time_long_strings_binary                                                                                                                                       1.63±0s
[15.38%] ··· votable.TimeVOTableLongStrings.time_long_strings_binary2                                                                                                                                      2.20±0s
[19.23%] ··· votable.TimeVOTableMixed.time_mixed_binary                                                                                                                                                    2.51±0s
[23.08%] ··· votable.TimeVOTableMixed.time_mixed_binary2                                                                                                                                                   3.05±0s
[26.92%] ··· votable.TimeVOTableNumeric.time_numeric_binary                                                                                                                                                1.57±0s
[30.77%] ··· votable.TimeVOTableNumeric.time_numeric_binary2                                                                                                                                               2.01±0s
[34.62%] ··· votable.TimeVOTableShortStrings.time_short_strings_binary                                                                                                                                     1.96±0s
[38.46%] ··· votable.TimeVOTableShortStrings.time_short_strings_binary2                                                                                                                                    2.45±0s
[42.31%] ··· votable.TimeVOTableSmallOverhead.time_small_binary                                                                                                                                           6.12±0ms
[46.15%] ··· votable.TimeVOTableSmallOverhead.time_small_binary2                                                                                                                                          8.35±0ms
[50.00%] ··· votable.TimeVOTableStringIntensive.time_string_intensive_binary2                                                                                                                              3.26±0s
```
For better visualization:

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| Numeric (BINARY) | 3.37s | 1.57s | 53% faster |
| Numeric (BINARY2) | 4.24s | 2.01s | 53% faster |
| Mixed (BINARY) | 4.37s | 2.51s | 43% faster |
| Mixed (BINARY2) | 5.77s | 3.05s | 47% faster |
| Long Strings (BINARY) | 2.45s | 1.63s | 33% faster |
| Long Strings (BINARY2) | 3.31s | 2.20s | 33% faster |
| Short Strings (BINARY) | 2.98s | 1.96s | 34% faster |
| Short Strings (BINARY2) | 3.82s | 2.45s | 36% faster |
| Boolean Fields (BINARY) | 2.19s | 1.82s | 17% faster |
| Boolean Fields (BINARY2) | 3.16s | 2.38s | 25% faster |
| Small Overhead (BINARY) | 10.5ms | 6.12ms | 42% faster |
| Small Overhead (BINARY2) | 13.9ms | 8.35ms | 40% faster |
| String Intensive (BINARY2) | 4.42s | 3.26s | 26% faster |


I've also tested parsing outside of the astropy-benchmark PR with a VOTable with 50000 rows and aprox. 1000 columns (~50 million cells).
With this table the parsing took 30 seconds, down from 65 seconds in the version currently on main.

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18442
<!-- Optional opt-out -->

Any thoughts on this approach? Are there alternatives that I haven't considered? Perhaps someone with more Cython experience can let me know if I've made any obvious mistakes or if there are better way of doing any of this.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
