### PR TITLE
Implement `.flags` in `nddata.CCDData.to_hdu` method to enable FITS file persistence of flags

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -95,13 +95,13 @@ class CCDData(NDDataArray):
 
     uncertainty : `~astropy.nddata.StdDevUncertainty`, \
             `~astropy.nddata.VarianceUncertainty`, \
-            `~astropy.nddata.InverseVariance`, `numpy.ndarray` or \
+            `~astropy.nddata.InverseVariance`, `~numpy.ndarray` or \
             None, optional
-        Uncertainties on the data. If the uncertainty is a `numpy.ndarray`, it
+        Uncertainties on the data. If the uncertainty is a `~numpy.ndarray`, it
         it assumed to be, and stored as, a `~astropy.nddata.StdDevUncertainty`.
         Default is ``None``.
 
-    mask : `numpy.ndarray` or None, optional
+    mask : `~numpy.ndarray` or None, optional
         Mask for the data, given as a boolean Numpy array with a shape
         matching that of the data. The values must be `False` where
         the data is *valid* and `True` when it is not (like Numpy
@@ -110,7 +110,7 @@ class CCDData(NDDataArray):
         ignored.
         Default is ``None``.
 
-    flags : `numpy.ndarray` or `~astropy.nddata.FlagCollection` or None, \
+    flags : `~numpy.ndarray` or `~astropy.nddata.FlagCollection` or None, \
             optional
         Flags giving information about each pixel. These can be specified
         either as a Numpy array of any type with a shape matching that of the
@@ -137,7 +137,7 @@ class CCDData(NDDataArray):
             If the unit is ``None`` or not otherwise specified it will raise a
             ``ValueError``
 
-    psf : `numpy.ndarray` or None, optional
+    psf : `~numpy.ndarray` or None, optional
         Image representation of the PSF at the center of this image. In order
         for convolution to be flux-preserving, this should generally be
         normalized to sum to unity.
@@ -340,12 +340,12 @@ class CCDData(NDDataArray):
         Raises
         ------
         ValueError
-            - If ``self.mask`` is set but not a `numpy.ndarray`.
+            - If ``self.mask`` is set but not a `~numpy.ndarray`.
             - If ``self.uncertainty`` is set but not a astropy uncertainty
               type.
             - If ``self.uncertainty`` is set but has another unit then
               ``self.data``.
-            - If ``self.flags`` is set but not a `numpy.ndarray` or
+            - If ``self.flags`` is set but not a `~numpy.ndarray` or
               `~astropy.nddata.FlagCollection`.
 
         Returns
@@ -637,7 +637,7 @@ def fits_ccddata_reader(
     hdu_flags : str or None, optional
         FITS extension name (or prefix) from which flags should be
         initialized. If a single extension with this exact name exists, flags
-        will be loaded as a `numpy.ndarray`. If multiple extensions exist
+        will be loaded as a `~numpy.ndarray`. If multiple extensions exist
         with names starting with this prefix (e.g., ``'FLAGS_*'``), they will
         be loaded into a `~astropy.nddata.FlagCollection` where the flag
         names are derived by removing the prefix and underscore.
@@ -698,9 +698,7 @@ def fits_ccddata_reader(
             # extensions (FlagCollection)
             # First, look for extensions that start with hdu_flags prefix
             flag_extensions = [
-                name
-                for name in hdus.info(output=False)
-                if isinstance(name[1], str) and name[1].startswith(f"{hdu_flags}_")
+                hdu.name for hdu in hdus if hdu.name.startswith(f"{hdu_flags}_")
             ]
 
             if hdu_flags in hdus and not flag_extensions:
@@ -712,8 +710,7 @@ def fits_ccddata_reader(
                 data_shape = hdus[hdu].data.shape
                 flags = FlagCollection(shape=data_shape)
 
-                for ext_info in flag_extensions:
-                    ext_name = ext_info[1]
+                for ext_name in flag_extensions:
                     # Remove the prefix and underscore to get flag name
                     flag_name = ext_name[len(hdu_flags) + 1 :]
                     flags[flag_name] = hdus[ext_name].data
@@ -841,12 +838,12 @@ def fits_ccddata_writer(
     Raises
     ------
     ValueError
-        - If ``self.mask`` is set but not a `numpy.ndarray`.
+        - If ``self.mask`` is set but not a `~numpy.ndarray`.
         - If ``self.uncertainty`` is set but not a
           `~astropy.nddata.StdDevUncertainty`.
         - If ``self.uncertainty`` is set but has another unit then
           ``self.data``.
-        - If ``self.flags`` is set but not a `numpy.ndarray` or
+        - If ``self.flags`` is set but not a `~numpy.ndarray` or
           `~astropy.nddata.FlagCollection`.
     """
     hdu = ccd_data.to_hdu(

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1195,6 +1195,8 @@ def test_write_read_with_flag_collection(tmp_path):
     assert isinstance(ccd_after.flags, FlagCollection)
     assert len(ccd_after.flags.keys()) == len(ccd_data.flags.keys())
     assert ccd_after.flags.shape == ccd_data.flags.shape
+    assert ccd_after.flags["BAD_PIXEL"].dtype == np.uint8
+    assert ccd_after.flags["SATURATED"].dtype == ">i8"
     np.testing.assert_array_equal(
         ccd_data.flags["BAD_PIXEL"], ccd_after.flags["BAD_PIXEL"]
     )

--- a/docs/changes/nddata/18862.feature.rst
+++ b/docs/changes/nddata/18862.feature.rst
@@ -1,0 +1,4 @@
+Implemented support for the ``.flags`` attribute in
+``CCDData.to_hdu()``, enabling the CCDData class to write and read
+``.flags`` in FITS format.
+Previously this was silent no-op even though it should have raised a ``NotImplementedError``.

--- a/docs/nddata/ccddata.rst
+++ b/docs/nddata/ccddata.rst
@@ -124,11 +124,10 @@ converting them to binary masks, see :ref:`bitmask_details`.
 
 A simple example on how to set flags can be:
 
-    >>> rng = np.random.default_rng()
-    >>> data = rng.normal(size=(10, 10), loc=1.0, scale=0.1)
+    >>> data = np.zeros((10, 10))
     >>> ccd = CCDData(data, unit="electron")
 
-    >>> flags = rng.random(size=(10, 10))  # Create a simple flags array
+    >>> flags = np.ones((10, 10))  # Create a simple flags array
     >>> ccd = CCDData(data, unit='adu', flags=flags)
 
 Flags can be also set using `~astropy.nddata.FlagCollection`, which provides a
@@ -141,20 +140,18 @@ convenient interface for managing multiple flags.
     >>> flags = FlagCollection(shape=(100, 100))
 
     >>> # Add different types of flags
-    >>> flags['COSMIC_RAY'] = rng.integers(0, 2, (100, 100), dtype=bool)
-    >>> flags['SATURATED'] = rng.integers(0, 2, (100, 100), dtype=int)
+    >>> flags['COSMIC_RAY'] = np.zeros((100, 100), dtype=float)
+    >>> flags['SATURATED'] = np.zeros((100, 100), dtype=int)
     >>> flags['BAD_PIXEL'] = np.zeros((100, 100), dtype=bool)
     >>> flags['BAD_PIXEL'][50:60, 50:60] = True  # Mark a region as bad
 
 
-Flags support FITS files storing as additional image HDU extensions. In order
+When writing `~astropy.nddata.CCDData` to FITS, flags are stored in additional image HDU extensions. In order
 to do this, the user must explicitly provide a key or name for the flags HDU
 when creating the `~astropy.nddata.CCDData` object using the ``hdu_flags``. In
-case that multiple flags are set using `~astropy.nddata.FlagCollection`, they will be stored in a multiple HDUs using the flag collection names, but user
+case that multiple flags are set using `~astropy.nddata.FlagCollection`, they will be stored in multiple HDUs using the flag collection names, but user
 must still provide a non-empty string to ``hdu_flags`` to indicate that flags should be saved.
 
-    >>> ccd.write('example_flag_collection.fits', hdu_flags='FLAGS')
-    >>> ccd_r = CCDData.read('example_flag_collection.fits', hdu_flags='FLAGS')
 
 WCS
 +++


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a missing implementation of the persistence of `.flags` attribute of `nddata.CCDData` objects, when converting using the `CCDData.to_hdu()` method, or the `CCDData.write` method. 
Also, use of `nddata.FlagCollection` is now supported and `.flags` set with them able to be written out and read in. 

This missing functionality was discovered when attempting to use it for the LSST survey alert stream distribution, and finding that no mask planes (stored as `.flags` attributes) were being sent to brokers. 

A new test is in place to verify this continues to work as expected. 
Documentation is also updated to provide examples of use of the new implementation.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Fixes #<Issue Number> -->
 
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
