### PR TITLE
Backport PR #18139 on `v7.1.x` (TST: improve `ArrayWrapper` roundtrips (preserve dtype byteorder))

### DIFF
--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -132,7 +132,12 @@ class ArrayWrapper:
     info = ArrayWrapperInfo()
 
     def __init__(self, data, copy=True):
-        self.data = np.array(data, copy=copy)
+        if isinstance(data, ArrayWrapper):
+            # this is done to preserve byteorder through copies
+            arr = data.data
+        else:
+            arr = data
+        self.data = np.array(arr, copy=copy)
         if "info" in getattr(data, "__dict__", ()):
             self.info = data.info
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -126,10 +126,17 @@ def assert_follows_unicode_guidelines(x, roundtrip=None):
             assert eval(repr_x, roundtrip) == x
 
 
-@pytest.fixture(params=[0, 1, -1])
+@pytest.fixture(params=[0, 1, 4, -1])
 def pickle_protocol(request):
     """
-    Fixture to run all the tests for protocols 0 and 1, and -1 (most advanced).
+    Fixture to run all the tests for protocols 0, 1, 4 and -1 (most advanced).
+
+    * 0 is the original "human-readable" protocol
+    * 1 is the oldest binary format
+    * 4 introduced in Python 3.4, has been the default in 3.8-3.13
+    * -1 is the most advanced, which is 5 since Python 3.8, default from 3.14,
+      and the first binary format to preserve byteorder.
+
     (Originally from astropy.table.tests.test_pickle).
     """
     return request.param

--- a/docs/changes/table/18139.bugfix.rst
+++ b/docs/changes/table/18139.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug in ``table.table_helpers.ArrayWrapper`` where byteorder of the
+underlying data was not necessarily preserved through roundtrips.


### PR DESCRIPTION
### Description
Manual backport for #18139 after seeing that it wasn't (fully) included in 7.1.0 as previously assumed.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
