### PR TITLE
docs(cosmo): add examples to traits

### DIFF
--- a/astropy/cosmology/_src/traits/baryons.py
+++ b/astropy/cosmology/_src/traits/baryons.py
@@ -15,7 +15,30 @@ from astropy.units import Quantity
 
 
 class BaryonComponent:
-    """The cosmology has attributes and methods for the baryon density."""
+    """The cosmology has attributes and methods for the baryon density.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> from astropy.cosmology.traits import BaryonComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasBaryons(BaryonComponent):
+    ...     Ob0: float
+    ...     def inv_efunc(self, z): return 1.0  # necessary for Ob(z)
+
+    >>> cosmo = ExampleHasBaryons(Ob0=0.05)
+    >>> cosmo.Ob0
+    0.05
+
+    >>> cosmo.Ob([0.0, 1.0, 2.0])
+    array([0.05, 0.4 , 1.35])
+
+    """
 
     Ob0: float | np.floating
     """Omega baryons: density of baryonic matter in units of the critical density at z=0."""

--- a/astropy/cosmology/_src/traits/curvature.py
+++ b/astropy/cosmology/_src/traits/curvature.py
@@ -22,6 +22,29 @@ class CurvatureComponent:
     This is a trait class; it is not meant to be instantiated directly, but
     instead to be used as a mixin to other classes.
 
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> from astropy.cosmology.traits import CurvatureComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasCurvature(CurvatureComponent):
+    ...     @property
+    ...     def Ok0(self): return 0.1
+    ...     def is_flat(self): return False
+    ...     def inv_efunc(self, z): return 1.0  # necessary for Ok(z)
+
+    >>> cosmo = ExampleHasCurvature()
+    >>> cosmo.Ok0
+    0.1
+
+    >>> cosmo.Ok([0.0, 1.0, 2.0])
+    array([0.1, 0.4, 0.9])
+
     """
 
     @property

--- a/astropy/cosmology/_src/traits/darkenergy.py
+++ b/astropy/cosmology/_src/traits/darkenergy.py
@@ -11,6 +11,34 @@ from astropy.units import Quantity
 
 
 class DarkEnergyComponent:
+    """The object has attributes and methods related to dark energy.
+
+    This is a trait class; it is not meant to be instantiated directly, but
+    instead to be used as a mixin to other classes.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.FlatwCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> from astropy.cosmology.traits import DarkEnergyComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasDarkEnergy(DarkEnergyComponent):
+    ...     Ode0: float = 0.7
+    ...     def w(self, z): return np.full(np.shape(z), -1.0)
+
+    >>> cosmo = ExampleHasDarkEnergy()
+    >>> cosmo.Ode0
+    0.7
+
+    >>> cosmo.w([0.0, 1.0, 2.0])
+    array([-1., -1., -1.])
+
+    """
+
     # Subclasses should use `Parameter` to make this a parameter of the cosmology.
     Ode0: float | np.floating
     """Omega dark energy; dark energy density/critical density at z=0."""

--- a/astropy/cosmology/_src/traits/darkmatter.py
+++ b/astropy/cosmology/_src/traits/darkmatter.py
@@ -16,8 +16,30 @@ from astropy.units import Quantity
 class DarkMatterComponent:
     """The cosmology has attributes and methods for the dark matter density.
 
