### PR TITLE
MNT: replace itertools.product in tests

### DIFF
--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import copy
-import itertools
 import warnings
 
 import numpy as np
@@ -557,7 +556,8 @@ class TestArithmetic:
         self.t2 = self.__class__.t2[use_mask]
         self.jd = self.__class__.jd[use_mask]
 
-    @pytest.mark.parametrize("kw, func", list(itertools.product(kwargs, functions)))
+    @pytest.mark.parametrize("func", functions)
+    @pytest.mark.parametrize("kw", kwargs)
     def test_argfuncs(self, kw, func, use_mask):
         """
         Test that ``np.argfunc(jd, **kw)`` is the same as ``t0.argfunc(**kw)``
@@ -581,7 +581,8 @@ class TestArithmetic:
         assert t0v.shape == jdv.shape
         assert t1v.shape == jdv.shape
 
-    @pytest.mark.parametrize("kw, func", list(itertools.product(kwargs, functions)))
+    @pytest.mark.parametrize("func", functions)
+    @pytest.mark.parametrize("kw", kwargs)
     def test_funcs(self, kw, func, use_mask):
         """
         Test that ``np.func(jd, **kw)`` is the same as ``t1.func(**kw)`` where

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Regression tests for the units package."""
 
-import itertools
 import operator
 import pickle
 from contextlib import nullcontext
@@ -584,7 +583,7 @@ def test_compose_no_duplicates():
 
 
 @pytest.mark.parametrize(
-    "dtype", tuple(map("".join, itertools.product("<>", "if", "48")))
+    "dtype", ("<i4", "<i8", "<f4", "<f8", ">i4", ">i8", ">f4", ">f8")
 )
 def test_endian_independence(dtype):
     """

--- a/docs/changes/19079.other.rst
+++ b/docs/changes/19079.other.rst
@@ -1,0 +1,1 @@
+Refactor test parametrization in time and units tests to avoid ``itertools.product``.

--- a/docs/changes/19079.other.rst
+++ b/docs/changes/19079.other.rst
@@ -1,1 +1,0 @@
-Refactor test parametrization in time and units tests to avoid ``itertools.product``.


### PR DESCRIPTION
## Summary
- replace itertools.product parametrization in time tests with stacked decorators
- replace dtype product in units tests with an explicit tuple
- remove unused itertools imports

## Testing
- pytest (fails: 262 failed, 31236 passed, 592 skipped, 222 xfailed)
  - failures dominated by DeprecationWarning from lxml HTMLParser (strip_cdata) via BeautifulSoup in HTML table reads; impacts cosmology HTML read/write and ascii HTML tests
  - additional failures: astropy/tests/test_logger.py::test_exception_logging*, docs/nddata/index.rst

## Related
- refs #18110