### PR TITLE
Replace deprecated indent() with textutils.indent() in io.fits warning

### DIFF
--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sys
 import warnings
+from textwrap import indent
 
 import numpy as np
 
@@ -23,7 +24,6 @@ from astropy.io.fits.util import (
     isfile,
 )
 from astropy.io.fits.verify import VerifyError, VerifyWarning, _ErrList, _Verify
-from astropy.utils import indent
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 # NOTE: Python can be built without bz2.
@@ -1369,7 +1369,7 @@ class HDUList(list, _Verify):
             except (VerifyError, ValueError) as exc:
                 warnings.warn(
                     f"Error validating header for HDU #{len(self)} (note: Astropy "
-                    f"uses zero-based indexing).\n{indent(str(exc))}\n"
+                    f"uses zero-based indexing).\n{indent(str(exc), 4 * ' ')}\n"
                     "There may be extra bytes after the last HDU or the "
                     "file is corrupted.",
                     VerifyWarning,

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1188,6 +1188,22 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(OSError):
             fits.open(filename, ignore_missing_end=True)
 
+    def test_warning_raised_extra_bytes_after_last_hdu(self):
+        filename = "test_extra_bytes.fits"
+        fits.writeto(self.temp(filename), np.arange(100))
+        # write some extra bytes to the end of the file
+        with open(self.temp(filename), "ab") as f:
+            f.write(b"extra bytes")
+
+        # this should not raise a DeprecationWarning about the indent
+        # function (#18607)
+        match = "There may be extra bytes after the last HDU"
+        with (
+            pytest.warns(VerifyWarning, match=match),
+            fits.open(self.temp(filename)) as hdul,
+        ):
+            assert len(hdul) == 1
+
     def test_pop_with_lazy_load(self):
         filename = self.data("checksum.fits")
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

#16223 deprecated ``astropy.utils.misc.indent()``, but that function is still used in `io.fits.hdu.hdulist` when raising a `VerifyWarning`.  Apparently there was not a test that triggered the warning where `astropy.misc.indent()` was still used. Simple example:

```python
>>> from astropy.io import fits
>>> url = 'https://www.stsci.edu/~jayander/HST1PASS/LIB/PSFs/STDPSFs/WFC3UV/STDPSF_WFC3UV_F606W.fits'
>>> data = fits.getdata(url)
WARNING: AstropyDeprecationWarning: The indent function is deprecated and may be removed in a future version.
        Use textwrap.indent() instead. [astropy.io.fits.hdu.hdulist]
WARNING: VerifyWarning: Error validating header for HDU #1 (note: Astropy uses zero-based indexing).
    Header size is not multiple of 2880: 1
There may be extra bytes after the last HDU or the file is corrupted. [astropy.io.fits.hdu.hdulist]
```

This PR replaces `astropy.utils.indent` with `textwrap.indent` to prevent the `AstropyDeprecationWarning` and adds a unit test for this warning case.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Followup to #16223.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
