### PR TITLE
DX: update default version number from `0.0.0` to `999.999.999`

### DIFF
--- a/astropy/version.py
+++ b/astropy/version.py
@@ -11,7 +11,14 @@ except ImportError:
     )
     del warnings
 
-    version = "0.0.0"
+    # this branch may be executed in rare but still valid conditions. For instance,
+    # if astropy is installed from a shallow clone, i.e., without most of the vcs
+    # history, which is needed to compute the dev version number dynamically.
+
+    # default to a virtually infinite version number, never to be reached, that should
+    # - alert the reader if seen in production
+    # - satisfy any real-world lower bound on astropy's version
+    version = "999.999.999"
 
 
 # We use Version to define major, minor, micro, but ignore any suffixes.


### PR DESCRIPTION
### Description
Part of the rationale is included as a long inline comment.
This is a small QoL improvement for the kind of work I've been conducting regarding reproducible CI builds, where the `0.0.0` version has caused me a couple avoidable headaches, most recently https://github.com/astral-sh/uv/issues/16978

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
