### PR TITLE
Generalize WCS API utility functions

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -134,7 +134,7 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
             )
 
 
-def high_level_objects_to_values(*world_objects, low_level_wcs):
+def high_level_objects_to_values(*world_objects, low_level_wcs, frame="output"):
     """
     Convert the input high level object to low level values.
 
@@ -155,8 +155,12 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
         The WCS object to use to interpret the coordinates.
     """
     # Cache the classes and components since this may be expensive
-    serialized_classes = low_level_wcs.world_axis_object_classes
-    components = low_level_wcs.world_axis_object_components
+    if frame == "output":
+        serialized_classes = low_level_wcs.world_axis_object_classes
+        components = low_level_wcs.world_axis_object_components
+    elif frame == "input":
+        serialized_classes = low_level_wcs.input_axis_object_classes
+        components = low_level_wcs.input_axis_object_components
 
     # Deserialize world_axis_object_classes using the default order
     classes = OrderedDict()
@@ -271,7 +275,7 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
     return world
 
 
-def values_to_high_level_objects(*world_values, low_level_wcs):
+def values_to_high_level_objects(*world_values, low_level_wcs, frame="output"):
     """
     Convert low level values into high level objects.
 
@@ -301,8 +305,12 @@ def values_to_high_level_objects(*world_values, low_level_wcs):
             )
 
     # Cache the classes and components since this may be expensive
-    components = low_level_wcs.world_axis_object_components
-    classes = low_level_wcs.world_axis_object_classes
+    if frame == "output":
+        components = low_level_wcs.world_axis_object_components
+        classes = low_level_wcs.world_axis_object_classes
+    elif frame == "input":
+        components = low_level_wcs.input_axis_object_components
+        classes = low_level_wcs.input_axis_object_classes
 
     # Deserialize classes
     if low_level_wcs.serialized_classes:

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -135,10 +135,7 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
 
 
 def high_level_objects_to_values(
-    *world_objects,
-    low_level_wcs,
-    object_classes=None,
-    object_components=None
+    *world_objects, low_level_wcs, object_classes=None, object_components=None
 ):
     """
     Convert the input high level object to low level values.
@@ -287,11 +284,8 @@ def high_level_objects_to_values(
 
 
 def values_to_high_level_objects(
-    *world_values,
-    low_level_wcs,
-    object_classes=None,
-    object_components=None
-    ):
+    *world_values, low_level_wcs, object_classes=None, object_components=None
+):
     """
     Convert low level values into high level objects.
 

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -153,11 +153,17 @@ def high_level_objects_to_values(
 
     Parameters
     ----------
-    *world_objects: object
+    *world_objects : object
         High level coordinate objects.
 
-    low_level_wcs: `.BaseLowLevelWCS`
+    low_level_wcs : `.BaseLowLevelWCS`
         The WCS object to use to interpret the coordinates.
+
+    object_classes : dict
+        The ``world_axis_object_classes`` for a frame in the ``low_level_wcs``.
+
+    object_components : list
+        The ``world_axis_object_components`` for a frame in the ``low_level_wcs``.
     """
     # Cache the classes and components since this may be expensive
     if object_classes is None:
