### PR TITLE
Improve the error message in case of unit name collisions

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1839,12 +1839,20 @@ class NamedUnit(UnitBase):
 
         # Loop through all of the names first, to ensure all of them
         # are new, then add them all as a single "transaction" below.
-        for name in (unicodedata.normalize("NFKC", name) for name in self._names):
-            if name in namespace and self != namespace[name]:
-                raise ValueError(
-                    f"Object with NFKC normalized name {name!r} already exists in "
-                    f"given namespace ({namespace[name]!r})."
+        for name in self._names:
+            nfkc_name = unicodedata.normalize("NFKC", name)
+            if nfkc_name in namespace and self != (obj := namespace[nfkc_name]):
+                msg = (
+                    f"the namespace already uses the name {name!r} for {obj!r}"
+                    if name == nfkc_name
+                    else (
+                        "the namespace already uses the NFKC normalized name "
+                        f"{nfkc_name!r} for {obj!r}\n\nSee "
+                        "https://docs.python.org/3/reference/lexical_analysis.html#identifiers "
+                        "for more information."
+                    )
                 )
+                raise ValueError(msg)
 
         for name in self._names:
             namespace[name] = self

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -720,21 +720,29 @@ def test_pickle_unrecognized_unit():
 
 
 @pytest.mark.parametrize(
-    "name",
+    "name,message",
     [
-        pytest.param("h", id="simple_conflict"),
-        pytest.param("ʰ", id="NFKC_normalization"),
+        pytest.param(
+            "h",
+            r"^the namespace already uses the name 'h' for Unit\(\"h\"\)$",
+            id="simple_conflict",
+        ),
+        pytest.param(
+            "ʰ",
+            (
+                "^the namespace already uses the NFKC normalized name 'h' for "
+                r'Unit\("h"\)'
+                "\n\nSee "
+                "https://docs.python.org/3/reference/lexical_analysis.html#identifiers "
+                r"for more information\.$"
+            ),
+            id="NFKC_normalization",
+        ),
     ],
 )
-def test_duplicate_define(name):
+def test_duplicate_define(name, message):
     namespace = {"h": u.h}
-    with pytest.raises(
-        ValueError,
-        match=(
-            "^Object with NFKC normalized name 'h' already exists in given namespace "
-            r'\(Unit\("h"\)\)\.$'
-        ),
-    ):
+    with pytest.raises(ValueError, match=message):
         u.def_unit(name, u.hourangle, namespace=namespace)
 
 


### PR DESCRIPTION
### Description

The machinery that injects units into a namespace checks for name collisions. Because [Python applies NFKC normalization to identifiers](https://docs.python.org/3/reference/lexical_analysis.html#identifiers) then a name collision can occur even if before normalization the names are different. Currently the error message that gets produced always mentions NFKC normalization. I am willing to guess that the typical `astropy` user is not very familiar neither with Unicode normalization in general, nor with NFKC in particular, so the current error message is both needlessly confusing if NFKC normalization is not required for a name collision, and not informative enough if it is required. The updated error message is an improvement in both cases.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
