### PR TITLE
Backport PR #18606 on branch v7.1.x (Only insert valid identifiers to unit definition module __all__ lists)

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_allclose
 
 from astropy import constants as c
 from astropy import units as u
-from astropy.units import utils
+from astropy.units import cds, utils
 from astropy.units.required_by_vounit import GsolLum, ksolMass, nsolRad
 from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT, HAS_DASK
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -743,6 +743,10 @@ def test_unit_module_dunder_all_nfkc_normalization():
     # that changes with NFKC normalization can only cause trouble.
     assert "ℓ" not in u.__all__
     assert u.ℓ is u.liter
+
+
+def test_unit_module_dunder_all_only_indentifiers():
+    assert "°" not in cds.__all__
 
 
 def test_all_units():

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -184,7 +184,11 @@ def generate_dunder_all(namespace: Mapping[str, object]) -> list[str]:
     return [
         name
         for name, value in namespace.items()
-        if isinstance(value, UnitBase) and name == unicodedata.normalize("NFKC", name)
+        if (
+            isinstance(value, UnitBase)
+            and name.isidentifier()
+            and name == unicodedata.normalize("NFKC", name)
+        )
     ]
 
 


### PR DESCRIPTION
### Description

Manual backport of #18606.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
