### PR TITLE
Added an image interval option that is symmetric about a midpoint

### DIFF
--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -19,6 +19,7 @@ __all__ = [
     "ManualInterval",
     "MinMaxInterval",
     "PercentileInterval",
+    "SymmetricInterval",
     "ZScaleInterval",
 ]
 
@@ -231,6 +232,36 @@ class PercentileInterval(AsymmetricPercentileInterval):
         lower_percentile = (100 - percentile) * 0.5
         upper_percentile = 100 - lower_percentile
         super().__init__(lower_percentile, upper_percentile, n_samples=n_samples)
+
+
+class SymmetricInterval(BaseInterval):
+    """
+    Interval based on a symmetric radius away from a midpoint.
+
+    Parameters
+    ----------
+    radius : float or None
+        The amount the interval extends to either side of the midpoint, so the total
+        interval is twice this value. If None, the radius is automatically
+        determined such that the resulting interval contains both the image minimum
+        and maximum (ignoring NaNs).
+    midpoint : float, optional
+        The midpoint of the symmetric interval.  Defaults to zero.
+    """
+
+    def __init__(self, radius=None, *, midpoint=0):
+        self.radius = radius
+        self.midpoint = midpoint
+
+    def get_limits(self, values):
+        radius = self.radius
+        if radius is None:
+            values = self._process_values(values)
+            radius = np.max(
+                [np.max(values) - self.midpoint, self.midpoint - np.min(values)]
+            )
+
+        return self.midpoint - radius, self.midpoint + radius
 
 
 class ZScaleInterval(BaseInterval):

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -11,6 +11,7 @@ from astropy.visualization.interval import (
     ManualInterval,
     MinMaxInterval,
     PercentileInterval,
+    SymmetricInterval,
     ZScaleInterval,
 )
 
@@ -75,6 +76,28 @@ class TestInterval:
             vmin, vmax = interval.get_limits(self.data)
         assert_allclose(vmin, -14.367676767676768)
         assert_allclose(vmax, 40.266666666666666)
+
+    def test_symmetric_interval_manual(self):
+        interval = SymmetricInterval(radius=40)
+        vmin, vmax = interval.get_limits(self.data)
+        assert_allclose(vmin, -40.0)
+        assert_allclose(vmax, +40.0)
+
+        interval = SymmetricInterval(radius=100, midpoint=10)
+        vmin, vmax = interval.get_limits(self.data)
+        assert_allclose(vmin, -90.0)
+        assert_allclose(vmax, +110.0)
+
+    def test_symmetric_interval_auto(self):
+        interval = SymmetricInterval()
+        vmin, vmax = interval.get_limits(self.data)
+        assert_allclose(vmin, -60.0)
+        assert_allclose(vmax, +60.0)
+
+        interval = SymmetricInterval(midpoint=50)
+        vmin, vmax = interval.get_limits(self.data)
+        assert_allclose(vmin, -20.0)
+        assert_allclose(vmax, +120.0)
 
 
 class TestIntervalList(TestInterval):

--- a/docs/changes/visualization/18602.feature.rst
+++ b/docs/changes/visualization/18602.feature.rst
@@ -1,0 +1,3 @@
+Added an image interval option (``SymmetricInterval``) for specifying a
+symmetric extent about a midpoint, and the extent that contains both the image
+minimum and maximum can be automatically determined.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds an image interval option (`SymmetricInterval`) that specifies a symmetric extent about a midpoint (defaults to zero).  This is primarily useful when having the radius of the interval be automatically determined such that the interval contains both the image minimum and maximum.

Example:
```python
>>> import numpy as np
>>> from astropy.visualization import SymmetricInterval

>>> data = np.linspace(-20, 60, 100)

# Manually defining the radius of the interval about the midpoint (defaults to zero)
>>> SymmetricInterval(radius=40).get_limits(data)
(-40, 40)

# Automatically determine the radius of the interval to contain both the image minimum (-20) and the image maximum (+60)
>>> SymmetricInterval().get_limits(data)
(-60.0, 60.0)
>>> SymmetricInterval(midpoint=50).get_limits(data)
(-20.0, 120.0)
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->



<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
