### PR TITLE
Remove unreachable code from `CoordinateTransform.__init__()`

### DIFF
--- a/astropy/coordinates/transformations/base.py
+++ b/astropy/coordinates/transformations/base.py
@@ -46,11 +46,7 @@ class CoordinateTransform(metaclass=ABCMeta):
         self.priority = float(priority)
 
         if register_graph:
-            # this will do the type-checking when it adds to the graph
             self.register(register_graph)
-        else:
-            if not isinstance(fromsys, type) or not isinstance(tosys, type):
-                raise TypeError("fromsys and tosys must be classes")
 
         self.overlapping_frame_attr_names = overlap = []
         if hasattr(fromsys, "frame_attributes") and hasattr(tosys, "frame_attributes"):


### PR DESCRIPTION
### Description

The removed code has been unreachable since beece136b3a224fc6eaf4d96cbe86b5b834a6693

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
