### PR TITLE
TST: ban a known incompatible pre-release version of pyparsing in devdeps testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -715,3 +715,8 @@ ignore-words-list = """
     te,
     wirth,
 """
+
+[tool.uv]
+constraint-dependencies = [
+    "pyparsing<3.3.0a1",  # https://github.com/astropy/astropy/issues/18652
+]


### PR DESCRIPTION
### Description

[example logs](https://github.com/astropy/astropy/actions/runs/18117495474/job/51555967470)
The issue is already known upstream, and will likely be addressed with the next release of matplotlib
xref: https://github.com/matplotlib/matplotlib/issues/30617

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
