### PR TITLE
Fixed issue 13539: Avoid logger info in CCDData.read when unit specifies matches that in FITS file

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -716,10 +716,11 @@ def fits_ccddata_reader(
                         "file before reading it."
                     )
             else:
-                log.info(
-                    f"using the unit {unit} passed to the FITS reader instead "
-                    f"of the unit {fits_unit_string} in the FITS file."
-                )
+                if str(unit) != str(fits_unit_string): #Only log if the specified unit differs from the FITS header unit!
+                    log.info(
+                        f"using the unit {unit} passed to the FITS reader instead "
+                        f"of the unit {fits_unit_string} in the FITS file."
+                    )
 
         use_unit = unit or fits_unit_string
         hdr, wcs = _generate_wcs_and_update_header(hdr)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request fixes an unnecessary log message in CCDData.read that was emitted even when the user-specified unit matched the FITS file’s BUNIT header value.

Previously, fits_ccddata_reader would always issue an INFO-level log message whenever a unit argument was provided, regardless of whether it differed from the FITS file unit. This PR adds a conditional check so that the log message is only displayed when the specified unit and the FITS BUNIT actually differ.

Additionally, new tests were added in astropy/nddata/tests/test_ccddata.py to verify that:
	•	No log message is emitted when the units match.
	•	A log message is still emitted when the units differ.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #13539 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
