### PR TITLE
Improve `SpectralCoord` relativistic Doppler shifts

### DIFF
--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -1119,7 +1119,6 @@ def test_spectralcoord_accuracy(specsys):
                 )
 
 
-@pytest.mark.xfail(reason="regression test to reveal a bug")
 def test_spectralcoord_with_spectral_equivalency():
     # Regression test for #19001 - enabling the `u.spectral()` equivalency could cause
     # the relativistic Doppler shift to be applied in the wrong direction.

--- a/docs/changes/coordinates/19001.bugfix.rst
+++ b/docs/changes/coordinates/19001.bugfix.rst
@@ -1,0 +1,6 @@
+Relativistic Doppler shifts are now applied to ``SpectralCoord`` in the correct
+direction even if the ``astropy.units.spectral()`` equivalency is enabled.
+Previously enabling the equivalency could cause wrong results with the
+``SpectralCoord.to_rest()``,
+``SpectralCoord.with_observer_stationary_relative_to()`` or
+``SpectralCoord.with_radial_velocity_shift()`` methods.


### PR DESCRIPTION
### Update

I first opened this PR to improve performance, but @mhvk [realized](https://github.com/astropy/astropy/pull/19001#pullrequestreview-3516847409) that in the process I had also fixed a bug regarding relativistic Doppler shifts with the [`u.spectral()` equivalency](https://docs.astropy.org/en/v7.2.0/api/astropy.units.spectral.html#astropy.units.spectral) enabled.

### Original description

I have managed to speed up a private function used in `SpectralCoord.to_rest()`, `SpectralCoord.with_radial_velocity_shift()` and `SpectralCoord.with_observer_stationary_relative_to()` methods. I will demonstrates the speedup by invoking `SpectralCoord.to_rest()`. On current `main`:

```
$ cat sc_performance_setup.py 
from astropy import units as u
from astropy.coordinates import SpectralCoord

sc_length = SpectralCoord(500 * u.nm, radial_velocity=10 * u.km / u.s)
sc_frequency = SpectralCoord(250 * u.MHz, radial_velocity=10 * u.km / u.s)
sc_energy = SpectralCoord(0.7 * u.eV, radial_velocity=10 * u.km / u.s)
sc_wavenumber = SpectralCoord(1 / (500 * u.nm), radial_velocity=10 * u.km / u.s)
$ ipython -i sc_performance_setup.py 
Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.7.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Use `object?` to see the help on `object`, `object??` to view its source

In [1]: %timeit sc_length.to_rest()
124 μs ± 306 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [2]: %timeit sc_frequency.to_rest()
122 μs ± 301 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit sc_energy.to_rest()
131 μs ± 171 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit sc_wavenumber.to_rest()
151 μs ± 271 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
With this patch:
```
In [1]: %timeit sc_length.to_rest()
93.5 μs ± 617 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [2]: %timeit sc_frequency.to_rest()
88.9 μs ± 76.6 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit sc_energy.to_rest()
98.2 μs ± 220 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [4]: %timeit sc_wavenumber.to_rest()
103 μs ± 117 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
