### PR TITLE
Add support for the membership operator in ColDefs

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1760,6 +1760,14 @@ class ColDefs(NotifierMixin):
         else:
             return ColDefs(x)
 
+    def __contains__(self, key):
+        if isinstance(key, str):
+            return key.lower().rstrip() in (n.lower().rstrip() for n in self.names)
+        elif isinstance(key, Column):
+            return key in self.columns
+        else:
+            return False
+
     def __len__(self):
         return len(self.columns)
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3614,6 +3614,28 @@ class TestColumnFunctions(FitsTestCase):
         assert cols["a"] == cols[0]
         assert cols["b"] == cols[1]
 
+    def test_column_membership(self):
+        """Tests that the membership operator can be used for `ColDefs`."""
+
+        a = fits.Column(name="a", format="D")
+        b = fits.Column(name="b", format="D")
+        c = fits.Column(name="c", format="D")
+
+        cols = fits.ColDefs([a, b])
+
+        # String tests
+        assert "a" in cols
+        assert "b" in cols
+        assert "c" not in cols
+        # Column tests
+        assert a in cols
+        assert b in cols
+        assert c not in cols
+        # General case (false)
+        assert 1 not in cols
+        assert cols not in cols
+        assert [a, b] not in cols
+
     def test_column_attribute_change_after_removal(self):
         """
         This is a test of the column attribute change notification system.

--- a/docs/changes/io.fits/18717.feature.rst
+++ b/docs/changes/io.fits/18717.feature.rst
@@ -1,0 +1,1 @@
+It is now possible to check the existence of ``Columns`` in ``ColDefs`` by using the membership operator.


### PR DESCRIPTION
### Description
This pull request is to address the lack of support for the membership operator in ColDefs

Fixes #18716


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
