### PR TITLE
Annotate `CoordinateTransform` and its subclasses

### DIFF
--- a/astropy/coordinates/transformations/function.py
+++ b/astropy/coordinates/transformations/function.py
@@ -5,8 +5,10 @@
 These are transformations that cannot be represented as an affine transformation.
 """
 
+from collections.abc import Callable
 from contextlib import suppress
 from inspect import signature
+from typing import TYPE_CHECKING, Union
 from warnings import warn
 
 from astropy import units as u
@@ -16,6 +18,11 @@ from astropy.coordinates.representation import (
 )
 from astropy.coordinates.transformations.base import CoordinateTransform
 from astropy.utils.exceptions import AstropyWarning
+
+if TYPE_CHECKING:
+    from astropy.coordinates import BaseCoordinateFrame
+
+    from .graph import TransformGraph
 
 __all__ = ["FunctionTransform", "FunctionTransformWithFiniteDifference"]
 
@@ -53,7 +60,16 @@ class FunctionTransform(CoordinateTransform):
 
     """
 
-    def __init__(self, func, fromsys, tosys, priority=1, register_graph=None):
+    def __init__(
+        self,
+        func: Callable[
+            ["BaseCoordinateFrame", "BaseCoordinateFrame"], "BaseCoordinateFrame"
+        ],
+        fromsys: type["BaseCoordinateFrame"],
+        tosys: type["BaseCoordinateFrame"],
+        priority: float = 1,
+        register_graph: Union["TransformGraph", None] = None,
+    ) -> None:
         if not callable(func):
             raise TypeError("func must be callable")
 
@@ -72,7 +88,9 @@ class FunctionTransform(CoordinateTransform):
             fromsys, tosys, priority=priority, register_graph=register_graph
         )
 
-    def __call__(self, fromcoord, toframe):
+    def __call__(
+        self, fromcoord: "BaseCoordinateFrame", toframe: "BaseCoordinateFrame"
+    ) -> "BaseCoordinateFrame":
         res = self.func(fromcoord, toframe)
         if not isinstance(res, self.tosys):
             raise TypeError(
@@ -133,26 +151,31 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
 
     def __init__(
         self,
-        func,
-        fromsys,
-        tosys,
-        priority=1,
-        register_graph=None,
-        finite_difference_frameattr_name="obstime",
-        finite_difference_dt=1 * u.second,
-        symmetric_finite_difference=True,
-    ):
+        func: Callable[
+            ["BaseCoordinateFrame", "BaseCoordinateFrame"], "BaseCoordinateFrame"
+        ],
+        fromsys: type["BaseCoordinateFrame"],
+        tosys: type["BaseCoordinateFrame"],
+        priority: float = 1,
+        register_graph: Union["TransformGraph", None] = None,
+        finite_difference_frameattr_name: str | None = "obstime",
+        finite_difference_dt: (
+            u.Quantity
+            | Callable[["BaseCoordinateFrame", "BaseCoordinateFrame"], u.Quantity]
+        ) = 1 * u.second,
+        symmetric_finite_difference: bool = True,
+    ) -> None:
         super().__init__(func, fromsys, tosys, priority, register_graph)
         self.finite_difference_frameattr_name = finite_difference_frameattr_name
         self.finite_difference_dt = finite_difference_dt
         self.symmetric_finite_difference = symmetric_finite_difference
 
     @property
-    def finite_difference_frameattr_name(self):
+    def finite_difference_frameattr_name(self) -> str | None:
         return self._finite_difference_frameattr_name
 
     @finite_difference_frameattr_name.setter
-    def finite_difference_frameattr_name(self, value):
+    def finite_difference_frameattr_name(self, value: str | None) -> None:
         if value is None:
             self._diff_attr_in_fromsys = self._diff_attr_in_tosys = False
         else:
@@ -168,7 +191,9 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
                 )
         self._finite_difference_frameattr_name = value
 
-    def __call__(self, fromcoord, toframe):
+    def __call__(
+        self, fromcoord: "BaseCoordinateFrame", toframe: "BaseCoordinateFrame"
+    ) -> "BaseCoordinateFrame":
         supcall = self.func
         if not fromcoord.data.differentials:
             return supcall(fromcoord, toframe)

--- a/astropy/coordinates/transformations/function.py
+++ b/astropy/coordinates/transformations/function.py
@@ -6,8 +6,6 @@ These are transformations that cannot be represented as an affine transformation
 """
 
 from collections.abc import Callable
-from contextlib import suppress
-from inspect import signature
 from typing import TYPE_CHECKING, Union
 from warnings import warn
 
@@ -72,16 +70,6 @@ class FunctionTransform(CoordinateTransform):
     ) -> None:
         if not callable(func):
             raise TypeError("func must be callable")
-
-        with suppress(TypeError):
-            sig = signature(func)
-            kinds = [x.kind for x in sig.parameters.values()]
-            if (
-                len(x for x in kinds if x == sig.POSITIONAL_ONLY) != 2
-                and sig.VAR_POSITIONAL not in kinds
-            ):
-                raise ValueError("provided function does not accept two arguments")
-
         self.func = func
 
         super().__init__(

--- a/astropy/coordinates/typing.py
+++ b/astropy/coordinates/typing.py
@@ -1,0 +1,10 @@
+"""Experimental module for supporting type annotations in :mod:`~astropy.coordinates`."""
+
+__all__ = ["Matrix3x3"]
+
+
+from typing import Literal, TypeAlias
+
+import numpy as np
+
+Matrix3x3: TypeAlias = np.ndarray[tuple[Literal[3], Literal[3]], np.dtype[np.floating]]


### PR DESCRIPTION
### Description

The first commit adds initial type annotations to `CoordinateTransform` and its subclasses. In many cases I rewrote type information from docstrings as annotations. If there are mistakes in the docstrings then the annotations will contain the same mistakes. I did check some of the types at runtime by adding temporary `isinstance()` checks to the code and running the `coordinates` tests, but this might not catch mistakes if test coverage is incomplete. I also used
```
mypy --follow-imports silent astropy/coordinates/transformations/
```
to ensure the new annotations are self-consistent, but that ignores unannotated code, so there is still the possibility that adding more annotations elsewhere in `coordinates` will reveal typing problems here.

Mypy did reveal that a code block in `FunctionTransform` is a no-op. The second commit here removes the block in question because otherwise Mypy would keep complaining about it.

I am not annotating `TransformGraph` yet because this pull request is large enough as it is and also because I don't want to create merge conflicts with #18695.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
