### PR TITLE
Make two unit definition files IDE-friendly

### DIFF
--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -16,80 +16,71 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
     >>> import astropy.units as u
     >>> u.imperial.enable()  # doctest: +SKIP
 """
-# avoid ruff complaints about undefined names defined by def_unit
-# ruff: noqa: F821
 
 __all__: list[str] = []  #  Units are added at the end
 
 from . import si
-from .core import add_enabled_units, def_unit
+from .core import def_unit
 from .docgen import generate_dunder_all, generate_unit_summary
-
-_ns = globals()
 
 ###########################################################################
 # LENGTH
 
-def_unit(["inch"], 2.54 * si.cm, namespace=_ns, doc="International inch")
-def_unit(["ft", "foot"], 12 * inch, namespace=_ns, doc="International foot")
-def_unit(["yd", "yard"], 3 * ft, namespace=_ns, doc="International yard")
-def_unit(["mi", "mile"], 5280 * ft, namespace=_ns, doc="International mile")
-def_unit(["mil", "thou"], 0.001 * inch, namespace=_ns, doc="Thousandth of an inch")
-def_unit(["nmi", "nauticalmile", "NM"], 1852 * si.m, namespace=_ns, doc="Nautical mile")
-def_unit(["fur", "furlong"], 660 * ft, namespace=_ns, doc="Furlong")
+inch = def_unit(["inch"], 2.54 * si.cm, doc="International inch")
+ft = foot = def_unit(["ft", "foot"], 12 * inch, doc="International foot")
+yd = yard = def_unit(["yd", "yard"], 3 * ft, doc="International yard")
+mi = mile = def_unit(["mi", "mile"], 5280 * ft, doc="International mile")
+mil = thou = def_unit(["mil", "thou"], 0.001 * inch, doc="Thousandth of an inch")
+nmi = nauticalmile = NM = def_unit(
+    ["nmi", "nauticalmile", "NM"], 1852 * si.m, doc="Nautical mile"
+)
+fur = furlong = def_unit(["fur", "furlong"], 660 * ft, doc="Furlong")
 
 
 ###########################################################################
 # AREAS
 
-def_unit(["ac", "acre"], 43560 * ft**2, namespace=_ns, doc="International acre")
+ac = acre = def_unit(["ac", "acre"], 43560 * ft**2, doc="International acre")
 
 
 ###########################################################################
 # VOLUMES
 
-def_unit(["gallon"], si.liter / 0.264172052, namespace=_ns, doc="U.S. liquid gallon")
-def_unit(["quart"], gallon / 4, namespace=_ns, doc="U.S. liquid quart")
-def_unit(["pint"], quart / 2, namespace=_ns, doc="U.S. liquid pint")
-def_unit(["cup"], pint / 2, namespace=_ns, doc="U.S. customary cup")
-def_unit(
-    ["foz", "fluid_oz", "fluid_ounce"], cup / 8, namespace=_ns, doc="U.S. fluid ounce"
+gallon = def_unit(["gallon"], si.liter / 0.264172052, doc="U.S. liquid gallon")
+quart = def_unit(["quart"], gallon / 4, doc="U.S. liquid quart")
+pint = def_unit(["pint"], quart / 2, doc="U.S. liquid pint")
+cup = def_unit(["cup"], pint / 2, doc="U.S. customary cup")
+foz = fluid_oz = fluid_ounce = def_unit(
+    ["foz", "fluid_oz", "fluid_ounce"], cup / 8, doc="U.S. fluid ounce"
 )
-def_unit(
-    ["tbsp", "tablespoon"], foz / 2, namespace=_ns, doc="U.S. customary tablespoon"
+tbsp = tablespoon = def_unit(
+    ["tbsp", "tablespoon"], foz / 2, doc="U.S. customary tablespoon"
 )
-def_unit(["tsp", "teaspoon"], tbsp / 3, namespace=_ns, doc="U.S. customary teaspoon")
+tsp = teaspoon = def_unit(["tsp", "teaspoon"], tbsp / 3, doc="U.S. customary teaspoon")
 
 
 ###########################################################################
 # MASS
 
-def_unit(
-    ["oz", "ounce"],
-    28.349523125 * si.g,
-    namespace=_ns,
-    doc="International avoirdupois ounce: mass",
+oz = ounce = def_unit(
+    ["oz", "ounce"], 28.349523125 * si.g, doc="International avoirdupois ounce: mass"
 )
-def_unit(
-    ["lb", "lbm", "pound"],
-    16 * oz,
-    namespace=_ns,
-    doc="International avoirdupois pound: mass",
+lb = lbm = pound = def_unit(
+    ["lb", "lbm", "pound"], 16 * oz, doc="International avoirdupois pound: mass"
 )
-def_unit(
-    ["st", "stone"], 14 * lb, namespace=_ns, doc="International avoirdupois stone: mass"
+st = stone = def_unit(
+    ["st", "stone"], 14 * lb, doc="International avoirdupois stone: mass"
 )
-def_unit(["ton"], 2000 * lb, namespace=_ns, doc="International avoirdupois ton: mass")
-def_unit(["slug"], 32.174049 * lb, namespace=_ns, doc="slug: mass")
+ton = def_unit(["ton"], 2000 * lb, doc="International avoirdupois ton: mass")
+slug = def_unit(["slug"], 32.174049 * lb, doc="slug: mass")
 
 
 ###########################################################################
 # SPEED
 
-def_unit(
+kn = kt = knot = NMPH = def_unit(
     ["kn", "kt", "knot", "NMPH"],
     nmi / si.h,
-    namespace=_ns,
     doc="nautical unit of speed: 1 nmi per hour",
 )
 
@@ -97,24 +88,22 @@ def_unit(
 ###########################################################################
 # FORCE
 
-def_unit("lbf", slug * ft * si.s**-2, namespace=_ns, doc="Pound: force")
-def_unit(["kip", "kilopound"], 1000 * lbf, namespace=_ns, doc="Kilopound: force")
+lbf = def_unit("lbf", slug * ft * si.s**-2, doc="Pound: force")
+kip = kilopound = def_unit(["kip", "kilopound"], 1000 * lbf, doc="Kilopound: force")
 
 
 ##########################################################################
 # ENERGY
 
-def_unit(["BTU", "btu"], 1.05505585 * si.kJ, namespace=_ns, doc="British thermal unit")
-def_unit(
+BTU = btu = def_unit(["BTU", "btu"], 1.05505585 * si.kJ, doc="British thermal unit")
+cal = calorie = def_unit(
     ["cal", "calorie"],
     4.184 * si.J,
-    namespace=_ns,
     doc="Thermochemical calorie: pre-SI metric unit of energy",
 )
-def_unit(
+kcal = Cal = Calorie = kilocal = kilocalorie = def_unit(
     ["kcal", "Cal", "Calorie", "kilocal", "kilocalorie"],
     1000 * cal,
-    namespace=_ns,
     doc="Calorie: colloquial definition of Calorie",
 )
 
@@ -122,34 +111,29 @@ def_unit(
 ##########################################################################
 # PRESSURE
 
-def_unit("psi", lbf * inch**-2, namespace=_ns, doc="Pound per square inch: pressure")
+psi = def_unit("psi", lbf * inch**-2, doc="Pound per square inch: pressure")
 
 
 ###########################################################################
 # POWER
 
 # Imperial units
-def_unit(
-    ["hp", "horsepower"],
-    si.W / 0.00134102209,
-    namespace=_ns,
-    doc="Electrical horsepower",
+hp = horsepower = def_unit(
+    ["hp", "horsepower"], si.W / 0.00134102209, doc="Electrical horsepower"
 )
 
 
 ###########################################################################
 # TEMPERATURE
 
-def_unit(
+deg_F = Fahrenheit = def_unit(
     ["deg_F", "Fahrenheit"],
-    namespace=_ns,
     doc="Degrees Fahrenheit",
     format={"latex": r"{}^{\circ}F", "unicode": "°F"},
 )
-def_unit(
+deg_R = Rankine = def_unit(
     ["deg_R", "Rankine"],
     5 / 9 * si.K,
-    namespace=_ns,
     doc="Rankine scale: absolute scale of thermodynamic temperature",
     format={"latex": r"{}^{\circ}R", "unicode": "°R"},
 )
@@ -174,4 +158,11 @@ def enable():
     This may be used with the ``with`` statement to enable Imperial
     units only temporarily.
     """
