### PR TITLE
Speed up a noticeably slow `coordinates` test

### DIFF
--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -685,7 +685,7 @@ def test_regression_10422(mjd):
     size=1 non-scalar Time.
     """
     # Avoid trying to download new IERS data.
-    with iers.earth_orientation_table.set(iers.IERS_B.open(iers.IERS_B_FILE)):
+    with iers.conf.set_temp("auto_max_age", None):
         t = Time(mjd, format="mjd", scale="tai")
         loc = EarthLocation(88258.0 * u.m, -4924882.2 * u.m, 3943729.0 * u.m)
         p, v = loc.get_gcrs_posvel(obstime=t)


### PR DESCRIPTION
### Description

On current `main`
```
$ pytest --quiet astropy/coordinates/tests/test_regression.py | tail -n 1
46 passed, 2 skipped in 1.38s
```
With this patch
```
$ pytest --quiet astropy/coordinates/tests/test_regression.py | tail -n 1
46 passed, 2 skipped in 0.69s
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
