### PR TITLE
Change the quotes in the repr of units from `"` to `'`

### DIFF
--- a/astropy/cosmology/_src/parameter/core.py
+++ b/astropy/cosmology/_src/parameter/core.py
@@ -274,7 +274,7 @@ class Parameter:
                   fvalidate='default', doc=None)
 
         >>> p.clone(unit="km")
-        Parameter(derived=False, unit=Unit("km"), equivalencies=[],
+        Parameter(derived=False, unit=Unit('km'), equivalencies=[],
                   fvalidate='default', doc=None)
         """
         kw.setdefault("fvalidate", self._fvalidate_in)  # prefer the input fvalidate

--- a/astropy/cosmology/_src/tests/parameter/test_parameter.py
+++ b/astropy/cosmology/_src/tests/parameter/test_parameter.py
@@ -405,8 +405,8 @@ class TestParameter(ParameterTestMixin):
         assert "Parameter(" in r
         for subs in (
             "derived=False",
-            'unit=Unit("m")',
-            'equivalencies=[(Unit("kg"), Unit("J")',
+            "unit=Unit('m')",
+            "equivalencies=[(Unit('kg'), Unit('J')",
             "doc='Description of example parameter.'",
         ):
             assert subs in r, subs

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -116,7 +116,7 @@ class NDData(NDDataBase):
         >>> nd2.data  # doctest: +FLOAT_CMP
         array([100., 200., 300., 400.])
         >>> nd2.unit
-        Unit("cm")
+        Unit('cm')
 
     See Also
     --------

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -520,8 +520,8 @@ def test_nddata_repr_dask():
     s = repr(arr)
     # just check repr equality for dask arrays, not round-tripping:
     assert s in (
-        'NDData(\n  data=dask.array<arange, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>,\n  unit=Unit("km")\n)',
-        'NDData(\n  data=dask.array<arange, shape=(3,), dtype=int32, chunksize=(3,), chunktype=numpy.ndarray>,\n  unit=Unit("km")\n)',
+        "NDData(\n  data=dask.array<arange, shape=(3,), dtype=int64, chunksize=(3,), chunktype=numpy.ndarray>,\n  unit=Unit('km')\n)",
+        "NDData(\n  data=dask.array<arange, shape=(3,), dtype=int32, chunksize=(3,), chunktype=numpy.ndarray>,\n  unit=Unit('km')\n)",
     )
 
 

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -74,7 +74,7 @@ class BoxLeastSquares(BasePeriodogram):
     >>> model = BoxLeastSquares(t, y)
     >>> results = model.autopower(0.16 * u.day)
     >>> results.period.unit
-    Unit("d")
+    Unit('d')
     >>> results.power.unit
     Unit(dimensionless)
 

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -84,7 +84,7 @@ class LombScargle(BasePeriodogram):
     >>> y = y * u.mag
     >>> frequency, power = LombScargle(t, y).autopower()
     >>> frequency.unit
-    Unit("1 / s")
+    Unit('1 / s')
     >>> power.unit
     Unit(dimensionless)
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -670,7 +670,7 @@ class UnitBase:
         return Generic.to_string(self)
 
     def __repr__(self) -> str:
-        return f'Unit("{self}")'
+        return f"Unit('{self}')"
 
     @cached_property
     def _physical_type_id(self) -> PhysicalTypeID:
@@ -1491,15 +1491,15 @@ class UnitBase:
         --------
         >>> import astropy.units as u
         >>> (u.N / u.m**2).to_system(u.si)  # preference for simpler units
-        [Unit("Pa"), Unit("N / m2"), Unit("J / m3")]
+        [Unit('Pa'), Unit('N / m2'), Unit('J / m3')]
         >>> u.Pa.to_system(u.cgs)
-        [Unit("10 Ba"), Unit("10 P / s")]
+        [Unit('10 Ba'), Unit('10 P / s')]
         >>> u.Ba.to_system(u.si)
-        [Unit("0.1 Pa"), Unit("0.1 N / m2"), Unit("0.1 J / m3")]
+        [Unit('0.1 Pa'), Unit('0.1 N / m2'), Unit('0.1 J / m3')]
         >>> (u.AU/u.yr).to_system(u.cgs)  # preference for base units
-        [Unit("474047 cm / s"), Unit("474047 Gal s")]
+        [Unit('474047 cm / s'), Unit('474047 Gal s')]
         >>> (u.m / u.s**2).to_system(u.cgs)
-        [Unit("100 cm / s2"), Unit("100 Gal")]
+        [Unit('100 cm / s2'), Unit('100 Gal')]
 
         """
         return sorted(

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -8,7 +8,7 @@ top-level `astropy.units` namespace, e.g.::
     >>> import astropy.units as u
     >>> mph = u.imperial.mile / u.hour
     >>> mph
-    Unit("mi / h")
+    Unit('mi / h')
 
 To include them in `~astropy.units.UnitBase.compose` and the results of
 `~astropy.units.UnitBase.find_equivalent_units`, do::

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -101,11 +101,11 @@ class StructuredUnit:
         >>> import astropy.units as u
         >>> su = u.Unit('(AU,AU/day),yr')
         >>> su
-        Unit("((AU, AU / d), yr)")
+        Unit('((AU, AU / d), yr)')
         >>> su.field_names
         (['f0', ('f0', 'f1')], 'f1')
         >>> su['f1']
-        Unit("yr")
+        Unit('yr')
         >>> su2 = u.StructuredUnit(((u.AU, u.AU/u.day), u.yr), names=(('p', 'v'), 't'))
         >>> su2 == su
         True
@@ -117,14 +117,14 @@ class StructuredUnit:
         >>> su3.keys()
         ('p_v', 't')
         >>> su3.values()
-        (Unit("(AU, AU / d)"), Unit("d"))
+        (Unit('(AU, AU / d)'), Unit('d'))
 
     Structured units share most methods with regular units::
 
         >>> su.physical_type
         astropy.units.structured.Structure((astropy.units.structured.Structure((PhysicalType('length'), PhysicalType({'speed', 'velocity'})), dtype=[('f0', 'O'), ('f1', 'O')]), PhysicalType('time')), dtype=[('f0', 'O'), ('f1', 'O')])
         >>> su.si
-        Unit("((1.49598e+11 m, 1.73146e+06 m / s), 3.15576e+07 s)")
+        Unit('((1.49598e+11 m, 1.73146e+06 m / s), 3.15576e+07 s)')
 
     """
 
@@ -492,7 +492,7 @@ class StructuredUnit:
         return self.to_string()
 
     def __repr__(self):
-        return f'Unit("{self.to_string()}")'
+        return f"Unit('{self.to_string()}')"
 
     def __eq__(self, other):
         try:

--- a/astropy/units/tests/test_structured.py
+++ b/astropy/units/tests/test_structured.py
@@ -228,7 +228,7 @@ class TestStructuredUnitBasics(StructuredTestBase):
 
     def test_repr(self):
         su = StructuredUnit(((u.km, u.km / u.s), u.yr))
-        assert repr(su) == 'Unit("((km, km / s), yr)")'
+        assert repr(su) == "Unit('((km, km / s), yr)')"
         assert eval(repr(su)) == su
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -129,7 +129,7 @@ def test_str():
 
 
 def test_repr():
-    assert repr(u.cm) == 'Unit("cm")'
+    assert repr(u.cm) == "Unit('cm')"
 
 
 def test_represents():
@@ -732,7 +732,7 @@ def test_duplicate_define(name):
         ValueError,
         match=(
             "^Object with NFKC normalized name 'h' already exists in given namespace "
-            r'\(Unit\("h"\)\)\.$'
+            r"\(Unit\('h'\)\)\.$"
         ),
     ):
         u.def_unit(name, u.hourangle, namespace=namespace)

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -536,7 +536,7 @@ lies in some less obvious attributes::
   {'l': 'lon', 'b': 'lat', 'distance': 'distance'}
 
   >>> sc_gal.representation_component_units
-  {'l': Unit("deg"), 'b': Unit("deg")}
+  {'l': Unit('deg'), 'b': Unit('deg')}
 
   >>> sc_gal.representation_type
   <class 'astropy.coordinates...SphericalRepresentation'>

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -98,7 +98,7 @@ floating point or array values::
   >>> from astropy.cosmology import WMAP9 as cosmo
   >>> H0 = cosmo.H(0)
   >>> H0.value, H0.unit  # doctest: +FLOAT_CMP
-  (np.float64(69.32), Unit("km / (Mpc s)"))
+  (np.float64(69.32), Unit('km / (Mpc s)'))
 
 
 Using `astropy.cosmology`

--- a/docs/io/unified_table_fits.rst
+++ b/docs/io/unified_table_fits.rst
@@ -42,7 +42,7 @@ If a column contains unit information, it will have an associated
 `astropy.units` object::
 
     >>> t["energy"].unit
-    Unit("eV")
+    Unit('eV')
 
 It is also possible to get directly a table with columns as
 `~astropy.units.Quantity` objects by using the `~astropy.table.QTable` class::

--- a/docs/modeling/units.rst
+++ b/docs/modeling/units.rst
@@ -37,7 +37,7 @@ It is then possible to access the individual properties of the parameter::
     >>> g1.mean.value
     np.float64(3.0)
     >>> g1.mean.unit
-    Unit("m")
+    Unit('m')
 
 If a parameter has been initialized as a Quantity, it should always be set to a
 quantity, but the units don't have to be compatible with the initial ones::

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -203,7 +203,7 @@ operation is between two `~astropy.nddata.CCDData` objects.
     >>> round(uncertainty_ratio, 5)   # doctest: +FLOAT_CMP
     np.float64(0.2)
     >>> result.unit
-    Unit("adu electron")
+    Unit('adu electron')
 
 .. note::
     The affiliated package `ccdproc <https://ccdproc.readthedocs.io>`_ provides

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -62,7 +62,7 @@ To wrap the result of an arithmetic operation between two Quantities::
     >>> ndd  # doctest: +FLOAT_CMP
     NDDataRef([10., 40.], unit='cm m')
     >>> ndd.unit
-    Unit("cm m")
+    Unit('cm m')
 
 Or take the inverse of an `~astropy.nddata.NDDataRef` object::
 
@@ -105,7 +105,7 @@ Adding two `~astropy.nddata.NDData` objects with the same unit works::
     >>> ndd.data  # doctest: +FLOAT_CMP
     array([101., 152., 203., 54., 505.])
     >>> ndd.unit
-    Unit("m")
+    Unit('m')
 
 Adding two `~astropy.nddata.NDData` objects with compatible units also works::
 
@@ -119,7 +119,7 @@ Adding two `~astropy.nddata.NDData` objects with compatible units also works::
     array([ -29.66013938,  -43.99020907,  -58.32027876,  -11.33006969,
            -148.30069689])
     >>> ndd.unit
-    Unit("pc")
+    Unit('pc')
 
 This will keep by default the unit of the first operand. However, units will
 not be decomposed during division::
@@ -128,7 +128,7 @@ not be decomposed during division::
     >>> ndd.data  # doctest: +FLOAT_CMP
     array([100. , 75. , 66.66666667, 12.5 , 100. ])
     >>> ndd.unit
-    Unit("lyr / pc")
+    Unit('lyr / pc')
 
 Mask
 ----

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -99,7 +99,7 @@ properties::
     >>> ndd2.data  # It has the same data as ndd
     array([1, 2, 3, 4])
     >>> ndd2.unit  # but it also has the same unit as ndd
-    Unit("m")
+    Unit('m')
 
 Another possibility is to use a `~astropy.units.Quantity` as a ``data``
 parameter::
@@ -110,7 +110,7 @@ parameter::
     >>> ndd3.data  # doctest: +FLOAT_CMP
     array([1., 1., 1.])
     >>> ndd3.unit
-    Unit("cm")
+    Unit('cm')
 
 Or a `numpy.ma.MaskedArray`::
 
@@ -130,7 +130,7 @@ explicit parameter will be used and an info message will be issued::
     >>> ndd6.data  # doctest: +FLOAT_CMP
     array([0.01, 0.01, 0.01])
     >>> ndd6.unit
-    Unit("m")
+    Unit('m')
 
 The unit of the `~astropy.units.Quantity` is being ignored and the unit is set
 to the explicitly passed one.
@@ -206,7 +206,7 @@ The ``unit`` represents the unit of the data values. It is required to be
     >>> import astropy.units as u
     >>> ndd = NDData([1, 2, 3, 4], unit="meter")  # using a string
     >>> ndd.unit
-    Unit("m")
+    Unit('m')
 
 ..note::
     Setting the ``unit`` on an instance is not possible.

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -1208,7 +1208,7 @@ a `~astropy.table.Column` object with a ``unit`` attribute::
   >>> type(t['velocity'])
   <class 'astropy.table.column.Column'>
   >>> t['velocity'].unit
-  Unit("m / s")
+  Unit('m / s')
 
 To learn more about using standard `~astropy.table.Column` objects with defined
 units, see the :ref:`columns_with_units` section.

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -92,10 +92,10 @@ attribute but does not have all of the features of a |Quantity|)::
   <class 'astropy.table.column.Column'>
 
   >>> t['velocity'].unit
-  Unit("m / s")
+  Unit('m / s')
 
   >>> (t['velocity'] ** 2).unit  # WRONG because Column is not smart about unit
-  Unit("m / s")
+  Unit('m / s')
 
 So instead let's do the same thing using a |QTable|::
 
@@ -112,10 +112,10 @@ The ``velocity`` column is now a |Quantity| and behaves accordingly::
   <class 'astropy.units.quantity.Quantity'>
 
   >>> qt['velocity'].unit
-  Unit("m / s")
+  Unit('m / s')
 
   >>> (qt['velocity'] ** 2).unit  # GOOD!
-  Unit("m2 / s2")
+  Unit('m2 / s2')
 
 You can conveniently convert |Table| to |QTable| and vice-versa::
 

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -1059,7 +1059,7 @@ To merge column attributes ``unit``, ``format``, or ``description``::
   MergeConflictWarning: In merged column 'a' the 'unit' attribute does
   not match (cm != m).  Using m for merged output
   >>> out['a'].unit
-  Unit("m")
+  Unit('m')
 
 The rules for merging are the same as for `Merging metadata`_, and the
 ``metadata_conflicts`` option also controls the merging of column attributes.

--- a/docs/timeseries/lombscargle.rst
+++ b/docs/timeseries/lombscargle.rst
@@ -129,7 +129,7 @@ To use the :class:`~astropy.timeseries.LombScargle` for
 >>> dy_mags = y * u.mag
 >>> frequency, power = LombScargle(t_days, y_mags, dy_mags).autopower()
 >>> frequency.unit
-Unit("1 / d")
+Unit('1 / d')
 >>> power.unit
 Unit(dimensionless)
 
@@ -456,7 +456,7 @@ power spectral density (PSD):
 >>> ls = LombScargle(t_days, y_mags, normalization='psd')
 >>> frequency, power = ls.autopower()
 >>> power.unit
-Unit("mag2")
+Unit('mag2')
 
 Note, however, that the ``normalization='psd'`` result only has these units
 *if uncertainties are not specified*. In the presence of uncertainties,

--- a/docs/uncertainty/index.rst
+++ b/docs/uncertainty/index.rst
@@ -188,7 +188,7 @@ the sampled distributions::
   >>> distr.size
   4
   >>> distr.unit
-  Unit("ct")
+  Unit('ct')
   >>> distr.n_samples
   1000
   >>> distr.pdf_mean() # doctest: +FLOAT_CMP

--- a/docs/units/combining_and_defining.rst
+++ b/docs/units/combining_and_defining.rst
@@ -12,7 +12,7 @@ numeric operators::
   >>> from astropy import units as u
   >>> fluxunit = u.erg / (u.cm ** 2 * u.s)
   >>> fluxunit
-  Unit("erg / (s cm2)")
+  Unit('erg / (s cm2)')
   >>> 52.0 * fluxunit  # doctest: +FLOAT_CMP
   <Quantity  52. erg / (s cm2)>
   >>> 52.0 * fluxunit / u.s  # doctest: +FLOAT_CMP
@@ -79,9 +79,9 @@ Users can see the definition of a unit and its :ref:`decomposition
 <decomposing>` via::
 
   >>> rofl.represents
-  Unit("4 guffaw")
+  Unit('4 guffaw')
   >>> rofl.decompose()
-  Unit("240 titter")
+  Unit('240 titter')
 
 By default, custom units are not searched by methods such as
 :meth:`~astropy.units.core.UnitBase.find_equivalent_units`. However, they

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -20,9 +20,9 @@ To decompose a unit with :meth:`~astropy.units.core.UnitBase.decompose`::
 
   >>> from astropy import units as u
   >>> u.Ry
-  Unit("Ry")
+  Unit('Ry')
   >>> u.Ry.decompose()
-  Unit("2.17987e-18 m2 kg / s2")
+  Unit('2.17987e-18 m2 kg / s2')
 
 To get the list of units in the decomposition, the
 `~astropy.units.core.UnitBase.bases` and `~astropy.units.core.UnitBase.powers`
@@ -30,13 +30,13 @@ properties can be used::
 
   >>> Ry = u.Ry.decompose()
   >>> [unit**power for unit, power in zip(Ry.bases, Ry.powers)]
-  [Unit("m2"), Unit("kg"), Unit("1 / s2")]
+  [Unit('m2'), Unit('kg'), Unit('1 / s2')]
 
 You can limit the selection of units that you want to decompose by
 using the ``bases`` keyword argument::
 
   >>> u.Ry.decompose(bases=[u.m, u.N])
-  Unit("2.17987e-18 N m")
+  Unit('2.17987e-18 N m')
 
 This is also useful to decompose to a particular system. For example,
 to decompose the Rydberg unit of energy in terms of `CGS
@@ -44,12 +44,12 @@ to decompose the Rydberg unit of energy in terms of `CGS
 units::
 
   >>> u.Ry.decompose(bases=u.cgs.bases)
-  Unit("2.17987e-11 cm2 g / s2")
+  Unit('2.17987e-11 cm2 g / s2')
 
 Finally, if you want to know how a unit was defined::
 
   >>> u.Ry.represents
-  Unit("13.6057 eV")
+  Unit('13.6057 eV')
 
 .. EXAMPLE END
 
@@ -69,43 +69,43 @@ To recompose a unit with :meth:`~astropy.units.core.UnitBase.compose`::
 
   >>> x = u.Ry.decompose()
   >>> x.compose()
-  [Unit("Ry"),
-   Unit("2.17987e-62 foe"),
-   Unit("2.17987e-18 J"),
-   Unit("2.17987e-11 erg"),
-   Unit("13.6057 eV")]
+  [Unit('Ry'),
+   Unit('2.17987e-62 foe'),
+   Unit('2.17987e-18 J'),
+   Unit('2.17987e-11 erg'),
+   Unit('13.6057 eV')]
 
 Some other interesting examples::
 
    >>> (u.s ** -1).compose()  # doctest: +SKIP
-   [Unit("Bq"), Unit("Hz"), Unit("2.7027e-11 Ci")]
+   [Unit('Bq'), Unit('Hz'), Unit('2.7027e-11 Ci')]
 
 Composition can be combined with :ref:`unit_equivalencies`::
 
    >>> (u.s ** -1).compose(equivalencies=u.spectral())  # doctest: +SKIP
-   [Unit("m"),
-    Unit("Hz"),
-    Unit("J"),
-    Unit("Bq"),
-    Unit("3.24078e-17 pc"),
-    Unit("1.057e-16 lyr"),
-    Unit("6.68459e-12 AU"),
-    Unit("1.4378e-09 solRad"),
-    Unit("0.01 k"),
-    Unit("100 cm"),
-    Unit("1e+06 micron"),
-    Unit("1e+07 erg"),
-    Unit("1e+10 Angstrom"),
-    Unit("3.7e+10 Ci"),
-    Unit("4.58743e+17 Ry"),
-    Unit("6.24151e+18 eV")]
+   [Unit('m'),
+    Unit('Hz'),
+    Unit('J'),
+    Unit('Bq'),
+    Unit('3.24078e-17 pc'),
+    Unit('1.057e-16 lyr'),
+    Unit('6.68459e-12 AU'),
+    Unit('1.4378e-09 solRad'),
+    Unit('0.01 k'),
+    Unit('100 cm'),
+    Unit('1e+06 micron'),
+    Unit('1e+07 erg'),
+    Unit('1e+10 Angstrom'),
+    Unit('3.7e+10 Ci'),
+    Unit('4.58743e+17 Ry'),
+    Unit('6.24151e+18 eV')]
 
 A name does not exist for every arbitrary derived unit
 imaginable. In that case, the system will do its best to reduce the
 unit to the fewest possible symbols::
 
    >>> (u.cd * u.sr * u.V * u.s).compose()
-   [Unit("Wb lm"), Unit("1e+08 Mx lm")]
+   [Unit('Wb lm'), Unit('1e+08 Mx lm')]
 
 .. EXAMPLE END
 
@@ -123,13 +123,13 @@ Examples
 To convert between unit systems::
 
    >>> u.Pa.to_system(u.cgs)
-   [Unit("10 Ba"), Unit("10 P / s")]
+   [Unit('10 Ba'), Unit('10 P / s')]
 
 There is also a shorthand for this which only returns the first of
 many possible matches::
 
    >>> u.Pa.cgs
-   Unit("10 Ba")
+   Unit('10 Ba')
 
 This is equivalent to decomposing into the new system and then
 composing into the simplest units possible in that system, though
@@ -139,10 +139,10 @@ units exists, it will be put sorted to the front::
 
    >>> unit = u.m**2 / u.s
    >>> unit.decompose(bases=u.cgs.bases)
-   Unit("10000 cm2 / s")
+   Unit('10000 cm2 / s')
    >>> _.compose(units=u.cgs)
-   [Unit("10000 St"), Unit("10000 cm2 / s")]
+   [Unit('10000 St'), Unit('10000 cm2 / s')]
    >>> unit.to_system(u.cgs)
-   [Unit("10000 cm2 / s"), Unit("10000 St")]
+   [Unit('10000 cm2 / s'), Unit('10000 St')]
 
 .. EXAMPLE END

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -127,11 +127,11 @@ Units can also be created from strings in a number of different
 formats using the `~astropy.units.Unit` class::
 
   >>> u.Unit("m")
-  Unit("m")
+  Unit('m')
   >>> u.Unit("erg / (s cm2)")
-  Unit("erg / (s cm2)")
+  Unit('erg / (s cm2)')
   >>> u.Unit("erg.s-1.cm-2", format="cds")
-  Unit("erg / (s cm2)")
+  Unit('erg / (s cm2)')
 
 It is also possible to create a scalar |Quantity| from a string::
 
@@ -301,7 +301,7 @@ code snippet shows how to set up Angstroem -> Angstrom::
     >>> u.set_enabled_aliases({"Angstroem": u.Angstrom})
     <astropy.units.core._UnitContext object at 0x...>
     >>> u.Unit("Angstroem")
-    Unit("Angstrom")
+    Unit('Angstrom')
     >>> u.Unit("Angstroem") == u.Angstrom
     True
 

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -48,7 +48,7 @@ value members::
     >>> q.value
     np.float64(42.0)
     >>> q.unit
-    Unit("m")
+    Unit('m')
 
 From this basic building block, it is possible to start combining
 quantities with different units::

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -61,7 +61,7 @@ The current unit and value can be accessed via the
 
     >>> q = 2.5 * u.m / u.s
     >>> q.unit
-    Unit("m / s")
+    Unit('m / s')
     >>> q.value
     np.float64(2.5)
 
@@ -297,7 +297,7 @@ u.km)`` is not scale-free by default:
 
     >>> q = (1. * u.m / u.km)
     >>> q.unit
-    Unit("m / km")
+    Unit('m / km')
     >>> q.unit.decompose()
     Unit(dimensionless with a scale of 0.001)
 
@@ -370,7 +370,7 @@ To verify if a |Quantity| argument can be used in calculations::
     ...     return myarg.unit
 
     >>> myfunction(100*u.arcsec)
-    Unit("arcsec")
+    Unit('arcsec')
     >>> myfunction(2*u.m)  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
@@ -385,7 +385,7 @@ It is also possible to instead specify the :ref:`physical type
     ...     return myarg.unit
 
     >>> myfunction(100*u.arcsec)
-    Unit("arcsec")
+    Unit('arcsec')
 
 Optionally, `None` keyword arguments are also supported; for such cases, the
 input is only checked when a value other than `None` is passed::
@@ -411,7 +411,7 @@ unit-aware Quantity-annotation syntax.
     ...     return myarg.unit
     >>>
     >>> myfunction(100*u.arcsec)
-    Unit("arcsec")
+    Unit('arcsec')
 
 You can also annotate for different types in non-unit expecting arguments:
 
@@ -419,7 +419,7 @@ You can also annotate for different types in non-unit expecting arguments:
     ... def myfunction(myarg: u.Quantity[u.arcsec], nice_string: str):
     ...     return myarg.unit, nice_string
     >>> myfunction(100*u.arcsec, "a nice string")
-    (Unit("arcsec"), 'a nice string')
+    (Unit('arcsec'), 'a nice string')
 
 The output can be specified to have a desired unit with a function annotation,
 for example
@@ -444,9 +444,9 @@ supported for functions that should accept inputs with multiple valid units:
     ...     return a.unit
 
     >>> myfunction(1.*u.km)
-    Unit("km")
+    Unit('km')
     >>> myfunction(1.*u.km/u.s)
-    Unit("km / s")
+    Unit('km / s')
 
 Representing Vectors with Units
 ===============================

--- a/docs/units/structured_units.rst
+++ b/docs/units/structured_units.rst
@@ -47,7 +47,7 @@ respectively. In addition, you can index any given field using its name::
          ([0., 1., 0.], [-0.125,  0.   ,  0.   ])],
         dtype=[('p', '<f8', (3,)), ('v', '<f8', (3,))])
   >>> pv.unit
-  Unit("(km, km / s)")
+  Unit('(km, km / s)')
   >>> pv['v']
   <Quantity [[ 0.   ,  0.125,  0.   ],
              [-0.125,  0.   ,  0.   ]] km / s>


### PR DESCRIPTION
### Description

The repr of Python strings uses `'`, not `"`, so to be consistent with that the repr of `astropy` units should also use `'`. The reason why `"` is currently used is a change in bd684a01ed3e969fde9be3c3eea3a1a19fc67e1c. From what I can tell the change was arbitrary and I couldn't find any discussion about it.

There is no change in the repr of `Quantity` and in any case APE 2 allows changing the output of `__repr__()` even in bugfix releases.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
