### PR TITLE
TST: make an explicit escape path to skip the single known case of a missing runtime signature in numpy 2.4 (np.fromstring)

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2930,6 +2930,8 @@ class CheckSignatureCompatibilityBase:
         except ValueError:
             if NUMPY_LT_2_4:
                 pytest.skip("Non Python function cannot be inspected at runtime")
+            elif target is np.fromstring:
+                pytest.skip(f"known case of missing runtime signature ({target})")
             else:
                 raise
 
@@ -2994,6 +2996,8 @@ class CheckSignatureCompatibilityBase:
         except ValueError:
             if NUMPY_LT_2_4:
                 pytest.skip("Non Python function cannot be inspected at runtime")
+            elif target is np.fromstring:
+                pytest.skip(f"known case of missing runtime signature ({target})")
             else:
                 raise
 


### PR DESCRIPTION
### Description

follow up to #18899
xref: https://github.com/numpy/numpy/pull/30235

I'm ahead of numpy nightlies here but the patch should be flexible enough to pass CI now.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
