### PR TITLE
feat(cosmo): complete Ob0=None deprecation

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -327,15 +327,6 @@ class FLRW(
     @Ob0.validator
     def Ob0(self, param: Parameter, value: Any) -> float:
         """Validate baryon density to a non-negative float > matter density."""
-        if value is None:
-            warnings.warn(
-                "Ob0=None is deprecated, use Ob0=0 instead, "
-                "which never causes methods to raise exceptions.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            return 0.0
-
         value = validate_non_negative(self, param, value)
         if value > self.Om0:
             raise ValueError(

--- a/astropy/cosmology/_src/flrw/lambdacdm.py
+++ b/astropy/cosmology/_src/flrw/lambdacdm.py
@@ -58,10 +58,9 @@ class LambdaCDM(FLRW):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
@@ -675,10 +674,9 @@ class FlatLambdaCDM(FlatFLRWMixin, LambdaCDM):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.

--- a/astropy/cosmology/_src/flrw/w0cdm.py
+++ b/astropy/cosmology/_src/flrw/w0cdm.py
@@ -60,10 +60,9 @@ class wCDM(FLRW):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
@@ -268,10 +267,9 @@ class FlatwCDM(FlatFLRWMixin, wCDM):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.

--- a/astropy/cosmology/_src/flrw/w0wacdm.py
+++ b/astropy/cosmology/_src/flrw/w0wacdm.py
@@ -64,10 +64,9 @@ class w0waCDM(FLRW):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
@@ -245,10 +244,9 @@ class Flatw0waCDM(FlatFLRWMixin, w0waCDM):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.

--- a/astropy/cosmology/_src/flrw/w0wzcdm.py
+++ b/astropy/cosmology/_src/flrw/w0wzcdm.py
@@ -65,10 +65,9 @@ class w0wzCDM(FLRW):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
@@ -241,10 +240,9 @@ class Flatw0wzCDM(FlatFLRWMixin, w0wzCDM):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.

--- a/astropy/cosmology/_src/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/_src/flrw/wpwazpcdm.py
@@ -69,10 +69,9 @@ class wpwaCDM(FLRW):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.
@@ -274,10 +273,9 @@ class FlatwpwaCDM(FlatFLRWMixin, wpwaCDM):
         provide three neutrino masses unless you are considering something like
         a sterile neutrino.
 
-    Ob0 : float or None, optional
+    Ob0 : float, optional
         Omega baryons: density of baryonic matter in units of the critical
-        density at z=0.  If this is set to None (the default), any computation
-        that requires its value will raise an exception.
+        density at z=0.
 
     name : str or None (optional, keyword-only)
         Name for this cosmological object.

--- a/astropy/cosmology/_src/tests/flrw/test_parameters.py
+++ b/astropy/cosmology/_src/tests/flrw/test_parameters.py
@@ -416,8 +416,6 @@ class ParameterOb0TestMixin(ParameterTestMixin):
         assert Ob0.default == 0.0
 
         # validation
-        with pytest.warns(DeprecationWarning, match="Ob0=None is deprecated"):
-            assert Ob0.validate(cosmo, None) == 0.0
         assert Ob0.validate(cosmo, 0.1) == 0.1
         assert Ob0.validate(cosmo, 0.1 * u.one) == 0.1
         with pytest.raises(ValueError, match="Ob0 cannot be negative"):
@@ -460,18 +458,18 @@ class ParameterOb0TestMixin(ParameterTestMixin):
         with pytest.raises(ValueError, match="baryonic density can not be larger"):
             cosmo_cls(*tba.args, **tba.kwargs)
 
-        # No baryons specified means baryons = 0 and gives a warning.
-        tba = copy.copy(ba)
-        tba.arguments["Ob0"] = None
-        with pytest.warns(DeprecationWarning, match="Ob0=None is deprecated"):
-            cosmo = cosmo_cls(*tba.args, **tba.kwargs)
-
         # In FLRW `Ob(z)` requires `w(z)`.
         if not self.abstract_w:
             assert cosmo.Ob(1) == 0
 
         # The default value is None
         assert cosmo_cls.parameters["Ob0"].default == 0.0
+
+    def test_Ob0_cannot_be_None(self, cosmo_cls: type[Cosmology], ba: BoundArguments):
+        """Test that Ob0 cannot be None."""
+        ba.arguments["Ob0"] = None
+        with pytest.raises(TypeError):
+            cosmo_cls(*ba.args, **ba.kwargs)
 
 
 # =============================================================================

--- a/docs/changes/cosmology/18874.api.rst
+++ b/docs/changes/cosmology/18874.api.rst
@@ -1,0 +1,3 @@
+The ``Ob0=None`` parameter value for cosmology classes is no longer supported.
+This deprecation was started in v7.0. Use ``Ob0=0`` instead to indicate zero
+baryonic matter density.


### PR DESCRIPTION
Started in v7. Completed now.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
