### PR TITLE
Remove parameter descriptions from two named tuple docstrings

### DIFF
--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -28,19 +28,6 @@ __all__ = [
 class CoordinateMatchResult(NamedTuple):
     """Results of matching a set of sources to a catalog.
 
-    Parameters
-    ----------
-    indices_to_catalog : int array
-        For each source the index of the match in the catalog.
-    angular_separation : `~astropy.coordinates.Angle`
-        The angular separation between each source and its match
-        in the catalog.
-    physical_separation : `~astropy.units.Quantity`
-        The physical separation between each source and its match
-        in the catalog. If the sources or the catalog lack distances
-        then the physical separations are computed assuming all
-        coordinates are points on the unit sphere.
-
     See Also
     --------
     astropy.coordinates.match_coordinates_3d
@@ -231,22 +218,6 @@ def match_coordinates_sky(
 
 class CoordinateSearchResult(NamedTuple):
     """Results of searching close pairs between two sets of sources.
-
-    Parameters
-    ----------
-    indices_to_first_set : int array
-        Indices of the elements of the found pairs in the first set of
-        sources.
-    indices_to_second_set : int array
-        Indices of the elements of the found pairs in the second set of
-        sources.
-    angular_separation : `~astropy.coordinates.Angle`
-        The angular separations between the paired sources.
-    physical_separation : `~astropy.units.Quantity`
-        The physical separations between the paired sources. If either
-        of the source sets lack distances then the physical separations
-        are computed assuming all coordinates are points on the unit
-        sphere.
 
     See Also
     --------


### PR DESCRIPTION
### Description

`CoordinateMatchResult` and `CoordinateSearchResult` are `NamedTuple` subclasses that provide named attributes for the results of coordinate searching and matching functions. Users are not expected to create instances of these tuples themselves, so there is no need to have "Parameters" sections in their docstrings. What is important is that the attributes are documented.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
