### PR TITLE
Generate stubs for CDS and Imperial units

### DIFF
--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -40,7 +40,13 @@ import numpy as np
 
 from astropy.constants import si as _si
 
-from .core import binary_prefixes, def_unit, set_enabled_units, si_prefixes
+from .core import (
+    _UnitContext,
+    binary_prefixes,
+    def_unit,
+    set_enabled_units,
+    si_prefixes,
+)
 from .docgen import generate_dunder_all, generate_unit_summary
 
 _ns = globals()
@@ -192,7 +198,7 @@ if __doc__ is not None:
     __doc__ += generate_unit_summary(globals())
 
 
-def enable():
+def enable() -> _UnitContext:
     """
     Enable CDS units so they appear in results of
     `~astropy.units.UnitBase.find_equivalent_units` and

--- a/astropy/units/imperial.py
+++ b/astropy/units/imperial.py
@@ -22,7 +22,7 @@ To include them in `~astropy.units.UnitBase.compose` and the results of
 __all__: list[str] = ["enable"]  #  Units are added at the end
 
 from . import si
-from .core import add_enabled_units, def_unit
+from .core import _UnitContext, add_enabled_units, def_unit
 from .docgen import generate_dunder_all, generate_unit_summary
 
 _ns = globals()
@@ -165,7 +165,7 @@ if __doc__ is not None:
     __doc__ += generate_unit_summary(globals())
 
 
-def enable():
+def enable() -> _UnitContext:
     """
     Enable Imperial units so they appear in results of
     `~astropy.units.UnitBase.find_equivalent_units` and

--- a/tox.ini
+++ b/tox.ini
@@ -173,7 +173,9 @@ commands =
     touch {env_site_packages_dir}/astropy/units/py.typed
     stubtest --mypy-config-file .stubtest.ini \
         astropy.units.astrophys \
+        astropy.units.cds \
         astropy.units.cgs \
+        astropy.units.imperial \
         astropy.units.misc \
         astropy.units.photometric \
         astropy.units.required_by_vounit \


### PR DESCRIPTION
### Description

The recently merged #18623 implemented infrastructure for testing automatically generated type stubs for unit definition modules in CI, and also included a script to generate stubs for most unit definition modules so that the CI tests could be exercised. However, that did not include the `cds` and `imperial` modules, which differ from the others because they define not just units but additionally `enable()` functions. This PR improves our stub generation machinery so that it can now write stubs for functions without parameters, which is good enough for the modules in question. The return types of the functions are looked up from the annotations of the implementations, which avoids needless hard-coding in the stub generation machinery.

Reviewers don't have to review the generated stubs in their entirety because the `stubtest` CI job ensures both that the stubs are complete and that all the units have correct annotations.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
