### PR TITLE
Deprecate `IERS.time_now`

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -41,6 +41,7 @@ from astropy.utils.data import (
     get_readable_fileobj,
     is_url_in_cache,
 )
+from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from astropy.utils.state import ScienceState
 
@@ -515,6 +516,7 @@ class IERS(QTable):
         return np.zeros_like(i)
 
     @property
+    @deprecated(since="8.0", alternative="Time.now()", obj_type="property")
     def time_now(self):
         """
         Property to provide the current time, but also allow for explicitly setting
@@ -860,7 +862,7 @@ class IERS_Auto(IERS_A):
         auto_max_age = _none_to_float(conf.auto_max_age)
         if (
             max_input_mjd > predictive_mjd
-            and self.time_now.mjd - predictive_mjd > auto_max_age
+            and Time.now().mjd - predictive_mjd > auto_max_age
         ):
             raise ValueError(INTERPOLATE_ERROR.format(auto_max_age))
 
@@ -885,7 +887,7 @@ class IERS_Auto(IERS_A):
 
         # Pass in initial to np.max to allow things to work for empty mjd.
         max_input_mjd = np.max(mjd, initial=50000)
-        now_mjd = self.time_now.mjd
+        now_mjd = Time.now().mjd
 
         # IERS-A table contains predictive data out for a year after
         # the available definitive values.

--- a/docs/changes/utils/19060.api.rst
+++ b/docs/changes/utils/19060.api.rst
@@ -1,0 +1,2 @@
+The ``astropy.utils.iers.IERS.time_now`` property is deprecated.
+The ``astropy.time.Time.now()`` function can be used as a replacement.


### PR DESCRIPTION
### Description

The property is meant to provide a way to test code that depends the output of `Time.now()` in a reproducible manner, but by making use of the monkeypatching functionality `pytest` offers it is possible to avoid having to implement test-specific code paths.

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
