### PR TITLE
BUG: warn instead of raise when failing to read specific files in fitsdiff script

### DIFF
--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -400,20 +400,29 @@ def main(args=None):
     try:
         for a, b in files:
             # TODO: pass in any additional arguments here too
-            diff = fits.diff.FITSDiff(
-                a,
-                b,
-                ignore_hdus=opts.ignore_hdus,
-                ignore_keywords=opts.ignore_keywords,
-                ignore_comments=opts.ignore_comments,
-                ignore_fields=opts.ignore_fields,
-                numdiffs=opts.numdiffs,
-                rtol=opts.rtol,
-                atol=opts.atol,
-                ignore_blanks=opts.ignore_blanks,
-                ignore_blank_cards=opts.ignore_blank_cards,
-            )
-
+            try:
+                diff = fits.diff.FITSDiff(
+                    a,
+                    b,
+                    ignore_hdus=opts.ignore_hdus,
+                    ignore_keywords=opts.ignore_keywords,
+                    ignore_comments=opts.ignore_comments,
+                    ignore_fields=opts.ignore_fields,
+                    numdiffs=opts.numdiffs,
+                    rtol=opts.rtol,
+                    atol=opts.atol,
+                    ignore_blanks=opts.ignore_blanks,
+                    ignore_blank_cards=opts.ignore_blank_cards,
+                )
+            except OSError:
+                if not opts.quiet:
+                    msg = f"Warning: failed to open {a}"
+                    if b != a:
+                        msg += f" (or {b})"
+                    msg += ". Skipping."
+                    print(msg, file=sys.stderr)
+                identical.append(None)
+                continue
             diff.report(fileobj=out_file)
             identical.append(diff.identical)
 

--- a/docs/changes/io.fits/18882.bugfix.rst
+++ b/docs/changes/io.fits/18882.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug in ``fitsdiff`` script where failing to read a single file could
+crash the entire program. A warning is now printed instead, and such files
+are simply ignored.


### PR DESCRIPTION
### Description
Fixes #18880

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
