### PR TITLE
Enable inplace multiplications of `numpy` array and `Quantity` with any dimensionless and unscaled unit

### DIFF
--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -375,7 +375,7 @@ def check_output(output, unit, inputs, function=None):
 
     else:
         # output is not a Quantity, so cannot obtain a unit.
-        if not (unit is None or unit is dimensionless_unscaled):
+        if not (unit is None or unit == dimensionless_unscaled):
             raise UnitTypeError(
                 "Cannot store quantity with dimension "
                 "{}in a non-Quantity instance.".format(

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1112,9 +1112,6 @@ class TestInplaceUfuncs:
         a[:2] += q  # This used to fail
         assert_array_equal(a, np.array([0.125, 1.25, 2.0]))
 
-    @pytest.mark.xfail(
-        reason="Regression test that reveals a bug", raises=u.UnitTypeError
-    )
     def test_ndarray_inplace_op_with_dimensionless_quantity(self):
         # Regression test for #18866 - multiplying a bare array inplace with
         # a dimensionless Quantity required the unit to be u.dimensionless_unscaled.


### PR DESCRIPTION
### Description

Inplace multiplications of a bare `numpy` array and a `Quantity` with a dimensionless and unscaled unit should succeed, but on current `main` they fail if the unit is not `u.dimensionless_unscaled` but merely equal to it. This became a problem with e93012e8b892f56fe7e643cf959a8cf182e58558, but it is simple enough to fix by replacing a strict identity check with an equality check.

An alternative would be
```patch
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -247,7 +247,7 @@ def helper_division(f, unit1, unit2):
     if unit1 is unit2:
         unit = dimensionless_unscaled
     elif unit1 is None:
-        unit = unit2**-1
+        unit = dimensionless_unscaled if unit2 is dimensionless_unscaled else unit2**-1
     elif unit2 is None:
         unit = unit1
     else:
```
but it is better to remove special cases from the code than to add them.

A change log entry is not needed because there are no `astropy` releases with the bug. Downstream caught it when testing v7.2.0rc1.

Fixes #18866

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
