### PR TITLE
DOC: Describe differences for setting mask between Masked and MaskedArray

### DIFF
--- a/docs/index_user_docs.rst
+++ b/docs/index_user_docs.rst
@@ -43,6 +43,7 @@ User Guide
    utils/iers
    visualization/index
    stats/index
+   utils/masked/index
    samp/index
 
 .. toctree::

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -25,9 +25,10 @@ The exceptions are below:
    :maxdepth: 1
 
    data
-   masked/index
 
 :ref:`utils-iers`
+
+:ref:`utils-masked`
 
 .. note:: The ``astropy.utils.compat`` subpackage is not included in this
     documentation. It contains utility modules for compatibility with

--- a/docs/utils/masked/index.rst
+++ b/docs/utils/masked/index.rst
@@ -1,26 +1,16 @@
 .. _utils-masked:
 
-**************************************
-Masked Values (`astropy.utils.masked`)
-**************************************
+*****************************************************
+Masked Values and Quantities (`astropy.utils.masked`)
+*****************************************************
 
 Often, data sets are incomplete or corrupted and it would be handy to be able
 to mask certain values.  Astropy provides a |Masked| class to help represent
 such data sets.
 
-.. warning:: |Masked| is experimental! While we hope basic usage will remain
-   similar, we are not yet sure whether it will not be necessary to change it
-   to make things work throughout Astropy. This also means that comments and
-   suggestions for improvements are especially welcome!
-
 .. note:: |Masked| is similar to Numpy's :class:`~numpy.ma.MaskedArray`,
    but it supports subclasses much better and also has some important
    :ref:`differences in behaviour <utils-masked-vs-numpy-maskedarray>`.
-   As a result, the behaviour of functions inside `numpy.ma` is poorly
-   defined, and one should instead use regular ``numpy`` functions, which
-   are overridden to work properly with masks (with non-obvious
-   choices documented in `astropy.utils.masked.function_helpers`; please
-   report numpy functions that do not work properly with |Masked| values!).
 
 Usage
 =====
@@ -49,6 +39,21 @@ should be substituted for any masked values, with
   >>> mq.filled(fill_value=-75*u.cm)
   <Quantity [ 1.  ,  2.  , -0.75] m>
 
+You can mask or unmask individual elements by setting them to
+`~numpy.ma.masked` or `~numpy.ma.nomask`::
+
+  >>> mq.mask
+  array([False, False,  True])
+  >>> mq[:] = np.ma.nomask
+  >>> mq[2] = np.ma.masked
+  >>> mq.mask
+  array([False, False,  True])
+  >>> mq
+  <MaskedQuantity [1., 2., ——] m>
+
+These same procedures also work for higher-level classes like |Time| and
+|SkyCoord|, which use |Masked| under the hood.
+
 For reductions such as sums, the mask propagates as if the sum was
 done directly::
 
@@ -69,15 +74,34 @@ elements from the calculation::
   >> ma.mean(-1)
   MaskedNDArray([0.0, 2.5])
 
+Numpy functions work as expected on |Masked| instances, with non-obvious
+choices documented in `astropy.utils.masked.function_helpers` (please report
+numpy functions that do not work properly with |Masked| values!). For example,
+:func:`~astropy.utils.masked.function_helpers.nansum` does not propagate
+masked elements, but instead replaces them with zero, and returns an unmasked
+instance::
+
+  >> np.nansum(ma, axis=-1)
+  array([0., 5.])
 
 .. _utils-masked-vs-numpy-maskedarray:
 
-Differences from `numpy.ma.MaskedArray`
-=======================================
+Differences from `~numpy.ma.MaskedArray`
+========================================
 
-|Masked| differs from `~numpy.ma.MaskedArray` in a number of ways.  In usage,
-a major difference is that most operations act on the masked values, i.e., no
-effort is made to preserve values.  For instance, compare::
+|Masked| differs from `~numpy.ma.MaskedArray` in a number of ways, which we
+detail below.  Overall, it may be helpful to think of |Masked| not as a
+replacement of `~numpy.ma.MaskedArray`, but just as a way of marking bad
+elements, as one might do without needing a different class by setting them to
+NaN (not-a-number).  Like those NaN, the mask just propagates, except that for
+some operations like taking the mean the equivalent of `~numpy.nanmean` is
+used.
+
+Values under masked are operated on
+-----------------------------------
+
+A difference in usage is that most operations act on the masked values,
+i.e., no effort is made to preserve values.  For instance, compare::
 
   >>> np_ma = np.ma.MaskedArray([1., 2., 3.], mask=[False, True, False])
   >>> (np_ma + 1).data
