### PR TITLE
Change the error for invalid site name types

### DIFF
--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -52,18 +52,19 @@ class SiteRegistry(Mapping):
         site : `~astropy.coordinates.EarthLocation`
             The location of the observatory.
         """
-        if site_name.lower() not in self._lowercase_names_to_locations:
-            # If site name not found, find close matches and suggest them in error
-            close_names = get_close_matches(
-                site_name, self._lowercase_names_to_locations
-            )
-            close_names = sorted(close_names, key=len)
-
+        try:
+            return self._lowercase_names_to_locations[site_name.lower()]
+        except KeyError:
             raise UnknownSiteException(
-                site_name, "the 'names' attribute", close_names=close_names
-            )
-
-        return self._lowercase_names_to_locations[site_name.lower()]
+                site=site_name,
+                attribute="the 'names' attribute",
+                close_names=sorted(
+                    get_close_matches(site_name, self._lowercase_names_to_locations),
+                    key=len,
+                ),
+            ) from None
+        except AttributeError:
+            raise TypeError(f"site name {site_name!r} is not a 'str'") from None
 
     def __len__(self) -> int:
         return len(self._lowercase_names_to_locations)

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -91,6 +91,9 @@ def test_EarthLocation_basic():
     ):
         EarthLocation.of_site("nonexistent")
 
+    with pytest.raises(TypeError, match="^site name None is not a 'str'$"):
+        EarthLocation.of_site(None)
+
 
 @pytest.mark.parametrize(
     "class_method,args",


### PR DESCRIPTION
### Description

The site registry (used e.g. in `EarthLocation.of_site()`) expects site names to be strings. Previously if an instance of an incorrect type was passed in an `AttributeError` was raised, but now a less surprising `TypeError` is produced.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
