### PR TITLE
Allow `"ogip"` unit formatter parse signed fractions as exponents

### DIFF
--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -48,10 +48,9 @@ class OGIP(Base, _ParsingFormatMixin):
         "WHITESPACE",
         "POWER",
         "STAR",
-        "SIGN",
-        "UFLOAT",
+        "FLOAT",
         "LIT10",
-        "UINT",
+        "INT",
         "UNKNOWN",
         "FUNCNAME",
         "UNIT",
@@ -106,19 +105,14 @@ class OGIP(Base, _ParsingFormatMixin):
 
         # NOTE THE ORDERING OF THESE RULES IS IMPORTANT!!
         # Regular expression rules for simple tokens
-        def t_UFLOAT(t):
-            r"(((\d+\.?\d*)|(\.\d+))([eE][+-]?\d+))|(((\d+\.\d*)|(\.\d+))([eE][+-]?\d+)?)"
+        def t_FLOAT(t):
+            r"[+-]?((((\d+\.?\d*)|(\.\d+))([eE][+-]?\d+))|(((\d+\.\d*)|(\.\d+))([eE][+-]?\d+)?))"
             t.value = float(t.value)
             return t
 
-        def t_UINT(t):
-            r"\d+"
+        def t_INT(t):
+            r"[+-]?\d+"
             t.value = int(t.value)
-            return t
-
-        def t_SIGN(t):
-            r"[+-](?=\d)"
-            t.value = 1 if t.value == "+" else -1
             return t
 
         def t_LIT10(t):
@@ -254,9 +248,8 @@ class OGIP(Base, _ParsingFormatMixin):
             """
             scale_factor : LIT10 POWER numeric_power
                          | LIT10
-                         | signed_float
-                         | signed_float POWER numeric_power
-                         | signed_int POWER numeric_power
+                         | number
+                         | number POWER numeric_power
             """
             if len(p) == 4:
                 p[0] = 10 ** p[3]
@@ -280,11 +273,9 @@ class OGIP(Base, _ParsingFormatMixin):
 
         def p_numeric_power(p):
             """
-            numeric_power : UINT
-                          | signed_float
-                          | OPEN_PAREN signed_int CLOSE_PAREN
-                          | OPEN_PAREN signed_float CLOSE_PAREN
-                          | OPEN_PAREN signed_float DIVISION UINT CLOSE_PAREN
+            numeric_power : number
+                          | OPEN_PAREN number CLOSE_PAREN
+                          | OPEN_PAREN INT DIVISION INT CLOSE_PAREN
             """
             if len(p) == 6:
                 p[0] = Fraction(int(p[2]), int(p[4]))
@@ -300,28 +291,12 @@ class OGIP(Base, _ParsingFormatMixin):
                         )
                     )
 
-        def p_sign(p):
+        def p_number(p):
             """
-            sign : SIGN
-                 |
+            number : INT
+                   | FLOAT
             """
-            if len(p) == 2:
-                p[0] = p[1]
-            else:
-                p[0] = 1.0
-
-        def p_signed_int(p):
-            """
-            signed_int : SIGN UINT
-            """
-            p[0] = p[1] * p[2]
-
-        def p_signed_float(p):
-            """
-            signed_float : sign UINT
-                         | sign UFLOAT
-            """
-            p[0] = p[1] * p[2]
+            p[0] = p[1]
 
         def p_error(p):
             raise ValueError()

--- a/astropy/units/format/ogip_lextab.py
+++ b/astropy/units/format/ogip_lextab.py
@@ -10,11 +10,11 @@
 
 # ogip_lextab.py. This file automatically created by PLY (version 3.11). Don't edit!
 _tabversion   = '3.10'
