### PR TITLE
TST: fix incorrect settings in testing dataframe support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,7 @@ dataframe = [
     "narwhals>=1.42.0",
     "pyarrow>=16.0",
     "pandas>=2.2.2",
-    "polars>=1.0.0",
+    "polars>=1.18.0",
     "duckdb>=1.1.0",
     "dask[dataframe]>=2024.8.0", # keep in sync with other declarations
 ]

--- a/scripts/lowest-resolved-tree.txt
+++ b/scripts/lowest-resolved-tree.txt
@@ -465,6 +465,6 @@ astropy
 ├── duckdb v1.1.0 (group: dataframe)
 ├── narwhals v1.42.0 (group: dataframe)
 ├── pandas v2.2.2 (group: dataframe) (*)
-├── polars v1.0.0 (group: dataframe)
+├── polars v1.18.0 (group: dataframe)
 └── pyarrow v16.0.0 (group: dataframe) (*)
 (*) Package tree already displayed

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ extras =
     alldeps, docdeps: all
     docdeps: docs
 
-dependency-groups =
+dependency_groups =
     alldeps: dataframe
 
 commands =
@@ -146,7 +146,7 @@ description = invoke sphinx-build to build the HTML docs
 extras =
   docs
   all
-dependency-groups =
+dependency_groups =
   dataframe
 
 setenv =


### PR DESCRIPTION
### Description
This issue was introduced silently in #18435. I just found out about in while working on #18984.
I except more work will be needed to get this into shape because, at the moment, it results in a stealth upgrade (#18965) to numpy, breaking `oldestdeps`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
