### PR TITLE
DOC: add a badge with currently supported Python versions (as of the latest stable release)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
 
 .. |Supported Python Versions| image:: https://img.shields.io/pypi/pyversions/astropy
     :target: https://pypi.org/project/astropy
-    :alt: Supported Python Versions
+    :alt: Supported Python Versions of latest released astropy
 
 .. |Zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4670728.svg
     :target: https://doi.org/10.5281/zenodo.4670728

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 ----
 
-|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Supported Python Versions| |Documentation Status| |Pre-Commit| |Ruff| |Zenodo|
 
 ----
 
@@ -104,6 +104,10 @@ Astropy is licensed under a 3-clause BSD style license - see the
 .. |PyPI Status| image:: https://img.shields.io/pypi/v/astropy.svg
     :target: https://pypi.org/project/astropy
     :alt: Astropy's PyPI Status
+
+.. |Supported Python Versions| image:: https://img.shields.io/pypi/pyversions/astropy
+    :target: https://pypi.org/project/astropy
+    :alt: Supported Python Versions
 
 .. |Zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4670728.svg
     :target: https://doi.org/10.5281/zenodo.4670728


### PR DESCRIPTION
### Description
This came up earlier today on Slack. @kelle thought this would improve discoverability and help answer the one question she gets most often: "Does astropy support Python x.y ?" (where I really hope x==3 by now)

I think we previously discussed this exact idea with @pllim and @bsipocz but I wasn't able to find back where. Anyway, if I recall correctly, I was the one opposing this addition, and I now changed my mind, so hopefully it's consensual now ? ^^'

preview:
<img width="866" height="275" alt="Screenshot 2025-08-20 at 21 40 06" src="https://github.com/user-attachments/assets/5e77fe23-8552-45e8-8f4a-cd591c56f7c2" />

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
