### PR TITLE
Remove support for `h5py` older than 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ all = [
     # Install all remaining optional dependencies
     "certifi>=2022.6.15.1",
     "dask[array]>=2022.5.1",
-    "h5py>=3.8.0",
+    "h5py>=3.9.0",  # older versions used deprecated np.product()
     "pyarrow>=10.0.1",
     "beautifulsoup4>=4.9.3", # imposed by pandas==2.0
     "html5lib>=1.1",


### PR DESCRIPTION
### Description

[`numpy.product()` was deprecated in `numpy` 1.25](https://numpy.org/doc/stable/release/1.25.0-notes.html#deprecations) but [`h5py` versions older than 3.9 were still using it](https://docs.h5py.org/en/stable/whatsnew/3.9.html#bug-fixes). Dropping support for older `h5py` versions prevents problems with our oldest dependencies CI job when we get to dropping support for `numpy` 1.24. In principle it will also prevent users who will have installed latest `astropy`, not the oldest supported `numpy` and the oldest supported `h5py` from seeing deprecation warnings they can't do anything about, but in practice I suspect the number of users who have such a set of packages installed is not large.

[`h5py` 3.9 was released in June 2023](https://pypi.org/project/h5py/3.9.0/), so [SPEC 0](https://scientific-python.org/specs/spec-0000/) allows us to move ahead with this.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
