### PR TITLE
Backport PR #18732 on branch `v7.1.x` (BUG: fix incoming incompatibilities with numpy 2.4)

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -48,6 +48,7 @@ from astropy.utils.compat import (
     NUMPY_LT_2_0,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
+    NUMPY_LT_2_4,
 )
 
 if NUMPY_LT_2_0:
@@ -1243,12 +1244,14 @@ def isin(element, test_elements, *args, **kwargs):
     return (ar1, ar2) + args, kwargs, None, None
 
 
-@function_helper  # np.in1d deprecated in not NUMPY_LT_2_0.
-def in1d(ar1, ar2, *args, **kwargs):
-    # This tests whether ar1 is in ar2, so we should change the unit of
-    # ar1 to that of ar2.
-    (ar2, ar1), unit = _quantities2arrays(ar2, ar1)
-    return (ar1, ar2) + args, kwargs, None, None
+if NUMPY_LT_2_4:
+    # np.in1d deprecated in not NUMPY_LT_2_0, removed in not NUMPY_LT_24
+    @function_helper
+    def in1d(ar1, ar2, *args, **kwargs):
+        # This tests whether ar1 is in ar2, so we should change the unit of
+        # ar1 to that of ar2.
+        (ar2, ar1), unit = _quantities2arrays(ar2, ar1)
+        return (ar1, ar2) + args, kwargs, None, None
 
 
 @dispatched_function

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -27,6 +27,7 @@ from astropy.utils.compat import (
     NUMPY_LT_2_0,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
+    NUMPY_LT_2_4,
 )
 
 VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
@@ -2287,6 +2288,7 @@ class TestSetOpsFunctions:
         self.check2(np.setdiff1d)
 
     @needs_array_function
+    @pytest.mark.skipif(not NUMPY_LT_2_4, reason="in1d was removed in numpy 2.4")
     @pytest.mark.filterwarnings("ignore:`in1d` is deprecated. Use `np.isin` instead.")
     def test_in1d(self):
         self.check2(np.in1d, unit=None)  # noqa: NPY201

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -17,6 +17,7 @@ __all__ = [
     "NUMPY_LT_2_1",
     "NUMPY_LT_2_2",
     "NUMPY_LT_2_3",
+    "NUMPY_LT_2_4",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -29,6 +30,7 @@ NUMPY_LT_2_0 = not minversion(np, "2.0")
 NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
+NUMPY_LT_2_4 = not minversion(np, "2.4.0.dev0")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -15,22 +15,20 @@ import warnings
 import numpy as np
 
 from astropy.units.quantity_helper.function_helpers import FunctionAssigner
-from astropy.utils.compat import NUMPY_LT_1_24, NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2
+from astropy.utils.compat import (
+    NUMPY_LT_1_24,
+    NUMPY_LT_2_0,
+    NUMPY_LT_2_1,
+    NUMPY_LT_2_2,
+    NUMPY_LT_2_4,
+)
 
 if NUMPY_LT_2_0:
     import numpy.core as np_core
-    from numpy.lib.function_base import (
-        _check_interpolation_as_method,
-        _quantile_is_valid,
-        _ureduce,
-    )
+    from numpy.lib.function_base import _quantile_is_valid, _ureduce
 else:
     import numpy._core as np_core
-    from numpy.lib._function_base_impl import (
-        _check_interpolation_as_method,
-        _quantile_is_valid,
-        _ureduce,
-    )
+    from numpy.lib._function_base_impl import _quantile_is_valid, _ureduce
 
 
 # This module should not really be imported, but we define __all__
@@ -817,10 +815,15 @@ def _preprocess_quantile(a, q, axis=None, out=None, **kwargs):
     if not _quantile_is_valid(q):
         raise ValueError("Quantiles must be in the range [0, 1]")
 
-    if (interpolation := kwargs.pop("interpolation")) is not None:
+    if (interpolation := kwargs.pop("interpolation", None)) is not None:
         # we have to duplicate logic from np.quantile here to avoid
         # passing down the 'interpolation' keyword argument, as it's not
         # supported by np.lib._function_base_impl._quantile_unchecked
+        if NUMPY_LT_2_0:
+            from numpy.lib.function_base import _check_interpolation_as_method
+        else:
+            assert NUMPY_LT_2_4  # 'interpolation' kwarg was removed in numpy 2.4
+            from numpy.lib._function_base_impl import _check_interpolation_as_method
         kwargs["method"] = _check_interpolation_as_method(
             kwargs.get("method", "linear"), interpolation, "quantile"
         )
@@ -883,7 +886,7 @@ elif NUMPY_LT_2_0:
         result = _ureduce(a, func=_masked_quantile, q=q, axis=axis, out=out, **kwargs)
         return result, None, None
 
-else:
+elif NUMPY_LT_2_4:
 
     @dispatched_function
     def quantile(
@@ -908,6 +911,33 @@ else:
             keepdims=keepdims,
             weights=weights,
             interpolation=interpolation,
+        )
+        result = _ureduce(a, func=_masked_quantile, q=q, axis=axis, out=out, **kwargs)
+        return result, None, None
+
+else:
+
+    @dispatched_function
+    def quantile(
+        a,
+        q,
+        axis=None,
+        out=None,
+        overwrite_input=False,
+        method="linear",
+        keepdims=False,
+        *,
+        weights=None,
+    ):
+        a, q, axis, out, kwargs = _preprocess_quantile(
+            a,
+            q,
+            axis,
+            out,
+            overwrite_input=overwrite_input,
+            method=method,
+            keepdims=keepdims,
+            weights=weights,
         )
         result = _ureduce(a, func=_masked_quantile, q=q, axis=axis, out=out, **kwargs)
         return result, None, None
@@ -1455,12 +1485,15 @@ if NUMPY_LT_1_24:  # "kind" argument introduced in 1.24.
         result.shape = element.shape
         return result, _copy_of_mask(element), None
 
-else:
+elif NUMPY_LT_2_4:  # in1d is removed in 2.4
 
     @dispatched_function
     def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         mask = _copy_of_mask(ar1).ravel()
         return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
+
+
+if not NUMPY_LT_1_24:
 
     @dispatched_function
     def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -29,6 +29,7 @@ from astropy.utils.compat import (
     NUMPY_LT_2_0,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
+    NUMPY_LT_2_4,
 )
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
@@ -1685,6 +1686,7 @@ class TestArraySetOps:
         c = np.isin(a.astype(dtype), b.astype(dtype))
         assert_masked_equal(c, ec)
 
+    @pytest.mark.skipif(not NUMPY_LT_2_4, reason="np.in1d was removed in numpy 2.4")
     @pytest.mark.filterwarnings("ignore:in1d.*deprecated")  # not NUMPY_LT_2_0
     def test_in1d(self):
         # Once we require numpy>=2.0, these tests should be joined with np.isin.
@@ -1703,6 +1705,7 @@ class TestArraySetOps:
         assert_masked_equal(np.in1d(Masked([]), [], invert=True), Masked([]))  # noqa: NPY201
 
     @pytest.mark.skipif(NUMPY_LT_1_24, reason="kind introduced in numpy 1.24")
+    @pytest.mark.skipif(not NUMPY_LT_2_4, reason="np.in1d was removed in numpy 2.4")
     def test_in1d_kind_table_error(self):
         with pytest.raises(ValueError, match="'table' method is not supported"):
             np.in1d(Masked([1, 2, 3]), [4, 5], kind="table")  # noqa: NPY201


### PR DESCRIPTION
### Description
Manual backport for #18732 to v7.1.x

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
