### PR TITLE
TST/DEP: add `contourpy` and `pillow` to the list of package we never want to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -732,11 +732,13 @@ ignore-words-list = """
 # with binary distributions even with --resolution=lowest[-direct]
 no-build-package = [
     "bottleneck",
+    "contourpy",
     "coverage",
     "h5py",
     "numpy",
     "matplotlib",
     "pandas",
+    "pillow",
     "polars",
     "scipy",
     "sgp4",


### PR DESCRIPTION
### Description
ref: #18782
extracted from #18780
for reference, both contourpy and pillow are transitive (optional) dependencies via matplotlib, and contain compiled code, so it's wasteful to build them from source.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
