### PR TITLE
Implementation of a `loc` keyword argument (similar to that of `matplotlib`'s label setters) for the `wcsaxes` `AxisLabels`

### DIFF
--- a/astropy/tests/figures/py311-test-image-mpl380-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpl380-cov.json
@@ -1,4 +1,8 @@
 {
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_left_bottom_loc_labels[left-bottom]": "224268cb149c73c3e3a6082d385f5bba752d2411acce3a8daa5a6b0e24a3e3de",
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_left_bottom_loc_labels[right-top]": "2c12f3e9ee1e64a21ce247e140bf680726faaf00aecb89638c9feb853226dfa4",
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_multi_loc_labels": "edab724fbb3d90bb25f46aca0dd894cddeeb1fed194bfbc4011f7212c4fe9720",
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_left_bottom_loc_labels_elliptical": "e0c40266c64166934c6fdfef92dfbda2175812e83b5daeccd9fef3c555740910",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_custom_frame": "cceb87beabe25ac4187b2ade40b1d4af551dbb77a35f71b59d41cbfb85a2c769",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_rectangular": "30e13643c770a26b2707745143f50a735daa6f37a6a8258e733ae35338a4a1bb",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_nonrectangular": "37de34740cef2897effc9de5e6726ef3955a3449d0fa6a929350301500557b8e",

--- a/astropy/tests/figures/py311-test-image-mpldev-cov.json
+++ b/astropy/tests/figures/py311-test-image-mpldev-cov.json
@@ -1,4 +1,8 @@
 {
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_left_bottom_loc_labels[left-bottom]": "c1881b7119dd80cfa82c6babe6a362f70f0994b3b488d4c403eaab6883642f7c",
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_left_bottom_loc_labels[right-top]": "eddc5b1595a38aa1f668b42680ab1d239868b8d2ff459218ada7e4c96dbbe42f",
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_multi_loc_labels": "7b0424479fcb0673d6d6e521ef69bc4f0eb2e7239c4b1d891aec70dab408136c",
+  "astropy.visualization.wcsaxes.tests.test_coordinate_helpers.test_left_bottom_loc_labels_elliptical": "98c036ca77ec3aa9c36353484ca30311c5df351fb8e8c846e9f556d98c921d42",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_custom_frame": "0c259f5278851bda21016cce3d5479e1d6202762587ad8d8ff9982fa5a9ce11a",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_rectangular": "d9ad505b7455d6f3a1305273547b177e58d1f36418f5983d0faad29ddd5134a2",
   "astropy.visualization.wcsaxes.tests.test_frame.TestFrame.test_update_clip_path_nonrectangular": "0c1528f0ac4c30b66b0f427851dd82ae6fca2982db5c86dd20166318e2271c5d",

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -1,11 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from typing import Literal
+
 import matplotlib.transforms as mtransforms
 import numpy as np
 from matplotlib import _api, rcParams
 from matplotlib.text import Text
 
 from .frame import RectangularFrame
+
+LocLiteral = Literal["center", "left", "right", "bottom", "top"] | None
 
 
 class AxisLabels(Text):
@@ -37,7 +41,7 @@ class AxisLabels(Text):
         else:
             return self._minpad
 
-    def get_loc(self, axis):
+    def get_loc(self, axis) -> LocLiteral:
         if isinstance(self._loc, dict):
             return self._loc[axis]
         else:
@@ -55,7 +59,7 @@ class AxisLabels(Text):
     def set_minpad(self, minpad):
         self._minpad = minpad
 
-    def set_loc(self, loc):
+    def set_loc(self, loc: LocLiteral | dict[str, LocLiteral]) -> None:
         self._loc = loc
 
     def set_visibility_rule(self, value):
@@ -121,7 +125,7 @@ class AxisLabels(Text):
                     "center": (0.5, "center"),
                     "top": (1, "left"),
                 }[loc]
-            elif loc is not None:
+            elif loc is not None and loc != "center":
                 raise NotImplementedError(
                     f"Received unsupported value {loc=!r}. "
                     f"Only loc='center' is implemented for {axis=!r}"
@@ -140,7 +144,11 @@ class AxisLabels(Text):
                 label_angle += 180
             self.set_rotation(label_angle)
             if 45 < label_angle < 135:
-                loc = {"left": "right", "right": "left"}.get(loc, loc)
+                match loc:
+                    case "left":
+                        loc = "right"
+                    case "right":
+                        loc = "left"
             self.set_ha(loc)
 
             # Find label position by looking at the bounding box of ticks'

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -9,7 +9,7 @@ from .frame import RectangularFrame
 
 
 class AxisLabels(Text):
-    def __init__(self, frame, minpad=1, *args, loc="center", **kwargs):
+    def __init__(self, frame, minpad=1, *args, loc=None, **kwargs):
         # Use rcParams if the following parameters were not specified explicitly
         if "weight" not in kwargs:
             kwargs["weight"] = rcParams["axes.labelweight"]
@@ -17,6 +17,8 @@ class AxisLabels(Text):
             kwargs["size"] = rcParams["axes.labelsize"]
         if "color" not in kwargs:
             kwargs["color"] = rcParams["axes.labelcolor"]
+        if "verticalalignment" not in kwargs and "va" not in kwargs:
+            kwargs["verticalalignment"] = "center"
 
         self._frame = frame
         super().__init__(*args, **kwargs)
@@ -30,15 +32,15 @@ class AxisLabels(Text):
         )
 
     def get_minpad(self, axis):
-        try:
+        if isinstance(self._minpad, dict):
             return self._minpad[axis]
-        except TypeError:
+        else:
             return self._minpad
 
     def get_loc(self, axis):
-        try:
+        if isinstance(self._loc, dict):
             return self._loc[axis]
-        except TypeError:
+        else:
             return self._loc
 
     def set_visible_axes(self, visible_axes):
@@ -101,7 +103,7 @@ class AxisLabels(Text):
             padding = text_size * self.get_minpad(axis)
 
             loc = self.get_loc(axis)
-            if axis in {"t", "b", "h", "c"}:
+            if axis in {"t", "b", "h"}:
                 loc = loc if loc is not None else rcParams["xaxis.labellocation"]
                 _api.check_in_list(("left", "center", "right"), loc=loc)
 
@@ -119,7 +121,7 @@ class AxisLabels(Text):
                     "center": (0.5, "center"),
                     "top": (1, "left"),
                 }[loc]
-            elif loc != "center":
+            elif loc is not None:
                 raise NotImplementedError(
                     f"Received unsupported value {loc=!r}. "
                     f"Only loc='center' is implemented for {axis=!r}"

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -729,7 +729,7 @@ class CoordinateHelper:
         """
         self._ticklabels.set_visible(visible)
 
-    def set_axislabel(self, text, minpad=1, *, loc="center", **kwargs):
+    def set_axislabel(self, text, minpad=1, **kwargs):
         """
         Set the text and optionally visual properties for the axis label.
 
@@ -737,12 +737,24 @@ class CoordinateHelper:
         ----------
         text : str
             The axis label text.
-        minpad : float, optional
+        minpad : float or dict of str,float, optional
             The padding for the label in terms of axis label font size.
-        loc : 'str', optional
-            The label position relative to the axis. This is equivalent to
+            If given a single float value, the same padding will be applied to
+            each label set to be visible via ``set_axislabel_position``.
+            If a different padding should be applied to distinct axes, this
+            parameter may instead be given as a configuration dictionary where
+            each entry customizes an axis configuration, with the key
+            corresponding to the axis tag (among those allowed by the parent
+            WCSAxes frame), and the value encoding the padding to use.
+        loc : str or dict of str,str, optional
+            The label location relative to the axis. This is equivalent to
             matplotlib's corresponding keyword argument availably in their
-            label setter.
+            label setter. Accordingly, the allowed locations are:
+            - {'left', 'center', 'right'} for horizontal axes,
+            - {'bottom', 'center', 'top'} for vertical axes.
+            Similar to parameter minpad above, different locations may be
+            configured for distinct axes using a configuration dictionary
+            similarly formatted in lieu of a single location.
         **kwargs
             Keywords are passed to :class:`matplotlib.text.Text`. These
             can include keywords to set the ``color``, ``size``, ``weight``, and
@@ -771,13 +783,13 @@ class CoordinateHelper:
                 "overwritten during the rendering. Use the 'loc' keyword "
                 "argument instead.",
                 AstropyUserWarning,
+                stacklevel=2,
             )
 
         self._axislabel_set = True
 
         self._axislabels.set_text(text)
         self._axislabels.set_minpad(minpad)
-        self._axislabels.set_loc(loc)
         self._axislabels.set(**kwargs)
 
         if fontdict is not None:

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -729,7 +729,7 @@ class CoordinateHelper:
         """
         self._ticklabels.set_visible(visible)
 
-    def set_axislabel(self, text, minpad=1, **kwargs):
+    def set_axislabel(self, text, minpad=1, loc="center", **kwargs):
         """
         Set the text and optionally visual properties for the axis label.
 
@@ -739,6 +739,10 @@ class CoordinateHelper:
             The axis label text.
         minpad : float, optional
             The padding for the label in terms of axis label font size.
+        loc : 'str', optional
+            The label position relative to the axis. This is equivalent to
+            matplotlib's corresponding keyword argument availably in their
+            label setter.
         **kwargs
             Keywords are passed to :class:`matplotlib.text.Text`. These
             can include keywords to set the ``color``, ``size``, ``weight``, and
@@ -752,10 +756,27 @@ class CoordinateHelper:
         if minpad is None:
             minpad = 1
 
+        protected_kw = [
+            "x",
+            "y",
+            "rotation",
+            "horizontalalignment",
+            "ha",
+            "rotation_mode",
+        ]
+        if {*kwargs} & {*protected_kw}:
+            warnings.warn(
+                "Any of the axis label low level keyword arguments "
+                f"({protected_kw}) of the 'loc' keyword argument will be "
+                "overwritten during the rendering. Use the 'loc' keyword "
+                "argument instead."
+            )
+
         self._axislabel_set = True
 
         self._axislabels.set_text(text)
         self._axislabels.set_minpad(minpad)
+        self._axislabels.set_loc(loc)
         self._axislabels.set(**kwargs)
 
         if fontdict is not None:

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -776,12 +776,12 @@ class CoordinateHelper:
             "ha",
             "rotation_mode",
         ]
