### PR TITLE
TST/DEP: drop pytest-astropy in favor of corresponding, direct test dependencies

### DIFF
--- a/.github/workflows/ci_cron_monthly.yml
+++ b/.github/workflows/ci_cron_monthly.yml
@@ -87,9 +87,12 @@ jobs:
                                   python3 \
                                   python3-erfa \
                                   python3-extension-helpers \
+                                  python3-hypothesis \
                                   python3-jinja2 \
                                   python3-numpy \
-                                  python3-pytest-astropy \
+                                  python3-pytest-astropy-header \
+                                  python3-pytest-cov \
+                                  python3-pytest-remotedata \
                                   python3-setuptools-scm \
                                   python3-yaml \
                                   python3-venv \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -172,9 +172,12 @@ jobs:
                                   python3 \
                                   python3-erfa \
                                   python3-extension-helpers \
+                                  python3-hypothesis \
                                   python3-jinja2 \
                                   python3-numpy \
-                                  python3-pytest-astropy \
+                                  python3-pytest-astropy-header \
+                                  python3-pytest-cov \
+                                  python3-pytest-remotedata \
                                   python3-setuptools-scm \
                                   python3-yaml \
                                   python3-venv \

--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -119,7 +119,7 @@ sys.exit(
     pytest.main(
         ["astropy_tests", "-k " + " and ".join("not " + test for test in SKIP_TESTS)],
         plugins=[
-            "pytest_astropy.plugin",
+            "pytest_skip_slow",
             "pytest_doctestplus.plugin",
             "pytest_remotedata.plugin",
             "pytest_astropy_header.display",

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -179,12 +179,7 @@ class TestRunnerBase:
         "pytest_doctestplus",
         "pytest_astropy_header",
     ]
-    _missing_dependancy_error = (
-        "Test dependencies are missing: {}. You should install the "
-        "'pytest-astropy' package (you may need to update the package if you "
-        "have a previous version installed, e.g., "
-        "'pip install pytest-astropy --upgrade' or the equivalent with conda)."
-    )
+    _missing_dependency_error = "Test dependencies are missing: {}. "
 
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover
@@ -201,8 +196,10 @@ class TestRunnerBase:
                 pluginmanager = pytest.PytestPluginManager()
                 try:
                     pluginmanager.import_plugin(module)
-                except ImportError:
-                    raise RuntimeError(cls._missing_dependancy_error.format(module))
+                except ImportError as exc:
+                    raise RuntimeError(
+                        cls._missing_dependency_error.format(module)
+                    ) from exc
 
     def run_tests(self, **kwargs):
         # This method is weirdly hooked into various things with docstring

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -543,7 +543,6 @@ links_to_become_substitutions: dict[str, str] = {
     "miniconda": "https://docs.conda.io/en/latest/miniconda.html",
     # pytest
     "pytest": "https://pytest.org/en/latest/index.html",
-    "pytest-astropy": "https://github.com/astropy/pytest-astropy",
     "pytest-doctestplus": "https://github.com/astropy/pytest-doctestplus",
     "pytest-remotedata": "https://github.com/astropy/pytest-remotedata",
     # fsspec

--- a/docs/development/maintainers/testhelpers.rst
+++ b/docs/development/maintainers/testhelpers.rst
@@ -11,10 +11,9 @@ overview of running or writing the tests.
 Details
 =======
 
-The dependencies used by the Astropy test suite are provided by a separate
-package called |pytest-astropy|. This package provides the ``pytest``
-dependency itself, in addition to several ``pytest`` plugins that are used by
-Astropy, and will also be of general use to other packages.
+The dependencies used by the Astropy test suite are optional and encapsulated
+with the ``test`` extra. This extra provides the ``pytest`` dependency itself,
+in addition to several ``pytest`` plugins that are used by Astropy.
 
 Since the testing dependencies are not actually required to install or use
 Astropy, in the ``pyproject.toml`` file they are not included under the

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -138,7 +138,8 @@ Test coverage reports
 
 Coverage reports can be generated using the `pytest-cov
 <https://pypi.org/project/pytest-cov/>`_ plugin (which is installed
-automatically when installing pytest-astropy) by using e.g.::
+automatically when installing astropy with ``test`` extra dependencies)
+by using e.g.::
 
     pytest --cov astropy --cov-report html
 
@@ -494,7 +495,7 @@ Imagine if random testing gave you minimal, non-flaky failing examples,
 and a clean way to describe even the most complicated data - that's
 property-based testing!
 
-``pytest-astropy`` includes a dependency on `Hypothesis
+astropy's ``test`` extra includes a dependency on `Hypothesis
 <https://hypothesis.readthedocs.io/>`_, so installation is easy -
 you can just read the docs or `work through the tutorial
 <https://github.com/Zac-HD/escape-from-automanual-testing/>`_

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -213,8 +213,6 @@ installed.
 
 The following packages can optionally be used when testing:
 
-- |pytest-astropy|: See :ref:`sourcebuildtest`
-
 - `pytest-xdist <https://pypi.org/project/pytest-xdist/>`_: Used for
   distributed testing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,11 @@ test = [
     "coverage>=7.2.0",
     "hypothesis>=6.84.0",
     "pytest>=8.0.1",
+    "pytest-astropy-header>=0.2.2",
+    "pytest-cov>=2.3.1",
     "pytest-doctestplus>=1.4.0",
-    "pytest-astropy-header>=0.2.1",
-    "pytest-astropy>=0.11.0",
+    "pytest-remotedata>=0.4.1",
+    "pytest-skip-slow==1.1.0",
     "pytest-xdist>=3.6.0",
     "threadpoolctl>=3.0.0",
 ]

--- a/scripts/lowest-resolved-tree.txt
+++ b/scripts/lowest-resolved-tree.txt
@@ -305,28 +305,17 @@ astropy
 │   ├── attrs v20.1.0
 │   └── sortedcontainers v2.1.0
 ├── pytest v8.0.1 (extra: test) (*)
-├── pytest-astropy v0.11.0 (extra: test)
-│   ├── attrs v20.1.0
-│   ├── hypothesis v6.84.0 (*)
-│   ├── pytest v8.0.1 (*)
-│   ├── pytest-arraydiff v0.5.0
-│   │   ├── numpy v2.0.0
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-astropy-header v0.2.2
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-cov v2.3.1
-│   │   ├── coverage v7.2.0
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-doctestplus v1.4.0 (*)
-│   ├── pytest-filter-subpackage v0.1.2
-│   │   └── pytest v8.0.1 (*)
-│   ├── pytest-mock v2.0.0
-│   │   └── pytest v8.0.1 (*)
-│   └── pytest-remotedata v0.4.1
-│       ├── packaging v25.0
-│       └── pytest v8.0.1 (*)
-├── pytest-astropy-header v0.2.2 (extra: test) (*)
+├── pytest-astropy-header v0.2.2 (extra: test)
+│   └── pytest v8.0.1 (*)
+├── pytest-cov v2.3.1 (extra: test)
+│   ├── coverage v7.2.0
+│   └── pytest v8.0.1 (*)
 ├── pytest-doctestplus v1.4.0 (extra: test) (*)
+├── pytest-remotedata v0.4.1 (extra: test)
+│   ├── packaging v25.0
+│   └── pytest v8.0.1 (*)
+├── pytest-skip-slow v1.1.0 (extra: test)
+│   └── pytest v8.0.1 (*)
 ├── pytest-xdist v3.6.1 (extra: test)
 │   ├── execnet v2.1.0
 │   └── pytest v8.0.1 (*)
@@ -361,9 +350,11 @@ astropy
 ├── pandas v2.2.2 (extra: test-all) (*)
 ├── pyarrow v16.0.0 (extra: test-all) (*)
 ├── pytest v8.0.1 (extra: test-all) (*)
-├── pytest-astropy v0.11.0 (extra: test-all) (*)
 ├── pytest-astropy-header v0.2.2 (extra: test-all) (*)
+├── pytest-cov v2.3.1 (extra: test-all) (*)
 ├── pytest-doctestplus v1.4.0 (extra: test-all) (*)
+├── pytest-remotedata v0.4.1 (extra: test-all) (*)
+├── pytest-skip-slow v1.1.0 (extra: test-all) (*)
 ├── pytest-xdist v3.6.1 (extra: test-all) (*)
 ├── pytz v2020.1 (extra: test-all)
 ├── s3fs v2023.4.0 (extra: test-all) (*)

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,6 @@ deps =
     devpytest: git+https://github.com/astropy/pytest-arraydiff.git
     devpytest: git+https://github.com/astropy/pytest-filter-subpackage.git
     devpytest: git+https://github.com/matplotlib/pytest-mpl.git
-    devpytest: git+https://github.com/astropy/pytest-astropy.git
 
     # Duplicates test_all in pyproject.toml due to upstream bug
     # https://github.com/tox-dev/tox/issues/3433
@@ -222,8 +221,8 @@ commands =
                 --exclude-module tkinter \
                 --collect-submodules=py \
                 --hidden-import pytest \
-                --hidden-import pytest_astropy.plugin \
-                --hidden-import pytest_remotedata.plugin \
                 --hidden-import pytest_doctestplus.plugin \
+                --hidden-import pytest_remotedata.plugin \
+                --hidden-import pytest_skip_slow \
                 --hidden-import pytest_mpl.plugin
     ./run_astropy_tests --astropy-root "{toxinidir}"


### PR DESCRIPTION
### Description
~Based of #18780~

fix #18783

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
