### PR TITLE
Added global default_preserve_units option

### DIFF
--- a/astropy/wcs/__init__.py
+++ b/astropy/wcs/__init__.py
@@ -24,8 +24,6 @@ Each of these transformations can be used independently or together in
 a standard pipeline.
 """
 
-from astropy.utils.state import ScienceState
-
 from . import utils
 from .wcs import *
 from .wcs import InvalidTabularParametersError  # just for docs
@@ -38,8 +36,3 @@ def get_include():
     import os
 
     return os.path.join(os.path.dirname(__file__), "include")
-
-
-class default_preserve_units(ScienceState):
-    _default_value = False
-    _value = False

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -51,6 +51,7 @@ from astropy.utils.exceptions import (
     AstropyUserWarning,
     AstropyWarning,
 )
+from astropy.utils.state import ScienceState
 
 from . import _wcs, docstrings
 
@@ -81,6 +82,7 @@ __all__ = [
     "WcsError",
     "Wcsprm",
     "Wtbarr",
+    "default_preserve_units",
     "find_all_wcs",
     "validate",
 ]
@@ -180,6 +182,11 @@ WCSHDO_SIP = 0x80000
 # range of 0-19, followed by an underscore and another number in range of 0-19.
 # Keyword optionally ends with a capital letter.
 SIP_KW = re.compile("""^[AB]P?_1?[0-9]_1?[0-9][A-Z]?$""")
+
+
+class default_preserve_units(ScienceState):
+    _default_value = False
+    _value = False
 
 
 def _parse_keysel(keysel):
@@ -429,8 +436,6 @@ class WCS(FITSWCSAPIMixin, WCSBase):
         close_fds = []
 
         if preserve_units is None:
-            from astropy.wcs import default_preserve_units
-
             preserve_units = default_preserve_units.get()
 
         # these parameters are stored to be used when unpickling a WCS object:


### PR DESCRIPTION
@mhvk suggested in https://github.com/astropy/astropy/pull/18338 having a way to globally set the default ``preserve_units`` behavior, so this takes a first stab at it.

I took the approach of using a ``ScienceState`` because my understanding is that ``ScienceState`` should be used for things that can actually change the results of a chunk of code, whereas configuration items are more for things that change how the code is run or any displayed information. However, I'm happy to discuss if my understanding is not correct.

Here changing from ``preserve_units`` to ``False`` to ``True`` will lead to numerical values e.g. from ``wcs.all_pix2world`` actually changing.

Anyway, this is open for discussion, and should not be merged at this point.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
