### PR TITLE
Fix TypeError when writing object dtype columns with variable-length strings to FITS binary tables

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1528,56 +1528,140 @@ class ColDefs(NotifierMixin):
                 f"Input data with shape {array.shape} is not a valid representation "
                 "of a row-oriented table. Expected a 1D array with rows as elements."
             )
-        self.columns = []
+
+        # Identify object dtype columns and determine their correct dtype
+        columns_to_fix = {}
         for idx in range(len(array.dtype)):
             cname = array.dtype.names[idx]
             ftype = array.dtype.fields[cname][0]
 
             if ftype.kind == "O":
-                dtypes = {
-                    np.array(array[cname][i]).dtype
-                    for i in range(len(array))
-                    if array[cname][i] is not None
-                }
+                col_array = array[cname]
+                # Get first non-None value
+                first_non_none = next(
+                    (
+                        col_array[i]
+                        for i in range(len(col_array))
+                        if col_array[i] is not None
+                    ),
+                    None,
+                )
 
-                if not dtypes:
+                if first_non_none is None:
                     raise TypeError(
                         f"Column '{cname}' contains only None or masked values"
                     )
 
-                # All entries are strings (unicode or byte)
-                if all(dt.kind in ("U", "S") for dt in dtypes):
-                    # Check if we have arrays of strings
-                    has_arrays = any(
-                        isinstance(v, (list, np.ndarray)) and np.ndim(v) > 0
-                        for v in array[cname]
-                        if v is not None
-                    )
+                # Check if this is an array of arrays
+                is_vla = isinstance(first_non_none, np.ndarray)
 
-                    if has_arrays:
-                        format = "PA()"
-                    else:
-                        # Single strings: use max length from dtypes
+                if is_vla:
+                    element_dtypes = {
+                        val.dtype
+                        for val in col_array
+                        if val is not None and isinstance(val, np.ndarray)
+                    }
+
+                    if not element_dtypes:
+                        raise TypeError(
+                            f"Column '{cname}' contains only None or masked values"
+                        )
+
+                    if len(element_dtypes) > 1:
+                        raise TypeError(
+                            f"Column '{cname}' contains unsupported object types or "
+                            f"mixed types: {element_dtypes}"
+                        )
+
+                    element_dtype = element_dtypes.pop()
+                    fits_code = NUMPY2FITS[element_dtype.str[1:]]
+                    columns_to_fix[cname] = ("VLA", fits_code, element_dtype.str[1:])
+                else:
+                    dtypes = {
+                        np.array(col_array[i]).dtype
+                        for i in range(len(col_array))
+                        if col_array[i] is not None
+                    }
+
+                    if not dtypes:
+                        raise TypeError(
+                            f"Column '{cname}' contains only None or masked values"
+                        )
+
+                    # Check for unresolved object types
+                    if np.dtype("O") in dtypes:
+                        raise TypeError(
+                            f"Column '{cname}' contains unsupported object types or "
+                            f"mixed types: {dtypes}"
+                        )
+
+                    # Single resolved dtype
+                    if len(dtypes) == 1:
+                        ftype_inner = dtypes.pop()
+
+                        # Compute max length if string
+                        if ftype_inner.kind in ("U", "S"):
+                            max_len = (
+                                ftype_inner.itemsize // 4
+                                if ftype_inner.kind == "U"
+                                else ftype_inner.itemsize
+                            )
+                            columns_to_fix[cname] = f"U{max_len}"
+                        else:
+                            columns_to_fix[cname] = ftype_inner.str
+
+                    # Multiple string types with different lengths, use max
+                    elif all(dt.kind in ("U", "S") for dt in dtypes):
                         max_len = max(
                             dt.itemsize // 4 if dt.kind == "U" else dt.itemsize
                             for dt in dtypes
                         )
-                        format = f"{max_len}A"
+                        columns_to_fix[cname] = f"U{max_len}"
 
-                # Homogeneous non-string type
-                elif len(dtypes) == 1:
-                    ftype_inner = dtypes.pop()
-                    format_code = self._col_format_cls.from_recformat(ftype_inner)
-                    format = f"P{format_code}()"
+                    else:
+                        raise TypeError(
+                            f"Column '{cname}' contains unsupported object types or "
+                            f"mixed types: {dtypes}"
+                        )
 
-                # Mixed or unsupported types
+        # Rebuild the recarray with corrected dtypes if needed (skip VLAs)
+        if columns_to_fix:
+            new_dtype_list = []
+            for idx in range(len(array.dtype)):
+                cname = array.dtype.names[idx]
+                if cname in columns_to_fix:
+                    fix_info = columns_to_fix[cname]
+                    if isinstance(fix_info, tuple) and fix_info[0] == "VLA":
+                        new_dtype_list.append((cname, array.dtype.fields[cname][0]))
+                    else:
+                        new_dtype_list.append((cname, fix_info))
                 else:
