### PR TITLE
WHL: test wheels against CPython 3.14 (GIL-enabled)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,8 @@ markers = [
 # We disable testing for the following wheels:
 # - MuslLinux (tests hang non-deterministically)
 test-skip = "*-musllinux_x86_64"
+enable = ["cpython-prerelease"] # this line can be removed when cibuildwheel is bumped to 3.1.0 or newer
+skip = ["cp314t-*"] # https://github.com/astropy/astropy/issues/16916
 environment-pass = ["EXTENSION_HELPERS_PY_LIMITED_API"]
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
### Description
Contributes to #18187
To reduce friction, The patch is future-proof against upgrades in cibuildwheel and `OpenAstronomy/github-actions-workflows`. A couple lines added here can be cleaned-up in the near future, but we'll be able to do this at our own pace.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
