### PR TITLE
Improve logarithmic quantity tests parametrization

### DIFF
--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -22,6 +22,12 @@ lq_subclasses = [u.Dex, u.Magnitude, u.Decibel]
 
 pu_sample = (u.dimensionless_unscaled, u.m, u.g / u.s**2, u.Jy)
 
+mJy = np.arange(1.0, 5.0).reshape(2, 2) * u.mag(u.Jy)
+m1 = np.arange(1.0, 5.5, 0.5).reshape(3, 3) * u.mag()
+log_quantity_parametrization = pytest.mark.parametrize(
+    "mag", [mJy, m1], ids=lambda x: str(x.unit.physical_unit.physical_type)
+)
+
 
 class TestLogUnitCreation:
     def test_logarithmic_units(self):
@@ -973,11 +979,6 @@ class TestLogQuantityComparisons:
 
 
 class TestLogQuantityMethods:
-    def setup_method(self):
-        self.mJy = np.arange(1.0, 5.0).reshape(2, 2) * u.mag(u.Jy)
-        self.m1 = np.arange(1.0, 5.5, 0.5).reshape(3, 3) * u.mag()
-        self.mags = (self.mJy, self.m1)
-
     @pytest.mark.parametrize(
         "method",
         (
@@ -992,59 +993,56 @@ class TestLogQuantityMethods:
             "ediff1d",
         ),
     )
-    def test_always_ok(self, method):
-        for mag in self.mags:
-            res = getattr(mag, method)()
-            assert np.all(res.value == getattr(mag._function_view, method)().value)
-            if method in ("std", "diff", "ediff1d"):
-                assert res.unit == u.mag()
-            elif method == "var":
-                assert res.unit == u.mag**2
-            else:
-                assert res.unit == mag.unit
+    @log_quantity_parametrization
+    def test_always_ok(self, method, mag):
+        res = getattr(mag, method)()
+        assert np.all(res.value == getattr(mag._function_view, method)().value)
+        if method in ("std", "diff", "ediff1d"):
+            assert res.unit == u.mag()
+        elif method == "var":
+            assert res.unit == u.mag**2
+        else:
+            assert res.unit == mag.unit
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="ptp method removed in numpy 2.0")
-    def test_always_ok_ptp(self):
-        for mag in self.mags:
-            res = mag.ptp()
-            assert np.all(res.value == mag._function_view.ptp().value)
-            assert res.unit == u.mag()
+    @log_quantity_parametrization
+    def test_always_ok_ptp(self, mag):
+        res = mag.ptp()
+        assert np.all(res.value == mag._function_view.ptp().value)
+        assert res.unit == u.mag()
 
-    def test_clip(self):
-        for mag in self.mags:
-            assert np.all(
-                mag.clip(2.0 * mag.unit, 4.0 * mag.unit).value
-                == mag.value.clip(2.0, 4.0)
-            )
+    @log_quantity_parametrization
+    def test_clip(self, mag):
+        assert np.all(
+            mag.clip(2.0 * mag.unit, 4.0 * mag.unit).value == mag.value.clip(2.0, 4.0)
+        )
 
     @pytest.mark.parametrize("method", ("sum", "cumsum"))
-    def test_only_ok_if_dimensionless(self, method):
-        res = getattr(self.m1, method)()
-        assert np.all(res.value == getattr(self.m1._function_view, method)().value)
-        assert res.unit == self.m1.unit
+    def test_ok_if_dimensionless(self, method):
+        res = getattr(m1, method)()
+        assert np.all(res.value == getattr(m1, method)().value)
+        assert res.unit == m1.unit
+
+    @pytest.mark.parametrize("method", ("sum", "cumsum"))
+    def test_not_ok_if_not_dimensionless(self, method):
         with pytest.raises(TypeError):
-            getattr(self.mJy, method)()
+            getattr(mJy, method)()
 
     def test_dot(self):
-        assert np.all(self.m1.dot(self.m1).value == self.m1.value.dot(self.m1.value))
+        assert np.all(m1.dot(m1).value == m1.value.dot(m1.value))
 
     @pytest.mark.parametrize("method", ("prod", "cumprod"))
-    def test_never_ok(self, method):
+    @log_quantity_parametrization
+    def test_never_ok(self, method, mag):
         with pytest.raises(TypeError):
-            getattr(self.mJy, method)()
-        with pytest.raises(TypeError):
-            getattr(self.m1, method)()
+            getattr(mag, method)()
 
 
 class TestLogQuantityFunctions:
     # TODO: add tests for all supported functions!
-    def setup_method(self):
-        self.mJy = np.arange(1.0, 5.0).reshape(2, 2) * u.mag(u.Jy)
-        self.m1 = np.arange(1.0, 5.5, 0.5).reshape(3, 3) * u.mag()
-        self.mags = (self.mJy, self.m1)
 
-    def test_ptp(self):
-        for mag in self.mags:
-            res = np.ptp(mag)
-            assert np.all(res.value == np.ptp(mag._function_view).value)
-            assert res.unit == u.mag()
+    @log_quantity_parametrization
+    def test_ptp(self, mag):
+        res = np.ptp(mag)
+        assert np.all(res.value == np.ptp(mag._function_view).value)
+        assert res.unit == u.mag()


### PR DESCRIPTION
### Description

I am replacing several `for`-loops inside logarithmic quantity tests with parametrized tests. These are better than `for`-loops inside tests because a parameter that causes a test to fail does not prevent other parameters from being tested. Furthermore, the output of `pytest` is much better if a test fails or if `pytest` is invoked with the `--verbose` option. In this particular case defining a module level decorator for parametrization also allows eliminating two test class setup methods.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