-_lextokens    = set(('CLOSE_PAREN', 'DIVISION', 'FUNCNAME', 'LIT10', 'OPEN_PAREN', 'POWER', 'SIGN', 'STAR', 'UFLOAT', 'UINT', 'UNIT', 'UNKNOWN', 'WHITESPACE'))
+_lextokens    = set(('CLOSE_PAREN', 'DIVISION', 'FLOAT', 'FUNCNAME', 'INT', 'LIT10', 'OPEN_PAREN', 'POWER', 'STAR', 'UNIT', 'UNKNOWN', 'WHITESPACE'))
 _lexreflags   = 64
 _lexliterals  = ''
 _lexstateinfo = {'INITIAL': 'inclusive'}
-_lexstatere   = {'INITIAL': [('(?P<t_UFLOAT>(((\\d+\\.?\\d*)|(\\.\\d+))([eE][+-]?\\d+))|(((\\d+\\.\\d*)|(\\.\\d+))([eE][+-]?\\d+)?))|(?P<t_UINT>\\d+)|(?P<t_SIGN>[+-](?=\\d))|(?P<t_LIT10>10)|(?P<t_UNKNOWN>[Uu][Nn][Kk][Nn][Oo][Ww][Nn])|(?P<t_FUNCNAME>((sqrt)|(ln)|(exp)|(log)|(sin)|(cos)|(tan)|(asin)|(acos)|(atan)|(sinh)|(cosh)|(tanh))(?=\\ *\\())|(?P<t_UNIT>[a-zA-Z][a-zA-Z_]*)|(?P<t_DIVISION>[ \t]*/[ \t]*)|(?P<t_WHITESPACE>[ \t]+)|(?P<t_POWER>\\*\\*)|(?P<t_OPEN_PAREN>\\()|(?P<t_CLOSE_PAREN>\\))|(?P<t_STAR>\\*)', [None, ('t_UFLOAT', 'UFLOAT'), None, None, None, None, None, None, None, None, None, None, ('t_UINT', 'UINT'), ('t_SIGN', 'SIGN'), ('t_LIT10', 'LIT10'), ('t_UNKNOWN', 'UNKNOWN'), ('t_FUNCNAME', 'FUNCNAME'), None, None, None, None, None, None, None, None, None, None, None, None, None, None, ('t_UNIT', 'UNIT'), (None, 'DIVISION'), (None, 'WHITESPACE'), (None, 'POWER'), (None, 'OPEN_PAREN'), (None, 'CLOSE_PAREN'), (None, 'STAR')])]}
+_lexstatere   = {'INITIAL': [('(?P<t_FLOAT>[+-]?((((\\d+\\.?\\d*)|(\\.\\d+))([eE][+-]?\\d+))|(((\\d+\\.\\d*)|(\\.\\d+))([eE][+-]?\\d+)?)))|(?P<t_INT>[+-]?\\d+)|(?P<t_LIT10>10)|(?P<t_UNKNOWN>[Uu][Nn][Kk][Nn][Oo][Ww][Nn])|(?P<t_FUNCNAME>((sqrt)|(ln)|(exp)|(log)|(sin)|(cos)|(tan)|(asin)|(acos)|(atan)|(sinh)|(cosh)|(tanh))(?=\\ *\\())|(?P<t_UNIT>[a-zA-Z][a-zA-Z_]*)|(?P<t_DIVISION>[ \t]*/[ \t]*)|(?P<t_WHITESPACE>[ \t]+)|(?P<t_POWER>\\*\\*)|(?P<t_OPEN_PAREN>\\()|(?P<t_CLOSE_PAREN>\\))|(?P<t_STAR>\\*)', [None, ('t_FLOAT', 'FLOAT'), None, None, None, None, None, None, None, None, None, None, None, ('t_INT', 'INT'), ('t_LIT10', 'LIT10'), ('t_UNKNOWN', 'UNKNOWN'), ('t_FUNCNAME', 'FUNCNAME'), None, None, None, None, None, None, None, None, None, None, None, None, None, None, ('t_UNIT', 'UNIT'), (None, 'DIVISION'), (None, 'WHITESPACE'), (None, 'POWER'), (None, 'OPEN_PAREN'), (None, 'CLOSE_PAREN'), (None, 'STAR')])]}
 _lexstateignore = {'INITIAL': ''}
 _lexstateerrorf = {'INITIAL': 't_error'}
 _lexstateeoff = {}

