### PR TITLE
TST: future proof a table test against pandas 3.0.0dev (fixup #18653)

### DIFF
--- a/astropy/table/tests/test_df.py
+++ b/astropy/table/tests/test_df.py
@@ -139,9 +139,11 @@ class TestDataFrameConversion:
             original_col = t[column]
             roundtrip_col = t2[column]
 
-            if column in ("u", "s"):
+            assert roundtrip_col.dtype.kind == original_col.dtype.kind
+
+            if original_col.dtype.kind in ("U", "S"):
                 assert_array_equal(roundtrip_col, original_col)
-                if backend == "pandas":
+                if original_col.dtype.kind == "U" and backend == "pandas":
                     # Pandas-specific checks
                     assert d[column].dtype == pandas_string_dtype
             else:


### PR DESCRIPTION
### Description
Follow up to #18653 which in the end, didn't fix the compatibility issue because of a messy merge conflict resolution I incorrectly conducted. This fixes the fix.

~I'm also going to check wether my manual backport for 7.1.x (#18722) needs revision.~
update: done. The backport branch is safe.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
