### PR TITLE
Fix checksum verification when opening VLA BintableHDUs

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1273,7 +1273,10 @@ class _ValidHDU(_BaseHDU, _Verify):
             - 2 - no ``DATASUM`` keyword present
         """
         if "DATASUM" in self._header:
-            datasum = self._calculate_datasum()
+            if self._header.get("XTENSION") == "BINTABLE" and not self.is_image:
+                datasum = self._calculate_datasum_with_heap()
+            else:
+                datasum = self._calculate_datasum()
             if datasum == int(self._header["DATASUM"]):
                 return 1
             else:
@@ -1296,7 +1299,10 @@ class _ValidHDU(_BaseHDU, _Verify):
         """
         if "CHECKSUM" in self._header:
             if "DATASUM" in self._header:
-                datasum = self._calculate_datasum()
+                if self._header.get("XTENSION") == "BINTABLE" and not self.is_image:
+                    datasum = self._calculate_datasum_with_heap()
+                else:
+                    datasum = self._calculate_datasum()
             else:
                 datasum = 0
             checksum = self._calculate_checksum(datasum)

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -217,6 +217,17 @@ class TestChecksumFunctions(BaseChecksumTests):
             assert checksum == hdul[1]._checksum
             assert datasum == hdul[1]._datasum
 
+    def test_variable_length_table_data3(self):
+        """regression test for #14396"""
+
+        testfile = self.temp("tmp.fits")
+        col1 = fits.Column(name="b", format="A", array=["a"])
+        col2 = fits.Column(name="c", format="QD", array=[[1, 2]])
+        tab = fits.BinTableHDU.from_columns(name="test", columns=[col2, col1])
+        tab.writeto(testfile, checksum=True, overwrite=True)
+        with fits.open(testfile, checksum=True) as hdul:
+            pass
+
     def test_ascii_table_data(self):
         a1 = np.array(["abc", "def"])
         r1 = np.array([11.0, 12.0])


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request calculate the datasum with the heap when opening a BintableHDU.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #14396

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