@@ -298,11 +304,17 @@ def values_to_high_level_objects(
 
     Parameters
     ----------
-    *world_values: object
+    *world_values : object
         Low level, "values" representations of the world coordinates.
 
-    low_level_wcs: `.BaseLowLevelWCS`
+    low_level_wcs : `.BaseLowLevelWCS`
         The WCS object to use to interpret the coordinates.
+
+    object_classes : dict
+        The ``world_axis_object_classes`` for a frame in the ``low_level_wcs``.
+
+    object_components : list
+       The ``world_axis_object_components`` for a frame in the ``low_level_wcs``.
     """
     # Check the type of the input values - should be scalars or plain Numpy
     # arrays, not e.g. Quantity. Note that we deliberately use type(w) because

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -134,7 +134,12 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
             )
 
 
-def high_level_objects_to_values(*world_objects, low_level_wcs, frame="output"):
+def high_level_objects_to_values(
+    *world_objects,
+    low_level_wcs,
+    object_classes=None,
+    object_components=None
+):
     """
     Convert the input high level object to low level values.
 
@@ -155,12 +160,12 @@ def high_level_objects_to_values(*world_objects, low_level_wcs, frame="output"):
         The WCS object to use to interpret the coordinates.
     """
     # Cache the classes and components since this may be expensive
-    if frame == "output":
+    if object_classes is None:
         serialized_classes = low_level_wcs.world_axis_object_classes
         components = low_level_wcs.world_axis_object_components
-    elif frame == "input":
-        serialized_classes = low_level_wcs.input_axis_object_classes
-        components = low_level_wcs.input_axis_object_components
+    else:
+        serialized_classes = object_classes
+        components = object_components
 
     # Deserialize world_axis_object_classes using the default order
     classes = OrderedDict()
@@ -275,7 +280,12 @@ def high_level_objects_to_values(*world_objects, low_level_wcs, frame="output"):
     return world
 
 
-def values_to_high_level_objects(*world_values, low_level_wcs, frame="output"):
+def values_to_high_level_objects(
+    *world_values,
+    low_level_wcs,
+    object_classes=None,
+    object_components=None
+    ):
     """
     Convert low level values into high level objects.
 
@@ -305,12 +315,12 @@ def values_to_high_level_objects(*world_values, low_level_wcs, frame="output"):
             )
 
     # Cache the classes and components since this may be expensive
-    if frame == "output":
+    if object_classes is None:
         components = low_level_wcs.world_axis_object_components
         classes = low_level_wcs.world_axis_object_classes
-    elif frame == "input":
-        components = low_level_wcs.input_axis_object_components
-        classes = low_level_wcs.input_axis_object_classes
+    else:
+        components = object_components
+        classes = object_classes
 
     # Deserialize classes
     if low_level_wcs.serialized_classes:

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -134,15 +134,13 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
             )
 
 
-def high_level_objects_to_values(
-    *world_objects, low_level_wcs, object_classes=None, object_components=None
-):
+def high_level_objects_to_values(*world_objects, low_level_wcs):
     """
     Convert the input high level object to low level values.
 
-    This function uses the information in ``wcs.world_axis_object_classes`` and
-    ``wcs.world_axis_object_components`` to convert the high level objects
-    (such as `~.SkyCoord`) to low level "values" which should be scalars or
+    This function uses the information in ``low_level_wcs.world_axis_object_classes``
+    and ``low_level_wcs.world_axis_object_components`` to convert the high level
+    objects (such as `~.SkyCoord`) to low level "values" which should be scalars or
     Numpy arrays.
 
     This is used in `.HighLevelWCSMixin.world_to_pixel`, but provided as a
@@ -153,27 +151,24 @@ def high_level_objects_to_values(
     *world_objects : object
         High level coordinate objects.
 
-    low_level_wcs : `.BaseLowLevelWCS`
-        The WCS object to use to interpret the coordinates.
-
-    object_classes : dict
-        The ``world_axis_object_classes`` for a frame in the ``low_level_wcs``.
-
-    object_components : list
-        The ``world_axis_object_components`` for a frame in the ``low_level_wcs``.
+    low_level_wcs : `.BaseLowLevelWCS` or object
+        Source of the world axis metadata to use for the conversion. A full
+        `.BaseLowLevelWCS` instance is accepted, but any object exposing
+        ``world_axis_object_classes`` and ``world_axis_object_components``
+        attributes also works (for example a `types.SimpleNamespace` or a
+        namedtuple). The ``serialized_classes`` attribute is read if present
+        and otherwise treated as ``False``. This is useful when the metadata
+        for the intended conversion direction does not match what a WCS
+        exposes by default.
     """
     # Cache the classes and components since this may be expensive
-    if object_classes is None:
-        serialized_classes = low_level_wcs.world_axis_object_classes
-        components = low_level_wcs.world_axis_object_components
-    else:
-        serialized_classes = object_classes
-        components = object_components
+    serialized_classes = low_level_wcs.world_axis_object_classes
+    components = low_level_wcs.world_axis_object_components
 
     # Deserialize world_axis_object_classes using the default order
     classes = OrderedDict()
     for key in default_order(components):
-        if low_level_wcs.serialized_classes:
+        if getattr(low_level_wcs, "serialized_classes", False):
             classes[key] = deserialize_class(serialized_classes[key], construct=False)
         else:
             classes[key] = serialized_classes[key]