+    from .core import add_enabled_units
+
     return add_enabled_units(globals())
+
+
+# Cleanup for the benefit of e.g. IDEs or other tools that don't execute
+# generate_dunder_all(). This is simpler than writing out __all__ explicitly.
+del si, def_unit, generate_dunder_all, generate_unit_summary

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -16,50 +16,55 @@ import numpy as np
 from astropy.constants.si import L_bol0
 
 from . import astrophys, cgs, si
-from .core import def_unit
-from .docgen import generate_dunder_all, generate_unit_summary
+from .core import PrefixUnit, def_unit
+from .docgen import generate_unit_summary
 
-__all__ = []  #  Units are added at the end
+__all__ = [
+    "AB",
+    "ST",
+    "ABflux",
+    "Bol",
+    "L_bol",
+    "STflux",
+    "bol",
+    "f_bol",
+    "maggy",
+    "mgy",
+    "nanomaggy",
+    "nmgy",
+]
 
-_ns = globals()
-
-def_unit(
+Bol = L_bol = def_unit(
     ["Bol", "L_bol"],
     L_bol0,
-    namespace=_ns,
-    prefixes=False,
     doc=(
         "Luminosity corresponding to absolute bolometric magnitude zero "
         "(magnitude ``M_bol``)."
     ),
 )
-def_unit(
+bol = f_bol = def_unit(
     ["bol", "f_bol"],
     L_bol0 / (4 * np.pi * (10.0 * astrophys.pc) ** 2),
-    namespace=_ns,
-    prefixes=False,
     doc=(
         "Irradiance corresponding to apparent bolometric magnitude zero "
         "(magnitude ``m_bol``)."
     ),
 )
-def_unit(
+AB = ABflux = def_unit(
     ["AB", "ABflux"],
     10.0 ** (48.6 / -2.5) * cgs.erg * cgs.cm**-2 / si.s / si.Hz,
-    namespace=_ns,
-    prefixes=False,
     doc="AB magnitude zero flux density (magnitude ``ABmag``).",
 )
-def_unit(
+ST = STflux = def_unit(
     ["ST", "STflux"],
     10.0 ** (21.1 / -2.5) * cgs.erg * cgs.cm**-2 / si.s / si.AA,
-    namespace=_ns,
-    prefixes=False,
     doc="ST magnitude zero flux density (magnitude ``STmag``).",
 )
-def_unit(
+nmgy: PrefixUnit
+nanomaggy: PrefixUnit
+mgy = maggy = def_unit(
     ["mgy", "maggy"],
-    namespace=_ns,
+    namespace=globals(),
     prefixes=[(["n"], ["nano"], 1e-9)],
     doc=(
         "Maggies - a linear flux unit that is the flux for a mag=0 object."
@@ -67,12 +72,6 @@ def_unit(
         "zero_point_flux equivalency should be used."
     ),
 )
-
-
-###########################################################################
-# ALL & DOCSTRING
-
-__all__ += generate_dunder_all(globals())  # noqa: PLE0605
 
 
 if __doc__ is not None:

--- a/astropy/units/scripts/typestubs_for_units.py
+++ b/astropy/units/scripts/typestubs_for_units.py
@@ -28,8 +28,6 @@ MODULES_TO_STUB = [
     "cgs",
     "astrophys",
     "misc",
-    "imperial",
-    "photometric",
     "function.units",
     "deprecated",
     "required_by_vounit",


### PR DESCRIPTION
### Description

Defining units with `def_unit()` can be too dynamic for IDEs and other tools if `def_unit()` is used to also generate the prefixed versions of the unit. Generating stub files is necessary to make unit definitions understandable by such tools. However, in `imperial.py` prefixes are not used at all, so it can be rewritten to not require a stub file. Furthermore, `photometric.py` uses a single prefix, so that file only requires two variable annotations, which is a small enough number that they can be written in the file itself and a separate stub file is not needed.

Other unit definition files use so many prefixes that generating stub files remains the best option for annotating them.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
