### PR TITLE
BUG: fix forward compatibility with numpy 2.4 (dev) in `np.array2string` helper function and tests

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -1327,15 +1327,10 @@ def array2string(a, *args, **kwargs):
     # also work around this by passing on a formatter (as is done in Angle).
     # So, we do nothing if the formatter argument is present and has the
     # relevant formatter for our dtype.
-    import inspect
-
-    sig = inspect.signature(np.array2string)
-    formatter_arg_pos = list(sig.parameters).index("formatter") - 1
-    formatter = (
-        args[formatter_arg_pos]
-        if len(args) >= formatter_arg_pos
-        else kwargs.get("formatter")
-    )
+    if NUMPY_LT_2_4:
+        formatter = args[6] if len(args) >= 7 else kwargs.get("formatter")
+    else:
+        formatter = kwargs.get("formatter")
 
     if formatter is None:
         a = a.value

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2068,10 +2068,8 @@ class TestStringFunctions:
         # Also as positional argument (no, nobody will do this!)
         if NUMPY_LT_2_4:
             args = (self.q, None, None, None, ", ", "", np._NoValue, {"float": str})
-        else:
-            args = (self.q, None, None, None, ", ", "", {"float": str})
-        out3 = np.array2string(*args)
-        assert out3 == expected2
+            out3 = np.array2string(*args)
+            assert out3 == expected2
         # But not if the formatter is not relevant for us.
         out4 = np.array2string(self.q, separator=", ", formatter={"int": str})
         assert out4 == expected1


### PR DESCRIPTION
### Description
follow up to https://github.com/astropy/astropy/pull/18821
xref: https://github.com/numpy/numpy/pull/30139

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
