### PR TITLE
Hide original exception when failing to match a site name

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -390,7 +390,7 @@ class EarthLocation(u.Quantity):
         except UnknownSiteException as e:
             raise UnknownSiteException(
                 e.site, "EarthLocation.get_site_names", close_names=e.close_names
-            ) from e
+            ) from None
 
         if cls is el.__class__:
             return el


### PR DESCRIPTION
The second exception duplicates most of the content from the primary exception and confuses things.

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address an issue where two exceptions are reported when an unknown earth location site is given. It replaces the `from e` with `from None` to hide the original exception. The content of the exceptions are mostly identical so the second one adds to the output verbosity without providing any additional content.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19072 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
