### PR TITLE
types: improve deprecated_keywords args

### DIFF
--- a/astropy/cosmology/_src/utils.py
+++ b/astropy/cosmology/_src/utils.py
@@ -105,7 +105,7 @@ def aszarr(
 
 
 def deprecated_keywords(
-    *kws: str, since: str | float | tuple[str | float, ...]
+    *kws: str, since: str | tuple[str, ...]
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Deprecate calling one or more arguments as keywords.
 
@@ -114,17 +114,15 @@ def deprecated_keywords(
     *kws: str
         Names of the arguments that will become positional-only.
 
-    since : str or number or sequence of str or number
-        The release at which the old argument became deprecated.
+    since : str, float, or tuple of str or float
+        The release at which the old argument became deprecated. Can be a single
+        version (e.g., "7.0" or 7.0) or a tuple of versions for multiple arguments.
     """
     return functools.partial(_depr_kws, kws=kws, since=since)
 
 
 def _depr_kws(
-    func: Callable[P, R],
-    /,
-    kws: tuple[str, ...],
-    since: str | float | tuple[str | float, ...],
+    func: Callable[P, R], /, kws: tuple[str, ...], since: str | tuple[str, ...]
 ) -> Callable[P, R]:
     wrapper = _depr_kws_wrap(func, kws, since)
     functools.update_wrapper(wrapper, func)


### PR DESCRIPTION
version strings should be strings only.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
