### PR TITLE
Remove obsolete `EarthLocation` builtin site registry documentation

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -346,10 +346,7 @@ class EarthLocation(u.Quantity):
             `astropy-data repository <https://github.com/astropy/astropy-data>`_ .
             If the cache already exists the function will use it even if the
             version in the astropy-data repository has been updated unless the
-            ``refresh_cache=True`` option is used.  If there is no cache and the
-            online version cannot be reached, this function falls back on a
-            built-in list, which currently only contains the Greenwich Royal
-            Observatory as an example case.
+            ``refresh_cache=True`` option is used.
 
         Parameters
         ----------
@@ -514,10 +511,7 @@ class EarthLocation(u.Quantity):
             `astropy-data repository <https://github.com/astropy/astropy-data>`_ .
             If the cache already exists the function will use it even if the
             version in the astropy-data repository has been updated unless the
-            ``refresh_cache=True`` option is used.  If there is no cache and the
-            online version cannot be reached, this function falls back on a
-            built-in list, which currently only contains the Greenwich Royal
-            Observatory as an example case.
+            ``refresh_cache=True`` option is used.
 
         Parameters
         ----------

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -329,10 +329,8 @@ Both :meth:`~astropy.coordinates.EarthLocation.of_site` and
 :meth:`~astropy.coordinates.EarthLocation.get_site_names`,
 `astropy.coordinates` attempt to access the site registry from the
 `astropy-data repository <https://github.com/astropy/astropy-data>`_ and will
-save the registry in the user's local cache (see :ref:`utils-data`).  If
-there is no local cache and Internet connection is not available, a built-in
-list (consisting of only the Greenwich Royal Observatory as an example case) is
-loaded. The cached version of the site registry is not updated automatically,
+save the registry in the user's local cache (see :ref:`utils-data`).
+The cached version of the site registry is not updated automatically,
 but the latest version may be downloaded using the ``refresh_cache=True``
 option of these methods. If you would like a site to be added to the registry,
 issue a pull request to the `astropy-data repository


### PR DESCRIPTION
### Description

The bare-bones builtin registry of observatory sites was removed in 32f7e02966e2a5960387133c29197fa5e397f2a1, but there is still some documentation that refers to it.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
