### PR TITLE
Revert "Remove `version` module"

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -62,7 +62,7 @@ def __dir__():
 
 
 from . import config as _config
-from ._version import version as __version__
+from .version import version as __version__
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -25,8 +25,8 @@ from urllib.parse import urlencode
 
 import numpy as np
 
-from astropy._version import version as __version__
 from astropy.utils import deprecated
+from astropy.version import version as __version__
 
 __all__ = [
     "JsonCustomEncoder",

--- a/astropy/version.py
+++ b/astropy/version.py
@@ -1,0 +1,35 @@
+from packaging.version import Version
+
+try:
+    from ._version import version
+except ImportError:
+    import warnings
+
+    warnings.warn(
+        f"could not determine {__name__.split('.')[0]} package version; "
+        "this indicates a broken installation"
+    )
+    del warnings
+
+    version = "0.0.0"
+
+
+# We use Version to define major, minor, micro, but ignore any suffixes.
+def split_version(version):
+    pieces = [0, 0, 0]
+
+    try:
+        v = Version(version)
+        pieces = [v.major, v.minor, v.micro]
+
+    except Exception:
+        pass
+
+    return pieces
+
+
+major, minor, bugfix = split_version(version)
+
+del split_version  # clean up namespace.
+
+release = "dev" not in version


### PR DESCRIPTION
Reverts astropy/astropy#18887

If you want to go ahead with the removal of this module, please go through the usual deprecation cycle first.

