### PR TITLE
Ensure no global changes to the warnings filter.

### DIFF
--- a/astropy/units/scripts/typestubs_for_units.py
+++ b/astropy/units/scripts/typestubs_for_units.py
@@ -35,9 +35,6 @@ MODULES_TO_STUB = [
     "required_by_vounit",
 ]
 
-# ignore deprecation warnings triggered by accessing units in deprecated.py
-warnings.simplefilter("ignore", AstropyDeprecationWarning)
-
 
 def main():
     args = _parse_args()
@@ -46,17 +43,19 @@ def main():
 
     log.info("Generating astropy.units stubs...")
 
-    for module_name in MODULES_TO_STUB:
-        full_module_name = f"astropy.units.{module_name}"
-        try:
-            module = importlib.import_module(full_module_name)
-        except ImportError:
-            log.warning(f"Could not import {full_module_name}, skipping.")
-            continue
+    # Ignore deprecation warnings triggered by accessing units in deprecated.py
+    with warnings.catch_warnings(action="ignore", category=AstropyDeprecationWarning):
+        for module_name in MODULES_TO_STUB:
+            full_module_name = f"astropy.units.{module_name}"
+            try:
+                module = importlib.import_module(full_module_name)
+            except ImportError:
+                log.warning(f"Could not import {full_module_name}, skipping.")
+                continue
 
-        stub_file_path = _get_stub_filepath(args.output_dir, module_name)
-        stub_lines = generate_stub_lines(module)
-        _write_stub_file(stub_file_path, stub_lines)
+            stub_file_path = _get_stub_filepath(args.output_dir, module_name)
+            stub_lines = generate_stub_lines(module)
+            _write_stub_file(stub_file_path, stub_lines)
 
 
 def generate_stub_lines(module) -> Iterator[str]:

--- a/astropy/units/tests/test_typestubs_for_units.py
+++ b/astropy/units/tests/test_typestubs_for_units.py
@@ -2,10 +2,7 @@ import sys
 import textwrap
 from pathlib import Path
 
-import pytest
-
 from astropy.units.scripts import typestubs_for_units
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_typestubs_for_units_script(tmp_path: Path, monkeypatch):
@@ -22,14 +19,7 @@ def test_typestubs_for_units_script(tmp_path: Path, monkeypatch):
     )
 
     # --- generate the stub files ---
-    # Even though the script filters the astropy.units.deprecated module's
-    # warnings for the user, pytest's warning capture system will still
-    # see them. We use pytest.warns to acknowledge these expected warnings
-    # and prevent test failure.
-    # FUTURE MAINTENANCE: When the astropy.units.deprecated module
-    # is removed, this pytest.warns() context manager should be removed.
-    with pytest.warns(AstropyDeprecationWarning):
-        typestubs_for_units.main()
+    typestubs_for_units.main()
 
     # --- spot-check the fundamental si.pyi file ---
     si_stub = tmp_path / "si.pyi"


### PR DESCRIPTION
Fixes #18567.

Ping @nstarman, @mikez - I think this ensures that we don't show DeprecationWarnings yet do not affect code running later. I found that the test now no longer has to worry about them, so it seems better.