### PR TITLE
Fix a typo in `coordinates` docs

### DIFF
--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -176,9 +176,8 @@ if it is present, it can be accessed from the ``data`` attribute::
     <UnitSphericalRepresentation (lon, lat) in deg
         (1.1, 2.2)>
 
-All of the above methods can also accept array data (in the form of
-class:`~astropy.units.Quantity`, or other Python sequences) to create arrays of
-coordinates::
+All of the above methods can also accept array data (in the form of |Quantity|,
+or other Python sequences) to create arrays of coordinates::
 
     >>> ICRS(ra=[1.5, 2.5]*u.deg, dec=[3.5, 4.5]*u.deg)  # doctest: +FLOAT_CMP
     <ICRS Coordinate: (ra, dec) in deg


### PR DESCRIPTION
### Description

In #18822 the upgraded `Sphinx Lint` hook correctly identified a mistake in `coordinates` documentation. I am fixing the mistake in a separate pull request because apparently we don't backport the monthly `pre-commit` updates, but I do want to backport this fix.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
