### PR TITLE
Backport PR #16411 on branch v7.1.x (Avoid calling wcsset if the wcsprm is unchanged)

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1622,6 +1622,12 @@ PyWcsprm_cset(
 
   int status = 0;
 
+  // We want to avoid calling wcsset whenever possible as it is not thread-safe. We use wcsenq
+  // to see if the checksum of the wcsprm elements has changed since wcsset was last called.
+  if (wcsenq(&self->x, WCSENQ_CHK)) {
+    return 0;
+  }
+
   if (convert) wcsprm_python2c(&self->x);
   status = wcsset(&self->x);
   if (convert) wcsprm_c2python(&self->x);

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1943,6 +1943,7 @@ def test_DistortionLookupTable():
             [12 + dx * 3, 22 + dy * 3],
         )
 
+
 def test_thread_safe_conversions():
     # This is a regression test for a bug which caused wcsset to be called
     # unnecessarily multiple times, including every time some attribute were

--- a/docs/changes/wcs/16411.bugfix.rst
+++ b/docs/changes/wcs/16411.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue which caused calls to WCS coordinate conversion routines to not be thread-safe due to calls to WCS.wcs.set() from multiple threads.


### PR DESCRIPTION
### Description

Manual backport of #16411 


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
