### PR TITLE
Prefer module level imports in `coordinates`

### DIFF
--- a/astropy/coordinates/angles/utils.py
+++ b/astropy/coordinates/angles/utils.py
@@ -24,6 +24,8 @@ from astropy.coordinates.representation import (
 )
 from astropy.utils.compat import COPY_IF_NEEDED
 
+from .core import Angle
+
 _TWOPI = 2 * np.pi
 
 
@@ -84,8 +86,6 @@ def position_angle(lon1, lat1, lon2, lat2):
         following the appropriate `numpy` broadcasting rules.
 
     """
-    from .core import Angle
-
     deltalon = lon2 - lon1
     colat = np.cos(lat2)
 
@@ -114,8 +114,6 @@ def offset_by(lon, lat, posang, distance):
         these will contain arrays following the appropriate `numpy` broadcasting rules.
         0 <= lon < 2pi.
     """
-    from .core import Angle
-
     # Calculations are done using the spherical trigonometry sine and cosine rules
     # of the triangle A at North Pole,   B at starting point,   C at final point
     # with angles     A (change in lon), B (posang),            C (not used, but negative reciprocal posang)

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -5,6 +5,7 @@ import numpy as np
 
 # Project
 from astropy import units as u
+from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat import COPY_IF_NEEDED
 
@@ -200,8 +201,6 @@ class TimeAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
-        from astropy.time import Time
-
         if value is None:
             return None, False
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -31,9 +31,14 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
 from . import representation as r
-from .angles import Angle, Latitude, Longitude, position_angle
+from .angles import Angle, Latitude, Longitude, angular_separation, position_angle
 from .attributes import Attribute