-    This trait provides an ``Odm`` method that returns the dark matter
-    density parameter (i.e., total matter minus baryons) at redshift ``z``.
+    This trait provides an ``Odm`` method that returns the dark matter density parameter
+    (i.e., total matter minus baryons) at redshift ``z``.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> from astropy.cosmology.traits import DarkMatterComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasDarkMatter(DarkMatterComponent):
+    ...     Odm0: float = 0.3
+    ...     def inv_efunc(self, z): return 1.0
+
+    >>> cosmo = ExampleHasDarkMatter()
+    >>> cosmo.Odm0
+    0.3
+
+    >>> cosmo.Odm([0.0, 1.0, 2.0])
+    array([0.3, 2.4, 8.1])
+
     """
 
     Odm0: float | np.floating

--- a/astropy/cosmology/_src/traits/hubble.py
+++ b/astropy/cosmology/_src/traits/hubble.py
@@ -20,7 +20,44 @@ from astropy.units import Quantity
 
 
 class HubbleParameter:
-    """The object has attributes and methods for the Hubble parameter."""
+    """The object has attributes and methods for the Hubble parameter.
+
+    This is a trait class; it is not meant to be instantiated directly, but instead to
+    be used as a mixin to other classes.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> import astropy.units as u
+    >>> from astropy.cosmology.traits import HubbleParameter
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasHubble(HubbleParameter):
+    ...     H0: u.Quantity
+    ...     def efunc(self, z): return np.ones_like(z)
+    ...     def inv_efunc(self, z): return np.ones_like(z)
+
+    >>> cosmo = ExampleHasHubble(H0=70 * u.km / u.s / u.Mpc)
+    >>> cosmo.H0
+    <Quantity 70. km / (Mpc s)>
+
+    >>> cosmo.H([0.0, 1.0, 2.0])
+    <Quantity [70., 70., 70.] km / (Mpc s)>
+
+    >>> float(cosmo.h)
+    0.7
+
+    >>> cosmo.hubble_time.round(2)
+    <Quantity 13.97 Gyr>
+
+    >>> cosmo.hubble_distance.round(2)
+    <Quantity 4282.75 Mpc>
+
+    """
 
     H0: Quantity
     """Hubble Parameter at redshift 0."""

--- a/astropy/cosmology/_src/traits/matter.py
+++ b/astropy/cosmology/_src/traits/matter.py
@@ -11,7 +11,33 @@ __all__ = ("MatterComponent",)
 
 
 class MatterComponent:
-    """The cosmology has attributes and methods for the matter density."""
+    """The cosmology has attributes and methods for the matter density.
+
+    This is a trait class; it is not meant to be instantiated directly, but instead to
+    be used as a mixin to other classes.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> from astropy.cosmology.traits import MatterComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasMatter(MatterComponent):
+    ...     Om0: float
+    ...     def inv_efunc(self, z): return 1.0  # necessary for Om(z)
+
+    >>> cosmo = ExampleHasMatter(Om0=0.3)
+    >>> cosmo.Om0
+    0.3
+
+    >>> cosmo.Om([0.0, 1.0, 2.0])
+    array([0.3, 2.4, 8.1])
+
+    """
 
     Om0: float | np.floating
     """Omega matter; matter density/critical density at z=0."""

--- a/astropy/cosmology/_src/traits/photoncomponent.py
+++ b/astropy/cosmology/_src/traits/photoncomponent.py
@@ -15,7 +15,33 @@ from astropy.units import Quantity
 
 
 class PhotonComponent:
-    """The cosmology has attributes and methods for the photon density."""
+    """The cosmology has attributes and methods for the photon density.
+
+    This is a trait class; it is not meant to be instantiated directly, but instead to
+    be used as a mixin to other classes.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> from astropy.cosmology.traits import MatterComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasPhotons(PhotonComponent):
+    ...     Ogamma0: float
+    ...     def inv_efunc(self, z): return 1.0  # necessary for Ogamma(z)
+
+    >>> cosmo = ExampleHasPhotons(Ogamma0=5e-5)
+    >>> cosmo.Ogamma0
+    5e-05
+
+    >>> cosmo.Ogamma([0.0, 1.0, 2.0])
+    array([5.00e-05, 8.00e-04, 4.05e-03])
+
+    """
 
     Ogamma0: float | np.floating
     """Omega gamma; the density/critical density of photons at z=0."""

--- a/astropy/cosmology/_src/traits/rhocrit.py
+++ b/astropy/cosmology/_src/traits/rhocrit.py
@@ -12,7 +12,35 @@ from astropy.units import Quantity
 
 
 class CriticalDensity:
-    """The object has attributes and methods for the critical density."""
+    """The object has attributes and methods for the critical density.
+
+    This is a trait class; it is not meant to be instantiated directly, but instead to
+    be used as a mixin to other classes.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.cosmology.traits import MatterComponent
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasCriticalDensity(CriticalDensity):
+    ...     critical_density0: u.Quantity
+    ...     def efunc(self, z): return np.ones_like(z)
+
+    >>> cosmo = ExampleHasCriticalDensity(critical_density0=1e-29 * u.g / u.cm**3)
+    >>> cosmo.critical_density0
+    <Quantity 1.e-29 g / cm3>
+
+    >>> cosmo.critical_density([0.0, 1.0, 2.0])
+    <Quantity [1.e-29, 1.e-29, 1.e-29] g / cm3>
+
+    """
 
     critical_density0: Quantity
     """Critical density at redshift 0."""

--- a/astropy/cosmology/_src/traits/scale_factor.py
+++ b/astropy/cosmology/_src/traits/scale_factor.py
@@ -19,6 +19,27 @@ class ScaleFactor:
 
     The scale factor is defined as :math:`a = a_0 / (1 + z)`.
 
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.cosmology.traits import ScaleFactor
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasScaleFactor(ScaleFactor): pass
+
+    >>> cosmo = ExampleHasScaleFactor()
+    >>> cosmo.scale_factor0
+    <Quantity 1.>
+
+    >>> cosmo.scale_factor([0.0, 1.0, 2.0])
+    <Quantity [1.        , 0.5       , 0.33333333]>
+
     """
 
     @property

--- a/astropy/cosmology/_src/traits/tcmb.py
+++ b/astropy/cosmology/_src/traits/tcmb.py
@@ -15,7 +15,33 @@ from astropy.units import Quantity
 
 
 class TemperatureCMB:
