### PR TITLE
Add docstrings to spline fitter call methods

### DIFF
--- a/astropy/modeling/spline.py
+++ b/astropy/modeling/spline.py
@@ -654,7 +654,8 @@ class SplineInterpolateFitter(_SplineFitter):
 
         if model.user_knots:
             warnings.warn(
-                "The current user specified knots maybe ignored for interpolating data",
+                "The user-specified knots from the input model "
+                "will be ignored for interpolating data.",
                 AstropyUserWarning,
             )
             model.user_knots = False
@@ -720,7 +721,8 @@ class SplineSmoothingFitter(_SplineFitter):
 
         if model.user_knots:
             warnings.warn(
-                "The current user specified knots maybe ignored for smoothing data",
+                "The user-specified knots from the input model "
+                "will be ignored for smoothing data.",
                 AstropyUserWarning,
             )
             model.user_knots = False
@@ -782,8 +784,9 @@ class SplineExactKnotsFitter(_SplineFitter):
         if t is not None:
             if model.user_knots:
                 warnings.warn(
-                    "The current user specified knots will be "
-                    "overwritten for by knots passed into this function",
+                    "The user-specified knots from the input model "
+                    "will be overwritten by knots passed into this "
+                    "function",
                     AstropyUserWarning,
                 )
         else:
@@ -871,8 +874,9 @@ class SplineSplrepFitter(_SplineFitter):
         if t is not None:
             if model.user_knots:
                 warnings.warn(
-                    "The current user specified knots will be "
-                    "overwritten for by knots passed into this function",
+                    "The user-specified knots from the input model "
+                    "will be overwritten by knots passed into this "
+                    "function",
                     AstropyUserWarning,
                 )
         else:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The spline fitters `__call__` method do not have any docstrings describing the allowed keyword parameters, e.g., `s`, `t`, `task` (example: https://docs.astropy.org/en/latest/api/astropy.modeling.spline.SplineSmoothingFitter.html).  This PR adds the docstrings.

This PR also fixes/clarifies the knot warning messages.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
