### PR TITLE
Remove needless `return` statements from `__init_subclass__()`

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -203,7 +203,7 @@ class _BaseHDU:
 
             cls.data = data_prop.deleter(data)
 
-        return super().__init_subclass__(**kwargs)
+        super().__init_subclass__(**kwargs)
 
     @property
     def header(self):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -189,7 +189,7 @@ class TimeFormat:
         if "subfmts" in cls.__dict__:
             cls.subfmts = _regexify_subfmts(cls.subfmts)
 
-        return super().__init_subclass__(**kwargs)
+        super().__init_subclass__(**kwargs)
 
     @classmethod
     def _get_allowed_subfmt(cls, subfmt):

--- a/astropy/utils/metadata/merge.py
+++ b/astropy/utils/metadata/merge.py
@@ -104,8 +104,6 @@ class MergeStrategy:
             for left, right in reversed(types):
                 MERGE_STRATEGIES.insert(0, (left, right, cls))
 
-        return cls
-
 
 class MergePlus(MergeStrategy):
     """


### PR DESCRIPTION
### Description

An `__init_subclass__()` class method is supposed to return `None`, and that can be done implicitly. I found an `__init_subclass__()` implementation in `utils` that erroneously returns the class instead of `None`. I then checked if there are any other erroneous implementations and found two that explicitly `return super().__init_subclass__(**kwargs)`. That's not necessarily wrong, but it does add verbosity for no benefit, so it's best not to do it.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
