### PR TITLE
TST/DEP: drop pytest-cov in favor of using coverage.py directly

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -136,11 +136,11 @@ affected test(s).
 Test coverage reports
 ---------------------
 
-Coverage reports can be generated using the `pytest-cov
-<https://pypi.org/project/pytest-cov/>`_ plugin (which is installed
-automatically when installing pytest-astropy) by using e.g.::
+Coverage reports can be generated using the coverage (which is installed
+automatically when installing astropy with the ``test`` extra) by using e.g.::
 
-    pytest --cov astropy --cov-report html
+    coverage run -m pytest astropy
+    coverage html
 
 There is some configuration inside the ``pyproject.toml`` file that
 defines files to omit as well as lines to exclude.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,9 @@ archs = ["auto", "aarch64"]
             "*/astropy/utils/compat/*",
             "*/astropy/version*",
             "*/astropy/wcs/docstrings*",
+            # generated test files
+            "*/test_parsing_lextab_*.py",
+            "*/test_parsing_parsetab_*.py",
         ]
 
     [tool.coverage.report]

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,8 @@ commands =
     docdeps-predeps: uv pip install sphinx -U --pre --no-deps
     {list_dependencies_command}
     !cov-!double: pytest --strict-markers --pyargs astropy "{toxinidir}/docs" {env:MPLFLAGS} {posargs}
-    cov-!double: pytest --strict-markers --pyargs astropy "{toxinidir}/docs" {env:MPLFLAGS} --cov astropy --cov-config="{toxinidir}/pyproject.toml" --cov-report xml:"{toxinidir}/coverage.xml" {posargs}
+    cov-!double: coverage run --rcfile="{toxinidir}/pyproject.toml" -m pytest --strict-markers --pyargs astropy "{toxinidir}/docs" {env:MPLFLAGS} astropy {posargs}
+    cov-!double: coverage xml --rcfile="{toxinidir}/pyproject.toml"
 
     double: pytest --keep-duplicates --strict-markers --pyargs astropy "{toxinidir}/docs" astropy "{toxinidir}/docs" {env:MPLFLAGS} {posargs}
 


### PR DESCRIPTION
### Description
ref: #18878

This PR makes pytest-cov unused. As mentionned on the issue, however, removing pytest-cov from the env graph will also require #18783. 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
