### PR TITLE
Fix slicing FITS compressed file with .section when data is scaled

### DIFF
--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -491,7 +491,9 @@ class CompImageHDU(ImageHDU):
 
         # Since .section has general code to load any arbitrary part of the
         # data, we can just use this
-        return self.section[...]
+        data = self.section[...]
+        self._update_header_scale_info(data.dtype)
+        return data
 
     @data.setter
     def data(self, data):

--- a/astropy/io/fits/hdu/compressed/section.py
+++ b/astropy/io/fits/hdu/compressed/section.py
@@ -69,9 +69,8 @@ class CompImageSection:
             )
             if self.hdu._do_not_scale_image_data:
                 return data
-            scaled_data = self.hdu._scale_data(data)
-            self.hdu._update_header_scale_info(scaled_data.dtype)
-            return scaled_data
+            else:
+                return self.hdu._scale_data(data)
 
         index = simplify_basic_index(index, shape=self._data_shape)
 
@@ -128,7 +127,5 @@ class CompImageSection:
 
         if self.hdu._do_not_scale_image_data:
             return data
-
-        scaled_data = self.hdu._scale_data(data)
-        self.hdu._update_header_scale_info(scaled_data.dtype)
-        return scaled_data
+        else:
+            return self.hdu._scale_data(data)

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1248,6 +1248,31 @@ def test_section_unwritten():
     assert hdu.section[3, 4] == data[3, 4]
 
 
+def test_section_scaling(tmp_path):
+    data = (np.arange(200 * 200).reshape(200, 200) - 20_000).astype(np.int16)
+    chdu = fits.CompImageHDU(data=data)
+    chdu._scale_internal(bzero=1.234, bscale=0.0002, blank=32767)
+    chdu.writeto(tmp_path / "compressed.fits")
+
+    with fits.open(tmp_path / "compressed.fits") as hdul:
+        section = hdul[1].section
+        # underlying data is int16 but accessing it triggers scaling
+        assert section.dtype == np.int16
+        assert section[:10].dtype == np.float32
+        # behavior should remain the same after data has been accessed
+        assert section.dtype == np.int16
+        assert section[:10].dtype == np.float32
+
+    with fits.open(tmp_path / "compressed.fits") as hdul:
+        section = hdul[1].section
+        # underlying data is int16 but accessing it triggers scaling
+        assert section.dtype == np.int16
+        assert section[...].dtype == np.float32
+        # behavior should remain the same after data has been accessed
+        assert section.dtype == np.int16
+        assert section[...].dtype == np.float32
+
+
 EXPECTED_HEADER = """
 XTENSION= 'IMAGE   '           / Image extension
 BITPIX  =                   16 / data type of original image

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -747,3 +747,27 @@ def test_cutout_section(tmp_path):
 
         # Partial cutout
         c = Cutout2D(hdul[1].section, (75, 75), 100 * u.pix, mode="partial")
+
+
+def test_cutout_section_with_bzero_bscale_blank(tmp_path):
+    # Make sure that one can pass ImageHDU.section and CompImageHDU.section
+    # to Cutout2D
+
+    data = (np.arange(200 * 200).reshape(200, 200) - 20_000).astype(np.int16)
+    hdu = fits.ImageHDU(data=data)
+    hdu._scale_internal(bzero=1.234, bscale=0.0002, blank=32767)
+    hdu.writeto(tmp_path / "uncompressed.fits")
+
+    position, size = (25, 25), 100 * u.pix
+
+    with fits.open(tmp_path / "uncompressed.fits") as hdul:
+        # Partial cutout
+        c = Cutout2D(hdul[1].section, position, size, mode="partial")
+
+    chdu = fits.CompImageHDU(data=data)
+    chdu._scale_internal(bzero=1.234, bscale=0.0002, blank=32767)
+    chdu.writeto(tmp_path / "compressed.fits")
+
+    with fits.open(tmp_path / "compressed.fits") as hdul:
+        # Partial cutout
+        c = Cutout2D(hdul[1].section, position, size, mode="partial")

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -272,9 +272,9 @@ def extract_array(
 
     # Extracting on the edges is presumably a rare case, so treat special here
     if (extracted_array.shape != shape) and (mode == "partial"):
-        extracted_array = np.zeros(shape, dtype=extracted_array.dtype)
+        extracted_array_large = np.zeros(shape, dtype=extracted_array.dtype)
         try:
-            extracted_array[:] = fill_value
+            extracted_array_large[:] = fill_value
         except ValueError as exc:
             exc.args += (
                 "fill_value is inconsistent with the data type of "
@@ -285,7 +285,8 @@ def extract_array(
             )
             raise exc
 
-        extracted_array[small_slices] = array_large[large_slices]
+        extracted_array_large[small_slices] = extracted_array
+        extracted_array = extracted_array_large
         if return_position:
             new_position = [i + s.start for i, s in zip(new_position, small_slices)]
     if return_position:

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -272,7 +272,7 @@ def extract_array(
 
     # Extracting on the edges is presumably a rare case, so treat special here
     if (extracted_array.shape != shape) and (mode == "partial"):
-        extracted_array = np.zeros(shape, dtype=array_large.dtype)
+        extracted_array = np.zeros(shape, dtype=extracted_array.dtype)
         try:
             extracted_array[:] = fill_value
         except ValueError as exc:

--- a/docs/changes/io.fits/18640.bugfix.rst
+++ b/docs/changes/io.fits/18640.bugfix.rst
@@ -1,1 +1,1 @@
-iFix slicing FITS compressed file with .section when data is scaled.
+Fix slicing FITS compressed file with ``.section`` when data is scaled.

--- a/docs/changes/io.fits/18640.bugfix.rst
+++ b/docs/changes/io.fits/18640.bugfix.rst
@@ -1,0 +1,1 @@
+iFix slicing FITS compressed file with .section when data is scaled.

--- a/docs/changes/nddata/18640.bugfix.rst
+++ b/docs/changes/nddata/18640.bugfix.rst
@@ -1,0 +1,1 @@
+Fix partial cutouts with FITS compressed file and scaled data.


### PR DESCRIPTION
Fix #18467

As mentioned in https://github.com/astropy/astropy/issues/18467#issuecomment-3129151903 I think `.section` should not call `._update_header_scale_info` since only a slice of the data is scaled and the raw data is still unscaled.
This affects `Cutout2D` but also repeated calls to `.section`, I added tests for both cases.


<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Close https://github.com/astropy/astropy/pull/18548

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
