### PR TITLE
Cosmo: neutrino info

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -106,9 +106,6 @@ class NeutrinoInfo(NamedTuple):
     has_massive_nu: bool
     """Boolean of which neutrinos are massive."""
 
-    massivenu_mass: NDArray[np.float64] | None
-    """Masses of the massive neutrinos in eV, or None if no massive neutrinos."""
-
     nmassivenu: int
     """Number of massive neutrinos."""
 
@@ -237,7 +234,6 @@ class FLRW(
                 nneutrinos=0,
                 neff_per_nu=None,
                 has_massive_nu=False,
-                massivenu_mass=None,
                 nmassivenu=0,
                 nmasslessnu=0,
                 nu_y=None,
@@ -254,11 +250,9 @@ class FLRW(
             # to do integrals with (perhaps surprisingly! But small python lists
             # are more efficient than small NumPy arrays).
             if has_massive_nu:
-                massivenu_mass = self.m_nu[massive].value
-                nu_y = (massivenu_mass / (_kB_evK * self.Tnu0)).value
+                nu_y = (self.m_nu[massive].value / (_kB_evK * self.Tnu0)).value
                 nu_y_list = nu_y.tolist()
             else:
-                massivenu_mass = None
                 nu_y = nu_y_list = None
 
             nu_info = NeutrinoInfo(
@@ -271,7 +265,6 @@ class FLRW(
                 # massless ones separately (since they are easy to deal with, and a
                 # common use case is to have only one massive neutrino).
                 has_massive_nu=has_massive_nu,
-                massivenu_mass=massivenu_mass,
                 nmassivenu=nmassivenu,
                 nmasslessnu=nneutrinos - nmassivenu,
                 nu_y=nu_y,

--- a/astropy/cosmology/_src/flrw/lambdacdm.py
+++ b/astropy/cosmology/_src/flrw/lambdacdm.py
@@ -107,7 +107,7 @@ class LambdaCDM(FLRW):
                     "_comoving_distance_z1z2",
                     self._elliptic_comoving_distance_z1z2,
                 )
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -611,7 +611,7 @@ class LambdaCDM(FLRW):
         # form for a cosmological constant
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -639,7 +639,7 @@ class LambdaCDM(FLRW):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -719,7 +719,7 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
             # of the LambaCDM above didn't actually create a flat cosmology.
             # That was done through the explicit tweak setting self.Ok0.
             self._optimize_flat_norad()
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -762,7 +762,7 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         # form for a cosmological constant
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -790,7 +790,7 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])

--- a/astropy/cosmology/_src/flrw/lambdacdm.py
+++ b/astropy/cosmology/_src/flrw/lambdacdm.py
@@ -107,7 +107,7 @@ class LambdaCDM(FLRW):
                     "_comoving_distance_z1z2",
                     self._elliptic_comoving_distance_z1z2,
                 )
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -122,9 +122,9 @@ class LambdaCDM(FLRW):
                 self.Ode0,
                 self.Ok0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
             )
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
@@ -611,7 +611,7 @@ class LambdaCDM(FLRW):
         # form for a cosmological constant
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -639,7 +639,7 @@ class LambdaCDM(FLRW):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -719,7 +719,7 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
             # of the LambaCDM above didn't actually create a flat cosmology.
             # That was done through the explicit tweak setting self.Ok0.
             self._optimize_flat_norad()
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -732,9 +732,9 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
                 self.Om0,
                 self.Ode0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
             )
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
         object.__setattr__(self, "_inv_efunc_scalar_args", inv_efunc_scalar_args)
@@ -762,7 +762,7 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         # form for a cosmological constant
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -790,7 +790,7 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])

--- a/astropy/cosmology/_src/flrw/w0cdm.py
+++ b/astropy/cosmology/_src/flrw/w0cdm.py
@@ -94,7 +94,7 @@ class wCDM(FLRW):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.Ok0, self.w0)
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -194,7 +194,7 @@ class wCDM(FLRW):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -225,7 +225,7 @@ class wCDM(FLRW):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -309,7 +309,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.w0)
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -352,7 +352,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -382,7 +382,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._nu_info.massivenu
+            if not self._nu_info.has_massive_nu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])

--- a/astropy/cosmology/_src/flrw/w0cdm.py
+++ b/astropy/cosmology/_src/flrw/w0cdm.py
@@ -94,7 +94,7 @@ class wCDM(FLRW):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.Ok0, self.w0)
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.wcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -110,9 +110,9 @@ class wCDM(FLRW):
                 self.Ode0,
                 self.Ok0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.w0,
             )
 
