### PR TITLE
Simplify regression tests for #6347

### DIFF
--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -271,6 +271,10 @@ def test_search_around_no_matches(function, search_limit):
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
 
+    # regression test for #6347 - we want Angle, not just Quantity,
+    # even if there are no matches.
+    assert isinstance(d2d, Angle)
+
 
 @pytest.mark.parametrize(
     "function,search_limit",

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -515,44 +515,6 @@ def test_regression_6236():
     assert msf4.my_attr == msf3.my_attr
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="No Scipy")
-def test_regression_6347():
-    sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
-    sc2 = SkyCoord([1.1, 2.1] * u.deg, [3.1, 4.1] * u.deg)
-    sc0 = sc1[:0]
-
-    idx1_10, idx2_10, d2d_10, d3d_10 = sc1.search_around_sky(sc2, 10 * u.arcmin)
-    idx1_1, idx2_1, d2d_1, d3d_1 = sc1.search_around_sky(sc2, 1 * u.arcmin)
-    idx1_0, idx2_0, d2d_0, d3d_0 = sc0.search_around_sky(sc2, 10 * u.arcmin)
-
-    assert len(d2d_10) == 2
-
-    assert len(d2d_0) == 0
-    assert type(d2d_0) is type(d2d_10)
-
-    assert len(d2d_1) == 0
-    assert type(d2d_1) is type(d2d_10)
-
-
-@pytest.mark.skipif(not HAS_SCIPY, reason="No Scipy")
-def test_regression_6347_3d():
-    sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, [5, 6] * u.kpc)
-    sc2 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, [5.1, 6.1] * u.kpc)
-    sc0 = sc1[:0]
-
-    idx1_10, idx2_10, d2d_10, d3d_10 = sc1.search_around_3d(sc2, 500 * u.pc)
-    idx1_1, idx2_1, d2d_1, d3d_1 = sc1.search_around_3d(sc2, 50 * u.pc)
-    idx1_0, idx2_0, d2d_0, d3d_0 = sc0.search_around_3d(sc2, 500 * u.pc)
-
-    assert len(d2d_10) > 0
-
-    assert len(d2d_0) == 0
-    assert type(d2d_0) is type(d2d_10)
-
-    assert len(d2d_1) == 0
-    assert type(d2d_1) is type(d2d_10)
-
-
 def test_gcrs_itrs_cartesian_repr():
     # issue 6436: transformation failed if coordinate representation was
     # Cartesian


### PR DESCRIPTION
### Description

The regression tests added in #6347 are meant to ensure that the angular separations returned by `search_around_3d()` and `search_around_sky()` functions are `Angle` instances even if there are no matches (i.e. the separations are empty), but learning that is only possible by reading the issue on GitHub despite how verbose the tests are.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
