### PR TITLE
Refactor unit formatter `_validate_unit()` methods

### DIFF
--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -256,8 +256,16 @@ class _ParsingFormatMixin:
         return did_you_mean(unit, cls._units, fix=cls._fix_deprecated)
 
     @classmethod
-    def _validate_unit(cls, unit: str) -> UnitBase:
-        return cls._units[unit]
+    def _validate_unit(cls, s: str) -> UnitBase:
+        if s in cls._deprecated_units:
+            alternative = (
+                unit.represents if isinstance(unit := cls._units[s], Unit) else None
+            )
+            msg = f"The unit {s!r} has been deprecated in the {cls.__name__} standard."
+            if alternative:
+                msg += f" Suggested: {cls.to_string(alternative)}."
+            warnings.warn(msg, UnitsWarning)
+        return cls._units[s]
 
     @classmethod
     def _invalid_unit_error_message(cls, unit: str) -> str:

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -423,7 +423,7 @@ class Generic(Base, _GenericParserMixin):
             elif s.endswith("R\N{INFINITY}"):
                 s = s[:-2] + "Ry"
 
-        return super()._validate_unit(s)
+        return cls._units[s]
 
     @classmethod
     def _invalid_unit_error_message(cls, unit: str) -> str:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -357,12 +357,3 @@ class OGIP(Base, _ParsingFormatMixin):
         cls, val: UnitScale | np.number, format_spec: str = "g"
     ) -> str:
         return format(val, format_spec)
-
-    @classmethod
-    def _validate_unit(cls, unit: str) -> UnitBase:
-        if unit in cls._deprecated_units:
-            warnings.warn(
-                f"The unit '{unit}' has been deprecated in the OGIP standard.",
-                UnitsWarning,
-            )
-        return super()._validate_unit(unit)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -20,12 +20,7 @@ from astropy.units.core import (
     dimensionless_unscaled,
     si_prefixes,
 )
-from astropy.units.errors import (
-    UnitParserWarning,
-    UnitScaleError,
-    UnitsError,
-    UnitsWarning,
-)
+from astropy.units.errors import UnitParserWarning, UnitScaleError, UnitsError
 from astropy.units.typing import UnitScale
 from astropy.utils import classproperty
 
@@ -216,14 +211,3 @@ class VOUnit(Base, _GenericParserMixin):
             if x in cls._deprecated_units
             else [x]
         )
-
-    @classmethod
-    def _validate_unit(cls, unit: str) -> UnitBase:
-        if unit in cls._deprecated_units:
-            warnings.warn(
-                UnitsWarning(
-                    f"The unit '{unit}' has been deprecated in the VOUnit standard."
-                    f" Suggested: {cls.to_string(cls._units[unit]._represents)}."
-                )
-            )
-        return super()._validate_unit(unit)


### PR DESCRIPTION
### Description

The `VOUnit` and `OGIP` unit formatters implement `_validate_unit()` methods that emit warnings when they encounter units deprecated in those formats. Turns out that those two `_validate_unit()` implementations can be replaced with a common implementation in `_ParsingFormatMixin`.

The `Generic._validate_unit()` implementation no longer calls `super()._validate_unit(...)` because not calling it is faster. The `"generic"` format does not have any deprecated units, so it would not benefit from the new code in `_ParsingFormatMixin._validate_unit()` anyways.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
