### PR TITLE
BUG: fix np.array's dispatcher for compatibility with numpy 2.4

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -617,12 +617,37 @@ def require(a, dtype=None, requirements=None):
     return (a, dtype, requirements), {}, out_unit, None
 
 
-@function_helper
-def array(object, dtype=None, *, copy=True, order="K", subok=False, ndmin=0):
+if not NUMPY_LT_2_4:
+
+    @function_helper
+    def array(
+        object, dtype=None, *, copy=True, order="K", subok=False, ndmin=0, ndmax=0
+    ):
+        return array_impl(
+            object,
+            dtype=dtype,
+            copy=copy,
+            order=order,
+            subok=subok,
+            ndmin=ndmin,
+            ndmax=ndmax,
+        )
+else:
+
+    @function_helper
+    def array(object, dtype=None, *, copy=True, order="K", subok=False, ndmin=0):
+        return array_impl(
+            object, dtype=dtype, copy=copy, order=order, subok=subok, ndmin=ndmin
+        )
+
+
+def array_impl(object, *, dtype, copy, order, subok, ndmin, ndmax=0):
     out_unit = getattr(object, "unit", UNIT_FROM_LIKE_ARG)
     if out_unit is not UNIT_FROM_LIKE_ARG:
         object = _as_quantity(object).value
     kwargs = {"copy": copy, "order": order, "subok": subok, "ndmin": ndmin}
+    if not NUMPY_LT_2_4:
+        kwargs |= {"ndmax": ndmax}
     return (object, dtype), kwargs, out_unit, None
 
 


### PR DESCRIPTION
### Description

xrefs:
- https://github.com/numpy/numpy/pull/29569
- https://github.com/numpy/numpy/pull/30138
- https://github.com/numpy/numpy/issues/30159
- https://github.com/numpy/numpy/pull/30160


Again here, I'm ahead on numpy nightlies, so this problem shouldn't be visible on unstable CI before Sunday or Monday. ~Hopefully the small issue I reported and patched upstream (see xrefs) is resolved in the mean time~
update: done

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
