### PR TITLE
Allow all angle-like `angle` arguments in `rotation_matrix()`

### DIFF
--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -55,18 +55,7 @@ def test_rotation_matrix():
 
 
 @pytest.mark.parametrize(
-    "angle",
-    [
-        Angle(0 * u.deg),
-        0 * u.deg,
-        np.array(0),
-        0,
-        pytest.param(
-            "0 deg",
-            marks=pytest.mark.xfail(reason="regression test that reveals a bug"),
-        ),
-    ],
-    ids=type,
+    "angle", [Angle(0 * u.deg), 0 * u.deg, np.array(0), 0, "0 deg"], ids=type
 )
 def test_rotation_angle_input_types(angle):
     assert_array_equal(rotation_matrix(angle), np.eye(3), strict=True)

--- a/docs/changes/coordinates/18504.bugfix.rst
+++ b/docs/changes/coordinates/18504.bugfix.rst
@@ -1,0 +1,4 @@
+The ``angle`` argument of the ``rotation_matrix()`` function can now be any
+angle-like value, like its docstring states.
+Previously some angle-like values (e.g. angle-like strings) were erroneously
+rejected.


### PR DESCRIPTION
### Description

According to the docstring the `angle` argument of `rotation_matrix()` is allowed to be angle-like, but since #9793 some angle-like values (e.g. strings) are erroneously rejected (as demonstrated by the regression test added in the first commit).

This pull request should not be backported to the `v7.1.x` branch because on that branch it is not clear if `rotation_matrix()` is public or private, and the change log should not contain entries about private implementation details. The bug fix could be backported, but without the change log entry.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
