### PR TITLE
Angle to string avoid older numpy warning

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import SpecificTypeQuantity
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from . import formats
 
@@ -175,11 +174,11 @@ class Angle(SpecificTypeQuantity):
 
                 if angle_unit is not unit:
                     # Possible conversion to `unit` will be done below.
-                    angle = u.Quantity(angle, angle_unit, copy=COPY_IF_NEEDED)
+                    angle = u.Quantity(angle, angle_unit, copy=None)
 
             elif isinstance(angle, np.ndarray):
                 if angle.dtype.kind in "SUVO":
-                    angle = [cls(x, unit, copy=COPY_IF_NEEDED) for x in angle]
+                    angle = [cls(x, unit, copy=None) for x in angle]
 
             elif hasattr(angle, "__array__") and (
                 not hasattr(angle, "dtype") or angle.dtype.kind not in "SUVO"
@@ -187,7 +186,7 @@ class Angle(SpecificTypeQuantity):
                 angle = np.asarray(angle)
 
             elif np.iterable(angle):
-                angle = [cls(x, unit, copy=COPY_IF_NEEDED) for x in angle]
+                angle = [cls(x, unit, copy=None) for x in angle]
 
         return super().__new__(cls, angle, unit, dtype=dtype, copy=copy, **kwargs)
 

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import SpecificTypeQuantity
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
+from astropy.utils.compat import COPY_IF_NEEDED
 
 from . import formats
 
@@ -398,12 +398,8 @@ class Angle(SpecificTypeQuantity):
         a360 = u.degree.to(self.unit, 360.0)
         wrap_angle = wrap_angle.to_value(self.unit)
         self_angle = self.view(np.ndarray)
-        if NUMPY_LT_2_0:
-            # Ensure ndim>=1 so that comparison is done using the angle dtype.
-            self_angle = self_angle[np.newaxis]
-        else:
-            # Use explicit float to ensure casting to self_angle.dtype (NEP 50).
-            wrap_angle = float(wrap_angle)
+        # Use explicit float to ensure casting to self_angle.dtype (NEP 50).
+        wrap_angle = float(wrap_angle)
         wrap_angle_floor = wrap_angle - a360
         # Do the wrapping, but only if any angles need to be wrapped
         #
@@ -616,11 +612,6 @@ class Latitude(Angle):
             limit = u.degree.to(angles.unit, 90.0)
 
         angles_view = angles.view(np.ndarray)
-        if NUMPY_LT_2_0:
-            # Ensure ndim>=1 so that comparison is done using the angle dtype.
-            # Otherwise, e.g., np.array(np.pi/2, 'f4') > np.pi/2 will yield True.
-            angles_view = angles_view[np.newaxis]
-
         if np.any(np.abs(angles_view) > limit):
             if np.size(angles) < 5:
                 raise ValueError(

--- a/astropy/coordinates/angles/utils.py
+++ b/astropy/coordinates/angles/utils.py
@@ -22,7 +22,6 @@ from astropy.coordinates.representation import (
     SphericalRepresentation,
     UnitSphericalRepresentation,
 )
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .core import Angle
 
@@ -227,5 +226,5 @@ def uniform_spherical_random_volume(size=1, max_radius=1):
 
     usph = uniform_spherical_random_surface(size=size)
 
-    r = np.cbrt(rng.uniform(size=size)) * u.Quantity(max_radius, copy=COPY_IF_NEEDED)
+    r = np.cbrt(rng.uniform(size=size)) * u.Quantity(max_radius, copy=None)
     return SphericalRepresentation(usph.lon, usph.lat, r)

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -7,7 +7,6 @@ import numpy as np
 from astropy import units as u
 from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .earth import EarthLocation
 from .representation import BaseDifferential, CartesianRepresentation
@@ -379,7 +378,7 @@ class QuantityAttribute(Attribute):
             )
 
         oldvalue = value
-        value = u.Quantity(oldvalue, self.unit, copy=COPY_IF_NEEDED)
+        value = u.Quantity(oldvalue, self.unit, copy=None)
         if self.shape is not None and value.shape != self.shape:
             if value.shape == () and oldvalue == 0:
                 # Allow a single 0 to fill whatever shape is needed.

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -14,7 +14,6 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .cirs import CIRS
@@ -54,15 +53,15 @@ def cirs_to_observed(cirs_coo, observed_frame):
 
     if is_unitspherical:
         rep = UnitSphericalRepresentation(
-            lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(lat, u.radian, copy=None),
+            lon=u.Quantity(lon, u.radian, copy=None),
             copy=False,
         )
     else:
         # since we've transformed to CIRS at the observatory location, just use CIRS distance
         rep = SphericalRepresentation(
-            lat=u.Quantity(lat, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(lon, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(lat, u.radian, copy=None),
+            lon=u.Quantity(lon, u.radian, copy=None),
             distance=cirs_coo.distance,
             copy=False,
         )

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -18,7 +18,6 @@ from astropy.coordinates.transformations import (
     FunctionTransformWithFiniteDifference,
 )
 from astropy.time import Time
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import format_doc
 
 from .baseradec import BaseRADecFrame, doc_components
@@ -182,11 +181,7 @@ def fk4_to_fk4_no_e(fk4coord, fk4noeframe):
     # the observing time/epoch) of the coordinates. See issue #1496 for a
     # discussion of this.
     eterms_a = CartesianRepresentation(
-        u.Quantity(
-            fk4_e_terms(fk4coord.equinox),
-            u.dimensionless_unscaled,
-            copy=COPY_IF_NEEDED,
-        ),
+        u.Quantity(fk4_e_terms(fk4coord.equinox), u.one, copy=None),
         copy=False,
     )
     rep = rep - eterms_a + eterms_a.dot(rep) * rep
@@ -235,11 +230,7 @@ def fk4_no_e_to_fk4(fk4noecoord, fk4frame):
     # the observing time/epoch) of the coordinates. See issue #1496 for a
     # discussion of this.
     eterms_a = CartesianRepresentation(
-        u.Quantity(
-            fk4_e_terms(fk4noecoord.equinox),
-            u.dimensionless_unscaled,
-            copy=COPY_IF_NEEDED,
-        ),
+        u.Quantity(fk4_e_terms(fk4noecoord.equinox), u.one, copy=None),
         copy=False,
     )
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -18,7 +18,6 @@ from astropy.coordinates.transformations import (
     AffineTransform,
     FunctionTransformWithFiniteDifference,
 )
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .cirs import CIRS
 from .gcrs import GCRS
@@ -42,8 +41,8 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(cirs_dec, u.radian, copy=None),
+            lon=u.Quantity(cirs_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -52,15 +51,15 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
         # no parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newcart = icrs_coo.cartesian - astrom_eb
         srepr = newcart.represent_as(SphericalRepresentation)
         cirs_ra, cirs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(
-            lat=u.Quantity(cirs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(cirs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(cirs_dec, u.radian, copy=None),
+            lon=u.Quantity(cirs_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
@@ -83,8 +82,8 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -94,14 +93,14 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
 
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newrep = intermedrep + astrom_eb
 
@@ -125,8 +124,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(gcrs_dec, u.radian, copy=None),
+            lon=u.Quantity(gcrs_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -135,7 +134,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         # parallax/PM. This ensures reversibility and is more sensible for
         # inside solar system objects
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newcart = icrs_coo.cartesian - astrom_eb
 
@@ -143,8 +142,8 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
         gcrs_ra, gcrs_dec = atciqz(srepr.without_differentials(), astrom)
 
         newrep = SphericalRepresentation(
-            lat=u.Quantity(gcrs_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(gcrs_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(gcrs_dec, u.radian, copy=None),
+            lon=u.Quantity(gcrs_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
@@ -168,8 +167,8 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # if no distance, just use the coordinate direction to yield the
         # infinite-distance/no parallax answer
         newrep = UnitSphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             copy=False,
         )
     else:
@@ -179,14 +178,14 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # the distance in intermedrep is *not* a real distance as it does not
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(
-            lat=u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED),
-            lon=u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED),
+            lat=u.Quantity(i_dec, u.radian, copy=None),
+            lon=u.Quantity(i_ra, u.radian, copy=None),
             distance=srepr.distance,
             copy=False,
         )
 
         astrom_eb = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newrep = intermedrep + astrom_eb
 
@@ -209,8 +208,8 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
     i_ra, i_dec = aticq(srepr.without_differentials(), astrom)
 
     # convert to Quantity objects
-    i_ra = u.Quantity(i_ra, u.radian, copy=COPY_IF_NEEDED)
-    i_dec = u.Quantity(i_dec, u.radian, copy=COPY_IF_NEEDED)
+    i_ra = u.Quantity(i_ra, u.radian, copy=None)
+    i_dec = u.Quantity(i_dec, u.radian, copy=None)
     if (
         gcrs_coo.data.name == "unitspherical"
         or gcrs_coo.data.to_cartesian().x.unit == u.one
@@ -235,7 +234,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # against the shape of the pv array.
         # broadcast em to eh and scale eh
         eh = astrom["eh"] * astrom["em"][..., np.newaxis]
-        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED)
+        eh = CartesianRepresentation(eh, unit=u.au, xyz_axis=-1, copy=None)
 
         newrep = intermedrep.to_cartesian() + eh
 

--- a/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_observed_transforms.py
@@ -15,7 +15,6 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .altaz import AltAz
 from .hadec import HADec
@@ -39,7 +38,7 @@ def icrs_to_observed(icrs_coo, observed_frame):
         srepr = icrs_coo.spherical
     else:
         observer_icrs = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         srepr = (icrs_coo.cartesian - observer_icrs).represent_as(
             SphericalRepresentation
@@ -92,13 +91,13 @@ def observed_to_icrs(observed_coo, icrs_frame):
     # Topocentric CIRS
     cirs_ra, cirs_dec = erfa.atoiq(coord_type, lon, lat, astrom) << u.radian
     if is_unitspherical:
-        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1, copy=COPY_IF_NEEDED)
+        srepr = SphericalRepresentation(cirs_ra, cirs_dec, 1, copy=None)
     else:
         srepr = SphericalRepresentation(
             lon=cirs_ra,
             lat=cirs_dec,
             distance=observed_coo.distance,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
 
     # BCRS (Astrometric) direction to source
@@ -106,16 +105,16 @@ def observed_to_icrs(observed_coo, icrs_frame):
 
     # Correct for parallax to get ICRS representation
     if is_unitspherical:
-        icrs_srepr = UnitSphericalRepresentation(bcrs_ra, bcrs_dec, copy=COPY_IF_NEEDED)
+        icrs_srepr = UnitSphericalRepresentation(bcrs_ra, bcrs_dec, copy=None)
     else:
         icrs_srepr = SphericalRepresentation(
             lon=bcrs_ra,
             lat=bcrs_dec,
             distance=observed_coo.distance,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
         observer_icrs = CartesianRepresentation(
-            astrom["eb"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+            astrom["eb"], unit=u.au, xyz_axis=-1, copy=None
         )
         newrepr = icrs_srepr.to_cartesian() + observer_icrs
         icrs_srepr = newrepr.represent_as(SphericalRepresentation)

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -10,7 +10,6 @@ import warnings
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyWarning
 
 from .angles import Angle
@@ -162,7 +161,7 @@ class Distance(u.SpecificTypeQuantity):
                     value <<= u.AU
 
         elif parallax is not None:
-            parallax = u.Quantity(parallax, copy=COPY_IF_NEEDED, subok=True)
+            parallax = u.Quantity(parallax, copy=None, subok=True)
             value = parallax.to(unit or u.pc, equivalencies=u.parallax())
 
             if np.any(parallax < 0):
@@ -254,12 +253,12 @@ class Distance(u.SpecificTypeQuantity):
     def distmod(self):
         """The distance modulus as a `~astropy.units.Quantity`."""
         val = 5.0 * np.log10(self.to_value(u.pc)) - 5.0
-        return u.Quantity(val, u.mag, copy=COPY_IF_NEEDED)
+        return u.Quantity(val, u.mag, copy=None)
 
     @classmethod
     def _distmod_to_pc(cls, dm):
         dm = u.Quantity(dm, u.mag)
-        return cls(10 ** ((dm.value + 5) / 5.0), u.pc, copy=COPY_IF_NEEDED)
+        return cls(10 ** ((dm.value + 5) / 5.0), u.pc, copy=None)
 
     @property
     def parallax(self):

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -13,7 +13,6 @@ from astropy import constants as consts
 from astropy import units as u
 from astropy.units.quantity import QuantityInfoBase
 from astropy.utils import data
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .angles import Angle, Latitude, Longitude
 from .errors import UnknownSiteException
@@ -269,9 +268,9 @@ class EarthLocation(u.Quantity):
         # in that it will no longer possible to initialize with a unit-full x,
         # and unit-less y, z. Arguably, though, that would just solve a bug.
         try:
-            x = u.Quantity(x, unit, copy=COPY_IF_NEEDED)
-            y = u.Quantity(y, unit, copy=COPY_IF_NEEDED)
-            z = u.Quantity(z, unit, copy=COPY_IF_NEEDED)
+            x = u.Quantity(x, unit, copy=None)
+            y = u.Quantity(y, unit, copy=None)
+            z = u.Quantity(z, unit, copy=None)
         except u.UnitsError:
             raise u.UnitsError("Geocentric coordinate units should all be consistent.")
 
@@ -315,11 +314,11 @@ class EarthLocation(u.Quantity):
         """
         ellipsoid = _check_ellipsoid(ellipsoid, default=cls._ellipsoid)
         # As wrapping fails on readonly input, we do so manually
-        lon = Angle(lon, u.degree, copy=COPY_IF_NEEDED).wrap_at(180 * u.degree)
-        lat = Latitude(lat, u.degree, copy=COPY_IF_NEEDED)
+        lon = Angle(lon, u.degree, copy=None).wrap_at(180 * u.degree)
+        lat = Latitude(lat, u.degree, copy=None)
         # don't convert to m by default, so we can use the height unit below.
         if not isinstance(height, u.Quantity):
-            height = u.Quantity(height, u.m, copy=COPY_IF_NEEDED)
+            height = u.Quantity(height, u.m, copy=None)
         # get geocentric coordinates.
         geodetic = ELLIPSOIDS[ellipsoid](lon, lat, height, copy=False)
         xyz = geodetic.to_cartesian().get_xyz(xyz_axis=-1) << height.unit

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -9,7 +9,6 @@ __all__ = ["is_rotation_or_reflection", "rotation_matrix"]
 import numpy as np
 
 from astropy import units as u
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import deprecated
 
 from .angles import Angle
@@ -55,7 +54,7 @@ def rotation_matrix(angle, axis="z", unit=None):
         A unitary rotation matrix.
     """
     if not isinstance(angle, u.Quantity):
-        angle = Angle(angle, unit=unit or u.deg, copy=COPY_IF_NEEDED)
+        angle = Angle(angle, unit=unit or u.deg, copy=None)
     angle_in_rad = angle.to_value(u.rad)
 
     s = np.sin(angle_in_rad)

--- a/astropy/coordinates/polarization.py
+++ b/astropy/coordinates/polarization.py
@@ -5,7 +5,6 @@ from typing import NamedTuple
 import numpy as np
 
 from astropy.utils import unbroadcast
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo
 from astropy.utils.shapes import ShapedLikeNDArray
 
@@ -186,7 +185,7 @@ class StokesCoord(ShapedLikeNDArray):
     def dtype(self):
         return self._data.dtype
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         return self._data.astype(dtype, copy=copy)
 
     def _apply(self, method, *args, **kwargs):

--- a/astropy/coordinates/representation/cylindrical.py
+++ b/astropy/coordinates/representation/cylindrical.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import astropy.units as u
 from astropy.coordinates.angles import Angle
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 from .cartesian import CartesianRepresentation
@@ -79,9 +78,9 @@ class CylindricalRepresentation(BaseRepresentation):
         sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
         l = np.broadcast_to(1.0, self.shape)
         return {
-            "rho": CartesianRepresentation(cosphi, sinphi, 0, copy=COPY_IF_NEEDED),
-            "phi": CartesianRepresentation(-sinphi, cosphi, 0, copy=COPY_IF_NEEDED),
-            "z": CartesianRepresentation(0, 0, l, unit=u.one, copy=COPY_IF_NEEDED),
+            "rho": CartesianRepresentation(cosphi, sinphi, 0, copy=None),
+            "phi": CartesianRepresentation(-sinphi, cosphi, 0, copy=None),
+            "z": CartesianRepresentation(0, 0, l, unit=u.one, copy=None),
         }
 
     def scale_factors(self):
@@ -123,7 +122,7 @@ class CylindricalRepresentation(BaseRepresentation):
         z_op = lambda x: op(x, *args)
 
         result = self.__class__(
-            rho_op(self.rho), phi_op(self.phi), z_op(self.z), copy=COPY_IF_NEEDED
+            rho_op(self.rho), phi_op(self.phi), z_op(self.z), copy=None
         )
         for key, differential in self.differentials.items():
             new_comps = (

--- a/astropy/coordinates/representation/spherical.py
+++ b/astropy/coordinates/representation/spherical.py
@@ -11,7 +11,6 @@ from astropy.coordinates.angles import Angle, Latitude, Longitude
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.matrix_utilities import is_rotation_or_reflection
 from astropy.utils import classproperty
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .base import BaseDifferential, BaseRepresentation
 from .cartesian import CartesianRepresentation
@@ -84,9 +83,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
         sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
         sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
         return {
-            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=COPY_IF_NEEDED),
+            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=None),
             "lat": CartesianRepresentation(
-                -sinlat * coslon, -sinlat * sinlon, coslat, copy=COPY_IF_NEEDED
+                -sinlat * coslon, -sinlat * sinlon, coslat, copy=None
             ),
         }
 
@@ -124,18 +123,10 @@ class UnitSphericalRepresentation(BaseRepresentation):
         if isinstance(other_class, type) and not differential_class:
             if issubclass(other_class, PhysicsSphericalRepresentation):
                 return other_class(
-                    phi=self.lon,
-                    theta=90 * u.deg - self.lat,
-                    r=1.0,
-                    copy=COPY_IF_NEEDED,
+                    phi=self.lon, theta=90 * u.deg - self.lat, r=1.0, copy=None
                 )
             elif issubclass(other_class, SphericalRepresentation):
-                return other_class(
-                    lon=self.lon,
-                    lat=self.lat,
-                    distance=1.0,
-                    copy=COPY_IF_NEEDED,
-                )
+                return other_class(lon=self.lon, lat=self.lat, distance=1.0, copy=None)
 
         return super().represent_as(other_class, differential_class)
 
@@ -501,12 +492,12 @@ class SphericalRepresentation(BaseRepresentation):
         sinlon, coslon = np.sin(self.lon), np.cos(self.lon)
         sinlat, coslat = np.sin(self.lat), np.cos(self.lat)
         return {
-            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=COPY_IF_NEEDED),
+            "lon": CartesianRepresentation(-sinlon, coslon, 0.0, copy=None),
             "lat": CartesianRepresentation(
-                -sinlat * coslon, -sinlat * sinlon, coslat, copy=COPY_IF_NEEDED
+                -sinlat * coslon, -sinlat * sinlon, coslat, copy=None
             ),
             "distance": CartesianRepresentation(
-                coslat * coslon, coslat * sinlon, sinlat, copy=COPY_IF_NEEDED
+                coslat * coslon, coslat * sinlon, sinlat, copy=None
             ),
         }
 
@@ -627,10 +618,7 @@ class SphericalRepresentation(BaseRepresentation):
         lon_op, lat_op, distance_op = _spherical_op_funcs(op, *args)
 
         result = self.__class__(
-            lon_op(self.lon),
-            lat_op(self.lat),
-            distance_op(self.distance),
-            copy=COPY_IF_NEEDED,
+            lon_op(self.lon), lat_op(self.lat), distance_op(self.distance), copy=None
         )
         for key, differential in self.differentials.items():
             new_comps = (
@@ -721,12 +709,12 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
         sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
         return {
-            "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=COPY_IF_NEEDED),
+            "phi": CartesianRepresentation(-sinphi, cosphi, 0.0, copy=None),
             "theta": CartesianRepresentation(
-                costheta * cosphi, costheta * sinphi, -sintheta, copy=COPY_IF_NEEDED
+                costheta * cosphi, costheta * sinphi, -sintheta, copy=None
             ),
             "r": CartesianRepresentation(
-                sintheta * cosphi, sintheta * sinphi, costheta, copy=COPY_IF_NEEDED
+                sintheta * cosphi, sintheta * sinphi, costheta, copy=None
             ),
         }
 
@@ -872,7 +860,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             phi_op(self.phi),
             phi_op(adjust_theta_sign(self.theta)),
             r_op(self.r),
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
         for key, differential in self.differentials.items():
             new_comps = (

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -12,7 +12,6 @@ from astropy import units as u
 from astropy.constants import c as speed_of_light
 from astropy.time import Time
 from astropy.utils import ShapedLikeNDArray
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.masked import MaskableShapedLikeNDArray, combine_masks
 
@@ -683,12 +682,12 @@ class SkyCoord(MaskableShapedLikeNDArray):
             new_distance = Distance(parallax=starpm[4] << u.arcsec)
 
         icrs2 = ICRS(
-            ra=u.Quantity(starpm[0], u.radian, copy=COPY_IF_NEEDED),
-            dec=u.Quantity(starpm[1], u.radian, copy=COPY_IF_NEEDED),
-            pm_ra=u.Quantity(starpm[2], u.radian / u.yr, copy=COPY_IF_NEEDED),
-            pm_dec=u.Quantity(starpm[3], u.radian / u.yr, copy=COPY_IF_NEEDED),
+            ra=u.Quantity(starpm[0], u.radian, copy=None),
+            dec=u.Quantity(starpm[1], u.radian, copy=None),
+            pm_ra=u.Quantity(starpm[2], u.radian / u.yr, copy=None),
+            pm_dec=u.Quantity(starpm[3], u.radian / u.yr, copy=None),
             distance=new_distance,
-            radial_velocity=u.Quantity(starpm[5], u.km / u.s, copy=COPY_IF_NEEDED),
+            radial_velocity=u.Quantity(starpm[5], u.km / u.s, copy=None),
             differential_type=SphericalDifferential,
         )
 

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.units import IrreducibleUnit, Unit
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .baseframe import (
     BaseCoordinateFrame,
@@ -528,9 +527,7 @@ def _parse_coordinate_arg(coords, frame, units):
         for frame_attr_name, repr_attr_class, value, unit in zip(
             frame_attr_names, repr_attr_classes, values, units
         ):
-            components[frame_attr_name] = repr_attr_class(
-                value, unit=unit, copy=COPY_IF_NEEDED
-            )
+            components[frame_attr_name] = repr_attr_class(value, unit=unit, copy=None)
     except Exception as err:
         raise ValueError(
             f'Cannot parse first argument data "{value}" for attribute'

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from astropy import units as u
 from astropy.constants import c as speed_of_light
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_JPLEPHEM
 from astropy.utils.data import download_file
 from astropy.utils.decorators import classproperty
@@ -266,14 +265,11 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None, get_velocity=True):
                     body_pv_bary = erfa.pvppv(body_pv_helio, sun_pv_bary)
 
             body_pos_bary = CartesianRepresentation(
-                body_pv_bary["p"], unit=u.au, xyz_axis=-1, copy=COPY_IF_NEEDED
+                body_pv_bary["p"], unit=u.au, xyz_axis=-1, copy=None
             )
             if get_velocity:
                 body_vel_bary = CartesianRepresentation(
-                    body_pv_bary["v"],
-                    unit=u.au / u.day,
-                    xyz_axis=-1,
-                    copy=COPY_IF_NEEDED,
+                    body_pv_bary["v"], unit=u.au / u.day, xyz_axis=-1, copy=None
                 )
 
         else:

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -13,7 +13,6 @@ from astropy.coordinates import (
 )
 from astropy.coordinates.baseframe import BaseCoordinateFrame, frame_transform_graph
 from astropy.coordinates.spectral_quantity import SpectralQuantity
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["SpectralCoord"]
@@ -389,7 +388,7 @@ class SpectralCoord(SpectralQuantity):
                 redshift=redshift,
                 doppler_convention=doppler_convention,
                 doppler_rest=doppler_rest,
-                copy=COPY_IF_NEEDED,
+                copy=None,
             )
 
     @property

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -19,7 +19,6 @@ from astropy.coordinates import (
     Latitude,
     Longitude,
 )
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 
 def test_create_angles():
@@ -203,11 +202,6 @@ def test_angle_methods():
     a_var = a.var()
     assert type(a_var) is u.Quantity
     assert a_var == 1.0 * u.degree**2
-    if NUMPY_LT_2_0:
-        # np.ndarray.ptp() method removed in numpy 2.0.
-        a_ptp = a.ptp()
-        assert type(a_ptp) is Angle
-        assert a_ptp == 2.0 * u.degree
     a_max = a.max()
     assert type(a_max) is Angle
     assert a_max == 2.0 * u.degree

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -43,7 +43,6 @@ from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from astropy.units import allclose
 from astropy.utils import iers
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_JPLEPHEM
 from astropy.utils.exceptions import AstropyWarning
 
@@ -1084,8 +1083,8 @@ def test_aa_hd_high_precision():
         moon_aa.alt.to_value(u.radian),
         lat.to_value(u.radian),
     )
-    ha = u.Quantity(ha, u.radian, copy=COPY_IF_NEEDED)
-    dec = u.Quantity(dec, u.radian, copy=COPY_IF_NEEDED)
+    ha = u.Quantity(ha, u.radian, copy=None)
+    dec = u.Quantity(dec, u.radian, copy=None)
     assert_allclose(moon_hd.ha, ha, atol=0.1 * u.uas, rtol=0)
     assert_allclose(moon_hd.dec, dec, atol=0.1 * u.uas, rtol=0)
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -31,7 +31,6 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
 )
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose_quantity
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import DuplicateRepresentationWarning
 
 # create matrices for use in testing ``.transform()`` methods
@@ -1810,7 +1809,7 @@ class TestCartesianRepresentationWithDifferential:
 
         # make sure other kwargs are handled properly
         s1 = CartesianRepresentation(
-            x=1, y=2, z=3, differentials=diff, copy=COPY_IF_NEEDED, unit=u.kpc
+            x=1, y=2, z=3, differentials=diff, copy=None, unit=u.kpc
         )
         assert len(s1.differentials) == 1
         assert s1.differentials["s"] is diff

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -43,7 +43,6 @@ from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 from astropy.time import Time
 from astropy.units import allclose as quantity_allclose
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.wcs import WCS
 
@@ -768,10 +767,7 @@ def test_repr():
 def test_repr_altaz():
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame="icrs", distance=1 * u.kpc)
 
-    if NUMPY_LT_2_0:
-        expected_el_repr = "(-2309223., -3695529., -4641767.)"
-    else:
-        expected_el_repr = "(-2309223.0, -3695529.0, -4641767.0)"
+    expected_el_repr = "(-2309223.0, -3695529.0, -4641767.0)"
 
     loc = EarthLocation(-2309223 * u.m, -3695529 * u.m, -4641767 * u.m)
     time = Time("2005-03-21 00:00:00")

--- a/astropy/cosmology/_src/utils.py
+++ b/astropy/cosmology/_src/utils.py
@@ -11,7 +11,6 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 from astropy.units import Quantity
-from astropy.utils.compat import COPY_IF_NEEDED
 
 # isort: split
 import astropy.cosmology._src.units as cu
@@ -98,7 +97,7 @@ def aszarr(
     elif isinstance(z, np.ndarray):
         return z
 
-    return Quantity(z, cu.redshift, copy=COPY_IF_NEEDED, subok=True).view(np.ndarray)
+    return Quantity(z, cu.redshift, copy=None, subok=True).view(np.ndarray)
 
 
 # ===================================================================

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -13,7 +13,6 @@ import pytest
 from astropy.io import fits
 from astropy.io.fits.hdu.base import _NonstandardHDU, _ValidHDU
 from astropy.io.fits.verify import VerifyError, VerifyWarning
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.data import get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
@@ -708,11 +707,7 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdul[0].header == orig_header[:-1]
             assert (hdul[0].data == data).all()
 
-        if (
-            sys.platform.startswith("win")
-            and sys.version_info < (3, 14)
-            and not NUMPY_LT_2_0
-        ):
+        if sys.platform.startswith("win") and sys.version_info < (3, 14):
             ctx = pytest.warns(
                 UserWarning,
                 match="Memory map object was closed but appears to still be referenced",

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -241,7 +241,7 @@ class AstropyDumper(yaml.SafeDumper):
 
     def represent_float(self, data):
         # Override to change repr(data) to str(data) since otherwise all the
-        # numpy scalars fail in not NUMPY_LT_2_0.
+        # numpy scalars fail;
         # otherwise, this function is identical to yaml.SafeDumper.represent_float
         # (as of pyyaml 6.0.1)
         if data != data or (data == 0.0 and data == 1.0):

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -13,7 +13,6 @@ from typing import Any, NamedTuple, Self
 import numpy as np
 
 from astropy.units import Quantity, UnitBase
-from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = ["CompoundBoundingBox", "ModelBoundingBox"]
 
@@ -542,9 +541,7 @@ class _BoundingDomain(abc.ABC):
         List containing filled in output values and units
         """
         if valid_outputs_unit is not None:
-            return Quantity(
-                outputs, valid_outputs_unit, copy=COPY_IF_NEEDED, subok=True
-            )
+            return Quantity(outputs, valid_outputs_unit, copy=None, subok=True)
 
         return outputs
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -30,7 +30,6 @@ from astropy.table import Table
 from astropy.units import Quantity, UnitsError, dimensionless_unscaled
 from astropy.utils import find_current_module, metadata, sharedmethod
 from astropy.utils.codegen import make_function_with_signature
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .bounding_box import CompoundBoundingBox, ModelBoundingBox
 from .parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
@@ -437,9 +436,7 @@ class _ModelMeta(abc.ABCMeta):
                     # default is not a Quantity, attach the unit to the
                     # default.
                     if unit is not None:
-                        default = Quantity(
-                            default, unit, copy=COPY_IF_NEEDED, subok=True
-                        )
+                        default = Quantity(default, unit, copy=None, subok=True)
                     kwargs.append((param_name, default))
             else:
                 args = ("self",) + tuple(pdict.keys())

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -15,7 +15,6 @@ import operator
 import numpy as np
 
 from astropy.units import MagUnit, Quantity, dimensionless_unscaled
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .utils import array_repr_oneline, get_inputs_and_params
 
@@ -729,7 +728,7 @@ class Parameter:
 
         return wrapper
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         # Make np.asarray(self) work a little more straightforwardly
         arr = np.asarray(self.value, dtype=dtype)
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -10,8 +10,6 @@ from textwrap import indent
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED
-
 from .core import FittableModel, Model
 from .functional_models import Shift
 from .parameters import Parameter
@@ -535,7 +533,7 @@ class Chebyshev1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -656,7 +654,7 @@ class Hermite1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -835,7 +833,7 @@ class Hermite2D(OrthoPolynomialBase):
         """
         Derivative of 1D Hermite series.
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:
@@ -938,7 +936,7 @@ class Legendre1D(_PolyDomainWindow1D):
         result : ndarray
             The Vandermonde matrix
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         v = np.empty((self.degree + 1,) + x.shape, dtype=x.dtype)
         v[0] = 1
         if self.degree > 0:
@@ -1491,7 +1489,7 @@ class Chebyshev2D(OrthoPolynomialBase):
         """
         Derivative of 1D Chebyshev series.
         """
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         d = np.empty((deg + 1, len(x)), dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:
@@ -1645,7 +1643,7 @@ class Legendre2D(OrthoPolynomialBase):
 
     def _legendderiv1d(self, x, deg):
         """Derivative of 1D Legendre polynomial."""
-        x = np.array(x, dtype=float, copy=COPY_IF_NEEDED, ndmin=1)
+        x = np.array(x, dtype=float, copy=None, ndmin=1)
         d = np.empty((deg + 1,) + x.shape, dtype=x.dtype)
         d[0] = x * 0 + 1
         if deg > 0:

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from astropy import log
 from astropy.units import Unit, UnitConversionError, UnitsError  # noqa: F401
-from astropy.utils.compat import COPY_IF_NEEDED
 
 from .flag_collection import FlagCollection
 from .mixins.ndarithmetic import NDArithmeticMixin
@@ -229,7 +228,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         else:
             self._flags = value
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         """
         This allows code that requests a Numpy array to use an NDData
         object as a Numpy array.

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -10,7 +10,6 @@ import numpy as np
 from astropy.nddata.nduncertainty import NDUncertainty
 from astropy.units import Quantity, dimensionless_unscaled
 from astropy.utils import format_doc, sharedmethod
-from astropy.utils.compat.numpycompat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.masked import Masked
 
@@ -408,49 +407,27 @@ class NDArithmeticMixin:
                     # effectively handing off dtype introspection to numpy at
                     # runtime.
                     Quantity(
-                        self.data,
-                        unit=dimensionless_unscaled,
-                        dtype=None,
-                        copy=COPY_IF_NEEDED,
+                        self.data, unit=dimensionless_unscaled, dtype=None, copy=None
                     ),
-                    Quantity(
-                        operand.data,
-                        unit=operand.unit,
-                        dtype=None,
-                        copy=COPY_IF_NEEDED,
-                    ),
+                    Quantity(operand.data, unit=operand.unit, dtype=None, copy=None),
                 )
         elif hasattr(operand, "unit"):
             if operand.unit is not None:
                 result = operation(
-                    Quantity(
-                        self.data, unit=self.unit, dtype=None, copy=COPY_IF_NEEDED
-                    ),
-                    Quantity(
-                        operand.data, unit=operand.unit, dtype=None, copy=COPY_IF_NEEDED
-                    ),
+                    Quantity(self.data, unit=self.unit, dtype=None, copy=None),
+                    Quantity(operand.data, unit=operand.unit, dtype=None, copy=None),
                 )
             else:
                 result = operation(
+                    Quantity(self.data, unit=self.unit, dtype=None, copy=None),
                     Quantity(
-                        self.data,
-                        unit=self.unit,
-                        dtype=None,
-                        copy=COPY_IF_NEEDED,
-                    ),
-                    Quantity(
-                        operand.data,
-                        unit=dimensionless_unscaled,
-                        dtype=None,
-                        copy=COPY_IF_NEEDED,
+                        operand.data, unit=dimensionless_unscaled, dtype=None, copy=None
                     ),
                 )
         elif operand is not None:
             result = operation(
-                Quantity(self.data, unit=self.unit, dtype=None, copy=COPY_IF_NEEDED),
-                Quantity(
-                    operand.data, unit=operand.unit, dtype=None, copy=COPY_IF_NEEDED
-                ),
+                Quantity(self.data, unit=self.unit, dtype=None, copy=None),
+                Quantity(operand.data, unit=operand.unit, dtype=None, copy=None),
             )
         else:
             result = operation(self.data, axis=kwds["axis"])

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -18,7 +18,6 @@ from astropy.nddata.nduncertainty import (
     VarianceUncertainty,
 )
 from astropy.units import Quantity, UnitsError
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.wcs import WCS
 
@@ -1535,14 +1534,7 @@ def test_dtypes_uncert_mask_with_scalars(nddata_ref1, scalar_type, meth):
     # Enforce the same behaviour as NumPy, rather than fixed behaviour:
     assert out.data.shape == ref_dat.shape
     assert out.data.dtype == ref_dat.dtype
-    if not (
-        NUMPY_LT_2_0
-        and nddata.uncertainty.array.dtype.kind in "biu"
-        and isinstance(scalar, (np.float16, np.float32))
-    ):
-        # A quirk of NumPy 1 arithmetic causes int uncertainty (admittedly a corner
-        # case) to get cast to float64 when float32 is expected (see #18392):
-        assert out.uncertainty.array.dtype == ref_unc.dtype
+    assert out.uncertainty.array.dtype == ref_unc.dtype
     assert out.mask.dtype == ref_msk.dtype
     assert np.ma.allclose(out.data, ref_dat)
     assert np.ma.allclose(out.uncertainty.array, ref_unc)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import Literal
 
 import numpy as np
+from numpy.lib.array_utils import normalize_axis_index
 from numpy.typing import ArrayLike, NDArray
 
 from astropy.stats._fast_sigma_clip import _sigma_clip_fast
@@ -21,13 +22,7 @@ from astropy.stats.nanfunctions import (
     nanvar,
 )
 from astropy.units import Quantity
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.exceptions import AstropyUserWarning
-
-if NUMPY_LT_2_0:
-    from numpy.core.multiarray import normalize_axis_index
-else:
-    from numpy.lib.array_utils import normalize_axis_index
 
 __all__ = ["SigmaClip", "SigmaClippedStats", "sigma_clip", "sigma_clipped_stats"]
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -14,7 +14,6 @@ from astropy.stats.sigma_clipping import (
     sigma_clipped_stats,
 )
 from astropy.table import MaskedColumn
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.compat.optional_deps import HAS_BOTTLENECK, HAS_SCIPY
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import NumpyRNGContext
@@ -296,7 +295,7 @@ def test_sigma_clip_large_float32_arrays(shape):
 
     arr = rng.random(size=shape, dtype="f4")
     for byteorder in (">", "<"):
-        data = arr.astype(dtype=f"{byteorder}f4", copy=COPY_IF_NEEDED)
+        data = arr.astype(dtype=f"{byteorder}f4", copy=None)
         res = sigma_clipped_stats(data, sigma=3, maxiters=5)
         assert_allclose(res, expected, rtol=3e-3)
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -733,11 +733,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
            we also want to consistently return an array rather than a column
            (see #1446 and #1685)
         """
-        if NUMPY_LT_2_0:
-            out_arr = super().__array_wrap__(out_arr, context)
-            return_scalar = True
-        else:
-            out_arr = super().__array_wrap__(out_arr, context, return_scalar)
+        out_arr = super().__array_wrap__(out_arr, context, return_scalar)
 
         if self.shape != out_arr.shape or (
             isinstance(out_arr, BaseColumn)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -9,7 +9,6 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -510,7 +509,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         unit=None,
         format=None,
         meta=None,
-        copy=COPY_IF_NEEDED,
+        copy=None,
         copy_indices=True,
     ):
         if data is None:
@@ -1236,7 +1235,7 @@ class Column(BaseColumn):
         unit=None,
         format=None,
         meta=None,
-        copy=COPY_IF_NEEDED,
+        copy=None,
         copy_indices=True,
     ):
         if isinstance(data, MaskedColumn) and np.any(data.mask):
@@ -1595,7 +1594,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         unit=None,
         format=None,
         meta=None,
-        copy=COPY_IF_NEEDED,
+        copy=None,
         copy_indices=True,
     ):
         if mask is None:

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -6,8 +6,6 @@ from operator import index as operator_index
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED
-
 
 class Row:
     """A class to represent one row of a Table object.
@@ -90,7 +88,7 @@ class Row:
             )
         return self.as_void() != other
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         """Support converting Row to np.array via np.array(table).
 
         Coercion to a different dtype via np.array(table, dtype) is not

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,6 @@ from astropy import log
 from astropy.io.registry import UnifiedReadWriteMethod
 from astropy.units import Quantity, QuantityInfo
 from astropy.utils import ShapedLikeNDArray, deprecated
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, DataInfo, MixinInfo
 from astropy.utils.decorators import format_doc
@@ -783,7 +782,7 @@ class Table:
             # self.__class__ and respects the `copy` arg.  The returned
             # Table object should NOT then be copied.
             data = data.__astropy_table__(self.__class__, copy, **kwargs)
-            copy = COPY_IF_NEEDED
+            copy = None
         elif kwargs:
             raise TypeError(
                 f"__init__() got unexpected keyword argument {next(iter(kwargs.keys()))!r}"
@@ -1170,7 +1169,7 @@ class Table:
         """
         return _IndexModeContext(self, mode)
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         """Support converting Table to np.array via np.array(table).
 
         Coercion to a different dtype via np.array(table, dtype) is not
@@ -1412,7 +1411,7 @@ class Table:
             # scalar then it gets returned unchanged so the original object gets
             # passed to `Column` later.
             data = _convert_sequence_data_to_array(data, dtype)
-            copy = COPY_IF_NEEDED  # Already made a copy above
+            copy = None  # Already made a copy above
             col_cls = (
                 masked_col_cls
                 if isinstance(data, np.ma.MaskedArray)
@@ -1493,7 +1492,7 @@ class Table:
         if isinstance(col, Column) and not isinstance(col, self.ColumnClass):
             col_cls = self._get_col_cls_for_table(col)
             if col_cls is not col.__class__:
-                col = col_cls(col, copy=COPY_IF_NEEDED)
+                col = col_cls(col, copy=None)
 
         return col
 
@@ -4396,7 +4395,7 @@ class QTable(Table):
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
             try:
-                qcol = q_cls(col.data, col.unit, copy=COPY_IF_NEEDED, subok=True)
+                qcol = q_cls(col.data, col.unit, copy=None, subok=True)
             except Exception as exc:
                 warnings.warn(
                     f"column {col.info.name} has a unit but is kept as "

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -12,7 +12,6 @@ from numpy.testing import assert_array_equal
 from astropy import table, time
 from astropy import units as u
 from astropy.tests.helper import assert_follows_unicode_guidelines
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
 
 
@@ -385,14 +384,7 @@ class TestColumn:
             c.insert(0, "string")
 
         c = Column(["a", "b"])
-        with pytest.raises(
-            TypeError,
-            match=(
-                "string operation on non-string array"
-                if NUMPY_LT_2_0
-                else "ufunc 'str_len' did not contain a loop"
-            ),
-        ):
+        with pytest.raises(TypeError, match="ufunc 'str_len' did not contain a loop"):
             c.insert(0, 1)
 
     def test_insert_multidim(self, Column):

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -10,7 +10,6 @@ import astropy.units as u
 from astropy.table import Column, MaskedColumn, QTable, Table
 from astropy.table.column import BaseColumn
 from astropy.time import Time
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.masked import Masked
 
 
@@ -196,15 +195,13 @@ class TestMaskedColumnInit(SetupData):
             MaskedColumn(name="b", length=4, mask=mask_list)
 
 
-DTYPES_TEST_INIT = ["?", "b", "i2", "f4", "c8", "S", "U", "O"]
-if not NUMPY_LT_2_0:
-    DTYPES_TEST_INIT.extend(
-        [
-            np.dtypes.StrDType,  # same as "U"
-            np.dtypes.BytesDType,  # same as "S"
-            np.dtypes.StringDType,
-        ]
-    )
+DTYPES_TEST_INIT = ["?", "b", "i2", "f4", "c8", "S", "U", "O"] + (
+    [  # new in numpy 2
+        np.dtypes.StrDType,  # same as "U"
+        np.dtypes.BytesDType,  # same as "S"
+        np.dtypes.StringDType,
+    ]
+)
 
 
 class TestTableInit(SetupData):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -27,7 +27,6 @@ from astropy.table import (
 from astropy.table.column import BaseColumn
 from astropy.table.serialize import represent_mixins_as_columns
 from astropy.table.table_helpers import ArrayWrapper
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.metadata import MergeConflictWarning
@@ -762,12 +761,6 @@ def test_quantity_representation():
             coordinates.CartesianRepresentation([0], [1], [0], unit=u.one),
             # With no unit we get "None" in the unit row
             [
-                "    col0    ",
-                "------------",
-                "(0., 1., 0.)",
-            ]
-            if NUMPY_LT_2_0
-            else [
                 "      col0     ",
                 "---------------",
                 "(0.0, 1.0, 0.0)",
@@ -777,13 +770,6 @@ def test_quantity_representation():
         pytest.param(
             coordinates.CartesianRepresentation([0], [1], [0], unit="m"),
             [
-                "    col0    ",
-                "     m      ",
-                "------------",
-                "(0., 1., 0.)",
-            ]
-            if NUMPY_LT_2_0
-            else [
                 "      col0     ",
                 "       m       ",
                 "---------------",
@@ -794,13 +780,6 @@ def test_quantity_representation():
         pytest.param(
             coordinates.SphericalRepresentation([10] * u.deg, [20] * u.deg, [1] * u.pc),
             [
-                "     col0     ",
-                " deg, deg, pc ",
-                "--------------",
-                "(10., 20., 1.)",
-            ]
-            if NUMPY_LT_2_0
-            else [
                 "       col0      ",
                 "   deg, deg, pc  ",
                 "-----------------",
@@ -811,13 +790,6 @@ def test_quantity_representation():
         pytest.param(
             coordinates.UnitSphericalRepresentation([10] * u.deg, [20] * u.deg),
             [
-                "   col0   ",
-                "   deg    ",
-                "----------",
-                "(10., 20.)",
-            ]
-            if NUMPY_LT_2_0
-            else [
                 "    col0    ",
                 "    deg     ",
                 "------------",
@@ -830,13 +802,6 @@ def test_quantity_representation():
                 [10] * u.mas / u.yr, [2] * u.mas / u.yr, [10] * u.km / u.s
             ),
             [
-                "           col0           ",
-                "mas / yr, mas / yr, km / s",
-                "--------------------------",
-                "            (10., 2., 10.)",
-            ]
-            if NUMPY_LT_2_0
-            else [
                 "           col0           ",
                 "mas / yr, mas / yr, km / s",
                 "--------------------------",
@@ -964,16 +929,6 @@ def test_ndarray_mixin(as_ndarray_mixin):
 
     assert t.pformat(show_dtype=True) == (
         [
-            "  a [f0, f1]     b [x, y]      c [rx, ry]      d    ",
-            "(int32, str1) (int32, str2) (float64, str3) int64[2]",
-            "------------- ------------- --------------- --------",
-            "     (1, 'a')    (10, 'aa')   (100., 'raa')   0 .. 1",
-            "     (2, 'b')    (20, 'bb')   (200., 'rbb')   2 .. 3",
-            "     (3, 'c')    (30, 'cc')   (300., 'rcc')   4 .. 5",
-            "     (4, 'd')    (40, 'dd')   (400., 'rdd')   6 .. 7",
-        ]
-        if NUMPY_LT_2_0
-        else [
             "  a [f0, f1]     b [x, y]      c [rx, ry]      d    ",
             "(int32, str1) (int32, str2) (float64, str3) int64[2]",
             "------------- ------------- --------------- --------",

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -32,7 +32,6 @@ from astropy.time import Time, TimeDelta
 from astropy.timeseries import TimeSeries
 from astropy.units.quantity import Quantity
 from astropy.utils import metadata
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_SCIPY
 from astropy.utils.masked import Masked
 from astropy.utils.metadata import MergeConflictError
@@ -974,14 +973,6 @@ class TestJoin:
             [
                 "structured [f, i] string_1 string_2",
                 "----------------- -------- --------",
-                "          (1., 1)      one       --",
-                "          (2., 2)      two    three",
-                "          (4., 4)       --     four",
-            ]
-            if NUMPY_LT_2_0
-            else [
-                "structured [f, i] string_1 string_2",
-                "----------------- -------- --------",
                 "         (1.0, 1)      one       --",
                 "         (2.0, 2)      two    three",
                 "         (4.0, 4)       --     four",
@@ -1556,15 +1547,6 @@ class TestVStack:
             [
                 "structured [f, i] string",
                 "----------------- ------",
-                "          (1., 1)    one",
-                "          (2., 2)    two",
-                "          (3., 3)  three",
-                "          (4., 4)   four",
-            ]
-            if NUMPY_LT_2_0
-            else [
-                "structured [f, i] string",
-                "----------------- ------",
                 "         (1.0, 1)    one",
                 "         (2.0, 2)    two",
                 "         (3.0, 3)  three",
@@ -1778,13 +1760,6 @@ class TestDStack:
         t12 = table.dstack([t1, t2])
         assert t12.pformat() == (
             [
-                "structured [f, i]     string   ",
-                "------------------ ------------",
-                "(1., 1) .. (3., 3) one .. three",
-                "(2., 2) .. (4., 4)  two .. four",
-            ]
-            if NUMPY_LT_2_0
-            else [
                 " structured [f, i]      string   ",
                 "-------------------- ------------",
                 "(1.0, 1) .. (3.0, 3) one .. three",

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -27,7 +27,6 @@ from astropy import units as u
 from astropy.extern import _strptime
 from astropy.units import UnitConversionError
 from astropy.utils import lazyproperty
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import MixinInfo, data_info_factory
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
@@ -1723,7 +1722,7 @@ class TimeBase(MaskableShapedLikeNDArray):
             val2=jd2,
             format="jd",
             scale=self.scale,
-            copy=COPY_IF_NEEDED,
+            copy=None,
         )
         result.format = self.format
         return result
@@ -1955,7 +1954,7 @@ class Time(TimeBase):
         in_subfmt=None,
         out_subfmt=None,
         location=None,
-        copy=COPY_IF_NEEDED,
+        copy=None,
     ):
         if location is not None:
             from astropy.coordinates import EarthLocation
@@ -2430,7 +2429,7 @@ class Time(TimeBase):
             longitude = longitude.lon
         else:
             # Sanity check on input; default unit is degree.
-            longitude = Longitude(longitude, u.degree, copy=COPY_IF_NEEDED)
+            longitude = Longitude(longitude, u.degree, copy=None)
 
         theta = self._call_erfa(function, scales)
 
@@ -2911,7 +2910,7 @@ class TimeDelta(TimeBase):
         precision=None,
         in_subfmt=None,
         out_subfmt=None,
-        copy=COPY_IF_NEEDED,
+        copy=None,
     ):
         if isinstance(val, TimeDelta):
             if scale is not None:
@@ -3070,7 +3069,7 @@ class TimeDelta(TimeBase):
         # If other is something consistent with a dimensionless quantity
         # (could just be a float or an array), then we can just multiple in.
         try:
-            other = u.Quantity(other, u.dimensionless_unscaled, copy=COPY_IF_NEEDED)
+            other = u.Quantity(other, u.dimensionless_unscaled, copy=None)
         except Exception:
             # If not consistent with a dimensionless quantity, try downgrading
             # self to a quantity and see if things work.
@@ -3103,7 +3102,7 @@ class TimeDelta(TimeBase):
         # If other is something consistent with a dimensionless quantity
         # (could just be a float or an array), then we can just divide in.
         try:
-            other = u.Quantity(other, u.dimensionless_unscaled, copy=COPY_IF_NEEDED)
+            other = u.Quantity(other, u.dimensionless_unscaled, copy=None)
         except Exception:
             # If not consistent with a dimensionless quantity, try downgrading
             # self to a quantity and see if things work.
@@ -3323,7 +3322,7 @@ class ScaleValueError(Exception):
     pass
 
 
-def _make_array(val, copy=COPY_IF_NEEDED):
+def _make_array(val, copy=None):
     """
     Take ``val`` and convert/reshape to an array.  If ``copy`` is `True`
     then copy input values.

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -10,7 +10,6 @@ from astropy.coordinates import EarthLocation
 from astropy.table import Table
 from astropy.time import Time, conf
 from astropy.utils import iers
-from astropy.utils.compat import NUMPY_LT_1_26
 from astropy.utils.compat.optional_deps import HAS_H5PY
 from astropy.utils.masked import Masked
 
@@ -328,11 +327,7 @@ def test_all_formats(format_, masked_cls, masked_array_type):
         t_format = getattr(t, format_)
         tm_format = getattr(tm, format_)
         assert isinstance(tm_format, out_cls)
-        if NUMPY_LT_1_26 and format_ == "ymdhms" and out_cls is np.ma.MaskedArray:
-            # Work around https://github.com/numpy/numpy/issues/24554
-            expected = out_cls(t_format, mask=mask)
-        else:
-            expected = t_format
+        expected = t_format
         assert np.all(tm_format == expected)
 
         # Check masked scalar.

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -7,20 +7,12 @@ Distribution class and associated machinery.
 import builtins
 
 import numpy as np
+from numpy.lib._function_base_impl import _parse_gufunc_signature
+from numpy.lib._stride_tricks_impl import DummyArray
+from numpy.lib.array_utils import normalize_axis_index
 
 from astropy import stats
 from astropy import units as u
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
-
-if NUMPY_LT_2_0:
-    from numpy.core.multiarray import normalize_axis_index
-    from numpy.lib.function_base import _parse_gufunc_signature
-    from numpy.lib.stride_tricks import DummyArray
-else:
-    from numpy.lib._function_base_impl import _parse_gufunc_signature
-    from numpy.lib._stride_tricks_impl import DummyArray
-    from numpy.lib.array_utils import normalize_axis_index
-
 
 from .function_helpers import FUNCTION_HELPERS
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Self, Union, 
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
@@ -347,7 +346,7 @@ class UnitBase:
         try:
             from .quantity import Quantity
 
-            return Quantity(m, self, copy=COPY_IF_NEEDED, subok=True)
+            return Quantity(m, self, copy=None, subok=True)
         except Exception:
             if isinstance(m, np.ndarray):
                 raise

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -7,6 +7,7 @@ from functools import cached_property
 from typing import Self
 
 import numpy as np
+from numpy._core import umath as np_umath
 
 from astropy.units import (
     Quantity,
@@ -18,12 +19,7 @@ from astropy.units import (
     dimensionless_unscaled,
 )
 from astropy.units.typing import PhysicalTypeID
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
-
-if NUMPY_LT_2_0:
-    from numpy.core import umath as np_umath
-else:
-    from numpy._core import umath as np_umath
+from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = ["FunctionQuantity", "FunctionUnitBase"]
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -19,7 +19,6 @@ from astropy.units import (
     dimensionless_unscaled,
 )
 from astropy.units.typing import PhysicalTypeID
-from astropy.utils.compat import COPY_IF_NEEDED
 
 __all__ = ["FunctionQuantity", "FunctionUnitBase"]
 
@@ -313,7 +312,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
     def __rlshift__(self, other):
         """Unit conversion operator ``<<``."""
         try:
-            return self._quantity_class(other, self, copy=COPY_IF_NEEDED, subok=True)
+            return self._quantity_class(other, self, copy=None, subok=True)
         except Exception:
             return NotImplemented
 

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -12,7 +12,6 @@ from astropy.units import (
     UnitTypeError,
     dimensionless_unscaled,
 )
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 from .core import FunctionQuantity, FunctionUnitBase
 
@@ -399,21 +398,13 @@ class LogQuantity(FunctionQuantity):
         unit = self.unit._copy(dimensionless_unscaled)
         return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof, unit=unit)
 
-    if NUMPY_LT_2_0:
-
-        def ptp(self, axis=None, out=None):
+    def __array_function__(self, function, types, args, kwargs):
+        # TODO: generalize this to all supported functions!
+        if function is np.ptp:
             unit = self.unit._copy(dimensionless_unscaled)
-            return self._wrap_function(np.ptp, axis, out=out, unit=unit)
-
-    else:
-
-        def __array_function__(self, function, types, args, kwargs):
-            # TODO: generalize this to all supported functions!
-            if function is np.ptp:
-                unit = self.unit._copy(dimensionless_unscaled)
-                return self._wrap_function(np.ptp, *args[1:], unit=unit, **kwargs)
-            else:
-                return super().__array_function__(function, types, args, kwargs)
+            return self._wrap_function(np.ptp, *args[1:], unit=unit, **kwargs)
+        else:
+            return super().__array_function__(function, types, args, kwargs)
 
     def diff(self, n=1, axis=-1):
         unit = self.unit._copy(dimensionless_unscaled)

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -10,8 +10,6 @@ import numbers
 from collections.abc import Iterator
 from typing import Final, Union
 
-from astropy.utils.compat import COPY_IF_NEEDED
-
 from . import astrophys, cgs, core, misc, quantity, si
 from .typing import PhysicalTypeID, QuantityLike, UnitPowerLike
 
@@ -531,7 +529,7 @@ def get_physical_type(
         unit = obj
     else:
         try:
-            unit = quantity.Quantity(obj, copy=COPY_IF_NEEDED).unit
+            unit = quantity.Quantity(obj, copy=None).unit
         except TypeError as exc:
             raise TypeError(f"{obj} does not correspond to a physical type.") from exc
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -17,7 +17,7 @@ from typing import ClassVar, Self
 import numpy as np
 
 from astropy import config as _config
-from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
+from astropy.utils.compat.numpycompat import COPY_IF_NEEDED
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyWarning
 
@@ -1727,14 +1727,6 @@ class Quantity(np.ndarray):
             _value = _value.astype(self.dtype, copy=False)
         return _value
 
-    if NUMPY_LT_2_0:
-
-        def itemset(self, *args):
-            if len(args) == 0:
-                raise ValueError("itemset must have at least one argument")
-
-            self.view(np.ndarray).itemset(*(args[:-1] + (self._to_own_unit(args[-1]),)))
-
     def tostring(self, order="C"):
         """Not implemented, use ``.value.tostring()`` instead."""
         raise NotImplementedError(
@@ -1811,17 +1803,10 @@ class Quantity(np.ndarray):
         )
 
     # ensure we do not return indices as quantities
-    if NUMPY_LT_2_0:
-
-        def argsort(self, axis=-1, kind=None, order=None):
-            return self.view(np.ndarray).argsort(axis=axis, kind=kind, order=order)
-
-    else:
-
-        def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
-            return self.view(np.ndarray).argsort(
-                axis=axis, kind=kind, order=order, stable=stable
-            )
+    def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
+        return self.view(np.ndarray).argsort(
+            axis=axis, kind=kind, order=order, stable=stable
+        )
 
     def searchsorted(self, v, *args, **kwargs):
         return np.searchsorted(

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -17,7 +17,6 @@ from typing import ClassVar, Self
 import numpy as np
 
 from astropy import config as _config
-from astropy.utils.compat.numpycompat import COPY_IF_NEEDED
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyWarning
 
@@ -223,7 +222,7 @@ class QuantityInfo(QuantityInfoBase):
             key: (data if key == "value" else getattr(cols[-1], key))
             for key in self._represent_as_dict_attrs
         }
-        map["copy"] = COPY_IF_NEEDED
+        map["copy"] = None
         out = self._construct_from_dict(map)
 
         # Set remaining info attributes
@@ -428,12 +427,12 @@ class Quantity(np.ndarray):
         if float_default:
             dtype = None
 
-        # optimize speed for Quantity with no dtype given, copy=COPY_IF_NEEDED
+        # optimize speed for Quantity with no dtype given, copy=None
         if isinstance(value, Quantity):
             if unit is not None and unit is not value.unit:
                 value = value.to(unit)
                 # the above already makes a copy (with float dtype)
-                copy = COPY_IF_NEEDED
+                copy = None
 
             if type(value) is not cls and not (subok and isinstance(value, cls)):
                 value = value.view(cls)
@@ -521,7 +520,7 @@ class Quantity(np.ndarray):
                 if unit is None:
                     unit = value_unit
                 elif unit is not value_unit:
-                    copy = COPY_IF_NEEDED  # copy will be made in conversion at end
+                    copy = None  # copy will be made in conversion at end
 
         value = np.array(
             value, dtype=dtype, copy=copy, order=order, subok=True, ndmin=ndmin
@@ -803,7 +802,7 @@ class Quantity(np.ndarray):
         if obj is None:
             obj = self.view(np.ndarray)
         else:
-            obj = np.array(obj, copy=COPY_IF_NEEDED, subok=True)
+            obj = np.array(obj, copy=None, subok=True)
 
         # Take the view, set the unit, and update possible other properties
         # such as ``info``, ``wrap_angle`` in `Longitude`, etc.
@@ -1712,7 +1711,7 @@ class Quantity(np.ndarray):
         if self.dtype.kind == "i" and check_precision:
             # If, e.g., we are casting float to int, we want to fail if
             # precision is lost, but let things pass if it works.
-            _value = np.array(_value, copy=COPY_IF_NEEDED, subok=True)
+            _value = np.array(_value, copy=None, subok=True)
             if not np.can_cast(_value.dtype, self.dtype):
                 self_dtype_array = np.array(_value, self.dtype, subok=True)
                 if not np.all((self_dtype_array == _value) | np.isnan(_value)):
@@ -2230,9 +2229,9 @@ def allclose(a, b, rtol=1.0e-5, atol=None, equal_nan=False) -> bool:
 
 
 def _unquantify_allclose_arguments(actual, desired, rtol, atol):
-    actual = Quantity(actual, subok=True, copy=COPY_IF_NEEDED)
+    actual = Quantity(actual, subok=True, copy=None)
 
-    desired = Quantity(desired, subok=True, copy=COPY_IF_NEEDED)
+    desired = Quantity(desired, subok=True, copy=None)
     try:
         desired = desired.to(actual.unit)
     except UnitsError:
@@ -2248,7 +2247,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         # units for a and b.
         atol = Quantity(0)
     else:
-        atol = Quantity(atol, subok=True, copy=COPY_IF_NEEDED)
+        atol = Quantity(atol, subok=True, copy=None)
         try:
             atol = atol.to(actual.unit)
         except UnitsError:
@@ -2257,7 +2256,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
                 f"({actual.unit}) are not convertible"
             )
 
-    rtol = Quantity(rtol, subok=True, copy=COPY_IF_NEEDED)
+    rtol = Quantity(rtol, subok=True, copy=None)
     try:
         rtol = rtol.to(dimensionless_unscaled)
     except Exception:

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -38,22 +38,17 @@ import functools
 import operator
 
 import numpy as np
+import numpy._core as np_core
 from numpy.lib import recfunctions as rfn
 
 from astropy.units.core import dimensionless_unscaled
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.utils.compat import (
     COPY_IF_NEEDED,
-    NUMPY_LT_2_0,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
     NUMPY_LT_2_4,
 )
-
-if NUMPY_LT_2_0:
-    import numpy.core as np_core
-else:
-    import numpy._core as np_core
 
 SUBCLASS_SAFE_FUNCTIONS = set()
 """Functions with implementations supporting subclasses like Quantity."""
@@ -113,33 +108,23 @@ SUBCLASS_SAFE_FUNCTIONS |= {
 
 SUBCLASS_SAFE_FUNCTIONS |= {np.median}
 
-if NUMPY_LT_2_0:
-    # functions (re)moved in numpy 2.0
-    SUBCLASS_SAFE_FUNCTIONS |= {
-        np.msort,
-        np.round_,  # noqa: NPY003, NPY201
-        np.trapz,  # noqa: NPY201
-        np.product,  # noqa: NPY003, NPY201
-        np.cumproduct,  # noqa: NPY003, NPY201
-    }
-if not NUMPY_LT_2_0:
-    # Array-API compatible versions (matrix axes always at end).
-    SUBCLASS_SAFE_FUNCTIONS |= {
-        np.matrix_transpose, np.linalg.matrix_transpose,
-        np.linalg.diagonal, np.linalg.trace,
-        np.linalg.matrix_norm, np.linalg.vector_norm, np.linalg.vecdot,
-    }  # fmt: skip
+# Array-API compatible versions (matrix axes always at end).
+SUBCLASS_SAFE_FUNCTIONS |= {
+    np.matrix_transpose, np.linalg.matrix_transpose,
+    np.linalg.diagonal, np.linalg.trace,
+    np.linalg.matrix_norm, np.linalg.vector_norm, np.linalg.vecdot,
+}  # fmt: skip
 
-    # these work out of the box (and are tested), because they
-    # delegate to other, already wrapped functions from the np namespace
-    SUBCLASS_SAFE_FUNCTIONS |= {
-        np.linalg.cross, np.linalg.svdvals, np.linalg.tensordot, np.linalg.matmul,
-        np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
-        np.astype,
-    }  # fmt: skip
+# these work out of the box (and are tested), because they
+# delegate to other, already wrapped functions from the np namespace
+SUBCLASS_SAFE_FUNCTIONS |= {
+    np.linalg.cross, np.linalg.svdvals, np.linalg.tensordot, np.linalg.matmul,
+    np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
+    np.astype,
+}  # fmt: skip
 
-    # trapz was renamed to trapezoid
-    SUBCLASS_SAFE_FUNCTIONS |= {np.trapezoid}
+# trapz was renamed to trapezoid
+SUBCLASS_SAFE_FUNCTIONS |= {np.trapezoid}
 if not NUMPY_LT_2_1:
     SUBCLASS_SAFE_FUNCTIONS |= {np.unstack, np.cumulative_prod, np.cumulative_sum}
 
@@ -154,11 +139,6 @@ UNSUPPORTED_FUNCTIONS |= {
     np.busday_count, np.busday_offset, np.datetime_as_string,
     np.is_busday, np.all, np.any,
 }  # fmt: skip
-
-if NUMPY_LT_2_0:
-    UNSUPPORTED_FUNCTIONS |= {  # removed in numpy 2.0
-        np.sometrue, np.alltrue,  # noqa: NPY003, NPY201
-    }  # fmt: skip
 
 # Could be supported if we had a natural logarithm unit.
 UNSUPPORTED_FUNCTIONS |= {np.linalg.slogdet}
@@ -223,7 +203,7 @@ dispatched_function = FunctionAssigner(DISPATCHED_FUNCTIONS)
         np.fft.fftn, np.fft.ifftn, np.fft.rfftn, np.fft.irfftn,
         np.fft.hfft, np.fft.ihfft,
         np.linalg.eigvals, np.linalg.eigvalsh,
-    } | ({np.asfarray} if NUMPY_LT_2_0 else set())  # noqa: NPY201
+    }
 )  # fmt: skip
 def invariant_a_helper(a, *args, **kwargs):
     return (a.view(np.ndarray),) + args, kwargs, a.unit, None
@@ -511,29 +491,6 @@ def _block(arrays, max_depth, result_ndim, depth=0):
 UNIT_FROM_LIKE_ARG = object()
 
 
-if not NUMPY_LT_2_0:
-
-    @function_helper
-    def arange(
-        start_or_stop,
-        /,
-        stop=None,
-        step=1,
-        *,
-        dtype=None,
-        device=None,
-    ):
-        return arange_impl(
-            start_or_stop, stop=stop, step=step, dtype=dtype, device=device
-        )
-
-else:
-
-    @function_helper
-    def arange(start_or_stop, /, stop=None, step=1, *, dtype=None):
-        return arange_impl(start_or_stop, stop=stop, step=step, dtype=dtype)
-
-
 def unwrap_arange_args(*, start_or_stop, stop_, step_):
     # handle the perilous task of disentangling original arguments
     # This isn't trivial because start_or_stop may actually bind to two
@@ -586,7 +543,16 @@ def wrap_arange_args(*, start, stop, step, expected_out_unit):
     return args, kwargs
 
 
-def arange_impl(start_or_stop, /, *, stop, step, dtype, device=None):
+@function_helper
+def arange(
+    start_or_stop,
+    /,
+    stop=None,
+    step=1,
+    *,
+    dtype=None,
+    device=None,
+):
     # Because this wrapper requires exceptional amounts of additional logic
     # to unwrap/wrap its complicated signature, we'll sprinkle a few
     # sanity checks in the form of `assert` statements, which should help making
@@ -615,41 +581,22 @@ def arange_impl(start_or_stop, /, *, stop, step, dtype, device=None):
     )
 
     kwargs["dtype"] = dtype
-    if not NUMPY_LT_2_0:
-        kwargs["device"] = device
+    kwargs["device"] = device
 
     return args, kwargs, out_unit, None
 
 
-if NUMPY_LT_2_0:
-
-    @function_helper(helps={np.empty, np.ones, np.zeros})
-    def creation_helper(shape, dtype=None, order="C"):
-        return (shape, dtype, order), {}, UNIT_FROM_LIKE_ARG, None
-else:
-
-    @function_helper(helps={np.empty, np.ones, np.zeros})
-    def creation_helper(shape, dtype=None, order="C", *, device=None):
-        return (shape, dtype, order), {"device": device}, UNIT_FROM_LIKE_ARG, None
+@function_helper(helps={np.empty, np.ones, np.zeros})
+def creation_helper(shape, dtype=None, order="C", *, device=None):
+    return (shape, dtype, order), {"device": device}, UNIT_FROM_LIKE_ARG, None
 
 
-if NUMPY_LT_2_0:
-
-    @function_helper
-    def full(shape, fill_value, dtype=None, order="C"):
-        return full_impl(shape, fill_value, dtype, order)
-else:
-
-    @function_helper
-    def full(shape, fill_value, dtype=None, order="C", *, device=None):
-        return full_impl(shape, fill_value, dtype, order, device=device)
-
-
-def full_impl(shape, fill_value, *args, **kwargs):
+@function_helper
+def full(shape, fill_value, dtype=None, order="C", *, device=None):
     out_unit = getattr(fill_value, "unit", UNIT_FROM_LIKE_ARG)
     if out_unit is not UNIT_FROM_LIKE_ARG:
         fill_value = _as_quantity(fill_value).value
-    return (shape, fill_value) + args, kwargs, out_unit, None
+    return (shape, fill_value, dtype, order), {"device": device}, out_unit, None
 
 
 @function_helper
@@ -694,10 +641,7 @@ def array_impl(object, *, dtype, copy, order, subok, ndmin, ndmax=0):
     return (object, dtype), kwargs, out_unit, None
 
 
-if NUMPY_LT_2_0:
-    asarray_impl_1_helps = {np.asarray, np.asanyarray}
-    asarray_impl_2_helps = {}
-elif NUMPY_LT_2_1:
+if NUMPY_LT_2_1:
     asarray_impl_1_helps = {np.asanyarray}
     asarray_impl_2_helps = {np.asarray}
 else:
@@ -1294,7 +1238,7 @@ def isin(element, test_elements, *args, **kwargs):
 
 
 if NUMPY_LT_2_4:
-    # np.in1d deprecated in not NUMPY_LT_2_0, removed in not NUMPY_LT_24
+    # np.in1d removed in not NUMPY_LT_24
     @function_helper
     def in1d(ar1, ar2, *args, **kwargs):
         # This tests whether ar1 is in ar2, so we should change the unit of
@@ -1379,10 +1323,7 @@ def array2string(a, *args, **kwargs):
         a = a.value
     else:
         # See whether it covers our dtype.
-        if NUMPY_LT_2_0:
-            from numpy.core.arrayprint import _get_format_function, _make_options_dict
-        else:
-            from numpy._core.arrayprint import _get_format_function, _make_options_dict
+        from numpy._core.arrayprint import _get_format_function, _make_options_dict
 
         with np.printoptions(formatter=formatter) as options:
             options = _make_options_dict(**options)
@@ -1436,29 +1377,19 @@ def inv(a, *args, **kwargs):
     return (a.view(np.ndarray),) + args, kwargs, 1 / a.unit, None
 
 
-if NUMPY_LT_2_0:
-
-    @function_helper(module=np.linalg)
-    def pinv(a, rcond=1e-15, *args, **kwargs):
+@function_helper(module=np.linalg)
+def pinv(a, rcond=None, hermitian=False, *, rtol=np._NoValue):
+    if rcond is not None:
         rcond = _interpret_tol(rcond, a.unit)
+    if rtol is not np._NoValue and rtol is not None:
+        rtol = _interpret_tol(rtol, a.unit)
 
-        return (a.view(np.ndarray), rcond) + args, kwargs, 1 / a.unit, None
-
-else:
-
-    @function_helper(module=np.linalg)
-    def pinv(a, rcond=None, hermitian=False, *, rtol=np._NoValue):
-        if rcond is not None:
-            rcond = _interpret_tol(rcond, a.unit)
-        if rtol is not np._NoValue and rtol is not None:
-            rtol = _interpret_tol(rtol, a.unit)
-
-        return (
-            (a.view(np.ndarray),),
-            dict(rcond=rcond, hermitian=hermitian, rtol=rtol),
-            1 / a.unit,
-            None,
-        )
+    return (
+        (a.view(np.ndarray),),
+        dict(rcond=rcond, hermitian=hermitian, rtol=rtol),
+        1 / a.unit,
+        None,
+    )
 
 
 @function_helper(module=np.linalg)
@@ -1479,7 +1410,7 @@ def solve(a, b, *args, **kwargs):
 
 
 @function_helper(module=np.linalg)
-def lstsq(a, b, rcond="warn" if NUMPY_LT_2_0 else None):
+def lstsq(a, b, rcond=None):
     a, b = _as_quantities(a, b)
 
     if rcond not in (None, "warn", -1):
@@ -1509,17 +1440,9 @@ def matrix_power(a, n):
     return (a.value, n), {}, a.unit**n, None
 
 
-if NUMPY_LT_2_0:
-
-    @function_helper(module=np.linalg)
-    def cholesky(a):
-        return (a.value,), {}, a.unit**0.5, None
-
-else:
-
-    @function_helper(module=np.linalg)
-    def cholesky(a, /, *, upper=False):
-        return (a.value,), {"upper": upper}, a.unit**0.5, None
+@function_helper(module=np.linalg)
+def cholesky(a, /, *, upper=False):
+    return (a.value,), {"upper": upper}, a.unit**0.5, None
 
 
 @function_helper(module=np.linalg)
@@ -1543,15 +1466,12 @@ def eig(a, *args, **kwargs):
     return (a.value,) + args, kwargs, (a.unit, dimensionless_unscaled), None
 
 
-if not NUMPY_LT_2_0:
-    # these functions were added in numpy 2.0
-
-    @function_helper(module=np.linalg)
-    def outer(x1, x2, /):
-        # maybe this one can be marked as subclass-safe in the near future ?
-        # see https://github.com/numpy/numpy/pull/25101#discussion_r1419879122
-        x1, x2 = _as_quantities(x1, x2)
-        return (x1.view(np.ndarray), x2.view(np.ndarray)), {}, x1.unit * x2.unit, None
+@function_helper(module=np.linalg)
+def outer(x1, x2, /):
+    # maybe this one can be marked as subclass-safe in the near future ?
+    # see https://github.com/numpy/numpy/pull/25101#discussion_r1419879122
+    x1, x2 = _as_quantities(x1, x2)
+    return (x1.view(np.ndarray), x2.view(np.ndarray)), {}, x1.unit * x2.unit, None
 
 
 # ======================= np.lib.recfunctions =======================

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -44,7 +44,6 @@ from numpy.lib import recfunctions as rfn
 from astropy.units.core import dimensionless_unscaled
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.utils.compat import (
-    COPY_IF_NEEDED,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
     NUMPY_LT_2_4,
@@ -388,7 +387,7 @@ def _as_quantity(a):
     from astropy.units import Quantity
 
     try:
-        return Quantity(a, copy=COPY_IF_NEEDED, subok=True)
+        return Quantity(a, copy=None, subok=True)
     except Exception:
         # If we cannot convert to Quantity, we should just bail.
         raise NotImplementedError
@@ -400,9 +399,7 @@ def _as_quantities(*args):
 
     try:
         # Note: this should keep the dtype the same
-        return tuple(
-            Quantity(a, copy=COPY_IF_NEEDED, subok=True, dtype=None) for a in args
-        )
+        return tuple(Quantity(a, copy=None, subok=True, dtype=None) for a in args)
     except Exception:
         # If we cannot convert to Quantity, we should just bail.
         raise NotImplementedError

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -10,20 +10,15 @@ units for a given ufunc, given input units.
 from fractions import Fraction
 
 import numpy as np
+from numpy._core import umath as np_umath
 
 from astropy.units.core import dimensionless_unscaled, unit_scale_converter
 from astropy.units.errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.utils.compat.numpycompat import (
-    NUMPY_LT_2_0,
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
     NUMPY_LT_2_3,
 )
-
-if NUMPY_LT_2_0:
-    from numpy.core import umath as np_umath
-else:
-    from numpy._core import umath as np_umath
 
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
 
@@ -391,37 +386,36 @@ UNSUPPORTED_UFUNCS |= {
     np.lcm,
 }
 
-if not NUMPY_LT_2_0:
-    # string utilities - make no sense for Quantity.
-    UNSUPPORTED_UFUNCS |= {
-        np.bitwise_count,
-        np._core.umath.count,
-        np._core.umath.isalpha,
-        np._core.umath.isdigit,
-        np._core.umath.isspace,
-        np._core.umath.isnumeric,
-        np._core.umath.isdecimal,
-        np._core.umath.isalnum,
-        np._core.umath.istitle,
-        np._core.umath.islower,
-        np._core.umath.isupper,
-        np._core.umath.index,
-        np._core.umath.rindex,
-        np._core.umath.startswith,
-        np._core.umath.endswith,
-        np._core.umath.find,
-        np._core.umath.rfind,
-        np._core.umath.str_len,
-        np._core.umath._strip_chars,
-        np._core.umath._lstrip_chars,
-        np._core.umath._rstrip_chars,
-        np._core.umath._strip_whitespace,
-        np._core.umath._lstrip_whitespace,
-        np._core.umath._rstrip_whitespace,
-        np._core.umath._replace,
-        np._core.umath._expandtabs,
-        np._core.umath._expandtabs_length,
-    }
+# string utilities - make no sense for Quantity.
+UNSUPPORTED_UFUNCS |= {
+    np.bitwise_count,
+    np._core.umath.count,
+    np._core.umath.isalpha,
+    np._core.umath.isdigit,
+    np._core.umath.isspace,
+    np._core.umath.isnumeric,
+    np._core.umath.isdecimal,
+    np._core.umath.isalnum,
+    np._core.umath.istitle,
+    np._core.umath.islower,
+    np._core.umath.isupper,
+    np._core.umath.index,
+    np._core.umath.rindex,
+    np._core.umath.startswith,
+    np._core.umath.endswith,
+    np._core.umath.find,
+    np._core.umath.rfind,
+    np._core.umath.str_len,
+    np._core.umath._strip_chars,
+    np._core.umath._lstrip_chars,
+    np._core.umath._rstrip_chars,
+    np._core.umath._strip_whitespace,
+    np._core.umath._lstrip_whitespace,
+    np._core.umath._rstrip_whitespace,
+    np._core.umath._replace,
+    np._core.umath._expandtabs,
+    np._core.umath._expandtabs_length,
+}
 if not NUMPY_LT_2_1:
     UNSUPPORTED_UFUNCS |= {
         np._core.umath._ljust,
@@ -567,8 +561,7 @@ for ufunc in twoarg_invtrig_ufuncs:
 # ufuncs handled as special cases
 UFUNC_HELPERS[np.multiply] = helper_multiplication
 UFUNC_HELPERS[np.matmul] = helper_multiplication
-if not NUMPY_LT_2_0:
-    UFUNC_HELPERS[np.vecdot] = helper_multiplication
+UFUNC_HELPERS[np.vecdot] = helper_multiplication
 if not NUMPY_LT_2_2:
     UFUNC_HELPERS[np.vecmat] = helper_multiplication
     UFUNC_HELPERS[np.matvec] = helper_multiplication

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -12,7 +12,6 @@ from numpy.testing import assert_allclose
 from astropy import constants as c
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 
 lu_units = [u.dex, u.mag, u.decibel]
 
@@ -1010,13 +1009,6 @@ class TestLogQuantityMethods:
             assert res.unit == u.mag**2
         else:
             assert res.unit == mag.unit
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="ptp method removed in numpy 2.0")
-    @log_quantity_parametrization
-    def test_always_ok_ptp(self, mag):
-        res = mag.ptp()
-        assert np.all(res.value == mag._function_view.ptp().value)
-        assert res.unit == u.mag()
 
     @log_quantity_parametrization
     def test_clip(self, mag):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -719,6 +719,7 @@ class TestQuantityOperations:
             operator.index(u.Quantity(val, u.m, dtype=int))
 
     def test__index_fails_for_list_multiplication(self):
+        # This used to work for numpy <= 1.10, but that's not coming back.
         # See https://github.com/numpy/numpy/issues/5074
         q4 = u.Quantity(2, u.dimensionless_unscaled, dtype=int)
         with pytest.raises(TypeError):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -701,14 +701,6 @@ class TestQuantityOperations:
             q5.__index__()
         assert exc.value.args[0] == index_err_msg
 
-    # See https://github.com/numpy/numpy/issues/5074
-    # It seems unlikely this will be resolved, so xfail'ing it.
-    @pytest.mark.xfail(reason="list multiplication only works for numpy <=1.10")
-    def test_numeric_converter_to_index_in_practice(self):
-        """Test that use of __index__ actually works."""
-        q4 = u.Quantity(2, u.dimensionless_unscaled, dtype=int)
-        assert q4 * ["a", "b", "c"] == ["a", "b", "c", "a", "b", "c"]
-
     def test_array_converters(self):
         # Scalar quantity
         q = u.Quantity(1.23, u.m)
@@ -725,6 +717,12 @@ class TestQuantityOperations:
 
         with pytest.raises(TypeError):
             operator.index(u.Quantity(val, u.m, dtype=int))
+
+    def test__index_fails_for_list_multiplication(self):
+        # See https://github.com/numpy/numpy/issues/5074
+        q4 = u.Quantity(2, u.dimensionless_unscaled, dtype=int)
+        with pytest.raises(TypeError):
+            q4 * ["a", "b", "c"]
 
 
 def test_quantity_conversion():

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_allclose, assert_array_almost_equal, assert_arr
 
 from astropy import units as u
 from astropy.units.quantity import _UNIT_NOT_INITIALISED
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.masked import Masked
 
@@ -2014,7 +2013,7 @@ class QuantityMimic:
         self.value = value
         self.unit = unit
 
-    def __array__(self, dtype=None, copy=COPY_IF_NEEDED):
+    def __array__(self, dtype=None, copy=None):
         return np.array(self.value, dtype=dtype, copy=copy)
 
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -6,7 +6,6 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.compat.optional_deps import HAS_ARRAY_API_STRICT
 
 
@@ -437,19 +436,6 @@ class TestArrayConversion:
         assert q1[1] == 1 * u.m / u.km
         with pytest.raises(TypeError):
             q1[1] = 1.5 * u.m / u.km
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="itemset method removed in numpy 2.0")
-    def test_itemset(self):
-        q1 = u.Quantity(np.array([1, 2, 3]), u.m / u.km, dtype=int)
-        assert q1.item(1) == 2 * q1.unit
-        q1.itemset(1, 1)
-        assert q1.item(1) == 1000 * u.m / u.km
-        q1.itemset(1, 100 * u.cm / u.km)
-        assert q1.item(1) == 1 * u.m / u.km
-        with pytest.raises(TypeError):
-            q1.itemset(1, 1.5 * u.m / u.km)
-        with pytest.raises(ValueError):
-            q1.itemset()
 
     def test_take_put(self):
         q1 = np.array([1, 2, 3]) * u.m / u.km

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -21,7 +21,7 @@ from astropy.units.quantity_helper.function_helpers import (
     TBD_FUNCTIONS,
     UNSUPPORTED_FUNCTIONS,
 )
-from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
+from astropy.utils.compat import NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
 
 VAR_POSITIONAL = inspect.Parameter.VAR_POSITIONAL
 VAR_KEYWORD = inspect.Parameter.VAR_KEYWORD
@@ -194,10 +194,8 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         assert type(a1) is np.ndarray
         assert type(a2) is np.ndarray
 
-    if not NUMPY_LT_2_0:
-
-        def test_matrix_transpose(self):
-            self.check(np.matrix_transpose)
+    def test_matrix_transpose(self):
+        self.check(np.matrix_transpose)
 
 
 class TestArgFunctions(NoUnitTestSetup):
@@ -295,12 +293,6 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         copy = np.copy(a=self.q)
         assert_array_equal(copy, self.q)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.asfarray is removed in NumPy 2.0")
-    def test_asfarray(self):
-        self.check(np.asfarray)  # noqa: NPY201
-        farray = np.asfarray(a=self.q)  # noqa: NPY201
-        assert_array_equal(farray, self.q)
-
     def test_empty_like(self):
         o = np.empty_like(self.q)
         assert o.shape == (3, 3)
@@ -329,11 +321,9 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.full_like(self.q, 0.5 * u.s)
 
-    if not NUMPY_LT_2_0:
-
-        def test_astype(self):
-            int32q = self.q.astype("int32")
-            assert_array_equal(np.astype(int32q, "int32"), int32q)
+    def test_astype(self):
+        int32q = self.q.astype("int32")
+        assert_array_equal(np.astype(int32q, "int32"), int32q)
 
     @pytest.mark.parametrize(
         "args, kwargs, expected",
@@ -844,39 +834,13 @@ class TestUfuncReductions(InvariantUnitTestSetup):
         with pytest.raises(TypeError):
             np.all(self.q)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
-    def test_sometrue(self):
-        with pytest.raises(TypeError):
-            np.sometrue(self.q)  # noqa: NPY003, NPY201
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
-    def test_alltrue(self):
-        with pytest.raises(TypeError):
-            np.alltrue(self.q)  # noqa: NPY003, NPY201
-
     def test_prod(self):
         with pytest.raises(u.UnitsError):
             np.prod(self.q)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
-    def test_product(self):
-        with pytest.raises(u.UnitsError):
-            np.product(self.q)  # noqa: NPY003, NPY201
-
     def test_cumprod(self):
         with pytest.raises(u.UnitsError):
             np.cumprod(self.q)
-
-    @pytest.mark.skipif(
-        not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
-    )
-    @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
-    def test_cumproduct(self):
-        with pytest.raises(u.UnitsError):
-            np.cumproduct(self.q)  # noqa: NPY003, NPY201
 
     @pytest.mark.skipif(NUMPY_LT_2_1, reason="np.cumulative_prod is new in NumPy 2.1")
     def test_cumulative_prod(self):
@@ -891,11 +855,6 @@ class TestUfuncLike(InvariantUnitTestSetup):
 
     def test_round(self):
         self.check(np.round)
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
-    def test_round_(self):
-        self.check(np.round_)  # noqa: NPY003, NPY201
 
     def test_around(self):
         self.check(np.around)
@@ -1386,15 +1345,8 @@ class TestIntDiffFunctions:
         expected = func(y.value, x.value) * y.unit * x.unit
         assert np.all(out == expected)
 
-    if NUMPY_LT_2_0:
-
-        def test_trapz(self):
-            self.check_trapezoid(np.trapz)  # noqa: NPY201
-
-    else:
-
-        def test_trapezoid(self):
-            self.check_trapezoid(np.trapezoid)
+    def test_trapezoid(self):
+        self.check_trapezoid(np.trapezoid)
 
     def test_diff(self):
         # Simple diff works out of the box.
@@ -1941,11 +1893,6 @@ class TestSortFunctions(InvariantUnitTestSetup):
     def test_sort_axis(self):
         self.check(np.sort, axis=0)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
-    def test_msort(self):
-        with pytest.warns(DeprecationWarning, match="^msort is deprecated"):
-            self.check(np.msort)
-
     def test_sort_complex(self):
         self.check(np.sort_complex)
 
@@ -2123,46 +2070,44 @@ class TestSetOpsFunctions:
     def test_unique_more_complex(self, kwargs):
         self.check1(np.unique, **kwargs)
 
-    if not NUMPY_LT_2_0:
+    def test_unique_all(self):
+        values, indices, inverse_indices, counts = np.unique(
+            self.q,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            equal_nan=False,
+        )
+        res = np.unique_all(self.q)
+        assert len(res) == 4
 
-        def test_unique_all(self):
-            values, indices, inverse_indices, counts = np.unique(
-                self.q,
-                return_index=True,
-                return_inverse=True,
-                return_counts=True,
-                equal_nan=False,
-            )
-            res = np.unique_all(self.q)
-            assert len(res) == 4
+        assert_array_equal(res.values, values)
+        assert_array_equal(res.indices, indices)
+        assert_array_equal(res.inverse_indices, inverse_indices)
+        assert_array_equal(res.counts, counts)
 
-            assert_array_equal(res.values, values)
-            assert_array_equal(res.indices, indices)
-            assert_array_equal(res.inverse_indices, inverse_indices)
-            assert_array_equal(res.counts, counts)
+    def test_unique_counts(self):
+        values, counts = np.unique(self.q, return_counts=True, equal_nan=False)
+        res = np.unique_counts(self.q)
+        assert len(res) == 2
 
-        def test_unique_counts(self):
-            values, counts = np.unique(self.q, return_counts=True, equal_nan=False)
-            res = np.unique_counts(self.q)
-            assert len(res) == 2
+        assert_array_equal(res.values, values)
+        assert_array_equal(res.counts, counts)
 
-            assert_array_equal(res.values, values)
-            assert_array_equal(res.counts, counts)
+    def test_unique_inverse(self):
+        values, inverse_indices = np.unique(
+            self.q, return_inverse=True, equal_nan=False
+        )
+        res = np.unique_inverse(self.q)
+        assert len(res) == 2
 
-        def test_unique_inverse(self):
-            values, inverse_indices = np.unique(
-                self.q, return_inverse=True, equal_nan=False
-            )
-            res = np.unique_inverse(self.q)
-            assert len(res) == 2
+        assert_array_equal(res.values, values)
+        assert_array_equal(res.inverse_indices, inverse_indices)
 
-            assert_array_equal(res.values, values)
-            assert_array_equal(res.inverse_indices, inverse_indices)
-
-        def test_unique_values(self):
-            values = np.unique(self.q, equal_nan=False)
-            res = np.unique_values(self.q)
-            assert_array_equal(res, values)
+    def test_unique_values(self):
+        values = np.unique(self.q, equal_nan=False)
+        res = np.unique_values(self.q)
+        assert_array_equal(res, values)
 
     @pytest.mark.parametrize("kwargs", ({}, dict(return_indices=True)))
     def test_intersect1d(self, kwargs):
@@ -2363,9 +2308,8 @@ class TestLinAlg(InvariantUnitTestSetup):
             np.linalg.pinv(self.q.value, rcond.to_value(self.q.unit)) / self.q.unit
         )
         assert_array_equal(pinv2, expected2)
-        if not NUMPY_LT_2_0:
-            pinv3 = np.linalg.pinv(self.q, rtol=rcond)
-            assert_array_equal(pinv3, expected2)
+        pinv3 = np.linalg.pinv(self.q, rtol=rcond)
+        assert_array_equal(pinv3, expected2)
 
     def test_tensorinv(self):
         inv = np.linalg.tensorinv(self.q, ind=1)
@@ -2494,71 +2438,68 @@ class TestLinAlg(InvariantUnitTestSetup):
         wx = np.linalg.eigvalsh(self.q.value) << self.q.unit
         assert_array_equal(w, wx)
 
-    if not NUMPY_LT_2_0:
-        # Numpy 2.0 added array-api compatible definitions of
-        # diagonal and trace to np.linalg. Since these have
-        # name conflicts with the main numpy namespace, they
-        # are tracked as linalg_diagonal and linalg_trace.
-        def test_diagonal(self):
-            self.check(np.linalg.diagonal)
+    # Numpy 2.0 added array-api compatible definitions of
+    # diagonal and trace to np.linalg. Since these have
+    # name conflicts with the main numpy namespace, they
+    # are tracked as linalg_diagonal and linalg_trace.
+    def test_diagonal(self):
+        self.check(np.linalg.diagonal)
 
-        def test_trace(self):
-            self.check(np.trace)
+    def test_trace(self):
+        self.check(np.trace)
 
-        def test_cross(self):
-            q1 = np.array([1, 2, 3]) << u.m
-            q2 = np.array([4, 5, 6]) << u.s
-            assert_array_equal(np.linalg.cross(q1, q2), np.cross(q1, q2))
-            assert_array_equal(np.linalg.cross(q1, q2.value), np.cross(q1, q2.value))
+    def test_cross(self):
+        q1 = np.array([1, 2, 3]) << u.m
+        q2 = np.array([4, 5, 6]) << u.s
+        assert_array_equal(np.linalg.cross(q1, q2), np.cross(q1, q2))
+        assert_array_equal(np.linalg.cross(q1, q2.value), np.cross(q1, q2.value))
 
-        def test_outer(self):
-            q = self.q.flatten()
-            assert_array_equal(np.linalg.outer(q, q), np.outer(q, q))
-            assert_array_equal(np.linalg.outer(q, q.value), np.outer(q, q.value))
+    def test_outer(self):
+        q = self.q.flatten()
+        assert_array_equal(np.linalg.outer(q, q), np.outer(q, q))
+        assert_array_equal(np.linalg.outer(q, q.value), np.outer(q, q.value))
 
-        def test_svdvals(self):
-            _, ref, _ = np.linalg.svd(self.q)
-            res = np.linalg.svdvals(self.q)
-            assert_allclose(res, ref, rtol=5e-16)
+    def test_svdvals(self):
+        _, ref, _ = np.linalg.svd(self.q)
+        res = np.linalg.svdvals(self.q)
+        assert_allclose(res, ref, rtol=5e-16)
 
-        def test_vecdot(self):
-            ref = (self.q * self.q).sum(-1)
-            res = np.linalg.vecdot(self.q, self.q)
-            assert_array_equal(res, ref)
+    def test_vecdot(self):
+        ref = (self.q * self.q).sum(-1)
+        res = np.linalg.vecdot(self.q, self.q)
+        assert_array_equal(res, ref)
 
-        def test_tensordot(self):
-            ref = np.tensordot(self.q, self.q)
-            res = np.linalg.tensordot(self.q, self.q)
-            assert_array_equal(res, ref)
+    def test_tensordot(self):
+        ref = np.tensordot(self.q, self.q)
+        res = np.linalg.tensordot(self.q, self.q)
+        assert_array_equal(res, ref)
 
-        def test_matmul(self):
-            ref = np.matmul(self.q, self.q)
-            res = np.linalg.matmul(self.q, self.q)
-            assert_array_equal(res, ref)
+    def test_matmul(self):
+        ref = np.matmul(self.q, self.q)
+        res = np.linalg.matmul(self.q, self.q)
+        assert_array_equal(res, ref)
 
-        def test_matrix_transpose(self):
-            t = np.linalg.matrix_transpose(self.q)
-            assert_array_equal(t, self.q.swapaxes(-2, -1))
+    def test_matrix_transpose(self):
+        t = np.linalg.matrix_transpose(self.q)
+        assert_array_equal(t, self.q.swapaxes(-2, -1))
 
-        def test_matrix_norm(self):
-            n = np.linalg.matrix_norm(self.q)
-            expected = np.linalg.norm(self.q.value) << self.q.unit
-            assert_array_equal(n, expected)
+    def test_matrix_norm(self):
+        n = np.linalg.matrix_norm(self.q)
+        expected = np.linalg.norm(self.q.value) << self.q.unit
+        assert_array_equal(n, expected)
 
-        def test_vector_norm(self):
-            n = np.linalg.vector_norm(self.q)
-            expected = np.linalg.norm(self.q.value.ravel()) << self.q.unit
-            assert_array_equal(n, expected)
-            # Special case: 1-D, ord=0.
-            n1 = np.linalg.vector_norm(self.q[0], ord=0)
-            expected1 = np.linalg.norm(self.q[0].value.ravel(), ord=0) << u.one
-            assert_array_equal(n1, expected1)
-            # Axis combo, just in case
-            n2 = np.linalg.vector_norm(self.q, axis=(-1, -2))
-            expected2 = (
-                np.linalg.vector_norm(self.q.value, axis=(-1, -2)) << self.q.unit
-            )
-            assert_array_equal(n2, expected2)
+    def test_vector_norm(self):
+        n = np.linalg.vector_norm(self.q)
+        expected = np.linalg.norm(self.q.value.ravel()) << self.q.unit
+        assert_array_equal(n, expected)
+        # Special case: 1-D, ord=0.
+        n1 = np.linalg.vector_norm(self.q[0], ord=0)
+        expected1 = np.linalg.norm(self.q[0].value.ravel(), ord=0) << u.one
+        assert_array_equal(n1, expected1)
+        # Axis combo, just in case
+        n2 = np.linalg.vector_norm(self.q, axis=(-1, -2))
+        expected2 = np.linalg.vector_norm(self.q.value, axis=(-1, -2)) << self.q.unit
+        assert_array_equal(n2, expected2)
 
 
 class TestRecFunctions:

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -10,19 +10,15 @@ from typing import NamedTuple
 import numpy as np
 import pytest
 from erfa import ufunc as erfa_ufunc
+from numpy._core import umath as np_umath
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy import units as u
 from astropy.units import quantity_helper as qh
 from astropy.units.quantity_helper.converters import UfuncHelpers
 from astropy.units.quantity_helper.helpers import helper_sqrt
-from astropy.utils.compat.numpycompat import NUMPY_LT_2_0, NUMPY_LT_2_3
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_SCIPY
-
-if NUMPY_LT_2_0:
-    from numpy.core import umath as np_umath
-else:
-    from numpy._core import umath as np_umath
 
 
 class testcase(NamedTuple):
@@ -384,7 +380,6 @@ class TestQuantityMathFuncs:
         r2 = np.matmul(q1, q2)
         assert np.all(r2 == np.matmul(q1.value, q2.value) * q1.unit * q2.unit)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="vecdot only added in numpy 2.0")
     def test_vecdot(self):
         q1 = np.array([1j, 2j, 3j]) * u.m
         q2 = np.array([4j, 5j, 6j]) / u.s

--- a/astropy/utils/compat/__init__.py
+++ b/astropy/utils/compat/__init__.py
@@ -8,3 +8,12 @@ packages or code.
 
 # Importing this module will also install monkey-patches defined in it
 from .numpycompat import *
+
+
+def __getattr__(attr):
+    if attr == "COPY_IF_NEEDED":
+        from .numpycompat import COPY_IF_NEEDED  # Will emit warning
+
+        return COPY_IF_NEEDED
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,6 @@ from astropy.utils import minversion
 
 __all__ = [
     "COPY_IF_NEEDED",
-    "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
     "NUMPY_LT_2_2",
     "NUMPY_LT_2_3",
@@ -20,11 +19,10 @@ __all__ = [
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_2_0 = not minversion(np, "2.0")
 NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
 NUMPY_LT_2_4 = not minversion(np, "2.4.0.dev0")
 
 
-COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None
+COPY_IF_NEEDED = None

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -4,9 +4,12 @@ This is a collection of monkey patches and workarounds for bugs in
 earlier versions of Numpy.
 """
 
+import warnings
+
 import numpy as np
 
 from astropy.utils import minversion
+from astropy.utils.exceptions import AstropyPendingDeprecationWarning
 
 __all__ = [
     "NUMPY_LT_2_1",
@@ -22,3 +25,16 @@ NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
 NUMPY_LT_2_4 = not minversion(np, "2.4.0.dev0")
+
+
+def __getattr__(attr):
+    # MHvK: Added in 8.0. Regular deprecation in 9.0, remove in 10.0?
+    if attr == "COPY_IF_NEEDED":
+        warnings.warn(
+            "COPY_IF_NEEDED is no longer needed now that astropy only "
+            "supports numpy >= 2. It can be safely replaced with 'None'. ",
+            AstropyPendingDeprecationWarning,
+        )
+        return None
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}.")

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -9,7 +9,6 @@ import numpy as np
 from astropy.utils import minversion
 
 __all__ = [
-    "COPY_IF_NEEDED",
     "NUMPY_LT_2_1",
     "NUMPY_LT_2_2",
     "NUMPY_LT_2_3",
@@ -23,6 +22,3 @@ NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
 NUMPY_LT_2_4 = not minversion(np, "2.4.0.dev0")
-
-
-COPY_IF_NEEDED = None

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -10,7 +10,6 @@ from astropy.utils import minversion
 
 __all__ = [
     "COPY_IF_NEEDED",
-    "NUMPY_LT_1_26",
     "NUMPY_LT_2_0",
     "NUMPY_LT_2_1",
     "NUMPY_LT_2_2",
@@ -21,7 +20,6 @@ __all__ = [
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
-NUMPY_LT_1_26 = not minversion(np, "1.26")
 NUMPY_LT_2_0 = not minversion(np, "2.0")
 NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -22,7 +22,7 @@ import importlib
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
+from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.shapes import NDArrayShapeMethods, ShapedLikeNDArray
 
@@ -872,17 +872,9 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             else:
                 # Parse signature with private numpy function. Note it
                 # cannot handle spaces in tuples, so remove those.
-                if NUMPY_LT_2_0:
-                    in_sig, out_sig = np.lib.function_base._parse_gufunc_signature(
-                        ufunc.signature.replace(" ", "")
-                    )
-                else:
-                    (
-                        in_sig,
-                        out_sig,
-                    ) = np.lib._function_base_impl._parse_gufunc_signature(
-                        ufunc.signature.replace(" ", "")
-                    )
+                (in_sig, out_sig) = np.lib._function_base_impl._parse_gufunc_signature(
+                    ufunc.signature.replace(" ", "")
+                )
                 axes = kwargs.get("axes")
                 if axes is None:
                     # Maybe axis was given? (Note: ufunc will not take both.)
@@ -1203,8 +1195,6 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             # As done inside the argsort implementation in multiarray/methods.c.
             if order is None:
                 order = self.dtype.names
-            elif NUMPY_LT_2_0:
-                order = np.core._internal._newnames(self.dtype, order)
             else:
                 order = np._core._internal._newnames(self.dtype, order)
 
@@ -1228,9 +1218,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
         they are present only so that subclasses can pass them on.
         """
         # TODO: probably possible to do this faster than going through argsort!
-        argsort_kwargs = dict(kind=kind, order=order)
-        if not NUMPY_LT_2_0:
-            argsort_kwargs["stable"] = stable
+        argsort_kwargs = dict(kind=kind, order=order, stable=stable)
         indices = self.argsort(axis, **argsort_kwargs)
         self[:] = np.take_along_axis(self, indices, axis=axis)
 

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -22,7 +22,6 @@ import importlib
 
 import numpy as np
 
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.shapes import NDArrayShapeMethods, ShapedLikeNDArray
 
@@ -216,12 +215,12 @@ class Masked(NDArrayShapeMethods):
     # Subclasses can override this in case the class does not work
     # with this signature, or to provide a faster implementation.
     @classmethod
-    def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
+    def from_unmasked(cls, data, mask=None, copy=None):
         """Create an instance from unmasked data and a mask."""
         return cls(data, mask=mask, copy=copy)
 
     @classmethod
-    def _get_masked_instance(cls, data, mask=None, copy=COPY_IF_NEEDED):
+    def _get_masked_instance(cls, data, mask=None, copy=None):
         data, data_mask = get_data_and_mask(data)
         if mask is None:
             mask = False if data_mask is None else data_mask
@@ -344,7 +343,7 @@ class Masked(NDArrayShapeMethods):
             data = getattr(self.unmasked, method)(*args, **kwargs)
             mask = getattr(self.mask, method)(*args, **kwargs)
 
-        result = self.from_unmasked(data, mask, copy=COPY_IF_NEEDED)
+        result = self.from_unmasked(data, mask, copy=None)
         if "info" in self.__dict__:
             result.info = self.info
 
@@ -627,7 +626,7 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
     # The two pieces typically overridden.
     @classmethod
-    def from_unmasked(cls, data, mask=None, copy=COPY_IF_NEEDED):
+    def from_unmasked(cls, data, mask=None, copy=None):
         # Note: have to override since __new__ would use ndarray.__new__
         # which expects the shape as its first argument, not an array.
         data = np.array(data, subok=True, copy=copy)

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -13,17 +13,11 @@ interpreted.
 import warnings
 
 import numpy as np
+import numpy._core as np_core
+from numpy.lib._function_base_impl import _quantile_is_valid, _ureduce
 
 from astropy.units.quantity_helper.function_helpers import FunctionAssigner
-from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
-
-if NUMPY_LT_2_0:
-    import numpy.core as np_core
-    from numpy.lib.function_base import _quantile_is_valid, _ureduce
-else:
-    import numpy._core as np_core
-    from numpy.lib._function_base_impl import _quantile_is_valid, _ureduce
-
+from astropy.utils.compat import NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
 
 # This module should not really be imported, but we define __all__
 # such that sphinx can typeset the functions with docstrings.
@@ -143,19 +137,10 @@ MASKED_SAFE_FUNCTIONS |= {
 }  # fmt: skip
 
 
-if NUMPY_LT_2_0:
-    # Safe in < 2.0, because it deferred to the method. Overridden in >= 2.0.
-    MASKED_SAFE_FUNCTIONS |= {np.ptp}
-    # Removed in numpy 2.0.  Just an alias to vstack.
-    MASKED_SAFE_FUNCTIONS |= {np.row_stack}  # noqa: NPY201
-    # renamed in numpy 2.0
-    MASKED_SAFE_FUNCTIONS |= {np.trapz}  # noqa: NPY201
-if not NUMPY_LT_2_0:
-    # new in numpy 2.0
-    MASKED_SAFE_FUNCTIONS |= {
-        np.astype, np.trapezoid,
-        np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
-    }  # fmt: skip
+MASKED_SAFE_FUNCTIONS |= {
+    np.astype, np.trapezoid,
+    np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
+}  # fmt: skip
 if not NUMPY_LT_2_1:
     MASKED_SAFE_FUNCTIONS |= {
         np.unstack,
@@ -248,12 +233,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 # Following are simple functions related to shapes, where the same function
 # should be applied to the data and the mask.  They cannot all share the
 # same helper, because the first arguments have different names.
-@apply_to_both(
-    helps=(
-        {np.copy, np.resize, np.moveaxis, np.rollaxis, np.roll}
-        | ({np.asfarray} if NUMPY_LT_2_0 else set())  # noqa: NPY201
-    )
-)
+@apply_to_both(helps=({np.copy, np.resize, np.moveaxis, np.rollaxis, np.roll}))
 def masked_a_helper(a, *args, **kwargs):
     data, mask = _get_data_and_mask_array(a)
     return (data,) + args, (mask,) + args, kwargs, None
@@ -295,173 +275,118 @@ def outer(a, b, out=None):
     return np.multiply.outer(np.ravel(a), np.ravel(b), out=out), None, None
 
 
-if not NUMPY_LT_2_0:
+def empty_like_impl(
+    prototype, /, dtype=None, order="K", subok=True, shape=None, *, device=None
+):
+    """Return a new array with the same shape and type as a given array.
 
-    def empty_like_impl(
+    Like `numpy.empty_like`, but will add an empty mask.
+    """
+    unmasked = np.empty_like(
+        prototype.unmasked,
+        dtype=dtype,
+        order=order,
+        subok=subok,
+        shape=shape,
+        device=device,
+    )
+    if dtype is not None:
+        dtype = (
+            np.ma.make_mask_descr(unmasked.dtype)
+            if unmasked.dtype.names
+            else np.dtype("?")
+        )
+    mask = np.empty_like(
+        prototype.mask,
+        dtype=dtype,
+        order=order,
+        subok=subok,
+        shape=shape,
+        device=device,
+    )
+
+    return unmasked, mask, None
+
+
+if not NUMPY_LT_2_4:
+
+    @dispatched_function
+    def empty_like(
         prototype, /, dtype=None, order="K", subok=True, shape=None, *, device=None
     ):
-        """Return a new array with the same shape and type as a given array.
-
-        Like `numpy.empty_like`, but will add an empty mask.
-        """
-        unmasked = np.empty_like(
-            prototype.unmasked,
+        return empty_like_impl(
+            prototype,
             dtype=dtype,
             order=order,
             subok=subok,
             shape=shape,
             device=device,
         )
-        if dtype is not None:
-            dtype = (
-                np.ma.make_mask_descr(unmasked.dtype)
-                if unmasked.dtype.names
-                else np.dtype("?")
-            )
-        mask = np.empty_like(
-            prototype.mask,
-            dtype=dtype,
-            order=order,
-            subok=subok,
-            shape=shape,
-            device=device,
-        )
-
-        return unmasked, mask, None
-
-    if not NUMPY_LT_2_4:
-
-        @dispatched_function
-        def empty_like(
-            prototype, /, dtype=None, order="K", subok=True, shape=None, *, device=None
-        ):
-            return empty_like_impl(
-                prototype,
-                dtype=dtype,
-                order=order,
-                subok=subok,
-                shape=shape,
-                device=device,
-            )
-    else:
-
-        @dispatched_function
-        def empty_like(
-            prototype, dtype=None, order="K", subok=True, shape=None, *, device=None
-        ):
-            return empty_like_impl(
-                prototype,
-                dtype=dtype,
-                order=order,
-                subok=subok,
-                shape=shape,
-                device=device,
-            )
-
-    @dispatched_function
-    def zeros_like(a, dtype=None, order="K", subok=True, shape=None, *, device=None):
-        """Return an array of zeros with the same shape and type as a given array.
-
-        Like `numpy.zeros_like`, but will add an all-false mask.
-        """
-        unmasked = np.zeros_like(
-            a.unmasked,
-            dtype=dtype,
-            order=order,
-            subok=subok,
-            shape=shape,
-            device=device,
-        )
-        return unmasked, False, None
-
-    @dispatched_function
-    def ones_like(a, dtype=None, order="K", subok=True, shape=None, *, device=None):
-        """Return an array of ones with the same shape and type as a given array.
-
-        Like `numpy.ones_like`, but will add an all-false mask.
-        """
-        unmasked = np.ones_like(
-            a.unmasked,
-            dtype=dtype,
-            order=order,
-            subok=subok,
-            shape=shape,
-            device=device,
-        )
-        return unmasked, False, None
-
-    @dispatched_function
-    def full_like(
-        a, fill_value, dtype=None, order="K", subok=True, shape=None, *, device=None
-    ):
-        """Return a full array with the same shape and type as a given array.
-
-        Like `numpy.full_like`, but with a mask that is also set.
-        If ``fill_value`` is `numpy.ma.masked`, the data will be left unset
-        (i.e., as created by `numpy.empty_like`).
-        """
-        result = np.empty_like(
-            a, dtype=dtype, order=order, subok=subok, shape=shape, device=device
-        )
-        result[...] = fill_value
-        return result, None, None
-
 else:
 
     @dispatched_function
-    def empty_like(prototype, dtype=None, order="K", subok=True, shape=None):
-        """Return a new array with the same shape and type as a given array.
-
-        Like `numpy.empty_like`, but will add an empty mask.
-        """
-        unmasked = np.empty_like(
-            prototype.unmasked, dtype=dtype, order=order, subok=subok, shape=shape
-        )
-        if dtype is not None:
-            dtype = (
-                np.ma.make_mask_descr(unmasked.dtype)
-                if unmasked.dtype.names
-                else np.dtype("?")
-            )
-        mask = np.empty_like(
-            prototype.mask, dtype=dtype, order=order, subok=subok, shape=shape
+    def empty_like(
+        prototype, dtype=None, order="K", subok=True, shape=None, *, device=None
+    ):
+        return empty_like_impl(
+            prototype,
+            dtype=dtype,
+            order=order,
+            subok=subok,
+            shape=shape,
+            device=device,
         )
 
-        return unmasked, mask, None
 
-    @dispatched_function
-    def zeros_like(a, dtype=None, order="K", subok=True, shape=None):
-        """Return an array of zeros with the same shape and type as a given array.
+@dispatched_function
+def zeros_like(a, dtype=None, order="K", subok=True, shape=None, *, device=None):
+    """Return an array of zeros with the same shape and type as a given array.
 
-        Like `numpy.zeros_like`, but will add an all-false mask.
-        """
-        unmasked = np.zeros_like(
-            a.unmasked, dtype=dtype, order=order, subok=subok, shape=shape
-        )
-        return unmasked, False, None
+    Like `numpy.zeros_like`, but will add an all-false mask.
+    """
+    unmasked = np.zeros_like(
+        a.unmasked,
+        dtype=dtype,
+        order=order,
+        subok=subok,
+        shape=shape,
+        device=device,
+    )
+    return unmasked, False, None
 
-    @dispatched_function
-    def ones_like(a, dtype=None, order="K", subok=True, shape=None):
-        """Return an array of ones with the same shape and type as a given array.
 
-        Like `numpy.ones_like`, but will add an all-false mask.
-        """
-        unmasked = np.ones_like(
-            a.unmasked, dtype=dtype, order=order, subok=subok, shape=shape
-        )
-        return unmasked, False, None
+@dispatched_function
+def ones_like(a, dtype=None, order="K", subok=True, shape=None, *, device=None):
+    """Return an array of ones with the same shape and type as a given array.
 
-    @dispatched_function
-    def full_like(a, fill_value, dtype=None, order="K", subok=True, shape=None):
-        """Return a full array with the same shape and type as a given array.
+    Like `numpy.ones_like`, but will add an all-false mask.
+    """
+    unmasked = np.ones_like(
+        a.unmasked,
+        dtype=dtype,
+        order=order,
+        subok=subok,
+        shape=shape,
+        device=device,
+    )
+    return unmasked, False, None
 
-        Like `numpy.full_like`, but with a mask that is also set.
-        If ``fill_value`` is `numpy.ma.masked`, the data will be left unset
-        (i.e., as created by `numpy.empty_like`).
-        """
-        result = np.empty_like(a, dtype=dtype, order=order, subok=subok, shape=shape)
-        result[...] = fill_value
-        return result, None, None
+
+@dispatched_function
+def full_like(
+    a, fill_value, dtype=None, order="K", subok=True, shape=None, *, device=None
+):
+    """Return a full array with the same shape and type as a given array.
+
+    Like `numpy.full_like`, but with a mask that is also set.
+    If ``fill_value`` is `numpy.ma.masked`, the data will be left unset
+    (i.e., as created by `numpy.empty_like`).
+    """
+    result = np.empty_like(
+        a, dtype=dtype, order=order, subok=subok, shape=shape, device=device
+    )
+    result[...] = fill_value
+    return result, None, None
 
 
 @dispatched_function
@@ -598,27 +523,15 @@ def bincount(x, /, weights=None, minlength=0):
     return result, mask, None
 
 
-if NUMPY_LT_2_0:
-
-    @dispatched_function
-    def msort(a):
-        warnings.warn(
-            "msort is deprecated, use np.sort(a, axis=0) instead", DeprecationWarning
-        )
-        result = a.copy()
-        result.sort(axis=0)
-        return result, None, None
-
-else:
-    # Used to work via ptp method, but now need to override, otherwise
-    # plain reduction is used, which gives different mask.
-    @dispatched_function
-    def ptp(a, axis=None, out=None, keepdims=np._NoValue):
-        if keepdims is np._NoValue:
-            keepdims = False
-        result = a.max(axis=axis, out=out, keepdims=keepdims)
-        result -= a.min(axis=axis, keepdims=keepdims)
-        return result, None, None
+# Used to work via ptp method, but now need to override, otherwise
+# plain reduction is used, which gives different mask.
+@dispatched_function
+def ptp(a, axis=None, out=None, keepdims=np._NoValue):
+    if keepdims is np._NoValue:
+        keepdims = False
+    result = a.max(axis=axis, out=out, keepdims=keepdims)
+    result -= a.min(axis=axis, keepdims=keepdims)
+    return result, None, None
 
 
 @dispatched_function
@@ -721,13 +634,12 @@ def broadcast_arrays(*args, subok=False):
     ]
     results = np.broadcast_arrays(*data, subok=subok)
 
-    return_type = list if NUMPY_LT_2_0 else tuple
     shape = results[0].shape
     masks = [
         (np.broadcast_to(arg.mask, shape, subok=subok) if is_masked else None)
         for arg, is_masked in zip(args, are_masked)
     ]
-    results = return_type(
+    results = tuple(
         (Masked(result, mask) if mask is not None else result)
         for (result, mask) in zip(results, masks)
     )
@@ -811,14 +723,7 @@ def _masked_quantile_1d(a, q, **kwargs):
     """
     unmasked = a.unmasked[~a.mask]
     if unmasked.size:
-        if NUMPY_LT_2_0:
-            if "weights" in kwargs:
-                kwargs.pop("weights")
-            result = np.lib.function_base._quantile_unchecked(unmasked, q, **kwargs)
-        else:
-            result = np.lib._function_base_impl._quantile_unchecked(
-                unmasked, q, **kwargs
-            )
+        result = np.lib._function_base_impl._quantile_unchecked(unmasked, q, **kwargs)
         return a.from_unmasked(result)
     else:
         return a.from_unmasked(np.zeros_like(a.unmasked, shape=q.shape), True)
@@ -857,45 +762,16 @@ def _preprocess_quantile(a, q, axis=None, out=None, **kwargs):
         # we have to duplicate logic from np.quantile here to avoid
         # passing down the 'interpolation' keyword argument, as it's not
         # supported by np.lib._function_base_impl._quantile_unchecked
-        if NUMPY_LT_2_0:
-            from numpy.lib.function_base import _check_interpolation_as_method
-        else:
-            assert NUMPY_LT_2_4  # 'interpolation' kwarg was removed in numpy 2.4
-            from numpy.lib._function_base_impl import _check_interpolation_as_method
+        assert NUMPY_LT_2_4  # 'interpolation' kwarg was removed in numpy 2.4
+        from numpy.lib._function_base_impl import _check_interpolation_as_method
+
         kwargs["method"] = _check_interpolation_as_method(
             kwargs.get("method", "linear"), interpolation, "quantile"
         )
     return a, q, axis, out, kwargs
 
 
-if NUMPY_LT_2_0:
-
-    @dispatched_function
-    def quantile(
-        a,
-        q,
-        axis=None,
-        out=None,
-        overwrite_input=False,
-        method="linear",
-        keepdims=False,
-        *,
-        interpolation=None,
-    ):
-        a, q, axis, out, kwargs = _preprocess_quantile(
-            a,
-            q,
-            axis,
-            out,
-            overwrite_input=overwrite_input,
-            method=method,
-            keepdims=keepdims,
-            interpolation=interpolation,
-        )
-        result = _ureduce(a, func=_masked_quantile, q=q, axis=axis, out=out, **kwargs)
-        return result, None, None
-
-elif NUMPY_LT_2_4:
+if NUMPY_LT_2_4:
 
     @dispatched_function
     def quantile(
@@ -1230,10 +1106,7 @@ class MaskedFormat:
 
     @classmethod
     def from_data(cls, data, **options):
-        if NUMPY_LT_2_0:
-            from numpy.core.arrayprint import _get_format_function
-        else:
-            from numpy._core.arrayprint import _get_format_function
+        from numpy._core.arrayprint import _get_format_function
 
         return cls(_get_format_function(data, **options))
 
@@ -1242,10 +1115,7 @@ def _array2string_impl(a, options, separator=" ", prefix=""):
     # Mostly copied from numpy.core.arrayprint, except:
     # - The format function is wrapped in a mask-aware class;
     # - Arrays scalars are not cast as arrays.
-    if NUMPY_LT_2_0:
-        from numpy.core.arrayprint import _formatArray, _leading_trailing
-    else:
-        from numpy._core.arrayprint import _formatArray, _leading_trailing
+    from numpy._core.arrayprint import _formatArray, _leading_trailing
 
     data = np.asarray(a)
 
@@ -1295,20 +1165,15 @@ def _array2string_main(
 ):
     # Copied from numpy.core.arrayprint, but using _array2string_impl above.
     if NUMPY_LT_2_1:
-        if NUMPY_LT_2_0:
-            from numpy.core.arrayprint import _format_options
-        else:
-            from numpy._core.arrayprint import _format_options
+        from numpy._core.arrayprint import _format_options
+
         options = _format_options.copy()
     else:
         from numpy._core.printoptions import format_options
 
         options = format_options.get().copy()
 
-    if NUMPY_LT_2_0:
-        from numpy.core.arrayprint import _make_options_dict
-    else:
-        from numpy._core.arrayprint import _make_options_dict
+    from numpy._core.arrayprint import _make_options_dict
 
     overrides = _make_options_dict(
         precision,
@@ -1425,7 +1290,7 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
     if a.shape == ():
         if a.dtype.names is None:
             return MaskedFormat(_array_str_scalar)(a), None, None
-        elif not NUMPY_LT_2_0:
+        else:
             from numpy._core.arrayprint import StructuredVoidFormat
 
             # Following numpy._core.arrayprint._void_scalar_to_string
@@ -1497,8 +1362,7 @@ def masked_nanfunc(nanfuncname):
     return nanfunc
 
 
-_nplibnanfunctions = np.lib.nanfunctions if NUMPY_LT_2_0 else np.lib._nanfunctions_impl
-for nanfuncname in _nplibnanfunctions.__all__:
+for nanfuncname in np.lib._nanfunctions_impl.__all__:
     globals()[nanfuncname] = dispatched_function(
         masked_nanfunc(nanfuncname), helps=getattr(np, nanfuncname)
     )

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -23,7 +23,7 @@ from astropy.units.tests.test_quantity_non_ufuncs import (
     get_covered_functions,
     get_wrapped_functions,
 )
-from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
+from astropy.utils.compat import NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
 from astropy.utils.masked import Masked, MaskedNDArray
 from astropy.utils.masked.function_helpers import (
     APPLY_TO_BOTH_FUNCTIONS,
@@ -105,10 +105,8 @@ class TestShapeManipulation(BasicTestSetup):
     def test_transpose(self):
         self.check(np.transpose)
 
-    if not NUMPY_LT_2_0:
-
-        def test_matrix_transpose(self):
-            self.check(np.matrix_transpose)
+    def test_matrix_transpose(self):
+        self.check(np.matrix_transpose)
 
     def test_atleast_1d(self):
         self.check(np.atleast_1d)
@@ -155,7 +153,7 @@ class TestShapeManipulation(BasicTestSetup):
         self.check2(np.broadcast_arrays, subok=False)
         # Regression test for bug for single array
         ba = np.broadcast_arrays(self.ma, subok=True)
-        assert isinstance(ba, list if NUMPY_LT_2_0 else tuple)
+        assert isinstance(ba, tuple)
         assert len(ba) == 1
         assert_array_equal(ba[0].unmasked, self.a)
         assert_array_equal(ba[0].mask, self.mask_a)
@@ -303,17 +301,9 @@ class TestCopyAndCreation(InvariantMaskTestSetup):
         copy = np.copy(a=self.ma)
         assert_array_equal(copy, self.ma)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.asfarray is removed in NumPy 2.0")
-    def test_asfarray(self):
-        self.check(np.asfarray)  # noqa: NPY201
-        farray = np.asfarray(a=self.ma)  # noqa: NPY201
-        assert_array_equal(farray, self.ma)
-
-    if not NUMPY_LT_2_0:
-
-        def test_astype(self):
-            int32ma = self.ma.astype("int32")
-            assert_array_equal(np.astype(int32ma, "int32"), int32ma)
+    def test_astype(self):
+        int32ma = self.ma.astype("int32")
+        assert_array_equal(np.astype(int32ma, "int32"), int32ma)
 
 
 class TestArrayCreation(MaskedArraySetup):
@@ -679,41 +669,14 @@ class TestMethodLikes(MaskedArraySetup):
     def test_all(self):
         self.check(np.all)
 
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.sometrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`sometrue` is deprecated as of NumPy 1.25.0")
-    def test_sometrue(self):
-        self.check(np.sometrue, method="any")  # noqa: NPY003, NPY201
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.alltrue is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`alltrue` is deprecated as of NumPy 1.25.0")
-    def test_alltrue(self):
-        self.check(np.alltrue, method="all")  # noqa: NPY003, NPY201
-
     def test_prod(self):
         self.check(np.prod)
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.product is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`product` is deprecated as of NumPy 1.25.0")
-    def test_product(self):
-        self.check(np.product, method="prod")  # noqa: NPY003, NPY201
 
     def test_cumprod(self):
         self.check(np.cumprod)
 
-    @pytest.mark.skipif(
-        not NUMPY_LT_2_0, reason="np.cumproduct is removed in NumPy 2.0"
-    )
-    @pytest.mark.filterwarnings("ignore:`cumproduct` is deprecated as of NumPy 1.25.0")
-    def test_cumproduct(self):
-        self.check(np.cumproduct, method="cumprod")  # noqa: NPY003, NPY201
-
     def test_round(self):
         self.check(np.round, method="round")
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.round_ is removed in NumPy 2.0")
-    @pytest.mark.filterwarnings("ignore:`round_` is deprecated as of NumPy 1.25.0")
-    def test_round_(self):
-        self.check(np.round_, method="round")  # noqa: NPY003, NPY201
 
     def test_around(self):
         self.check(np.around, method="round")
@@ -1001,11 +964,6 @@ class TestReductionLikeFunctions(MaskedArraySetup):
         assert o2 is out
         assert_array_equal(o2.unmasked, expected.unmasked)
         assert_array_equal(o2.mask, expected.mask)
-        if NUMPY_LT_2_0:
-            # Method is removed in numpy 2.0.
-            o3 = self.ma.ptp(**kwargs)
-            assert_array_equal(o3.unmasked, expected.unmasked)
-            assert_array_equal(o3.mask, expected.mask)
 
     def test_trace(self):
         o = np.trace(self.ma)
@@ -1093,15 +1051,8 @@ class TestIntDiffFunctions(MaskedArraySetup):
         assert_array_equal(out.unmasked, func(self.a))
         assert_array_equal(out.mask, np.array([True, False]))
 
-    if NUMPY_LT_2_0:
-
-        def test_trapz(self):
-            self.check_trapezoid(np.trapz)  # noqa: NPY201
-
-    else:
-
-        def test_trapezoid(self):
-            self.check_trapezoid(np.trapezoid)
+    def test_trapezoid(self):
+        self.check_trapezoid(np.trapezoid)
 
     def test_gradient(self):
         out = np.gradient(self.ma)
@@ -1148,7 +1099,7 @@ class TestSpaceFunctions:
         # are determined just by their respective point?
         if function is np.geomspace:
             expected_mask[0] = self.mask_a
-        if NUMPY_LT_2_0 or function is not np.geomspace:
+        else:
             expected_mask[-1] = self.mask_b
 
         assert_array_equal(out.unmasked, expected)
@@ -1256,13 +1207,6 @@ class TestSortFunctions(MaskedArraySetup):
         )
         o = np.sort_complex(ma)
         expected = ma[np.lexsort((ma.unmasked.imag, ma.unmasked.real, ma.mask))]
-        assert_masked_equal(o, expected)
-
-    @pytest.mark.skipif(not NUMPY_LT_2_0, reason="np.msort was removed in numpy 2.0")
-    def test_msort(self):
-        with pytest.warns(DeprecationWarning, match="msort is deprecated"):
-            o = np.msort(self.ma)
-        expected = np.sort(self.ma, axis=0)
         assert_masked_equal(o, expected)
 
     def test_partition(self):
@@ -1571,30 +1515,25 @@ class TestArraySetOps:
         assert_array_equal(indices2, [1, 0, 2])
         assert_array_equal(inverse_indices2, [1, 0, 2])
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def check_unique(self, test):
         for name in test._fields:
             assert_array_equal(getattr(test, name), getattr(self, name))
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_all(self):
         test = np.unique_all(self.data)
         assert len(test) == 4
         self.check_unique(test)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_counts(self):
         test = np.unique_counts(self.data)
         assert len(test) == 2
         self.check_unique(test)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_inverse(self):
         test = np.unique_inverse(self.data)
         assert len(test) == 2
         self.check_unique(test)
 
-    @pytest.mark.skipif(NUMPY_LT_2_0, reason="new in numpy 2.0")
     def test_unique_values(self):
         test = np.unique_values(self.data)
         assert isinstance(test, Masked)
@@ -1676,9 +1615,9 @@ class TestArraySetOps:
         assert_masked_equal(c, ec)
 
     @pytest.mark.skipif(not NUMPY_LT_2_4, reason="np.in1d was removed in numpy 2.4")
-    @pytest.mark.filterwarnings("ignore:in1d.*deprecated")  # not NUMPY_LT_2_0
+    @pytest.mark.filterwarnings("ignore:in1d.*deprecated")
     def test_in1d(self):
-        # Once we require numpy>=2.0, these tests should be joined with np.isin.
+        # Once we require numpy>=2.4, these tests should be joined with np.isin.
         a = Masked([1, 2, 5, -2, -1], mask=[0, 0, 0, 1, 1])
         b = Masked([1, 2, 3, 4, 5, -2], mask=[0, 0, 0, 0, 0, 1])
         test = np.in1d(a, b)  # noqa: NPY201

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
-from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_2, NUMPY_LT_2_3
+from astropy.utils.compat import NUMPY_LT_2_2, NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
 
@@ -1440,16 +1440,12 @@ def test_masked_str_explicit_structured():
     sa = np.array([(1.0, 2.0), (3.0, 4.0)], dtype="f8,f8")
     msa = Masked(sa, [(False, True), (False, False)])
     assert str(msa) == "[(1., ——) (3., 4.)]"
-    assert str(msa[0]) == ("(1., ——)" if NUMPY_LT_2_0 else "(1.0, ———)")
-    assert str(msa[1]) == str(sa[1]) == ("(3., 4.)" if NUMPY_LT_2_0 else "(3.0, 4.0)")
+    assert str(msa[0]) == "(1.0, ———)"
+    assert str(msa[1]) == str(sa[1]) == "(3.0, 4.0)"
     with np.printoptions(precision=3, floatmode="fixed"):
         assert str(msa) == "[(1.000,   ———) (3.000, 4.000)]"
-        assert str(msa[0]) == ("(1.000,   ———)" if NUMPY_LT_2_0 else "(1.0, ———)")
-        assert (
-            str(msa[1])
-            == str(sa[1])
-            == ("(3.000, 4.000)" if NUMPY_LT_2_0 else "(3.0, 4.0)")
-        )
+        assert str(msa[0]) == "(1.0, ———)"
+        assert str(msa[1]) == str(sa[1]) == "(3.0, 4.0)"
 
 
 def test_masked_repr_explicit_structured():

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -10,17 +10,11 @@ from types import EllipsisType
 from typing import Self, TypeVar
 
 import numpy as np
+import numpy._core as np_core
+from numpy.lib.array_utils import normalize_axis_index
 from numpy.typing import NDArray
 
-from astropy.utils.compat import NUMPY_LT_2_0
 from astropy.utils.decorators import deprecated
-
-if NUMPY_LT_2_0:
-    import numpy.core as np_core
-    from numpy.core.multiarray import normalize_axis_index
-else:
-    import numpy._core as np_core
-    from numpy.lib.array_utils import normalize_axis_index
 
 __all__ = [
     "IncompatibleShapeError",
@@ -356,8 +350,7 @@ class ShapedLikeNDArray(NDArrayShapeMethods, metaclass=abc.ABCMeta):
                 function in {np.atleast_1d, np.atleast_2d, np.atleast_3d}
                 and len(args) > 1
             ):
-                seq_cls = list if NUMPY_LT_2_0 else tuple
-                return seq_cls(function(arg, **kwargs) for arg in args)
+                return tuple(function(arg, **kwargs) for arg in args)
 
             if self is not args[0]:
                 return NotImplemented

--- a/astropy/utils/tests/test_compat.py
+++ b/astropy/utils/tests/test_compat.py
@@ -1,0 +1,18 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Just deprecation tests, the rest is tested throughout astropy.
+"""
+
+import pytest
+
+from astropy.utils.exceptions import AstropyPendingDeprecationWarning
+
+
+def test_copy_if_needed_deprecation():
+    with pytest.warns(AstropyPendingDeprecationWarning, match="COPY_IF_NEEDED"):
+        from astropy.utils.compat.numpycompat import COPY_IF_NEEDED
+    assert COPY_IF_NEEDED is None
+
+    with pytest.warns(AstropyPendingDeprecationWarning, match="COPY_IF_NEEDED"):
+        from astropy.utils.compat import COPY_IF_NEEDED
+    assert COPY_IF_NEEDED is None

--- a/docs/changes/18986.other.rst
+++ b/docs/changes/18986.other.rst
@@ -1,0 +1,1 @@
+The minimum supported version of numpy is now 2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,6 @@ filterwarnings = [
     # https://github.com/astropy/astropy/issues/18126
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
     # Weird warning from the vectorized do_format in Angle.to_string. low numpy/python?
-    "ignore:invalid value encountered in do_format:RuntimeWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=1.26",
+    "numpy>=2.0",
     "pyerfa>=2.0.1.1",  # For >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2025.12.1.0.45.12",
     "PyYAML>=6.0.0",
@@ -255,20 +255,11 @@ doctest_subpackage_requires = [
     "astropy/cosmology/_src/io/builtin/mapping.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
     "astropy/cosmology/_src/io/builtin/row.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
     "astropy/cosmology/_src/io/builtin/table.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
-    "astropy/cosmology/_src/traits/curvature.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 18232)
     "astropy/table/table.py = python>=3.12",  # not PYTHON_LT_3_12 (PR 17277)
     "astropy/table/mixins/dask.py = dask",
-    "docs/* = numpy>=2",   # not NUMPY_LT_2_0 (PR 15065)
     "docs/units/type_hints.rst = python<=3.13",  # PYTHON_LT_3_14 (PR 18140)
     "docs/units/structured_units.rst = pyerfa<2.0.1.7",  # PYERFA_LT_2_0_1_7
     "docs/timeseries/index.rst = numpy<2.2.0.dev0",  # NUMPY_LT_2_2 (PR 17364)
-    "astropy/stats/info_theory.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/stats/jackknife.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/table/row.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/time/formats.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/timeseries/periodograms/bls/core.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/timeseries/periodograms/lombscargle/core.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
-    "astropy/units/structured.py = numpy>=2",  # not NUMPY_LT_2_0 (PR 15065)
     "astropy/modeling/_fitting_parallel.py = dask",
     "docs/modeling/parallel-fitting.rst = dask",
     "docs/coordinates/example_gallery_plot_galactocentric_frame.rst = matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
 ]
 dependencies = [
     "numpy>=2.0",
-    "pyerfa>=2.0.1.1",  # For >=2.0.1.7, adjust structured_units.rst and doctest-requires
+    "pyerfa>=2.0.1.2",  # for numpy>=2.0; for >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2025.12.1.0.45.12",
     "PyYAML>=6.0.0",
     "packaging>=22.0.0",
@@ -72,7 +72,7 @@ jupyter = [  # these are optional dependencies for utils.console and table
     # jupyter-core is a transitive dependency via ipykernel, we declare it as
     # a direct dependency in order to set a lower bound for oldest-deps testing
     "jupyter-core>=4.11.2",
-    "pandas>=2.0.2",
+    "pandas>=2.2.2",  # minimum that supports numpy 2.0
 ]
 # This is ALL the run-time optional dependencies.
 all = [
@@ -83,9 +83,9 @@ all = [
     # Install all remaining optional dependencies
     "certifi>=2022.6.15.1",
     "dask[dataframe]>=2024.8.0", # keep in sync with dependency-groups.dataframe
-    "h5py>=3.9.0",  # older versions used deprecated np.product()
-    "pyarrow>=14.0.2",
-    "beautifulsoup4>=4.9.3", # imposed by pandas==2.0
+    "h5py>=3.11.0",  # older versions are not compatible with numpy 2.0
+    "pyarrow>=16.0",  # older versions are not compatible with numpy 2.0
+    "beautifulsoup4>=4.11.2", # imposed by pandas==2.2.2
     "html5lib>=1.1",
     "bleach>=3.2.1",
     "sortedcontainers>=2.1.0", # imposed by testing with hypothesis
@@ -93,7 +93,7 @@ all = [
     "jplephem>=2.17.0",
     "mpmath>=1.2.1",
     "asdf-astropy>=0.7.0",
-    "bottleneck>=1.3.3",
+    "bottleneck>=1.4.0",  # minimum for numpy 2.0 compatibility
     "fsspec[http]>=2023.4.0",
     "s3fs>=2023.4.0",
     "uncompresspy>=0.4.0"
@@ -172,7 +172,7 @@ requires = ["setuptools>=77.0.0",
             "cython>=3.0.0, <4",
             "numpy>=2.0.0, <3",
             "extension-helpers>=1.4,<2",
-            "pyerfa>=2.0.1.1"]
+            "pyerfa>=2.0.1.2"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
@@ -183,8 +183,8 @@ dataframe = [
     # and project.optional-dependencies.all
     # and project.optional-dependencies.typing
     "narwhals>=1.42.0",
-    "pyarrow>=14.0.2",
-    "pandas>=2.0.2",
+    "pyarrow>=16.0",  # minimum for numpy 2.0 support
+    "pandas>=2.2.2",  # minimum for numpy 2.0 support
     "polars>=1.0.0",
     "duckdb>=1.1.0",
     "dask[dataframe]>=2024.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,8 @@ filterwarnings = [
     "error",
     # https://github.com/astropy/astropy/issues/18126
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
+    # Weird warning from the vectorized do_format in Angle.to_string. low numpy/python?
+    "ignore:invalid value encountered in do_format:RuntimeWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=1.25",
+    "numpy>=1.26",
     "pyerfa>=2.0.1.1",  # For >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2025.12.1.0.45.12",
     "PyYAML>=6.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy126,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy20,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -54,7 +54,7 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of direct dependencies
     cov: and test coverage
-    numpy126: with numpy 1.26.*
+    numpy20: with numpy 2.0.*
     image: with image tests
     mpl380: with matplotlib 3.8.0
     mpldev: with the latest developer version of matplotlib
@@ -62,7 +62,7 @@ description =
     noscipy: without scipy-dev
 
 deps =
-    numpy126: numpy==1.26.*
+    numpy20: numpy==2.0.*
 
     mpl380: matplotlib==3.8.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy125,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-devinfra,-predeps,-numpy126,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -54,7 +54,7 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of direct dependencies
     cov: and test coverage
-    numpy125: with numpy 1.25.*
+    numpy126: with numpy 1.26.*
     image: with image tests
     mpl380: with matplotlib 3.8.0
     mpldev: with the latest developer version of matplotlib
@@ -62,7 +62,7 @@ description =
     noscipy: without scipy-dev
 
 deps =
-    numpy125: numpy==1.25.*
+    numpy126: numpy==1.26.*
 
     mpl380: matplotlib==3.8.0
 


### PR DESCRIPTION
This pull request is to address a very minor problem, of getting a `RuntimeError` from `Angle.to_string()` on older numpy combined with older python (and apparently only if installed in the way our CI does it; @pllim cannot reproduce it). It basically avoids using `np.vectorize` and instead explicitly iterates. Not elegant, but it works.

Note that this is on top of #18986 only because with that PR, the problem is shown in `oldestdeps` -- one gets the same warning on main, but this is not caught on CI as relevant combination is not tested. I made it draft for that reason; for now, only look at the last commit.

In principle, we could take this opportunity to use the new string type ("T") introduced in numpy 2.0, which would be better for performance and memory usage, but I think that is better done as a more general overhaul.

EDIT: p.s. Perhaps needs discussion on whether this should be backported.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18989
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