--- a/astropy/units/format/ogip_parsetab.py
+++ b/astropy/units/format/ogip_parsetab.py
@@ -16,9 +16,9 @@ _tabversion = '3.10'
 
 _lr_method = 'LALR'
 
-_lr_signature = 'CLOSE_PAREN DIVISION FUNCNAME LIT10 OPEN_PAREN POWER SIGN STAR UFLOAT UINT UNIT UNKNOWN WHITESPACE\n            main : UNKNOWN\n                 | complete_expression\n                 | scale_factor complete_expression\n                 | scale_factor WHITESPACE complete_expression\n            \n            complete_expression : unit_expression\n                                | product_of_units\n                                | division_of_units\n            \n            product_of_units : complete_expression product unit_expression\n            \n            division_of_units : DIVISION unit_expression\n                              | complete_expression DIVISION unit_expression\n            \n            unit_expression : UNIT\n                            | function\n                            | UNIT POWER numeric_power\n                            | UNIT OPEN_PAREN complete_expression CLOSE_PAREN\n                            | OPEN_PAREN complete_expression CLOSE_PAREN\n                            | UNIT OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power\n                            | OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power\n            \n            function : FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN\n                     | FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power\n            \n            scale_factor : LIT10 POWER numeric_power\n                         | LIT10\n                         | signed_float\n                         | signed_float POWER numeric_power\n                         | signed_int POWER numeric_power\n            \n            product : WHITESPACE\n                    | STAR\n                    | WHITESPACE STAR\n                    | WHITESPACE STAR WHITESPACE\n                    | STAR WHITESPACE\n            \n            numeric_power : UINT\n                          | signed_float\n                          | OPEN_PAREN signed_int CLOSE_PAREN\n                          | OPEN_PAREN signed_float CLOSE_PAREN\n                          | OPEN_PAREN signed_float DIVISION UINT CLOSE_PAREN\n            \n            sign : SIGN\n                 |\n            \n            signed_int : SIGN UINT\n            \n            signed_float : sign UINT\n                         | sign UFLOAT\n            '
+_lr_signature = 'CLOSE_PAREN DIVISION FLOAT FUNCNAME INT LIT10 OPEN_PAREN POWER STAR UNIT UNKNOWN WHITESPACE\n            main : UNKNOWN\n                 | complete_expression\n                 | scale_factor complete_expression\n                 | scale_factor WHITESPACE complete_expression\n            \n            complete_expression : unit_expression\n                                | product_of_units\n                                | division_of_units\n            \n            product_of_units : complete_expression product unit_expression\n            \n            division_of_units : DIVISION unit_expression\n                              | complete_expression DIVISION unit_expression\n            \n            unit_expression : UNIT\n                            | function\n                            | UNIT POWER numeric_power\n                            | UNIT OPEN_PAREN complete_expression CLOSE_PAREN\n                            | OPEN_PAREN complete_expression CLOSE_PAREN\n                            | UNIT OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power\n                            | OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power\n            \n            function : FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN\n                     | FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power\n            \n            scale_factor : LIT10 POWER numeric_power\n                         | LIT10\n                         | number\n                         | number POWER numeric_power\n            \n            product : WHITESPACE\n                    | STAR\n                    | WHITESPACE STAR\n                    | WHITESPACE STAR WHITESPACE\n                    | STAR WHITESPACE\n            \n            numeric_power : number\n                          | OPEN_PAREN number CLOSE_PAREN\n                          | OPEN_PAREN INT DIVISION INT CLOSE_PAREN\n            \n            number : INT\n                   | FLOAT\n            '
     
