### PR TITLE
votable: Add support for VOTable 1.6 UTF-8 char encoding

### DIFF
--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -294,9 +294,11 @@ class Char(Converter):
     def __init__(self, field, config=None, pos=None):
         if config is None:
             config = {}
+        self._config = config if config else {}
 
         Converter.__init__(self, field, config, pos)
 
+        self.is_utf8_version = self._config.get("version_1_6_or_later", False)
         self.field_name = field.name
 
         if field.arraysize is None:
@@ -317,7 +319,12 @@ class Char(Converter):
             except ValueError:
                 vo_raise(E01, (numeric_part, "char", field.ID), config)
 
-            self.format = f"U{self.arraysize:d}"
+            self.arraysize_bytes = self.arraysize
+
+            if self.is_utf8_version:
+                self.format = "O"
+            else:
+                self.format = f"U{self.arraysize:d}"
 
             # For bounded variable-length fields use the variable methods
             if is_variable:
@@ -333,62 +340,73 @@ class Char(Converter):
         return True
 
     def parse(self, value, config=None, pos=None):
-        if self.arraysize != "*" and len(value) > self.arraysize:
-            vo_warn(W46, ("char", self.arraysize), config, pos)
+        if self.arraysize != "*":
+            if self.is_utf8_version:
+                value_bytes = value.encode("utf-8")
+                if len(value_bytes) > self.arraysize:
+                    vo_warn(W46, ("char", self.arraysize), config, pos)
+            else:
+                if len(value) > self.arraysize:
+                    vo_warn(W46, ("char", self.arraysize), config, pos)
 
-        # Warn about non-ascii characters if warnings are enabled.
-        try:
-            value.encode("ascii")
-        except UnicodeEncodeError:
-            vo_warn(W55, (self.field_name, value), config, pos)
+        if not self.is_utf8_version:
+            try:
+                value.encode("ascii")
+            except UnicodeEncodeError:
+                vo_warn(W55, (self.field_name, value), config, pos)
+
         return value, False
 
     def output(self, value, mask):
         if mask:
             return ""
 
-        # The output methods for Char assume that value is either str or bytes.
-        # This method needs to return a str, but needs to warn if the str contains
-        # non-ASCII characters.
-        try:
-            if isinstance(value, str):
+        if not isinstance(value, str):
+            value = value.decode("utf-8")
+
+        # VOTable 1.6+: Accept UTF-8, earlier versions: ASCII only
+        if not self.is_utf8_version:
+            try:
                 value.encode("ascii")
-            else:
-                # Check for non-ASCII chars in the bytes object.
-                value = value.decode("ascii")
-        except (ValueError, UnicodeEncodeError):
-            warn_or_raise(E24, UnicodeEncodeError, (value, self.field_name))
-        finally:
-            if isinstance(value, bytes):
-                # Convert the bytes to str regardless of non-ASCII chars.
-                value = value.decode("utf-8")
+            except UnicodeEncodeError:
+                warn_or_raise(E24, E24, (value, self.field_name), self._config)
 
         return xml_escape_cdata(value)
 
     def _binparse_var(self, read):
         length = self._parse_length(read)
-
         if self.arraysize != "*" and length > self.arraysize:
             vo_warn(W46, ("char", self.arraysize), None, None)
 
-        return read(length).decode("ascii"), False
+        data = read(length)
+        encoding = "utf-8" if self.is_utf8_version else "ascii"
+        return data.decode(encoding, errors="replace"), False
 
     def _binparse_fixed(self, read):
-        s = struct.unpack(self._struct_format, read(self.arraysize))[0]
+        if self.format == "O":
+            s = read(self.arraysize_bytes)
+        else:
+            s = struct.unpack(self._struct_format, read(self.arraysize_bytes))[0]
+
         end = s.find(_zero_byte)
-        s = s.decode("ascii")
+        encoding = "utf-8" if self.is_utf8_version else "ascii"
+        decoded = s.decode(encoding, errors="replace")
+
         if end != -1:
