### PR TITLE
Fixed an image-normalization bug where the interval could be ignored when plotting

### DIFF
--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -133,6 +133,14 @@ class ImageNormalize(Normalize):
             if self.vmax is None:
                 self.vmax = _vmax
 
+    # Override the matplotlib method
+    def autoscale_None(self, A):
+        """
+        If vmin or vmax are not set, set them according to the interval.
+        If no interval is set, set them to the min/max of the data array.
+        """
+        self._set_limits(A)
+
     def __call__(self, values, clip=None, invalid=None):
         """
         Transform values using this normalization.

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -340,3 +340,22 @@ def test_imshow_norm():
     imres, norm = imshow_norm(image, ax=None)
 
     assert isinstance(norm, ImageNormalize)
+
+
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
+def test_norm_without_data():
+    from matplotlib.figure import Figure
+
+    image = np.arange(10).reshape((1, 10))
+    interval = ManualInterval(2, 5)
+    norm_without_data = ImageNormalize(interval=interval)
+
+    assert norm_without_data.vmin is None
+    assert norm_without_data.vmax is None
+
+    fig = Figure()
+    ax = fig.add_subplot()
+    ax.imshow(image, norm=norm_without_data)  # calls norm_without_data.autoscale_None()
+
+    assert norm_without_data.vmin == interval.vmin
+    assert norm_without_data.vmax == interval.vmax

--- a/docs/changes/visualization/18590.bugfix.rst
+++ b/docs/changes/visualization/18590.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an image-normalization bug where the interval on a ``ImageNormalize``
+instance could be ignored when plotting.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes an image-normalization bug where the interval could be ignored when plotting.

When creating an `ImageNormalize` instance by providing both an interval and the data array, and then vmin/vmax are set [during instantiation](https://github.com/astropy/astropy/blob/f3981259481831b3728b50a79480a5537eff400c/astropy/visualization/mpl_normalize.py#L115-L117).  In some situations, it can be useful to create an `ImageNormalize` instance with an interval but *without* a data array.  With such an instance, vmin/vmax are not set during instantantion, but rather can be determined later, for example when this `ImageNormalize` instance is [called on an array](https://github.com/astropy/astropy/blob/f3981259481831b3728b50a79480a5537eff400c/astropy/visualization/mpl_normalize.py#L179-L180).

The problem is that an `ImageNormalize` instance with unset vmin/vmax that is then passed to matplotlib plotting will first hit a call to the `autoscale_None()` method – [inherited from matplotlib's `Normalize` class](https://github.com/matplotlib/matplotlib/blob/2d52498b9d14dfce1a842233d9375bf9820365f8/lib/matplotlib/colors.py#L2543-L2555) – which will always set vmin/vmax to the min/max of the data array, regardless of any interval set on the `ImageNormalize` instance.  That is, the interval is completely ignored.  This PR fixes this bug by simply overriding `autoscale_None()` to call the private `ImageNormalize` method `_set_limits()`.

(Presumably `_set_limits()` does not need to continue to exist separate from `autoscale_None()`, but I do not remove it in this PR to avoid any potential of breaking code in the wild.)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
