### PR TITLE
Drop support for `numpy<1.25`

### DIFF
--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -12,19 +12,13 @@ from astropy.coordinates import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
-from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 
 from .test_representation import representation_equal
 
 
-@pytest.fixture(params=[True, False] if ARRAY_FUNCTION_ENABLED else [True])
+@pytest.fixture(params=[True, False])
 def method(request):
     return request.param
-
-
-needs_array_function = pytest.mark.xfail(
-    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
-)
 
 
 class ShapeSetup:
@@ -302,7 +296,6 @@ class TestSetShape(ShapeSetup):
 
 
 class TestShapeFunctions(ShapeSetup):
-    @needs_array_function
     def test_broadcast_to(self):
         s0_broadcast = np.broadcast_to(self.s0, (3, 6, 7))
         s0_diff = s0_broadcast.differentials["s"]
@@ -339,7 +332,6 @@ class TestShapeFunctions(ShapeSetup):
         sc.lon[0, 0] = 22.0 * u.hourangle
         assert np.all(sc_broadcast.lon[:, 0, 0] == 22.0 * u.hourangle)
 
-    @needs_array_function
     def test_atleast_1d(self):
         s00 = self.s0.ravel()[0]
         assert s00.ndim == 0
@@ -348,7 +340,6 @@ class TestShapeFunctions(ShapeSetup):
         assert np.all(representation_equal(s00[np.newaxis], s00_1d))
         assert np.may_share_memory(s00_1d.lon, s00.lon)
 
-    @needs_array_function
     def test_atleast_2d(self):
         s0r = self.s0.ravel()
         assert s0r.ndim == 1
@@ -357,7 +348,6 @@ class TestShapeFunctions(ShapeSetup):
         assert np.all(representation_equal(s0r[np.newaxis], s0r_2d))
         assert np.may_share_memory(s0r_2d.lon, s0r.lon)
 
-    @needs_array_function
     def test_atleast_3d(self):
         assert self.s0.ndim == 2
         s0_3d, s1_3d = np.atleast_3d(self.s0, self.s1)
@@ -380,25 +370,21 @@ class TestShapeFunctions(ShapeSetup):
         assert np.all(representation_equal(self.s0.T, s0_10))
         assert np.may_share_memory(s0_10.lon, self.s0.lon)
 
-    @needs_array_function
     def test_fliplr(self):
         s0_lr = np.fliplr(self.s0)
         assert np.all(representation_equal(self.s0[:, ::-1], s0_lr))
         assert np.may_share_memory(s0_lr.lon, self.s0.lon)
 
-    @needs_array_function
     def test_rot90(self):
         s0_270 = np.rot90(self.s0, 3)
         assert np.all(representation_equal(self.s0.T[:, ::-1], s0_270))
         assert np.may_share_memory(s0_270.lon, self.s0.lon)
 
-    @needs_array_function
     def test_roll(self):
         s0r = np.roll(self.s0, 1, axis=0)
         assert np.all(representation_equal(s0r[1:], self.s0[:-1]))
         assert np.all(representation_equal(s0r[0], self.s0[-1]))
 
-    @needs_array_function
     def test_delete(self):
         s0d = np.delete(self.s0, [2, 3], axis=0)
         assert np.all(representation_equal(s0d[:2], self.s0[:2]))

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -11,17 +11,11 @@ from astropy.coordinates import EarthLocation, Latitude, Longitude, SkyCoord
 from astropy.coordinates.builtin_frames import GCRS, ICRS, AltAz
 from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.time import Time
-from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 
 
-@pytest.fixture(params=[True, False] if ARRAY_FUNCTION_ENABLED else [True])
+@pytest.fixture(params=[True, False])
 def method(request):
     return request.param
-
-
-needs_array_function = pytest.mark.xfail(
-    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
-)
 
 
 class ShapeSetup:
@@ -333,7 +327,6 @@ class TestManipulation(ShapeSetup):
 
     # Much more detailed tests of shape manipulation via numpy functions done
     # in test_representation_methods.
-    @needs_array_function
     def test_broadcast_to(self):
         s1_broadcast = np.broadcast_to(self.s1, (20, 6, 7))
         assert s1_broadcast.shape == (20, 6, 7)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,7 @@ from astropy import log
 from astropy.io.registry import UnifiedReadWriteMethod
 from astropy.units import Quantity, QuantityInfo
 from astropy.utils import ShapedLikeNDArray, deprecated
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_1_25
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, DataInfo, MixinInfo
 from astropy.utils.decorators import format_doc
@@ -3888,10 +3888,7 @@ class Table:
         self_is_masked = self.has_masked_columns
         other_is_masked = isinstance(other, np.ma.MaskedArray)
 
-        allowed_numpy_exceptions = (
-            TypeError,
-            ValueError if not NUMPY_LT_1_25 else DeprecationWarning,
-        )
+        allowed_numpy_exceptions = (TypeError, ValueError)
         # One table is masked and the other is not
         if self_is_masked ^ other_is_masked:
             # remap variables to a and b where a is masked and b isn't

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -29,7 +29,6 @@ from astropy.table import (
 )
 from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.time import Time
-from astropy.utils.compat import NUMPY_LT_1_25
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
@@ -1693,21 +1692,13 @@ def test_values_equal_part1():
         # Shape mismatch
         t3.values_equal(t1)
 
-    if NUMPY_LT_1_25:
-        with pytest.raises(ValueError, match="unable to compare column c"):
-            # Type mismatch in column c causes FutureWarning
-            t1.values_equal(2)
+    eq = t2.values_equal(2)
+    for col in eq.colnames:
+        assert np.all(eq[col] == [False, True])
 
-        with pytest.raises(ValueError, match="unable to compare column c"):
-            t1.values_equal([1, 2])
-    else:
-        eq = t2.values_equal(2)
-        for col in eq.colnames:
-            assert np.all(eq[col] == [False, True])
-
-        eq = t2.values_equal([1, 2])
-        for col in eq.colnames:
-            assert np.all(eq[col] == [True, True])
+    eq = t2.values_equal([1, 2])
+    for col in eq.colnames:
+        assert np.all(eq[col] == [True, True])
 
     eq = t2.values_equal(t2)
     for col in eq.colnames:

--- a/astropy/time/tests/test_functions.py
+++ b/astropy/time/tests/test_functions.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 from astropy.time import Time, TimeDelta
-from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 
 
 class TestFunctionsTime:
@@ -42,9 +41,6 @@ class TestFunctionsTimeDelta(TestFunctionsTime):
         self.check(func, axis=axis)
 
 