-                    raise TypeError(
-                        f"Column '{cname}' contains unsupported object types or "
-                        f"mixed types: {dtypes}"
+                    new_dtype_list.append((cname, array.dtype.fields[cname][0]))
+
+            new_dtype = np.dtype(new_dtype_list)
+            array = np.array([tuple(row) for row in array], dtype=new_dtype)
+
+        # Create columns from the (now corrected) array
+        self.columns = []
+        for idx in range(len(array.dtype)):
+            cname = array.dtype.names[idx]
+            ftype = array.dtype.fields[cname][0]
+
+            if cname in columns_to_fix:
+                fix_info = columns_to_fix[cname]
+                if isinstance(fix_info, tuple) and fix_info[0] == "VLA":
+                    fits_code = fix_info[1]
+                    element_dtype_str = fix_info[2]
+                    format = self._col_format_cls(f"1P{fits_code}")
+                    col_array = _VLF(
+                        array.view(np.ndarray)[cname], dtype=element_dtype_str
                     )
+                else:
+                    format = self._col_format_cls.from_recformat(ftype)
+                    col_array = array.view(np.ndarray)[cname]
             else:
                 format = self._col_format_cls.from_recformat(ftype)
+                col_array = array.view(np.ndarray)[cname]
 
             # Determine the appropriate dimensions for items in the column
             dim = array.dtype[idx].shape[::-1]
@@ -1605,7 +1689,7 @@ class ColDefs(NotifierMixin):
             c = Column(
                 name=cname,
                 format=format,
-                array=array.view(np.ndarray)[cname],
+                array=col_array,
                 bzero=bzero,
                 dim=dim,
             )

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -493,7 +493,7 @@ class TestSingleTable:
         See https://github.com/astropy/astropy/issues/1906
         """
         filename = tmp_path / "test_table_object.fits"
-        msg = r"Column 'col1' contains unsupported object types or mixed types: {dtype\('O'\)}"
+        msg = r"Column 'col1' contains only None or masked values"
         # Make a FITS table with an object column
         tab = Table({"col1": [None]})
         with pytest.raises(TypeError, match=msg):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -4033,7 +4033,7 @@ def test_object_column_variable_length_strings(tmp_path):
     assert hdu1.header["TFORM1"] == "5A"
     assert hdu1.header["TFORM2"] == "E"
 
-    hdu1.writeto(tmp_path / "test1.fits", overwrite=True)
+    hdu1.writeto(tmp_path / "test1.fits")
     with fits.open(tmp_path / "test1.fits") as hdul:
         assert hdul[1].header["TFORM1"] == "5A"
         actual = np.array([v.strip() for v in hdul[1].data["type"]])
@@ -4051,7 +4051,7 @@ def test_object_column_variable_length_strings(tmp_path):
     assert hdu2.header["TFORM1"] == "16A"
     assert hdu2.header["TFORM2"] == "D"
 
-    hdu2.writeto(tmp_path / "test2.fits", overwrite=True)
+    hdu2.writeto(tmp_path / "test2.fits")
     with fits.open(tmp_path / "test2.fits") as hdul:
         assert hdul[1].header["TFORM1"] == "16A"
         actual = np.array([v.strip() for v in hdul[1].data["name"]])
@@ -4070,7 +4070,7 @@ def test_object_column_variable_length_strings(tmp_path):
     assert hdu3.header["TFORM2"] == "10A"
     assert hdu3.header["TFORM3"] == "J"
 
-    hdu3.writeto(tmp_path / "test3.fits", overwrite=True)
+    hdu3.writeto(tmp_path / "test3.fits")
     with fits.open(tmp_path / "test3.fits") as hdul:
         assert hdul[1].header["TFORM1"] == "3A"
         assert hdul[1].header["TFORM2"] == "10A"
@@ -4090,7 +4090,7 @@ def test_object_column_variable_length_strings(tmp_path):
     assert hdu4.header["TFORM1"] == "1A"
     assert hdu4.header["TFORM2"] == "J"
 
-    hdu4.writeto(tmp_path / "test4.fits", overwrite=True)
+    hdu4.writeto(tmp_path / "test4.fits")
     with fits.open(tmp_path / "test4.fits") as hdul:
         assert hdul[1].header["TFORM1"] == "1A"
         np.testing.assert_array_equal(

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -4017,3 +4017,83 @@ def test_zero_row_string_column(tmp_path):
     with fits.open(outfile) as hdul:
         table_data = hdul[1].data
     assert table_data.shape[0] == 0
+
+
+def test_object_column_variable_length_strings(tmp_path):
+    # issue #18696 variable-Length strings fail when writing to FITS binary
+    # tables
+
+    # Test Case 1: Single dtype (all strings same length)
+    data1 = np.array(
+        [("image", 11.1), ("image", 12.3), ("image", 15.2)],
+        dtype=[("type", "O"), ("value", "f4")],
+    )
+
+    hdu1 = fits.BinTableHDU(data1)
+    assert hdu1.header["TFORM1"] == "5A"
+    assert hdu1.header["TFORM2"] == "E"
+
+    hdu1.writeto(tmp_path / "test1.fits", overwrite=True)
+    with fits.open(tmp_path / "test1.fits") as hdul:
+        assert hdul[1].header["TFORM1"] == "5A"
+        actual = np.array([v.strip() for v in hdul[1].data["type"]])
+        expected = np.array([v[0] for v in data1])
+        np.testing.assert_array_equal(actual, expected)
+        np.testing.assert_allclose(hdul[1].data["value"], data1["value"])
+
+    # Test Case 2: Strings of different lengths
+    data2 = np.array(
+        [("img", 1.0), ("image", 2.0), ("very_long_string", 3.0), ("x", 4.0)],
+        dtype=[("name", "O"), ("val", "f8")],
+    )
+
+    hdu2 = fits.BinTableHDU(data2)
+    assert hdu2.header["TFORM1"] == "16A"
+    assert hdu2.header["TFORM2"] == "D"
+
+    hdu2.writeto(tmp_path / "test2.fits", overwrite=True)
+    with fits.open(tmp_path / "test2.fits") as hdul:
+        assert hdul[1].header["TFORM1"] == "16A"
+        actual = np.array([v.strip() for v in hdul[1].data["name"]])
+        expected = np.array([v[0] for v in data2])
+        np.testing.assert_array_equal(actual, expected)
+        np.testing.assert_allclose(hdul[1].data["val"], data2["val"])
+
+    # Test Case 3: Multiple object columns with different max lengths
+    data3 = np.array(
+        [("a", "short", 100), ("ab", "medium_len", 200), ("abc", "x", 300)],
+        dtype=[("col1", "O"), ("col2", "O"), ("col3", "i4")],
+    )
+
+    hdu3 = fits.BinTableHDU(data3)
+    assert hdu3.header["TFORM1"] == "3A"
+    assert hdu3.header["TFORM2"] == "10A"
+    assert hdu3.header["TFORM3"] == "J"
+
+    hdu3.writeto(tmp_path / "test3.fits", overwrite=True)
+    with fits.open(tmp_path / "test3.fits") as hdul:
+        assert hdul[1].header["TFORM1"] == "3A"
+        assert hdul[1].header["TFORM2"] == "10A"
+        assert hdul[1].header["TFORM3"] == "J"
+        np.testing.assert_array_equal(
+            [v.strip() for v in hdul[1].data["col1"]], [v[0] for v in data3]
+        )
+        np.testing.assert_array_equal(
+            [v.strip() for v in hdul[1].data["col2"]], [v[1] for v in data3]
+        )
+        np.testing.assert_array_equal(hdul[1].data["col3"], data3["col3"])
+
+    # Test Case 4: Empty strings
+    data4 = np.array([("", 1), ("a", 2), ("", 3)], dtype=[("str", "O"), ("num", "i4")])
+
+    hdu4 = fits.BinTableHDU(data4)
+    assert hdu4.header["TFORM1"] == "1A"
+    assert hdu4.header["TFORM2"] == "J"
+
+    hdu4.writeto(tmp_path / "test4.fits", overwrite=True)
+    with fits.open(tmp_path / "test4.fits") as hdul:
+        assert hdul[1].header["TFORM1"] == "1A"
+        np.testing.assert_array_equal(
+            [v.strip() for v in hdul[1].data["str"]], [v[0] for v in data4]
+        )
+        np.testing.assert_array_equal(hdul[1].data["num"], data4["num"])

--- a/docs/changes/io.fits/18757.bugfix.rst
+++ b/docs/changes/io.fits/18757.bugfix.rst
@@ -1,0 +1,1 @@
+Fix TypeError when writing object dtype columns with variable-length strings to FITS binary tables


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request attempts to fix an issue where numpy arrays with object dtype columns containing variable-length strings (common from TAP/VOTable queries) fail when writing to FITS binary tables.

Previously, when attempting to create a FITS binary table from arrays with object dtype columns containing strings of different lengths (e.g., `dtype('<U3') vs dtype('<U17'))`, the code would raise one of two errors:

```
VerifyError: Illegal format 'PnA()' - when all strings had the same length
TypeError: mixed types - when strings had different lengths
```

This occurred because `ColDefs._init_from_array()` treated strings of different lengths as incompatible "mixed types" and attempted to create invalid formats. A bit more detail on the issue can be found here:
https://github.com/astropy/astropy/issues/18696

The fix:
- Detects when an object dtype column contains strings (Unicode or byte strings)
- Distinguishes between single strings and arrays of strings
- For single strings: create a fixed-length format nA where n is the maximum string length
- For arrays of strings: create a variable-length array format PA()

This allows PyVO tables with arraysize="*" fields to be written to FITS without manual conversion.

Fixes #18696

Per @saimn's suggestion, I initially attempted to use just "A" without computing the max length, relying on later processing to fill it in. 
However when I tried that the tests failed, as the format remains as "A" which leads to truncated data. 

Perhaps I have misinterpreted the suggestion though, so I'm open to trying out any suggested changes that would simplify and not require the extra max length calculation.

I've added some tests that exercise the bugfix.

Note that I'm not very familiar with FITS and have not looked into this side of the codebase much, so there may be better solutions and I'm open to suggestions for improving/changing the approach for this PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
