### PR TITLE
TST/DEP: bump minimal requirement on `pytest-xdist` (2.5.0 -> 3.6.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ test = [
     "pytest-doctestplus>=1.4.0",
     "pytest-astropy-header>=0.2.1",
     "pytest-astropy>=0.10.0",
-    "pytest-xdist>=2.5.0",
+    "pytest-xdist>=3.6.0",
     "threadpoolctl>=3.0.0",
 ]
 test_all = [


### PR DESCRIPTION
### Description
ref: #18782
From where I'm standing this *looks* like one of the last required changes so make \`oldestdeps\` builds reproducible (in combination with #18780)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
