### PR TITLE
Add basic mypy configuration

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -148,6 +148,20 @@ jobs:
           cache-path: .tox
           cache-key: stub_tests-${{ github.ref_name }}
 
+  mypy:
+    needs: [initial_checks]
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d9b81a07e789d1b1921ab5fe33de2ddcbbd02c3f  # v2.3.0
+    with:
+      setenv: |
+        ARCH_ON_CI: "normal"
+        IS_CRON: "false"
+      submodules: false
+      envs: |
+        - name: Type checking select modules
+          linux: mypy
+          cache-path: .tox
+          cache-key: mypy-${{ github.ref_name }}
+
   test_wheel_building:
     needs: [initial_checks]
     # This ensures that a couple of wheel targets work fine in pull requests and pushes

--- a/.stubtest.ini
+++ b/.stubtest.ini
@@ -1,2 +1,0 @@
-[mypy]
-follow_imports = silent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -850,3 +850,9 @@ constraint-dependencies = [
     "toolz>=0.12.0", # can be removed once dask<=2025.11.0 is dropped
     "cloudpickle>=2.1.0", # can be removed once dask<2024.8.1 is dropped
 ]
+
+[tool.mypy]
+follow_imports = "silent"
+packages = [
+    "astropy.coordinates.sites",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -179,7 +179,7 @@ commands =
     # We do not want to distribute py.typed files, but we need one or else Mypy
     # refuses to look at the generated stubs.
     touch {env_site_packages_dir}/astropy/units/py.typed
-    stubtest --mypy-config-file .stubtest.ini \
+    stubtest --mypy-config-file pyproject.toml \
         astropy.units.astrophys \
         astropy.units.cds \
         astropy.units.cgs \

--- a/tox.ini
+++ b/tox.ini
@@ -190,6 +190,18 @@ commands =
         astropy.units.si \
         astropy.units.function.units
 
+[testenv:mypy]
+description = check type annotations in files declared to be type-checkable
+allowlist_externals =
+    touch
+deps =
+    mypy
+commands =
+    # We do not want to distribute py.typed files, but we need one or else Mypy
+    # refuses to type check anything (in tox).
+    touch {env_site_packages_dir}/astropy/py.typed
+    mypy
+
 [testenv:pyinstaller]
 # Check that astropy can be included in a PyInstaller bundle without any issues. This
 # also serves as a test that tests do not import anything from outside the tests


### PR DESCRIPTION
### Description

In the December developer telecon speeding up parts of `astropy` by compiling them with [mypyc](https://mypyc.readthedocs.io/en/stable/introduction.html) was discussed (see also #19011). The conclusion was that right now providing wheels with mypyc-compiled code is not worthwhile, one of the main reasons being that mypyc will only compile code that [mypy](https://mypy.readthedocs.io/en/stable/) approves and the fraction of code with type annotations is still very low. However, mypyc compilation might eventually become worthwhile if more code gets annotated, so there should be a CI job that prevents typing errors from being introduced to modules mypy already approves.

There have been several attempts to configure type checkers for `astropy` (#12971, #15794, #15815, #16312, #17918). Those PRs attempted to nominally turn on type checking for all or large fractions of `astropy`, but that necessitates listing a large number of modules and rules to be ignored. This PR takes the opposite approach where mypy only checks modules it is explicitly told to check, but none of the default rules are ignored.

During local development I recommend running mypy directly instead of running it through tox, but as far as I know the tox environment is required for CI.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
