### PR TITLE
TST: CircleCI blobless or full checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
     environment:
       TOXENV=<< parameters.jobname >>
     steps:
-      - checkout
+      - checkout:
+          method: blobless
       - run:
           name: Install dependencies
           command: |
@@ -52,7 +53,8 @@ jobs:
       TOXENV: << parameters.jobname >>
       GIT_SSH_COMMAND: ssh -i ~/.ssh/id_rsa_bfaaefe38d95110b75c79252bafbe0fc
     steps:
-      - checkout
+      - checkout:
+          method: blobless
       - run:
           name: Install dependencies
           command: |


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

We've introduced [blobless checkout](https://circleci.com/changelog/introducing-a-faster-checkout-option/) - starting November 3rd, we'll begin gradually rolling out blobless checkout as the default checkout method.


Most builds will continue working without changes with blobless checkout. However, you need to take action if your builds require access to historical file contents. For example, tools like Sonar (SonarQube, SonarCloud), Sentry, some coverage or security scanning tools, and custom scripts that rely on git blame, git diff, or git config commands may require full checkout.

To opt into blobless checkout immediately, or to test compatibility, edit your config to use the “blobless” method.

```yaml
steps:
  - checkout:
      method: blobless

```
 
If your CircleCI job fails, or you prefer to keep the current checkout behavior, edit your config to use the “full” method.

```yaml
steps:
  - checkout:
      method: full

```
 
If you do nothing and your builds break after November 3rd, you will be able to fix them by editing your config to use the "full" method.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