-        if set(kwargs).intersection(protected_kw):
+        if ignored := set(kwargs).intersection(protected_kw):
             warnings.warn(
-                "Any of the axis label low level keyword arguments "
-                f"({protected_kw}) of the 'loc' keyword argument will be "
-                "overwritten during the rendering. Use the 'loc' keyword "
-                "argument instead.",
+                "The following low level keyword arguments "
+                "will be overwritten during the rendering."
+                f"{ignored}.\n"
+                "Use the 'loc' keyword argument instead.",
                 AstropyUserWarning,
                 stacklevel=2,
             )

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -15,7 +15,7 @@ from matplotlib.transforms import Affine2D, ScaledTranslation
 
 from astropy import units as u
 from astropy.utils.decorators import deprecated_renamed_argument
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from .axislabels import AxisLabels
 from .formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
@@ -729,7 +729,7 @@ class CoordinateHelper:
         """
         self._ticklabels.set_visible(visible)
 
-    def set_axislabel(self, text, minpad=1, loc="center", **kwargs):
+    def set_axislabel(self, text, minpad=1, *, loc="center", **kwargs):
         """
         Set the text and optionally visual properties for the axis label.
 
@@ -764,12 +764,13 @@ class CoordinateHelper:
             "ha",
             "rotation_mode",
         ]
