### PR TITLE
DOC: Backport with milestone instead of labels

### DIFF
--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -42,7 +42,6 @@ jobs:
             - [ ] Did the CI pass? If no, are the failures related? If you need to run daily and weekly cron jobs as part of the PR, please apply the "Extra CI" label. Codestyle issues can be fixed by the [bot](https://docs.astropy.org/en/latest/development/development_details.html#pre-commit).
             - [ ] Is a change log needed? If yes, did the change log check pass? If no, add the "no-changelog-entry-needed" label. If this is a manual backport, use the "skip-changelog-checks" label unless special changelog handling is necessary.
             - [ ] Is this a big PR that makes a "What's new?" entry worthwhile and if so, is (1) a "what's new" entry included in this PR and (2) the "whatsnew-needed" label applied?
-            - [ ] At the time of adding the milestone, if the milestone set requires a backport to release branch(es), apply the appropriate "backport-X.Y.x" label(s) *before* merge.`
           })
     - name: Greet new contributors
       uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3.1.0

--- a/.github/workflows/update_astropy_iers_data_pin.yml
+++ b/.github/workflows/update_astropy_iers_data_pin.yml
@@ -53,6 +53,6 @@ jobs:
         body: |
           This is an automated update of the minimum version of astropy-iers-data package.
 
-          :pray: Please apply backport labels to any active backport branches for v6.0.x or later. :pray:
+          :pray: Please apply milestone to be backported to the active bug fix release branch at the time this PR is opened. :pray:
 
           :warning: Please close and re-open this pull request to trigger the CI. :warning:

--- a/docs/development/maintainers/releasing.rst
+++ b/docs/development/maintainers/releasing.rst
@@ -48,8 +48,9 @@ updates, and so on. New features can then continue to be added in parallel to th
 The procedure for the feature freeze is as follows:
 
 #. On the GitHub issue tracker, add a new milestone for the next major version
-   and for the next bugfix version, and also create a ``backport-v<version>.x``
-   label which can be used to label pull requests that should be backported
+   and for the next bugfix version. For the next bugfix version milestone,
+   set the description to ``on-merge: backport to v<version>.x``, so that any
+   pull request merged with that milestone would attempt an automatic backport
    to the new release branch. You can then start to move any issues and pull
    requests that you know will not be included in the release to the next milestones.
 
@@ -136,10 +137,6 @@ The procedure for the feature freeze is as follows:
    activated automatically.
 
 #. Inform the Astropy developer community that the branching has occurred.
-
-#. Once the feature freeze has happened, you should go through the PRs labeled
-   with ``backport-v<prev_version>.x`` to see if they must also be labeled with
-   the new version backport label.
 
 .. _release-procedure-first-rc:
 
@@ -244,7 +241,7 @@ and commit this and the ``.mailmap`` changes::
    $ git add docs/credits.rst
    $ git commit -m "Updated list of contributors and .mailmap file"
 
-Open a pull request to merge this into ``main`` and mark it as requiring backporting to
+Open a pull request to merge this into ``main`` and milestone it as requiring backporting to
 the release branch.
 
 .. _release-procedure-check-ci:
@@ -314,7 +311,7 @@ tag::
    git tag -d v<version>
 
 Make any fixes by adding commits to the release branch (no need to remove
-previous commits) e.g. via pull requests to the release branch, backports,
+previous commits), e.g., via pull requests to the release branch, backports,
 or direct commits on the release branch, as appropriate. Once you are
 ready to try and release again, create the tag, then force push the tag
 to GitHub to overwrite the previous one.
@@ -338,7 +335,7 @@ Releasing subsequent release candidates
 
 It is very likely that some issues will be reported with the first release
 candidate. Any issues should be fixed via pull requests to the ``main`` branch
-and marked for backporting to the release branch. The process for backporting
+and milestoned for backporting to the release branch. The process for backporting
 fixes is described in :ref:`release-procedure-bug-fix-backport`.
 
 Once you have backported any required fixes, repeat the following steps
@@ -389,7 +386,7 @@ e.g. v6.0.x.
    We render the changelog on the latest release branch and forward-port it
    rather than rendering on ``main`` and backporting, since the latter would
    render all news fragments into the changelog rather than only the ones
-   intended for the e.g. v6.0.x release branch.
+   intended for the, e.g., v6.0.x release branch.
 
 .. _release-procedure-checking-changelog:
 
@@ -562,7 +559,7 @@ and on GitHub::
    git push upstream :refs/tags/v6.0.1
 
 Make any fixes by adding commits to the release branch (no need to remove
-previous commits) e.g. via pull requests to the release branch, backports,
+previous commits), e.g., via pull requests to the release branch, backports,
 or direct commits on the release branch, as appropriate. Once you are
 ready to try and release again, create the tag, then force push the tag
 to GitHub to overwrite the previous one.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to update the documentation portion of https://github.com/astropy/astropy/issues/18814

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
