### PR TITLE
Ensure `pyarrow.csv` is available in tests (if installed)

### DIFF
--- a/astropy/io/misc/pyarrow/tests/test_csv.py
+++ b/astropy/io/misc/pyarrow/tests/test_csv.py
@@ -16,6 +16,7 @@ from astropy.utils.compat.optional_deps import HAS_BZ2, HAS_LZMA, HAS_PYARROW
 
 if HAS_PYARROW:
     import pyarrow as pa
+    import pyarrow.csv
 else:
     pytest.skip("pyarrow is not available", allow_module_level=True)
 


### PR DESCRIPTION
### Description

In #19049 the [parallel tests CI job failed](https://github.com/astropy/astropy/actions/runs/20150016088/job/57840384213#step:10:737) with `AttributeError: module 'pyarrow' has no attribute 'csv'`. This happens if the test in question is executed before anything imports `pyarrow.csv`, which can happen in the parallel tests job where the test execution order is not deterministic. A simple way to prevent this problem is to import `pyarrow.csv` at the module level.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
