### PR TITLE
Deprecate the `frame` parameter of `SkyCoord.from_name()`

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -13,6 +13,7 @@ from astropy.constants import c as speed_of_light
 from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat import COPY_IF_NEEDED
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
@@ -1827,6 +1828,7 @@ class SkyCoord(MaskableShapedLikeNDArray):
 
     # Name resolve
     @classmethod
+    @deprecated_renamed_argument("frame", None, since="8.0")
     def from_name(cls, name, frame="icrs", parse=False, cache=True):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
@@ -1842,6 +1844,10 @@ class SkyCoord(MaskableShapedLikeNDArray):
             The name of the object to get coordinates for, e.g. ``'M42'``.
         frame : str or `BaseCoordinateFrame` class or instance
             The frame to transform the object to.
+
+            .. versionchanged :: 8.0
+                The ``frame`` parameter is deprecated.
+
         parse : bool
             Whether to attempt extracting the coordinates from the name by
             parsing with a regex. For objects catalog names that have

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -18,20 +18,27 @@ from numpy import testing as npt
 from astropy import coordinates as coords
 from astropy import time
 from astropy import units as u
+from astropy.coordinates import (
+    FK5,
+    ICRS,
+    Angle,
+    BaseCoordinateFrame,
+    CartesianRepresentation,
+    Distance,
+    DynamicMatrixTransform,
+    Latitude,
+    Longitude,
+    PhysicsSphericalRepresentation,
+    SphericalRepresentation,
+    UnitSphericalRepresentation,
+    frame_transform_graph,
+)
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 
 def test_representations_api():
-    from astropy.coordinates import Angle, Distance, Latitude, Longitude
-    from astropy.coordinates.representation import (
-        CartesianRepresentation,
-        PhysicsSphericalRepresentation,
-        SphericalRepresentation,
-        UnitSphericalRepresentation,
-    )
-
     # <-----------------Classes for representation of coordinate data-------------->
     # These classes inherit from a common base class and internally contain Quantity
     # objects, which are arrays (although they may act as scalars, like numpy's
@@ -158,12 +165,6 @@ def test_representations_api():
 
 
 def test_frame_api():
-    from astropy.coordinates.builtin_frames import FK5, ICRS
-    from astropy.coordinates.representation import (
-        SphericalRepresentation,
-        UnitSphericalRepresentation,
-    )
-
     # <--------------------Reference Frame/"Low-level" classes--------------------->
     # The low-level classes have a dual role: they act as specifiers of coordinate
     # frames and they *may* also contain data as one of the representation objects,
@@ -249,11 +250,6 @@ def test_frame_api():
 
 
 def test_transform_api():
-    from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
-    from astropy.coordinates.builtin_frames import FK5, ICRS
-    from astropy.coordinates.representation import UnitSphericalRepresentation
-    from astropy.coordinates.transformations import DynamicMatrixTransform
-
     # <------------------------Transformations------------------------------------->
     # Transformation functionality is the key to the whole scheme: they transform
     # low-level classes from one frame to another.

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -19,6 +19,7 @@ from astropy import coordinates as coords
 from astropy import time
 from astropy import units as u
 from astropy.coordinates import (
+    FK4,
     FK5,
     ICRS,
     Angle,
@@ -36,6 +37,7 @@ from astropy.coordinates import (
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.units import allclose
 from astropy.utils.compat.optional_deps import HAS_SCIPY
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_representations_api():
@@ -449,7 +451,7 @@ def test_highlevel_api():
 
 @pytest.mark.remote_data
 def test_highlevel_api_remote():
-    m31icrs = coords.SkyCoord.from_name("M31", frame="icrs")
+    m31icrs = coords.SkyCoord.from_name("M31")
 
     m31str = str(m31icrs)
     assert m31str.startswith("<SkyCoord (ICRS): (ra, dec) in deg\n    (")
@@ -461,7 +463,11 @@ def test_highlevel_api_remote():
     # to fail
     # assert str(m31icrs) == '<SkyCoord (ICRS): (ra, dec) in deg\n    (10.6847083, 41.26875)>'
 
-    m31fk4 = coords.SkyCoord.from_name("M31", frame="fk4")
 
-    assert not m31icrs.is_equivalent_frame(m31fk4)
-    assert np.abs(m31icrs.ra - m31fk4.ra) > 0.5 * u.deg
+@pytest.mark.remote_data
+def test_from_name_frame_deprecation():
+    with pytest.warns(AstropyDeprecationWarning, match='^"frame" was deprecated'):
+        m31fk4 = coords.SkyCoord.from_name("M31", frame="fk4")
+
+    assert type(m31fk4.frame) is FK4
+    npt.assert_allclose(m31fk4.ra.deg, 10.000396)

--- a/docs/changes/coordinates/18847.api.rst
+++ b/docs/changes/coordinates/18847.api.rst
@@ -1,0 +1,4 @@
+The ``frame`` parameter of the ``SkyCoord.from_name()`` class method is
+deprecated.
+Calling ``SkyCoord.from_name(..., frame=new_frame)`` can be replaced with
+calling ``SkyCoord.from_name(...).transform_to(new_frame)``.


### PR DESCRIPTION
### Description

The `frame` parameter is not required because the output of `SkyCoord.from_name()` can be easily converted to a different frame by calling its `transform_to()` method. For updating the tests it was convenient to prefer module-level imports in the one file that tested the parameter.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
