### PR TITLE
TST: stop running slow tests on macOS

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -92,7 +92,7 @@ jobs:
 
         - name: Python 3.12 with all optional dependencies (MacOS X)
           macos: py312-test-alldeps
-          posargs: --durations=50 --run-slow
+          posargs: --durations=50
           runs-on: macos-latest
 
         # FIXME: Add aarch64 to name when bump Python version.


### PR DESCRIPTION
### Description
I noticed that macOS CI was extraordinarily slow as of late (this job takes about an hour, VS ~10min for comparable jobs).
Let's see if this is sufficient to make it complete under 15min.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
