### PR TITLE
Make the string representation of the liter consistent between different unit formatters

### DIFF
--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -89,7 +89,6 @@ def_unit(
     1000 * cm**3.0,
     namespace=_ns,
     prefixes=True,
-    format={"latex": r"\mathcal{l}", "unicode": "ℓ"},
     doc="liter: metric unit of volume",
 )
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -1161,3 +1161,16 @@ def test_Fits_name_deprecation():
     ):
         from astropy.units.format import Fits
     assert Fits is u.format.FITS
+
+
+@pytest.mark.parametrize(
+    "format_spec",
+    [
+        "generic",
+        pytest.param(
+            "unicode", marks=pytest.mark.xfail(reason="regression test to reveal a bug")
+        ),
+    ],
+)
+def test_liter(format_spec):
+    assert format(u.liter, format_spec) == "l"

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -1163,14 +1163,6 @@ def test_Fits_name_deprecation():
     assert Fits is u.format.FITS
 
 
-@pytest.mark.parametrize(
-    "format_spec",
-    [
-        "generic",
-        pytest.param(
-            "unicode", marks=pytest.mark.xfail(reason="regression test to reveal a bug")
-        ),
-    ],
-)
+@pytest.mark.parametrize("format_spec", ["generic", "unicode"])
 def test_liter(format_spec):
     assert format(u.liter, format_spec) == "l"

--- a/docs/changes/units/18500.bugfix.rst
+++ b/docs/changes/units/18500.bugfix.rst
@@ -1,0 +1,4 @@
+The string representations of the liter with the different ``astropy`` unit
+formatters are now more consistent with each other.
+This change only affects converting units to strings, it has no effect on
+parsing strings to units.


### PR DESCRIPTION
### Description

According to Table 8. of the [SI brochure](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf) the symbol for the liter is `"l"` or `"L"`, but that is not how all the `astropy` unit formatters represent it:
```python
>>> from astropy import units as u
>>> u.liter.to_string("unicode")
'ℓ'
```
That the `"unicode"` (and `"latex"` and `"latex_inline"`) represent the liter differently is therefore a mistake that should be fixed. Using `"l"` (like some formats already do) is permitted by the SI brochure, but a footnote of Table 8. implies that using `"L"` should be preferred 
> in order to avoid the risk of confusion between the letter l (el) and the numeral 1 (one).

I have therefore opened this pull request by updating the string representation of the liter with all the unit formatters, but if the maintainers think backwards compatibility is more important than future usability then we could only update the formats that currently use `"ℓ"`.

EDIT: We decided to use `"l"` instead of `"L"`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
