### PR TITLE
Backport PR #18577: Fix units error on `CoordinateHelper.set_ticks`

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -1047,9 +1047,8 @@ class CoordinateHelper:
                 )
 
         # format tick labels, add to scene
-        text = self.formatter(
-            self._lbl_world * tick_world_coordinates.unit, spacing=self._fl_spacing
-        )
+        text = self.formatter(u.Quantity(self._lbl_world), spacing=self._fl_spacing)
+
         for kwargs, txt in zip(self._lblinfo, text):
             self._ticklabels.add(text=txt, **kwargs)
 
@@ -1139,7 +1138,9 @@ class CoordinateHelper:
                             axis_displacement=imin + frac,
                         )
                     )
-                    self._lbl_world.append(world)
+                    self._lbl_world.append(
+                        (world * self.coord_unit).to(tick_world_coordinates.unit)
+                    )
 
                 else:
                     self._ticks.add_minor(

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -184,3 +184,24 @@ def test_deprecated_getters():
     with pytest.warns(AstropyDeprecationWarning):
         axislabels = helper.axislabels
     assert axislabels.get_visibility_rule() == "labels"
+
+
+def test_set_ticks_values():
+    fig = Figure()
+    _canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=WCS(MSX_HEADER))
+    fig.add_axes(ax)
+
+    xticks = [1795, 1780, 1783] * u.arcsec
+    ax.coords[0].set_format_unit(u.arcsec)
+    ax.coords[0].set_ticks(xticks)
+
+    # Force a draw to calculate the tick positions
+    _canvas.draw()
+    # This attribute only exists after a draw
+    lbl_world = ax.coords[0]._lbl_world
+    lbl_world1 = lbl_world[: len(lbl_world) // 2]
+
+    lbl_locations = u.Quantity(lbl_world1, unit=u.deg)
+    assert u.allclose(lbl_locations, ax.coords[0]._formatter_locator.values)
+    assert u.Quantity(lbl_world).unit is xticks.unit

--- a/docs/changes/visualization/18577.bugfix.rst
+++ b/docs/changes/visualization/18577.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where the units of the ``values=`` keyword argument to ``set_ticks`` was not respected.


### PR DESCRIPTION
Backport #18577