### PR TITLE
MNT: sign myself up for custom notifications via `.github/CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,14 +19,14 @@ astropy/convolution         @larrybradley
 astropy/cosmology           @astropy/cosmology
 astropy/io/ascii            @taldcroft          @dhomeier
 astropy/io/fits             @saimn
-astropy/io/misc             @WilliamJamieson    @matteobachetti
-astropy/io/registry         @nstarman
+astropy/io/misc             @WilliamJamieson    @matteobachetti    @neutrinoceros
+astropy/io/registry         @nstarman           @neutrinoceros
 # astropy/io/votable
 astropy/modeling            @astropy/modeling
 # astropy/nddata
 # astropy/samp
 astropy/stats               @larrybradley
-astropy/table               @taldcroft
+astropy/table               @taldcroft    @neutrinoceros
 astropy/time                @taldcroft
 # astropy/timeseries
 # astropy/uncertainty
@@ -47,7 +47,7 @@ docs/modeling               @astropy/modeling
 # docs/nddata
 # docs/samp
 docs/stats                  @larrybradley
-docs/table                  @taldcroft
+docs/table                  @taldcroft    @neutrinoceros
 docs/time                   @taldcroft
 # docs/timeseries
 # docs/uncertainty
@@ -56,5 +56,10 @@ docs/time                   @taldcroft
 docs/visualization          @astrofrog      @larrybradley
 docs/wcs                    @mcara
 
-.pre-commit-config.yaml     @WilliamJamieson    @nstarman
-.ruff.toml                   @WilliamJamieson    @nstarman
+pyproject.toml              @neutrinoceros
+setup.py                    @neutrinoceros
+MANIFEST.in                 @neutrinoceros
+tox.ini                     @neutrinoceros
+*.git*                      @neutrinoceros # git files and .github dir
+.pre-commit-config.yaml     @WilliamJamieson    @nstarman    @neutrinoceros
+.ruff.toml                  @WilliamJamieson    @nstarman    @neutrinoceros


### PR DESCRIPTION
### Description
I've tried two different approaches to setup my notifications:
- watch everything -> I found this isn't manageable for me in the long run
- count on pings + semi-regular, manual watch -> I don't see *enough* stuff

so let's try a different route, using CODEOWNERS to sign myself up for certain notifications.
Basically I aim to watch most (main) project-level configuration and CI files. I'm also (temporarily) signing up for updates to `table` and general `io` stuff, because I'll be working on MRT support in the coming weeks/months. 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
