### PR TITLE
BUG: fix forward compatibility with numpy 2.4 (dev) in `np.array2string` helper function and tests (utils.masked)

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1348,13 +1348,13 @@ if not NUMPY_LT_2_4:
         suppress_small=None,
         separator=" ",
         prefix="",
+        *,
         formatter=None,
         threshold=None,
         edgeitems=None,
         sign=None,
         floatmode=None,
         suffix="",
-        *,
         legacy=None,
     ):
         return _array2string_main(

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -1301,10 +1301,8 @@ class TestStringFunctions:
         # Also as positional argument (no, nobody will do this!)
         if NUMPY_LT_2_4:
             args = (self.ma, None, None, None, ", ", "", np._NoValue, {"int": hex})
-        else:
-            args = (self.ma, None, None, None, ", ", "", {"int": hex})
-        out3 = np.array2string(*args)
-        assert out3 == out2
+            out3 = np.array2string(*args)
+            assert out3 == out2
         # But not if the formatter is not relevant for us.
         out4 = np.array2string(self.ma, separator=", ", formatter={"float": hex})
         assert out4 == out1


### PR DESCRIPTION
### Description
This is the same as #18885, this time for `utils.masked`


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
