### PR TITLE
DOC/TST: adjust a doctest for compatibility with pyerfa-dev

### DIFF
--- a/docs/units/structured_units.rst
+++ b/docs/units/structured_units.rst
@@ -117,7 +117,7 @@ To use a position-velocity structured array with |PyERFA|::
   >>> erfa.pvu(86400*u.s, pv)
   <Quantity [([ 1.   ,  0.125,  0.   ], [ 0.   ,  0.125,  0.   ]),
              ([-0.125,  1.   ,  0.   ], [-0.125,  0.   ,  0.   ])] (AU, AU / d)>
-  >>> erfa.pv2s(pv)  # doctest: +FLOAT_CMP
+  >>> tuple(erfa.pv2s(pv))  # doctest: +FLOAT_CMP
   (<Quantity [0.        , 1.57079633] rad>,
    <Quantity [0., 0.] rad>,
    <Quantity [1., 1.] AU>,


### PR DESCRIPTION
### Description

[example logs](https://github.com/astropy/astropy/actions/runs/17200700356/job/48790582091)
xref: https://github.com/liberfa/pyerfa/pull/176

I took the path of least resistance to fix this: explicit conversion to a builtin `tuple` is a no-op (well, technically, it creates a copy) on older `pyerfa`, and restores the repr with the dev version.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
