### PR TITLE
Fix simple-to-address typing errors in `coordinates`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -17,7 +17,7 @@ import functools
 import operator
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Literal, NamedTuple, Union
+from typing import TYPE_CHECKING, ClassVar, Literal, NamedTuple, Union
 
 import numpy as np
 
@@ -437,14 +437,16 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
     where ``{lon}`` and ``{lat}`` are the frame names of the angular components.
     """
 
-    default_representation = None
-    default_differential = None
+    default_representation: ClassVar[type[r.BaseRepresentation] | None] = None
+    default_differential: ClassVar[type[r.BaseDifferential] | None] = None
 
     # Specifies special names and units for representation and differential
     # attributes.
-    frame_specific_representation_info = {}
+    frame_specific_representation_info: ClassVar[
+        dict[type[r.BaseRepresentationOrDifferential], list[RepresentationMapping]]
+    ] = {}
 
-    frame_attributes = {}
+    frame_attributes: dict[str, Attribute] = {}
     # Default empty frame_attributes dict
 
     # Declare that BaseCoordinateFrame can be used as a Table column by defining

--- a/astropy/coordinates/calculation.py
+++ b/astropy/coordinates/calculation.py
@@ -6,6 +6,7 @@ import re
 import textwrap
 import warnings
 from datetime import datetime
+from typing import Final
 from urllib.request import Request, urlopen
 
 # Third-party
@@ -14,7 +15,7 @@ from astropy.utils.console import _color_text, color_print
 
 from .funcs import get_sun
 
-__all__ = []
+__all__: Final[list[str]] = []
 
 
 class HumanError(ValueError):

--- a/astropy/coordinates/erfa_astrom.py
+++ b/astropy/coordinates/erfa_astrom.py
@@ -7,6 +7,7 @@ expense of accuracy.
 
 import functools
 import warnings
+from typing import Final
 
 import erfa
 import numpy as np
@@ -25,7 +26,7 @@ from .builtin_frames.utils import (
 )
 from .matrix_utilities import rotation_matrix
 
-__all__ = []
+__all__: Final[list[str]] = []
 
 
 def _refco(frame_or_coord):

--- a/astropy/coordinates/polarization.py
+++ b/astropy/coordinates/polarization.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import NamedTuple
 
@@ -41,7 +42,7 @@ UNKNOWN_STOKES_VALUE = -99999
 @contextmanager
 def custom_stokes_symbol_mapping(
     mapping: dict[int, StokesSymbol], replace: bool = False
-) -> None:
+) -> Generator[None, None, None]:
     """
     Add a custom set of mappings from values to Stokes symbols.
 
@@ -68,7 +69,7 @@ def custom_stokes_symbol_mapping(
 
 class StokesCoordInfo(MixinInfo):
     # The attributes containing actual information.
-    _represent_as_dict_attrs = {"value"}
+    _represent_as_dict_attrs = ("value",)
     # Since there is only one attribute, use a column with the name to represent it
     # (rather than as name.value)
     _represent_as_dict_primary_data = "value"

--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -20,8 +20,8 @@ from astropy.utils.masked import MaskableShapedLikeNDArray, Masked, combine_mask
 # Module-level dict mapping representation string alias names to classes.
 # This is populated by __init_subclass__ when called by Representation or
 # Differential classes so that they are all registered automatically.
-REPRESENTATION_CLASSES = {}
-DIFFERENTIAL_CLASSES = {}
+REPRESENTATION_CLASSES: dict[str, type["BaseRepresentation"]] = {}
+DIFFERENTIAL_CLASSES: dict[str, type["BaseDifferential"]] = {}
 # set for tracking duplicates
 DUPLICATE_REPRESENTATIONS = set()
 
@@ -654,7 +654,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
 
     info = RepresentationInfo()
     # Ensure _differentials always exists.
-    _differentials = {}
+    _differentials: dict[str, "BaseDifferential"] = {}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)  # sets `cls.name`

--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -13,6 +13,7 @@ import subprocess
 from collections import defaultdict
 from contextlib import contextmanager
 from itertools import pairwise
