### PR TITLE
Fix for latex representation for DexUnit in astropy.units

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -419,8 +419,10 @@ class FunctionUnitBase(metaclass=ABCMeta):
         if pu_str == "":
             pu_str = "1"
         if format.startswith("latex"):
-            # need to strip leading and trailing "$"
-            self_str += rf"$\mathrm{{\left( {pu_str[1:-1]} \right)}}$"
+            # Add the physical unit with parentheses, removing its latex
+            # initialization stuff ("$\mathrm{" and "}$").
+            # For self_str, remove trailing "}$" and put it back at the end.
+            self_str = rf"{self_str[:-2]}\left({pu_str[9:-2]}\right)}}$"
         else:
             pu_lines = pu_str.splitlines()
             if len(pu_lines) == 1:

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -187,7 +187,7 @@ class DexUnit(LogUnit):
             else:
                 return f"[{self.physical_unit.to_string(format=format)}]"
         else:
-            return super().to_string()
+            return super().to_string(format=format)
 
 
 class DecibelUnit(LogUnit):

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -1137,8 +1137,8 @@ def test_celsius_fits():
     "test_pair",
     list_format_string_pairs(
         ("generic", "dB(1 / m)"),
-        ("latex", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{\frac{1}{m}} \right)}$"),
-        ("latex_inline", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
+        ("latex", r"$\mathrm{dB\left(\frac{1}{m}\right)}$"),
+        ("latex_inline", r"$\mathrm{dB\left(m^{-1}\right)}$"),
         ("console", "dB(m^-1)"),
         ("unicode", "dB(m⁻¹)"),
     ),
@@ -1157,8 +1157,8 @@ def test_function_format_styles(test_pair: FormatStringPair):
         ("console", "inline", "dB(1 / m)"),
         ("unicode", "multiline", "   1\ndB(─)\n   m"),
         ("unicode", "inline", "dB(1 / m)"),
-        ("latex", False, r"$\mathrm{dB}$$\mathrm{\left( \mathrm{m^{-1}} \right)}$"),
-        ("latex", "inline", r"$\mathrm{dB}$$\mathrm{\left( \mathrm{1 / m} \right)}$"),
+        ("latex", False, r"$\mathrm{dB\left(m^{-1}\right)}$"),
+        ("latex", "inline", r"$\mathrm{dB\left(1 / m\right)}$"),
     ],
 )
 def test_function_format_styles_non_default_fraction(format_spec, fraction, string):

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -208,6 +208,13 @@ class TestLogUnitStrings:
         latex_str = r"$\mathrm{mag}$$\mathrm{\left( \mathrm{ct\,s^{-1}} \right)}$"
         assert lu5.to_string("latex_inline") == latex_str
 
+    def test_dexunit_latex_format(self):
+        from astropy import units as u
+        dex = 1* u.Dex(u.cm / u.s**2)
+        s = dex.to_string(format="latex")
+        assert r"\mathrm{dex}" in s
+        assert r"\frac{\mathrm{cm}}{\mathrm{s}^{2}}" in s
+
 
 class TestLogUnitConversion:
     @pytest.mark.parametrize("physical_unit", pu_sample)

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -196,24 +196,23 @@ class TestLogUnitStrings:
 
         lu4 = u.mag(u.ct)
         assert lu4.to_string("generic") == "mag(ct)"
-        latex_str = r"$\mathrm{mag}$$\mathrm{\left( \mathrm{ct} \right)}$"
+        latex_str = r"$\mathrm{mag\left(ct\right)}$"
         assert lu4.to_string("latex") == latex_str
         assert lu4.to_string("latex_inline") == latex_str
         assert lu4._repr_latex_() == latex_str
 
         lu5 = u.mag(u.ct / u.s)
-        assert lu5.to_string("latex") == (
-            r"$\mathrm{mag}$$\mathrm{\left( \mathrm{\frac{ct}{s}} \right)}$"
-        )
-        latex_str = r"$\mathrm{mag}$$\mathrm{\left( \mathrm{ct\,s^{-1}} \right)}$"
+        latex_str = r"$\mathrm{mag\left(\frac{ct}{s}\right)}$"
+        assert lu5.to_string("latex") == latex_str
+        latex_str = r"$\mathrm{mag\left(ct\,s^{-1}\right)}$"
         assert lu5.to_string("latex_inline") == latex_str
 
-    def test_dexunit_latex_format(self):
-        from astropy import units as u
-        dex = 1* u.Dex(u.cm / u.s**2)
-        s = dex.to_string(format="latex")
-        assert r"\mathrm{dex}" in s
-        assert r"\frac{\mathrm{cm}}{\mathrm{s}^{2}}" in s
+    def test_dex_latex_str(self):
+        # Regression test for gh-18618.
+        lu = u.dex(u.cm / u.s**2)
+        latex_str = r"$\mathrm{dex\left(\frac{cm}{s^{2}}\right)}$"
+        assert lu.to_string(format="latex") == latex_str
+        assert lu._repr_latex_() == latex_str
 
 
 class TestLogUnitConversion:

--- a/docs/changes/18627.bugfix.rst
+++ b/docs/changes/18627.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the LaTeX representation of ``DexUnit`` in ``astropy.units``.  
+It now correctly renders as ``\mathrm{dex}\left(\frac{\mathrm{cm}}{\mathrm{s}^{2}}\right)`` instead of the incomplete form (e.g., ``5 ex(cm/s2``).

--- a/docs/changes/18627.bugfix.rst
+++ b/docs/changes/18627.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed the LaTeX representation of ``DexUnit`` in ``astropy.units``.  
-It now correctly renders as ``\mathrm{dex}\left(\frac{\mathrm{cm}}{\mathrm{s}^{2}}\right)`` instead of the incomplete form (e.g., ``5 ex(cm/s2``).

--- a/docs/changes/units/18627.bugfix.rst
+++ b/docs/changes/units/18627.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the LaTeX representation of ``DexUnit`` in ``astropy.units``,
+and thus also how it is represented in, e.g., jupyter notebooks.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the LaTeX representation for DexUnit in astropy.units

Previously, displaying a DexUnit in Jupyter returned an incomplete and incorrect LaTeX string, such as `5 ex(cm/s2.` With this change, the output now matches the expected style of other logarithmic units, for example `5 \mathrm{dex}\left(\frac{\mathrm{cm}}{\mathrm{s}^2}\right).`

This makes DexUnit consistent with the other log units, which were already rendering properly.

**Tests**

A test case has been added to confirm that DexUnit now returns the correct LaTeX string.

**Notes**
1. This PR resolves the first part of the reported issue (incorrect LaTeX formatting for DexUnit).

2. The second part of the issue, where VSCode fails to render due to consecutive $$, is not addressed here, as that appears to be tied to VSCode’s LaTeX renderer rather than astropy itself.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18618

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
