### PR TITLE
TST/DEP: set direct requirements on test dependencies with accurate lower bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,10 @@ filterwarnings = [
     "error",
     # https://github.com/astropy/astropy/issues/18126
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
+
     # warnings showing up in oldestdeps runs (last checked with not PYTHON_LT_3_11)
+    # TODO: clean up the following filters once warnings are not treated as errors
+    # anymore in oldestdeps (https://github.com/astropy/astropy/issues/18853)
     'ignore:_SixMetaPathImporter\.find_spec\(\) not found; falling back to find_module\(\):ImportWarning', # from hypothesis
     'ignore:_SixMetaPathImporter\.exec_module\(\) not found; falling back to load_module\(\):ImportWarning', # from prompt-toolkit
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",


### PR DESCRIPTION
### Description
Problem: mindeps testing still runs on the latest version of hypothesis, because it isn't already declared as a direct dependency (instead we rely on the meta-package `pytest-astropy` to provide it), and we resolve this test env with `--resolution=lowest-direct` (I'm actively working on moving to `--resolution=lowest` but this will take some work upstream and time).
Other test dependencies that we only pull in via `pytest-astropy` might also create issues but hypothesis is the one blocker I'm having right now in my trials for `--resolution=lowest`, because it emits a warning (for which I'm adding a filter here) at collection time.

partially address #18783

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