-    """The trait for computing the cosmological background temperature."""
+    """The trait for computing the cosmological background temperature.
+
+    This is a trait class; it is not meant to be instantiated directly, but instead to
+    be used as a mixin to other classes.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> import astropy.units as u
+    >>> from astropy.cosmology.traits import TemperatureCMB
+    >>> import dataclasses
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasTcmb(TemperatureCMB):
+    ...     Tcmb0: u.Quantity
+
+    >>> cosmo = ExampleHasTcmb(Tcmb0=2.7255 * u.K)
+    >>> cosmo.Tcmb0
+    <Quantity 2.7255 K>
+
+    >>> cosmo.Tcmb([0.0, 1.0, 2.0])
+    <Quantity [2.7255, 5.451 , 8.1765] K>
+
+    """
 
     Tcmb0: Quantity
     """Temperature of the CMB at z=0."""

--- a/astropy/cosmology/_src/traits/totalcomponent.py
+++ b/astropy/cosmology/_src/traits/totalcomponent.py
@@ -16,6 +16,26 @@ class TotalComponent:
 
     This trait has the abstract ``Otot`` method that returns the total density
     parameter at redshift ``z``. It should be the sum of all other components.
+
+    Examples
+    --------
+    For an example of a real cosmology that implements this trait, see
+    :class:`~astropy.cosmology.LambdaCDM`. Here we will define an illustrative example
+    class that meets the minimum API requirements, but is not cosmologically meaningful:
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.cosmology.traits import TotalComponent, MatterComponent, DarkEnergyComponent
+    >>> import dataclasses
+
+
+    >>> @dataclasses.dataclass(frozen=True)
+    ... class ExampleHasTotalDensity(TotalComponent, MatterComponent, DarkEnergyComponent):
+    ...     Om0: float = 0.3
+    ...     Ode0: float = 0.7
+    ...     def Otot0(self): return self.Om0 + self.Ode0
+    ...     def Otot(self, z): return self.Om(z) + self.Ode(z)
+
     """
 
     @property

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,3 +1,3 @@
 Added docstring examples to cosmology traits (``BaryonComponent``,
-``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``), improving
-documentation and demonstrating their usage.
+``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
+``HubbleParameter``), improving documentation and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,4 +1,4 @@
 Added docstring examples to cosmology traits (``BaryonComponent``,
 ``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
-``HubbleParameter``, ``MatterComponent``), improving documentation and demonstrating
-their usage.
+``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``), improving documentation
+and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,4 +1,5 @@
 Added docstring examples to cosmology traits (``BaryonComponent``, ``CriticalDensity``,
 ``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
 ``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``, ``ScaleFactor``, and
-``TemperatureCMB``), improving documentation and demonstrating their usage.
+``TemperatureCMB``, ``TotalComponent``), improving documentation and demonstrating their
+usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,0 +1,2 @@
+Added docstring examples to cosmology traits (``BaryonComponent``), improving
+documentation and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,2 +1,2 @@
-Added docstring examples to cosmology traits (``BaryonComponent``), improving
-documentation and demonstrating their usage.
+Added docstring examples to cosmology traits (``BaryonComponent``,
+``CurvatureComponent``), improving documentation and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,4 +1,4 @@
 Added docstring examples to cosmology traits (``BaryonComponent``, ``CriticalDensity``,
 ``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
-``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``), improving documentation
-and demonstrating their usage.
+``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``, ``ScaleFactor``),
+improving documentation and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,4 +1,4 @@
-Added docstring examples to cosmology traits (``BaryonComponent``,
+Added docstring examples to cosmology traits (``BaryonComponent``, ``CriticalDensity``,
 ``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
 ``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``), improving documentation
 and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,3 +1,4 @@
 Added docstring examples to cosmology traits (``BaryonComponent``,
 ``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
-``HubbleParameter``), improving documentation and demonstrating their usage.
+``HubbleParameter``, ``MatterComponent``), improving documentation and demonstrating
+their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,2 +1,3 @@
 Added docstring examples to cosmology traits (``BaryonComponent``,
-``CurvatureComponent``), improving documentation and demonstrating their usage.
+``CurvatureComponent``, ``DarkEnergyComponent``), improving documentation and
+demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,4 +1,4 @@
 Added docstring examples to cosmology traits (``BaryonComponent``, ``CriticalDensity``,
 ``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``,
-``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``, ``ScaleFactor``),
-improving documentation and demonstrating their usage.
+``HubbleParameter``, ``MatterComponent``, ``PhotonComponent``, ``ScaleFactor``, and
+``TemperatureCMB``), improving documentation and demonstrating their usage.

--- a/docs/changes/cosmology/18875.feature.rst
+++ b/docs/changes/cosmology/18875.feature.rst
@@ -1,3 +1,3 @@
 Added docstring examples to cosmology traits (``BaryonComponent``,
-``CurvatureComponent``, ``DarkEnergyComponent``), improving documentation and
-demonstrating their usage.
+``CurvatureComponent``, ``DarkEnergyComponent``, ``DarkMatterComponent``), improving
+documentation and demonstrating their usage.


### PR DESCRIPTION
Illustrative examples.
The target audience of these classes are devs, whom already have their intended physics and want illustrative examples when writing the code.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
