### PR TITLE
MNT: configure automatic labels for dependabot auto updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: ".github/workflows" # Location of package manifests
+    labels:
+      - dependencies
+      - dev-automation
+      - github_actions
+      - no-changelog-entry-needed
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
### Description
The important part is to add "no-changelog-entry-needed", to mitigate the fact that the changelog-checker CI jobs stuggles when this label is added post-opening, frequently requiring wasteful close/open cycles.
Ultimately, the core problem is with the changelog checker job itself, though this is an easy quality-of-life win.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
