### PR TITLE
MNT: fix a typo in a comment (`tox.ini`)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ setenv =
     # on oldestdeps, we let warnings be warnings (-Wdefault) instead of treated-as-errors,
     # so we don't need to deal with filtering anything triggered from dependencies
     # Other options replicate the static configuration from pyproject.toml, since they
-    # would otherwise be shaddowed by the env variable.
+    # would otherwise be shadowed by the env variable.
     oldestdeps: PYTEST_ADDOPTS = -Wdefault -ra --doctest-rst --strict-config --strict-markers
 
 # Run the tests in a temporary directory to make sure that we don't import


### PR DESCRIPTION
### Description
Follow up to #19000, requested in https://github.com/astropy/astropy/pull/19000#discussion_r2594039515

While I was at it, I checked that this was the *only* detectable typo in `tox.ini` or in `.github` (why not) with `uvx typos <paths>`.
We do have a pre-commit hook for typos (`codespell`) but it only checks Python files. I don't actually recommend using `typos` as a more capable replacement, even though it *does* define a pre-commit hook, because I find that the tagging strategy used by maintainers doesn't play nicely with `pre-commit.ci` autoupdates, though it's worth keeping in mind that it exists.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
