### PR TITLE
Prevent unit equivalencies from interfering with an error message

### DIFF
--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -311,15 +311,30 @@ def test_negative_distance(icrs_coords):
     assert quantity_allclose(c.dec, -55.8 * u.deg)
 
 
-def test_velocity_units():
+@pytest.mark.parametrize(
+    "equivalency",
+    [
+        pytest.param([], id="no equivalencies"),
+        # Regression test for #19043 - equivalencies could mess up the error message.
+        pytest.param(
+            u.doppler_redshift(),
+            id="doppler_redshift equivalency",
+            marks=pytest.mark.xfail(reason="regression test to reveal a bug"),
+        ),
+    ],
+)
+def test_velocity_units(equivalency):
     """Check that the differential data given has compatible units
     with the time-derivative of representation data"""
-    with pytest.raises(
-        ValueError,
-        match=(
-            '^x has unit "pc" with physical type "length", but v_x has incompatible'
-            ' unit "" with physical type "dimensionless" instead of the expected'
-            r' "speed/velocity".$'
+    with (
+        u.set_enabled_equivalencies(equivalency),
+        pytest.raises(
+            ValueError,
+            match=(
+                '^x has unit "pc" with physical type "length", but v_x has incompatible'
+                ' unit "" with physical type "dimensionless" instead of the expected'
+                r' "speed/velocity".$'
+            ),
         ),
     ):
         ICRS(**CARTESIAN_POSITION, v_x=1, v_y=2, v_z=3, differential_type="cartesian")

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -316,11 +316,7 @@ def test_negative_distance(icrs_coords):
     [
         pytest.param([], id="no equivalencies"),
         # Regression test for #19043 - equivalencies could mess up the error message.
-        pytest.param(
-            u.doppler_redshift(),
-            id="doppler_redshift equivalency",
-            marks=pytest.mark.xfail(reason="regression test to reveal a bug"),
-        ),
+        pytest.param(u.doppler_redshift(), id="doppler_redshift equivalency"),
     ],
 )
 def test_velocity_units(equivalency):


### PR DESCRIPTION
### Description

If a user tries to create a `SkyCoord` with positions and velocities that have incompatible units then normally they get an informative error message:

```
>>> from astropy import units as u
>>> from astropy.coordinates import SkyCoord
>>> SkyCoord(0 * u.deg, 0 * u.deg, 1 * u.kpc, radial_velocity=1)
Traceback (most recent call last):
  ...
ValueError: distance has unit "kpc" with physical type "length", but radial_velocity has incompatible unit "" with physical type "dimensionless" instead of the expected "speed/velocity".
```
But unit equivalencies can interfere with that, in which case the error message will be quite cryptic:
```
>>> with u.set_enabled_equivalencies(u.doppler_redshift()):
...     SkyCoord(0 * u.deg, 0 * u.deg, 1 * u.kpc, radial_velocity=1)
... 
Traceback (most recent call last):
  ...
ValueError: For differential object '<RadialDifferential (d_distance) [dimensionless]
    (1.,)>', expected unit key = 'm' but received key = 's'
```
The problem can be solved by using physical types, which are not affected by unit equivalencies.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.