### PR TITLE
Demonstrate Mypyc compilation

### DIFF
--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -26,7 +26,7 @@ def is_effectively_unity(value: UnitScaleLike) -> bool | np.bool_:
     # value is *almost* always real, except, e.g., for u.mag**0.5, when
     # it will be complex.  Use try/except to ensure normal case is fast
     try:
-        return _JUST_BELOW_UNITY <= value <= _JUST_ABOVE_UNITY
+        return _JUST_BELOW_UNITY <= value <= _JUST_ABOVE_UNITY  # type: ignore[operator]
     except TypeError:  # value is complex
         return (
             _JUST_BELOW_UNITY <= value.real <= _JUST_ABOVE_UNITY
@@ -63,7 +63,7 @@ def maybe_simple_fraction(p: UnitPowerLike, max_denominator: int = 100) -> UnitP
 
     If the input is zero, an integer or `fractions.Fraction`, just return it.
     """
-    if p.__class__ is int or p.__class__ is Fraction:
+    if type(p) is int or type(p) is Fraction:
         return p
     if p == 0:
         return 0  # p might be some numpy number, but we want a Python int
@@ -98,7 +98,7 @@ def sanitize_power(p: UnitPowerLike) -> UnitPower:
     p : float, int, Rational, Fraction
         Power to be converted.
     """
-    if p.__class__ is int:
+    if type(p) is int:
         return p
 
     p = maybe_simple_fraction(p)
@@ -130,10 +130,10 @@ def resolve_fractions(
     # We short-circuit on the most common cases of int and float, since
     # isinstance(a, Fraction) is very slow for any non-Fraction instances.
     a_is_fraction = (
-        a.__class__ is not int and a.__class__ is not float and isinstance(a, Fraction)
+        type(a) is not int and type(a) is not float and isinstance(a, Fraction)
     )
     b_is_fraction = (
-        b.__class__ is not int and b.__class__ is not float and isinstance(b, Fraction)
+        type(b) is not int and type(b) is not float and isinstance(b, Fraction)
     )
     if a_is_fraction and not b_is_fraction:
         b = maybe_simple_fraction(b)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,7 @@ filterwarnings = [
 doctest_norecursedirs = [
     "*/setup_package.py",
     "*/tests/command.py",
+    "astropy/units/utils.py",
 ]
 doctest_subpackage_requires = [
     "astropy/cosmology/_src/io/builtin/mapping.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)


### PR DESCRIPTION
### Original Description

[Mypyc](https://mypyc.readthedocs.io/en/stable/) is a tool that can automatically generate C extensions from type annotated Python. This PR demonstrates performance improvements achievable by compiling just two functions in `units`. The only changes I've made to the code are that I've replaced `x.__class__` with `type(x)`. It might be possible that further work on the Python code could produce faster compiled code, but the purpose of this PR is to demonstrate that speedups are possible even with minimal effort.

The functions can be compiled with the command `mypyc astropy/units/utils_mypyc_compiled.py` (I am using Mypy 1.19.0)

<details>
<summary>Setup and interpreted Python timings of the relevant functions</summary>

```
$ cat mypyc_demo.py
from fractions import Fraction

from astropy import units as u
from astropy.units.utils import maybe_simple_fraction, resolve_fractions


p_float = 1.5
p_fraction = Fraction(2, 3)
p_int = 2
$ ipython -i mypyc_demo.py
Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.7.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Use `--theme`, or the `%colors` magic to change IPython's themes and colors.

In [1]: %timeit maybe_simple_fraction(p_float)
599 ns ± 0.573 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit maybe_simple_fraction(p_fraction)
43.2 ns ± 0.0868 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit maybe_simple_fraction(p_int)
34.1 ns ± 0.066 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %timeit resolve_fractions(p_float, p_fraction)
725 ns ± 0.297 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [5]: %timeit resolve_fractions(p_float, p_int)
72.9 ns ± 0.0427 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]: %timeit resolve_fractions(p_fraction, p_int)
116 ns ± 0.29 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

</details>

<details>
<summary>Unit arithmetic timings with interpreted Python</summary>

```
In [7]: %timeit u.m**p_float
2.8 μs ± 5.76 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [8]: %timeit u.m**p_fraction
2.65 μs ± 4.73 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [9]: %timeit u.m**p_int
767 ns ± 1.49 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [10]: %timeit u.m**p_float * u.m**p_fraction
11.7 μs ± 9.78 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [11]: %timeit u.m**p_float * u.m**p_int
8.16 μs ± 7.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [12]: %timeit u.m**p_fraction * u.m**p_int
9.29 μs ± 41.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

</details>

<details>
<summary>Direct function call timings with compiled Python</summary>

```
In [1]: %timeit maybe_simple_fraction(p_float)
566 ns ± 3.31 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit maybe_simple_fraction(p_fraction)
25.7 ns ± 0.0827 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [3]: %timeit maybe_simple_fraction(p_int)
18.3 ns ± 0.0702 ns per loop (mean ± std. dev. of 7 runs, 100,000,000 loops each)

In [4]: %timeit resolve_fractions(p_float, p_fraction)
603 ns ± 0.527 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [5]: %timeit resolve_fractions(p_float, p_int)
35.3 ns ± 0.0861 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]: %timeit resolve_fractions(p_fraction, p_int)
46.2 ns ± 0.171 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

</details>

<details>

<summary>Unit arithmetic timings with compiled Python</summary>

```
In [7]: %timeit u.m**p_float
2.66 μs ± 3.77 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [8]: %timeit u.m**p_fraction
2.57 μs ± 8.16 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [9]: %timeit u.m**p_int
725 ns ± 1.31 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [10]: %timeit u.m**p_float * u.m**p_fraction
11.5 μs ± 10.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [11]: %timeit u.m**p_float * u.m**p_int
7.75 μs ± 18 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [12]: %timeit u.m**p_fraction * u.m**p_int
8.95 μs ± 22.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

</details>

It should be kept in mind that the overall performance of `astropy` will improve as the fraction of compiled code grows, so I expect that unit arithmetic could be sped up even more by compiling more of our code.

To adopt Mypyc we need to do two things. First, code compiled by Mypyc must be approved by Mypy, so we will need to set up a CI job to type check the subset of our code that we compile. Second, we will need to update our build infrastructure to incorporate Mypyc. Note that Mypyc should not be invoked by editable installs, and we might want to provide versions of `astropy` with and without Mypyc-compiled code.

### Update

This PR now allows compiling all of `astropy.units.utils`.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
