### PR TITLE
Make a pass-job

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -165,3 +165,14 @@ jobs:
         name: Run build
         env:
           EXTENSION_HELPERS_PY_LIMITED_API: 'cp311'
+
+  status:
+    name: CI Pass
+    runs-on: ubuntu-latest
+    needs: [initial_checks, tests, test_wheel_building, test_limited_api_build]
+    if: always()
+    steps:
+      - name: All required jobs passed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Following https://learn.scientific-python.org/development/guides/gha-basic/#pass-job 

@pllim I think this means we can change most of the CI pass requirements to just this job.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
