### PR TITLE
Fix checksum bug when heap is smaller than 4 bytes

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -885,7 +885,7 @@ class BinTableHDU(_TableBaseHDU):
             heap_data = data._get_heap_data(try_from_disk)
             if extra := self._theap % 4:
                 first_part = np.zeros(4, dtype=np.ubyte)
-                first_part[extra:] = heap_data[: 4 - extra]
+                first_part[extra : extra + len(heap_data)] = heap_data[: 4 - extra]
                 csum = self._compute_checksum(first_part, csum)
                 return self._compute_checksum(heap_data[4 - extra :], csum)
 

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -262,6 +262,50 @@ class TestChecksumFunctions(BaseChecksumTests):
             assert hdul[1].header["DATASUM"] == "1648357376"
             assert hdul[1].header["CHECKSUM"] == "jcdDjZZBjabBjYZB"
 
+    def test_small_heap(self):
+        """regression test for #18735"""
+        # Tests situations where the start of the heap is not aligned with
+        # 4-byte blocks (32 bit integers), and the size of our heap is smaller
+        # than 4 bytes
+        testfile = self.temp("tmp.fits")
+        col1 = fits.Column(name="a", format="1A", array=["a"])
+        tab = fits.BinTableHDU.from_columns(name="test", columns=[col1])
+
+        tab.writeto(testfile, checksum=True)
+        with fits.open(testfile, checksum=True) as hdul:
+            assert hdul[1].header["DATASUM"] == "1627389952"
+            assert hdul[1].header["CHECKSUM"] == "nNejoMchnMchnMch"
+
+        testfile = self.temp("tmp2.fits")
+        col1 = fits.Column(name="a", format="1A", array=["a"])
+        col2 = fits.Column(name="b", format="PB", array=[[1]])
+        tab = fits.BinTableHDU.from_columns(name="test", columns=[col1, col2])
+
+        tab.writeto(testfile, checksum=True)
+        with fits.open(testfile, checksum=True) as hdul:
+            assert hdul[1].header["DATASUM"] == "1644232704"
+            assert hdul[1].header["CHECKSUM"] == "4IIH7H9H4HGH4H9H"
+
+        testfile = self.temp("tmp3.fits")
+        col1 = fits.Column(name="a", format="1A", array=["a"])
+        col2 = fits.Column(name="b", format="PB", array=[[1, 2]])
+        tab = fits.BinTableHDU.from_columns(name="test", columns=[col1, col2])
+
+        tab.writeto(testfile, checksum=True)
+        with fits.open(testfile, checksum=True) as hdul:
+            assert hdul[1].header["DATASUM"] == "1661010432"
+            assert hdul[1].header["CHECKSUM"] == "4IHK6I9H4IGH4I9H"
+
+        testfile = self.temp("tmp4.fits")
+        col1 = fits.Column(name="a", format="1A", array=["a"])
+        col2 = fits.Column(name="b", format="PB", array=[[1, 2, 3]])
+        tab = fits.BinTableHDU.from_columns(name="test", columns=[col1, col2])
+
+        tab.writeto(testfile, checksum=True)
+        with fits.open(testfile, checksum=True) as hdul:
+            assert hdul[1].header["DATASUM"] == "1677787651"
+            assert hdul[1].header["CHECKSUM"] == "1HCH3G9F1GCF1G9F"
+
     def test_ascii_table_data(self):
         a1 = np.array(["abc", "def"])
         r1 = np.array([11.0, 12.0])


### PR DESCRIPTION
### Description
This pull request is to address a bug that occurred when calculating the checksum, if the start of the heap was not aligned with 4-byte blocks and the size of the heap was smaller than 4 bytes

Fixes #18735

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
