### PR TITLE
TST: drop `--color=yes` as a pytest addopted argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ jobs:
     docker:
       - image: cimg/python:3.11
     environment:
-      TOXENV=<< parameters.jobname >>
+      TOXENV: << parameters.jobname >>
+      PY_COLORS: "1"
     steps:
       - checkout
       - run:
@@ -50,6 +51,7 @@ jobs:
       - image: cimg/python:3.11
     environment:
       TOXENV: << parameters.jobname >>
+      PY_COLORS: "1"
       GIT_SSH_COMMAND: ssh -i ~/.ssh/id_rsa_bfaaefe38d95110b75c79252bafbe0fc
     steps:
       - checkout

--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   ARCH_ON_CI: "normal"
   IS_CRON: "true"
+  PY_COLORS: "1"
 
 permissions:
   contents: read

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -27,6 +27,7 @@ concurrency:
 
 env:
   IS_CRON: 'true'
+  PY_COLORS: "1"
 
 permissions:
   contents: read

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -56,6 +56,7 @@ jobs:
       setenv: |
         ARCH_ON_CI: "normal"
         IS_CRON: "false"
+        PY_COLORS: "1"
       submodules: false
       coverage: ''
       libraries: |
@@ -110,6 +111,7 @@ jobs:
       setenv: |
         ARCH_ON_CI: "normal"
         IS_CRON: "false"
+        PY_COLORS: "1"
       submodules: false
       coverage: ''
       libraries: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,6 @@ doctest_plus = "enabled"
 text_file_format = "rst"
 remote_data_strict = true
 addopts = [
-    "--color=yes",
     "--doctest-rst",
     "--strict-config",
     "--strict-markers",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ requires =
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
-passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI,PY_COLORS
 
 setenv =
     NUMPY_WARN_IF_NO_MEM_POLICY = 1


### PR DESCRIPTION
### Description
A long standing (albeit small) issue I've had with `--color=yes` as a hardcoded addopted argument is that it makes some of my command-line-based workflows harder than they should be: typically, when redirecting pytest's output to a log file as
```shell
$ pytest astropy ... > test.log
```
The resulting log would be heavily polluted with color (de)activator characters (I'm sure there's a more colloquial term for it, I just don't know it), so I regularily waste a couple minutes producing such useless logs before I remember to also pass `--color=no`.

This fixes this problem, while not changing anything for typical workflows.

I believe the actual intention of this addopt was to enable color in CI logs, which can be also done with minimal repetition by setting the appropriate environment variables, so I made sure they were there.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