-@pytest.mark.xfail(
-    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
-)
 @pytest.mark.parametrize("attribute", ["shape", "ndim", "size"])
 @pytest.mark.parametrize(
     "t",

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -10,7 +10,7 @@ from astropy.coordinates import EarthLocation
 from astropy.table import Table
 from astropy.time import Time, conf
 from astropy.utils import iers
-from astropy.utils.compat import NUMPY_LT_1_25, NUMPY_LT_1_26
+from astropy.utils.compat import NUMPY_LT_1_26
 from astropy.utils.compat.optional_deps import HAS_H5PY
 from astropy.utils.masked import Masked
 
@@ -338,9 +338,6 @@ def test_all_formats(format_, masked_cls, masked_array_type):
         # Check masked scalar.
         tm0_format = getattr(tm[0], format_)
         assert isinstance(tm0_format, out_cls)
-        if NUMPY_LT_1_25 and tm0_format.dtype.kind == "M":
-            # Comparison bug in older numpy, just skip it.
-            return
         comparison = tm0_format == tm_format[0]
         assert comparison.mask
         if out_cls is Masked:

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -11,13 +11,8 @@ from numpy.testing import assert_array_equal
 import astropy.units as u
 from astropy.time import Time
 from astropy.time.utils import day_frac
-from astropy.units.quantity_helper.function_helpers import ARRAY_FUNCTION_ENABLED
 from astropy.utils import iers
 from astropy.utils.exceptions import AstropyDeprecationWarning
-
-needs_array_function = pytest.mark.xfail(
-    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
-)
 
 
 def assert_time_all_equal(t1, t2):
@@ -364,7 +359,6 @@ class TestSetShape(ShapeSetup):
 
 @pytest.mark.parametrize("use_mask", ("masked", "not_masked"))
 class TestShapeFunctions(ShapeSetup):
-    @needs_array_function
     def test_broadcast(self, use_mask):
         """Test as supported numpy function."""
         self.create_data(use_mask)
@@ -386,7 +380,6 @@ class TestShapeFunctions(ShapeSetup):
         assert t2_broadcast.location.shape == t2_broadcast.shape
         assert np.may_share_memory(t2_broadcast.location, self.t2.location)
 
-    @needs_array_function
     def test_atleast_1d(self, use_mask):
         self.create_data(use_mask)
 
@@ -398,7 +391,6 @@ class TestShapeFunctions(ShapeSetup):
         # Actual jd1 will not share memory, as cast to scalar.
         assert np.may_share_memory(t00_1d._time.jd1, t00._time.jd1)
 
-    @needs_array_function
     def test_atleast_2d(self, use_mask):
         self.create_data(use_mask)
 
@@ -409,7 +401,6 @@ class TestShapeFunctions(ShapeSetup):
         assert_time_all_equal(t0r[np.newaxis], t0r_2d)
         assert np.may_share_memory(t0r_2d.jd1, t0r.jd1)
 
-    @needs_array_function
     def test_atleast_3d(self, use_mask):
         self.create_data(use_mask)
 
@@ -438,7 +429,6 @@ class TestShapeFunctions(ShapeSetup):
         assert_time_all_equal(self.t0.T, t0_10)
         assert np.may_share_memory(t0_10.jd1, self.t0.jd1)
 
-    @needs_array_function
     def test_fliplr(self, use_mask):
         self.create_data(use_mask)
 
@@ -446,7 +436,6 @@ class TestShapeFunctions(ShapeSetup):
         assert_time_all_equal(self.t0[:, ::-1], t0_lr)
         assert np.may_share_memory(t0_lr.jd2, self.t0.jd2)
 
-    @needs_array_function
     def test_rot90(self, use_mask):
         self.create_data(use_mask)
 
@@ -454,7 +443,6 @@ class TestShapeFunctions(ShapeSetup):
         assert_time_all_equal(self.t0.T[:, ::-1], t0_270)
         assert np.may_share_memory(t0_270.jd2, self.t0.jd2)
 
-    @needs_array_function
     def test_roll(self, use_mask):
         self.create_data(use_mask)
 
@@ -462,7 +450,6 @@ class TestShapeFunctions(ShapeSetup):
         assert_time_all_equal(t0r[1:], self.t0[:-1])
         assert_time_all_equal(t0r[0], self.t0[-1])
 
-    @needs_array_function
     def test_delete(self, use_mask):
         self.create_data(use_mask)
 

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -55,10 +55,6 @@ if NUMPY_LT_2_0:
 else:
     import numpy._core as np_core
 
-# In 1.17, overrides are enabled by default, but it is still possible to
-# turn them off using an environment variable.  We use getattr since it
-# is planned to remove that possibility in later numpy versions.
-ARRAY_FUNCTION_ENABLED = getattr(np_core.overrides, "ENABLE_ARRAY_FUNCTION", True)
 SUBCLASS_SAFE_FUNCTIONS = set()
 """Functions with implementations supporting subclasses like Quantity."""
 FUNCTION_HELPERS = {}
@@ -118,7 +114,7 @@ SUBCLASS_SAFE_FUNCTIONS |= {
 SUBCLASS_SAFE_FUNCTIONS |= {np.median}
 
 if NUMPY_LT_2_0:
-    # functions (re)moved in numpy 2.0; alias for np.round in NUMPY_LT_1_25
+    # functions (re)moved in numpy 2.0
     SUBCLASS_SAFE_FUNCTIONS |= {
         np.msort,
         np.round_,  # noqa: NPY003, NPY201

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -9,10 +9,10 @@ import numpy as np
 import numpy.lib.recfunctions as rfn
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing.overrides import allows_array_function_override
 
 from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
-    ARRAY_FUNCTION_ENABLED,
     DISPATCHED_FUNCTIONS,
     FUNCTION_HELPERS,
     IGNORED_FUNCTIONS,
@@ -21,13 +21,7 @@ from astropy.units.quantity_helper.function_helpers import (
     TBD_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
-from astropy.utils.compat import (
-    NUMPY_LT_1_25,
-    NUMPY_LT_2_0,
-    NUMPY_LT_2_1,
-    NUMPY_LT_2_2,
-    NUMPY_LT_2_4,
-)
+from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
 
 VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
@@ -39,26 +33,10 @@ EMPTY_DEFAULT = inspect.Parameter.empty
 ARCSEC_PER_DEGREE = 60 * 60
 ARCSEC_PER_RADIAN = ARCSEC_PER_DEGREE * np.rad2deg(1)
 
-needs_array_function = pytest.mark.xfail(
-    not ARRAY_FUNCTION_ENABLED, reason="Needs __array_function__ support"
-)
-
 
 # To get the functions that could be covered, we look for those that
 # are in modules we care about and have been overridden.
 def get_wrapped_functions(*modules: ModuleType) -> set[FunctionType]:
-    if NUMPY_LT_1_25:
-
-        def allows_array_function_override(f):
-            return (
-                hasattr(f, "__wrapped__")
-                and f is not np.printoptions
-                and not f.__name__.startswith("_")
-            )
-
-    else:
-        from numpy.testing.overrides import allows_array_function_override
-
     return {
         f
         for module in modules
@@ -248,7 +226,6 @@ class TestArgFunctions(NoUnitTestSetup):
     def test_argwhere(self):
         self.check(np.argwhere)
 
-    @needs_array_function
     def test_argpartition(self):
         self.check(np.argpartition, 2)
 
@@ -278,7 +255,6 @@ class TestAlongAxis(BasicTestSetup):
         expected = np.apply_along_axis(np.square, axis, self.q.value) * self.q.unit**2
         assert_array_equal(out, expected)
 
-    @needs_array_function
     @pytest.mark.parametrize("axes", ((1,), (0,), (0, 1)))
     def test_apply_over_axes(self, axes):
         def function(x, axis):
@@ -313,7 +289,6 @@ class TestRealImag(InvariantUnitTestSetup):
 
 
 class TestCopyAndCreation(InvariantUnitTestSetup):
-    @needs_array_function
     def test_copy(self):
         self.check(np.copy)
         # Also as kwarg
@@ -321,7 +296,6 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         assert_array_equal(copy, self.q)
 
     @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.asfarray is removed in NumPy 2.0")
-    @needs_array_function
     def test_asfarray(self):
         self.check(np.asfarray)  # noqa: NPY201
         farray = np.asfarray(a=self.q)  # noqa: NPY201
@@ -347,7 +321,6 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
     def test_ones_like(self):
         self.check(np.ones_like)
 
-    @needs_array_function
     def test_full_like(self):
         o = np.full_like(self.q, 0.5 * u.km)
         expected = np.empty_like(self.q.value) * u.m
@@ -362,7 +335,6 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
             int32q = self.q.astype("int32")
             assert_array_equal(np.astype(int32q, "int32"), int32q)
 
-    @needs_array_function
     @pytest.mark.parametrize(
         "args, kwargs, expected",
         [
@@ -571,7 +543,6 @@ class TestAccessingParts(InvariantUnitTestSetup):
     def test_diag(self):
         self.check(np.diag)
 
-    @needs_array_function
     def test_diag_1d_input(self):
         # Also check 1-D case; drops unit w/o __array_function__.
         q = self.q.ravel()
@@ -624,7 +595,6 @@ class TestSettingParts:
         expected = [50, 100, 150] * u.cm
         assert np.all(q == expected)
 
-    @needs_array_function
     def test_putmask(self):
         q = np.arange(3.0) * u.m
         mask = [True, False, True]
@@ -643,7 +613,6 @@ class TestSettingParts:
         expected = np.array([0.5, 1.0, 1.5])
         assert np.all(a == expected)
 
-    @needs_array_function
     def test_place(self):
         q = np.arange(3.0) * u.m
         np.place(q, [True, False, True], [50, 150] * u.cm)
@@ -657,7 +626,6 @@ class TestSettingParts:
         expected = np.array([0.5, 1.0, 1.5])
         assert np.all(a == expected)
 
-    @needs_array_function
     def test_copyto(self):
         q = np.arange(3.0) * u.m
         np.copyto(q, [50, 0, 150] * u.cm, where=[True, False, True])
@@ -688,7 +656,6 @@ class TestRepeat(InvariantUnitTestSetup):
     def test_repeat(self):
         self.check(np.repeat, 2)
 
-    @needs_array_function
     def test_resize(self):
         self.check(np.resize, (4, 4))
 
@@ -707,7 +674,6 @@ class TestConcatenate:
         assert o.shape == expected.shape
         assert np.all(o == expected)
 
-    @needs_array_function
     def test_concatenate(self):
         self.check(np.concatenate)
         self.check(np.concatenate, axis=1)
@@ -733,34 +699,27 @@ class TestConcatenate:
         with pytest.raises(TypeError):
             np.concatenate([self.q1, object()])
 
-    @needs_array_function
     def test_stack(self):
         self.check(np.stack)
 
-    @needs_array_function
     def test_column_stack(self):
         self.check(np.column_stack)
 
-    @needs_array_function
     def test_hstack(self):
         self.check(np.hstack)
 
-    @needs_array_function
     def test_vstack(self):
         self.check(np.vstack)
 
-    @needs_array_function
     def test_dstack(self):
         self.check(np.dstack)
 
-    @needs_array_function
     def test_block(self):
         self.check(np.block)
 
         result = np.block([[0.0, 1.0 * u.m], [1.0 * u.cm, 2.0 * u.km]])
         assert np.all(result == np.block([[0, 1.0], [0.01, 2000.0]]) << u.m)
 
-    @needs_array_function
     def test_append(self):
         out = np.append(self.q1, self.q2, axis=0)
         assert out.unit == self.q1.unit
@@ -777,7 +736,6 @@ class TestConcatenate:
         expected = np.append(a, 0.5) * u.dimensionless_unscaled
         assert np.all(result == expected)
 
-    @needs_array_function
     def test_insert(self):
         # Unit of inserted values is not ignored.
         q = np.arange(12.0).reshape(6, 2) * u.m
@@ -803,7 +761,6 @@ class TestConcatenate:
         with pytest.raises(u.UnitsError):
             np.insert(q, (3, 5), 0.0 * u.s)
 
-    @needs_array_function
     def test_pad(self):
         q = np.arange(1.0, 6.0) * u.m
         out = np.pad(q, (2, 3), "constant", constant_values=(0.0, 150.0 * u.cm))
@@ -971,7 +928,6 @@ class TestUfuncLike(InvariantUnitTestSetup):
         )
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_sinc(self):
         q = [0.0, 3690.0, -270.0, 690.0] * u.deg
         out = np.sinc(q)
@@ -981,13 +937,11 @@ class TestUfuncLike(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.sinc(1.0 * u.one)
 
-    @needs_array_function
     def test_where(self):
         out = np.where([True, False, True], self.q, 1.0 * u.km)
         expected = np.where([True, False, True], self.q.value, 1000.0) * self.q.unit
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_choose(self):
         # from np.choose docstring
         a = np.array([0, 1]).reshape((2, 1, 1))
@@ -998,7 +952,6 @@ class TestUfuncLike(InvariantUnitTestSetup):
         expected = np.choose(a, (q1.value, q2.to_value(q1.unit))) * u.cm
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_select(self):
         q = self.q
         out = np.select(
@@ -1010,22 +963,18 @@ class TestUfuncLike(InvariantUnitTestSetup):
         )
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_real_if_close(self):
         q = np.array([1 + 0j, 0 + 1j, 1 + 1j, 0 + 0j]) * u.m
         out = np.real_if_close(q)
         expected = np.real_if_close(q.value) * u.m
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_tril(self):
         self.check(np.tril)
 
-    @needs_array_function
     def test_triu(self):
         self.check(np.triu)
 
-    @needs_array_function
     def test_unwrap(self):
         q = [0.0, 3690.0, -270.0, 690.0] * u.deg
         out = np.unwrap(q)
@@ -1043,7 +992,6 @@ class TestUfuncLike(InvariantUnitTestSetup):
         expected = np.nan_to_num(q.value) * q.unit
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_nan_to_num_complex(self):
         q = np.array([-np.inf, +np.inf, np.nan, 3.0, 4.0]) * u.m
         out = np.nan_to_num(q, nan=1.0 * u.km, posinf=2.0 * u.km, neginf=-2 * u.km)
@@ -1094,7 +1042,6 @@ class TestUfuncLikeTests:
         assert out.dtype.kind == "b"
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_allclose_atol_default_unit(self):
         q_cm = self.q.to(u.cm)
         out = np.isclose(self.q, q_cm)
@@ -1138,7 +1085,6 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         result = np.median(data)
         assert_array_equal(result, np.nan * u.km)
 
-    @needs_array_function
     def test_quantile(self):
         self.check(np.quantile, 0.5)
         o = np.quantile(self.q, 50 * u.percent)
@@ -1157,7 +1103,6 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         assert result is o4
         assert np.all(o4 == expected)
 
-    @needs_array_function
     def test_percentile(self):
         self.check(np.percentile, 0.5)
         o = np.percentile(self.q, 0.5 * u.one)
@@ -1167,7 +1112,6 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_trace(self):
         self.check(np.trace)
 
-    @needs_array_function
     def test_count_nonzero(self):
         q1 = np.arange(9.0).reshape(3, 3) * u.m
         o = np.count_nonzero(q1)
@@ -1186,7 +1130,6 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         assert np.allclose(q1, q2, atol=atol)
         assert np.allclose(q1, q2, atol=0.0, rtol=rtol)
 
-    @needs_array_function
     def test_allclose_atol_default_unit(self):
         q1 = np.arange(3.0) * u.m
         q2 = np.array([0.0, 101.0, 199.0]) * u.cm
@@ -1201,7 +1144,6 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.allclose(q1, q2, atol=0, rtol=1.0 * u.s)
 
-    @needs_array_function
     def test_array_equal(self):
         q1 = np.arange(3.0) * u.m
         q2 = q1.to(u.cm)
@@ -1220,7 +1162,6 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_array_equal_incompatible_units(self):
         assert not np.array_equal([1, 2] * u.m, [1, 2] * u.s)
 
-    @needs_array_function
     def test_array_equiv(self):
         q1 = np.array([[0.0, 1.0, 2.0]] * 3) * u.m
         q2 = q1[0].to(u.cm)
@@ -1330,14 +1271,12 @@ class TestNanFunctions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.nancumprod(self.q)
 
-    @needs_array_function
     def test_nanquantile(self):
         self.check(np.nanquantile, 0.5)
         o = np.nanquantile(self.q, 50 * u.percent)
         expected = np.nanquantile(self.q.value, 0.5) * u.m
         assert np.all(o == expected)
 
-    @needs_array_function
     def test_nanpercentile(self):
         self.check(np.nanpercentile, 0.5)
         o = np.nanpercentile(self.q, 0.5 * u.one)
@@ -1350,7 +1289,6 @@ class TestVariousProductFunctions:
     Test functions that are similar to gufuncs
     """
 
-    @needs_array_function
     def test_cross(self):
         q1 = np.arange(6.0).reshape(2, 3) * u.m
         q2 = np.array([4.0, 5.0, 6.0]) / u.s
@@ -1358,7 +1296,6 @@ class TestVariousProductFunctions:
         expected = np.cross(q1.value, q2.value) * u.m / u.s
         assert np.all(o == expected)
 
-    @needs_array_function
     def test_outer(self):
         q1 = np.array([1, 2, 3]) * u.m
         q2 = np.array([1, 2]) / u.s
@@ -1373,28 +1310,24 @@ class TestVariousProductFunctions:
         with pytest.raises(TypeError):
             np.outer(q1, q2, out=object())
 
-    @needs_array_function
     def test_inner(self):
         q1 = np.array([1, 2, 3]) * u.m
         q2 = np.array([4, 5, 6]) / u.s
         o = np.inner(q1, q2)
         assert o == 32 * u.m / u.s
 
-    @needs_array_function
     def test_dot(self):
         q1 = np.array([1.0, 2.0, 3.0]) * u.m
         q2 = np.array([4.0, 5.0, 6.0]) / u.s
         o = np.dot(q1, q2)
         assert o == 32.0 * u.m / u.s
 
-    @needs_array_function
     def test_vdot(self):
         q1 = np.array([1j, 2j, 3j]) * u.m
         q2 = np.array([4j, 5j, 6j]) / u.s
         o = np.vdot(q1, q2)
         assert o == (32.0 + 0j) * u.m / u.s
 
-    @needs_array_function
     def test_tensordot(self):
         # From the docstring example
         a = np.arange(60.0).reshape(3, 4, 5) * u.m
@@ -1403,7 +1336,6 @@ class TestVariousProductFunctions:
         expected = np.tensordot(a.value, b.value, axes=([1, 0], [0, 1])) * u.m / u.s
         assert np.all(c == expected)
 
-    @needs_array_function
     def test_kron(self):
         q1 = np.eye(2) * u.m
         q2 = np.ones(2) / u.s
@@ -1411,7 +1343,6 @@ class TestVariousProductFunctions:
         expected = np.kron(q1.value, q2.value) * u.m / u.s
         assert np.all(o == expected)
 
-    @needs_array_function
     def test_einsum(self):
         q1 = np.arange(9.0).reshape(3, 3) * u.m
         o = np.einsum("...i", q1)
@@ -1472,7 +1403,6 @@ class TestIntDiffFunctions:
         expected = np.diff(x.value) * u.m
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_diff_prepend_append(self):
         x = np.arange(10.0) * u.m
         out = np.diff(x, prepend=-12.5 * u.cm, append=1 * u.km)
@@ -1493,7 +1423,6 @@ class TestIntDiffFunctions:
         expected = np.gradient(x.value) * u.m
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_gradient_spacing(self):
         # Simple gradient works out of the box.
         x = np.arange(10.0) * u.m
@@ -1530,7 +1459,6 @@ class TestSpaceFunctions:
         expected = np.linspace(q1.to_value(q2.unit), q2.value, 5) * q2.unit
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_logspace(self):
         unit = u.m / u.s**2
         out = np.logspace(10.0 * u.dex(unit), 20 * u.dex(unit), 10)
@@ -1540,7 +1468,6 @@ class TestSpaceFunctions:
         expected = np.logspace(10.0, 20.0, 10, base=10.0 ** (-0.4)) * u.ST
         assert u.allclose(out, expected)
 
-    @needs_array_function
     def test_geomspace(self):
         out = np.geomspace(1000.0 * u.m, 10.0 * u.km, 5)
         expected = np.geomspace(1, 10, 5) * u.km
@@ -1554,7 +1481,6 @@ class TestSpaceFunctions:
 
 
 class TestInterpolationFunctions:
-    @needs_array_function
     def test_interp(self):
         x = np.array([1250.0, 2750.0]) * u.m
         xp = np.arange(5.0) * u.km
@@ -1567,7 +1493,6 @@ class TestInterpolationFunctions:
         assert type(out) is np.ndarray
         assert np.all(out == expected.value)
 
-    @needs_array_function
     def test_piecewise(self):
         x = np.linspace(-2.5, 2.5, 6) * u.m
         out = np.piecewise(x, [x < 0, x >= 0], [-1 * u.s, 1 * u.day])
@@ -1604,7 +1529,6 @@ class TestInterpolationFunctions:
 
 
 class TestBincountDigitize:
-    @needs_array_function
     def test_bincount(self):
         i = np.array([1, 1, 2, 3, 2, 4])
         weights = np.arange(len(i)) * u.Jy
@@ -1615,7 +1539,6 @@ class TestBincountDigitize:
         with pytest.raises(TypeError):
             np.bincount(weights)
 
-    @needs_array_function
     def test_digitize(self):
         x = np.array([1500.0, 2500.0, 4500.0]) * u.m
         bins = np.arange(10.0) * u.km
@@ -1680,7 +1603,6 @@ class TestHistogramFunctions:
                 e_bin = e_bin * e_unit
             assert_array_equal(o_bin, e_bin)
 
-    @needs_array_function
     def test_histogram(self):
         x = self.x
         weights = self.weights
@@ -1744,7 +1666,6 @@ class TestHistogramFunctions:
             return [cls._range_value(r, unit) for r in range]
 
     @pytest.mark.parametrize("range", [[2 * u.m, 500 * u.cm], [2, 5] * u.m])
-    @needs_array_function
     def test_histogram_range(self, range):
         self.check(
             np.histogram,
@@ -1755,7 +1676,6 @@ class TestHistogramFunctions:
             expected_units=(None, self.x.unit),
         )
 
-    @needs_array_function
     def test_histogram_bin_edges(self):
         x = np.array([1.1, 1.2, 1.3, 2.1, 5.1]) * u.m
         out_b = np.histogram_bin_edges(x)
@@ -1775,7 +1695,6 @@ class TestHistogramFunctions:
             np.histogram_bin_edges(x.value, [125, 200] * u.s)
 
     @pytest.mark.parametrize("range", [[2 * u.m, 500 * u.cm], [2, 5] * u.m])
-    @needs_array_function
     def test_histogram_bin_edges_range(self, range):
         out_b = np.histogram_bin_edges(self.x, range=range)
         expected_b = np.histogram_bin_edges(
@@ -1783,7 +1702,6 @@ class TestHistogramFunctions:
         )
         assert np.all(out_b.value == expected_b)
 
-    @needs_array_function
     def test_histogram2d(self):
         x, y = self.x, self.y
         weights = self.weights
@@ -1861,7 +1779,6 @@ class TestHistogramFunctions:
             [[200, 500], [1, 4]] * u.cm,
         ],
     )
-    @needs_array_function
     def test_histogram2d_range(self, range):
         self.check(
             np.histogram2d,
@@ -1878,7 +1795,6 @@ class TestHistogramFunctions:
             expected_units=(None, self.x.unit, self.y.unit),
         )
 
-    @needs_array_function
     def test_histogramdd(self):
         # First replicates of the histogram2d tests, but using the
         # histogramdd override.  Normally takes the sample as a tuple
@@ -1976,7 +1892,6 @@ class TestHistogramFunctions:
             [[200, 500], [1, 4]] * u.cm,
         ],
     )
-    @needs_array_function
     def test_histogramdd_range(self, range):
         self.check(
             np.histogramdd,
@@ -1992,7 +1907,6 @@ class TestHistogramFunctions:
             expected_units=(None, (self.x.unit, self.y.unit)),
         )
 
-    @needs_array_function
     def test_correlate(self):
         x1 = [1, 2, 3] * u.m
         x2 = [0, 1, 0.5] * u.m
@@ -2000,7 +1914,6 @@ class TestHistogramFunctions:
         expected = np.correlate(x1.value, x2.value) * u.m**2
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_convolve(self):
         x1 = [1, 2, 3] * u.m
         x2 = [0, 1, 0.5] * u.m
@@ -2008,14 +1921,12 @@ class TestHistogramFunctions:
         expected = np.convolve(x1.value, x2.value) * u.m**2
         assert np.all(out == expected)
 
-    @needs_array_function
     def test_cov(self):
         # Do not see how we can use cov with Quantity
         x = np.array([[0, 2], [1, 1], [2, 0]]).T * u.m
         with pytest.raises(TypeError):
             np.cov(x)
 
-    @needs_array_function
     def test_corrcoef(self):
         # Do not see how we can use cov with Quantity
         x = np.array([[0, 2], [1, 1], [2, 0]]).T * u.m
@@ -2035,7 +1946,6 @@ class TestSortFunctions(InvariantUnitTestSetup):
         with pytest.warns(DeprecationWarning, match="^msort is deprecated"):
             self.check(np.msort)
 
-    @needs_array_function
     def test_sort_complex(self):
         self.check(np.sort_complex)
 
@@ -2049,7 +1959,6 @@ class TestStringFunctions:
     def setup_method(self):
         self.q = np.arange(3.0) * u.Jy
 
-    @needs_array_function
     def test_array2string(self):
         # The default formatters cannot handle units, so if we do not pass
         # a relevant formatter, we are better off just treating it as an
@@ -2074,7 +1983,6 @@ class TestStringFunctions:
         out4 = np.array2string(self.q, separator=", ", formatter={"int": str})
         assert out4 == expected1
 
-    @needs_array_function
     def test_array_repr(self):
         out = np.array_repr(self.q)
         assert out == "Quantity([0., 1., 2.], unit='Jy')"
@@ -2082,7 +1990,6 @@ class TestStringFunctions:
         out2 = np.array_repr(q2)
         assert out2 == "Quantity([0., 1., 2.], unit='Jy', dtype=float32)"
 
-    @needs_array_function
     def test_array_str(self):
         out = np.array_str(self.q)
         expected = str(self.q)
@@ -2096,35 +2003,30 @@ class TestBitAndIndexFunctions:
         self.q = np.arange(3) * u.m
         self.uint_q = u.Quantity(np.arange(3), "m", dtype="u1")
 
-    @needs_array_function
     def test_packbits(self):
         with pytest.raises(TypeError):
             np.packbits(self.q)
         with pytest.raises(TypeError):
             np.packbits(self.uint_q)
 
-    @needs_array_function
     def test_unpackbits(self):
         with pytest.raises(TypeError):
             np.unpackbits(self.q)
         with pytest.raises(TypeError):
             np.unpackbits(self.uint_q)
 
-    @needs_array_function
     def test_unravel_index(self):
         with pytest.raises(TypeError):
             np.unravel_index(self.q, 3)
         with pytest.raises(TypeError):
             np.unravel_index(self.uint_q, 3)
 
-    @needs_array_function
     def test_ravel_multi_index(self):
         with pytest.raises(TypeError):
             np.ravel_multi_index((self.q,), 3)
         with pytest.raises(TypeError):
             np.ravel_multi_index((self.uint_q,), 3)
 
-    @needs_array_function
     def test_ix_(self):
         with pytest.raises(TypeError):
             np.ix_(self.q)
@@ -2210,7 +2112,6 @@ class TestSetOpsFunctions:
     def test_unique(self, kwargs):
         self.check1(np.unique, **kwargs)
 
-    @needs_array_function
     @pytest.mark.parametrize(
         "kwargs",
         (
@@ -2224,7 +2125,6 @@ class TestSetOpsFunctions:
 
     if not NUMPY_LT_2_0:
 
-        @needs_array_function
         def test_unique_all(self):
             values, indices, inverse_indices, counts = np.unique(
                 self.q,
@@ -2241,7 +2141,6 @@ class TestSetOpsFunctions:
             assert_array_equal(res.inverse_indices, inverse_indices)
             assert_array_equal(res.counts, counts)
 
-        @needs_array_function
         def test_unique_counts(self):
             values, counts = np.unique(self.q, return_counts=True, equal_nan=False)
             res = np.unique_counts(self.q)
@@ -2250,7 +2149,6 @@ class TestSetOpsFunctions:
             assert_array_equal(res.values, values)
             assert_array_equal(res.counts, counts)
 
-        @needs_array_function
         def test_unique_inverse(self):
             values, inverse_indices = np.unique(
                 self.q, return_inverse=True, equal_nan=False
@@ -2261,33 +2159,27 @@ class TestSetOpsFunctions:
             assert_array_equal(res.values, values)
             assert_array_equal(res.inverse_indices, inverse_indices)
 
-        @needs_array_function
         def test_unique_values(self):
             values = np.unique(self.q, equal_nan=False)
             res = np.unique_values(self.q)
             assert_array_equal(res, values)
 
-    @needs_array_function
     @pytest.mark.parametrize("kwargs", ({}, dict(return_indices=True)))
     def test_intersect1d(self, kwargs):
         self.check2(np.intersect1d, **kwargs)
 
-    @needs_array_function
     def test_setxor1d(self):
         self.check2(np.setxor1d)
 
-    @needs_array_function
     def test_union1d(self):
         self.check2(np.union1d)
         result = np.union1d(np.array([0.0, np.nan]), np.arange(3) << u.m)
         assert result.unit is u.m
         assert_array_equal(result.value, np.array([0.0, 1.0, 2.0, np.nan]))
 
-    @needs_array_function
     def test_setdiff1d(self):
         self.check2(np.setdiff1d)
 
-    @needs_array_function
     @pytest.mark.skipif(not NUMPY_LT_2_4, reason="in1d was removed in numpy 2.4")
     @pytest.mark.filterwarnings("ignore:`in1d` is deprecated. Use `np.isin` instead.")
     def test_in1d(self):
@@ -2297,7 +2189,6 @@ class TestSetOpsFunctions:
         with pytest.raises(u.UnitsError):
             np.in1d(np.ones(1), self.q2)  # noqa: NPY201
 
-    @needs_array_function
     def test_isin(self):
         self.check2(np.isin, unit=None)
 
@@ -2337,7 +2228,6 @@ def test_fft_frequencies(function):
     assert_array_equal(out, expected)
 
 
-@needs_array_function
 class TestFFT(InvariantUnitTestSetup):
     tested_module = np.fft
 
@@ -2413,7 +2303,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         x = np.linalg.matrix_rank(self.q.value)
         assert r == x
 
-    @needs_array_function
     def test_matrix_rank_with_tol(self):
         # Use a matrix that is not so good, so tol=1 and tol=0.01 differ.
         q = np.arange(9.0).reshape(3, 3) / 4 * u.m
@@ -2430,7 +2319,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         q2 = np.linalg.matrix_power(self.q, 4)
         assert_array_equal(q2, self.q @ self.q @ self.q @ self.q)
 
-    @needs_array_function
     def test_matrix_inv_power(self):
         qinv = np.linalg.inv(self.q.value) / self.q.unit
         qm1 = np.linalg.matrix_power(self.q, -1)
@@ -2438,7 +2326,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         qm3 = np.linalg.matrix_power(self.q, -3)
         assert_array_equal(qm3, qinv @ qinv @ qinv)
 
-    @needs_array_function
     def test_multi_dot(self):
         q2 = np.linalg.multi_dot([self.q, self.q])
         q2x = self.q @ self.q
@@ -2447,7 +2334,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         q3x = self.q @ self.q @ self.q
         assert_array_equal(q3, q3x)
 
-    @needs_array_function
     def test_svd(self):
         m = np.arange(10.0) * np.arange(5.0)[:, np.newaxis] * u.m
         svd_u, svd_s, svd_vt = np.linalg.svd(m, full_matrices=False)
@@ -2462,13 +2348,11 @@ class TestLinAlg(InvariantUnitTestSetup):
         svd_s2x = np.linalg.svd(m.value, compute_uv=False) << m.unit
         assert_array_equal(s2, svd_s2x)
 
-    @needs_array_function
     def test_inv(self):
         inv = np.linalg.inv(self.q)
         expected = np.linalg.inv(self.q.value) / self.q.unit
         assert_array_equal(inv, expected)
 
-    @needs_array_function
     def test_pinv(self):
         pinv = np.linalg.pinv(self.q)
         expected = np.linalg.pinv(self.q.value) / self.q.unit
@@ -2483,13 +2367,11 @@ class TestLinAlg(InvariantUnitTestSetup):
             pinv3 = np.linalg.pinv(self.q, rtol=rcond)
             assert_array_equal(pinv3, expected2)
 
-    @needs_array_function
     def test_tensorinv(self):
         inv = np.linalg.tensorinv(self.q, ind=1)
         expected = np.linalg.tensorinv(self.q.value, ind=1) / self.q.unit
         assert_array_equal(inv, expected)
 
-    @needs_array_function
     def test_det(self):
         det = np.linalg.det(self.q)
         expected = np.linalg.det(self.q.value)
@@ -2500,14 +2382,12 @@ class TestLinAlg(InvariantUnitTestSetup):
         with pytest.raises(np.linalg.LinAlgError):
             np.linalg.det(self.q[:-1])  # Not square.
 
-    @needs_array_function
     def test_slogdet(self):
         # TODO: Could be supported if we had a natural logarithm unit.
         with pytest.raises(TypeError):
             logdet = np.linalg.slogdet(self.q)
             assert hasattr(logdet, "unit")
 
-    @needs_array_function
     def test_solve(self):
         b = np.array([1.0, 2.0, 4.0]) * u.m / u.s
         x = np.linalg.solve(self.q, b)
@@ -2516,7 +2396,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         assert_array_equal(x, xx)
         assert u.allclose(self.q @ x, b)
 
-    @needs_array_function
     def test_tensorsolve(self):
         b = np.array([1.0, 2.0, 4.0]) * u.m / u.s
         x = np.linalg.tensorsolve(self.q, b)
@@ -2525,7 +2404,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         assert_array_equal(x, xx)
         assert u.allclose(self.q @ x, b)
 
-    @needs_array_function
     def test_lstsq(self):
         b = np.array([1.0, 2.0, 4.0]) * u.m / u.s
         x, residuals, rank, s = np.linalg.lstsq(self.q, b, rcond=None)
@@ -2552,7 +2430,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.linalg.lstsq(m, b, rcond=1.0 * u.s)
 
-    @needs_array_function
     def test_norm(self):
         n = np.linalg.norm(self.q)
         expected = np.linalg.norm(self.q.value) << self.q.unit
@@ -2562,7 +2439,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         expected1 = np.linalg.norm(self.q[0].value, ord=0) << u.one
         assert_array_equal(n1, expected1)
 
-    @needs_array_function
     def test_cholesky(self):
         # Numbers from np.linalg.cholesky docstring.
         q = np.array([[1, -2j], [2j, 5]]) * u.m
@@ -2571,7 +2447,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         assert_array_equal(cd, cdx)
         assert u.allclose(cd @ cd.T.conj(), q)
 
-    @needs_array_function
     def test_qr(self):
         # This is not exhaustive...
         a = np.array([[1, -2j], [2j, 5]]) * u.m
@@ -2583,7 +2458,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         assert_array_equal(r, rx)
         assert u.allclose(q @ r, a)
 
-    @needs_array_function
     def test_eig(self):
         w, v = np.linalg.eig(self.q)
         wx, vx = np.linalg.eig(self.q.value)
@@ -2598,7 +2472,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         assert_array_equal(w, np.arange(1, 4) * u.m)
         assert_array_equal(v, np.eye(3))
 
-    @needs_array_function
     def test_eigvals(self):
         w = np.linalg.eigvals(self.q)
         wx = np.linalg.eigvals(self.q.value) << self.q.unit
@@ -2608,7 +2481,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         w = np.linalg.eigvals(q)
         assert_array_equal(w, np.arange(1, 4) * u.m)
 
-    @needs_array_function
     def test_eigh(self):
         w, v = np.linalg.eigh(self.q)
         wx, vx = np.linalg.eigh(self.q.value)
@@ -2617,7 +2489,6 @@ class TestLinAlg(InvariantUnitTestSetup):
         assert_array_equal(w, wx)
         assert_array_equal(v, vx)
 
-    @needs_array_function
     def test_eigvalsh(self):
         w = np.linalg.eigvalsh(self.q)
         wx = np.linalg.eigvalsh(self.q.value) << self.q.unit
@@ -2634,38 +2505,32 @@ class TestLinAlg(InvariantUnitTestSetup):
         def test_trace(self):
             self.check(np.trace)
 
-        @needs_array_function
         def test_cross(self):
             q1 = np.array([1, 2, 3]) << u.m
             q2 = np.array([4, 5, 6]) << u.s
             assert_array_equal(np.linalg.cross(q1, q2), np.cross(q1, q2))
             assert_array_equal(np.linalg.cross(q1, q2.value), np.cross(q1, q2.value))
 
-        @needs_array_function
         def test_outer(self):
             q = self.q.flatten()
             assert_array_equal(np.linalg.outer(q, q), np.outer(q, q))
             assert_array_equal(np.linalg.outer(q, q.value), np.outer(q, q.value))
 
-        @needs_array_function
         def test_svdvals(self):
             _, ref, _ = np.linalg.svd(self.q)
             res = np.linalg.svdvals(self.q)
             assert_allclose(res, ref, rtol=5e-16)
 
-        @needs_array_function
         def test_vecdot(self):
             ref = (self.q * self.q).sum(-1)
             res = np.linalg.vecdot(self.q, self.q)
             assert_array_equal(res, ref)
 
-        @needs_array_function
         def test_tensordot(self):
             ref = np.tensordot(self.q, self.q)
             res = np.linalg.tensordot(self.q, self.q)
             assert_array_equal(res, ref)
 
-        @needs_array_function
         def test_matmul(self):
             ref = np.matmul(self.q, self.q)
             res = np.linalg.matmul(self.q, self.q)
@@ -2675,13 +2540,11 @@ class TestLinAlg(InvariantUnitTestSetup):
             t = np.linalg.matrix_transpose(self.q)
             assert_array_equal(t, self.q.swapaxes(-2, -1))
 
-        @needs_array_function
         def test_matrix_norm(self):
             n = np.linalg.matrix_norm(self.q)
             expected = np.linalg.norm(self.q.value) << self.q.unit
             assert_array_equal(n, expected)
 
-        @needs_array_function
         def test_vector_norm(self):
             n = np.linalg.vector_norm(self.q)
             expected = np.linalg.norm(self.q.value.ravel()) << self.q.unit
@@ -2862,7 +2725,6 @@ rec_functions = {
 untested_functions |= rec_functions
 
 
-@needs_array_function
 def test_testing_completeness():
     assert not tested_functions.intersection(untested_functions)
     assert all_wrapped_functions == (tested_functions | untested_functions)
@@ -2886,7 +2748,6 @@ class TestFunctionHelpersCompleteness:
     def test_no_duplicates(self, one, two):
         assert not one.intersection(two)
 
-    @needs_array_function
     def test_all_included(self):
         included_in_helpers = (
             SUBCLASS_SAFE_FUNCTIONS
@@ -2896,7 +2757,6 @@ class TestFunctionHelpersCompleteness:
         )
         assert all_wrapped_functions == included_in_helpers
 
-    @needs_array_function
     def test_ignored_are_untested(self):
         assert IGNORED_FUNCTIONS | TBD_FUNCTIONS == untested_functions
 

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -16,7 +16,7 @@ from astropy import units as u
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_25, NUMPY_LT_2_0, NUMPY_LT_2_3
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 
 if NUMPY_LT_2_0:
@@ -1131,9 +1131,6 @@ class TestWhere:
         assert result is out
         assert_array_equal(result, [1000.0, 1001.0, 1002.0, 0.0] << u.m)
 
-    @pytest.mark.xfail(
-        NUMPY_LT_1_25, reason="where array_ufunc support introduced in numpy 1.25"
-    )
     def test_exception_with_where_quantity(self):
         a = np.ones(2)
         where = np.ones(2, bool) << u.m

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,6 @@ from astropy.utils import minversion
 
 __all__ = [
     "COPY_IF_NEEDED",
-    "NUMPY_LT_1_25",
     "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
@@ -22,7 +21,6 @@ __all__ = [
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_25 = not minversion(np, "1.25")
 NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0")
 NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -987,12 +987,6 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
                     axis = kwargs.get("axis", 0)
                     mask = np.logical_or.accumulate(mask, axis=axis, out=out_mask)
 
-            elif out is None:
-                # Can only get here if neither input nor output was masked, but
-                # perhaps where was masked (possible in "not NUMPY_LT_1_25").
-                # We don't support this.
-                return NotImplemented
-
         elif method in {"reduceat", "at"}:  # pragma: no cover
             raise NotImplementedError(
                 "masked instances cannot yet deal with 'reduceat' or 'at'."

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -23,13 +23,7 @@ from astropy.units.tests.test_quantity_non_ufuncs import (
     get_covered_functions,
     get_wrapped_functions,
 )
-from astropy.utils.compat import (
-    NUMPY_LT_1_25,
-    NUMPY_LT_2_0,
-    NUMPY_LT_2_1,
-    NUMPY_LT_2_2,
-    NUMPY_LT_2_4,
-)
+from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
     APPLY_TO_BOTH_FUNCTIONS,
@@ -1047,11 +1041,6 @@ class TestPartitionLikeFunctions:
         assert_array_equal(o.filled(np.nan), expected)
         assert_array_equal(o.mask, np.isnan(expected))
         # Also check that we can give an output MaskedArray.
-        if NUMPY_LT_1_25 and kwargs.get("keepdims", False):
-            # numpy bug gh-22714 prevents using out with keepdims=True.
-            # This is fixed in numpy 1.25.
-            return
-
         out = np.zeros_like(o)
         o2 = function(self.ma, *args, out=out, **kwargs)
         assert o2 is out

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -18,7 +18,6 @@ from numpy.testing import assert_allclose, assert_array_equal
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.utils import minversion
-from astropy.utils.compat.numpycompat import NUMPY_LT_1_25
 from astropy.utils.masked.core import Masked
 
 from .test_masked import (
@@ -116,10 +115,8 @@ class MaskedUfuncTests(MaskedArraySetup):
         with pytest.raises(TypeError):
             np.add(self.ma, self.mb, out=out)
 
-    @pytest.mark.xfail(NUMPY_LT_1_25, reason="masked where not supported in numpy<1.25")
     def test_ufunc_inplace_error_masked_where(self):
         # Input and output are not masked, but where is.
-        # Note: prior to numpy 1.25, we cannot control this.
         out = self.a.copy()
         with pytest.raises(TypeError):
             np.add(self.a, self.b, out=out, where=Masked(True, mask=True))

--- a/docs/changes/18962.other.rst
+++ b/docs/changes/18962.other.rst
@@ -1,0 +1,1 @@
+The minimum required NumPy version is now 1.25.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=1.24",
+    "numpy>=1.25",
     "pyerfa>=2.0.1.1",  # For >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2025.10.27.0.39.10",
     "PyYAML>=6.0.0",
@@ -53,7 +53,7 @@ dependencies = [
 [project.optional-dependencies]
 # Recommended run-time dependencies to enable a lot of functionality within Astropy.
 recommended = [
-    "scipy>=1.9.2",
+    "scipy>=1.10",
     "matplotlib>=3.8.0",
     "narwhals>=1.42.0",  # keep in sync with dependency-groups.dataframe
 ]
@@ -72,7 +72,7 @@ jupyter = [  # these are optional dependencies for utils.console and table
     # jupyter-core is a transitive dependency via ipykernel, we declare it as
     # a direct dependency in order to set a lower bound for oldest-deps testing
     "jupyter-core>=4.11.2",
-    "pandas>=2.0.0",
+    "pandas>=2.0.2",
 ]
 # This is ALL the run-time optional dependencies.
 all = [
@@ -121,7 +121,7 @@ test_all = [
     "array-api-strict<2.4;python_version<'3.12'",  # PYTHON_LT_3_12
 ]
 typing = [
-    "pandas-stubs>=2.0.0",
+    "pandas-stubs>=2.0.2",
     "narwhals>=1.42.0" # keep in sync with dependency-groups.dataframe
 ]
 docs = [
@@ -184,7 +184,7 @@ dataframe = [
     # and project.optional-dependencies.typing
     "narwhals>=1.42.0",
     "pyarrow>=14.0.2",
-    "pandas>=2.0.0",
+    "pandas>=2.0.2",
     "polars>=1.0.0",
     "duckdb>=1.1.0",
     "dask[dataframe]>=2024.8.0"

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ class EditableInstallWithStubs(editable_wheel):
 # Specify the minimum version for the Numpy C-API
 for ext in ext_modules:
     if ext.include_dirs and "numpy" in ext.include_dirs[0]:
-        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_24_API_VERSION"))
+        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_25_API_VERSION"))
         ext.define_macros.append(("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"))
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy124,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -54,7 +54,6 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of direct dependencies
     cov: and test coverage
-    numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
     image: with image tests
     mpl380: with matplotlib 3.8.0
@@ -63,7 +62,6 @@ description =
     noscipy: without scipy-dev
 
 deps =
-    numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
 
     mpl380: matplotlib==3.8.0


### PR DESCRIPTION
### Description

[NEP 18 — A dispatch mechanism for NumPy’s high level array functions](https://numpy.org/neps/nep-0018-array-function-protocol.html) introduced the `__array_function__` protocol, but some versions of `numpy` have allowed disabling that functionality with the `NUMPY_EXPERIMENTAL_ARRAY_FUNCTION` environment variable. `astropy` is also trying to support that variable, but because `astropy` looks up `numpy.core.overrides.ENABLE_ARRAY_FUNCTION` instead of `numpy.core.overrides.ARRAY_FUNCTION_ENABLED` then `astropy` has actually never supported disabling NEP 18 dispatching. Given that [`numpy>=1.25` does not support the disabling](https://numpy.org/doc/stable/release/1.25.0-notes.html#expired-deprecations), it is simplest for `astropy` to solve the problem by dropping support for `numpy<1.25`. [SPEC 0](https://scientific-python.org/specs/spec-0000/) would allow us to drop support for `numpy<2`, so we are still being very generous with our `numpy` support.

EDIT: I should clarify that this is not a runtime bug because `numpy` NEP 18 implementation does not depend on `astropy`. But it does mean that if someone uses the environment variable to turn off `__array_function__` and then runs `astropy` tests then the tests fail at collection despite all the infrastructure that was added for this feature. So we can either fix the tests to support running `NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=0 pytest` with `numpy==1.24` or we avoid the problem by dropping support for `numpy<1.25`. The latter is much simpler.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
