### PR TITLE
MAINT: simplify __array_finalize__ when superclass can be ndarray.

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -700,8 +700,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         if obj is None:
             return
 
-        if callable(super().__array_finalize__):
-            super().__array_finalize__(obj)
+        super().__array_finalize__(obj)
 
         # Self was created from template (e.g. obj[slice] or (obj * 2))
         # or viewcast e.g. obj.view(Column).  In either case we want to

--- a/astropy/table/ndarray_mixin.py
+++ b/astropy/table/ndarray_mixin.py
@@ -40,8 +40,7 @@ class NdarrayMixin(np.ndarray):
         if obj is None:
             return
 
-        if callable(super().__array_finalize__):
-            super().__array_finalize__(obj)
+        super().__array_finalize__(obj)
 
         # Self was created from template (e.g. obj[slice] or (obj * 2))
         # or viewcast e.g. obj.view(Column).  In either case we want to

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -558,12 +558,7 @@ class Quantity(np.ndarray):
             return value.to(unit)
 
     def __array_finalize__(self, obj):
-        # Check whether super().__array_finalize should be called
-        # (sadly, ndarray.__array_finalize__ is None; we cannot be sure
-        # what is above us).
-        super_array_finalize = super().__array_finalize__
-        if super_array_finalize is not None:
-            super_array_finalize(obj)
+        super().__array_finalize__(obj)
 
         # If we're a new object or viewing an ndarray, nothing has to be done.
         if obj is None or obj.__class__ is np.ndarray:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -2077,9 +2077,7 @@ class TestQuantitySubclassAboveAndBelow:
     def setup_class(cls):
         class MyArray(np.ndarray):
             def __array_finalize__(self, obj):
-                super_array_finalize = super().__array_finalize__
-                if super_array_finalize is not None:
-                    super_array_finalize(obj)
+                super().__array_finalize__(obj)
                 if hasattr(obj, "my_attr"):
                     self.my_attr = obj.my_attr
 

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -708,11 +708,9 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         if obj is None or obj.__class__ is np.ndarray:
             return
 
-        # Logically, this should come from ndarray and hence be None, but
-        # just in case someone creates a new mixin, we check.
-        super_array_finalize = super().__array_finalize__
-        if super_array_finalize:  # pragma: no cover
-            super_array_finalize(obj)
+        # Logically, this should come from ndarray and hence do nothing, but
+        # just in case someone creates a new mixin, we run it.
+        super().__array_finalize__(obj)
 
         if self._mask is None:
             # Got here after, e.g., a view of another masked class.


### PR DESCRIPTION
Previously, `ndarray.__array_finalize__` could be None, so we had to check before just calling it.  But since numpy 1.23 it is always callable.  Since our minimum version is above that, this PR makes the appropriate changes.

EDIT: the relevant https://github.com/numpy/numpy/pull/20766 was by me -- why I didn't follow up I don't know...