-from .errors import NonRotationTransformationError, NonRotationTransformationWarning
+from .distances import Distance
+from .errors import (
+    ConvertError,
+    NonRotationTransformationError,
+    NonRotationTransformationWarning,
+)
 from .transformations import (
     DynamicMatrixTransform,
     StaticMatrixTransform,
@@ -1460,8 +1465,6 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
         ValueError
             If there is no possible transformation route.
         """
-        from .errors import ConvertError
-
         if self._data is None:
             raise ValueError("Cannot transform a frame with no data")
 
@@ -2062,8 +2065,6 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
         .. [1] https://en.wikipedia.org/wiki/Great-circle_distance
 
         """
-        from .angles import Angle, angular_separation
-
         return Angle(
             angular_separation(
                 *self._prepare_unit_sphere_coords(other, origin_mismatch)
@@ -2094,8 +2095,6 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
         ValueError
             If this or the other coordinate do not have distances.
         """
-        from .distances import Distance
-
         if isinstance(self.data, r.UnitSphericalRepresentation):
             raise ValueError(
                 "This object does not have a distance; cannot compute 3d separation."

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -2,6 +2,7 @@
 
 from astropy.coordinates.attributes import EarthLocationAttribute, TimeAttribute
 from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
+from astropy.coordinates.earth import EarthLocation
 from astropy.coordinates.representation import (
     CartesianDifferential,
     CartesianRepresentation,
@@ -79,8 +80,6 @@ class ITRS(BaseCoordinateFrame):
         """
         The data in this frame as an `~astropy.coordinates.EarthLocation` class.
         """
-        from astropy.coordinates.earth import EarthLocation
-
         cart = self.represent_as(CartesianRepresentation)
         return EarthLocation(
             x=cart.x + self.location.x,

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -16,14 +16,16 @@ from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
-from .angles import Angle
+from .angles import Angle, offset_by
 from .baseframe import (
     BaseCoordinateFrame,
     CoordinateFrameInfo,
     GenericFrame,
     frame_transform_graph,
 )
+from .builtin_frames import SkyOffsetFrame
 from .distances import Distance
+from .errors import ConvertError
 from .representation import (
     SphericalDifferential,
     SphericalRepresentation,
@@ -501,8 +503,6 @@ class SkyCoord(MaskableShapedLikeNDArray):
             If there is no possible transformation route.
 
         """
-        from astropy.coordinates.errors import ConvertError
-
         frame_kwargs = {}
 
         # Frame name (string) or frame class?  Coerce into an instance.
@@ -1127,8 +1127,6 @@ class SkyCoord(MaskableShapedLikeNDArray):
             inverse operation for the ``separation`` component
 
         """
-        from .angles import offset_by
-
         slat = self.represent_as(UnitSphericalRepresentation).lat
         slon = self.represent_as(UnitSphericalRepresentation).lon
 
@@ -1407,8 +1405,6 @@ class SkyCoord(MaskableShapedLikeNDArray):
             this object has an ICRS coordinate, the resulting frame is
             SkyOffsetICRS, with the origin set to this object)
         """
-        from .builtin_frames.skyoffset import SkyOffsetFrame
-
         return SkyOffsetFrame(origin=self, rotation=rotation)
 
     def get_constellation(self, short_name=False, constellation_list="iau"):
@@ -1541,8 +1537,6 @@ class SkyCoord(MaskableShapedLikeNDArray):
             ymax, xmax = image.shape
         else:
             xmax, ymax = wcs._naxis
-
-        import warnings
 
         with warnings.catch_warnings():
             #  Suppress warnings since they just mean we didn't find the coordinate

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -15,6 +15,7 @@ from .baseframe import (
     _get_repr_cls,
     frame_transform_graph,
 )
+from .builtin_frames import ICRS
 from .representation import (
     BaseRepresentation,
     SphericalRepresentation,
@@ -177,8 +178,6 @@ def _get_frame_without_data(args, kwargs):
                     )
 
     if frame_cls is None:
-        from .builtin_frames import ICRS
-
         frame_cls = ICRS
 
     # By now, frame_cls should be set - if it's not, something went wrong

--- a/astropy/coordinates/transformations/affine.py
+++ b/astropy/coordinates/transformations/affine.py
@@ -6,6 +6,13 @@ from abc import abstractmethod
 
 import numpy as np
 
+from astropy.coordinates.representation import (
+    CartesianDifferential,
+    RadialDifferential,
+    SphericalCosLatDifferential,
+    SphericalDifferential,
+    UnitSphericalRepresentation,
+)
 from astropy.coordinates.transformations.base import CoordinateTransform
 
 __all__ = [
@@ -32,14 +39,6 @@ class BaseAffineTransform(CoordinateTransform):
     """
 
     def _apply_transform(self, fromcoord, matrix, offset):
-        from astropy.coordinates.representation import (
-            CartesianDifferential,
-            RadialDifferential,
-            SphericalCosLatDifferential,
-            SphericalDifferential,
-            UnitSphericalRepresentation,
-        )
-
         data = fromcoord.data
         has_velocity = "s" in data.differentials
 

--- a/astropy/coordinates/transformations/function.py
+++ b/astropy/coordinates/transformations/function.py
@@ -10,6 +10,10 @@ from inspect import signature
 from warnings import warn
 
 from astropy import units as u
+from astropy.coordinates.representation import (
+    CartesianDifferential,
+    CartesianRepresentation,
+)
 from astropy.coordinates.transformations.base import CoordinateTransform
 from astropy.utils.exceptions import AstropyWarning
 
@@ -165,11 +169,6 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
         self._finite_difference_frameattr_name = value
 
     def __call__(self, fromcoord, toframe):
-        from astropy.coordinates.representation import (
-            CartesianDifferential,
-            CartesianRepresentation,
-        )
-
         supcall = self.func
         if not fromcoord.data.differentials:
             return supcall(fromcoord, toframe)


### PR DESCRIPTION
### Description

I am not aware of a good reason why imports should be done inside functions if they could be done at module level instead.

I did not look at the `coordinates` tests even though I know they are full of needless local imports.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
