### PR TITLE
Support masked data in wcs transformation.

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -4,6 +4,8 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 
+from astropy.utils.masked import Masked, MaskedNDArray, combine_masks
+
 from .utils import deserialize_class
 
 __all__ = [
@@ -261,7 +263,11 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
     # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
     # we don't want to match Numpy subclasses.
     for w in world:
-        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
+        if (
+            not isinstance(w, numbers.Number)
+            and not type(w) == np.ndarray
+            and not type(w) == MaskedNDArray
+        ):
             raise TypeError(
                 f"WCS world_axis_object_components results in "
                 f"values which are not scalars or plain Numpy "
@@ -294,7 +300,11 @@ def values_to_high_level_objects(*world_values, low_level_wcs):
     # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
     # we don't want to match Numpy subclasses.
     for w in world_values:
-        if not isinstance(w, numbers.Number) and not type(w) == np.ndarray:
+        if (
+            not isinstance(w, numbers.Number)
+            and not type(w) == np.ndarray
+            and not type(w) == MaskedNDArray
+        ):
             raise TypeError(
                 f"Expected world coordinates as scalars or plain Numpy "
                 f"arrays (got {type(w)})"
@@ -351,21 +361,27 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         return self
 
     def world_to_pixel(self, *world_objects):
+        values, masks = MaskedNDArray._get_data_and_masks(world_objects)
         world_values = high_level_objects_to_values(
-            *world_objects, low_level_wcs=self.low_level_wcs
+            *values, low_level_wcs=self.low_level_wcs
         )
 
         # Finally we convert to pixel coordinates
         pixel_values = self.low_level_wcs.world_to_pixel_values(*world_values)
-
+        if (mask := combine_masks(masks)) is not False:
+            pixel_values = tuple(Masked(value, mask) for value in pixel_values)
         return pixel_values
 
     def pixel_to_world(self, *pixel_arrays):
+        values, masks = MaskedNDArray._get_data_and_masks(pixel_arrays)
         # Compute the world coordinate values
-        world_values = self.low_level_wcs.pixel_to_world_values(*pixel_arrays)
+        world_values = self.low_level_wcs.pixel_to_world_values(*values)
 
         if self.low_level_wcs.world_n_dim == 1:
             world_values = (world_values,)
+
+        if (mask := combine_masks(masks)) is not False:
+            world_values = tuple(Masked(value, mask) for value in world_values)
 
         pixel_values = values_to_high_level_objects(
             *world_values, low_level_wcs=self.low_level_wcs

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -30,6 +30,7 @@ from astropy.units import Quantity, UnitsWarning
 from astropy.utils import iers
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.masked import Masked
 from astropy.wcs.wcs import WCS, WCSLIB_VERSION, FITSFixedWarning, NoConvergence, Sip
 from astropy.wcs.wcsapi.fitswcs import VELOCITY_FRAMES, custom_ctype_to_ucd_mapping
 
@@ -1652,3 +1653,24 @@ def test_array_index_conversions_scalars_2d():
     x, y = wcs.world_to_pixel(scoord)
     assert isinstance(x, np.ndarray) and x.ndim == 0
     assert isinstance(y, np.ndarray) and y.ndim == 0
+
+
+class TestMaskedData:
+    wcs = WCS_SIMPLE_CELESTIAL
+
+    def test_pixel_to_world(self):
+        mask = [False, True]
+        x = Masked([4.907, -75.09299637], mask=mask)
+        y = Masked([73.8485, 223.84849637], mask=mask)
+        world = self.wcs.pixel_to_world(x, y)
+        assert_array_equal(world.mask, mask)
+
+    def test_world_to_pixel(self):
+        coord = SkyCoord(
+            l=Masked([0, 1] * u.deg, mask=[False, True]),
+            b=Masked([0, 1] * u.deg, mask=[False, True]),
+            frame="galactic",
+        )
+        x, y = self.wcs.world_to_pixel(coord)
+        assert_array_equal(x.mask, coord.mask)
+        assert_array_equal(y.mask, coord.mask)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1588,6 +1588,7 @@ def test_restfrq_restwav():
 def test_array_index_conversions_arrays_1d():
     # Regression test for a bug that caused world_to_array_index to return lists
     # instead of Numpy arrays - 1D version
+    # Also ensures that pixels are plain arrays if the array is not Masked.
 
     wcs = WCS(naxis=1)
     wcs.wcs.ctype = ("FREQ",)
@@ -1600,7 +1601,7 @@ def test_array_index_conversions_arrays_1d():
 
     with pytest.warns(AstropyUserWarning, match="No observer defined on WCS"):
         x = wcs.world_to_pixel(coord)
-    assert isinstance(x, np.ndarray)
+    assert isinstance(x, np.ndarray) and not isinstance(x, Masked)
 
 
 def test_array_index_conversions_arrays_2d():
@@ -1618,7 +1619,21 @@ def test_array_index_conversions_arrays_2d():
 
     x, y = wcs.world_to_pixel(coord)
     assert isinstance(x, np.ndarray)
-    assert isinstance(x, np.ndarray)
+    assert isinstance(y, np.ndarray)
+
+    # Also check that pixels are plain arrays if the array is not Masked.
+    assert not isinstance(x, Masked) and not isinstance(y, Masked)
+    # But will be masked once mask has been set on any item.
+    coord[0] = np.ma.masked
+    x, y = wcs.world_to_pixel(coord)
+    assert isinstance(x, Masked) and isinstance(y, Masked)
+    assert_array_equal(x.mask, coord.mask)
+    assert_array_equal(y.mask, coord.mask)
+    # Even if the mask is later unset.
+    coord[:] = np.ma.nomask
+    x, y = wcs.world_to_pixel(coord)
+    assert isinstance(x, Masked) and isinstance(y, Masked)
+    assert not x.mask.any() and not y.mask.any()
 
 
 def test_array_index_conversions_scalars_1d():

--- a/docs/changes/wcs/18743.feature.rst
+++ b/docs/changes/wcs/18743.feature.rst
@@ -1,0 +1,1 @@
+``world_to_pixel`` and ``pixel_to_world`` now can take ``Masked`` input.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds the ability of wcs transformation to support masked input.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18052 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