-_lr_action_items = {'UNKNOWN':([0,],[2,]),'LIT10':([0,],[8,]),'UNIT':([0,4,8,9,13,14,18,19,20,21,23,28,31,32,34,37,38,40,41,42,45,46,51,57,58,66,],[11,11,-21,-22,11,11,11,11,-25,-26,11,11,-38,-39,11,-27,-29,-20,-30,-31,-23,-24,-28,-32,-33,-34,]),'OPEN_PAREN':([0,4,8,9,11,13,14,17,18,19,20,21,23,24,25,26,27,28,31,32,34,37,38,40,41,42,45,46,51,55,57,58,60,62,66,],[13,13,-21,-22,28,13,13,34,13,13,-25,-26,13,43,43,43,43,13,-38,-39,13,-27,-29,-20,-30,-31,-23,-24,-28,43,-32,-33,43,43,-34,]),'DIVISION':([0,3,4,5,6,7,8,9,11,12,13,22,23,28,29,30,31,32,34,35,36,39,40,41,42,45,46,47,48,49,50,53,54,56,57,58,61,64,65,66,],[14,19,14,-5,-6,-7,-21,-22,-11,-12,14,19,14,14,19,-9,-38,-39,14,-8,-10,19,-20,-30,-31,-23,-24,-13,19,-15,19,59,-14,-18,-32,-33,-17,-16,-19,-34,]),'SIGN':([0,24,25,26,27,43,55,60,62,],[16,44,44,44,44,16,44,44,44,]),'FUNCNAME':([0,4,8,9,13,14,18,19,20,21,23,28,31,32,34,37,38,40,41,42,45,46,51,57,58,66,],[17,17,-21,-22,17,17,17,17,-25,-26,17,17,-38,-39,17,-27,-29,-20,-30,-31,-23,-24,-28,-32,-33,-34,]),'UINT':([0,15,16,24,25,26,27,43,44,55,59,60,62,],[-36,31,33,41,41,41,41,-36,-35,41,63,41,41,]),'UFLOAT':([0,15,16,24,25,26,27,43,44,55,60,62,],[-36,32,-35,-36,-36,-36,-36,-36,-35,-36,-36,-36,]),'$end':([1,2,3,5,6,7,11,12,22,30,31,32,35,36,39,41,42,47,49,54,56,57,58,61,64,65,66,],[0,-1,-2,-5,-6,-7,-11,-12,-3,-9,-38,-39,-8,-10,-4,-30,-31,-13,-15,-14,-18,-32,-33,-17,-16,-19,-34,]),'WHITESPACE':([3,4,5,6,7,8,9,11,12,21,22,29,30,31,32,35,36,37,39,40,41,42,45,46,47,48,49,50,54,56,57,58,61,64,65,66,],[20,23,-5,-6,-7,-21,-22,-11,-12,38,20,20,-9,-38,-39,-8,-10,51,20,-20,-30,-31,-23,-24,-13,20,-15,20,-14,-18,-32,-33,-17,-16,-19,-34,]),'STAR':([3,5,6,7,11,12,20,22,29,30,31,32,35,36,39,41,42,47,48,49,50,54,56,57,58,61,64,65,66,],[21,-5,-6,-7,-11,-12,37,21,21,-9,-38,-39,-8,-10,21,-30,-31,-13,21,-15,21,-14,-18,-32,-33,-17,-16,-19,-34,]),'CLOSE_PAREN':([5,6,7,11,12,29,30,31,32,33,35,36,41,42,47,48,49,50,52,53,54,56,57,58,61,63,64,65,66,],[-5,-6,-7,-11,-12,49,-9,-38,-39,-37,-8,-10,-30,-31,-13,54,-15,56,57,58,-14,-18,-32,-33,-17,66,-16,-19,-34,]),'POWER':([8,9,10,11,31,32,33,49,54,56,],[24,25,26,27,-38,-39,-37,55,60,62,]),}
+_lr_action_items = {'UNKNOWN':([0,],[2,]),'LIT10':([0,],[8,]),'UNIT':([0,4,8,9,12,13,14,15,17,18,19,20,22,26,29,32,33,35,36,38,43,49,57,],[10,10,-21,-22,10,10,-32,-33,10,10,-24,-25,10,10,10,-26,-28,-20,-29,-23,-27,-30,-31,]),'OPEN_PAREN':([0,4,8,9,10,12,13,14,15,16,17,18,19,20,22,23,24,25,26,29,32,33,35,36,38,43,47,49,51,53,57,],[12,12,-21,-22,26,12,12,-32,-33,29,12,12,-24,-25,12,37,37,37,12,12,-26,-28,-20,-29,-23,-27,37,-30,37,37,-31,]),'DIVISION':([0,3,4,5,6,7,8,9,10,11,12,14,15,21,22,26,27,28,29,30,31,34,35,36,38,39,40,41,42,45,46,48,49,52,55,56,57,],[13,18,13,-5,-6,-7,-21,-22,-11,-12,13,-32,-33,18,13,13,18,-9,13,-8,-10,18,-20,-29,-23,-13,18,-15,18,50,-14,-18,-30,-17,-16,-19,-31,]),'INT':([0,23,24,25,37,47,50,51,53,],[14,14,14,14,45,14,54,14,14,]),'FLOAT':([0,23,24,25,37,47,51,53,],[15,15,15,15,15,15,15,15,]),'FUNCNAME':([0,4,8,9,12,13,14,15,17,18,19,20,22,26,29,32,33,35,36,38,43,49,57,],[16,16,-21,-22,16,16,-32,-33,16,16,-24,-25,16,16,16,-26,-28,-20,-29,-23,-27,-30,-31,]),'$end':([1,2,3,5,6,7,10,11,14,15,21,28,30,31,34,36,39,41,46,48,49,52,55,56,57,],[0,-1,-2,-5,-6,-7,-11,-12,-32,-33,-3,-9,-8,-10,-4,-29,-13,-15,-14,-18,-30,-17,-16,-19,-31,]),'WHITESPACE':([3,4,5,6,7,8,9,10,11,14,15,20,21,27,28,30,31,32,34,35,36,38,39,40,41,42,46,48,49,52,55,56,57,],[19,22,-5,-6,-7,-21,-22,-11,-12,-32,-33,33,19,19,-9,-8,-10,43,19,-20,-29,-23,-13,19,-15,19,-14,-18,-30,-17,-16,-19,-31,]),'STAR':([3,5,6,7,10,11,14,15,19,21,27,28,30,31,34,36,39,40,41,42,46,48,49,52,55,56,57,],[20,-5,-6,-7,-11,-12,-32,-33,32,20,20,-9,-8,-10,20,-29,-13,20,-15,20,-14,-18,-30,-17,-16,-19,-31,]),'CLOSE_PAREN':([5,6,7,10,11,14,15,27,28,30,31,36,39,40,41,42,44,45,46,48,49,52,54,55,56,57,],[-5,-6,-7,-11,-12,-32,-33,41,-9,-8,-10,-29,-13,46,-15,48,49,-32,-14,-18,-30,-17,57,-16,-19,-31,]),'POWER':([8,9,10,14,15,41,46,48,],[23,24,25,-32,-33,47,51,53,]),}
 
 _lr_action = {}
 for _k, _v in _lr_action_items.items():
