### PR TITLE
MNT: cleanup unused enable:cpython-prerelease parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,6 @@ markers = [
 # We disable testing for the following wheels:
 # - MuslLinux (tests hang non-deterministically)
 test-skip = "*-musllinux_x86_64"
-enable = ["cpython-prerelease"] # this line can be removed when cibuildwheel is bumped to 3.1.0 or newer
 skip = ["cp*t-*"] # https://github.com/astropy/astropy/issues/16916
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
### Description
This is a manual, partial (and noop) backport of a change from `main` I found while cleaning up my backlog.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
