### PR TITLE
style(cosmo): update `__all__` across modules

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -7,27 +7,7 @@ measures and other cosmology-related calculations.
 See the :ref:`astropy-cosmology` for more detailed usage examples and references.
 """
 
-from . import io, realizations, traits, units
-from ._src.core import Cosmology, CosmologyError, FlatCosmologyMixin
-from ._src.flrw import (
-    FLRW,
-    FlatFLRWMixin,
-    FlatLambdaCDM,
-    Flatw0waCDM,
-    Flatw0wzCDM,
-    FlatwCDM,
-    FlatwpwaCDM,
-    LambdaCDM,
-    w0waCDM,
-    w0wzCDM,
-    wCDM,
-    wpwaCDM,
-)
-from ._src.funcs import cosmology_equal, z_at_value
-from ._src.parameter import Parameter
-from .realizations import available, default_cosmology
-
-__all__ = [  #  noqa: RUF100, RUF022
+__all__ = (  #  noqa: RUF100, RUF022
     # Public Submodules
     "realizations",
     "units",
@@ -66,7 +46,27 @@ __all__ = [  #  noqa: RUF100, RUF022
     "Planck13",
     "Planck15",
     "Planck18",
-]
+)
+
+from . import io, realizations, traits, units
+from ._src.core import Cosmology, CosmologyError, FlatCosmologyMixin
+from ._src.flrw import (
+    FLRW,
+    FlatFLRWMixin,
+    FlatLambdaCDM,
+    Flatw0waCDM,
+    Flatw0wzCDM,
+    FlatwCDM,
+    FlatwpwaCDM,
+    LambdaCDM,
+    w0waCDM,
+    w0wzCDM,
+    wCDM,
+    wpwaCDM,
+)
+from ._src.funcs import cosmology_equal, z_at_value
+from ._src.parameter import Parameter
+from .realizations import available, default_cosmology
 
 
 def __getattr__(name: str) -> Cosmology:

--- a/astropy/cosmology/_src/core.py
+++ b/astropy/cosmology/_src/core.py
@@ -1,5 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Originally authored by Andrew Becker (becker@astro.washington.edu),
+# and modified by Neil Crighton (neilcrighton@gmail.com), Roban Kramer
+# (robanhk@gmail.com), and Nathaniel Starkman (n.starkman@mail.utoronto.ca).
 
+# Many of these adapted from Hogg 1999, astro-ph/9905116
+# and Linder 2003, PRL 90, 91301
+
+__all__ = ("Cosmology", "CosmologyError", "FlatCosmologyMixin")
 
 import inspect
 from abc import ABCMeta, abstractmethod
@@ -27,16 +34,6 @@ from astropy.cosmology.io import (
     CosmologyToFormat,
     CosmologyWrite,
 )
-
-# Originally authored by Andrew Becker (becker@astro.washington.edu),
-# and modified by Neil Crighton (neilcrighton@gmail.com), Roban Kramer
-# (robanhk@gmail.com), and Nathaniel Starkman (n.starkman@mail.utoronto.ca).
-
-# Many of these adapted from Hogg 1999, astro-ph/9905116
-# and Linder 2003, PRL 90, 91301
-
-__all__ = ["Cosmology", "CosmologyError", "FlatCosmologyMixin"]
-
 
 ##############################################################################
 # Parameters

--- a/astropy/cosmology/_src/default.py
+++ b/astropy/cosmology/_src/default.py
@@ -1,7 +1,7 @@
 """Default Cosmology."""
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["default_cosmology"]
+__all__ = ("default_cosmology",)
 
 
 from typing import ClassVar

--- a/astropy/cosmology/_src/flrw/__init__.py
+++ b/astropy/cosmology/_src/flrw/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Astropy FLRW classes."""
 