@@ -27,7 +27,7 @@ for _k, _v in _lr_action_items.items():
       _lr_action[_x][_k] = _y
 del _lr_action_items
 
-_lr_goto_items = {'main':([0,],[1,]),'complete_expression':([0,4,13,23,28,34,],[3,22,29,39,48,50,]),'scale_factor':([0,],[4,]),'unit_expression':([0,4,13,14,18,19,23,28,34,],[5,5,5,30,35,36,5,5,5,]),'product_of_units':([0,4,13,23,28,34,],[6,6,6,6,6,6,]),'division_of_units':([0,4,13,23,28,34,],[7,7,7,7,7,7,]),'signed_float':([0,24,25,26,27,43,55,60,62,],[9,42,42,42,42,53,42,42,42,]),'signed_int':([0,43,],[10,52,]),'function':([0,4,13,14,18,19,23,28,34,],[12,12,12,12,12,12,12,12,12,]),'sign':([0,24,25,26,27,43,55,60,62,],[15,15,15,15,15,15,15,15,15,]),'product':([3,22,29,39,48,50,],[18,18,18,18,18,18,]),'numeric_power':([24,25,26,27,55,60,62,],[40,45,46,47,61,64,65,]),}
+_lr_goto_items = {'main':([0,],[1,]),'complete_expression':([0,4,12,22,26,29,],[3,21,27,34,40,42,]),'scale_factor':([0,],[4,]),'unit_expression':([0,4,12,13,17,18,22,26,29,],[5,5,5,28,30,31,5,5,5,]),'product_of_units':([0,4,12,22,26,29,],[6,6,6,6,6,6,]),'division_of_units':([0,4,12,22,26,29,],[7,7,7,7,7,7,]),'number':([0,23,24,25,37,47,51,53,],[9,36,36,36,44,36,36,36,]),'function':([0,4,12,13,17,18,22,26,29,],[11,11,11,11,11,11,11,11,11,]),'product':([3,21,27,34,40,42,],[17,17,17,17,17,17,]),'numeric_power':([23,24,25,47,51,53,],[35,38,39,52,55,56,]),}
 
 _lr_goto = {}
 for _k, _v in _lr_goto_items.items():