-        if {*kwargs} & {*protected_kw}:
+        if set(kwargs).intersection(protected_kw):
             warnings.warn(
                 "Any of the axis label low level keyword arguments "
                 f"({protected_kw}) of the 'loc' keyword argument will be "
                 "overwritten during the rendering. Use the 'loc' keyword "
-                "argument instead."
+                "argument instead.",
+                AstropyUserWarning,
             )
 
         self._axislabel_set = True

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -135,7 +135,7 @@ class Spine:
         pixel = self._get_pixel()
         normal_angle = self.normal_angle
         # Flip pixels if element vectors are not well oriented
-        if np.all(np.abs((self.normal_angle - 135) % 360 - 180) <= 90.0, axis=0):
+        if np.all(np.abs((normal_angle - 135) % 360 - 180) <= 90.0, axis=0):
             pixel = pixel[::-1]
             normal_angle = normal_angle[::-1]
         x_disp, y_disp = pixel[:, 0], pixel[:, 1]

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -105,7 +105,11 @@ class Spine:
 
     def _update_normal(self):
         pixel = self._get_pixel()
-        # Find angle normal to border and inwards, in display coordinate
+        # Find angle normal to border and inwards, in display coordinate, such that:
+        # -   0° corresponds to a vertical vector from top to bottom
+        # -  90° corresponds to a horizontal vector from left to right
+        # - 180° corresponds to a vertical vector from bottom to top
+        # - -90° corresponds to a horizontal vector from right to left
         dx = pixel[1:, 0] - pixel[:-1, 0]
         dy = pixel[1:, 1] - pixel[:-1, 1]
         self.normal_angle = np.degrees(np.arctan2(dx, -dy))
