### PR TITLE
TST: avoid a deprecation warning from numpy 2.4 (`np.testing.suppress_warnings` is deprecated)

### DIFF
--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
+import warnings
 
 import numpy as np
 import pytest
@@ -72,15 +73,15 @@ def test_nanmean_reduceat():
 
     data = data.astype("float")
     data[::2] = np.nan
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(RuntimeWarning, "Mean of empty slice")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Mean of empty slice", RuntimeWarning)
         reduceat_output2 = reduceat(data, indices, np.nanmean)
     nanmean_output2 = nanmean_reduceat(data, indices)
     assert_equal(reduceat_output2, nanmean_output2)
 
     data[:] = np.nan
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(RuntimeWarning, "Mean of empty slice")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Mean of empty slice", RuntimeWarning)
         reduceat_output3 = reduceat(data, indices, np.nanmean)
     nanmean_output3 = nanmean_reduceat(data, indices)
     assert_equal(reduceat_output3, nanmean_output3)


### PR DESCRIPTION
### Description
[Example logs](https://github.com/astropy/astropy/actions/runs/17108671075/job/48524205092?pr=18537)
xref https://github.com/numpy/numpy/pull/29550

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
