### PR TITLE
Stop inserting keywords into unit definition module `__all__` lists

### DIFF
--- a/astropy/units/docgen.py
+++ b/astropy/units/docgen.py
@@ -6,6 +6,7 @@ None of the functions in the module are meant for use outside of the
 package.
 """
 
+import keyword
 import re
 import unicodedata
 from collections.abc import Iterable, Mapping
@@ -140,6 +141,7 @@ def generate_dunder_all(namespace: Mapping[str, object]) -> list[str]:
         if (
             isinstance(value, UnitBase)
             and name.isidentifier()
+            and not keyword.iskeyword(name)
             and name == unicodedata.normalize("NFKC", name)
         )
     ]

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -757,11 +757,7 @@ def test_unit_module_dunder_all_nfkc_normalization():
     "string",
     [
         pytest.param("°", id="invalid characters"),  # Regression test for #18606
-        pytest.param(
-            "as",
-            id="keyword",
-            marks=pytest.mark.xfail(reason="regression test to reveal a bug"),
-        ),
+        pytest.param("as", id="keyword"),  # Regression test for #18614
     ],
 )
 def test_unit_module_dunder_all_only_indentifiers(string):


### PR DESCRIPTION
### Description

The first commit adds a regression test which reveals that unit definition module `__all__` lists can contain Python keywords. This is a problem because keywords cannot be used as variable names:
```python
>>> from astropy.units import cds
>>> "as" in cds.__all__
True
>>> cds.as
  File "<stdin>", line 1
    cds.as
        ^^
SyntaxError: invalid syntax
```
The second commit solves the problem by updating `generate_dunder_all()`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
