### PR TITLE
Backport PR #18614 on branch v7.1.x (Stop inserting keywords into unit definition module __all__ lists)

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -745,8 +745,15 @@ def test_unit_module_dunder_all_nfkc_normalization():
     assert u.ℓ is u.liter
 
 
-def test_unit_module_dunder_all_only_indentifiers():
-    assert "°" not in cds.__all__
+@pytest.mark.parametrize(
+    "string",
+    [
+        pytest.param("°", id="invalid characters"),  # Regression test for #18606
+        pytest.param("as", id="keyword"),  # Regression test for #18614
+    ],
+)
+def test_unit_module_dunder_all_only_indentifiers(string):
+    assert string not in cds.__all__
 
 
 def test_all_units():

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -7,6 +7,7 @@ package.
 """
 
 import io
+import keyword
 import re
 import unicodedata
 from collections.abc import Generator, Mapping
@@ -187,6 +188,7 @@ def generate_dunder_all(namespace: Mapping[str, object]) -> list[str]:
         if (
             isinstance(value, UnitBase)
             and name.isidentifier()
+            and not keyword.iskeyword(name)
             and name == unicodedata.normalize("NFKC", name)
         )
     ]


### PR DESCRIPTION
### Description

Manual backport of #18614.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
