### PR TITLE
style: make some util function arguments positional only

### DIFF
--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -34,7 +34,7 @@ def is_effectively_unity(value: UnitScaleLike) -> bool | np.bool_:
         )
 
 
-def sanitize_scale(scale: UnitScaleLike) -> UnitScale:
+def sanitize_scale(scale: UnitScaleLike, /) -> UnitScale:
     if is_effectively_unity(scale):
         return 1.0
     if not scale:
@@ -52,7 +52,7 @@ def sanitize_scale(scale: UnitScaleLike) -> UnitScale:
     return complex(scale)
 
 
-def maybe_simple_fraction(p: UnitPowerLike, max_denominator: int = 100) -> UnitPower:
+def maybe_simple_fraction(p: UnitPowerLike, /, max_denominator: int = 100) -> UnitPower:
     """Fraction very close to x with denominator at most max_denominator.
 
     The fraction has to be such that fraction/x is unity to within 4 ulp.
@@ -124,7 +124,7 @@ def sanitize_power(p: UnitPowerLike) -> UnitPower:
 
 
 def resolve_fractions(
-    a: UnitPowerLike, b: UnitPowerLike
+    a: UnitPowerLike, b: UnitPowerLike, /
 ) -> tuple[UnitPowerLike, UnitPowerLike]:
     """
     If either input is a Fraction, convert the other to a Fraction


### PR DESCRIPTION
### Description

A very minor cleanup for arguments whose positions matter more than their variable names.
As a nice side-benefit, call-site mapping (e.g. `f(x=x)`) is always slower than unpacking (e.g. `f(x)`) so this change helps ensure these utils functions are always called in a performance-maximizing way.

Makes parameters positional-only in `astropy/units/utils.py`:

- `sanitize_scale(scale, /)` — `scale` is now positional-only
- `maybe_simple_fraction(p, /, max_denominator=100)` — `p` is now positional-only, `max_denominator` remains keyword-capable
- `resolve_fractions(a, b, /)` — both `a` and `b` are now positional-only

```python
# These now raise TypeError:
sanitize_scale(scale=1.5)
maybe_simple_fraction(p=0.5)
resolve_fractions(a=1, b=2)

# These still work:
sanitize_scale(1.5)
maybe_simple_fraction(0.5)
maybe_simple_fraction(0.5, max_denominator=50)
resolve_fractions(1, 2)
```

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> Make `def sanitize_scale(scale: UnitScaleLike)` have 'scale' be a positional-only parameter. Also do this for 'p' in `maybe_simple_fraction(p` (not 'max_denominator', the 2nd argument). Also make all the arguments in `resolve_fractions` be positional-only.


</details>


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
