### PR TITLE
Document ability to explicitly set axis units with Matplotlib

### DIFF
--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -158,3 +158,15 @@ def test_small_range():
 
     # check uniqueness of labels
     assert len(set(labels)) == len(labels)
+
+
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
+def test_override_axis_unit():
+    fig = Figure()
+    ax = fig.add_subplot()
+
+    with quantity_support():
+        ax.plot([1, 2, 3] * u.m)
+        ax.yaxis.set_units(u.cm)
+        fig.canvas.draw()
+        assert ax.yaxis.get_units() == u.cm

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -19,12 +19,18 @@ def quantity_support(format="latex_inline"):
       >>> from astropy import units as u
       >>> from astropy import visualization
       >>> with visualization.quantity_support():
-      ...     plt.figure()
-      ...     plt.plot([1, 2, 3] * u.m)
+      ...     fig, ax = plt.subplots()
+      ...     ax.plot([1, 2, 3] * u.m)
       [...]
-      ...     plt.plot([101, 125, 150] * u.cm)
+      ...     ax.plot([101, 125, 150] * u.cm)
       [...]
+      ...     ax.yaxis.set_units(u.km)
       ...     plt.draw()
+
+    The default axis unit is inferred from the first plot using a Quantity.
+    To override it, you can explicitly set the axis unit using
+    :meth:`matplotlib.axis.Axis.set_units`, for example,
+    ``ax.yaxis.set_units(u.km)``.
 
     Parameters
     ----------

--- a/docs/visualization/matplotlib_integration.rst
+++ b/docs/visualization/matplotlib_integration.rst
@@ -40,6 +40,21 @@ though the second line is given in ``cm``:
 
     ax.plot([1, 2, 3] * u.cm)
 
+If you want more control, you can explicitly set the units for the x-axis
+and/or y-axis by passing a unit argument to ``ax.xaxis.set_units()`` or
+``ax.yaxis.set_units()``.
+
+For example, you can set the y-axis units to centimeters:
+
+.. plot::
+    :include-source:
+    :context:
+
+    ax.yaxis.set_units(u.cm)
+
+This keeps the axis units fixed, regardless of the data's units or plot order.
+For more information, see the Matplotlib documentation for :meth:`matplotlib.axis.Axis.set_units`.
+
 Plotting a quantity with an incompatible unit will raise an exception.
 For example, calling ``ax.plot([1, 2, 3] * u.kg)`` (mass unit) to overplot
 on the plot above that is displaying length units.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR adds documentation to address the issue raised in #18540, where users found the behavior of axis units confusing. Specifically, the order of plots determined the units of the axis, causing inconsistencies when reordering the plots.

The update provides examples and clear instructions on how to set the axis units explicitly using `matplotlib.axis.Axis.set_units`.

Closes #18540

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
