### PR TITLE
Use matmul instead of dot, avoiding reshapes.

### DIFF
--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -57,7 +57,7 @@ def spherical2cartesian(alpha, delta):
     x = np.cos(alpha) * cosd
     y = cosd * np.sin(alpha)
     z = np.sin(delta)
-    return np.array([x, y, z])
+    return x, y, z
 
 
 def cartesian2spherical(x, y, z):
@@ -127,13 +127,9 @@ class RotationSequence3D(Model):
         """
         if x.shape != y.shape or x.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
-        # Note: If the original shape was () (an array scalar) convert to a
-        # 1-element 1-D array on output for consistency with most other models
-        orig_shape = x.shape or (1,)
-        inarr = np.array([x.ravel(), y.ravel(), z.ravel()])
-        result = np.dot(_create_matrix(angles[0], self.axes_order), inarr)
-        x, y, z = np.reshape(result, (3, *orig_shape))
-        return x, y, z
+        inarr = np.stack([x, y, z], axis=-2)
+        result = np.matmul(_create_matrix(angles[0], self.axes_order), inarr)
+        return tuple(np.moveaxis(result, -2, 0))
 
 
 class SphericalRotationSequence(RotationSequence3D):
@@ -181,19 +177,10 @@ class _EulerRotation:
     _separable = False
 
     def evaluate(self, alpha, delta, phi, theta, psi, axes_order):
-        shape = None
-        if isinstance(alpha, np.ndarray):
-            alpha = alpha.ravel()
-            delta = delta.ravel()
-            shape = alpha.shape
-        inp = spherical2cartesian(alpha, delta)
         matrix = _create_matrix([phi, theta, psi], axes_order)
-        result = np.dot(matrix, inp)
-        a, b = cartesian2spherical(*result)
-        if shape is not None:
-            a = a.reshape(shape)
-            b = b.reshape(shape)
-        return a, b
+        inp = np.stack(np.atleast_1d(spherical2cartesian(alpha, delta)), axis=-2)
+        result = np.matmul(matrix, inp)
+        return cartesian2spherical(*np.moveaxis(result, -2, 0))
 
     _input_units_strict = True
 
@@ -536,14 +523,11 @@ class Rotation2D(Model):
             else:
                 raise u.UnitsError("x and y must have compatible units")
 
-        # Note: If the original shape was () (an array scalar) convert to a
-        # 1-element 1-D array on output for consistency with most other models
-        orig_shape = x.shape or (1,)
-        inarr = np.array([x.ravel(), y.ravel()])
+        inarr = np.stack(np.atleast_1d(x, y), axis=-2)
         if isinstance(angle, u.Quantity):
             angle = angle.to_value(u.rad)
-        result = np.dot(cls._compute_matrix(angle), inarr)
-        x, y = np.reshape(result, (2, *orig_shape))
+        res = np.matmul(cls._compute_matrix(angle), inarr)
+        x, y = np.moveaxis(res, -2, 0)
         if has_units:
             return u.Quantity(x, unit=x_unit, subok=True), u.Quantity(
                 y, unit=y_unit, subok=True

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -509,14 +509,7 @@ class Rotation2D(Model):
             If float, assumed in degrees.
 
         """
-        if x.shape != y.shape:
-            raise ValueError("Expected input arrays to have the same shape")
-        try:
-            inarr = np.stack(np.atleast_1d(x, y), axis=-2)
-        except u.UnitsError:
-            # Keep error message the same as it was with an explicit check.
-            raise u.UnitsError("x and y must have compatible units") from None
-
+        inarr = np.stack(np.atleast_1d(x, y), axis=-2)
         if isinstance(angle, u.Quantity):
             angle = angle.to_value(u.rad)
         x, y = np.moveaxis(np.matmul(cls._compute_matrix(angle), inarr), -2, 0)

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -511,27 +511,15 @@ class Rotation2D(Model):
         """
         if x.shape != y.shape:
             raise ValueError("Expected input arrays to have the same shape")
+        try:
+            inarr = np.stack(np.atleast_1d(x, y), axis=-2)
+        except u.UnitsError:
+            # Keep error message the same as it was with an explicit check.
+            raise u.UnitsError("x and y must have compatible units") from None
 
-        # If one argument has units, enforce they both have units and they are compatible.
-        x_unit = getattr(x, "unit", None)
-        y_unit = getattr(y, "unit", None)
-        has_units = x_unit is not None and y_unit is not None
-        if x_unit != y_unit:
-            if has_units and y_unit.is_equivalent(x_unit):
-                y = y.to(x_unit)
-                y_unit = x_unit
-            else:
-                raise u.UnitsError("x and y must have compatible units")
-
-        inarr = np.stack(np.atleast_1d(x, y), axis=-2)
         if isinstance(angle, u.Quantity):
             angle = angle.to_value(u.rad)
-        res = np.matmul(cls._compute_matrix(angle), inarr)
-        x, y = np.moveaxis(res, -2, 0)
-        if has_units:
-            return u.Quantity(x, unit=x_unit, subok=True), u.Quantity(
-                y, unit=y_unit, subok=True
-            )
+        x, y = np.moveaxis(np.matmul(cls._compute_matrix(angle), inarr), -2, 0)
         return x, y
 
     @staticmethod

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -114,8 +114,7 @@ def test_Rotation2D_errors():
     # Bad evaluation input shapes
     x = np.array([1, 2])
     y = np.array([1, 2, 3])
-    MESSAGE = r"Expected input arrays to have the same shape"
-
+    MESSAGE = "all input arrays must have the same shape"
     with pytest.raises(ValueError, match=MESSAGE):
         model.evaluate(x, y, model.angle)
     with pytest.raises(ValueError, match=MESSAGE):
@@ -124,7 +123,7 @@ def test_Rotation2D_errors():
     # Bad evaluation units
     x = np.array([1, 2])
     y = np.array([1, 2])
-    MESSAGE = r"x and y must have compatible units"
+    MESSAGE = r"'' \(dimensionless\) and 'm' \(length\) are not convertible"
     with pytest.raises(u.UnitsError, match=MESSAGE):
         model.evaluate(x * u.m, y, model.angle)
 


### PR DESCRIPTION
This pull request is a quick follow up to #18562, where I noticed that a routine raveled and reshaped an array to work correctly with `np.dot`, when this is no longer necessary with `matmul` ~and the newer `matvec`. Note that the routine will become even simpler once our minimal numpy version is 2.2, since then we can count on `np.matvec` being available.~ EDIT: the PR is not really quick any more and changed after initial feedback. It now uses `np.stack` to automatically take care of getting units to match.

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
