### PR TITLE
TST/DEP: drop pre-commit as a Python (test) dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ all = [
 # The base set of test-time dependencies.
 test = [
     "coverage>=6.4.4",
-    "pre-commit>=2.9.3", # lower bound is not tested beyond installation
     "pytest>=8.0.0",
     "pytest-doctestplus>=1.4.0",
     "pytest-astropy-header>=0.2.1",


### PR DESCRIPTION
### Description
Part of #18782

There are many reasons not to declare `pre-commit` as a Python dependency:
- there are many other ways to install it, including at system level. Making it a test dependency is a waste of disk space and bandwidth (a small one, admittedly)
- it's not the *only* implementation of this software (`pre-commit-rust` and `prek` also exist), and there's no reason to only "support" one
- it's not used in CI (pre-commit.ci has it installed at system level)
- even our `tox.ini` configuration doesn't rely on it being a package dependency (see the `codestyle` factor)
- and finally, the reason that actually drives me to open this: even recent versions of pre-commit have incorrect lower bounds on its dependencies. Considering all of the above, it seems preferable to just drop it than "fix" it with constraints[^1]


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


[^1]: though, FWIW, I *do* have the constraints figured out, if need be.