### PR TITLE
TST: make `oldestdeps` CI reproducible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,7 @@ doctest_plus = "enabled"
 text_file_format = "rst"
 remote_data_strict = true
 addopts = [
+    # keep in sync with tox.ini (oldestdeps's PYTEST_ADDOPTS)
     "--doctest-rst",
     "--strict-config",
     "--strict-markers",

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,11 @@ setenv =
     mpldev: UV_INDEX = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     devdeps, mpldev: UV_INDEX_STRATEGY = unsafe-best-match # match pip's behavior
     fitsio: ASTROPY_ALWAYS_TEST_FITSIO = true
+    # on oldestdeps, we let warnings be warnings (-Wdefault) instead of treated-as-errors,
+    # so we don't need to deal with filtering anything triggered from dependencies
+    # Other options replicate the static configuration from pyproject.toml, since they
+    # would otherwise be shaddowed by the env variable.
+    oldestdeps: PYTEST_ADDOPTS = -Wdefault -ra --doctest-rst --strict-config --strict-markers
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree

--- a/tox.ini
+++ b/tox.ini
@@ -128,8 +128,10 @@ pip_pre =
 
 uv_resolution =
     # The oldestdeps factor is intended to be used to install
-    # the oldest versions of all dependencies
-    oldestdeps: lowest-direct
+    # the oldest versions of all dependencies.
+    # Let uv handle this for us by requesting all requirements should be
+    # resolved to their oldest compatible versions (including transitive dependencies)
+    oldestdeps: lowest
 
 # This lets developers use tox to build docs and ignores warnings.
 # This is not used in CI; For that, we have RTD PR builder.


### PR DESCRIPTION
### Description
This includes #18955 and adds minimal changes to finalize #18782, including a workaround for #18992 (which I don't intend to get merged). This is meant as a demonstration of where the effort is at, and illustrates what's still missing to resolve #18782.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