@@ -194,7 +194,7 @@ class wCDM(FLRW):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -225,7 +225,7 @@ class wCDM(FLRW):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -309,7 +309,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.w0)
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.fwcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -323,9 +323,9 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
                 self.Om0,
                 self.Ode0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.w0,
             )
         object.__setattr__(self, "_inv_efunc_scalar", inv_efunc_scalar)
@@ -352,7 +352,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])
@@ -382,7 +382,7 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         """
         Or = self.Ogamma0 + (
             self.Onu0
-            if not self._massivenu
+            if not self._nu_info.massivenu
             else self.Ogamma0 * self.nu_relative_density(z)
         )
         zp1 = aszarr(z) + 1.0  # (converts z [unit] -> z [dimensionless])

--- a/astropy/cosmology/_src/flrw/w0wacdm.py
+++ b/astropy/cosmology/_src/flrw/w0wacdm.py
@@ -117,7 +117,7 @@ class w0waCDM(FLRW):
                 self.w0,
                 self.wa,
             )
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -134,9 +134,9 @@ class w0waCDM(FLRW):
                 self.Ode0,
                 self.Ok0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.w0,
                 self.wa,
             )
@@ -291,7 +291,7 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.w0, self.wa)
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -306,9 +306,9 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
                 self.Om0,
                 self.Ode0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.w0,
                 self.wa,
             )

--- a/astropy/cosmology/_src/flrw/w0wacdm.py
+++ b/astropy/cosmology/_src/flrw/w0wacdm.py
@@ -117,7 +117,7 @@ class w0waCDM(FLRW):
                 self.w0,
                 self.wa,
             )
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.w0wacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -291,7 +291,7 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.w0, self.wa)
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,

--- a/astropy/cosmology/_src/flrw/w0wzcdm.py
+++ b/astropy/cosmology/_src/flrw/w0wzcdm.py
@@ -110,7 +110,7 @@ class w0wzCDM(FLRW):
                 self.w0,
                 self.wz,
             )
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -127,9 +127,9 @@ class w0wzCDM(FLRW):
                 self.Ode0,
                 self.Ok0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.w0,
                 self.wz,
             )
@@ -273,7 +273,7 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.w0, self.wz)
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -288,9 +288,9 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
                 self.Om0,
                 self.Ode0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.w0,
                 self.wz,
             )

--- a/astropy/cosmology/_src/flrw/w0wzcdm.py
+++ b/astropy/cosmology/_src/flrw/w0wzcdm.py
@@ -110,7 +110,7 @@ class w0wzCDM(FLRW):
                 self.w0,
                 self.wz,
             )
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.w0wzcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -273,7 +273,7 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
         if self.Tcmb0.value == 0:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_norel
             inv_efunc_scalar_args = (self.Om0, self.Ode0, self.w0, self.wz)
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.fw0wzcdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,

--- a/astropy/cosmology/_src/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/_src/flrw/wpwazpcdm.py
@@ -135,7 +135,7 @@ class wpwaCDM(FLRW):
                 apiv,
                 self.wa,
             )
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -153,9 +153,9 @@ class wpwaCDM(FLRW):
                 self.Ode0,
                 self.Ok0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.wp,
                 apiv,
                 self.wa,
@@ -325,7 +325,7 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
                 apiv,
                 self.wa,
             )
-        elif not self._massivenu:
+        elif not self._nu_info.massivenu:
             inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -341,9 +341,9 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
                 self.Om0,
                 self.Ode0,
                 self.Ogamma0,
-                self._neff_per_nu,
-                self._nmasslessnu,
-                self._nu_y_list,
+                self._nu_info.neff_per_nu,
+                self._nu_info.nmasslessnu,
+                self._nu_info.nu_y_list,
                 self.wp,
                 apiv,
                 self.wa,

--- a/astropy/cosmology/_src/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/_src/flrw/wpwazpcdm.py
@@ -135,7 +135,7 @@ class wpwaCDM(FLRW):
                 apiv,
                 self.wa,
             )
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.wpwacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,
@@ -325,7 +325,7 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
                 apiv,
                 self.wa,
             )
-        elif not self._nu_info.massivenu:
+        elif not self._nu_info.has_massive_nu:
             inv_efunc_scalar = scalar_inv_efuncs.fwpwacdm_inv_efunc_nomnu
             inv_efunc_scalar_args = (
                 self.Om0,

--- a/astropy/cosmology/_src/tests/flrw/test_base.py
+++ b/astropy/cosmology/_src/tests/flrw/test_base.py
@@ -166,7 +166,7 @@ class FLRWTest(
         if cosmo.Tnu0 == 0:
             assert cosmo.has_massive_nu is False
         else:
-            assert cosmo.has_massive_nu is cosmo._massivenu
+            assert cosmo.has_massive_nu is cosmo._nu_info.massivenu
 
     def test_h(self, cosmo_cls, cosmo):
         """Test ``cached_property`` ``h``."""

--- a/astropy/cosmology/_src/tests/flrw/test_base.py
+++ b/astropy/cosmology/_src/tests/flrw/test_base.py
@@ -166,7 +166,7 @@ class FLRWTest(
         if cosmo.Tnu0 == 0:
             assert cosmo.has_massive_nu is False
         else:
-            assert cosmo.has_massive_nu is cosmo._nu_info.massivenu
+            assert cosmo.has_massive_nu is cosmo._nu_info.has_massive_nu
 
     def test_h(self, cosmo_cls, cosmo):
         """Test ``cached_property`` ``h``."""

--- a/astropy/cosmology/_src/tests/flrw/test_parameters.py
+++ b/astropy/cosmology/_src/tests/flrw/test_parameters.py
@@ -301,7 +301,7 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
         # set differently depending on the other inputs
         if cosmo.Tnu0.value == 0:
             assert cosmo.m_nu is None
-        elif not cosmo._nu_info.massivenu:  # only massless
+        elif not cosmo._nu_info.has_massive_nu:  # only massless
             assert_quantity_allclose(cosmo.m_nu, 0 * u.eV)
         elif self._nu_info.nmasslessnu == 0:  # only massive
             assert cosmo.m_nu == cosmo._nu_info.massivenu_mass

--- a/astropy/cosmology/_src/tests/flrw/test_parameters.py
+++ b/astropy/cosmology/_src/tests/flrw/test_parameters.py
@@ -8,6 +8,7 @@ from inspect import BoundArguments
 import numpy as np
 import pytest
 
+import astropy.constants as const
 import astropy.units as u
 from astropy.cosmology import Cosmology, FlatFLRWMixin, Parameter
 from astropy.cosmology._src.parameter import MISSING
@@ -304,11 +305,12 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
         elif not cosmo._nu_info.has_massive_nu:  # only massless
             assert_quantity_allclose(cosmo.m_nu, 0 * u.eV)
         elif self._nu_info.nmasslessnu == 0:  # only massive
-            assert cosmo.m_nu == cosmo._nu_info.massivenu_mass
+            assert cosmo.m_nu == cosmo._nu_info.nu_y * const.k_B * cosmo.Tnu0
         else:  # a mix -- the most complicated case
             assert_quantity_allclose(cosmo.m_nu[: self._nu_info.nmasslessnu], 0 * u.eV)
             assert_quantity_allclose(
-                cosmo.m_nu[self._nu_info.nmasslessnu], cosmo._nu_info.massivenu_mass
+                cosmo.m_nu[self._nu_info.nmasslessnu],
+                cosmo._nu_info.nu_y * const.k_B * cosmo.Tnu0,
             )
 
     def test_init_m_nu(self, cosmo_cls: type[Cosmology], ba: BoundArguments):

--- a/astropy/cosmology/_src/tests/flrw/test_parameters.py
+++ b/astropy/cosmology/_src/tests/flrw/test_parameters.py
@@ -301,14 +301,14 @@ class Parameterm_nuTestMixin(ParameterTestMixin):
         # set differently depending on the other inputs
         if cosmo.Tnu0.value == 0:
             assert cosmo.m_nu is None
-        elif not cosmo._massivenu:  # only massless
+        elif not cosmo._nu_info.massivenu:  # only massless
             assert_quantity_allclose(cosmo.m_nu, 0 * u.eV)
-        elif self._nmasslessnu == 0:  # only massive
-            assert cosmo.m_nu == cosmo._massivenu_mass
+        elif self._nu_info.nmasslessnu == 0:  # only massive
+            assert cosmo.m_nu == cosmo._nu_info.massivenu_mass
         else:  # a mix -- the most complicated case
-            assert_quantity_allclose(cosmo.m_nu[: self._nmasslessnu], 0 * u.eV)
+            assert_quantity_allclose(cosmo.m_nu[: self._nu_info.nmasslessnu], 0 * u.eV)
             assert_quantity_allclose(
-                cosmo.m_nu[self._nmasslessnu], cosmo._massivenu_mass
+                cosmo.m_nu[self._nu_info.nmasslessnu], cosmo._nu_info.massivenu_mass
             )
 
     def test_init_m_nu(self, cosmo_cls: type[Cosmology], ba: BoundArguments):


### PR DESCRIPTION
This PR consolidates all the private neutrino-related attributes into a single named tuple.
This brings FLRW cosmologies closer to being proper data classes, which are defined by their fields.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
