### PR TITLE
TST/DEP: bump minimal requirement on `pytest-mpl` to 0.18.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
 
     image: latex
     image, devinfra: scipy
-    image: pytest-mpl>=0.17
+    image: pytest-mpl>=0.18
 
     # Some FITS tests use fitsio as a comparison
     fitsio: fitsio


### PR DESCRIPTION
### Description
ref #18782, in order to benefit from https://github.com/matplotlib/pytest-mpl/pull/252


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
