### PR TITLE
refactor: consolidate trait method dependencies

### DIFF
--- a/astropy/cosmology/_src/tests/traits/test_trait_darkenergy.py
+++ b/astropy/cosmology/_src/tests/traits/test_trait_darkenergy.py
@@ -6,7 +6,9 @@ from astropy.cosmology._src.traits.darkenergy import DarkEnergyComponent
 from .helper import is_positional_only
 
 
-class MinimalDarkEnergy(DarkEnergyComponent):
+class FailingDarkEnergy(DarkEnergyComponent):
+    """A class that fails to implement the required inv_efunc method."""
+
     Ode0 = 0.7
 
     def w(self, z, /):
@@ -19,13 +21,8 @@ class ConcreteDarkEnergy(DarkEnergyComponent):
     def w(self, z, /):
         return -1.0
 
-    def inv_efunc(self, z):
+    def inv_efunc(self, z, /):
         return np.ones_like(np.asarray(z))
-
-
-@pytest.fixture
-def minimal_de():
-    return MinimalDarkEnergy()
 
 
 @pytest.fixture
@@ -33,12 +30,12 @@ def concrete_de():
     return ConcreteDarkEnergy()
 
 
-def test_darkenergy_signature_and_missing_inv_efunc_raises(minimal_de):
+def test_darkenergy_signature_and_missing_inv_efunc_raises():
     assert hasattr(DarkEnergyComponent, "w")
     assert is_positional_only(DarkEnergyComponent.w, "z")
-    # Ode requires inv_efunc; calling should raise NotImplementedError
-    with pytest.raises(NotImplementedError):
-        minimal_de.Ode(1)
+    # inv_efunc is abstract; FailingDarkEnergy (which lacks it) cannot be instantiated
+    with pytest.raises(TypeError, match="abstract"):
+        FailingDarkEnergy()
 
 
 def test_darkenergy_with_inv_efunc(concrete_de):

--- a/astropy/cosmology/_src/traits/baryons.py
+++ b/astropy/cosmology/_src/traits/baryons.py
@@ -3,24 +3,22 @@
 
 __all__ = ("BaryonComponent",)
 
-from collections.abc import Callable
-from typing import Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 
 from astropy.cosmology._src.typing import FArray
 from astropy.cosmology._src.utils import aszarr
 from astropy.units import Quantity
 
+from .hubble import _HasH0overH
 
-class BaryonComponent:
+
+class BaryonComponent(_HasH0overH):
     """The cosmology has attributes and methods for the baryon density."""
 
     Ob0: float | np.floating
     """Omega baryons: density of baryonic matter in units of the critical density at z=0."""
-
-    inv_efunc: Callable[[NDArray[Any]], NDArray[Any]]
 
     def Ob(self, z: Quantity | ArrayLike, /) -> FArray:
         """Return the density parameter for baryonic matter at redshift ``z``.

--- a/astropy/cosmology/_src/traits/curvature.py
+++ b/astropy/cosmology/_src/traits/curvature.py
@@ -15,8 +15,10 @@ from numpy.typing import ArrayLike, NDArray
 from astropy.cosmology._src.utils import aszarr
 from astropy.units import Quantity
 
+from .hubble import _HasH0overH
 
-class CurvatureComponent:
+
+class CurvatureComponent(_HasH0overH):
     """The object has attributes and methods related to the global curvature.
 
     This is a trait class; it is not meant to be instantiated directly, but

--- a/astropy/cosmology/_src/traits/darkenergy.py
+++ b/astropy/cosmology/_src/traits/darkenergy.py
@@ -11,8 +11,10 @@ from astropy.cosmology._src.typing import FArray
 from astropy.cosmology._src.utils import aszarr
 from astropy.units import Quantity
 
+from .hubble import _HasH0overH
 
-class DarkEnergyComponent:
+
+class DarkEnergyComponent(_HasH0overH):
     # Subclasses should use `Parameter` to make this a parameter of the cosmology.
     Ode0: float | np.floating
     """Omega dark energy; dark energy density/critical density at z=0."""

--- a/astropy/cosmology/_src/traits/darkmatter.py
+++ b/astropy/cosmology/_src/traits/darkmatter.py
@@ -2,18 +2,18 @@
 
 __all__ = ("DarkMatterComponent",)
 
-from collections.abc import Callable
-from typing import Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 
 from astropy.cosmology._src.typing import FArray
 from astropy.cosmology._src.utils import aszarr
 from astropy.units import Quantity
 