@@ -92,8 +116,11 @@ should its value not change?).  But it also helps to keep the implementation
 considerably simpler, as the |Masked| class now primarily has to deal with
 propagating the mask rather than deciding what to do with values.
 
-A second difference is that for reductions, the mask propagates as it would
-have if the operations were done on the individual elements::
+Masked values are not skipped in reductions
+-------------------------------------------
+
+In reductions, the mask propagates as it would have if the operations were
+done on the individual elements::
 
   >>> np_ma.prod()
   np.float64(3.0)
@@ -113,8 +140,13 @@ would be rather surprising!).  As noted above, however, masked elements are
 skipped for operations for which this is well defined, such as for getting the
 mean and other sample properties such as the variance and standard deviation.
 
-A third difference is what happens when one sets the mask attribute.  For
-`~numpy.ma.MaskedArray`, this attempts to change the mask inplace::
+.. _utils-masked-mask-setting:
+
+Setting the mask attribute replaces it
+--------------------------------------
+
+If one sets the mask attribute of a `~numpy.ma.MaskedArray`, it will
+attempt to change the mask inplace::
 
   >>> np_ma = np.ma.MaskedArray([1., 2., 3.], mask=[False, True, False])
   >>> np_ma_mask_ref = np_ma.mask
@@ -169,9 +201,25 @@ Indeed, also for `~numpy.ma.MaskedArray` it does not always work::
   >>> np_ma[0].mask = True
   Traceback (most recent call last):
   ...
-  AttributeError: 'numpy.float64' object has no attribute 'mask' and no __dict__ for setting new attributes
+  AttributeError: 'numpy.float64' object has no attribute 'mask'...
 
-A fourth difference is more conceptual.  For `~numpy.ma.MaskedArray`, the
+.. note:: We recommend not dealing with the mask directly but setting
+  the instance to `~numpy.ma.masked` or `~numpy.ma.nomask`, as described
+  above. This is also the only way to mask values for the
+  higher-level classes such as |Time| and |SkyCoord|.
+
+Numpy functions work as expected
+--------------------------------
+
+For `~numpy.ma.MaskedArray`, a number of regular numpy functions do not work
+properly, and instead one has to use variants from the ``np.ma`` namespace.
+For |Masked|, numpy functions do work as expected (but those under the
+``np.ma`` namespace typically do not).
+
+Masked subclasses behave like the subclass
+------------------------------------------
+
+A more conceptual difference is that for `~numpy.ma.MaskedArray`, the
 instance that is created is a masked version of the unmasked instance, i.e.,
 `~numpy.ma.MaskedArray` remembers that is has wrapped a subclass like
 |Quantity|, but does not share any of its methods.  Hence, even though the
@@ -190,7 +238,7 @@ resulting class looks reasonable at first glance, it does not work as expected::
   >>> np_mq / u.s
   <Quantity [1., 2.] 1 / s>
 
-In contrast, |Masked| is always wrapped around the data properly, i.e., a
+In contrast, |Masked| is always wrapped around the data proper, i.e., a
 ``MaskedQuantity`` is a quantity which has masked values, but with a unit that
 is never masked.  Indeed, one can see this from the class hierarchy::
 
@@ -211,12 +259,6 @@ the result is a new ``MaskedColumn`` that "just works", with no need for the
 overrides and special-casing that were needed to make `~numpy.ma.MaskedArray`
 work with `~astropy.table.Column`.  (Because the behaviour does change
 somewhat, however, we chose not to replace the existing implementation.)
-
-In some respects, rather than think of |Masked| as similar to
-`~numpy.ma.MaskedArray`, it may be more useful to think of |Masked| as similar
-to marking bad elements in arrays with NaN (not-a-number).  Like those NaN,
-the mask just propagates, except that for some operations like taking the mean
-the equivalence of `~numpy.nanmean` is used.
 
 Reference/API
 =============


### PR DESCRIPTION
As the title states. My current sense is that setting an attribute should not make in-place changes to arrays.

Fixes #18741 (by effectively stating "won't fix" and here explaining why)
Fixes #18740 (this is fixed by using the `ma[item] = np.ma.masked` suggested here instead of setting mask directly)
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