@@ -283,14 +278,12 @@ def high_level_objects_to_values(
     return world
 
 
-def values_to_high_level_objects(
-    *world_values, low_level_wcs, object_classes=None, object_components=None
-):
+def values_to_high_level_objects(*world_values, low_level_wcs):
     """
     Convert low level values into high level objects.
 
-    This function uses the information in ``wcs.world_axis_object_classes`` and
-    ``wcs.world_axis_object_components`` to convert low level "values"
+    This function uses the information in ``low_level_wcs.world_axis_object_classes``
+    and ``low_level_wcs.world_axis_object_components`` to convert low level "values"
     `~.Quantity` objects, to high level objects (such as `~.SkyCoord`).
 
     This is used in `.HighLevelWCSMixin.pixel_to_world`, but provided as a
@@ -301,14 +294,15 @@ def values_to_high_level_objects(
     *world_values : object
         Low level, "values" representations of the world coordinates.
 
-    low_level_wcs : `.BaseLowLevelWCS`
-        The WCS object to use to interpret the coordinates.
-
-    object_classes : dict
-        The ``world_axis_object_classes`` for a frame in the ``low_level_wcs``.
-
-    object_components : list
-       The ``world_axis_object_components`` for a frame in the ``low_level_wcs``.
+    low_level_wcs : `.BaseLowLevelWCS` or object
+        Source of the world axis metadata to use for the conversion. A full
+        `.BaseLowLevelWCS` instance is accepted, but any object exposing
+        ``world_axis_object_classes`` and ``world_axis_object_components``
+        attributes also works (for example a `types.SimpleNamespace` or a
+        namedtuple). The ``serialized_classes`` attribute is read if present
+        and otherwise treated as ``False``. This is useful when the metadata
+        for the intended conversion direction does not match what a WCS
+        exposes by default.
     """
     # Check the type of the input values - should be scalars or plain Numpy
     # arrays, not e.g. Quantity. Note that we deliberately use type(w) because
@@ -321,15 +315,11 @@ def values_to_high_level_objects(
             )
 
     # Cache the classes and components since this may be expensive
-    if object_classes is None:
-        components = low_level_wcs.world_axis_object_components
-        classes = low_level_wcs.world_axis_object_classes
-    else:
-        components = object_components
-        classes = object_classes
+    components = low_level_wcs.world_axis_object_components
+    classes = low_level_wcs.world_axis_object_classes
 
     # Deserialize classes
-    if low_level_wcs.serialized_classes:
+    if getattr(low_level_wcs, "serialized_classes", False):
         classes_new = {}
         for key, value in classes.items():
             classes_new[key] = deserialize_class(value, construct=False)

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -209,6 +209,52 @@ def test_values_to_objects():
     assert c2.b == c2_out.b
 
 
+def test_low_level_wcs_duck_typed():
+    # Anything exposing world_axis_object_classes and world_axis_object_components
+    # should be accepted as low_level_wcs; serialized_classes is optional.
+    from collections import namedtuple
+    from types import SimpleNamespace
+
+    wcs = SkyCoordDuplicateWCS()
+    c1, c2 = wcs.pixel_to_world(1, 2, 3, 4)
+
+    ns = SimpleNamespace(
+        world_axis_object_classes=wcs.world_axis_object_classes,
+        world_axis_object_components=wcs.world_axis_object_components,
+    )
+    assert np.allclose(
+        high_level_objects_to_values(c1, c2, low_level_wcs=ns), [2, 4, 6, 8]
+    )
+    c1_out, c2_out = values_to_high_level_objects(*[2, 4, 6, 8], low_level_wcs=ns)
+    assert c1.ra == c1_out.ra and c1.dec == c1_out.dec
+    assert c2.l == c2_out.l and c2.b == c2_out.b
+
+    Frame = namedtuple("Frame", ["world_axis_object_classes", "world_axis_object_components"])
+    nt = Frame(wcs.world_axis_object_classes, wcs.world_axis_object_components)
+    assert np.allclose(
+        high_level_objects_to_values(c1, c2, low_level_wcs=nt), [2, 4, 6, 8]
+    )
+
+
+def test_low_level_wcs_duck_typed_serialized():
+    # serialized_classes=True on a duck-typed object still triggers deserialization.
+    from types import SimpleNamespace
+
+    wcs = SerializedWCS()
+    q = wcs.pixel_to_world(1)
+
+    ns = SimpleNamespace(
+        world_axis_object_classes=wcs.world_axis_object_classes,
+        world_axis_object_components=wcs.world_axis_object_components,
+        serialized_classes=True,
+    )
+    (value,) = high_level_objects_to_values(q, low_level_wcs=ns)
+    assert_allclose(value, 2)
+    (q_out,) = values_to_high_level_objects(2.0, low_level_wcs=ns)
+    assert isinstance(q_out, Quantity)
+    assert_allclose(q_out.to_value(u.deg), 2.0)
+
+
 class InvalidWCSQuantity(SkyCoordDuplicateWCS):
     """
     WCS which defines ``world_axis_object_components`` which returns Quantity

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -212,8 +212,8 @@ def test_values_to_objects():
 def test_low_level_wcs_duck_typed():
     # Anything exposing world_axis_object_classes and world_axis_object_components
     # should be accepted as low_level_wcs; serialized_classes is optional.
-    from collections import namedtuple
     from types import SimpleNamespace
+    from typing import NamedTuple
 
     wcs = SkyCoordDuplicateWCS()
     c1, c2 = wcs.pixel_to_world(1, 2, 3, 4)
@@ -229,7 +229,10 @@ def test_low_level_wcs_duck_typed():
     assert c1.ra == c1_out.ra and c1.dec == c1_out.dec
     assert c2.l == c2_out.l and c2.b == c2_out.b
 
-    Frame = namedtuple("Frame", ["world_axis_object_classes", "world_axis_object_components"])
+    class Frame(NamedTuple):
+        world_axis_object_classes: dict
+        world_axis_object_components: list
+
     nt = Frame(wcs.world_axis_object_classes, wcs.world_axis_object_components)
     assert np.allclose(
         high_level_objects_to_values(c1, c2, low_level_wcs=nt), [2, 4, 6, 8]

--- a/docs/changes/wcs/19064.api.rst
+++ b/docs/changes/wcs/19064.api.rst
@@ -1,0 +1,4 @@
+``wcs.high_level_objects_to_values`` and ``wcs.values_to_high_level_objects``
+now accept two new optional parameters - ``object_classes`` and ``object_components``, which are the
+``world_axis_object_classes`` and ``world_axis_object_components`` for a specific coordinate
+frame in the WCS pipeline. This change applies mostly to GWCS.

--- a/docs/changes/wcs/19064.api.rst
+++ b/docs/changes/wcs/19064.api.rst
@@ -1,6 +1,6 @@
 ``wcs.high_level_objects_to_values`` and ``wcs.values_to_high_level_objects``
 no longer require their ``low_level_wcs`` argument to be a full
-`~astropy.wcs.wcsapi.BaseLowLevelWCS` instance. Any object exposing
+``astropy.wcs.wcsapi.BaseLowLevelWCS`` instance. Any object exposing
 ``world_axis_object_classes`` and ``world_axis_object_components`` attributes
 is accepted, and ``serialized_classes`` is now optional (treated as ``False``
 if absent).

--- a/docs/changes/wcs/19064.api.rst
+++ b/docs/changes/wcs/19064.api.rst
@@ -1,4 +1,6 @@
 ``wcs.high_level_objects_to_values`` and ``wcs.values_to_high_level_objects``
-now accept two new optional parameters - ``object_classes`` and ``object_components``, which are the
-``world_axis_object_classes`` and ``world_axis_object_components`` for a specific coordinate
-frame in the WCS pipeline. This change applies mostly to GWCS.
+no longer require their ``low_level_wcs`` argument to be a full
+`~astropy.wcs.wcsapi.BaseLowLevelWCS` instance. Any object exposing
+``world_axis_object_classes`` and ``world_axis_object_components`` attributes
+is accepted, and ``serialized_classes`` is now optional (treated as ``False``
+if absent).


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to generalize the two WCS API functions converting to and from High Level Objects (HLO).
It removes the assumption that the forward WCS transform is detector-> world. While this is not necessary for astropy.wcs it fixes an issue with GWCS.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19063

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