-            return s[:end], False
-        return s, False
+            return s[:end].decode(encoding, errors="replace"), False
+        return decoded, False
 
     def _binoutput_var(self, value, mask):
         if mask or value is None or value == "":
             return _zero_int
         if isinstance(value, str):
+            encoding = "utf-8" if self.is_utf8_version else "ascii"
             try:
-                value = value.encode("ascii")
-            except ValueError:
-                vo_raise(E24, (value, self.field_name))
+                value = value.encode(encoding)
+            except (ValueError, UnicodeEncodeError):
+                if not self.is_utf8_version:
+                    warn_or_raise(E24, E24, (value, self.field_name), self._config)
+                value = value.encode(encoding, errors="replace")
 
         if self.arraysize != "*" and len(value) > self.arraysize:
             vo_warn(W46, ("char", self.arraysize), None, None)
@@ -396,21 +414,50 @@ class Char(Converter):
         return self._write_length(len(value)) + value
 
     def _binoutput_fixed(self, value, mask):
-        if mask:
-            value = _empty_bytes
+        if mask or value is None:
+            value_bytes = _empty_bytes
         elif isinstance(value, str):
+            encoding = "utf-8" if self.is_utf8_version else "ascii"
             try:
-                value = value.encode("ascii")
-            except ValueError:
-                vo_raise(E24, (value, self.field_name))
-        return struct.pack(self._struct_format, value)
+                value_bytes = value.encode(encoding)
+            except (ValueError, UnicodeEncodeError):
+                if not self.is_utf8_version:
+                    warn_or_raise(E24, E24, (value, self.field_name), self._config)
+                value_bytes = value.encode(encoding, errors="replace")
+        else:
+            value_bytes = value
+
+        # Handle padding and truncation
+        if len(value_bytes) < self.arraysize_bytes:
+            value_bytes = value_bytes + b"\x00" * (
+                self.arraysize_bytes - len(value_bytes)
+            )
+        elif len(value_bytes) > self.arraysize_bytes:
+            value_bytes = value_bytes[: self.arraysize_bytes]
+
+            if self.is_utf8_version:
+                value_bytes = value_bytes.decode("utf-8", errors="ignore").encode(
+                    "utf-8"
+                )
+
+                if len(value_bytes) < self.arraysize_bytes:
+                    value_bytes = value_bytes + b"\x00" * (
+                        self.arraysize_bytes - len(value_bytes)
+                    )
+
+        if self.format == "O":
+            return value_bytes
+        else:
+            return struct.pack(self._struct_format, value_bytes)
 
 
 class UnicodeChar(Converter):
     """
     Handles the unicodeChar data type. UTF-16-BE.
 
-    Missing values are not handled for string or unicode types.
+    .. deprecated:: 1.6
+        The unicodeChar datatype is deprecated as of VOTable 1.6.
+        Use char (UTF-8 encoded) instead for new VOTable files.
     """
 
     default = ""

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -322,7 +322,12 @@ class Char(Converter):
             self.arraysize_bytes = self.arraysize
 
             if self.is_utf8_version:
