### PR TITLE
Replace `lazyproperty` with `cached_property` in `units`

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Self, Union, 
 import numpy as np
 
 from astropy.utils.compat import COPY_IF_NEEDED
-from astropy.utils.decorators import deprecated, lazyproperty
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
 from .errors import UnitConversionError, UnitParserWarning, UnitsError, UnitsWarning
@@ -954,14 +954,14 @@ class UnitBase:
             key=lambda x: len(set(x.bases).difference(system.bases)),
         )
 
-    @lazyproperty
+    @cached_property
     def si(self) -> "UnitBase":
         """The unit expressed in terms of SI units."""
         from . import si
 
         return self.to_system(si)[0]
 
-    @lazyproperty
+    @cached_property
     def cgs(self) -> "UnitBase":
         """The unit expressed in terms of CGS units."""
         from . import cgs

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numbers
+from functools import cached_property
 
 import numpy as np
 
@@ -11,7 +12,6 @@ from astropy.units import (
     UnitTypeError,
     dimensionless_unscaled,
 )
-from astropy.utils import lazyproperty
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 from .core import FunctionQuantity, FunctionUnitBase
@@ -47,7 +47,7 @@ class LogUnit(FunctionUnitBase):
     """
 
     # the four essential overrides of FunctionUnitBase
-    @lazyproperty
+    @cached_property
     def _default_function_unit(self):
         from .units import dex
 
@@ -145,7 +145,7 @@ class MagUnit(LogUnit):
         unit such as ``2 mag``.
     """
 
-    @lazyproperty
+    @cached_property
     def _default_function_unit(self):
         from .units import mag
 
@@ -170,7 +170,7 @@ class DexUnit(LogUnit):
         unit such as ``0.5 dex``.
     """
 
-    @lazyproperty
+    @cached_property
     def _default_function_unit(self):
         from .units import dex
 
@@ -204,7 +204,7 @@ class DecibelUnit(LogUnit):
         unit such as ``2 dB``.
     """
 
-    @lazyproperty
+    @cached_property
     def _default_function_unit(self):
         from .units import dB
 


### PR DESCRIPTION
### Description

In `units` the standard library [`cached_property`](https://docs.python.org/3.11/library/functools.html#functools.cached_property) can be used as a drop-in replacement for our own [`lazyproperty`](https://docs.astropy.org/en/v7.1.0/api/astropy.utils.decorators.lazyproperty.html).

Contributes towards #9036

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
