### PR TITLE
Remove a hardcoded list of month name abbreviations

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -9,6 +9,7 @@ celestial-to-terrestrial coordinate transformations
 (in `astropy.coordinates`).
 """
 
+import calendar
 import os
 import re
 from datetime import UTC, datetime
@@ -96,21 +97,6 @@ suppressed by setting the auto_max_age configuration variable to
   from astropy.utils.iers import conf
   conf.auto_max_age = None
 """
-
-MONTH_ABBR = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-]
 
 
 class IERSWarning(AstropyWarning):
@@ -1224,7 +1210,7 @@ class LeapSeconds(QTable):
                 match = cls._re_expires.match(line)
                 if match:
                     day, month, year = match.groups()[0].split()
-                    month_nb = MONTH_ABBR.index(month[:3]) + 1
+                    month_nb = calendar.Month[month.upper()].value
                     expires = Time(
                         f"{year}-{month_nb:02d}-{day}", scale="tai", out_subfmt="date"
                     )


### PR DESCRIPTION
### Description

There is a hardcoded list of month name abbreviations in the IERS utilities, but there is no point in wasting 15 lines of code for something that can be easily looked up using the Python standard library.

EDIT

Turns out [`calendar.Month`](https://docs.python.org/3.12/library/calendar.html#calendar.Month) was introduced in Python 3.12, so we do need the hardcoded list as long as we support Python 3.11.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