+from typing import Final
 
 from astropy.coordinates.transformations.affine import (
     AffineTransform,
@@ -29,12 +30,13 @@ __all__ = ["TransformGraph"]
 
 
 # map class names to colorblind-safe colors
-trans_to_color = {}
-trans_to_color[AffineTransform] = "#555555"  # gray
-trans_to_color[FunctionTransform] = "#783001"  # dark red-ish/brown
-trans_to_color[FunctionTransformWithFiniteDifference] = "#d95f02"  # red-ish
-trans_to_color[StaticMatrixTransform] = "#7570b3"  # blue-ish
-trans_to_color[DynamicMatrixTransform] = "#1b9e77"  # green-ish
+trans_to_color: Final = {
+    AffineTransform: "#555555",  # gray
+    FunctionTransform: "#783001",  # dark red-ish/brown
+    FunctionTransformWithFiniteDifference: "#d95f02",  # red-ish
+    StaticMatrixTransform: "#7570b3",  # blue-ish
+    DynamicMatrixTransform: "#1b9e77",  # green-ish
+}
 
 
 def frame_attrs_from_set(frame_set):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -12,7 +12,7 @@ import re
 import warnings
 from collections.abc import Collection
 from fractions import Fraction
-from typing import Self
+from typing import ClassVar, Self
 
 import numpy as np
 
@@ -178,7 +178,7 @@ class QuantityInfo(QuantityInfoBase):
     be used as a general way to store meta information.
     """
 
-    _represent_as_dict_attrs = ("value", "unit")
+    _represent_as_dict_attrs: tuple[str, ...] = ("value", "unit")
     _construct_from_dict_args = ["value"]
     _represent_as_dict_primary_data = "value"
 
@@ -867,7 +867,7 @@ class Quantity(np.ndarray):
         super().__setstate__(nd_state)
         self.__dict__.update(own_state)
 
-    info = QuantityInfo()
+    info: QuantityInfoBase = QuantityInfo()
 
     def _to_value(self, unit, equivalencies=[]):
         """Helper method for to and to_value."""
@@ -2127,7 +2127,7 @@ class SpecificTypeQuantity(Quantity):
 
     # The unit for the specific physical type.  Instances can only be created
     # with units that are equivalent to this.
-    _equivalent_unit = None
+    _equivalent_unit: ClassVar[UnitBase | tuple[UnitBase, ...] | None] = None
 
     # The default unit used for views.  Even with `None`, views of arrays
     # without units are possible, but will have an uninitialized unit.

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -294,20 +294,20 @@ class DataInfo(metaclass=DataInfoMeta):
     # (SkyCoordInfo).  These attributes may be scalars or arrays.  If arrays
     # that match the object length they will be serialized as an independent
     # column.
-    _represent_as_dict_attrs = ()
+    _represent_as_dict_attrs: tuple[str, ...] = ()
 
     # This specifies attributes which are to be provided to the class
     # initializer as ordered args instead of keyword args.  This is needed
     # for Quantity subclasses where the keyword for data varies (e.g.
     # between Quantity and Angle).
-    _construct_from_dict_args = ()
+    _construct_from_dict_args: tuple[str, ...] = ()
 
     # This specifies the name of an attribute which is the "primary" data.
     # Then when representing as columns
     # (table.serialize._represent_mixin_as_column) the output for this
     # attribute will be written with the just name of the mixin instead of the
     # usual "<name>.<attr>".
-    _represent_as_dict_primary_data = None
+    _represent_as_dict_primary_data: str | None = None
 
     def __init__(self, bound=False):
         # If bound to a data object instance then create the dict of attributes


### PR DESCRIPTION
### Description

The changes here halve the number of errors Mypy reports if invoked with
```
mypy --follow-imports silent --exclude tests/ -- astropy/coordinates/
```
In most cases the cause of the reported error was a missing annotation, which caused Mypy to automatically infer a type that was too narrow. Sometimes the correct place for the annotation was a parent class outside `coordinates`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
