### PR TITLE
feat(cosmo): `angular_diameter_distance(z1,z2)`

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -18,7 +18,7 @@ from numpy.typing import ArrayLike, NDArray
 import astropy.constants as const
 import astropy.units as u
 from astropy.cosmology._src.typing import CosmoMeta, FArray
-from astropy.utils.decorators import lazyproperty
+from astropy.utils.decorators import deprecated, lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 
 # isort: split
@@ -962,17 +962,33 @@ class FLRW(
         else:
             return dh / sqrtOk0 * sin(sqrtOk0 * dc.value / dh.value)
 
-    def angular_diameter_distance(self, z: u.Quantity | ArrayLike, /) -> u.Quantity:
-        """Angular diameter distance in Mpc at a given redshift.
+    @overload
+    def angular_diameter_distance(self, z: _InputT, /) -> u.Quantity: ...
+    @overload
+    def angular_diameter_distance(self, z: _InputT, z2: _InputT, /) -> u.Quantity: ...
+    def angular_diameter_distance(
+        self, z: _InputT, z2: _InputT | None = None, /
+    ) -> u.Quantity:
+        """Angular diameter distance between objects at 2 redshifts.
 
-        This gives the proper (sometimes called 'physical') transverse
-        distance corresponding to an angle of 1 radian for an object
-        at redshift ``z`` ([1]_, [2]_, [3]_).
+        This gives the proper (sometimes called 'physical') transverse distance
+        corresponding to an angle of 1 radian for an object at redshift ``z2`` as seen
+        by an observer at redshift ``z1`` ([1]_, [2]_, [3]_). When one redshift is given
+        the observer is at ``z1=0`` and ``z2=z``.
+
+        The two redshift form is useful for e.g. gravitational lensing for computing the
+        angular diameter distance between a lensed galaxy and the foreground lens.
 
         Parameters
         ----------
-        z : Quantity-like ['redshift'], array-like
-            Input redshift.
+        z1, z2 : Quantity-like ['redshift'], array-like
+            Input redshifts. If one argument ``z`` is given, the distance :math:`d_A(0,
+            z)` is returned. If two arguments ``z1, z2`` are given, the distance
+            :math:`d_A(z_1, z_2)` is returned.
+
+            For most practical applications such as gravitational
+            lensing, ``z2`` should be larger than ``z1``. The method will work for ``z2
+            < z1``; however, this will return negative distances.
 
             .. versionchanged:: 7.0
                 Passing z as a keyword argument is deprecated.
@@ -991,8 +1007,24 @@ class FLRW(
         .. [2] Weedman, D. (1986). Quasar astronomy, pp 65-67.
         .. [3] Peebles, P. (1993). Principles of Physical Cosmology, pp 325-327.
         """
-        z = aszarr(z)
-        return self.comoving_transverse_distance(z) / (z + 1.0)
+        z1, z2 = (0.0, z) if z2 is None else (z, z2)
+        z1, z2 = aszarr(z1), aszarr(z2)
+        if np.any(z2 < z1):
+            warnings.warn(
+                f"Second redshift(s) z2 ({z2}) is less than first "
+                f"redshift(s) z1 ({z1}).",
+                AstropyUserWarning,
+            )
+        return self._comoving_transverse_distance_z1z2(z1, z2) / (z2 + 1.0)
+
+    @deprecated(
+        since="8.0", message="Use ``angular_diameter_distance(z1, z2)`` instead."
+    )
+    def angular_diameter_distance_z1z2(
+        self, z1: u.Quantity | ArrayLike, z2: u.Quantity | ArrayLike
+    ) -> u.Quantity:
+        """See ``angular_diameter_distance(z1, z2)``."""
+        return self.angular_diameter_distance(z1, z2)
 
     def luminosity_distance(self, z: u.Quantity | ArrayLike, /) -> u.Quantity:
         """Luminosity distance in Mpc at redshift ``z``.
@@ -1026,37 +1058,6 @@ class FLRW(
         """
         z = aszarr(z)
         return (z + 1.0) * self.comoving_transverse_distance(z)
-
-    def angular_diameter_distance_z1z2(
-        self, z1: u.Quantity | ArrayLike, z2: u.Quantity | ArrayLike
-    ) -> u.Quantity:
-        """Angular diameter distance between objects at 2 redshifts.
-
-        Useful for gravitational lensing, for example computing the angular
-        diameter distance between a lensed galaxy and the foreground lens.
-
-        Parameters
-        ----------
-        z1, z2 : Quantity-like ['redshift'], array-like
-            Input redshifts. For most practical applications such as
-            gravitational lensing, ``z2`` should be larger than ``z1``. The
-            method will work for ``z2 < z1``; however, this will return
-            negative distances.
-
-        Returns
-        -------
-        d : Quantity ['length']
-            The angular diameter distance between each input redshift pair.
-            Returns scalar if input is scalar, array else-wise.
-        """
-        z1, z2 = aszarr(z1), aszarr(z2)
-        if np.any(z2 < z1):
-            warnings.warn(
-                f"Second redshift(s) z2 ({z2}) is less than first "
-                f"redshift(s) z1 ({z1}).",
-                AstropyUserWarning,
-            )
-        return self._comoving_transverse_distance_z1z2(z1, z2) / (z2 + 1.0)
 
     @vectorize_redshift_method
     def absorption_distance(self, z: u.Quantity | ArrayLike, /) -> FArray:

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -809,10 +809,8 @@ class FLRW(
 
     @overload
     def comoving_distance(self, z: _InputT, /) -> u.Quantity: ...
-
     @overload
     def comoving_distance(self, z: _InputT, z2: _InputT, /) -> u.Quantity: ...
-
     def comoving_distance(self, z: _InputT, z2: _InputT | None = None, /) -> u.Quantity:
         r"""Comoving line-of-sight distance :math:`d_c(z1, z2)` in Mpc.
 
@@ -962,10 +960,6 @@ class FLRW(
         else:
             return dh / sqrtOk0 * sin(sqrtOk0 * dc.value / dh.value)
 
-    @overload
-    def angular_diameter_distance(self, z: _InputT, /) -> u.Quantity: ...
-    @overload
-    def angular_diameter_distance(self, z: _InputT, z2: _InputT, /) -> u.Quantity: ...
     def angular_diameter_distance(
         self, z: _InputT, z2: _InputT | None = None, /
     ) -> u.Quantity:

--- a/astropy/cosmology/_src/tests/flrw/test_lambdacdm.py
+++ b/astropy/cosmology/_src/tests/flrw/test_lambdacdm.py
@@ -3,6 +3,7 @@
 """Testing :mod:`astropy.cosmology.flrw.lambdacdm`."""
 
 import pathlib
+import re
 
 import numpy as np
 import pytest
@@ -16,7 +17,7 @@ from astropy.cosmology._src.tests.helper import get_redshift_methods
 from astropy.cosmology._src.tests.test_core import invalid_zs, valid_zs
 from astropy.table import QTable
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from .test_base import FlatFLRWMixinTest, FLRWTest
 
@@ -495,20 +496,18 @@ def test_angular_diameter_distance_z1z2():
     tcos = FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
 
     with pytest.raises(ValueError):  # test diff size z1, z2 fail
-        tcos.angular_diameter_distance_z1z2([1, 2], [3, 4, 5])
+        tcos.angular_diameter_distance([1, 2], [3, 4, 5])
 
     # Tests that should actually work, target values computed with
     # http://www.astro.multivax.de:8000/phillip/angsiz_prog/README.HTML
     # Kayser, Helbig, and Schramm (Astron.Astrophys. 318 (1997) 680-686)
-    assert u.allclose(
-        tcos.angular_diameter_distance_z1z2(1, 2), 646.22968662822018 * u.Mpc
-    )
+    assert u.allclose(tcos.angular_diameter_distance(1, 2), 646.22968662822018 * u.Mpc)
 
     z1 = 2  # Separate test for z2<z1, returns negative value with warning
     z2 = 1
     results = -969.34452994 * u.Mpc
     with pytest.warns(AstropyUserWarning, match="less than first redshift"):
-        assert u.allclose(tcos.angular_diameter_distance_z1z2(z1, z2), results)
+        assert u.allclose(tcos.angular_diameter_distance(z1, z2), results)
 
     z1 = 0, 0, 0.5, 1
     z2 = 2, 1, 2.5, 1.1
@@ -519,23 +518,26 @@ def test_angular_diameter_distance_z1z2():
         115.72768186186921,
     ) * u.Mpc
 
-    assert u.allclose(tcos.angular_diameter_distance_z1z2(z1, z2), results)
+    assert u.allclose(tcos.angular_diameter_distance(z1, z2), results)
 
     z1 = 0.1
     z2 = 0.1, 0.2, 0.5, 1.1, 2
     results = (0.0, 332.09893173, 986.35635069, 1508.37010062, 1621.07937976) * u.Mpc
-    assert u.allclose(tcos.angular_diameter_distance_z1z2(0.1, z2), results)
+    assert u.allclose(tcos.angular_diameter_distance(z1, z2), results)
 
     # Non-flat (positive Ok0) test
     tcos = LambdaCDM(H0=70.4, Om0=0.2, Ode0=0.5, Tcmb0=0.0)
-    assert u.allclose(
-        tcos.angular_diameter_distance_z1z2(1, 2), 620.1175337852428 * u.Mpc
-    )
+    assert u.allclose(tcos.angular_diameter_distance(1, 2), 620.1175337852428 * u.Mpc)
     # Non-flat (negative Ok0) test
     tcos = LambdaCDM(H0=100, Om0=2, Ode0=1, Tcmb0=0.0)
-    assert u.allclose(
-        tcos.angular_diameter_distance_z1z2(1, 2), 228.42914659246014 * u.Mpc
-    )
+    assert u.allclose(tcos.angular_diameter_distance(1, 2), 228.42914659246014 * u.Mpc)
+
+    # Test deprecated method
+    with pytest.warns(
+        AstropyDeprecationWarning,
+        match=re.escape("Use ``angular_diameter_distance(z1, z2)`` instead"),
+    ):
+        tcos.angular_diameter_distance_z1z2(z1, z2)
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="test requires scipy")
@@ -616,7 +618,6 @@ def test_units():
     assert cosmo.comoving_transverse_distance(1.0).unit == u.Mpc
     assert cosmo._comoving_transverse_distance_z1z2(1.0, 2.0).unit == u.Mpc
     assert cosmo.angular_diameter_distance(1.0).unit == u.Mpc
-    assert cosmo.angular_diameter_distance_z1z2(1.0, 2.0).unit == u.Mpc
     assert cosmo.luminosity_distance(1.0).unit == u.Mpc
     assert cosmo.lookback_time(1.0).unit == u.Gyr
     assert cosmo.lookback_distance(1.0).unit == u.Mpc

--- a/astropy/cosmology/_src/tests/funcs/test_funcs.py
+++ b/astropy/cosmology/_src/tests/funcs/test_funcs.py
@@ -419,7 +419,7 @@ def test_z_at_value_roundtrip(cosmo):
         func_z1z2 = [
             lambda z1: cosmo.comoving_distance(z1, z2),
             lambda z1: cosmo._comoving_transverse_distance_z1z2(z1, z2),
-            lambda z1: cosmo.angular_diameter_distance_z1z2(z1, z2),
+            lambda z1: cosmo.angular_diameter_distance(z1, z2),
         ]
         for func in func_z1z2:
             fval = func(z)

--- a/astropy/cosmology/_src/tests/helper.py
+++ b/astropy/cosmology/_src/tests/helper.py
@@ -17,23 +17,32 @@ from astropy.cosmology._src import core
 # FUNCTIONS
 
 
-def get_redshift_methods(cosmology, include_private=True, include_z2=True):
+def get_redshift_methods(
+    cosmology,
+    include_deprecated: bool = False,
+    include_private: bool = True,
+    include_z2: bool = True,
+) -> set[str]:
     """Get redshift methods from a cosmology.
 
     Parameters
     ----------
     cosmology : |Cosmology| class or instance
-    include_private : bool
+    include_deprecated : bool, optional
+        Whether to include deprecated methods, i.e. methods with a
+        ``__deprecated__`` attribute. Default is False.
+    include_private : bool, optional
         Whether to include private methods, i.e. starts with an underscore.
-    include_z2 : bool
+        Default is True.
+    include_z2 : bool, optional
         Whether to include methods that are functions of 2 (or more) redshifts,
-        not the more common 1 redshift argument.
+        not the more common 1 redshift argument. Default is True.
 
     Returns
     -------
     set[str]
         The names of the redshift methods on `cosmology`, satisfying
-        `include_private` and `include_z2`.
+        `include_deprecated`, `include_private` and `include_z2`.
     """
     # Get all the method names, optionally sieving out private methods
     methods = set()
@@ -43,8 +52,12 @@ def get_redshift_methods(cosmology, include_private=True, include_z2=True):
         except NotImplementedError:
             continue
 
-        # Add anything callable, optionally excluding private methods.
-        if callable(m) and (not n.startswith("_") or include_private):
+        # Add anything callable, optionally excluding private and deprecated methods.
+        if (
+            callable(m)
+            and (not n.startswith("_") or include_private)
+            and (not hasattr(m, "__deprecated__") or include_deprecated)
+        ):
             methods.add(n)
 
     # Sieve out incompatible methods.

--- a/docs/changes/cosmology/18807.feature.rst
+++ b/docs/changes/cosmology/18807.feature.rst
@@ -1,0 +1,4 @@
+The ``angular_diameter_distance`` method now accepts two redshift arguments
+to compute the angular diameter distance between objects at different redshifts.
+The previous separate method ``angular_diameter_distance_z1z2`` is deprecated
+and will be removed in a future version.


### PR DESCRIPTION
This PR upgrades `angular_diameter_distance` to be a two-argument form, deprecating the now unnecessary `angular_diameter_distance_z1z2`.  Previously this was done for `comoving_distance`, https://github.com/astropy/astropy/blob/19a688f7f87e5c3ab18608d67b3fa830b93690a0/astropy/cosmology/_src/flrw/base.py#L857-L863


~Requires #18800~ Complete!

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
