### PR TITLE
DEP: use PEP 735 dependency groups instead of tox-only deps specs for image tests and pyinstaller dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,14 @@ dataframe = [
     "duckdb>=1.1.0",
     "dask[dataframe]>=2024.8.0", # keep in sync with other declarations
 ]
+image_tests = [
+    "pytest-mpl>=0.18",
+]
+pyinstaller = [
+    "pyinstaller>=6.16.0",
+    {include-group = "image_tests"},
+]
+
 # re-define historical optional dependencies (a.k.a. 'extras') as
 # user-invisible, PEP 735 dependency groups
 # These group together all the dependencies needed for developing in Astropy.
@@ -203,6 +211,7 @@ dev = [
 dev_all = [
     {include-group = "dev"},
     {include-group = "dataframe"},
+    {include-group = "image_tests"},
     "astropy[test_all]",
     "tox>=4.33.0", # keep in sync with tox.minversion in tox.ini
 ]
@@ -824,6 +833,9 @@ no-build-package = [
     # even with --resolution=lowest
     "cffi",
     "joblib",
+
+    # via pyinstaller
+    "altgraph",
 ]
 
 # ensure that uv resolves envs that are compatible with macOS arm64,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,14 @@ dataframe = [
     "duckdb>=1.1.0",
     "dask[dataframe]>=2024.8.0", # keep in sync with other declarations
 ]
+image_tests = [
+    "pytest-mpl>=0.18",
+]
+pyinstaller = [
+    "pyinstaller>=6.16.0",
+    {include-group = "image_tests"},
+]
+
 # re-define historical optional dependencies (a.k.a. 'extras') as
 # user-invisible, PEP 735 dependency groups
 # These group together all the dependencies needed for developing in Astropy.