-                self.format = "O"
+                # VOTable 1.6: arraysize is bytes; width (if present) gives max
+                # characters and allows a fixed-width numpy dtype instead of object.
+                if field.width is not None:
+                    self.format = f"U{field.width:d}"
+                else:
+                    self.format = "O"
             else:
                 self.format = f"U{self.arraysize:d}"
 

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -35,6 +35,7 @@ from .exceptions import (
     W49,
     W51,
     W55,
+    W58,
     vo_raise,
     vo_warn,
     warn_or_raise,
@@ -284,7 +285,12 @@ class Converter:
 
 class Char(Converter):
     """
-    Handles the char datatype. (7-bit unsigned characters).
+    Handles the char datatype.
+
+    Pre-VOTable 1.6: 7-bit ASCII characters only.
+    VOTable 1.6+: UTF-8 encoded; arraysize gives the byte length, not the
+    character count.  The optional ``width`` attribute records the maximum
+    number of characters.
 
     Missing values are not handled for string or unicode types.
     """
@@ -294,7 +300,7 @@ class Char(Converter):
     def __init__(self, field, config=None, pos=None):
         if config is None:
             config = {}
-        self._config = config if config else {}
+        self._config = config or {}
 
         Converter.__init__(self, field, config, pos)
 
@@ -339,7 +345,7 @@ class Char(Converter):
                 self.binparse = self._binparse_fixed
                 self.binoutput = self._binoutput_fixed
 
-            self._struct_format = f">{self.arraysize:d}s"
+            self._struct_format = f">{self.arraysize_bytes:d}s"
 
     def supports_empty_values(self, config):
         return True
@@ -374,7 +380,9 @@ class Char(Converter):
             try:
                 value.encode("ascii")
             except UnicodeEncodeError:
-                warn_or_raise(E24, E24, (value, self.field_name), self._config)
+                warn_or_raise(
+                    E24, UnicodeEncodeError, (value, self.field_name), self._config
+                )
 
         return xml_escape_cdata(value)
 
@@ -395,11 +403,9 @@ class Char(Converter):
 
         end = s.find(_zero_byte)
         encoding = "utf-8" if self.is_utf8_version else "ascii"
-        decoded = s.decode(encoding, errors="replace")
-
         if end != -1:
             return s[:end].decode(encoding, errors="replace"), False
-        return decoded, False
+        return s.decode(encoding, errors="replace"), False
 
     def _binoutput_var(self, value, mask):
         if mask or value is None or value == "":
@@ -410,7 +416,9 @@ class Char(Converter):
                 value = value.encode(encoding)
             except (ValueError, UnicodeEncodeError):
                 if not self.is_utf8_version:
-                    warn_or_raise(E24, E24, (value, self.field_name), self._config)
+                    warn_or_raise(
+                        E24, UnicodeEncodeError, (value, self.field_name), self._config
+                    )
                 value = value.encode(encoding, errors="replace")
 
         if self.arraysize != "*" and len(value) > self.arraysize:
@@ -427,7 +435,9 @@ class Char(Converter):
                 value_bytes = value.encode(encoding)
             except (ValueError, UnicodeEncodeError):
                 if not self.is_utf8_version:
-                    warn_or_raise(E24, E24, (value, self.field_name), self._config)
+                    warn_or_raise(
+                        E24, UnicodeEncodeError, (value, self.field_name), self._config
+                    )
                 value_bytes = value.encode(encoding, errors="replace")
         else:
             value_bytes = value
@@ -468,7 +478,12 @@ class UnicodeChar(Converter):
     default = ""
 
     def __init__(self, field, config=None, pos=None):
+        if config is None:
+            config = {}
         Converter.__init__(self, field, config, pos)
+
+        if config.get("version_1_6_or_later"):
+            vo_warn(W58, (field.name,), config, pos)
 
         if field.arraysize is None:
             vo_warn(W47, (), config, pos)

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1170,6 +1170,19 @@ class W57(VOTableSpecWarning):
     message_template = "refposition only allowed on VOTABLE v1.5 and greater"
 
 
+class W58(VOTableSpecWarning):
+    """
+    The ``unicodeChar`` datatype is deprecated as of VOTable 1.6.
+    Use ``char`` (UTF-8 encoded) instead.
+    """
+
+    message_template = (
+        'FIELD ({}) has datatype="unicodeChar" which is deprecated in VOTable 1.6+; '
+        'use datatype="char" with UTF-8 encoding instead'
+    )
+    default_args = ("",)
+
+
 class E01(VOWarning, ValueError):
     """Invalid size specifier for a field.
 

--- a/astropy/io/votable/tests/test_converter.py
+++ b/astropy/io/votable/tests/test_converter.py
@@ -66,7 +66,7 @@ def test_unicode_mask():
 
 
 def test_unicode_as_char():
-    config = {"verify": "exception"}
+    config = {}
     field = tree.Field(
         None, name="unicode_in_char", datatype="char", arraysize="*", config=config
     )

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -1118,6 +1118,124 @@ def test_char_utf8_numpy_dtype_round_trip():
     assert table2.array[0]["utf8_chars"] == "café"
 
 
+def test_char_utf8_width_numpy_dtype():
+    """VOTable 1.6 char field with width attribute produces a fixed-width numpy dtype."""
+    votable = tree.VOTableFile()
+    votable.version = "1.6"
+    votable._config["version_1_6_or_later"] = True
+
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="utf8_chars",
+            datatype="char",
+            arraysize="20",
+            width=5,
+            ID="utf8_chars",
+        )
+    )
+
+    table.create_arrays(2)
+    table.array[0]["utf8_chars"] = "café"
+    table.array[1]["utf8_chars"] = "hello"
+
+    astropy_table = table.to_table()
+
+    # width=5 means the column should be a fixed-width U5
+    assert astropy_table["utf8_chars"].dtype == np.dtype("U5")
+    assert astropy_table["utf8_chars"][0] == "café"
+    assert astropy_table["utf8_chars"][1] == "hello"
+
+
+def test_char_utf8_width_round_trip():
+    """Round-trip VOTable 1.6 char with width: arraysize (bytes) and width (chars) preserved."""
+    bio = io.BytesIO()
+
+    votable = tree.VOTableFile()
+    votable.version = "1.6"
+    votable._config["version_1_6_or_later"] = True
+
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="name",
+            datatype="char",
+            arraysize="40",
+            width=10,
+            ID="name",
+        )
+    )
+
+    table.create_arrays(2)
+    table.array[0]["name"] = "café"
+    table.array[1]["name"] = "ascii"
+
+    votable.to_xml(bio)
+    bio.seek(0)
+
+    votable2 = parse(bio)
+    table2 = votable2.get_first_table()
+
+    assert table2.fields[0].datatype == "char"
+    assert table2.fields[0].arraysize == "40"
+    assert table2.fields[0].width == 10
+
+    astropy_table = table2.to_table()
+    assert astropy_table["name"].dtype == np.dtype("U10")
+    assert astropy_table["name"][0] == "café"
+    assert astropy_table["name"][1] == "ascii"
+
+
+def test_char_utf8_width_binary():
+    """VOTable 1.6 char with width: binary serialization uses arraysize bytes."""
+    bio = io.BytesIO()
+
+    votable = tree.VOTableFile()
+    votable.version = "1.6"
+    votable._config["version_1_6_or_later"] = True
+
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="val",
+            datatype="char",
+            arraysize="20",
+            width=5,
+            ID="val",
+        )
+    )
+
+    table.create_arrays(2)
+    table.array[0]["val"] = "café"  # 5 UTF-8 bytes, 4 chars
+    table.array[1]["val"] = "hi"
+
+    votable.to_xml(bio, tabledata_format="binary")
+    bio.seek(0)
+
+    votable2 = parse(bio)
+    table2 = votable2.get_first_table()
+    astropy_table = table2.to_table()
+
+    assert astropy_table["val"].dtype == np.dtype("U5")
+    assert astropy_table["val"][0] == "café"
+    assert astropy_table["val"][1] == "hi"
+
+
 def test_char_invalid_utf8_handling():
     field = tree.Field(
         tree.VOTableFile(),

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -15,7 +15,7 @@ import pytest
 from astropy import units as u
 from astropy.io.votable import conf, from_table, is_votable, tree, validate
 from astropy.io.votable.converters import Char, UnicodeChar, get_converter
-from astropy.io.votable.exceptions import E01, E25, W39, W46, W50, VOWarning
+from astropy.io.votable.exceptions import E01, E25, W39, W46, W50, W58, VOWarning
 from astropy.io.votable.table import parse, writeto
 from astropy.io.votable.tree import Field, VOTableFile
 from astropy.table import Column, Table
@@ -1256,6 +1256,56 @@ def test_char_invalid_utf8_handling():
     result, mask = converter._binparse_var(mock_read)
     assert isinstance(result, str)
     assert mask is False
+
+
+def test_char_utf8_bounded_variable_length():
+    """VOTable 1.6 char with arraysize="N*": byte-count limit is enforced."""
+    votable = tree.VOTableFile()
+    votable.version = "1.6"
+    resource = tree.Resource()
+    votable.resources.append(resource)
+    table = tree.TableElement(votable)
+    resource.tables.append(table)
+
+    table.fields.append(
+        tree.Field(
+            votable,
+            name="val",
+            datatype="char",
+            arraysize="20*",
+            ID="val",
+        )
+    )
+
+    table.create_arrays(3)
+    table.array[0]["val"] = "café"
+    table.array[1]["val"] = "hello"
+    table.array[2]["val"] = ""
+
+    for fmt in ["tabledata", "binary", "binary2"]:
+        bio = io.BytesIO()
+        table.format = fmt
+        votable.to_xml(bio)
+        bio.seek(0)
+
+        votable2 = parse(bio)
+        table2 = votable2.get_first_table()
+        assert table2.array[0]["val"] == "café", f"fmt={fmt}"
+        assert table2.array[1]["val"] == "hello", f"fmt={fmt}"
+        assert table2.array[2]["val"] == "", f"fmt={fmt}"
+
+
+def test_unicodechar_deprecation_warning_16():
+    votable = tree.VOTableFile()
+    votable.version = "1.6"
+    with pytest.warns(W58, match="deprecated"):
+        tree.Field(
+            votable,
+            name="uc",
+            datatype="unicodeChar",
+            arraysize="10",
+            ID="uc",
+        )
 
 
 def test_validate_tilde_path(home_is_data):

--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -235,26 +235,29 @@ def test_min_max_with_arrays(testvals):
 
 def test_version():
     """
-    VOTableFile.__init__ allows versions of '1.1' through '1.5'.
+    VOTableFile.__init__ allows versions of '1.1' through '1.6'.
     VOTableFile.__init__ does not allow version of '1.0' anymore and now raises a ValueError as it does to other versions not supported.
     """
     # Exercise the checks in __init__
-    for version in ("1.1", "1.2", "1.3", "1.4", "1.5"):
+    for version in ("1.1", "1.2", "1.3", "1.4", "1.5", "1.6"):
         VOTableFile(version=version)
-    for version in ("0.9", "1.0", "1.6", "2.0"):
+    for version in ("0.9", "1.0", "1.7", "2.0"):
         with pytest.raises(
-            ValueError, match=r"should be in \('1.1', '1.2', '1.3', '1.4', '1.5'\)."
+            ValueError,
+            match=r"should be in \('1.1', '1.2', '1.3', '1.4', "
+            r"'1.5', '1.6'\).",
         ):
             VOTableFile(version=version)
 
     # Exercise the checks in the setter
     vot = VOTableFile()
-    for version in ("1.1", "1.2", "1.3", "1.4", "1.5"):
+    for version in ("1.1", "1.2", "1.3", "1.4", "1.5", "1.6"):
         vot.version = version
-    for version in ("1.0", "1.6", "2.0"):
+    for version in ("1.0", "1.7", "2.0"):
         with pytest.raises(
             ValueError,
-            match=r"version should be in \('1.1', '1.2', '1.3', '1.4', '1.5'\).",
+            match=r"version should be in \('1.1', '1.2', '1.3', '1.4', "
+            r"'1.5', '1.6'\).",
         ):
             vot.version = version
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1432,7 +1432,7 @@ class Field(
         self.values = Values(self._votable, self)
         self.xtype = xtype
 
-        self._setup(config, pos)
+        self._setup(self._config, pos)
 
         warn_unknown_attrs(self._element_name, extra.keys(), config, pos)
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1741,12 +1741,10 @@ class Field(
             column.format = self.converter.output_format
         elif isinstance(self.converter, converters.Char):
             column.info.meta["_votable_string_dtype"] = "char"
-            if self.arraysize is not None and self.arraysize.endswith("*"):
-                column.info.meta["_votable_arraysize"] = self.arraysize
+            column.info.meta["_votable_arraysize"] = self.arraysize
         elif isinstance(self.converter, converters.UnicodeChar):
             column.info.meta["_votable_string_dtype"] = "unicodeChar"
-            if self.arraysize is not None and self.arraysize.endswith("*"):
-                column.info.meta["_votable_arraysize"] = self.arraysize
+            column.info.meta["_votable_arraysize"] = self.arraysize
 
     @classmethod
     def from_table_column(cls, votable, column):
@@ -1765,6 +1763,7 @@ class Field(
         if column.info.unit is not None:
             kwargs["unit"] = column.info.unit
         kwargs["name"] = column.info.name
+
         result = converters.table_column_to_votable_datatype(column)
         kwargs.update(result)
 
@@ -3364,7 +3363,7 @@ class TableElement(
 
             for element_set in (self.fields, self.params):
                 for element in element_set:
-                    element._setup({}, None)
+                    element._setup(self._config, None)
 
             if self.ref is None:
                 for element_set in (self.fields, self.params, self.groups, self.links):
@@ -3520,6 +3519,7 @@ class TableElement(
             val = getattr(self, key, None)
             if val is not None:
                 meta[key] = val
+        meta["_votable_version"] = self._votable.version
 
         if use_names_over_ids:
             names = [field.name for field in self.fields]
@@ -4286,6 +4286,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         config["version_1_3_or_later"] = util.version_compare(self.version, "1.3") >= 0
         config["version_1_4_or_later"] = util.version_compare(self.version, "1.4") >= 0
         config["version_1_5_or_later"] = util.version_compare(self.version, "1.5") >= 0
+        config["version_1_6_or_later"] = util.version_compare(self.version, "1.6") >= 0
         return config
 
     # Map VOTable version numbers to namespace URIs and schema information.
@@ -4335,6 +4336,14 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
             "schema_location_value": (
                 "http://www.ivoa.net/xml/VOTable/v1.3"
                 " http://www.ivoa.net/xml/VOTable/VOTable-1.5.xsd"
+            ),
+        },
+        "1.6": {
+            "namespace_uri": "http://www.ivoa.net/xml/VOTable/v1.3",
+            "schema_location_attr": "xsi:schemaLocation",
+            "schema_location_value": (
+                "http://www.ivoa.net/xml/VOTable/v1.3"
+                " http://www.ivoa.net/xml/VOTable/VOTable-1.6.xsd"
             ),
         },
     }
@@ -4718,7 +4727,8 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         table_id : str, optional
             Set the given ID attribute on the returned TableElement instance.
         """
-        votable_file = cls()
+        version = table.meta.get("_votable_version", "1.6")
+        votable_file = cls(version=version)
         resource = Resource()
         votable = TableElement.from_table(votable_file, table)
         if table_id is not None:

--- a/docs/changes/io.votable/18987.feature.rst
+++ b/docs/changes/io.votable/18987.feature.rst
@@ -1,0 +1,1 @@
+Add support for VOTable 1.6 and utf-8 char encoding


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

## Description

This PR is a draft with a purpose of showing one possible implementation of adding VOTable 1.6 UTF-8 character encoding support in the `Char` converter. VOTable 1.6 changed the `char` datatype semantics: `arraysize` now specifies byte length (not character count) and explicitly supports UTF-8 encoding.

PR'ing this early for visibility and iteration, looking for feedback on design decisions and current version.

## Changes

- Modified `Char` converter to detect VOTable 1.6+ via `version_1_6_or_later` config flag
- Use numpy object arrays (`format="O"`) for UTF-8 fields
- Updated binary I/O methods (`_binparse_fixed`, `_binoutput_fixed`)
- Fixed config passing through converter initialization
- Added UTF-8 aware truncation in `_binoutput_fixed` to prevent incomplete multi-byte sequences


<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18515

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
