### PR TITLE
Overwrite constructor for UnifiedReadWriteMethod property

### DIFF
--- a/astropy/io/registry/interface.py
+++ b/astropy/io/registry/interface.py
@@ -144,7 +144,7 @@ class UnifiedReadWriteMethod(property):
 
     """
 
-    def __init__(self, readwritecls: UnifiedReadWrite):
+    def __init__(self, readwritecls: UnifiedReadWrite, /) -> None:  # type: ignore[arg-type]
         super().__init__(fget=readwritecls)
 
     # We subclass property to ensure that __set__ is defined and that,


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description

The current builtins [typing stubs for a `property`](https://github.com/python/typeshed/blob/cc53f5497f9983bc01f2381d9625e20f792e6455/stdlib/builtins.pyi#L1359-L1373) declare `fget` et al as `callable`, rather than class instances, which means type checkers complain, like so:

```console
$ uv run mypy --follow-untyped-imports gwpy/detector/channel.py
...
gwpy/detector/channel.py:751: error: Argument 1 to "UnifiedReadWriteMethod" has incompatible type "type[ChannelListRead]"; expected "Callable[[Any], Any] | None"  [arg-type]
gwpy/detector/channel.py:752: error: Argument 1 to "UnifiedReadWriteMethod" has incompatible type "type[ChannelListWrite]"; expected "Callable[[Any], Any] | None"  [arg-type]
```

Where the lines in question are:

```python
    read = UnifiedReadWriteMethod(ChannelListRead)
    write = UnifiedReadWriteMethod(ChannelListWrite)
````

This PR overrides the constructor for the `UnifiedReadWriteMethod` to annotate the 'correct' types for creating a `UnifiedReadWriteMethod`.

I haven't put a huge amount of thought into this, so I'm happy to implement any suggestions.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
