### PR TITLE
Fix bug where coordinate frame fails serializing to YAML

### DIFF
--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from yaml import SafeDumper
 
+import astropy.coordinates as coords
 import astropy.units as u
 from astropy.coordinates import (
     Angle,
@@ -223,14 +224,14 @@ def test_representations(rep):
     assert np.all(representation_equal(rrep, rep))
 
 
-@pytest.mark.parametrize(
-    "frame_cls",
-    [
-        cls
-        for cls in frame_transform_graph.frame_set
-        if cls.__module__.startswith("astropy.")
-    ],
+# Note: consistent test order (e.g. sorting) needed for parallel testing.
+frame_clss = sorted(
+    [cls for cls in frame_transform_graph.frame_set if cls.__name__ in dir(coords)],
+    key=lambda x: x.__name__,
 )
+
+
+@pytest.mark.parametrize("frame_cls", frame_clss)
 def test_frames(frame_cls):
     """Test that bare instances of built-in frames round-trip through YAML
 

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -223,11 +223,25 @@ def test_representations(rep):
     assert np.all(representation_equal(rrep, rep))
 
 
-@pytest.mark.parametrize("frame_cls", frame_transform_graph.frame_set)
+@pytest.mark.parametrize(
+    "frame_cls",
+    [
+        cls
+        for cls in frame_transform_graph.frame_set
+        if cls.__module__.startswith("astropy.")
+    ],
+)
 def test_frames(frame_cls):
+    """Test that bare instances of built-in frames round-trip through YAML
+
+    This excludes dynamically-created SkyOffset frames like ``abc.SkyOffsetAltAz``.
+    This one in particular fails tests since it tries to construct an ``AltAz``
+    instance. Possibly related to https://github.com/astropy/astropy/issues/10157.
+    """
     frame = frame_cls()
-    rframe = load(dump(frame))
-    compare_coord(frame, rframe, has_data=False)
+    frame_dump = dump(frame)
+    frame_rt = load(frame_dump)
+    compare_coord(frame, frame_rt, has_data=False)
 
 
 def _get_time():

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -329,25 +329,17 @@ for cls, tag in (
     AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
     AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
 
-# Add representations, differentials, frames defined in astropy.
-cls_coords = []
-cls_coords.extend(
+# Add representations, differentials, and built-in frames defined in astropy and in the
+# ``astropy.coordinates`` public API.
+cls_coords = [
     cls
     for cls in itertools.chain(
         coords.representation.REPRESENTATION_CLASSES.values(),
         coords.representation.DIFFERENTIAL_CLASSES.values(),
+        coords.frame_transform_graph.frame_set,
     )
-    if cls.__name__ in coords.representation.__all__
-)
-# Add built-in frame classes, excluding dynamically-created frames like
-# ``abc.SkyOffsetAltAz``. This one fails tests since it tries to construct an ``AltAz``
-# instance. Possibly related to https://github.com/astropy/astropy/issues/10157.
-cls_coords.extend(
-    cls
-    for cls in coords.frame_transform_graph.frame_set
-    if cls.__module__.startswith("astropy.")
-)
-
+    if cls.__name__ in dir(coords)
+]
 for cls in cls_coords:
     name = cls.__name__
     tag = "!astropy.coordinates." + name

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -55,6 +55,7 @@ Examples
 """
 
 import base64
+import itertools
 
 import numpy as np
 import yaml
@@ -328,15 +329,23 @@ for cls, tag in (
     AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
     AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
 
-for cls in list(coords.representation.REPRESENTATION_CLASSES.values()) + list(
-    coords.representation.DIFFERENTIAL_CLASSES.values()
-):
+# Add representations, differentials, frames defined in astropy.
+cls_coords = []
+cls_coords.extend(
+    cls
+    for cls in itertools.chain(
+        coords.representation.REPRESENTATION_CLASSES.values(),
+        coords.representation.DIFFERENTIAL_CLASSES.values(),
+    )
+    if cls.__name__ in coords.representation.__all__
+)
+cls_coords.extend(coords.frame_transform_graph.frame_set)
+
+for cls in cls_coords:
     name = cls.__name__
-    # Add representations/differentials defined in astropy.
-    if name in coords.representation.__all__:
-        tag = "!astropy.coordinates." + name
-        AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
-        AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
+    tag = "!astropy.coordinates." + name
+    AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
+    AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
 
 
 def load(stream):

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -339,7 +339,14 @@ cls_coords.extend(
     )
     if cls.__name__ in coords.representation.__all__
 )
-cls_coords.extend(coords.frame_transform_graph.frame_set)
+# Add built-in frame classes, excluding dynamically-created frames like
+# ``abc.SkyOffsetAltAz``. This one fails tests since it tries to construct an ``AltAz``
+# instance. Possibly related to https://github.com/astropy/astropy/issues/10157.
+cls_coords.extend(
+    cls
+    for cls in coords.frame_transform_graph.frame_set
+    if cls.__module__.startswith("astropy.")
+)
 
 for cls in cls_coords:
     name = cls.__name__

--- a/docs/changes/io.misc/18526.bugfix.rst
+++ b/docs/changes/io.misc/18526.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug where coordinate frame objects could not be serialized to YAML. This caused
+an exception when saving a ``SkyCoord`` object in particular frames like
+``galactocentric`` in which frame attributes are themselves a frame.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to fix a bug where trying to dump a coordinate frame object (e.g. `ICRS(ra=1*u.deg, dec=2*u.deg)` to YAML fails. This is an oversight in the astropyl YAML code. Serializing frames is required for a `SkyCoord` object with `frame="galactocentric"` which has attributes like `galcen_coord` that are a frame. This came up in https://stackoverflow.com/q/79735659/323631, where the user was trying to save such a coordinate to FITS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
