### PR TITLE
TST/RFC: avoid upcoming deprecation warnings from pytest 9.1 (dev)

### DIFF
--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -225,13 +225,15 @@ def test_skycoord_skyoffset_frame():
 
 @pytest.mark.parametrize(
     "from_origin,to_origin",
-    combinations(
-        (
-            ICRS(10.6847929 * u.deg, 41.2690650 * u.deg, M31_DISTANCE),
-            FK5(10.6847929 * u.deg, 41.2690650 * u.deg, M31_DISTANCE),
-            Galactic(121.1744050 * u.deg, -21.5729360 * u.deg, M31_DISTANCE),
-        ),
-        r=2,
+    list(
+        combinations(
+            (
+                ICRS(10.6847929 * u.deg, 41.2690650 * u.deg, M31_DISTANCE),
+                FK5(10.6847929 * u.deg, 41.2690650 * u.deg, M31_DISTANCE),
+                Galactic(121.1744050 * u.deg, -21.5729360 * u.deg, M31_DISTANCE),
+            ),
+            r=2,
+        )
     ),
 )
 def test_m31_coord_transforms(from_origin, to_origin):

--- a/astropy/coordinates/tests/test_spectral_quantity.py
+++ b/astropy/coordinates/tests/test_spectral_quantity.py
@@ -33,7 +33,9 @@ class TestSpectralQuantity:
         ):
             SpectralQuantity(1 * unit)
 
