### PR TITLE
TST: remove macOS + x86_64 combo from weekly cron

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -63,11 +63,6 @@ jobs:
             python: '3.13'
             toxenv: py313-test-devinfra
 
-          - name: Python 3.13 on macOS (x86_64) with all optional dependencies
-            os: macos-13
-            python: '3.13'
-            toxenv: py313-test-alldeps
-
           - name: Python 3.13t (free-threading) with recommended dependencies
             os: ubuntu-latest
             python: '3.13t'


### PR DESCRIPTION
### Description
The `macos-13` image is soon to be discontinued, so we can't keep this job around for much longer.
`macosx-x86_64` wheels are still being cross-compiled and tested.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
