### PR TITLE
 poisson_conf_interval failing for large N : Issue #13334 

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -651,7 +651,7 @@ def poisson_conf_interval(
 
     This function has an optional dependency: Either `Scipy
     <https://www.scipy.org/>`_ or `mpmath <https://mpmath.org/>`_  need
-    to be available (Scipy works only for N < 100).
+    to be available.
     This code is very intense numerically, which makes it much slower than
     the other methods, in particular for large count numbers (above 1000
     even with ``mpmath``). Fortunately, some of the other methods or a
@@ -1137,30 +1137,32 @@ def _scipy_kraft_burrows_nousek(N: int, B: float, CL: float) -> tuple[float, flo
 
     Notes
     -----
-    Requires :mod:`~scipy`. This implementation will cause Overflow Errors for
-    about N > 100 (the exact limit depends on details of how scipy was
-    compiled). See `~astropy.stats.mpmath_poisson_upper_limit` for an
-    implementation that is slower, but can deal with arbitrarily high numbers
-    since it is based on the `mpmath <https://mpmath.org/>`_ library.
+    Requires :mod:`~scipy`.
     """
     from scipy.integrate import quad
     from scipy.optimize import brentq
-    from scipy.special import factorial
+    from scipy.special import gammaln
+
+    B = float(B)
 
     def eqn8(N: int, B: float) -> float:
         n = np.arange(N + 1, dtype=np.float64)
-        return 1.0 / (math.exp(-B) * np.sum(np.power(B, n) / factorial(n)))
+        # version of math.exp(-B) * np.sum(np.power(B, n) / factorial(n))
+        # which is safe for large N
+        return 1.0 / np.sum(np.exp(n * math.log(B) - B - gammaln(n + 1)))
 
     # The parameters of eqn8 do not vary between calls so we can calculate the
     # result once and reuse it. The same is True for the factorial of N.
     # eqn7 is called hundred times so "caching" these values yields a
     # significant speedup (factor 10).
     eqn8_res = eqn8(N, B)
-    factorial_N = float(math.factorial(N))
 
     def eqn7(S: float, N: int, B: float) -> float:
         SpB = S + B
-        return eqn8_res * (math.exp(-SpB) * SpB**N / factorial_N)
+        # We use gammaln to avoid overflow for large N.
+        # It is identical to eqn8_res * (math.exp(-SpB) * SpB**N / factorial_N)
+        # See https://en.wikipedia.org/wiki/Poisson_distribution#Computational_methods
+        return eqn8_res * math.exp(N * math.log(SpB) - SpB - gammaln(N + 1))
 
     def eqn9_left(S_min: float, S_max: float, N: int, B: float) -> tuple[float, float]:
         return quad(eqn7, S_min, S_max, args=(N, B), limit=500)
@@ -1185,7 +1187,9 @@ def _scipy_kraft_burrows_nousek(N: int, B: float, CL: float) -> tuple[float, flo
         out = eqn9_left(s_min, s, N, B)
         return out[0] - CL
 
-    S_max = brentq(func, N - B, 100)
+    # max(100, np.sqrt(N) * 10 + N) chosen to represent ~10 sigma over input number
+    # while never being smaller than 100
+    S_max = brentq(func, N - B, max(100, np.sqrt(N) * 10 + N))
     S_min = find_s_min(S_max, N, B)
     return S_min, S_max
 
@@ -1311,10 +1315,9 @@ def _kraft_burrows_nousek(N: int, B: float, CL: float) -> tuple[float, float]:
     Notes
     -----
     This functions has an optional dependency: Either :mod:`scipy` or `mpmath
-    <https://mpmath.org/>`_  need to be available. (Scipy only works for
-    N < 100).
+    <https://mpmath.org/>`_  need to be available.
     """
-    if HAS_SCIPY and N <= 100:
+    if HAS_SCIPY:
         try:
             return _scipy_kraft_burrows_nousek(N, B, CL)
         except OverflowError:

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -666,6 +666,12 @@ def test_scipy_poisson_limit():
         (0, 10.67),
         rtol=1e-3,
     )
+    # Regression test for gh-13334
+    assert_allclose(
+        funcs._scipy_kraft_burrows_nousek(98, 3.8, 0.95),
+        (76.04, 114.92),
+        rtol=1e-3,
+    )
     conf = funcs.poisson_conf_interval(
         [5, 6],
         "kraft-burrows-nousek",

--- a/docs/changes/stats/18676.bugfix.rst
+++ b/docs/changes/stats/18676.bugfix.rst
@@ -1,0 +1,1 @@
+``poisson_conf_interval`` ``kraft-burrows-nousek`` no longer fails for large N.


### PR DESCRIPTION
Fixes Issue #13334  in poisson_conf_interval 'kraft-burrows-nousek' where the function would fail due to a hard coded limit of 100. By replacing the poisson distribution with a more numerically stable version as seen on https://en.wikipedia.org/wiki/Poisson_distribution#Computational_methods. Additionally added a test.

Fixes #13334 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
