### PR TITLE
WHL: workaround broken defaut `MACOSX_DEPLOYMENT_TARGET` on cp314 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,11 @@ archs = ["x86_64", "arm64"]
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 
+[[tool.cibuildwheel.overrides]]
+# https://github.com/pypa/cibuildwheel/issues/2612
+select = "cp314-macosx_x86_64"
+inherit.environment="append"
+environment = {MACOSX_DEPLOYMENT_TARGET="10.15"}
 
 [tool.docformatter]
     # The ``summaries`` are not (yet) 75 characters because the summary lines can't be


### PR DESCRIPTION
### Description
Temporary patch for https://github.com/astropy/astropy/issues/18691 to unblock the release of astropy 7.1.1

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
