### PR TITLE
TST: simplify a warning-capturing test

### DIFF
--- a/astropy/table/tests/test_df.py
+++ b/astropy/table/tests/test_df.py
@@ -417,12 +417,10 @@ class TestDataFrameConversion:
             self._from_dataframe(df, backend, use_legacy_pandas_api, units=[u.m, u.s])
 
         # test warning is raised if additional columns in units dict
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning, match="{'y'}"):
             self._from_dataframe(
                 df, backend, use_legacy_pandas_api, units={"x": u.m, "t": u.s, "y": u.m}
             )
-        assert len(record) == 1
-        assert "{'y'}" in str(record[0].message.args[0])
 
     @pytest.mark.parametrize("unsigned", ["u", ""])
     @pytest.mark.parametrize("bits", [8, 16, 32, 64])


### PR DESCRIPTION
### Description
I stumbled upon a failure mode of this test case while working on #18782, and it took me longer than it should have to figure out what was happening. This should be a simple refactor, but a QoL improvement for debugging.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
