### PR TITLE
Stop inserting non-NFKC names to unit definition module `__all__` lists

### DIFF
--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -12,8 +12,8 @@ import numpy as np
 from astropy.constants import si as _si
 
 from . import si
-from .core import UnitBase, def_unit, set_enabled_units
-from .docgen import generate_unit_summary
+from .core import def_unit, set_enabled_units
+from .docgen import generate_dunder_all, generate_unit_summary
 
 # To ensure si units of the constants can be interpreted.
 set_enabled_units([si])
@@ -218,7 +218,7 @@ def_unit(
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -40,8 +40,8 @@ import numpy as np
 
 from astropy.constants import si as _si
 
-from .core import UnitBase, binary_prefixes, def_unit, set_enabled_units, si_prefixes
-from .docgen import generate_unit_summary
+from .core import binary_prefixes, def_unit, set_enabled_units, si_prefixes
+from .docgen import generate_dunder_all, generate_unit_summary
 
 _ns = globals()
 
@@ -184,7 +184,7 @@ _initialize_module()
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/cgs.py
+++ b/astropy/units/cgs.py
@@ -11,8 +11,8 @@ from fractions import Fraction
 import numpy as np
 
 from . import si
-from .core import UnitBase, def_unit
-from .docgen import generate_unit_summary
+from .core import def_unit
+from .docgen import generate_dunder_all, generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -184,7 +184,7 @@ bases = {cm, g, s, rad, cd, K, mol}
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/deprecated.py
+++ b/astropy/units/deprecated.py
@@ -23,8 +23,12 @@ from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import astrophys, cgs
-from .core import UnitBase, _add_prefixes, add_enabled_units, def_unit
-from .docgen import generate_prefixonly_unit_summary, generate_unit_summary
+from .core import _add_prefixes, add_enabled_units, def_unit
+from .docgen import (
+    generate_dunder_all,
+    generate_prefixonly_unit_summary,
+    generate_unit_summary,
+)
 
 local_units = {}
 
@@ -35,9 +39,7 @@ _add_prefixes(astrophys.earthMass, namespace=local_units, prefixes=True)
 _add_prefixes(astrophys.jupiterRad, namespace=local_units, prefixes=True)
 _add_prefixes(astrophys.earthRad, namespace=local_units, prefixes=True)
 
-__all__ = [
-    name for (name, member) in local_units.items() if isinstance(member, UnitBase)
-]
+__all__ = generate_dunder_all(local_units)  # noqa: PLE0605
 __all__ += ["enable"]
 
 if __doc__ is not None:

--- a/astropy/units/docgen.py
+++ b/astropy/units/docgen.py
@@ -7,6 +7,7 @@ package.
 """
 
 import re
+import unicodedata
 from collections.abc import Iterable, Mapping
 from io import StringIO
 
@@ -130,3 +131,11 @@ def generate_prefixonly_unit_summary(namespace: Mapping[str, object]) -> str:
      - Only
 """
     return _summarize_units(non_prefixed_units, set(), StringIO(), template)
+
+
+def generate_dunder_all(namespace: Mapping[str, object]) -> list[str]:
+    return [
+        name
+        for name, value in namespace.items()
+        if isinstance(value, UnitBase) and name == unicodedata.normalize("NFKC", name)
+    ]

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -12,6 +12,8 @@ All units are also available in (and should be used through) the
 `astropy.units` namespace.
 """
 
+import unicodedata
+
 from astropy.units import photometric
 from astropy.units.core import CompositeUnit, UnitBase, _add_prefixes
 
@@ -70,7 +72,11 @@ m_bol.__doc__ = (
 ###########################################################################
 # DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, (UnitBase, MagUnit))]
+__all__ += [
+    n
+    for n, v in _ns.items()
+    if isinstance(v, (UnitBase, MagUnit)) and unicodedata.normalize("NFKC", n) == n
+]
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -22,8 +22,8 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 __all__: list[str] = []  #  Units are added at the end
 
 from . import si
-from .core import UnitBase, add_enabled_units, def_unit
-from .docgen import generate_unit_summary
+from .core import add_enabled_units, def_unit
+from .docgen import generate_dunder_all, generate_unit_summary
 
 _ns = globals()
 
@@ -157,7 +157,7 @@ def_unit(
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/misc.py
+++ b/astropy/units/misc.py
@@ -12,8 +12,8 @@ import numpy as np
 from astropy.constants import si as _si
 
 from . import si
-from .core import UnitBase, binary_prefixes, def_unit, si_prefixes
-from .docgen import generate_unit_summary
+from .core import binary_prefixes, def_unit, si_prefixes
+from .docgen import generate_dunder_all, generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -154,7 +154,7 @@ def_unit(
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 
 if __doc__ is not None:

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -16,8 +16,8 @@ import numpy as np
 from astropy.constants.si import L_bol0
 
 from . import astrophys, cgs, si
-from .core import UnitBase, def_unit
-from .docgen import generate_unit_summary
+from .core import def_unit
+from .docgen import generate_dunder_all, generate_unit_summary
 
 __all__ = []  #  Units are added at the end
 
@@ -72,7 +72,7 @@ def_unit(
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 
 if __doc__ is not None:

--- a/astropy/units/required_by_vounit.py
+++ b/astropy/units/required_by_vounit.py
@@ -9,14 +9,18 @@ possible for the non-prefixed unit, ``astropy.units.solMass``.
 """
 
 from . import astrophys
-from .core import UnitBase, _add_prefixes
-from .docgen import generate_prefixonly_unit_summary, generate_unit_summary
+from .core import _add_prefixes
+from .docgen import (
+    generate_dunder_all,
+    generate_prefixonly_unit_summary,
+    generate_unit_summary,
+)
 
 _add_prefixes(astrophys.solMass, namespace=globals(), prefixes=True)
 _add_prefixes(astrophys.solRad, namespace=globals(), prefixes=True)
 _add_prefixes(astrophys.solLum, namespace=globals(), prefixes=True)
 
-__all__ = [name for (name, member) in globals().items() if isinstance(member, UnitBase)]
+__all__ = generate_dunder_all(globals())  # noqa: PLE0605
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -8,8 +8,8 @@ This package defines the SI units.  They are also available in
 
 import numpy as np
 
-from .core import CompositeUnit, UnitBase, def_unit
-from .docgen import generate_unit_summary
+from .core import CompositeUnit, def_unit
+from .docgen import generate_dunder_all, generate_unit_summary
 
 __all__: list[str] = []  #  Units are added at the end
 
@@ -478,7 +478,7 @@ bases = {m, s, kg, A, cd, rad, K, mol}
 ###########################################################################
 # ALL & DOCSTRING
 
-__all__ += [n for n, v in _ns.items() if isinstance(v, UnitBase)]
+__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 if __doc__ is not None:
     # This generates a docstring for this module that describes all of the

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -746,7 +746,6 @@ def test_duplicate_define(name, message):
         u.def_unit(name, u.hourangle, namespace=namespace)
 
 
-@pytest.mark.xfail(reason="regression test to reveal a bug")
 def test_unit_module_dunder_all_nfkc_normalization():
     # Python applies NFKC normalization to identifiers, so inserting a name to __all__
     # that changes with NFKC normalization can only cause trouble.


### PR DESCRIPTION
### Description

The regression test in the first commit reveals that unit definition modules can insert names into their `__all__` lists that are not NFKC normalized. Such names are invalid because [Python automatically applies NFKC normalization to all identifiers](https://docs.python.org/3/reference/lexical_analysis.html#identifiers). However, the automatic NFKC normalization also means that e.g.
```python
>>> from astropy import units as u
>>> u.ℓ
Unit("l")
```
with or without this patch, so the changes here are in fact fully backwards-compatible and a change log entry is not required.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
