### PR TITLE
Fix datasum calculation with heap

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -866,12 +866,13 @@ class BinTableHDU(_TableBaseHDU):
         Calculate the value for the ``DATASUM`` card given the input data.
         """
         with _binary_table_byte_swap(self.data) as data:
-            csum = self._compute_checksum(data.view(type=np.ndarray, dtype=np.ubyte))
-
-            # Now add in the heap data to the checksum (we can skip any gap
+            # Now append the heap data to the table data (we can skip any gap
             # between the table and the heap since it's all zeros and doesn't
             # contribute to the checksum
-            return self._compute_checksum(data._get_heap_data(), csum)
+            full_data = np.concatenate(
+                (data.view(type=np.ndarray, dtype=np.ubyte), data._get_heap_data())
+            )
+            return self._compute_checksum(full_data)
 
     def _calculate_datasum(self):
         """

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -217,6 +217,19 @@ class TestChecksumFunctions(BaseChecksumTests):
             assert checksum == hdul[1]._checksum
             assert datasum == hdul[1]._datasum
 
+    def test_variable_length_table_data3(self):
+        """regression test for #14396"""
+
+        testfile = self.temp("tmp.fits")
+        col1 = fits.Column(name="a", format="1A", array=["a"])
+        col2 = fits.Column(name="b", format="QD", array=[[1]])
+        tab = fits.BinTableHDU.from_columns(name="test", columns=[col1, col2])
+
+        tab.writeto(testfile, checksum=True)
+        with fits.open(testfile, checksum=True) as hdul:
+            assert hdul[1].header["DATASUM"] == "1648357376"
+            assert hdul[1].header["CHECKSUM"] == "2CoL4BnL2BnL2BnL"
+
     def test_ascii_table_data(self):
         a1 = np.array(["abc", "def"])
         r1 = np.array([11.0, 12.0])


### PR DESCRIPTION
### Description
This pull request is to address the incorrect calculation of the checksum in FITS binary tables, which under certain circumstances lead to incorrect DATASUM and CHECKSUM header values.

Fixes #14396. Big thanks to @cmarmo for spotting that `_calculate_datasum_with_heap` was related to this issue (see #18679).

My current understanding of the issue is that the previous code calculated the checksum for the table data first and then separately for the heap data, and then added both results (through the sum32 parameter). The assumption here is that this would lead to the same result as calculating the checksum of the concatenated arrays. However, this is incorrect due to the fact `_compute_checksum` adds padding when the number of bytes cannot be split into 4. In cases where the table data could not be split into sets of 4 bytes, in practice we were adding padding between the table and heap data which shifted the way the bytes in the heap data were then interpreted. With my change, the padding is now properly added at the end of the entire data (table+heap).

Notes:

- This will cause merge conflicts with #18487 (@saimn please have a look)
- This fix has the downside of creating a temporary copy of the data in memory due to the concatenate function. In theory, we should be able to avoid this copy by "joining" the arrays with something like `itertools.chain` instead, but the current interface for `_compute_checksum` requires receiving a `ndarray`. It might be worth reworking this function to avoid copies? I'm open to ideas on how to do this.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
