### PR TITLE
TST: unpin pyparsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -731,8 +731,3 @@ ignore-words-list = """
     te,
     wirth,
 """
-
-[tool.uv]
-constraint-dependencies = [
-    "pyparsing<3.3.0a1",  # https://github.com/astropy/astropy/issues/18652
-]


### PR DESCRIPTION
### Description

matplotlib 3.10.7 is out and is compatible with pyparsing 3.3

Fixes #18652
revert #18651

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
