### PR TITLE
Backport PR #18786 on branch v7.1.x (Add arm64 windows support)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     # or if triggered manually via the workflow dispatch, or for a tag.
     permissions:
       contents: none
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@930ac90540ecc5f43ba6d3d176efd25cd5f3c6c2  # v2.2.2
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@d9b81a07e789d1b1921ab5fe33de2ddcbbd02c3f  # v2.3.0
     if: (github.repository == 'astropy/astropy' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
     with:
 
@@ -97,6 +97,11 @@ jobs:
         - cp312*win_amd64
         - cp313*win_amd64
         - cp314*win_amd64
+
+        - cp311*win_arm64
+        - cp312*win_arm64
+        - cp313*win_arm64
+        - cp314*win_arm64
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.dll
 __pycache__
 
+# Ignore .pyi files since those are all auto-generated, and there are no plans
+# to use them otherwise (as of 2025-08-31). Can be adjusted as needed.
+*.pyi
+
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, put that into the src/ subdirectory of a
 # package or else use `git add -f filename.c`.

--- a/docs/changes/18786.other.rst
+++ b/docs/changes/18786.other.rst
@@ -1,0 +1,1 @@
+Wheels are now provided for Windows arm64.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport

* #18786
* the ignore added in #18573 so devs do not accidentally check in `.pyi` files when switching branches locally

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
