### PR TITLE
Remove clutter from `UnitBase.to_string()` error messages

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -744,12 +744,13 @@ class UnitBase:
         from .format import get_format
 
         try:
-            return get_format(format).to_string(self, **kwargs)
+            formatter = get_format(format)
         except (TypeError, ValueError) as err:
             from .format import known_formats
 
             err.add_note(known_formats())
             raise err
+        return formatter.to_string(self, **kwargs)
 
     def __format__(self, format_spec: str) -> str:
         try:

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -608,7 +608,6 @@ def test_multiline_fraction_different_if_available(format_spec):
         assert multiline_format != inline_format
 
 
-@pytest.mark.xfail(reason="regression test that reveals a bug")
 @pytest.mark.parametrize("format_spec", u_format.Base.registry)
 def test_unknown_fraction_style(format_spec):
     fluxunit = u.W / u.m**2

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -608,10 +608,11 @@ def test_multiline_fraction_different_if_available(format_spec):
         assert multiline_format != inline_format
 
 
+@pytest.mark.xfail(reason="regression test that reveals a bug")
 @pytest.mark.parametrize("format_spec", u_format.Base.registry)
 def test_unknown_fraction_style(format_spec):
     fluxunit = u.W / u.m**2
-    msg = "fraction can only be False, 'inline', or 'multiline', not 'parrot'"
+    msg = r"^fraction can only be False, 'inline', or 'multiline', not 'parrot'\.$"
     with pytest.raises(ValueError, match=msg):
         fluxunit.to_string(format_spec, fraction="parrot")
 


### PR DESCRIPTION
### Description

If `UnitBase.to_string()` raises an error then the message can contain irrelevant and misleading text about unit formatters:
```
>>> from astropy import units as u
>>> (u.m / u.s).to_string(format="unicode", fraction="foo")
Traceback (most recent call last):
  ...
ValueError: fraction can only be False, 'inline', or 'multiline', not 'foo'.
Valid formatter names are: 'cds', 'console', 'generic', 'fits', 'latex', 'latex_inline', 'ogip', 'unicode', 'vounit'
```
The updated code only complains about the formatter if that was the cause of the error.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
