### PR TITLE
Remove separate `BaseCoordinateFrame._get_representation_info()`

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1067,14 +1067,13 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
     def differential_type(self, value):
         self.set_representation_cls(s=value)
 
-    @classmethod
-    def _get_representation_info(cls):
-        # This exists as a class method only to support handling frame inputs
-        # without units, which are deprecated and will be removed.  This can be
-        # moved into the representation_info property at that time.
-        # note that if so moved, the cache should be acceessed as
-        # self.__class__._frame_class_cache
-
+    @functools.cached_property
+    def representation_info(self):
+        """
+        A dictionary with the information of what attribute names for this frame
+        apply to particular representations.
+        """
+        cls = type(self)
         if (
             cls._frame_class_cache.get("last_reprdiff_hash", None)
             != r.get_reprdiff_cls_hash()
@@ -1120,14 +1119,6 @@ class BaseCoordinateFrame(MaskableShapedLikeNDArray):
             cls._frame_class_cache["representation_info"] = repr_attrs
             cls._frame_class_cache["last_reprdiff_hash"] = r.get_reprdiff_cls_hash()
         return cls._frame_class_cache["representation_info"]
-
-    @functools.cached_property
-    def representation_info(self):
-        """
-        A dictionary with the information of what attribute names for this frame
-        apply to particular representations.
-        """
-        return self._get_representation_info()
 
     def get_representation_component_names(self, which="base"):
         cls = self.get_representation_cls(which)


### PR DESCRIPTION
### Description

There is an 11 year old comment that says code from `BaseCoordinateFrame._get_representation_info()` can be moved to `BaseCoordinateFrame.representation_info()` once some deprecated functionality is removed, but no one has gotten around to doing it.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
