### PR TITLE
cosmo: `comoving_transverse_distance(z1, z2)`

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -902,7 +902,7 @@ class FLRW(
     # ---------------------------------------------------------------
 
     def comoving_transverse_distance(
-        self, z: _InputT, z2: _InputT | None = None, /
+        self, z: _InputT | float, z2: _InputT | float | None = None, /
     ) -> u.Quantity:
         r"""Comoving transverse distance :math:`d(z1, z2)` in Mpc.
 

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -819,7 +819,7 @@ class FLRW(
 
         Parameters
         ----------
-        z, z2 : Quantity ['redshift']
+        z, z2 : Quantity ['redshift'], array-like
             Input redshifts. If one argument ``z`` is given, the distance
             :math:`d_c(0, z)` is returned. If two arguments ``z1, z2`` are
             given, the distance :math:`d_c(z_1, z_2)` is returned.
@@ -901,18 +901,22 @@ class FLRW(
 
     # ---------------------------------------------------------------
 
-    def comoving_transverse_distance(self, z: u.Quantity | ArrayLike, /) -> u.Quantity:
-        r"""Comoving transverse distance in Mpc at a given redshift.
+    def comoving_transverse_distance(
+        self, z: _InputT, z2: _InputT | None = None, /
+    ) -> u.Quantity:
+        r"""Comoving transverse distance :math:`d(z1, z2)` in Mpc.
 
-        This value is the transverse comoving distance at redshift ``z``
-        corresponding to an angular separation of 1 radian. This is the same as
-        the comoving distance if :math:`\Omega_k` is zero (as in the current
-        concordance Lambda-CDM model).
+        This value is the transverse comoving distance between redshifts ``z1`` and
+        ``z2`` corresponding to an angular separation of 1 radian. This is the same as
+        the comoving distance if :math:`\Omega_k` is zero (as in the current concordance
+        Lambda-CDM model).
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
+        z, z2 : Quantity ['redshift'], array-like
+            Input redshifts. If one argument ``z`` is given, the distance :math:`d(0,
+            z)` is returned. If two arguments ``z1, z2`` are given, the distance
+            :math:`d(z_1, z_2)` is returned.
 
         Returns
         -------
@@ -923,32 +927,8 @@ class FLRW(
         -----
         This quantity is also called the 'proper motion distance' in some texts.
         """
-        return self._comoving_transverse_distance_z1z2(0, z)
+        z1, z2 = (0.0, z) if z2 is None else (z, z2)
 
-    def _comoving_transverse_distance_z1z2(
-        self, z1: u.Quantity | ArrayLike, z2: u.Quantity | ArrayLike, /
-    ) -> u.Quantity:
-        r"""Comoving transverse distance in Mpc between two redshifts.
-
-        This value is the transverse comoving distance at redshift ``z2`` as
-        seen from redshift ``z1`` corresponding to an angular separation of
-        1 radian. This is the same as the comoving distance if :math:`\Omega_k`
-        is zero (as in the current concordance Lambda-CDM model).
-
-        Parameters
-        ----------
-        z1, z2 : Quantity-like ['redshift'], array-like
-            Input redshifts.
-
-        Returns
-        -------
-        d : Quantity ['length']
-            Comoving transverse distance in Mpc between input redshift.
-
-        Notes
-        -----
-        This quantity is also called the 'proper motion distance' in some texts.
-        """
         Ok0 = self.Ok0
         dc = self._comoving_distance_z1z2(z1, z2)
         if Ok0 == 0:
@@ -1009,7 +989,7 @@ class FLRW(
                 f"redshift(s) z1 ({z1}).",
                 AstropyUserWarning,
             )
-        return self._comoving_transverse_distance_z1z2(z1, z2) / (z2 + 1.0)
+        return self.comoving_transverse_distance(z1, z2) / (z2 + 1.0)
 
     @deprecated(
         since="8.0", message="Use ``angular_diameter_distance(z1, z2)`` instead."

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -8,7 +8,6 @@ from dataclasses import field
 from functools import cached_property
 from inspect import signature
 from math import floor, pi, sqrt
-from numbers import Number
 from typing import Any, Final, NamedTuple, TypeVar, overload
 
 import numpy as np
@@ -50,7 +49,7 @@ from astropy.cosmology._src.traits import (
 from astropy.cosmology._src.utils import aszarr, vectorize_redshift_method
 
 __doctest_requires__ = {"*": ["scipy"]}
-_InputT = TypeVar("_InputT", bound=u.Quantity | np.ndarray | np.generic | Number)
+_InputT = TypeVar("_InputT", bound=u.Quantity | ArrayLike)
 
 
 ##############################################################################
@@ -927,10 +926,12 @@ class FLRW(
         -----
         This quantity is also called the 'proper motion distance' in some texts.
         """
-        z1, z2 = (0.0, z) if z2 is None else (z, z2)
+        z1_val, z2_val = (0.0, z) if z2 is None else (z, z2)
+        z1 = aszarr(z1_val)
+        z2_arr = aszarr(z2_val)
 
         Ok0 = self.Ok0
-        dc = self._comoving_distance_z1z2(z1, z2)
+        dc = self._comoving_distance_z1z2(z1, z2_arr)
         if Ok0 == 0:
             return dc
         sqrtOk0 = sqrt(abs(Ok0))
@@ -981,15 +982,16 @@ class FLRW(
         .. [2] Weedman, D. (1986). Quasar astronomy, pp 65-67.
         .. [3] Peebles, P. (1993). Principles of Physical Cosmology, pp 325-327.
         """
-        z1, z2 = (0.0, z) if z2 is None else (z, z2)
-        z1, z2 = aszarr(z1), aszarr(z2)
-        if np.any(z2 < z1):
+        z1_val, z2_val = (0.0, z) if z2 is None else (z, z2)
+        z1 = aszarr(z1_val)
+        z2_arr = aszarr(z2_val)
+        if np.any(z2_arr < z1):
             warnings.warn(
-                f"Second redshift(s) z2 ({z2}) is less than first "
+                f"Second redshift(s) z2 ({z2_arr}) is less than first "
                 f"redshift(s) z1 ({z1}).",
                 AstropyUserWarning,
             )
-        return self.comoving_transverse_distance(z1, z2) / (z2 + 1.0)
+        return self.comoving_transverse_distance(z1, z2_arr) / (z2_arr + 1.0)
 
     @deprecated(
         since="8.0", message="Use ``angular_diameter_distance(z1, z2)`` instead."

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -912,7 +912,7 @@ class FLRW(
 
         Parameters
         ----------
-        z, z2 : Quantity ['redshift'], array-like
+        z, z2 : Quantity['redshift'], array-like, positional-only
             Input redshifts. If one argument ``z`` is given, the distance :math:`d(0,
             z)` is returned. If two arguments ``z1, z2`` are given, the distance
             :math:`d(z_1, z_2)` is returned.

--- a/astropy/cosmology/_src/tests/flrw/test_lambdacdm.py
+++ b/astropy/cosmology/_src/tests/flrw/test_lambdacdm.py
@@ -418,17 +418,17 @@ def test_flat_open_closed_icosmo(file_name):
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
-def test_comoving_transverse_distance_z1z2():
+def test_comoving_transverse_distance():
     tcos = FlatLambdaCDM(100, 0.3, Tcmb0=0.0)
 
     with pytest.raises(ValueError):  # test diff size z1, z2 fail
-        tcos._comoving_transverse_distance_z1z2((1, 2), (3, 4, 5))
+        tcos.comoving_transverse_distance((1, 2), (3, 4, 5))
 
     # Tests that should actually work, target values computed with
     # http://www.astro.multivax.de:8000/phillip/angsiz_prog/README.HTML
     # Kayser, Helbig, and Schramm (Astron.Astrophys. 318 (1997) 680-686)
     assert u.allclose(
-        tcos._comoving_transverse_distance_z1z2(1, 2), 1313.2232194828466 * u.Mpc
+        tcos.comoving_transverse_distance(1, 2), 1313.2232194828466 * u.Mpc
     )
 
     # In a flat universe comoving distance and comoving transverse
@@ -438,7 +438,7 @@ def test_comoving_transverse_distance_z1z2():
 
     assert u.allclose(
         tcos.comoving_distance(z1, z2),
-        tcos._comoving_transverse_distance_z1z2(z1, z2),
+        tcos.comoving_transverse_distance(z1, z2),
     )
 
     # Test Flat Universe with Omega_M > 1.  Rarely used, but perfectly valid.
@@ -451,7 +451,7 @@ def test_comoving_transverse_distance_z1z2():
         85.09286258,
     ) * u.Mpc
 
-    assert u.allclose(tcos._comoving_transverse_distance_z1z2(z1, z2), results)
+    assert u.allclose(tcos.comoving_transverse_distance(z1, z2), results)
 
     # In a flat universe comoving distance and comoving transverse
     # distance are identical
@@ -460,7 +460,7 @@ def test_comoving_transverse_distance_z1z2():
 
     assert u.allclose(
         tcos.comoving_distance(z1, z2),
-        tcos._comoving_transverse_distance_z1z2(z1, z2),
+        tcos.comoving_transverse_distance(z1, z2),
     )
     # Test non-flat cases to avoid simply testing
     # comoving_distance. Test array, array case.
@@ -473,7 +473,7 @@ def test_comoving_transverse_distance_z1z2():
         151.36592003406884,
     ) * u.Mpc
 
-    assert u.allclose(tcos._comoving_transverse_distance_z1z2(z1, z2), results)
+    assert u.allclose(tcos.comoving_transverse_distance(z1, z2), results)
 
     # Test positive curvature with scalar, array combination.
     tcos = LambdaCDM(100, 1.0, 0.2, Tcmb0=0.0)
@@ -488,7 +488,7 @@ def test_comoving_transverse_distance_z1z2():
         2287.5626543279927,
     ) * u.Mpc
 
-    assert u.allclose(tcos._comoving_transverse_distance_z1z2(z1, z2), results)
+    assert u.allclose(tcos.comoving_transverse_distance(z1, z2), results)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
@@ -616,7 +616,7 @@ def test_units():
 
     assert cosmo.comoving_distance(1.0).unit == u.Mpc
     assert cosmo.comoving_transverse_distance(1.0).unit == u.Mpc
-    assert cosmo._comoving_transverse_distance_z1z2(1.0, 2.0).unit == u.Mpc
+    assert cosmo.comoving_transverse_distance(1.0, 2.0).unit == u.Mpc
     assert cosmo.angular_diameter_distance(1.0).unit == u.Mpc
     assert cosmo.luminosity_distance(1.0).unit == u.Mpc
     assert cosmo.lookback_time(1.0).unit == u.Gyr

--- a/astropy/cosmology/_src/tests/flrw/test_lambdacdm.py
+++ b/astropy/cosmology/_src/tests/flrw/test_lambdacdm.py
@@ -433,8 +433,8 @@ def test_comoving_transverse_distance():
 
     # In a flat universe comoving distance and comoving transverse
     # distance are identical
-    z1 = 0, 0, 2, 0.5, 1
-    z2 = 2, 1, 1, 2.5, 1.1
+    z1 = np.array([0, 0, 2, 0.5, 1])
+    z2 = np.array([2, 1, 1, 2.5, 1.1])
 
     assert u.allclose(
         tcos.comoving_distance(z1, z2),

--- a/astropy/cosmology/_src/tests/funcs/test_funcs.py
+++ b/astropy/cosmology/_src/tests/funcs/test_funcs.py
@@ -418,7 +418,7 @@ def test_z_at_value_roundtrip(cosmo):
         z2 = 2.0
         func_z1z2 = [
             lambda z1: cosmo.comoving_distance(z1, z2),
-            lambda z1: cosmo._comoving_transverse_distance_z1z2(z1, z2),
+            lambda z1: cosmo.comoving_transverse_distance(z1, z2),
             lambda z1: cosmo.angular_diameter_distance(z1, z2),
         ]
         for func in func_z1z2:

--- a/docs/changes/cosmology/18803.feature.rst
+++ b/docs/changes/cosmology/18803.feature.rst
@@ -1,0 +1,4 @@
+``FLRW.comoving_transverse_distance`` now accepts an optional second redshift argument
+``z2``, so that calling ``cosmo.comoving_transverse_distance(z1, z2)`` returns the
+distance :math:`d(z_1, z_2)` between two redshifts, consistent with the existing
+two-argument form of ``FLRW.comoving_distance``.


### PR DESCRIPTION
Make the 2-argument form of `comoving_transverse_distance` public.

Requires #18800, #18807

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
