### PR TITLE
Fix units error on `CoordinateHelper.set_ticks`

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -1046,9 +1046,8 @@ class CoordinateHelper:
                 )
 
         # format tick labels, add to scene
-        text = self.formatter(
-            self._lbl_world * tick_world_coordinates.unit, spacing=self._fl_spacing
-        )
+        text = self.formatter(u.Quantity(self._lbl_world), spacing=self._fl_spacing)
+
         for kwargs, txt in zip(self._lblinfo, text):
             self._ticklabels.add(text=txt, **kwargs)
 
@@ -1138,7 +1137,9 @@ class CoordinateHelper:
                             axis_displacement=imin + frac,
                         )
                     )
-                    self._lbl_world.append(world)
+                    self._lbl_world.append(
+                        (world * self.coord_unit).to(tick_world_coordinates.unit)
+                    )
 
                 else:
                     self._ticks.add_minor(

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -262,3 +262,24 @@ def test_set_position_invalid_gridline():
         r"or a tuple, e.g. \('my-grid-line',\).",
     ):
         ax.coords[1].set_ticks_position("my-grid-line")
+
+
+def test_set_ticks_values():
+    fig = Figure()
+    _canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=WCS(MSX_HEADER))
+    fig.add_axes(ax)
+
+    xticks = [1795, 1780, 1783] * u.arcsec
+    ax.coords[0].set_format_unit(u.arcsec)
+    ax.coords[0].set_ticks(xticks)
+
+    # Force a draw to calculate the tick positions
+    _canvas.draw()
+    # This attribute only exists after a draw
+    lbl_world = ax.coords[0]._lbl_world
+    lbl_world1 = lbl_world[: len(lbl_world) // 2]
+
+    lbl_locations = u.Quantity(lbl_world1, unit=u.deg)
+    assert u.allclose(lbl_locations, ax.coords[0]._formatter_locator.values)
+    assert u.Quantity(lbl_world).unit is xticks.unit

--- a/docs/changes/visualization/18577.bugfix.rst
+++ b/docs/changes/visualization/18577.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where the units of the ``values=`` keyword argument to ``set_ticks`` was not respected.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

There was a units error where things were being cast to deg for some calculations and the unit wasn't being preserved afterwards.

I'm not super happy with my regression test, but short of making another figure test I couldn't figure out a better way.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18576

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.