### PR TITLE
SEC: add a 7 days cooldown rule to dependabot's config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
### Description
This is explained in https://docs.zizmor.sh/audits/#dependabot-cooldown
zizmor 1.15 and newer auto flag this automatically, though for some reason it looks like the pre-commit hook doesn't. I assume this is a bug in zizmor-pre-commit, but in any case, I think this rule makes plenty sense from a security perspective.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