@@ -123,6 +127,15 @@ class Spine:
         Return the x, y, normal_angle values at a barycentric coordinate in [0,1]
         along the spine.
 
+        If possible, the corresponding position will reflect an orientation of
+        the spine relative to the parent figure such that:
+        - the coordinate 0 returns the position located on the lower or left end
+        of the spine,
+        - and the coordinate 1 returns the position located on the upper or right
+        end of the spine.
+        This criteria does not apply to spines that are curved in such a way that
+        no specific orientation can be determined.
+
         Parameters
         ----------
         bary : float
@@ -134,7 +147,11 @@ class Spine:
             )
         pixel = self._get_pixel()
         normal_angle = self.normal_angle
-        # Flip pixels if element vectors are not well oriented
+        # Flip pixels if element vectors are not oriented from lower/left to upper/right;
+        # the orientation can be determined by testing the normal angle of each vector,
+        # verifying if they all fall around -45°±90°, modulo 360°, which would indicate
+        # that they are oriented from upper/right to lower/left, and that the pixels must
+        # be flipped in order to orient the spine from lower/left to upper/right.
         if np.all(np.abs((normal_angle - 135) % 360 - 180) <= 90.0, axis=0):
             pixel = pixel[::-1]
             normal_angle = normal_angle[::-1]

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -110,13 +110,15 @@ class Spine:
         dy = pixel[1:, 1] - pixel[:-1, 1]
         self.normal_angle = np.degrees(np.arctan2(dx, -dy))
 
-    def _halfway_x_y_angle(self):
+    def _halfway_x_y_angle(self) -> tuple[float, float, float]:
         """
         Return the x, y, normal_angle values halfway along the spine.
         """
         return self._barycentric_x_y_angle(0.5)
 
