### PR TITLE
Simplify `astropy.units.utils.sanitize_power()`

### DIFF
--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -101,16 +101,11 @@ def sanitize_power(p: UnitPowerLike) -> UnitPower:
     if p.__class__ is int:
         return p
 
-    denom = getattr(p, "denominator", None)
-    if denom is None:
-        # This returns either a (simple) Fraction or the same float.
-        p = maybe_simple_fraction(p)
-        # If still a float, nothing more to be done.
-        if isinstance(p, float):
-            return p
-
-        # Otherwise, check for simplifications.
-        denom = p.denominator
+    p = maybe_simple_fraction(p)
+    if isinstance(p, float):
+        return p  # If still a float, nothing more to be done.
+    # Otherwise, check for simplifications.
+    denom = p.denominator
 
     if denom == 1:
         return int(p.numerator)


### PR DESCRIPTION
### Description

I am simplifying a utility function in `units`. Performance tests setup and timings on current `main`:
```
$ cat sanitize_power.py 
from fractions import Fraction

from astropy.units.utils import sanitize_power

one_and_half = Fraction(3, 2)
one_third = Fraction(1, 3)
$ ipython -i sanitize_power.py
Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.7.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: IPython supports combining unicode identifiers, eg F\vec<tab> will become F⃗, useful for physics equations. Play with \dot \ddot and others.

In [1]: %timeit sanitize_power(1.5)
910 ns ± 1.99 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit sanitize_power(0.3333333333333333333333)
944 ns ± 2.23 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [3]: %timeit sanitize_power(one_and_half)
218 ns ± 0.0913 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [4]: %timeit sanitize_power(one_third)
86.7 ns ± 0.0551 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
Performance with this PR:
```
In [1]: %timeit sanitize_power(1.5)
855 ns ± 1.97 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [2]: %timeit sanitize_power(0.3333333333333333333333)
909 ns ± 10.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [3]: %timeit sanitize_power(one_and_half)
252 ns ± 3.44 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [4]: %timeit sanitize_power(one_third)
117 ns ± 0.0913 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
So handling a `float` is now slightly faster, but the cost is that handling a `Fraction` is now slightly slower. The function in question already converts a `Fraction` to a `float` if it can be done without loss of precision, so it makes sense to prefer `float` performance over `Fraction` performance. I didn't bother benchmarking with `numpy` numbers because we should not be optimizing this code for them.

Relevant for #19011 is that on current `main` running `mypy --follow-imports silent -- astropy/units/utils.py` reports 7 errors, but with this PR it only reports 4.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.