### PR TITLE
Add a shortcut to `PhysicalType` equality checks

### DIFF
--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -259,6 +259,8 @@ class PhysicalType:
         Return `True` if ``other`` represents a physical type that is
         consistent with the physical type of the `PhysicalType` instance.
         """
+        if self is other:
+            return True
         if isinstance(other, PhysicalType):
             return self._unit._physical_type_id == other._unit._physical_type_id
         elif isinstance(other, str):


### PR DESCRIPTION
### Description

Checking for identity in `PhysicalType.__eq__()` speeds up the comparison quite a lot if the identity check produces `True` and slows down the comparison by very little if it is not. Compare timings on current `main`:
```
Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.7.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: You can use Ctrl-O to force a new line in terminal IPython

In [1]: from astropy.units.physical import length, mass

In [2]: %timeit length == length
84.1 ns ± 0.0881 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit length == mass
92.5 ns ± 0.168 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
and with this patch:
```
In [1]: from astropy.units.physical import length, mass

In [2]: %timeit length == length
40.8 ns ± 0.0257 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit length == mass
96.4 ns ± 0.0488 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
This is a good tradeoff because in practice the case of a physical type being compared with itself is often on the happy path (e.g. validating that some quantity has the expected physical type). `UnitBase.__eq__()` already contains an analogous shortcut: https://github.com/astropy/astropy/blob/5d0876b88128a5d34811b303a51c75b927daab17/astropy/units/core.py#L379-L381

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.