### PR TITLE
Fix separability_matrix for CompoundModel with fix_inputs

### DIFF
--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -302,10 +302,23 @@ def _separable(transform):
         transform_matrix := transform._calculate_separability_matrix()
     ) is not NotImplemented:
         return transform_matrix
+
     elif isinstance(transform, CompoundModel):
+        if transform.op == "fix_inputs":
+            sepleft = _separable(transform.left)
+
+            fixed_inputs = set(transform.right.keys())
+            input_names = transform.left.inputs
+
+            keep_indices = [
+                i for i, name in enumerate(input_names) if name not in fixed_inputs
+            ]
+            return sepleft[:, keep_indices]
+
         sepleft = _separable(transform.left)
         sepright = _separable(transform.right)
         return _operators[transform.op](sepleft, sepright)
+
     elif isinstance(transform, Model):
         return _coord_matrix(transform, "left", transform.n_outputs)
 

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -22,6 +22,9 @@ from astropy.modeling.separable import (
     separability_matrix,
 )
 
+from astropy.modeling.models import Shift
+from astropy.modeling import CompoundModel
+
 sh1 = models.Shift(1, name="shift1")
 sh2 = models.Shift(2, name="sh2")
 scl1 = models.Scale(1, name="scl1")
@@ -191,3 +194,11 @@ def test_custom_model_separable():
 
     assert not model_c().separable
     assert np.all(separability_matrix(model_c()) == [True, True])
+
+def test_separability_with_fix_inputs():
+    s = Shift() & Shift() & Shift()
+    c = CompoundModel("fix_inputs", s, {"x0": 0.3})
+    mat = separability_matrix(c)
+
+    assert mat.shape == (3, 2)
+    assert mat.dtype == np.bool_

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -10,9 +10,9 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from astropy.modeling import custom_model, models
+from astropy.modeling import CompoundModel, custom_model, models
 from astropy.modeling.core import ModelDefinitionError
-from astropy.modeling.models import Mapping
+from astropy.modeling.models import Mapping, Shift
 from astropy.modeling.separable import (
     _arith_oper,
     _cdot,
@@ -21,9 +21,6 @@ from astropy.modeling.separable import (
     is_separable,
     separability_matrix,
 )
-
-from astropy.modeling.models import Shift
-from astropy.modeling import CompoundModel
 
 sh1 = models.Shift(1, name="shift1")
 sh2 = models.Shift(2, name="sh2")
@@ -194,6 +191,7 @@ def test_custom_model_separable():
 
     assert not model_c().separable
     assert np.all(separability_matrix(model_c()) == [True, True])
+
 
 def test_separability_with_fix_inputs():
     s = Shift() & Shift() & Shift()

--- a/docs/changes/modeling/18525.bugfix.rst
+++ b/docs/changes/modeling/18525.bugfix.rst
@@ -1,1 +1,1 @@
-Fix crash in ``separability_matrix`` when used with ``CompoundModel`` involving ``fix_inputs``. Now correctly handles fixed input dictionaries and returns expected separability matrix shape. (`#18523 <https://github.com/astropy/astropy/issues/18523>`__)
+Fixed crash in ``separability_matrix`` when used with ``CompoundModel`` involving ``fix_inputs``. Now correctly handles fixed input dictionaries and returns expected separability matrix shape.

--- a/docs/changes/modeling/18525.bugfix.rst
+++ b/docs/changes/modeling/18525.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash in ``separability_matrix`` when used with ``CompoundModel`` involving ``fix_inputs``. Now correctly handles fixed input dictionaries and returns expected separability matrix shape. (`#18523 <https://github.com/astropy/astropy/issues/18523>`__)


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes a bug in the separability_matrix function when used with compound models involving "fix_inputs" operations as reported in [#18523](https://github.com/astropy/astropy/issues/18523), calling separability_matrix() on models with fix_inputs would raise an AttributeError.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18523

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