-__all__ = [  # noqa: RUF100, RUF022
+__all__ = (  # noqa: RUF100, RUF022
     # base
     "FLRW",
     "FlatFLRWMixin",
@@ -20,7 +20,7 @@ __all__ = [  # noqa: RUF100, RUF022
     # wpwazpcdm
     "wpwaCDM",
     "FlatwpwaCDM",
-]
+)
 
 from .base import FLRW, FlatFLRWMixin
 from .lambdacdm import FlatLambdaCDM, LambdaCDM

--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["FLRW", "FlatFLRWMixin"]
+__all__ = ("FLRW", "FlatFLRWMixin")
 
 import inspect
 import warnings

--- a/astropy/cosmology/_src/flrw/lambdacdm.py
+++ b/astropy/cosmology/_src/flrw/lambdacdm.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = ("FlatLambdaCDM", "LambdaCDM")
+
 from math import acos, cos, inf, sin, sqrt
 from numbers import Number
 
@@ -16,8 +18,6 @@ from astropy.units import Quantity
 
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
-
-__all__ = ["FlatLambdaCDM", "LambdaCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/_src/flrw/w0cdm.py
+++ b/astropy/cosmology/_src/flrw/w0cdm.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = ("FlatwCDM", "wCDM")
 
 import numpy as np
 from numpy import sqrt
@@ -13,8 +14,6 @@ from astropy.units import Quantity
 
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
-
-__all__ = ["FlatwCDM", "wCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/_src/flrw/w0wacdm.py
+++ b/astropy/cosmology/_src/flrw/w0wacdm.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = ("Flatw0waCDM", "w0waCDM")
 
 from numpy import exp
 from numpy.typing import ArrayLike
@@ -12,8 +13,6 @@ from astropy.units import Quantity
 
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
-
-__all__ = ["Flatw0waCDM", "w0waCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/_src/flrw/w0wzcdm.py
+++ b/astropy/cosmology/_src/flrw/w0wzcdm.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = ("Flatw0wzCDM", "w0wzCDM")
 
 from numpy import exp
 from numpy.typing import ArrayLike
@@ -12,8 +13,6 @@ from astropy.units import Quantity
 
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
-
-__all__ = ["Flatw0wzCDM", "w0wzCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/_src/flrw/wpwazpcdm.py
+++ b/astropy/cosmology/_src/flrw/wpwazpcdm.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = ("FlatwpwaCDM", "wpwaCDM")
 
 from numpy import exp
 from numpy.typing import ArrayLike
@@ -13,8 +14,6 @@ from astropy.units import Quantity
 
 from . import scalar_inv_efuncs
 from .base import FLRW, FlatFLRWMixin
-
-__all__ = ["FlatwpwaCDM", "wpwaCDM"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/_src/funcs/__init__.py
+++ b/astropy/cosmology/_src/funcs/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions for `astropy.cosmology`."""
 
-__all__ = ["cosmology_equal", "z_at_value"]
+__all__ = ("cosmology_equal", "z_at_value")
 
 from .comparison import cosmology_equal
 from .optimize import z_at_value

--- a/astropy/cosmology/_src/funcs/optimize.py
+++ b/astropy/cosmology/_src/funcs/optimize.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Convenience functions for `astropy.cosmology`."""
 
+__all__ = ("z_at_value",)
+
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, NotRequired, Protocol, TypeAlias, TypedDict
@@ -19,8 +21,6 @@ from astropy.cosmology._src.typing import FArray
 
 if TYPE_CHECKING:
     import scipy.optimize
-
-__all__ = ["z_at_value"]
 
 __doctest_requires__ = {"*": ["scipy"]}
 

--- a/astropy/cosmology/_src/io/connect.py
+++ b/astropy/cosmology/_src/io/connect.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = [
+__all__ = (
     # classes
     "CosmologyFromFormat",
     "CosmologyRead",
     "CosmologyToFormat",
     "CosmologyWrite",
-]
+)
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload

--- a/astropy/cosmology/_src/parameter/__init__.py
+++ b/astropy/cosmology/_src/parameter/__init__.py
@@ -1,7 +1,7 @@
 """Cosmological Parameters. Private API."""
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = [  # noqa: RUF100, RUF022
+__all__ = (  # noqa: RUF100, RUF022
     "Parameter",
     "ParametersAttribute",
     "MISSING",
@@ -11,7 +11,7 @@ __all__ = [  # noqa: RUF100, RUF022
     "validate_to_float",
     "validate_to_scalar",
     "validate_non_negative",
-]
+)
 
 from .converter import (
     validate_non_negative,

--- a/astropy/cosmology/_src/parameter/converter.py
+++ b/astropy/cosmology/_src/parameter/converter.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = [
+__all__ = (
     "validate_non_negative",
     "validate_to_float",
     "validate_to_scalar",
     "validate_with_unit",
-]
+)
 
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any

--- a/astropy/cosmology/_src/parameter/core.py
+++ b/astropy/cosmology/_src/parameter/core.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["MISSING", "Parameter"]
+__all__ = ("MISSING", "Parameter")
 
 import copy
 from collections.abc import Sequence

--- a/astropy/cosmology/_src/scipy_compat.py
+++ b/astropy/cosmology/_src/scipy_compat.py
@@ -1,10 +1,10 @@
 """Scipy compatibility."""
 
+__all__ = ("ellipkinc", "hyp2f1", "quad")
+
 from typing import Any, Never
 
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-
-__all__ = ("ellipkinc", "hyp2f1", "quad")
 
 if HAS_SCIPY:
     from scipy.integrate import quad

--- a/astropy/cosmology/_src/tests/helper.py
+++ b/astropy/cosmology/_src/tests/helper.py
@@ -5,13 +5,13 @@ This module provides the tools used to internally run the cosmology test suite
 from the installed astropy.  It makes use of the |pytest| testing framework.
 """
 
+__all__ = ("clean_registry", "get_redshift_methods")
+
 import inspect
 
 import pytest
 
 from astropy.cosmology._src import core
-
-__all__ = ["clean_registry", "get_redshift_methods"]
 
 ###############################################################################
 # FUNCTIONS

--- a/astropy/cosmology/_src/traits/__init__.py
+++ b/astropy/cosmology/_src/traits/__init__.py
@@ -4,7 +4,7 @@
 The public API is provided by `astropy.cosmology.traits`.
 """
 
-__all__ = [
+__all__ = (
     "BaryonComponent",
     "CriticalDensity",
     "CurvatureComponent",
@@ -16,7 +16,7 @@ __all__ = [
     "ScaleFactor",
     "TemperatureCMB",
     "TotalComponent",
-]
+)
 
 from .baryons import BaryonComponent
 from .curvature import CurvatureComponent

--- a/astropy/cosmology/_src/traits/baryons.py
+++ b/astropy/cosmology/_src/traits/baryons.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Baryon component."""
 
-__all__ = ["BaryonComponent"]
+__all__ = ("BaryonComponent",)
 
 from collections.abc import Callable
 from typing import Any

--- a/astropy/cosmology/_src/traits/curvature.py
+++ b/astropy/cosmology/_src/traits/curvature.py
@@ -5,7 +5,7 @@ This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
 
-__all__ = ["CurvatureComponent"]
+__all__ = ("CurvatureComponent",)
 
 import abc
 

--- a/astropy/cosmology/_src/traits/darkmatter.py
+++ b/astropy/cosmology/_src/traits/darkmatter.py
@@ -1,4 +1,6 @@
-__all__ = ["DarkMatterComponent"]
+"""Trait for dark matter component of cosmology."""
+
+__all__ = ("DarkMatterComponent",)
 
 from collections.abc import Callable
 from typing import Any

--- a/astropy/cosmology/_src/traits/hubble.py
+++ b/astropy/cosmology/_src/traits/hubble.py
@@ -4,7 +4,7 @@
 This is private API. See `~astropy.cosmology.traits` for public API.
 """
 
-__all__ = ["HubbleParameter"]
+__all__ = ("HubbleParameter",)
 
 from collections.abc import Callable
 from functools import cached_property

--- a/astropy/cosmology/_src/traits/matterdensity.py
+++ b/astropy/cosmology/_src/traits/matterdensity.py
@@ -6,7 +6,7 @@ from astropy.cosmology._src.typing import FArray
 from astropy.cosmology._src.utils import aszarr, deprecated_keywords
 from astropy.units import Quantity
 
-__all__ = ["MatterComponent"]
+__all__ = ("MatterComponent",)
 
 
 class MatterComponent:

--- a/astropy/cosmology/_src/traits/photoncomponent.py
+++ b/astropy/cosmology/_src/traits/photoncomponent.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Photon component."""
 
-__all__ = ["PhotonComponent"]
+__all__ = ("PhotonComponent",)
 
 from collections.abc import Callable
 from typing import Any

--- a/astropy/cosmology/_src/traits/rhocrit.py
+++ b/astropy/cosmology/_src/traits/rhocrit.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Critical density component."""
 
-__all__ = ["CriticalDensity"]
+__all__ = ("CriticalDensity",)
 
 from collections.abc import Callable
 from typing import Any

--- a/astropy/cosmology/_src/traits/scale_factor.py
+++ b/astropy/cosmology/_src/traits/scale_factor.py
@@ -5,7 +5,7 @@ This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
 
-__all__ = ["ScaleFactor"]
+__all__ = ("ScaleFactor",)
 
 
 from numpy.typing import ArrayLike

--- a/astropy/cosmology/_src/traits/tcmb.py
+++ b/astropy/cosmology/_src/traits/tcmb.py
@@ -5,7 +5,7 @@ This is private API. See `~astropy.cosmology.traits` for public API.
 
 """
 
-__all__ = ["TemperatureCMB"]
+__all__ = ("TemperatureCMB",)
 
 
 from numpy.typing import ArrayLike

--- a/astropy/cosmology/_src/traits/totalcomponent.py
+++ b/astropy/cosmology/_src/traits/totalcomponent.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["TotalComponent"]
+__all__ = ("TotalComponent",)
 
 from abc import abstractmethod
 

--- a/astropy/cosmology/_src/typing.py
+++ b/astropy/cosmology/_src/typing.py
@@ -1,7 +1,7 @@
 """Static typing for :mod:`astropy.cosmology`. PRIVATE API."""
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["CosmoMeta", "FArray", "_CosmoT"]
+__all__ = ("CosmoMeta", "FArray", "_CosmoT")
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar

--- a/astropy/cosmology/_src/units.py
+++ b/astropy/cosmology/_src/units.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cosmological units."""
 
-__all__ = ["littleh", "redshift"]
+__all__ = ("littleh", "redshift")
 
 from typing import Final
 

--- a/astropy/cosmology/_src/units_equivalencies.py
+++ b/astropy/cosmology/_src/units_equivalencies.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cosmological unit equivalencies."""
 
-__all__ = [
+__all__ = (
     # redshift equivalencies
     "dimensionless_redshift",
     "redshift_distance",
@@ -10,7 +10,7 @@ __all__ = [
     # other equivalencies
     "with_H0",
     "with_redshift",
-]
+)
 
 
 import sys

--- a/astropy/cosmology/io.py
+++ b/astropy/cosmology/io.py
@@ -13,14 +13,14 @@ on the `~astropy.cosmology.Cosmology` class (and its subclasses) and its instanc
 - |Cosmology.to_format| to convert a Cosmology to an object
 """
 
-__all__ = [
+__all__ = (
     "CosmologyFromFormat",
     "CosmologyRead",
     "CosmologyToFormat",
     "CosmologyWrite",
     "convert_registry",
     "readwrite_registry",
-]
+)
 
 # Importing the I/O subpackage registers the I/O methods.
 from ._src.io.connect import (

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -9,8 +9,9 @@ from types import MappingProxyType
 
 from .realizations import available
 
-__all__ = ["available"]
-__all__ += [  # noqa: F822
+__all__ = (  # noqa: F822, RUF022
+    "available",
+    # ----
     "WMAP1",
     "WMAP3",
     "WMAP5",
@@ -19,7 +20,7 @@ __all__ += [  # noqa: F822
     "Planck13",
     "Planck15",
     "Planck18",
-]
+)
 
 
 def __getattr__(name):

--- a/astropy/cosmology/traits.py
+++ b/astropy/cosmology/traits.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Traits for building ``astropy`` :class:`~astropy.cosmology.Cosmology` classes."""
 
-__all__ = [
+__all__ = (
     "BaryonComponent",
     "CriticalDensity",
     "CurvatureComponent",
@@ -13,7 +13,7 @@ __all__ = [
     "ScaleFactor",
     "TemperatureCMB",
     "TotalComponent",
-]
+)
 
 from ._src.traits import (
     BaryonComponent,

--- a/astropy/cosmology/units.py
+++ b/astropy/cosmology/units.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cosmological units and equivalencies."""
 
-from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
-
-__all__ = [
+__all__ = (
     # redshift equivalencies
     "dimensionless_redshift",
     "littleh",
@@ -14,10 +12,10 @@ __all__ = [
     # other equivalencies
     "with_H0",
     "with_redshift",
-]
-
+)
 
 from astropy.units import add_enabled_equivalencies as _add_enabled_equivalencies
+from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
 
 from ._src.units import littleh, redshift
 from ._src.units_equivalencies import (


### PR DESCRIPTION
This PR does a few things:

1. Makes most `__all__` into tuples to signify their immutability.
2. Moves most `__all__` into the PEP8-recommended location. This actually isn't the most standard location (which is below all imports), but I prefer it because it makes it much more obvious when code is dynamically modifying `__all__`,  which should generally be avoided.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