@@ -203,8 +211,13 @@ dev = [
 dev_all = [
     {include-group = "dev"},
     {include-group = "dataframe"},
+    {include-group = "image_tests"},
     "astropy[test_all]",
     "tox>=4.33.0", # keep in sync with tox.minversion in tox.ini
+]
+imagetest = [
+    "latex>=0.7.0",
+    "scipy>=1.13",
 ]
 
 [tool.setuptools]
@@ -824,6 +837,12 @@ no-build-package = [
     # even with --resolution=lowest
     "cffi",
     "joblib",
+
+    # via pyinstaller
+    "altgraph",
+
+    # via latex
+    "future",
 ]
 
 # ensure that uv resolves envs that are compatible with macOS arm64,

--- a/scripts/lowest-resolved-tree.txt
+++ b/scripts/lowest-resolved-tree.txt
@@ -429,27 +429,51 @@ astropy
 │   │   │   │   ├── pandas v2.2.2 (group: dev-all) (*)
 │   │   │   │   ├── polars v1.18.0 (group: dev-all)
 │   │   │   │   ├── pyarrow v16.0.0 (group: dev-all) (*)
-│   │   │   │   └── tox v4.33.0 (group: dev-all)
-│   │   │   │       ├── cachetools v6.2.4
-│   │   │   │       ├── chardet v5.2.0
-│   │   │   │       ├── colorama v0.4.6
-│   │   │   │       ├── filelock v3.20.2
-│   │   │   │       ├── packaging v25.0
-│   │   │   │       ├── platformdirs v4.5.1
-│   │   │   │       ├── pluggy v1.6.0
-│   │   │   │       ├── pyproject-api v1.10.0
-│   │   │   │       │   └── packaging v25.0
-│   │   │   │       └── virtualenv v20.35.4
-│   │   │   │           ├── distlib v0.3.7
-│   │   │   │           ├── filelock v3.20.2
-│   │   │   │           └── platformdirs v4.5.1
+│   │   │   │   ├── pytest-mpl v0.18.0 (group: dev-all)
+│   │   │   │   │   ├── jinja2 v3.1.3 (*)
+│   │   │   │   │   ├── matplotlib v3.8.4 (*)
+│   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   ├── pillow v9.2.0
+│   │   │   │   │   └── pytest v8.0.1 (*)
+│   │   │   │   ├── tox v4.33.0 (group: dev-all)
+│   │   │   │   │   ├── cachetools v6.2.4
+│   │   │   │   │   ├── chardet v5.2.0
+│   │   │   │   │   ├── colorama v0.4.6
+│   │   │   │   │   ├── filelock v3.20.2
+│   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   ├── platformdirs v4.5.1
+│   │   │   │   │   ├── pluggy v1.6.0
+│   │   │   │   │   ├── pyproject-api v1.10.0
+│   │   │   │   │   │   └── packaging v25.0
+│   │   │   │   │   └── virtualenv v20.35.4
+│   │   │   │   │       ├── distlib v0.3.7
+│   │   │   │   │       ├── filelock v3.20.2
+│   │   │   │   │       └── platformdirs v4.5.1
+│   │   │   │   ├── pytest-mpl v0.18.0 (group: image-tests) (*)
+│   │   │   │   ├── pyinstaller v6.16.0 (group: pyinstaller)
+│   │   │   │   │   ├── altgraph v0.13
+│   │   │   │   │   ├── macholib v1.8
+│   │   │   │   │   │   └── altgraph v0.13
+│   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   ├── pefile v2022.5.30
+│   │   │   │   │   │   └── future v0.0.1
+│   │   │   │   │   ├── pyinstaller-hooks-contrib v2025.8
+│   │   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   │   └── setuptools v77.0.1
+│   │   │   │   │   ├── pywin32-ctypes v0.2.1
+│   │   │   │   │   └── setuptools v77.0.1
+│   │   │   │   └── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 │   │   │   ├── dask[dataframe] v2024.8.0 (group: dev-all) (*)
 │   │   │   ├── duckdb v1.1.0 (group: dev-all)
 │   │   │   ├── narwhals v1.42.0 (group: dev-all)
 │   │   │   ├── pandas v2.2.2 (group: dev-all) (*)
 │   │   │   ├── polars v1.18.0 (group: dev-all)
 │   │   │   ├── pyarrow v16.0.0 (group: dev-all) (*)
-│   │   │   └── tox v4.33.0 (group: dev-all) (*)
+│   │   │   ├── pytest-mpl v0.18.0 (group: dev-all) (*)
+│   │   │   ├── tox v4.33.0 (group: dev-all) (*)
+│   │   │   ├── pytest-mpl v0.18.0 (group: image-tests) (*)
+│   │   │   ├── pyinstaller v6.16.0 (group: pyinstaller) (*)
+│   │   │   └── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 │   │   ├── astropy[docs, recommended, test, test-all, typing] (group: dev-all) (*)
 │   │   ├── dask[dataframe] v2024.8.0 (group: dev-all) (*)
 │   │   ├── duckdb v1.1.0 (group: dev-all)
@@ -457,7 +481,11 @@ astropy
 │   │   ├── pandas v2.2.2 (group: dev-all) (*)
 │   │   ├── polars v1.18.0 (group: dev-all)
 │   │   ├── pyarrow v16.0.0 (group: dev-all) (*)
-│   │   └── tox v4.33.0 (group: dev-all) (*)
+│   │   ├── pytest-mpl v0.18.0 (group: dev-all) (*)
+│   │   ├── tox v4.33.0 (group: dev-all) (*)
+│   │   ├── pytest-mpl v0.18.0 (group: image-tests) (*)
+│   │   ├── pyinstaller v6.16.0 (group: pyinstaller) (*)
+│   │   └── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 │   ├── numpy v2.0.0
 │   └── packaging v25.0
 ├── beautifulsoup4 v4.11.2 (extra: all) (*)
@@ -577,5 +605,9 @@ astropy
 ├── pandas v2.2.2 (group: dev-all) (*)
 ├── polars v1.18.0 (group: dev-all)
 ├── pyarrow v16.0.0 (group: dev-all) (*)
-└── tox v4.33.0 (group: dev-all) (*)
+├── pytest-mpl v0.18.0 (group: dev-all) (*)
+├── tox v4.33.0 (group: dev-all) (*)
+├── pytest-mpl v0.18.0 (group: image-tests) (*)
+├── pyinstaller v6.16.0 (group: pyinstaller) (*)
+└── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 (*) Package tree already displayed

--- a/scripts/lowest-resolved-tree.txt
+++ b/scripts/lowest-resolved-tree.txt
@@ -429,27 +429,60 @@ astropy
 │   │   │   │   ├── pandas v2.2.2 (group: dev-all) (*)
 │   │   │   │   ├── polars v1.18.0 (group: dev-all)
 │   │   │   │   ├── pyarrow v16.0.0 (group: dev-all) (*)
-│   │   │   │   └── tox v4.33.0 (group: dev-all)
-│   │   │   │       ├── cachetools v6.2.4
-│   │   │   │       ├── chardet v5.2.0
-│   │   │   │       ├── colorama v0.4.6
-│   │   │   │       ├── filelock v3.20.2
-│   │   │   │       ├── packaging v25.0
-│   │   │   │       ├── platformdirs v4.5.1
-│   │   │   │       ├── pluggy v1.6.0
-│   │   │   │       ├── pyproject-api v1.10.0
-│   │   │   │       │   └── packaging v25.0
-│   │   │   │       └── virtualenv v20.35.4
-│   │   │   │           ├── distlib v0.3.7
-│   │   │   │           ├── filelock v3.20.2
-│   │   │   │           └── platformdirs v4.5.1
+│   │   │   │   ├── pytest-mpl v0.18.0 (group: dev-all)
+│   │   │   │   │   ├── jinja2 v3.1.3 (*)
+│   │   │   │   │   ├── matplotlib v3.8.4 (*)
+│   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   ├── pillow v9.2.0
+│   │   │   │   │   └── pytest v8.0.1 (*)
+│   │   │   │   ├── tox v4.33.0 (group: dev-all)
+│   │   │   │   │   ├── cachetools v6.2.4
+│   │   │   │   │   ├── chardet v5.2.0
+│   │   │   │   │   ├── colorama v0.4.6
+│   │   │   │   │   ├── filelock v3.20.2
+│   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   ├── platformdirs v4.5.1
+│   │   │   │   │   ├── pluggy v1.6.0
+│   │   │   │   │   ├── pyproject-api v1.10.0
+│   │   │   │   │   │   └── packaging v25.0
+│   │   │   │   │   └── virtualenv v20.35.4
+│   │   │   │   │       ├── distlib v0.3.7
+│   │   │   │   │       ├── filelock v3.20.2
+│   │   │   │   │       └── platformdirs v4.5.1
+│   │   │   │   ├── pytest-mpl v0.18.0 (group: image-tests) (*)
+│   │   │   │   ├── latex v0.7.0 (group: imagetest)
+│   │   │   │   │   ├── data v0.1
+│   │   │   │   │   │   └── six v1.9.0
+│   │   │   │   │   ├── future v1.0.0
+│   │   │   │   │   ├── shutilwhich v1.0
+│   │   │   │   │   └── tempdir v0.5
+│   │   │   │   ├── scipy v1.13.0 (group: imagetest) (*)
+│   │   │   │   ├── pyinstaller v6.16.0 (group: pyinstaller)
+│   │   │   │   │   ├── altgraph v0.13
+│   │   │   │   │   ├── macholib v1.8
+│   │   │   │   │   │   └── altgraph v0.13
+│   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   ├── pefile v2022.5.30
+│   │   │   │   │   │   └── future v1.0.0
+│   │   │   │   │   ├── pyinstaller-hooks-contrib v2025.8
+│   │   │   │   │   │   ├── packaging v25.0
+│   │   │   │   │   │   └── setuptools v77.0.1
+│   │   │   │   │   ├── pywin32-ctypes v0.2.1
+│   │   │   │   │   └── setuptools v77.0.1
+│   │   │   │   └── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 │   │   │   ├── dask[dataframe] v2024.8.0 (group: dev-all) (*)
 │   │   │   ├── duckdb v1.1.0 (group: dev-all)
 │   │   │   ├── narwhals v1.42.0 (group: dev-all)
 │   │   │   ├── pandas v2.2.2 (group: dev-all) (*)
 │   │   │   ├── polars v1.18.0 (group: dev-all)
 │   │   │   ├── pyarrow v16.0.0 (group: dev-all) (*)
-│   │   │   └── tox v4.33.0 (group: dev-all) (*)
+│   │   │   ├── pytest-mpl v0.18.0 (group: dev-all) (*)
+│   │   │   ├── tox v4.33.0 (group: dev-all) (*)
+│   │   │   ├── pytest-mpl v0.18.0 (group: image-tests) (*)
+│   │   │   ├── latex v0.7.0 (group: imagetest) (*)
+│   │   │   ├── scipy v1.13.0 (group: imagetest) (*)
+│   │   │   ├── pyinstaller v6.16.0 (group: pyinstaller) (*)
+│   │   │   └── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 │   │   ├── astropy[docs, recommended, test, test-all, typing] (group: dev-all) (*)
 │   │   ├── dask[dataframe] v2024.8.0 (group: dev-all) (*)
 │   │   ├── duckdb v1.1.0 (group: dev-all)
@@ -457,7 +490,13 @@ astropy
 │   │   ├── pandas v2.2.2 (group: dev-all) (*)
 │   │   ├── polars v1.18.0 (group: dev-all)
 │   │   ├── pyarrow v16.0.0 (group: dev-all) (*)
-│   │   └── tox v4.33.0 (group: dev-all) (*)
+│   │   ├── pytest-mpl v0.18.0 (group: dev-all) (*)
+│   │   ├── tox v4.33.0 (group: dev-all) (*)
+│   │   ├── pytest-mpl v0.18.0 (group: image-tests) (*)
+│   │   ├── latex v0.7.0 (group: imagetest) (*)
+│   │   ├── scipy v1.13.0 (group: imagetest) (*)
+│   │   ├── pyinstaller v6.16.0 (group: pyinstaller) (*)
+│   │   └── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 │   ├── numpy v2.0.0
 │   └── packaging v25.0
 ├── beautifulsoup4 v4.11.2 (extra: all) (*)
@@ -577,5 +616,11 @@ astropy
 ├── pandas v2.2.2 (group: dev-all) (*)
 ├── polars v1.18.0 (group: dev-all)
 ├── pyarrow v16.0.0 (group: dev-all) (*)
-└── tox v4.33.0 (group: dev-all) (*)
+├── pytest-mpl v0.18.0 (group: dev-all) (*)
+├── tox v4.33.0 (group: dev-all) (*)
+├── pytest-mpl v0.18.0 (group: image-tests) (*)
+├── latex v0.7.0 (group: imagetest) (*)
+├── scipy v1.13.0 (group: imagetest) (*)
+├── pyinstaller v6.16.0 (group: pyinstaller) (*)
+└── pytest-mpl v0.18.0 (group: pyinstaller) (*)
 (*) Package tree already displayed

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ deps =
 
     image: latex
     image, devpytest: scipy
-    image: pytest-mpl>=0.18
 
     # Some FITS tests use fitsio as a comparison
     fitsio: fitsio
@@ -118,6 +117,7 @@ extras =
 
 dependency_groups =
     alldeps: dataframe
+    image: image-tests
 
 commands =
     # docdeps-predeps: Override sphinx max pin in sphinx-design
@@ -209,11 +209,9 @@ commands =
 # to run them.
 description = check that astropy can be included in a pyinstaller bundle
 changedir = .pyinstaller
-deps =
-    pyinstaller
-    pytest-mpl
-    matplotlib
 extras = test
+dependency_groups =
+    pyinstaller
 commands =
     pyinstaller --onefile run_astropy_tests.py \
                 --distpath . \

--- a/tox.ini
+++ b/tox.ini
@@ -70,10 +70,6 @@ deps =
     mpl380: matplotlib==3.8.4
     mpl380: pyparsing==3.2.5
 
-    image: latex
-    image, devpytest: scipy
-    image: pytest-mpl>=0.18
-
     # Some FITS tests use fitsio as a comparison
     fitsio: fitsio
 
@@ -90,6 +86,7 @@ deps =
     mpldev: matplotlib>=0.0.dev0
 
     # Latest developer version of infrastructure packages.
+    devpytest: scipy
     devpytest: git+https://github.com/pytest-dev/pytest.git
     devpytest: git+https://github.com/astropy/extension-helpers.git
     devpytest: git+https://github.com/scientific-python/pytest-doctestplus.git
@@ -118,6 +115,7 @@ extras =
 
 dependency_groups =
     alldeps: dataframe
+    image: image-tests
 
 commands =
     # docdeps-predeps: Override sphinx max pin in sphinx-design
@@ -209,11 +207,9 @@ commands =
 # to run them.
 description = check that astropy can be included in a pyinstaller bundle
 changedir = .pyinstaller
-deps =
-    pyinstaller
-    pytest-mpl
-    matplotlib
 extras = test
+dependency_groups =
+    pyinstaller
 commands =
     pyinstaller --onefile run_astropy_tests.py \
                 --distpath . \


### PR DESCRIPTION
### Description
Using PEP 735 dependency groups makes these dependencies discoverable through other tools than tox (including uv), which is helpful when debugging problems like #18982 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
