### PR TITLE
ci: update autofix commit message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ci:
+  autofix_commit_msg: "chore: pre-commit fixes"
   autofix_prs: false
   autoupdate_schedule: 'monthly'
 


### PR DESCRIPTION
### Description

This PR responds to CI failures in https://github.com/astropy/astropy/pull/19012

This pull request is to address the missing `autofix_commit_msg` configuration in `.pre-commit-config.yaml` as flagged by sp-repo-review (PC902).

Adds the required CI configuration so automated pre-commit fixes use conventional commit format:

```yaml
ci:
  autofix_commit_msg: "chore: pre-commit fixes"
```

<!-- START COPILOT CODING AGENT SUFFIX -->

<details>

<summary>Original prompt</summary>

> Help me fix id=397027;https://learn.scientific-python.org/development/guides/style#PC902\Custom pre-commit CI autofix message]8;;\ ❌
>     Should have something like this in .pre-commit-config.yaml:                 
>     
>                                                                                 
>      ci:                                                                        
>        autofix_commit_msg: "style: pre-commit fixes"
> 
> Except make it "chore", not "style"


</details>


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