+from .hubble import _HasH0overH
 
-class DarkMatterComponent:
+
+class DarkMatterComponent(_HasH0overH):
     """The cosmology has attributes and methods for the dark matter density.
 
     This trait provides an ``Odm`` method that returns the dark matter
@@ -22,8 +22,6 @@ class DarkMatterComponent:
 
     Odm0: float | np.floating
     """Omega dark matter: dark matter density/critical density at z=0."""
-
-    inv_efunc: Callable[[NDArray[Any]], NDArray[Any]]
 
     def Odm(self, z: Quantity | ArrayLike, /) -> FArray:
         """Return the density parameter for dark matter at redshift ``z``.

--- a/astropy/cosmology/_src/traits/hubble.py
+++ b/astropy/cosmology/_src/traits/hubble.py
@@ -6,6 +6,7 @@ This is private API. See `~astropy.cosmology.traits` for public API.
 
 __all__ = ("HubbleParameter",)
 
+from abc import abstractmethod
 from collections.abc import Callable
 from functools import cached_property
 from typing import Any, Protocol
@@ -28,6 +29,7 @@ class _HasHoverH0(Protocol):  # noqa: PYI046
 class _HasH0overH(Protocol):  # noqa: PYI046
     """Protocol for objects that have method ``inv_efunc``."""
 
+    @abstractmethod
     def inv_efunc(self, z: Quantity | ArrayLike, /) -> FArray: ...
 
 

--- a/astropy/cosmology/_src/traits/hubble.py
+++ b/astropy/cosmology/_src/traits/hubble.py
@@ -8,15 +8,27 @@ __all__ = ("HubbleParameter",)
 
 from collections.abc import Callable
 from functools import cached_property
-from typing import Any
+from typing import Any, Protocol
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 
 import astropy.units as u
 from astropy import constants as const
 from astropy.cosmology._src.typing import FArray
 from astropy.units import Quantity
+
+
+class _HasHoverH0(Protocol):  # noqa: PYI046
+    """Protocol for objects that have method ``efunc``."""
+
+    def efunc(self, z: Quantity | ArrayLike, /) -> FArray: ...
+
+
+class _HasH0overH(Protocol):  # noqa: PYI046
+    """Protocol for objects that have method ``inv_efunc``."""
+
+    def inv_efunc(self, z: Quantity | ArrayLike, /) -> FArray: ...
 
 
 class HubbleParameter:
@@ -25,7 +37,7 @@ class HubbleParameter:
     H0: Quantity
     """Hubble Parameter at redshift 0."""
 
-    efunc: Callable[[Any], NDArray[Any]]
+    efunc: Callable[[Any], FArray]
 
     inv_efunc: Callable[[Any], FArray | float]
 

--- a/astropy/cosmology/_src/traits/matter.py
+++ b/astropy/cosmology/_src/traits/matter.py
@@ -7,10 +7,12 @@ from astropy.cosmology._src.typing import FArray
 from astropy.cosmology._src.utils import aszarr
 from astropy.units import Quantity
 
+from .hubble import _HasH0overH
+
 __all__ = ("MatterComponent",)
 
 
-class MatterComponent:
+class MatterComponent(_HasH0overH):
     """The cosmology has attributes and methods for the matter density."""
 
     Om0: float | np.floating

--- a/astropy/cosmology/_src/traits/rhocrit.py
+++ b/astropy/cosmology/_src/traits/rhocrit.py
@@ -3,21 +3,19 @@
 
 __all__ = ("CriticalDensity",)
 
-from collections.abc import Callable
-from typing import Any
 
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 
 from astropy.units import Quantity
 
+from .hubble import _HasHoverH0
 
-class CriticalDensity:
+
+class CriticalDensity(_HasHoverH0):
     """The object has attributes and methods for the critical density."""
 
     critical_density0: Quantity
     """Critical density at redshift 0."""
-
-    efunc: Callable[[Any], NDArray[Any]]
 
     def critical_density(self, z: Quantity | ArrayLike, /) -> Quantity:
         """Critical density in grams per cubic cm at redshift ``z``.


### PR DESCRIPTION
I've been trying to figure out the best way to vendor these trait classes that rely on having either `efunc` or `inv_efunc` for calculating the z-dependent quantities.
If I'm reading https://mypyc.readthedocs.io/en/latest/native_classes.html#inheritance correctly, then using a Protocol that unifies the expectations for these methods is the best solution.

Input appreciated.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
