### PR TITLE
Use `utils.data` to handle compressed ecsv

### DIFF
--- a/astropy/io/misc/ecsv.py
+++ b/astropy/io/misc/ecsv.py
@@ -64,13 +64,13 @@ import os
 import re
 import warnings
 from collections.abc import Iterable
-from contextlib import ExitStack
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
+
+from astropy.utils.data import get_readable_fileobj
 
 if TYPE_CHECKING:
     from astropy.table import SerializedColumn, Table
@@ -441,8 +441,8 @@ def get_header_lines(
     ----------
     input_file : str | os.PathLike | io.BytesIO
         The input file path or file-like object to read. If a file path is
-        provided, the function automatically handles compressed files with
-        extensions `.gz` or `.bz2`.
+        provided, the function automatically handles compressed file formats
+        that are supported by `~astropy.utils.data.get_readable_fileobj`.
     encoding : str, optional
         The encoding used to decode the file content. Default is "utf-8".
 
@@ -463,25 +463,8 @@ def get_header_lines(
     n_empty = 0
     n_comment = 0
 
-    with ExitStack() as stack:
-        # Get a file-like object as tmp_input_file
-        if isinstance(input_file, (str, os.PathLike)):
-            ext = Path(input_file).suffix
-            if ext == ".gz":
-                import gzip
-
-                opener = gzip.open
-            elif ext == ".bz2":
-                import bz2
-
-                opener = bz2.open
-            else:
-                opener = open
-            tmp_input_file = stack.enter_context(opener(input_file, "rb"))
-        else:
-            tmp_input_file = input_file
-
-        for idx, line in enumerate(tmp_input_file):
+    with get_readable_fileobj(input_file, encoding="binary") as f:
+        for idx, line in enumerate(f):
             line_strip = line.strip()
             if line_strip.startswith(header_prefix):
                 lines.append(line_strip[2:].decode(encoding))

--- a/astropy/io/misc/pyarrow/tests/test_csv.py
+++ b/astropy/io/misc/pyarrow/tests/test_csv.py
@@ -2,6 +2,7 @@ import contextlib
 import datetime
 import decimal
 import io
+import sys
 import textwrap
 from pathlib import Path
 
@@ -11,7 +12,7 @@ from numpy.testing import assert_array_equal
 
 from astropy.io.misc.pyarrow.csv import strip_comment_lines
 from astropy.table import Table
-from astropy.utils.compat.optional_deps import HAS_PYARROW
+from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA, HAS_PYARROW
 
 if HAS_PYARROW:
     import pyarrow as pa
@@ -718,3 +719,49 @@ def test_read_whitespace_handling():
         "     3     4.0  w z ",
     ]
     assert out.pformat(show_dtype=True) == exp
+
+
+@pytest.mark.xfail(sys.platform.startswith("win"), reason="Broken on Windows")
+@pytest.mark.parametrize(
+    "compressed_filename",
+    [
+        "test.csv.gz",
+        pytest.param(
+            "test.csv.bz2",
+            marks=pytest.mark.xfail(not HAS_BZ2, reason="no bz2 support"),
+        ),
+        pytest.param(
+            "test.csv.xz",
+            marks=pytest.mark.xfail(not HAS_LZMA, reason="no lzma support"),
+        ),
+    ],
+)
+def test_compressed_files(tbl, tmp_path, compressed_filename):
+    filename = tmp_path / "test.csv"
+    tbl.write(filename)
+
+    compressed_filename = tmp_path / compressed_filename
+    if compressed_filename.suffix == ".gz":
+        import gzip
+
+        opener = gzip.open
+    elif compressed_filename.suffix == ".bz2":
+        import bz2
+
+        opener = bz2.open
+    elif compressed_filename.suffix == ".xz":
+        import lzma
+
+        opener = lzma.open
+    else:
+        # Shouldn't really happen
+        opener = open
+
+    # Compress ecsv file
+    with open(filename, "rb") as f_in:
+        with opener(compressed_filename, "wb") as f_out:
+            f_out.writelines(f_in)
+
+    # Open compressed file and compare to ensure it's read correctly
+    t_comp = Table.read(compressed_filename, format="pyarrow.csv")
+    assert_array_equal(tbl, t_comp)

--- a/docs/changes/io.misc/18712.feature.rst
+++ b/docs/changes/io.misc/18712.feature.rst
@@ -1,0 +1,3 @@
+Improve support for compressed file formats in the ECSV and the pyarrow CSV
+Table readers. All formats supported  by ``astropy.utils.data.get_readable_fileobj()``
+(currently gzip, bzip2, lzma (xz) or lzw (Z)) will now work with these readers.


### PR DESCRIPTION
### Description
This pull request is to change `io.misc.ecsv` to handle compressed data via `utils.data`, rather than having its own implementation. This expands its compression support to include LZMA- and LZW-compressed files while also keeping its support of gzip and bz2 files.

Fixes #18490.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
