### PR TITLE
TST: use `--strict-markers` when running pytest with `--pyargs`

### DIFF
--- a/.github/workflows/ci_cron_monthly.yml
+++ b/.github/workflows/ci_cron_monthly.yml
@@ -104,4 +104,4 @@ jobs:
             pip install -U --no-build-isolation pyerfa
             pip install -v --no-build-isolation -e .[test]
             pip list
-            python3 -m pytest --pyargs astropy -m "not hypothesis"
+            python3 -m pytest --strict-markers --pyargs astropy -m "not hypothesis"

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -185,4 +185,4 @@ jobs:
             pip install -U --no-build-isolation pyerfa
             ASTROPY_USE_SYSTEM_ALL=1 pip install -v --no-build-isolation -e .[test]
             pip list
-            python3 -m pytest --pyargs astropy -m "not hypothesis"
+            python3 -m pytest --strict-markers --pyargs astropy -m "not hypothesis"

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -145,7 +145,7 @@ jobs:
       upload_to_pypi: false
       upload_to_anaconda: false
       test_extras: test
-      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --pyargs astropy
+      test_command: pytest -Wdefault --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --strict-markers --pyargs astropy
       targets: |
         - cp311-manylinux_x86_64
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
       # currently fails, see https://github.com/astropy/astropy/issues/10409
       # We also exclude test_set_locale as it sometimes relies on the correct locale
       # packages being installed, which it isn't always.
-      test_command: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --pyargs astropy
+      test_command: pytest -Wdefault --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_set_locale and not TestQuantityTyping" --strict-markers --pyargs astropy
       targets: |
         # Linux wheels
         - cp3*-manylinux_x86_64

--- a/tox.ini
+++ b/tox.ini
@@ -119,10 +119,10 @@ dependency-groups =
 
 commands =
     {list_dependencies_command}
-    !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
-    cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
+    !cov-!double: pytest --strict-markers --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    cov-!double: pytest --strict-markers --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
 
-    double: pytest --keep-duplicates --pyargs astropy {toxinidir}/docs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    double: pytest --keep-duplicates --strict-markers --pyargs astropy {toxinidir}/docs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
 
 pip_pre =
     devdeps: true


### PR DESCRIPTION
### Description

extracted from #18784.
Enabling this option makes a tremendous difference in debugging the kind of problems I'm hitting in that PR.
In brief, `--pyargs astropy` is used to test an *installed package* in place, so any test marker defined in the repo-level `conftest.py` is undefined. By default, pytest warns about such markers, but doesn't raise. The `--strict-markers` flag requires that all markers are defined.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
