### PR TITLE
TST/DEP: add a constraint on iniconfig (from pytest)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -754,6 +754,11 @@ constraint-dependencies = [
     "asdf>=2.12.0",
     "asdf-coordinates-schemas>=0.2.0",
 
+    # via pytest
+    # iniconfig 1.0.1 is the first version with proper wheels
+    # this constraint can be removed once pytest>=9.0 is required
+    "iniconfig>=1.0.1",
+
     # reproduce IPython minimal requirements on its dependencies
     # as of version 9.7.0 (dev), the earliest time at which lower bounds
     # started being consistently declared and tested.


### PR DESCRIPTION
### Description
Part of #18782
Mirrors https://github.com/pytest-dev/pytest/pull/13791

this helps with making `oldestdeps` builds reproducible by avoiding arbitrary code execution when building `inifix` 1.0.0

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