-    @pytest.mark.parametrize(("unit1", "unit2"), zip(SPECTRAL_UNITS, SPECTRAL_UNITS))
+    @pytest.mark.parametrize(
+        ("unit1", "unit2"), list(zip(SPECTRAL_UNITS, SPECTRAL_UNITS))
+    )
     def test_spectral_conversion(self, unit1, unit2):
         sq1 = SpectralQuantity(1 * unit1)
         sq2 = sq1.to(unit2)

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -22,7 +22,7 @@ from astropy.modeling import (
 from astropy.modeling.math_functions import ArctanhUfunc
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
-MATH_FUNCTIONS = (func for func in math_functions.__all__ if func != "ArctanhUfunc")
+MATH_FUNCTIONS = [func for func in math_functions.__all__ if func != "ArctanhUfunc"]
 
 
 PROJ_TO_REMOVE = (
@@ -45,7 +45,7 @@ PROJ_TO_REMOVE = (
     + [f"Sky2Pix_{code}" for code in projections.projcodes]
 )
 
-PROJECTIONS = (func for func in projections.__all__ if func not in PROJ_TO_REMOVE)
+PROJECTIONS = [func for func in projections.__all__ if func not in PROJ_TO_REMOVE]
 
 OTHER_MODELS = [
     mappings.Mapping((1, 0)),

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -640,7 +640,9 @@ collapse_ignore_masked = permute // len(collapse_ignore_masked) * collapse_ignor
 
 @pytest.mark.parametrize(
     "mask, unit, propagate_uncertainties, operation_ignores_mask",
-    zip(collapse_masks, collapse_units, collapse_propagate, collapse_ignore_masked),
+    list(
+        zip(collapse_masks, collapse_units, collapse_propagate, collapse_ignore_masked)
+    ),
 )
 def test_collapse(mask, unit, propagate_uncertainties, operation_ignores_mask):
     # unique set of combinations of each of the N-1 axes for an N-D cube:

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -379,9 +379,11 @@ def test_self_conversion_via_variance_supported(UncertClass):
 
 @pytest.mark.parametrize(
     "UncertClass,to_variance_func",
-    zip(
-        uncertainty_types_with_conversion_support,
-        (lambda x: x**2, lambda x: x, lambda x: 1 / x),
+    list(
+        zip(
+            uncertainty_types_with_conversion_support,
+            (lambda x: x**2, lambda x: x, lambda x: 1 / x),
+        )
     ),
 )
 def test_conversion_to_from_variance_supported(UncertClass, to_variance_func):

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -482,7 +482,7 @@ def test_add_array_equal_shape():
 
 
 @pytest.mark.parametrize(
-    ("position", "subpixel_index"), zip(test_positions, test_position_indices)
+    ("position", "subpixel_index"), list(zip(test_positions, test_position_indices))
 )
 def test_subpixel_indices(position, subpixel_index):
     """

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -570,7 +570,7 @@ class TestArithmetic:
         self.t2 = self.__class__.t2[use_mask]
         self.jd = self.__class__.jd[use_mask]
 
-    @pytest.mark.parametrize("kw, func", itertools.product(kwargs, functions))
+    @pytest.mark.parametrize("kw, func", list(itertools.product(kwargs, functions)))
     def test_argfuncs(self, kw, func, use_mask):
         """
         Test that ``np.argfunc(jd, **kw)`` is the same as ``t0.argfunc(**kw)``
@@ -594,7 +594,7 @@ class TestArithmetic:
         assert t0v.shape == jdv.shape
         assert t1v.shape == jdv.shape
 
-    @pytest.mark.parametrize("kw, func", itertools.product(kwargs, functions))
+    @pytest.mark.parametrize("kw, func", list(itertools.product(kwargs, functions)))
     def test_funcs(self, kw, func, use_mask):
         """
         Test that ``np.func(jd, **kw)`` is the same as ``t1.func(**kw)`` where

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -36,7 +36,7 @@ class TestLogUnitCreation:
         assert u.dex.to(u.mag) == -2.5
         assert u.mag.to(u.dB) == -4
 
-    @pytest.mark.parametrize("lu_unit, lu_cls", zip(lu_units, lu_subclasses))
+    @pytest.mark.parametrize("lu_unit, lu_cls", list(zip(lu_units, lu_subclasses)))
     def test_callable_units(self, lu_unit, lu_cls):
         assert isinstance(lu_unit, u.UnitBase)
         assert callable(lu_unit)
@@ -510,7 +510,8 @@ def test_hashable():
 
 class TestLogQuantityCreation:
     @pytest.mark.parametrize(
-        "lq, lu", zip(lq_subclasses + [u.LogQuantity], lu_subclasses + [u.LogUnit])
+        "lq, lu",
+        list(zip(lq_subclasses + [u.LogQuantity], lu_subclasses + [u.LogUnit])),
     )
     def test_logarithmic_quantities(self, lq, lu):
         """Check logarithmic quantities are all set up correctly"""

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2873,14 +2873,16 @@ def test_testing_completeness():
 class TestFunctionHelpersCompleteness:
     @pytest.mark.parametrize(
         "one, two",
-        itertools.combinations(
-            (
-                SUBCLASS_SAFE_FUNCTIONS,
-                UNSUPPORTED_FUNCTIONS,
-                set(FUNCTION_HELPERS.keys()),
-                set(DISPATCHED_FUNCTIONS.keys()),
+        list(
+            itertools.combinations(
+                (
+                    SUBCLASS_SAFE_FUNCTIONS,
+                    UNSUPPORTED_FUNCTIONS,
+                    set(FUNCTION_HELPERS.keys()),
+                    set(DISPATCHED_FUNCTIONS.keys()),
+                ),
+                2,
             ),
-            2,
         ),
     )
     def test_no_duplicates(self, one, two):

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1774,14 +1774,16 @@ def test_testing_completeness():
 class TestFunctionHelpersCompleteness:
     @pytest.mark.parametrize(
         "one, two",
-        itertools.combinations(
-            (
-                MASKED_SAFE_FUNCTIONS,
-                UNSUPPORTED_FUNCTIONS,
-                set(APPLY_TO_BOTH_FUNCTIONS.keys()),
-                set(DISPATCHED_FUNCTIONS.keys()),
+        list(
+            itertools.combinations(
+                (
+                    MASKED_SAFE_FUNCTIONS,
+                    UNSUPPORTED_FUNCTIONS,
+                    set(APPLY_TO_BOTH_FUNCTIONS.keys()),
+                    set(DISPATCHED_FUNCTIONS.keys()),
+                ),
+                2,
             ),
-            2,
         ),
     )
     def test_no_duplicates(self, one, two):


### PR DESCRIPTION
### Description

xref: https://github.com/pytest-dev/pytest/pull/13877

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
