### PR TITLE
Ensure imperial.__all__ also contains 'enable'

### DIFF
--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -19,7 +19,7 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 # avoid ruff complaints about undefined names defined by def_unit
 # ruff: noqa: F821
 
-__all__: list[str] = []  #  Units are added at the end
+__all__: list[str] = ["enable"]  #  Units are added at the end
 
 from . import si
 from .core import add_enabled_units, def_unit


### PR DESCRIPTION
Split off from #18573 on @eerovaher's request. Just adds missing "enable" to `imperial.__all__` -- totally trivial and not really worth running CI for (hence not backporting), but might as well get it in.