### PR TITLE
Add WCS.preserve_units property

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1984,6 +1984,10 @@ class TestPreserveUnits:
         self.coords = rsn.uniform(-10, 10, (100, 5))
         self.scale = np.array([1 / 3600, 1e9, 1 / 3600, 1e-9, 1])
 
+    def test_preserve_units_property(self):
+        assert not self.wcs_default.preserve_units
+        assert self.wcs_preserve.preserve_units
+
     def test_get_cunit(self):
         assert list(self.wcs_default.wcs.cunit) == ["deg", "Hz", "deg", "m", "arcmin"]
         assert list(self.wcs_preserve.wcs.cunit) == [

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -424,9 +424,11 @@ class WCS(FITSWCSAPIMixin, WCSBase):
         fix=True,
         translate_units="",
         _do_set=True,
-        preserve_units=False,
+        preserve_units=None,
     ):
         close_fds = []
+
+        self._preserve_units = False if preserve_units is None else preserve_units
 
         # these parameters are stored to be used when unpickling a WCS object:
         self._init_kwargs = {
@@ -3585,6 +3587,16 @@ reduce these to 2 dimensions using the naxis kwarg.
         pccd = np.dot(cdelt, pc)
 
         return pccd
+
+    @property
+    def preserve_units(self):
+        """
+        Indicates whether the ``WCS`` class is preserving the original units.
+
+        If `True`, units are always kept as specified, whereas is `False`, some
+        units may in some cases be converted to SI or degrees.
+        """
+        return self._preserve_units
 
     def footprint_contains(self, coord, **kwargs):
         """


### PR DESCRIPTION
This indicates whether the WCS class is preserving the original units from the header or set programmatically, or whether some units may have been converted to SI or degrees. Not adding a changelog entry since this just affects a feature added in dev.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
