### PR TITLE
Return NamedTuples from coordinate match functions

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1162,20 +1162,13 @@ class SkyCoord(MaskableShapedLikeNDArray):
 
         Returns
         -------
-        idx : int array
-            Indices into ``catalogcoord`` to get the matched points for
-            each of this object's coordinates. Shape matches this
-            object.
-        sep2d : `~astropy.coordinates.Angle`
-            The on-sky separation between the closest match for each
-            element in this object in ``catalogcoord``. Shape matches
-            this object.
-        dist3d : `~astropy.units.Quantity` ['length']
-            The 3D distance between the closest match for each element
-            in this object in ``catalogcoord``. Shape matches this
-            object. Unless both this and ``catalogcoord`` have associated
-            distances, this quantity assumes that all sources are at a
-            distance of 1 (dimensionless).
+        CoordinateMatchResult
+            A `~typing.NamedTuple` with attributes representing for each
+            source in this |SkyCoord| the indices and angular and
+            physical separations of the match in ``catalogcoord``. If
+            either the |SkyCoord| or ``catalogcoord`` don't have
+            distances, the physical separation is the 3D distance on the
+            unit sphere, rather than a true distance.
 
         Notes
         -----
@@ -1230,18 +1223,10 @@ class SkyCoord(MaskableShapedLikeNDArray):
 
         Returns
         -------
-        idx : int array
-            Indices into ``catalogcoord`` to get the matched points for
-            each of this object's coordinates. Shape matches this
-            object.
-        sep2d : `~astropy.coordinates.Angle`
-            The on-sky separation between the closest match for each
-            element in this object in ``catalogcoord``. Shape matches
-            this object.
-        dist3d : `~astropy.units.Quantity` ['length']
-            The 3D distance between the closest match for each element
-            in this object in ``catalogcoord``. Shape matches this
-            object.
+        CoordinateMatchResult
+            A `~typing.NamedTuple` with attributes representing for each
+            source in this |SkyCoord| the indices and angular and physical
+            separations of the match in ``catalogcoord``.
 
         Notes
         -----
@@ -1292,20 +1277,13 @@ class SkyCoord(MaskableShapedLikeNDArray):
 
         Returns
         -------
-        idxsearcharound : int array
-            Indices into ``searcharoundcoords`` that match the
-            corresponding elements of ``idxself``. Shape matches
-            ``idxself``.
-        idxself : int array
-            Indices into ``self`` that match the
-            corresponding elements of ``idxsearcharound``. Shape matches
-            ``idxsearcharound``.
-        sep2d : `~astropy.coordinates.Angle`
-            The on-sky separation between the coordinates. Shape matches
-            ``idxsearcharound`` and ``idxself``.
-        dist3d : `~astropy.units.Quantity` ['length']
-            The 3D distance between the coordinates. Shape matches
-            ``idxsearcharound`` and ``idxself``.
+        CoordinateSearchResult
+            A `~typing.NamedTuple` with attributes representing the
+            indices of the elements of found pairs in the other set of
+            coordinates and this |SkyCoord| and angular and physical
+            separations of the pairs. If either set of sources lack
+            distances, the physical separation is the 3D distance on the
+            unit sphere, rather than a true distance.
 
         Notes
         -----
@@ -1352,20 +1330,11 @@ class SkyCoord(MaskableShapedLikeNDArray):
 
         Returns
         -------
