### PR TITLE
Add tools for updating MRT header metadata

### DIFF
--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -135,8 +135,8 @@ def update_mrt_file_header(input, title=None, authors=None, table=None, notes=No
     line_start = ["Title:", "Authors:", "Table:"]
     for i, prefix in enumerate(line_start):
         if not lines[i].startswith(prefix):
-            msg = f"line #{i} = \"{lines[i]}\"\n"
-            msg += "line #{i} should start with \"{prefix}\" for an MRT file"
+            msg = f"line #{i} = \"{lines[i]}\" \n"
+            msg += f"line #{i} should start with \"{prefix}\" for an MRT file"
             raise ValueError(msg)
 
     header = generate_mrt_header(title=title, authors=authors, table=table, notes=notes, update=False)

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -82,10 +82,10 @@ def generate_mrt_header(title=None, authors=None, table=None, notes=None, update
     global MRT_TEMPLATE
 
     if reset: 
-        MRT_TEMPLATE = [row for row in EMPTY_MRT_TEMPLATE]
+        MRT_TEMPLATE = EMPTY_MRT_TEMPLATE.copy()
         return MRT_TEMPLATE
 
-    template = [row for row in EMPTY_MRT_TEMPLATE]
+    template = EMPTY_MRT_TEMPLATE.copy()
 
     if title is not None:
         template[0] += " " + title

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -157,7 +157,7 @@ def update_mrt_file_header(input, title=None, authors=None, table=None, notes=No
                 break
 
     if (not isinstance(input, list)) & overwrite:
-        with open(file, "w") as fp:
+        with open(input, "w") as fp:
             fp.writelines(lines)
         return None
     else:

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -81,7 +81,7 @@ def generate_mrt_header(title=None, authors=None, table=None, notes=None, update
     """
     global MRT_TEMPLATE
 
-    if reset: 
+    if reset:
         MRT_TEMPLATE = EMPTY_MRT_TEMPLATE.copy()
         return MRT_TEMPLATE
 

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -768,7 +768,12 @@ class Mrt(core.BaseReader):
     Machine Readable Table (MRT) format.
 
     Note that the metadata of the table, apart from units, column names and
-    description, will not be written. These have to be filled in by hand later.
+    description, will not be written by default. The `astropy.io.ascii.mrt.generate_mrt_header` function
+    can be used to update the metadata that will then be used when the table is output:
+
+      >>> from astropy.io import ascii
+      >>> ascii.mrt.generate_mrt_header(authors="A. Einstein", update=True)
+      >>> table.write('data.mrt', format='mrt')
 
     See also: :ref:`cds_mrt_format`.
 

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -59,7 +59,15 @@ MRT_TEMPLATE = [
 ]
 
 
-def generate_mrt_header(title=None, authors=None, table=None, notes=None, update=False, reset=False, **kwargs):
+def generate_mrt_header(
+    title=None,
+    authors=None,
+    table=None,
+    notes=None,
+    update=False,
+    reset=False,
+    **kwargs,
+):
     """
     Generate a header for a MRT
 
@@ -105,7 +113,9 @@ def generate_mrt_header(title=None, authors=None, table=None, notes=None, update
     return template
 
 
-def update_mrt_file_header(input, title=None, authors=None, table=None, notes=None, overwrite=True):
+def update_mrt_file_header(
+    input, title=None, authors=None, table=None, notes=None, overwrite=True
+):
     """
     Update the header of an existing MRT file
 
@@ -135,11 +145,13 @@ def update_mrt_file_header(input, title=None, authors=None, table=None, notes=No
     line_start = ["Title:", "Authors:", "Table:"]
     for i, prefix in enumerate(line_start):
         if not lines[i].startswith(prefix):
-            msg = f"line #{i} = \"{lines[i]}\" \n"
-            msg += f"line #{i} should start with \"{prefix}\" for an MRT file"
+            msg = f"line #{i} = '{lines[i]}' \n"
+            msg += f"line #{i} should start with '{prefix}' for an MRT file"
             raise ValueError(msg)
 
-    header = generate_mrt_header(title=title, authors=authors, table=table, notes=notes, update=False)
+    header = generate_mrt_header(
+        title=title, authors=authors, table=table, notes=notes, update=False
+    )
 
     if title is not None:
         lines[0] = header[0] + line_end_char

--- a/astropy/io/ascii/mrt.py
+++ b/astropy/io/ascii/mrt.py
@@ -38,6 +38,16 @@ BYTE_BY_BYTE_TEMPLATE = [
     "--------------------------------------------------------------------------------",
 ]
 
+EMPTY_MRT_TEMPLATE = [
+    "Title:",
+    "Authors:",
+    "Table:",
+    "================================================================================",
+    "$bytebybyte",
+    "Notes:",
+    "--------------------------------------------------------------------------------",
+]
+
 MRT_TEMPLATE = [
     "Title:",
     "Authors:",
@@ -47,6 +57,111 @@ MRT_TEMPLATE = [
     "Notes:",
     "--------------------------------------------------------------------------------",
 ]
+
+
+def generate_mrt_header(title=None, authors=None, table=None, notes=None, update=False, reset=False, **kwargs):
+    """
+    Generate a header for a MRT
+
+    Parameters
+    ----------
+    title, authors, table, notes : str or None
+        Metadata entries
+
+    update : bool
+        Update the ``MRT_TEMPLATE`` global variable to be used the next time a file is written
+
+    reset : bool
+        Reset the global variable to the empty default
+
+    Returns
+    -------
+    template : list
+        List of strings for the table template
+    """
+    global MRT_TEMPLATE
+
+    if reset: 
+        MRT_TEMPLATE = [row for row in EMPTY_MRT_TEMPLATE]
+        return MRT_TEMPLATE
+
+    template = [row for row in EMPTY_MRT_TEMPLATE]
+
+    if title is not None:
+        template[0] += " " + title
+
+    if authors is not None:
+        template[1] += " " + authors
+
+    if table is not None:
+        template[2] += " " + table
+
+    if notes is not None:
+        template[5] += " " + notes
+
+    if update:
+        MRT_TEMPLATE = template
+
+    return template
+
+
+def update_mrt_file_header(input, title=None, authors=None, table=None, notes=None, overwrite=True):
+    """
+    Update the header of an existing MRT file
+
+    Parameters
+    ----------
+    input : str, list
+        Either the string filename of a table or a list of the row strings of an existing table
+
+    title, authors, table, notes : str, None
+        Metadata keys
+
+    Returns
+    -------
+    lines : None, list
+        Returns None if ``input`` was a filename and the output was written to a file, otherwise returns
+        the list of updated line strings
+    """
+    if isinstance(input, list):
+        lines = input
+        line_end_char = ""
+    else:
+        # Append newline character to output lines when read from input
+        line_end_char = "\n"
+        with open(input) as fp:
+            lines = fp.readlines()
+
+    line_start = ["Title:", "Authors:", "Table:"]
+    for i, prefix in enumerate(line_start):
+        if not lines[i].startswith(prefix):
+            msg = f"line #{i} = \"{lines[i]}\"\n"
+            msg += "line #{i} should start with \"{prefix}\" for an MRT file"
+            raise ValueError(msg)
+
+    header = generate_mrt_header(title=title, authors=authors, table=table, notes=notes, update=False)
+
+    if title is not None:
+        lines[0] = header[0] + line_end_char
+
+    if authors is not None:
+        lines[1] = header[1] + line_end_char
+
+    if table is not None:
+        lines[2] = header[2] + line_end_char
+
+    if notes is not None:
+        for i, line in enumerate(lines):
+            if line.startswith("Notes:"):
+                lines[i] = header[5] + line_end_char
+                break
+
+    if (not isinstance(input, list)) & overwrite:
+        with open(file, "w") as fp:
+            fp.writelines(lines)
+        return None
+    else:
+        return lines
 
 
 class MrtSplitter(fixedwidth.FixedWidthSplitter):

--- a/astropy/io/ascii/tests/test_cds.py
+++ b/astropy/io/ascii/tests/test_cds.py
@@ -85,6 +85,62 @@ def test_roundtrip_mrt_table():
     assert lines == exp_output
 
 
+def test_mrt_header():
+
+    dat = get_pkg_data_filename(
+        "data/cdsFunctional2.dat", package="astropy.io.ascii.tests"
+    )
+    t = Table.read(dat, format="ascii.mrt")
+    out = StringIO()
+    t.write(out, format="ascii.mrt")
+    lines = out.getvalue().splitlines()
+
+    # Baseline
+    assert lines[0] == "Title:"
+    assert lines[1] == "Authors:"
+
+    # Update in place
+    out_lines = ascii.mrt.update_mrt_file_header(lines, authors="A. Einstein")
+    assert lines[0] == "Title:"
+    assert lines[1] == "Authors: A. Einstein\n"
+
+    assert out_lines[0] == "Title:"
+    assert out_lines[1] == "Authors: A. Einstein\n"
+
+    out_lines = ascii.mrt.update_mrt_file_header(lines, authors="I. Newton", title="Apples and oranges")
+
+    assert lines[0] == "Title: Apples and oranges"
+    assert lines[1] == "Authors: I. Newton"
+
+    assert out_lines[0] == "Title: Apples and oranges"
+    assert out_lines[1] == "Authors: I. Newton"
+
+    # Output again should be empty
+    out = StringIO()
+    t.write(out, format="ascii.mrt")
+    lines = out.getvalue().splitlines()
+    assert lines[0] == "Title:"
+    assert lines[1] == "Authors:"
+
+    # Update the header template
+    header_ = ascii.mrt.generate_mrt_header(authors="B. Dylan", title="Greatest hits", update=True)
+
+    out = StringIO()
+    t.write(out, format="ascii.mrt")
+    lines = out.getvalue().splitlines()
+
+    assert lines[0] == "Title: Greatest hits"
+    assert lines[1] == "Authors: B. Dylan"
+
+    # Reset the header template to empty default
+    header_ = ascii.mrt.generate_mrt_header(reset=True)
+    out = StringIO()
+    t.write(out, format="ascii.mrt")
+    lines = out.getvalue().splitlines()
+    assert lines[0] == "Title:"
+    assert lines[1] == "Authors:"
+
+
 def test_write_byte_by_byte_units():
     t = ascii.read(test_dat)
     col_units = [None, u.C, u.kg, u.m / u.s, u.year]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request adds some basic functionality for modifying the header metadata in `astropy.io.ascii.mrt` machine-readable tables.  The header metadata still isn't processed at the point of running ``table.write(...)``, but it can be set separately and will then be included in the output.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
