### PR TITLE
Speed up converting `Angle` instances to strings

### DIFF
--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -16,6 +16,7 @@ astropy.coordinates.angles. Mainly they are conversions from one format
 of data to another.
 """
 
+import math
 import threading
 from warnings import warn
 
@@ -383,11 +384,9 @@ def _decimal_to_sexagesimal_string(
     """
     values = _decimal_to_sexagesimal(angle)
     # Check to see if values[0] is negative, using np.copysign to handle -0
-    sign = np.copysign(1.0, values[0])
+    sign = math.copysign(1.0, values[0])
     # If the coordinates are negative, we need to take the absolute values.
-    # We use np.abs because abs(-0) is -0
-    # TODO: Is this true? (MHvK, 2018-02-01: not on my system)
-    values = [np.abs(value) for value in values]
+    values = [abs(value) for value in values]
 
     if pad:
         pad = 3 if sign == -1 else 2
@@ -434,7 +433,7 @@ def _decimal_to_sexagesimal_string(
     elif fields < 2 and values[1] >= 30.0:
         values[0] += 1.0
 
-    literal = f"{np.copysign(values[0], sign):0{pad}.0f}{sep[0]}"
+    literal = f"{math.copysign(values[0], sign):0{pad}.0f}{sep[0]}"
     if fields >= 2:
         literal += f"{int(values[1]):02d}{sep[1]}"
     if fields == 3:


### PR DESCRIPTION
### Description

`_decimal_to_sexagesimal_string()`, used in formatting `Angle` instances, is always called with scalar inputs, for which the Python standard library functions are faster than the `numpy` equivalents.

Timing setup and results on current `main`:
```
$ cat angle_setup.py 
```
```python
from astropy.coordinates import Angle

a_scalar = Angle(0, unit="deg")
a_array = Angle([0, 1], unit="deg")
```
```
$ ipython -i angle_setup.py
```
```python
Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.7.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: IPython 9.0+ has hooks to integrate AI/LLM completions.

In [1]: %timeit a_scalar.to_string()
15.5 μs ± 32.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit a_array.to_string()
23.8 μs ± 8.97 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Timings with this patch:
```python
In [1]: %timeit a_scalar.to_string()
13.1 μs ± 21.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [2]: %timeit a_array.to_string()
19.3 μs ± 52.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
