### PR TITLE
TST: stop skipping signature checks for numpy functions missing a runtime signature (for sufficiently recent versions of numpy)

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2927,7 +2927,10 @@ class CheckSignatureCompatibilityBase:
         try:
             sig_target = inspect.signature(target)
         except ValueError:
-            pytest.skip("Non Python function cannot be inspected at runtime")
+            if NUMPY_LT_2_4:
+                pytest.skip("Non Python function cannot be inspected at runtime")
+            else:
+                raise
 
         params_target = sig_target.parameters
         sig_helper = inspect.signature(helper)
@@ -2988,7 +2991,10 @@ class CheckSignatureCompatibilityBase:
         try:
             sig_target = inspect.signature(target)
         except ValueError:
-            pytest.skip("Non Python function cannot be inspected at runtime")
+            if NUMPY_LT_2_4:
+                pytest.skip("Non Python function cannot be inspected at runtime")
+            else:
+                raise
 
         params_target = sig_target.parameters
         sig_helper = inspect.signature(helper)


### PR DESCRIPTION
### Description
close #18842


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
