### PR TITLE
ci: log level in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ addopts = [
     "-p no:legacypath",
 ]
 log_cli_level = "info"
+log_level = "INFO"
 xfail_strict = true
 filterwarnings = [
     "error",


### PR DESCRIPTION
### Description

This PR responds to CI failures in https://github.com/astropy/astropy/pull/19012.

This pull request is to address the PP304 check from [Scientific Python Development Guide](https://learn.scientific-python.org/development/guides/pytest#PP304).

Adds `log_level = "INFO"` to `[tool.pytest.ini_options]` in `pyproject.toml`. This enables log capture during test runs, allowing logs to be displayed on test failures for easier debugging.

<!-- START COPILOT CODING AGENT SUFFIX -->

<details>

<summary>Original prompt</summary>

> Help me fix https://learn.scientific-python.org/development/guides/pytest#PP304\Sets the log level in pytest]8;;\ ❌
>     log_level should be set. This will allow logs to be displayed on failures.  
>     
>                                                                                 
>      [tool.pytest.ini_options]                                                  
>      log_level = "INFO"


</details>



<!-- START COPILOT CODING AGENT TIPS -->




- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
