### PR TITLE
RFC: re-define table.bst sentinel values as immutable singletons

### DIFF
--- a/astropy/table/bst.py
+++ b/astropy/table/bst.py
@@ -1,11 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import operator
 from collections.abc import Hashable, Mapping, Sequence
+from dataclasses import dataclass
 from numbers import Integral
 
-__all__ = ["BST"]
+__all__ = ["BST", "Bottom", "Top"]
 
 
+@dataclass(frozen=True, eq=False, slots=True)
 class MaxValue:
     """
     Represents an infinite value for purposes
@@ -29,7 +31,14 @@ class MaxValue:
 
     __str__ = __repr__
 
+    def __hash__(self):
+        return hash(str(self))
 
+
+Top = MaxValue()
+
+
+@dataclass(frozen=True, eq=False, slots=True)
 class MinValue:
     """
     The opposite of MaxValue, i.e. a representation of
@@ -53,40 +62,11 @@ class MinValue:
 
     __str__ = __repr__
 
+    def __hash__(self):
+        return hash(str(self))
 
-class Epsilon:
-    """
-    Represents the "next largest" version of a given value,
-    so that for all valid comparisons we have
-    x < y < Epsilon(y) < z whenever x < y < z and x, z are
-    not Epsilon objects.
 
-    Parameters
-    ----------
-    val : object
-        Original value
-    """
-
-    __slots__ = ("val",)
-
-    def __init__(self, val):
-        self.val = val
-
-    def __lt__(self, other):
-        if self.val == other:
-            return False
-        return self.val < other
-
-    def __gt__(self, other):
-        if self.val == other:
-            return True
-        return self.val > other
-
-    def __eq__(self, other):
-        return False
-
-    def __repr__(self):
-        return repr(self.val) + " + epsilon"
+Bottom = MinValue()
 
 
 class Node:

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -133,7 +133,7 @@ When a query is performed using `.loc[]`:
 
 3. **Index Lookup**: The appropriate index engine performs the search:
    - Single/multiple lookups use `find()` method
-   - Range queries use `range()` method with MinValue/MaxValue sentinels
+   - Range queries use `range()` method with Top/Bottom sentinels
 
 4. **Coordinate Translation**: For sliced tables, row indices are translated from
    original coordinates to sliced coordinates using `sliced_coords()`
@@ -213,7 +213,7 @@ import numpy as np
 
 from astropy.utils.decorators import deprecated
 
-from .bst import MaxValue, MinValue
+from .bst import Bottom, Top
 from .sorted_array import SortedArray
 
 if TYPE_CHECKING:
@@ -510,8 +510,8 @@ class Index:
         """
         n = len(lower)
         ncols = len(self.columns)
-        a = MinValue() if bounds[0] else MaxValue()
-        b = MaxValue() if bounds[1] else MinValue()
+        a = Bottom if bounds[0] else Top
+        b = Top if bounds[1] else Bottom
         # [x, y] search corresponds to [(x, min), (y, max)]
         # (x, y) search corresponds to ((x, max), (x, min))
         lower = lower + tuple((ncols - n) * [a])
@@ -1145,8 +1145,8 @@ class TableLoc:
 
         if isinstance(item, slice):
             # None signifies no upper/lower bound
-            start = MinValue() if item.start is None else item.start
-            stop = MaxValue() if item.stop is None else item.stop
+            start = Bottom if item.start is None else item.start
+            stop = Top if item.stop is None else item.stop
             rows = index.range((start,), (stop,))
         else:
             if not isinstance(item, (list, np.ndarray)):  # single element


### PR DESCRIPTION
### Description

This is done in support of https://github.com/astropy/astropy/pull/18725


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