@@ -37,43 +37,37 @@ for _k, _v in _lr_goto_items.items():
 del _lr_goto_items
 _lr_productions = [
   ("S' -> main","S'",1,None,None,None),
-  ('main -> UNKNOWN','main',1,'p_main','ogip.py',165),
-  ('main -> complete_expression','main',1,'p_main','ogip.py',166),
-  ('main -> scale_factor complete_expression','main',2,'p_main','ogip.py',167),
-  ('main -> scale_factor WHITESPACE complete_expression','main',3,'p_main','ogip.py',168),
-  ('complete_expression -> unit_expression','complete_expression',1,'p_complete_expression','ogip.py',180),
-  ('complete_expression -> product_of_units','complete_expression',1,'p_complete_expression','ogip.py',181),
-  ('complete_expression -> division_of_units','complete_expression',1,'p_complete_expression','ogip.py',182),
-  ('product_of_units -> complete_expression product unit_expression','product_of_units',3,'p_product_of_units','ogip.py',190),
-  ('division_of_units -> DIVISION unit_expression','division_of_units',2,'p_division_of_units','ogip.py',196),
-  ('division_of_units -> complete_expression DIVISION unit_expression','division_of_units',3,'p_division_of_units','ogip.py',197),
-  ('unit_expression -> UNIT','unit_expression',1,'p_unit_expression','ogip.py',207),
-  ('unit_expression -> function','unit_expression',1,'p_unit_expression','ogip.py',208),
-  ('unit_expression -> UNIT POWER numeric_power','unit_expression',3,'p_unit_expression','ogip.py',209),
-  ('unit_expression -> UNIT OPEN_PAREN complete_expression CLOSE_PAREN','unit_expression',4,'p_unit_expression','ogip.py',210),
-  ('unit_expression -> OPEN_PAREN complete_expression CLOSE_PAREN','unit_expression',3,'p_unit_expression','ogip.py',211),
-  ('unit_expression -> UNIT OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power','unit_expression',6,'p_unit_expression','ogip.py',212),
-  ('unit_expression -> OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power','unit_expression',5,'p_unit_expression','ogip.py',213),
-  ('function -> FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN','function',4,'p_function','ogip.py',242),
-  ('function -> FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power','function',6,'p_function','ogip.py',243),
-  ('scale_factor -> LIT10 POWER numeric_power','scale_factor',3,'p_scale_factor','ogip.py',258),
-  ('scale_factor -> LIT10','scale_factor',1,'p_scale_factor','ogip.py',259),
-  ('scale_factor -> signed_float','scale_factor',1,'p_scale_factor','ogip.py',260),
-  ('scale_factor -> signed_float POWER numeric_power','scale_factor',3,'p_scale_factor','ogip.py',261),
-  ('scale_factor -> signed_int POWER numeric_power','scale_factor',3,'p_scale_factor','ogip.py',262),
-  ('product -> WHITESPACE','product',1,'p_product','ogip.py',277),
-  ('product -> STAR','product',1,'p_product','ogip.py',278),
-  ('product -> WHITESPACE STAR','product',2,'p_product','ogip.py',279),
-  ('product -> WHITESPACE STAR WHITESPACE','product',3,'p_product','ogip.py',280),
-  ('product -> STAR WHITESPACE','product',2,'p_product','ogip.py',281),
-  ('numeric_power -> UINT','numeric_power',1,'p_numeric_power','ogip.py',286),
-  ('numeric_power -> signed_float','numeric_power',1,'p_numeric_power','ogip.py',287),
-  ('numeric_power -> OPEN_PAREN signed_int CLOSE_PAREN','numeric_power',3,'p_numeric_power','ogip.py',288),
-  ('numeric_power -> OPEN_PAREN signed_float CLOSE_PAREN','numeric_power',3,'p_numeric_power','ogip.py',289),
-  ('numeric_power -> OPEN_PAREN signed_float DIVISION UINT CLOSE_PAREN','numeric_power',5,'p_numeric_power','ogip.py',290),
-  ('sign -> SIGN','sign',1,'p_sign','ogip.py',308),
-  ('sign -> <empty>','sign',0,'p_sign','ogip.py',309),
-  ('signed_int -> SIGN UINT','signed_int',2,'p_signed_int','ogip.py',318),
-  ('signed_float -> sign UINT','signed_float',2,'p_signed_float','ogip.py',324),
-  ('signed_float -> sign UFLOAT','signed_float',2,'p_signed_float','ogip.py',325),
+  ('main -> UNKNOWN','main',1,'p_main','ogip.py',158),
+  ('main -> complete_expression','main',1,'p_main','ogip.py',159),
+  ('main -> scale_factor complete_expression','main',2,'p_main','ogip.py',160),
+  ('main -> scale_factor WHITESPACE complete_expression','main',3,'p_main','ogip.py',161),
+  ('complete_expression -> unit_expression','complete_expression',1,'p_complete_expression','ogip.py',171),
+  ('complete_expression -> product_of_units','complete_expression',1,'p_complete_expression','ogip.py',172),
+  ('complete_expression -> division_of_units','complete_expression',1,'p_complete_expression','ogip.py',173),
+  ('product_of_units -> complete_expression product unit_expression','product_of_units',3,'p_product_of_units','ogip.py',181),
+  ('division_of_units -> DIVISION unit_expression','division_of_units',2,'p_division_of_units','ogip.py',187),
+  ('division_of_units -> complete_expression DIVISION unit_expression','division_of_units',3,'p_division_of_units','ogip.py',188),
+  ('unit_expression -> UNIT','unit_expression',1,'p_unit_expression','ogip.py',198),
+  ('unit_expression -> function','unit_expression',1,'p_unit_expression','ogip.py',199),
+  ('unit_expression -> UNIT POWER numeric_power','unit_expression',3,'p_unit_expression','ogip.py',200),
+  ('unit_expression -> UNIT OPEN_PAREN complete_expression CLOSE_PAREN','unit_expression',4,'p_unit_expression','ogip.py',201),
+  ('unit_expression -> OPEN_PAREN complete_expression CLOSE_PAREN','unit_expression',3,'p_unit_expression','ogip.py',202),
+  ('unit_expression -> UNIT OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power','unit_expression',6,'p_unit_expression','ogip.py',203),
+  ('unit_expression -> OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power','unit_expression',5,'p_unit_expression','ogip.py',204),
+  ('function -> FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN','function',4,'p_function','ogip.py',233),
+  ('function -> FUNCNAME OPEN_PAREN complete_expression CLOSE_PAREN POWER numeric_power','function',6,'p_function','ogip.py',234),
+  ('scale_factor -> LIT10 POWER numeric_power','scale_factor',3,'p_scale_factor','ogip.py',249),
+  ('scale_factor -> LIT10','scale_factor',1,'p_scale_factor','ogip.py',250),
+  ('scale_factor -> number','scale_factor',1,'p_scale_factor','ogip.py',251),
+  ('scale_factor -> number POWER numeric_power','scale_factor',3,'p_scale_factor','ogip.py',252),
+  ('product -> WHITESPACE','product',1,'p_product','ogip.py',267),
+  ('product -> STAR','product',1,'p_product','ogip.py',268),
+  ('product -> WHITESPACE STAR','product',2,'p_product','ogip.py',269),
+  ('product -> WHITESPACE STAR WHITESPACE','product',3,'p_product','ogip.py',270),
+  ('product -> STAR WHITESPACE','product',2,'p_product','ogip.py',271),
+  ('numeric_power -> number','numeric_power',1,'p_numeric_power','ogip.py',276),
+  ('numeric_power -> OPEN_PAREN number CLOSE_PAREN','numeric_power',3,'p_numeric_power','ogip.py',277),
+  ('numeric_power -> OPEN_PAREN INT DIVISION INT CLOSE_PAREN','numeric_power',5,'p_numeric_power','ogip.py',278),
+  ('number -> INT','number',1,'p_number','ogip.py',296),
+  ('number -> FLOAT','number',1,'p_number','ogip.py',297),
 ]

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -355,14 +355,7 @@ def test_ogip_ohm():
 
 @pytest.mark.parametrize(
     "string",
-    [
-        pytest.param("m**(-0.5)", id="float"),
-        pytest.param(
-            "m**(-1/2)",
-            id="fraction",
-            marks=pytest.mark.xfail(reason="regression test to reveal a bug"),
-        ),
-    ],
+    [pytest.param("m**(-0.5)", id="float"), pytest.param("m**(-1/2)", id="fraction")],
 )
 def test_ogip_negative_powers(string):
     # Regression test for #18776 - negative fractions were not recognized

--- a/docs/changes/units/18776.bugfix.rst
+++ b/docs/changes/units/18776.bugfix.rst
@@ -1,0 +1,2 @@
+The ``"ogip"`` unit formatter can now parse strings that include signed
+fractions in the exponent, e.g. ``u.Unit("m**(-1/2)", format="ogip")``.


### PR DESCRIPTION
### Description

Currently the `"ogip"` unit formatter can already parse strings involving unsigned floats or fractions as exponents, and it can also parse signed floats as exponents, but not signed fractions as exponents:
```
Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from astropy import units as u
>>> u.Unit("m**(0.5)", format="ogip")
Unit("m(1/2)")
>>> u.Unit("m**(1/2)", format="ogip")
Unit("m(1/2)")
>>> u.Unit("m**(-0.5)", format="ogip")
Unit("1 / m(1/2)")
>>> u.Unit("m**(-1/2)", format="ogip")
Traceback (most recent call last):
  ...
ValueError: 'm**(-1/2)' did not parse as ogip unit: ...
```
This PR simplifies parsing numbers and fixes the bug in the process.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
