### PR TITLE
Delete a no-op code block from `FunctionTransform`

### DIFF
--- a/astropy/coordinates/transformations/function.py
+++ b/astropy/coordinates/transformations/function.py
@@ -5,8 +5,6 @@
 These are transformations that cannot be represented as an affine transformation.
 """
 
-from contextlib import suppress
-from inspect import signature
 from warnings import warn
 
 from astropy import units as u
@@ -56,16 +54,6 @@ class FunctionTransform(CoordinateTransform):
     def __init__(self, func, fromsys, tosys, priority=1, register_graph=None):
         if not callable(func):
             raise TypeError("func must be callable")
-
-        with suppress(TypeError):
-            sig = signature(func)
-            kinds = [x.kind for x in sig.parameters.values()]
-            if (
-                len(x for x in kinds if x == sig.POSITIONAL_ONLY) != 2
-                and sig.VAR_POSITIONAL not in kinds
-            ):
-                raise ValueError("provided function does not accept two arguments")
-
         self.func = func
 
         super().__init__(


### PR DESCRIPTION
### Description

When I added type annotations to `CoordinateTransform` and its subclasses in #18739 Mypy started complaining about a code block in `FunctionTransform` that turned out to be a no-op. The patch to remove the no-op code was originally the second commit in #18739, but there is no good reason why applying the patch should wait for the typing PR.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
