### PR TITLE
MNT: adjust ruff configuration table (noop)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,11 +405,6 @@ lint.extend-select = [
     "W",     # pycodestyle
     "YTT",   # flake8-2020
 ]
-exclude=[
-    "astropy/extern/*",
-    "*_parsetab.py",
-    "*_lextab.py"
-]
 lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
 
     # flake8-builtins (A) : shadowing a Python built-in.
@@ -476,6 +471,11 @@ lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml
 
     # flake8-todos (TD)
     "TD002",  # Missing author in TODO
+]
+exclude = [
+    "astropy/extern/*",
+    "*_parsetab.py",
+    "*_lextab.py"
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
### Description

This is a pure noop reformatting of the tool configuration. Why would anyone care ? glad you asked. This is a very small QoL improvement for myself or anyone who uses `uv add` in development. Basically, this just  works around a bug in uv that actually originates in another rust crate (`toml`), but it doesn't look like it'll be fixed there any time soon.

xref:
- https://github.com/astral-sh/uv/issues/16719#issuecomment-3527484267
- https://github.com/toml-rs/toml/issues/163

BTW, this one is on the house; I do not intend to bill a *workaround* for an *upstream*, *minor* inconvenience that probably doesn't affect any one else.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
