### PR TITLE
DEP: temporary ban for newest `beautifulsoup4` to restore CI stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ all = [
     "dask[array]>=2022.5.1",
     "h5py>=3.9.0",  # older versions used deprecated np.product()
     "pyarrow>=10.0.1",
-    "beautifulsoup4>=4.9.3", # imposed by pandas==2.0
+    "beautifulsoup4>=4.9.3,!= 4.14.0", # lower bound imposed by pandas==2.0, 4.14.0 excluded because of https://github.com/astropy/astropy/issues/18646
     "html5lib>=1.1",
     "bleach>=3.2.1",
     "pandas>=2.0",


### PR DESCRIPTION
### Description
Quick patch to restore CI stability until a better solution is found (most likely requires changes upstream).
I'll dig into further details on Monday and make sure the problem is known to pandas devs and bs4 devs.

ref #18646 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
