### PR TITLE
TST/DEP: bump minimal requirement on `pytest-astropy` to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,11 @@ all = [
 # The base set of test-time dependencies.
 test = [
     "coverage>=7.2.0",
+    "hypothesis>=6.84.0",
     "pytest>=8.0.0",
     "pytest-doctestplus>=1.4.0",
     "pytest-astropy-header>=0.2.1",
-    "pytest-astropy>=0.10.0",
+    "pytest-astropy>=0.11.0",
     "pytest-xdist>=3.6.0",
     "threadpoolctl>=3.0.0",
 ]


### PR DESCRIPTION
### Description
ref: https://github.com/astropy/astropy/issues/18782
This supersedes #18780, with the benefit of not requiring additional warning filters.

obviously in conflict with #18784; but that other PR is currently stuck any way. To be clear, I still want to move forward on #18784, but this is an incremental, yet useful, step towards the end goal.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
