### PR TITLE
Handle `np.average` with different shape weights and input array and returning sum of weights

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -467,6 +467,31 @@ def _quantities2arrays(*args, unit_from_first=False):
     return arrays, q.unit
 
 
+@function_helper
+def average(a, axis=None, weights=None, returned=False, *, keepdims=np._NoValue):
+    # This override should no longer be needed once
+    # https://github.com/numpy/numpy/pull/30522 is merged (likely for
+    # "not NUMPY_LT_2_4_1").
+
+    a_value, a_unit = (_a := _as_quantity(a)).value, _a.unit
+    w_value, w_unit = (
+        (None, dimensionless_unscaled)
+        if weights is None
+        else ((_w := _as_quantity(weights)).value, _w.unit)
+    )
+    return (
+        (a_value,),
+        {
+            "axis": axis,
+            "weights": w_value,
+            "returned": returned,
+            "keepdims": keepdims,
+        },
+        ((a_unit, w_unit) if returned else a_unit),
+        None,
+    )
+
+
 def _iterable_helper(*args, out=None, **kwargs):
     """Convert arguments to Quantity, and treat possible 'out'."""
     if out is not None:
@@ -1683,32 +1708,5 @@ def merge_arrays(
             asrecarray=asrecarray,
         ),
         unit,
-        None,
-    )
-
-
-@function_helper
-def average(a, axis=None, weights=None, returned=False, *, keepdims=np._NoValue):
-    # This override should no longer be needed once
-    # https://github.com/numpy/numpy/pull/30522 is merged (likely for
-    # "not NUMPY_LT_2_4_1").
-
-    a = _as_quantity(a)
-    a_value, a_unit = a.value, a.unit
-    weights = _as_quantity(weights)
-    w_value, w_unit = (
-        (None, dimensionless_unscaled)
-        if weights is None
-        else (weights.value, weights.unit)
-    )
-    return (
-        (a_value,),
-        {
-            "axis": axis,
-            "weights": w_value,
-            "returned": returned,
-            "keepdims": keepdims,
-        },
-        ((a_unit, w_unit) if returned else a_unit),
         None,
     )

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1065,6 +1065,12 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         expected = np.average(q1.value, weights=q2.value) * u.m
         assert np.all(o == expected)
 
+    def test_average_no_weights(self):
+        q1 = np.arange(9.0).reshape(3, 3) * u.m
+        o = np.average(q1)
+        expected = np.average(q1.value) * u.m
+        assert np.all(o == expected)
+
     def test_average_a_and_weights_different_shapes_and_returned(self):
         q1 = np.arange(9.0).reshape(3, 3) * u.m
         q2 = np.ones(3) / u.s

--- a/docs/changes/units/19055.bugfix.rst
+++ b/docs/changes/units/19055.bugfix.rst
@@ -1,1 +1,3 @@
-Fixed a bug in the ``np.average`` function when weights with units and a different shape to the input array were passed and the optionally-returned sum of the weights was requested. The sum of the weights now has correct units.
+Fixed a bug in the ``np.average`` function when weights with units and a
+different shape to the input array were passed and the optionally-returned sum
+of the weights was requested. The sum of the weights now has correct units.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address an issue where the `np.average` function strips the units from the optionally-returned sum of weights. A complete description and instructions to reproduce are at #19054

The fix is simple: I've just moved `np.average` out of `SUBCLASS_SAFE_FUNCTIONS` and into `FUNCTION_HELPERS` and written a suitable helper. I've also added a regression test.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19054

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
