### PR TITLE
Revert "CI: enable python dependencies caching"

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -63,15 +63,12 @@ jobs:
         apt:
           - language-pack-fr
           - tzdata
-
       envs: |
         # NOTE: this coverage test is needed for tests and code that
         #       run only with minimal dependencies.
         - name: Python 3.12 with minimal dependencies and full coverage
           linux: py312-test-cov
           coverage: codecov
-          cache-path: .tox
-          cache-key: mindeps-${{ github.ref_name }}
 
         - name: Python 3.12 in Parallel with all optional dependencies
           linux: py312-test-alldeps-fitsio
@@ -83,8 +80,6 @@ jobs:
               - libcfitsio-dev
           toxargs: -v --develop
           posargs: -n=4 --run-slow
-          cache-path: .tox
-          cache-key: alldeps-linux-${{ github.ref_name }}
 
         - name: Python 3.11 with oldest supported version of all dependencies
           linux: py311-test-oldestdeps-alldeps-cov-clocale
@@ -94,15 +89,11 @@ jobs:
         - name: Python 3.12 with all optional dependencies (Windows)
           windows: py312-test-alldeps
           posargs: --durations=50
-          cache-path: .tox
-          cache-key: alldeps-windows-${{ github.ref_name }}
 
         - name: Python 3.12 with all optional dependencies (MacOS X)
           macos: py312-test-alldeps
           posargs: --durations=50 --run-slow
           runs-on: macos-latest
-          cache-path: .tox
-          cache-key: alldeps-macos-${{ github.ref_name }}
 
         # FIXME: Add aarch64 to name when bump Python version.
         - name: Python 3.11 Double test (Run tests twice)
@@ -112,8 +103,6 @@ jobs:
           setenv: |
             ARCH_ON_CI: "arm64"
             IS_CRON: "false"
-          cache-path: .tox
-          cache-key: doubletest-${{ github.ref_name }}
 
   allowed_failures:
     needs: [initial_checks]
@@ -145,8 +134,6 @@ jobs:
       envs: |
         - name: Stubs for unit definition modules
           linux: stubtest
-          cache-path: .tox
-          cache-key: stub_tests-${{ github.ref_name }}
 
   test_wheel_building:
     needs: [initial_checks]


### PR DESCRIPTION
Reverts astropy/astropy#18835

Close https://github.com/astropy/astropy/issues/18982

On the off-chance it is actually the cause of pyinstaller failure. That PR did not run Extra CI before merge.