### PR TITLE
Remove unneeded code from `coordinates/sites.py`

### DIFF
--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -72,9 +72,6 @@ class SiteRegistry(Mapping):
     def __iter__(self) -> Iterator[str]:
         return iter(self._lowercase_names_to_locations)
 
-    def __contains__(self, site_name: object) -> bool:
-        return site_name.lower() in self._lowercase_names_to_locations
-
     @property
     def names(self) -> list[str]:
         """
@@ -122,8 +119,6 @@ class SiteRegistry(Mapping):
             location.info.meta = site_info  # whatever is left
 
             reg.add_site([site] + aliases, location)
-
-        reg._loaded_jsondb = jsondb
         return reg
 
 


### PR DESCRIPTION
### Description

On current `main`
```
$ mypy --follow-imports silent astropy/coordinates/sites.py 
astropy/coordinates/sites.py:76: error: "object" has no attribute "lower"  [attr-defined]
astropy/coordinates/sites.py:126: error: "Self" has no attribute "_loaded_jsondb"  [attr-defined]
```
The simplest way to solve both problems is to delete the offending code. Deleting `SiteRegistry.__contains__()` is safe because the `__contains__()` implementation `SiteRegistry` inherits from `Mapping` works just fine. Deleting the code that creates the `_loaded_jsondb` attribute is safe because according to `git grep` that attribute is not used anywhere.

With the changes here `mypy --follow-imports silent astropy/coordinates/sites.py` succeeds.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