-        idxsearcharound : int array
-            Indices into ``searcharoundcoords`` that match the
-            corresponding elements of ``idxself``. Shape matches
-            ``idxself``.
-        idxself : int array
-            Indices into ``self`` that match the
-            corresponding elements of ``idxsearcharound``. Shape matches
-            ``idxsearcharound``.
-        sep2d : `~astropy.coordinates.Angle`
-            The on-sky separation between the coordinates. Shape matches
-            ``idxsearcharound`` and ``idxself``.
-        dist3d : `~astropy.units.Quantity` ['length']
-            The 3D distance between the coordinates. Shape matches
-            ``idxsearcharound`` and ``idxself``.
+        CoordinateSearchResult
+            A `~typing.NamedTuple` with attributes representing the
+            indices of the elements of found pairs in the other set of
+            coordinates and this |SkyCoord| and angular and physical
+            separations of the pairs.
 
         Notes
         -----

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -43,10 +43,10 @@ def test_matching_function():
     npt.assert_array_almost_equal(d2d.degree, [0, 0.1])
     assert d3d.value[0] == 0
 
-    idx, d2d, d3d = match_coordinates_3d(cmatch, ccatalog, nthneighbor=2)
-    assert np.all(idx == 2)
-    npt.assert_array_almost_equal(d2d.degree, [1, 0.9])
-    npt.assert_array_less(d3d.value, 0.02)
+    results = match_coordinates_3d(cmatch, ccatalog, nthneighbor=2)
+    assert np.all(results.indices_to_catalog == 2)
+    npt.assert_array_almost_equal(results.angular_separation.degree, [1, 0.9])
+    npt.assert_array_less(results.physical_separation.value, 0.02)
 
 
 def test_matching_function_3d_and_sky():
@@ -144,11 +144,11 @@ def test_matching_method():
 
     # should be the same as above because there's no distance, but just make sure this method works
     idx1, d2d1, d3d1 = SkyCoord(cmatch).match_to_catalog_sky(ccatalog)
-    idx2, d2d2, d3d2 = match_coordinates_sky(cmatch, ccatalog)
+    results = match_coordinates_sky(cmatch, ccatalog)
 
-    npt.assert_array_equal(idx1, idx2)
-    assert_allclose(d2d1, d2d2)
-    assert_allclose(d3d1, d3d2)
+    npt.assert_array_equal(idx1, results.indices_to_catalog)
+    assert_allclose(d2d1, results.angular_separation)
+    assert_allclose(d3d1, results.physical_separation)
 
     assert len(idx1) == len(d2d1) == len(d3d1) == 20
 
@@ -301,15 +301,15 @@ def test_search_around_no_matches(function, search_limit):
 )
 def test_search_around_empty_input(sources, catalog, function, search_limit):
     # Test when one or both of the coordinate arrays is empty, #4875
-    idx1, idx2, d2d, d3d = function(sources, catalog, search_limit)
-    assert idx1.size == 0
-    assert idx2.size == 0
-    assert d2d.size == 0
-    assert d3d.size == 0
-    assert idx1.dtype == int
-    assert idx2.dtype == int
-    assert d2d.unit == u.deg
-    assert d3d.unit == u.kpc
+    result = function(sources, catalog, search_limit)
+    assert result.indices_to_first_set.size == 0
+    assert result.indices_to_second_set.size == 0
+    assert result.angular_separation.size == 0
+    assert result.physical_separation.size == 0
+    assert result.indices_to_first_set.dtype == int
+    assert result.indices_to_second_set.dtype == int
+    assert result.angular_separation.unit == u.deg
+    assert result.physical_separation.unit == u.kpc
 
 
 @pytest.mark.parametrize(

--- a/docs/changes/coordinates/18459.feature.rst
+++ b/docs/changes/coordinates/18459.feature.rst
@@ -1,0 +1,3 @@
+The results of ``match_coordinates_3d()``, ``match_coordinates_sky()``,
+``search_around_3d()`` and ``search_around_sky()`` and the corresponding
+``SkyCoord`` methods now have named attributes.


### PR DESCRIPTION
### Description

The coordinate matching and searching functions and the corresponding `SkyCoord` methods have so far returned tuples. Returning instances of new `NamedTuple` subclasses allows accessing values in the returned tuples via named attributes. I have updated some of the relevant tests to demonstrate the new functionality, but I have left others as they were to prove the changes are backwards-compatible.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.