### PR TITLE
Add method to project separation onto an ellipse

### DIFF
--- a/astropy/coordinates/tests/test_separation_projected.py
+++ b/astropy/coordinates/tests/test_separation_projected.py
@@ -1,0 +1,37 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for projected separation / elliptical distance feature.
+"""
+
+import numpy as np
+
+from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
+
+
+def test_projected_components_simple():
+    c1 = SkyCoord(ra=0 * u.deg, dec=0 * u.deg)
+    c2 = SkyCoord(ra=1 * u.deg, dec=0 * u.deg)
+
+    # project onto PA=90 deg (eastwards major axis)
+    dmaj, dmin = c1.frame.separation_projected(
+        c2, pa=Angle(90, "deg"), return_components=True
+    )
+    assert np.allclose(dmaj.to(u.deg).value, 1.0, atol=1e-8)
+    assert np.allclose(dmin.to(u.deg).value, 0.0, atol=1e-8)
+
+
+def test_elliptical_distance_basic():
+    c1 = SkyCoord(ra=0 * u.deg, dec=0 * u.deg)
+    c2 = SkyCoord(ra=1 * u.deg, dec=1 * u.deg)
+
+    # get components
+    dmaj, dmin = c1.frame.separation_projected(
+        c2, pa=Angle(0, "deg"), return_components=True
+    )
+    assert hasattr(dmaj, "to") and hasattr(dmin, "to")
+
+    # elliptical distance with b_over_a = 0.5 should return an Angle
+    ed = c1.frame.separation_projected(c2, pa=Angle(0, "deg"), b_over_a=0.5)
+    assert hasattr(ed, "to")
+    assert ed.unit == u.deg


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the addition of another common "separation" in astronomy, which is the distance projected along a particular axis (e.g. the major axis of a galaxy). This PR adds a separation_projected method for projected separation calculations.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #1012

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
