### PR TITLE
Only insert valid identifiers to unit definition module `__all__` lists

### DIFF
--- a/astropy/units/docgen.py
+++ b/astropy/units/docgen.py
@@ -137,5 +137,9 @@ def generate_dunder_all(namespace: Mapping[str, object]) -> list[str]:
     return [
         name
         for name, value in namespace.items()
-        if isinstance(value, UnitBase) and name == unicodedata.normalize("NFKC", name)
+        if (
+            isinstance(value, UnitBase)
+            and name.isidentifier()
+            and name == unicodedata.normalize("NFKC", name)
+        )
     ]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -753,7 +753,6 @@ def test_unit_module_dunder_all_nfkc_normalization():
     assert u.ℓ is u.liter
 
 
-@pytest.mark.xfail(reason="regression test to reveal a bug")
 def test_unit_module_dunder_all_only_indentifiers():
     assert "°" not in cds.__all__
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_allclose
 
 from astropy import constants as c
 from astropy import units as u
-from astropy.units import utils
+from astropy.units import cds, utils
 from astropy.units.required_by_vounit import GsolLum, ksolMass, nsolRad
 from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT, HAS_DASK
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -751,6 +751,11 @@ def test_unit_module_dunder_all_nfkc_normalization():
     # that changes with NFKC normalization can only cause trouble.
     assert "ℓ" not in u.__all__
     assert u.ℓ is u.liter
+
+
+@pytest.mark.xfail(reason="regression test to reveal a bug")
+def test_unit_module_dunder_all_only_indentifiers():
+    assert "°" not in cds.__all__
 
 
 def test_all_units():


### PR DESCRIPTION
### Description

The first commit reveals that `astropy.units.cds.__all__` contains the entry `"°"` even though `°` is not a valid identifier. Normally Ruff would spot mistakes like that, but in unit definition modules we don't write out the `__all__` lists because they are too long for that to be feasible. Instead the `astropy.units.docgen.generate_dunder_all()` function creates the entries at runtime, so it is the job of that function to ensure that its output contains only valid identifiers.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
