### PR TITLE
Remove `detailed_exception` parameter from unit formatter `_validate_unit()` methods

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2042,10 +2042,10 @@ class _UnitMetaClass(type):
                 s = s.decode("ascii")
 
             try:
-                return f._validate_unit(s, detailed_exception=False)  # Try a shortcut
-            except (AttributeError, ValueError):
+                return f._validate_unit(s)  # Try a shortcut
+            except (AttributeError, KeyError):
                 # No `f._validate_unit()` (AttributeError)
-                # or `s` was a composite unit (ValueError).
+                # or `s` was a composite unit (KeyError).
                 pass
 
             try:

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -28,7 +28,6 @@ from astropy.units.core import CompositeUnit, Unit, UnitBase, get_current_unit_r
 from astropy.units.errors import UnitsWarning
 from astropy.units.typing import UnitScale
 from astropy.utils import classproperty, parsing
-from astropy.utils.misc import did_you_mean
 from astropy.utils.parsing import ThreadSafeParser
 
 from .base import Base, _ParsingFormatMixin
@@ -404,9 +403,12 @@ class Generic(Base, _GenericParserMixin):
     supports any unit available in the `astropy.units` namespace.
     """
 
+    @classproperty
+    def _units(cls) -> dict[str, UnitBase]:
+        return get_current_unit_registry().registry
+
     @classmethod
     def _validate_unit(cls, s: str, detailed_exception: bool = True) -> UnitBase:
-        registry = get_current_unit_registry().registry
         if s in cls._unit_symbols:
             s = cls._unit_symbols[s]
 
@@ -418,13 +420,11 @@ class Generic(Base, _GenericParserMixin):
             elif s.endswith("R\N{INFINITY}"):
                 s = s[:-2] + "Ry"
 
-        if s in registry:
-            return registry[s]
+        return super()._validate_unit(s, detailed_exception)
 
-        if detailed_exception:
-            raise ValueError(f"{s} is not a valid unit. {did_you_mean(s, registry)}")
-        else:
-            raise ValueError()
+    @classmethod
+    def _invalid_unit_error_message(cls, unit: str) -> str:
+        return f"{unit} is not a valid unit. {cls._did_you_mean_units(unit)}"
 
     _unit_symbols: ClassVar[dict[str, str]] = {
         "%": "percent",

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -379,7 +379,10 @@ class _GenericParserMixin(_ParsingFormatMixin):
                 p[0] = p[3] ** 0.5
                 return
             elif p[1] in ("mag", "dB", "dex"):
-                function_unit = cls._validate_unit(p[1])
+                try:
+                    function_unit = cls._validate_unit(p[1])
+                except KeyError:
+                    raise ValueError(cls._invalid_unit_error_message(p[1])) from None
                 # In Generic, this is callable, but that does not have to
                 # be the case in subclasses (e.g., in VOUnit it is not).
                 if callable(function_unit):
@@ -408,7 +411,7 @@ class Generic(Base, _GenericParserMixin):
         return get_current_unit_registry().registry
 
     @classmethod
-    def _validate_unit(cls, s: str, detailed_exception: bool = True) -> UnitBase:
+    def _validate_unit(cls, s: str) -> UnitBase:
         if s in cls._unit_symbols:
             s = cls._unit_symbols[s]
 
@@ -420,7 +423,7 @@ class Generic(Base, _GenericParserMixin):
             elif s.endswith("R\N{INFINITY}"):
                 s = s[:-2] + "Ry"
 
-        return super()._validate_unit(s, detailed_exception)
+        return super()._validate_unit(s)
 
     @classmethod
     def _invalid_unit_error_message(cls, unit: str) -> str:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -359,10 +359,10 @@ class OGIP(Base, _ParsingFormatMixin):
         return format(val, format_spec)
 
     @classmethod
-    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
+    def _validate_unit(cls, unit: str) -> UnitBase:
         if unit in cls._deprecated_units:
             warnings.warn(
                 f"The unit '{unit}' has been deprecated in the OGIP standard.",
                 UnitsWarning,
             )
-        return super()._validate_unit(unit, detailed_exception)
+        return super()._validate_unit(unit)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -218,7 +218,7 @@ class VOUnit(Base, _GenericParserMixin):
         )
 
     @classmethod
-    def _validate_unit(cls, unit: str, detailed_exception: bool = True) -> UnitBase:
+    def _validate_unit(cls, unit: str) -> UnitBase:
         if unit in cls._deprecated_units:
             warnings.warn(
                 UnitsWarning(
@@ -226,4 +226,4 @@ class VOUnit(Base, _GenericParserMixin):
                     f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
                 )
             )
-        return super()._validate_unit(unit, detailed_exception)
+        return super()._validate_unit(unit)


### PR DESCRIPTION
### Description

The first commit reduces code duplication between `Generic._validate_unit()` and `_ParsingFormatMixin._validate_unit()`. Most importantly `Generic._validate_unit()` no longer contains code to control the verbosity of the error message in case of an invalid unit.

The second commit moves error message handling out from `_ParsingFormatMixin._validate_unit()`, which allows the `detailed_exception` parameter to be removed entirely.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