-    def _barycentric_x_y_angle(self, bary=0.5):
+    def _barycentric_x_y_angle(
+        self, bary: float = 0.5, /
+    ) -> tuple[float, float, float]:
         """
         Return the x, y, normal_angle values at a barycentric coordinate in [0,1]
         along the spine.

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -401,31 +401,16 @@ def test_set_ticks_values():
 
 
 @figure_test
-def test_left_bottom_loc_labels():
-    # Test axislabel loc on default WCSAxes with left xlabel and bottom ylabel
+@pytest.mark.parametrize("xloc, yloc", [("left", "bottom"), ("right", "top")])
+def test_left_bottom_loc_labels(xloc, yloc):
     fig = Figure(figsize=(6, 6))
     canvas = FigureCanvasAgg(fig)
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
     fig.add_axes(ax)
     ax.coords[0].set_axislabel_position("tb")
     ax.coords[1].set_axislabel_position("lr")
-    ax.coords[0].set_axislabel("X", loc="left")
-    ax.coords[1].set_axislabel("Y", loc="bottom")
-    canvas.draw()
-    return fig
-
-
-@figure_test
-def test_right_top_loc_labels():
-    # Test axislabel loc on default WCSAxes with right xlabel and top ylabel
-    fig = Figure(figsize=(6, 6))
-    canvas = FigureCanvasAgg(fig)
-    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
-    fig.add_axes(ax)
-    ax.coords[0].set_axislabel_position("tb")
-    ax.coords[1].set_axislabel_position("lr")
-    ax.coords[0].set_axislabel("X", loc="right")
-    ax.coords[1].set_axislabel("Y", loc="top")
+    ax.coords[0].set_axislabel(f"X ({xloc=!r})", loc=xloc)
+    ax.coords[1].set_axislabel(f"Y ({yloc=!r})", loc=yloc)
     canvas.draw()
     return fig
 
@@ -439,20 +424,10 @@ def test_multi_loc_labels():
     fig.add_axes(ax)
     ax.coords[0].set_axislabel_position("tb")
     ax.coords[1].set_axislabel_position("lr")
-    ax.coords[0].set_axislabel(
-        "X",
-        loc={
-            "t": "left",
-            "b": "right",
-        },
-    )
-    ax.coords[1].set_axislabel(
-        "Y",
-        loc={
-            "l": "bottom",
-            "r": "top",
-        },
-    )
+    xloc = {"t": "left", "b": "right"}
+    ax.coords[0].set_axislabel(f"X ({xloc=})", loc=xloc)
+    yloc = {"l": "bottom", "r": "top"}
+    ax.coords[1].set_axislabel(f"Y ({yloc=})", loc=yloc)
     canvas.draw()
     return fig
 
@@ -466,9 +441,9 @@ def test_left_bottom_loc_labels_elliptical():
     fig.add_axes(ax)
     ax.coords[0].set_axislabel_visibility_rule("always")
     ax.coords[0].set_axislabel_position("h")
-    ax.coords[0].set_axislabel("X", loc="left")
+    ax.coords[0].set_axislabel("X (xloc='left')", loc="left")
     ax.coords[1].set_axislabel_visibility_rule("always")
     ax.coords[1].set_axislabel_position("v")
-    ax.coords[1].set_axislabel("Y", loc="bottom")
+    ax.coords[1].set_axislabel("Y (loc='bottom')", loc="bottom")
     canvas.draw()
     return fig

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -9,10 +9,12 @@ from matplotlib.figure import Figure
 
 from astropy import units as u
 from astropy.io import fits
+from astropy.tests.figures import figure_test
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.wcsaxes.coordinate_helpers import CoordinateHelper
 from astropy.visualization.wcsaxes.core import WCSAxes
+from astropy.visualization.wcsaxes.frame import EllipticalFrame
 from astropy.wcs import WCS
 
 MSX_HEADER = fits.Header.fromtextfile(get_pkg_data_filename("data/msx_header"))
@@ -396,3 +398,77 @@ def test_set_ticks_values():
     lbl_locations = u.Quantity(lbl_world1, unit=u.deg)
     assert u.allclose(lbl_locations, ax.coords[0]._formatter_locator.values)
     assert u.Quantity(lbl_world).unit is xticks.unit
+
+
+@figure_test
+def test_left_bottom_loc_labels():
+    # Test axislabel loc on default WCSAxes with left xlabel and bottom ylabel
+    fig = Figure(figsize=(6, 6))
+    canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
+    fig.add_axes(ax)
+    ax.coords[0].set_axislabel_position("tb")
+    ax.coords[1].set_axislabel_position("lr")
+    ax.coords[0].set_axislabel("X", loc="left")
+    ax.coords[1].set_axislabel("Y", loc="bottom")
+    canvas.draw()
+    return fig
+
+
+@figure_test
+def test_right_top_loc_labels():
+    # Test axislabel loc on default WCSAxes with right xlabel and top ylabel
+    fig = Figure(figsize=(6, 6))
+    canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
+    fig.add_axes(ax)
+    ax.coords[0].set_axislabel_position("tb")
+    ax.coords[1].set_axislabel_position("lr")
+    ax.coords[0].set_axislabel("X", loc="right")
+    ax.coords[1].set_axislabel("Y", loc="top")
+    canvas.draw()
+    return fig
+
+
+@figure_test
+def test_multi_loc_labels():
+    # Test axislabel loc on default WCSAxes with xlabel/ylabel in multiple locations
+    fig = Figure(figsize=(6, 6))
+    canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
+    fig.add_axes(ax)
+    ax.coords[0].set_axislabel_position("tb")
+    ax.coords[1].set_axislabel_position("lr")
+    ax.coords[0].set_axislabel(
+        "X",
+        loc={
+            "t": "left",
+            "b": "right",
+        },
+    )
+    ax.coords[1].set_axislabel(
+        "Y",
+        loc={
+            "l": "bottom",
+            "r": "top",
+        },
+    )
+    canvas.draw()
+    return fig
+
+
+@figure_test
+def test_left_bottom_loc_labels_elliptical():
+    # Test axislabel loc on EllipticalFrame WCSAxes horizontal and vertical axes
+    fig = Figure(figsize=(6, 6))
+    canvas = FigureCanvasAgg(fig)
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal", frame_class=EllipticalFrame)
+    fig.add_axes(ax)
+    ax.coords[0].set_axislabel_visibility_rule("always")
+    ax.coords[0].set_axislabel_position("h")
+    ax.coords[0].set_axislabel("X", loc="left")
+    ax.coords[1].set_axislabel_visibility_rule("always")
+    ax.coords[1].set_axislabel_position("v")
+    ax.coords[1].set_axislabel("Y", loc="bottom")
+    canvas.draw()
+    return fig

--- a/docs/changes/visualization/18749.feature.rst
+++ b/docs/changes/visualization/18749.feature.rst
@@ -1,0 +1,3 @@
+Added a ``loc`` kwarg to the ``wcsaxes`` ``AxisLabels`` label setter similar
+in function to that of ``matplotlib``'s label setters to control the label
+position along its corresponding axis

--- a/docs/changes/visualization/18749.feature.rst
+++ b/docs/changes/visualization/18749.feature.rst
@@ -1,3 +1,3 @@
 Added a ``loc`` kwarg to the ``wcsaxes`` ``AxisLabels`` label setter similar
-in function to that of ``matplotlib``'s label setters to control the label
+in function to that of ``matplotlib`` 's label setters to control the label
 position along its corresponding axis


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to propose the implementation of a `loc` keyword argument to control label position in a `WCSAxes` similar to that available in `matplotlib`'s label setters.

In `matplotlib`, the label setters allow the assignment of a `loc` keyword argument as a high-level alternative for passing class `Text` parameters `horizontalalignment` (determining the `Text` object horizontal alignment), and `x` or `y` (determining the `Text` object position) depending if the setter affect the label of the x or y axis. The value that are allowed are either [`'left'`, `'center'` or `'right'` for the xlabel setter](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_xlabel.html), or [`'bottom'`, `'center'` or `'top'` for the ylabel setter](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.set_ylabel.html), each intuitively providing control as to which position the label will take relative the corresponding axis.

On the other hand, while the `astropy.visualization.wcsaxes.core.WCSAxes` provide equivalent label setting methods via the method `set_axislabel` of the its `astropy.visualization.wcsaxes.coordinate_helpers.CoordinateHelper` API, neither this method nor the class' other methods provide a satisfyingly equivalent customization mean. It is technically possible to manually set the `x`, `y` and `horizontalalignment` [`matplotlib.text.Text`](https://matplotlib.org/stable/api/text_api.html#matplotlib.text.Text) attributes of the underlying corresponding label class `astropy.visualization.wcsaxes.axislabels.AxisLabels` (an inherited class of `Text`) from the `wcsaxes` API, but in the current implementation, `x` and `y` eventually get overwritten anyway by the class `draw` method, forcing the label to be centered along the axis length.

This implementation add the `loc` keyword argument to the definition of class `AxisLabels`, with its assignment accessible to the user via the method `CoordinateHelper.set_axislabel` which, as mentioned, is currently already the method of use to assign both the label text and padding for that class. The goal of the implementation is to be as equal as possible to that of `matplotlib`, while retaining a similar style of customization to that implemented for the `minpad` attribute (where a dictionary of different parameters can be given to set different value for each visible axis). In order to be fully functional and satisfyingly modular enough, some choices needed to be made, some of which affecting past functionalities that were most likely niche and probably already inconsistent:
- the past implementation allowed `horizontalalignment` (or `ha`) to be set by the user, which gave little to no control, as the most important attributes to adequately position the label were the position ones `x` and `y` that are overwritten in the method `draw`; the newer implementation leaves its unrestricted control to the `loc` definition.
- the past implementation was inconsistent with the `matplotlib`'s convention to have the `verticalalignment` set by default to `baseline` for all labels; the new implementation follow now that convention (which also caused the bbox_tests to accordingly be modified as the old reference extents were incompatible)
- the past implementation was also partially inconsistent with the `matplotlib`s convention to set the `rotation_mode` to `'anchor'` in the case of y-axis labels with vertical rotation; in order to be fully compatible with the multi-axes label drawing feature of the `AxisLabels` API, the `rotation_mode` is set by default to `'anchor'` for all axes (note that the user may still change if if he wishes, even if if it may lead to unexpected results and is likely unadvisable)
- the newer implementation includes a warning printed to the user in the event that they attempt to set in `CoordinateHelper.set_axislabel` any of the Text low-level attributes that are controlled by `loc` (those include `x`, `y`, `rotation`, `horizontalalignment` & `ha`, and `rotation_mode` - the latter to disincentivize its usage)

Allowing this implementation to be fully functional required the method `_halfway_x_y_angle` of class `astropy.visualization.wcsaxes.frame.Spine` to be repurposed and generalized into a new method `_barycentric_x_y_angle`. The method `_halfway_x_y_angle` was previously used to return the x, y, and rotation angle corresponding to the very center of an axis Spine object, which was then used to center the axis label along that axis at the drawing stage. The method `_barycentric_x_y_angle` does the same thing but using instead a given scale parameter between 0 and 1, with each value corresponding to either end of the axis Spine (making `_halfway_x_y_angle` a special case at scale factor equal to 0.5). Its implementation was also adapted to always return that 0 to 1 position assuming a general orientation of the Spine from the lower left corner of the figure to its upper right corner (except if the Spine vertices do not follow a generally defined direction, such as in the case of an elliptical spine). For the purpose of the `loc` keyword argument implementation, the `_barycentric_x_y_angle` method is replacing `_halfway_x_y_angle` with an input determined by the `loc` value.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Fixes #<Issue Number> -->

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
