### PR TITLE
MAINT: Update masked function signatures for NumPy 2.4

### DIFF
--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -8,15 +8,10 @@ from typing import Self
 
 import numpy as np
 
-from astropy.units import (
-    Quantity,
-    Unit,
-    UnitBase,
-    UnitConversionError,
-    UnitsError,
-    UnitTypeError,
-    dimensionless_unscaled,
-)
+# Import directly from submodules to break the circular dependency
+from ..core import Unit, UnitBase, dimensionless_unscaled
+from ..quantity import Quantity
+from ..errors import UnitConversionError, UnitsError, UnitTypeError
 from astropy.units.typing import PhysicalTypeID
 from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,8 +20,9 @@ from astropy import config as _config
 from astropy.utils.compat.numpycompat import COPY_IF_NEEDED, NUMPY_LT_2_0
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyWarning
+from .function.logarithmic import LogUnit
 
-from .core import LogUnit, Unit, UnitBase, dimensionless_unscaled, get_current_unit_registry
+from .core import Unit, UnitBase, dimensionless_unscaled, get_current_unit_registry
 from .errors import UnitConversionError, UnitsError, UnitTypeError
 from .format import Base, Latex
 from .quantity_helper import can_have_arbitrary_unit, check_output, converters_and_unit
@@ -742,17 +743,7 @@ class Quantity(np.ndarray):
             - `~astropy.units.Quantity` subclass
             - bool: True if subclasses of the given class are ok
         """
-        from astropy.units import StructuredUnit
-        if isinstance(unit, StructuredUnit):
-            from astropy.units.structured import StructuredQuantity
-            return StructuredQuantity, True
 
-        
-        from astropy.units import LogUnit
-        if isinstance(unit, LogUnit):
-            from astropy.units import LogQuantity
-            return LogQuantity, True
-        
         return Quantity, True
 
     def _new_view(self, obj=None, unit=None, propagate_info=True):
@@ -2299,3 +2290,4 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         raise UnitsError("'rtol' should be dimensionless")
 
     return actual.value, desired.value, rtol.value, atol.value
+

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -8,7 +8,6 @@ units for a given ufunc, given input units.
 """
 
 from fractions import Fraction
-from .function_helpers import _get_np_func_name
 import numpy as np
 
 from astropy.units.core import dimensionless_unscaled, unit_scale_converter
@@ -27,7 +26,8 @@ else:
 
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
 
-
+def _get_np_func_name(func):
+    return getattr(func, "__name__", str(func))
 def _d(unit):
     if unit is None:
         return dimensionless_unscaled

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -510,7 +510,7 @@ for ufunc in radian_to_dimensionless_ufuncs:
     UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_radian_to_dimensionless
 
 # ufuncs handled as special cases
-UFUNC_HELPERS[_get_np_func_name(np.sqrt)] = helper_sqrt
+UFUNC_HELPERS["sqrt"] = helper_sqrt
 UFUNC_HELPERS[_get_np_func_name(np.square)] = helper_square
 UFUNC_HELPERS[_get_np_func_name(np.reciprocal)] = helper_reciprocal
 UFUNC_HELPERS[_get_np_func_name(np.cbrt)] = helper_cbrt

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -8,7 +8,7 @@ units for a given ufunc, given input units.
 """
 
 from fractions import Fraction
-
+from .function_helpers import _get_np_func_name
 import numpy as np
 
 from astropy.units.core import dimensionless_unscaled, unit_scale_converter
@@ -348,8 +348,8 @@ def helper_clip(f, unit1, unit2, unit3):
             ]
         except UnitsError:
             raise UnitConversionError(
-                f"Can only apply '{f.__name__}' function to quantities with "
-                "compatible dimensions"
+                f"Can only apply '{_get_np_func_name(f)}' function to quantities "
+                "with compatible dimensions"
             )
 
     else:
@@ -376,66 +376,66 @@ def helper_clip(f, unit1, unit2, unit3):
 # https://numpy.org/doc/stable/reference/ufuncs.html#available-ufuncs
 
 UNSUPPORTED_UFUNCS |= {
-    np.bitwise_and,
-    np.bitwise_or,
-    np.bitwise_xor,
-    np.invert,
-    np.left_shift,
-    np.right_shift,
-    np.logical_and,
-    np.logical_or,
-    np.logical_xor,
-    np.logical_not,
-    np.isnat,
-    np.gcd,
-    np.lcm,
+    "bitwise_and",
+    "bitwise_or",
+    "bitwise_xor",
+    "invert",
+    "left_shift",
+    "right_shift",
+    "logical_and",
+    "logical_or",
+    "logical_xor",
+    "logical_not",
+    "isnat",
+    "gcd",
+    "lcm",
 }
 
 if not NUMPY_LT_2_0:
     # string utilities - make no sense for Quantity.
     UNSUPPORTED_UFUNCS |= {
-        np.bitwise_count,
-        np._core.umath.count,
-        np._core.umath.isalpha,
-        np._core.umath.isdigit,
-        np._core.umath.isspace,
-        np._core.umath.isnumeric,
-        np._core.umath.isdecimal,
-        np._core.umath.isalnum,
-        np._core.umath.istitle,
-        np._core.umath.islower,
-        np._core.umath.isupper,
-        np._core.umath.index,
-        np._core.umath.rindex,
-        np._core.umath.startswith,
-        np._core.umath.endswith,
-        np._core.umath.find,
-        np._core.umath.rfind,
-        np._core.umath.str_len,
-        np._core.umath._strip_chars,
-        np._core.umath._lstrip_chars,
-        np._core.umath._rstrip_chars,
-        np._core.umath._strip_whitespace,
-        np._core.umath._lstrip_whitespace,
-        np._core.umath._rstrip_whitespace,
-        np._core.umath._replace,
-        np._core.umath._expandtabs,
-        np._core.umath._expandtabs_length,
+        "bitwise_count",
+        "count",
+        "isalpha",
+        "isdigit",
+        "isspace",
+        "isnumeric",
+        "isdecimal",
+        "isalnum",
+        "istitle",
+        "islower",
+        "isupper",
+        "index",
+        "rindex",
+        "startswith",
+        "endswith",
+        "find",
+        "rfind",
+        "str_len",
+        "_strip_chars",
+        "_lstrip_chars",
+        "_rstrip_chars",
+        "_core.umath._strip_whitespace",
+        "_core.umath._lstrip_whitespace",
+        "_core.umath._rstrip_whitespace",
+        "_core.umath._replace",
+        "_core.umath._expandtabs",
+        "_core.umath._expandtabs_length",
     }
 if not NUMPY_LT_2_1:
     UNSUPPORTED_UFUNCS |= {
-        np._core.umath._ljust,
-        np._core.umath._rjust,
-        np._core.umath._center,
-        np._core.umath._zfill,
-        np._core.umath._partition_index,
-        np._core.umath._rpartition,
-        np._core.umath._rpartition_index,
-        np._core.umath._partition,
+        "_core.umath._ljust",
+        "_core.umath._rjust",
+        "_core.umath._center",
+        "_core.umath._zfill",
+        "_core.umath._partition_index",
+        "_core.umath._rpartition",
+        "_core.umath._rpartition_index",
+        "_core.umath._partition",
     }
 if not NUMPY_LT_2_3:
     UNSUPPORTED_UFUNCS |= {
-        np._core.umath._slice,
+        "_core.umath._slice",
     }
 
 # SINGLE ARGUMENT UFUNCS
@@ -444,7 +444,7 @@ if not NUMPY_LT_2_3:
 # (but rather a boolean, or -1, 0, or +1 for np.sign).
 onearg_test_ufuncs = (np.isfinite, np.isinf, np.isnan, np.sign, np.signbit)
 for ufunc in onearg_test_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_onearg_test
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_onearg_test
 
 # ufuncs that return a value with the same unit as the input
 invariant_ufuncs = (
@@ -461,7 +461,7 @@ invariant_ufuncs = (
     np.positive,
 )
 for ufunc in invariant_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_invariant
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_invariant
 
 # ufuncs that require dimensionless input and and give dimensionless output
 dimensionless_to_dimensionless_ufuncs = (
@@ -480,7 +480,7 @@ if isinstance(getattr(np_umath, "erf", None), np.ufunc):
     dimensionless_to_dimensionless_ufuncs += (np_umath.erf,)
 
 for ufunc in dimensionless_to_dimensionless_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_dimensionless_to_dimensionless
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_dimensionless_to_dimensionless
 
 # ufuncs that require dimensionless input and give output in radians
 dimensionless_to_radian_ufuncs = (
@@ -492,31 +492,31 @@ dimensionless_to_radian_ufuncs = (
     np.arctanh,
 )
 for ufunc in dimensionless_to_radian_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_dimensionless_to_radian
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_dimensionless_to_radian
 
 # ufuncs that require input in degrees and give output in radians
 degree_to_radian_ufuncs = (np.radians, np.deg2rad)
 for ufunc in degree_to_radian_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_degree_to_radian
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_degree_to_radian
 
 # ufuncs that require input in radians and give output in degrees
 radian_to_degree_ufuncs = (np.degrees, np.rad2deg)
 for ufunc in radian_to_degree_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_radian_to_degree
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_radian_to_degree
 
 # ufuncs that require input in radians and give dimensionless output
 radian_to_dimensionless_ufuncs = (np.cos, np.sin, np.tan, np.cosh, np.sinh, np.tanh)
 for ufunc in radian_to_dimensionless_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_radian_to_dimensionless
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_radian_to_dimensionless
 
 # ufuncs handled as special cases
-UFUNC_HELPERS[np.sqrt] = helper_sqrt
-UFUNC_HELPERS[np.square] = helper_square
-UFUNC_HELPERS[np.reciprocal] = helper_reciprocal
-UFUNC_HELPERS[np.cbrt] = helper_cbrt
-UFUNC_HELPERS[np_umath._ones_like] = helper__ones_like
-UFUNC_HELPERS[np.modf] = helper_modf
-UFUNC_HELPERS[np.frexp] = helper_frexp
+UFUNC_HELPERS[_get_np_func_name(np.sqrt)] = helper_sqrt
+UFUNC_HELPERS[_get_np_func_name(np.square)] = helper_square
+UFUNC_HELPERS[_get_np_func_name(np.reciprocal)] = helper_reciprocal
+UFUNC_HELPERS[_get_np_func_name(np.cbrt)] = helper_cbrt
+UFUNC_HELPERS[_get_np_func_name(np_umath._ones_like)] = helper__ones_like
+UFUNC_HELPERS[_get_np_func_name(np.modf)] = helper_modf
+UFUNC_HELPERS[_get_np_func_name(np.frexp)] = helper_frexp
 
 
 # TWO ARGUMENT UFUNCS
@@ -525,7 +525,7 @@ UFUNC_HELPERS[np.frexp] = helper_frexp
 # dimensionless output
 two_arg_dimensionless_ufuncs = (np.logaddexp, np.logaddexp2)
 for ufunc in two_arg_dimensionless_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_two_arg_dimensionless
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_two_arg_dimensionless
 
 # two argument ufuncs that return a value with the same unit as the input
 twoarg_invariant_ufuncs = (
@@ -542,7 +542,7 @@ twoarg_invariant_ufuncs = (
     np.fmod,
 )
 for ufunc in twoarg_invariant_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_twoarg_invariant
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_twoarg_invariant
 
 # two argument ufuncs that need compatible inputs and return a boolean
 twoarg_comparison_ufuncs = (
@@ -554,7 +554,7 @@ twoarg_comparison_ufuncs = (
     np.equal,
 )
 for ufunc in twoarg_comparison_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_twoarg_comparison
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_twoarg_comparison
 
 # two argument ufuncs that do inverse trigonometry
 twoarg_invtrig_ufuncs = (np.arctan2,)
@@ -562,27 +562,30 @@ twoarg_invtrig_ufuncs = (np.arctan2,)
 if isinstance(getattr(np_umath, "_arg", None), np.ufunc):
     twoarg_invtrig_ufuncs += (np_umath._arg,)
 for ufunc in twoarg_invtrig_ufuncs:
-    UFUNC_HELPERS[ufunc] = helper_twoarg_invtrig
+    UFUNC_HELPERS[_get_np_func_name(ufunc)] = helper_twoarg_invtrig
 
 # ufuncs handled as special cases
-UFUNC_HELPERS[np.multiply] = helper_multiplication
-UFUNC_HELPERS[np.matmul] = helper_multiplication
+UFUNC_HELPERS[_get_np_func_name(np.multiply)] = helper_multiplication
+UFUNC_HELPERS[_get_np_func_name(np.matmul)] = helper_multiplication
+
 if not NUMPY_LT_2_0:
-    UFUNC_HELPERS[np.vecdot] = helper_multiplication
+    UFUNC_HELPERS[_get_np_func_name(np.vecdot)] = helper_multiplication
 if not NUMPY_LT_2_2:
-    UFUNC_HELPERS[np.vecmat] = helper_multiplication
-    UFUNC_HELPERS[np.matvec] = helper_multiplication
-UFUNC_HELPERS[np.divide] = helper_division
-UFUNC_HELPERS[np.true_divide] = helper_division
-UFUNC_HELPERS[np.power] = helper_power
-UFUNC_HELPERS[np.ldexp] = helper_ldexp
-UFUNC_HELPERS[np.copysign] = helper_copysign
-UFUNC_HELPERS[np.floor_divide] = helper_twoarg_floor_divide
-UFUNC_HELPERS[np.heaviside] = helper_heaviside
-UFUNC_HELPERS[np.float_power] = helper_power
-UFUNC_HELPERS[np.divmod] = helper_divmod
+    UFUNC_HELPERS[_get_np_func_name(np.vecmat)] = helper_multiplication
+    UFUNC_HELPERS[_get_np_func_name(np.matvec)] = helper_multiplication
+UFUNC_HELPERS[_get_np_func_name(np.divide)] = helper_division
+UFUNC_HELPERS[_get_np_func_name(np.true_divide)] = helper_division
+UFUNC_HELPERS[_get_np_func_name(np.power)] = helper_power
+UFUNC_HELPERS[_get_np_func_name(np.ldexp)] = helper_ldexp
+UFUNC_HELPERS[_get_np_func_name(np.copysign)] = helper_copysign
+UFUNC_HELPERS[_get_np_func_name(np.floor_divide)] = helper_twoarg_floor_divide
+UFUNC_HELPERS[_get_np_func_name(np.heaviside)] = helper_heaviside
+UFUNC_HELPERS[_get_np_func_name(np.float_power)] = helper_power
+UFUNC_HELPERS[_get_np_func_name(np.divmod)] = helper_divmod
 # Check for clip ufunc; note that np.clip is a wrapper function, not the ufunc.
 if isinstance(getattr(np_umath, "clip", None), np.ufunc):
-    UFUNC_HELPERS[np_umath.clip] = helper_clip
+    clip_ufunc = getattr(np_umath, "clip", None)
+if isinstance(clip_ufunc, np.ufunc):
+    UFUNC_HELPERS[_get_np_func_name(clip_ufunc)] = helper_clip
 
 del ufunc

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1003,11 +1003,13 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
     def __array_function__(self, function, types, args, kwargs):
         # TODO: go through functions systematically to see which ones
         # work and/or can be supported.
-        if function in MASKED_SAFE_FUNCTIONS:
+        function_name = _get_np_func_name(function)
+
+        if function_name in MASKED_SAFE_FUNCTIONS:
             return super().__array_function__(function, types, args, kwargs)
 
-        elif function in APPLY_TO_BOTH_FUNCTIONS:
-            helper = APPLY_TO_BOTH_FUNCTIONS[function]
+        elif function_name in APPLY_TO_BOTH_FUNCTIONS:
+            helper = APPLY_TO_BOTH_FUNCTIONS[function_name]
             try:
                 helper_result = helper(*args, **kwargs)
             except NotImplementedError:
@@ -1024,8 +1026,8 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
             mask = function(*mask_args, **kwargs)
             result = function(*data_args, **kwargs)
 
-        elif function in DISPATCHED_FUNCTIONS:
-            dispatched_function = DISPATCHED_FUNCTIONS[function]
+        elif function_name in DISPATCHED_FUNCTIONS:
+            dispatched_function = DISPATCHED_FUNCTIONS[function_name]
             try:
                 dispatched_result = dispatched_function(*args, **kwargs)
             except NotImplementedError:
@@ -1036,11 +1038,11 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
 
             result, mask, out = dispatched_result
 
-        elif function in UNSUPPORTED_FUNCTIONS:
+        elif function_name in UNSUPPORTED_FUNCTIONS:
             return NotImplemented
 
         else:  # pragma: no cover
-            # By default, just pass it through for now.
+                # By default, just pass it through for now.
             return super().__array_function__(function, types, args, kwargs)
 
         if mask is None:

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -14,6 +14,8 @@ import warnings
 
 import numpy as np
 
+from astropy.utils.compat.numpy import _get_np_func_name
+from astropy.units.quantity_helper.function_helpers import FunctionAssigner
 from astropy.units.quantity_helper.function_helpers import FunctionAssigner
 from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_4
 
@@ -96,11 +98,11 @@ if not NUMPY_LT_2_2:
     # xref https://github.com/numpy/numpy/issues/27451
     SUPPORTED_NEP35_FUNCTIONS |= set()
     UNSUPPORTED_FUNCTIONS |= {
-        np.arange,
-        np.empty, np.ones, np.zeros, np.full,
-        np.array, np.asarray, np.asanyarray, np.ascontiguousarray, np.asfortranarray,
-        np.frombuffer, np.fromfile, np.fromfunction, np.fromiter, np.fromstring,
-        np.require, np.identity, np.eye, np.tri, np.genfromtxt, np.loadtxt,
+        "arange",
+        "empty", "ones", "zeros", "full",
+        "array", "asarray", "asanyarray", "ascontiguousarray", "asfortranarray",
+        "frombuffer", "fromfile", "fromfunction", "fromiter", "fromstring",
+        "require", "identity", "eye", "tri", "genfromtxt", "loadtxt",
     }  # fmt: skip
 
 # Almost all from np.core.fromnumeric defer to methods so are OK.
@@ -111,81 +113,81 @@ MASKED_SAFE_FUNCTIONS |= {
 }
 MASKED_SAFE_FUNCTIONS |= {
     # built-in from multiarray
-    np.may_share_memory, np.can_cast, np.min_scalar_type, np.result_type,
-    np.shares_memory,
+    "may_share_memory", "can_cast", "min_scalar_type", "result_type",
+    "shares_memory",
     # np.core.arrayprint
-    np.array_repr,
+    "array_repr",
     # np.core.function_base
-    np.linspace, np.logspace, np.geomspace,
+    "linspace", "logspace", "geomspace",
     # np.core.numeric
-    np.isclose, np.allclose, np.flatnonzero, np.argwhere,
+    "isclose", "allclose", "flatnonzero", "argwhere",
     # np.core.shape_base
-    np.atleast_1d, np.atleast_2d, np.atleast_3d, np.stack, np.hstack, np.vstack,
+    "atleast_1d", "atleast_2d", "atleast_3d", "stack", "hstack", "vstack",
     # np.lib._function_base_impl
-    np.average, np.diff, np.extract, np.meshgrid, np.gradient,
+    "average", "diff", "extract", "meshgrid", "gradient",
     # np.lib.index_tricks
-    np.diag_indices_from, np.triu_indices_from, np.tril_indices_from,
-    np.fill_diagonal,
+    "diag_indices_from", "triu_indices_from", "tril_indices_from",
+    "fill_diagonal",
     # np.lib.shape_base
-    np.column_stack, np.dstack,
-    np.array_split, np.split, np.hsplit, np.vsplit, np.dsplit,
-    np.expand_dims, np.apply_along_axis, np.kron, np.tile,
-    np.take_along_axis, np.put_along_axis,
+    "column_stack", "dstack",
+    "array_split", "split", "hsplit", "vsplit", "dsplit",
+    "expand_dims", "apply_along_axis", "kron", "tile",
+    "take_along_axis", "put_along_axis",
     # np.lib.type_check (all but nan_to_num)
-    np.iscomplexobj, np.isrealobj, np.imag, np.isreal, np.real,
-    np.real_if_close, np.common_type,
+    "iscomplexobj", "isrealobj", "imag", "isreal", "real",
+    "real_if_close", "common_type",
     # np.lib.ufunclike
-    np.fix, np.isneginf, np.isposinf,
+    "fix", "isneginf", "isposinf",
     # np.lib._function_base_impl
-    np.angle, np.i0,
+    "angle", "i0",
     # np.lib._arraysetops_impl
-    np.intersect1d, np.setxor1d, np.union1d, np.unique,
+    "intersect1d", "setxor1d", "union1d", "unique",
 }  # fmt: skip
 
 
 if NUMPY_LT_2_0:
     # Safe in < 2.0, because it deferred to the method. Overridden in >= 2.0.
-    MASKED_SAFE_FUNCTIONS |= {np.ptp}
+    MASKED_SAFE_FUNCTIONS |= {"ptp"}
     # Removed in numpy 2.0.  Just an alias to vstack.
-    MASKED_SAFE_FUNCTIONS |= {np.row_stack}  # noqa: NPY201
+    MASKED_SAFE_FUNCTIONS |= {"row_stack"}  # noqa: NPY201
     # renamed in numpy 2.0
-    MASKED_SAFE_FUNCTIONS |= {np.trapz}  # noqa: NPY201
+    MASKED_SAFE_FUNCTIONS |= {"trapz"}  # noqa: NPY201
 if not NUMPY_LT_2_0:
     # new in numpy 2.0
     MASKED_SAFE_FUNCTIONS |= {
-        np.astype, np.trapezoid,
-        np.unique_all, np.unique_counts, np.unique_inverse, np.unique_values,
+        "astype", "trapezoid",
+        "unique_all", "unique_counts", "unique_inverse", "unique_values",
     }  # fmt: skip
 if not NUMPY_LT_2_1:
     MASKED_SAFE_FUNCTIONS |= {
-        np.unstack,
+        "unstack",
     }  # fmt: skip
 IGNORED_FUNCTIONS = {
     # I/O - useless for Masked, since no way to store the mask.
-    np.save, np.savez, np.savetxt, np.savez_compressed,
+    "save", "savez", "savetxt", "savez_compressed",
     # Polynomials
-    np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
-    np.polymul, np.polysub, np.polyval, np.roots, np.vander,
+    "poly", "polyadd", "polyder", "polydiv", "polyfit", "polyint",
+    "polymul", "polysub", "polyval", "roots", "vander",
 }  # fmt: skip
 IGNORED_FUNCTIONS |= {
-    np.pad, np.searchsorted, np.digitize,
-    np.is_busday, np.busday_count, np.busday_offset,
+    "pad", "searchsorted", "digitize",
+    "is_busday", "busday_count", "busday_offset",
     # numpy.lib._function_base_impl
-    np.cov, np.corrcoef, np.trim_zeros,
+    "cov", "corrcoef", "trim_zeros",
     # numpy.core.numeric
-    np.correlate, np.convolve,
+    "correlate", "convolve",
     # numpy.lib.histograms
-    np.histogram, np.histogram2d, np.histogramdd, np.histogram_bin_edges,
+    "histogram", "histogram2d", "histogramdd", "histogram_bin_edges",
     # TODO!!
-    np.dot, np.vdot, np.inner, np.tensordot, np.cross,
-    np.einsum, np.einsum_path,
+    "dot", "vdot", "inner", "tensordot", "cross",
+    "einsum", "einsum_path",
 }  # fmt: skip
 
 # Explicitly unsupported functions
 UNSUPPORTED_FUNCTIONS |= {
-    np.unravel_index,
-    np.ravel_multi_index,
-    np.ix_,
+    "unravel_index",
+    "ravel_multi_index",
+    "ix_",
 }
 
 # No support for the functions also not supported by Quantity
@@ -250,8 +252,8 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 # same helper, because the first arguments have different names.
 @apply_to_both(
     helps=(
-        {np.copy, np.resize, np.moveaxis, np.rollaxis, np.roll}
-        | ({np.asfarray} if NUMPY_LT_2_0 else set())  # noqa: NPY201
+        {"copy", "resize", "moveaxis", "rollaxis", "roll"}
+        | ({"asfarray"} if NUMPY_LT_2_0 else set())  # noqa: NPY201
     )
 )
 def masked_a_helper(a, *args, **kwargs):
@@ -259,19 +261,19 @@ def masked_a_helper(a, *args, **kwargs):
     return (data,) + args, (mask,) + args, kwargs, None
 
 
-@apply_to_both(helps={np.flip, np.flipud, np.fliplr, np.rot90, np.triu, np.tril})
+@apply_to_both(helps={"flip", "flipud", "fliplr", "rot90", "triu", "tril"})
 def masked_m_helper(m, *args, **kwargs):
     data, mask = _get_data_and_mask_array(m)
     return (data,) + args, (mask,) + args, kwargs, None
 
 
-@apply_to_both(helps={np.diag, np.diagflat})
+@apply_to_both(helps={"diag", "diagflat"})
 def masked_v_helper(v, *args, **kwargs):
     data, mask = _get_data_and_mask_array(v)
     return (data,) + args, (mask,) + args, kwargs, None
 
 
-@apply_to_both(helps={np.delete})
+@apply_to_both(helps={"delete"})
 def masked_arr_helper(array, *args, **kwargs):
     data, mask = _get_data_and_mask_array(array)
     return (data,) + args, (mask,) + args, kwargs, None
@@ -1343,6 +1345,7 @@ if not NUMPY_LT_2_4:
     @dispatched_function
     def array2string(
         a,
+        /,
         max_line_width=None,
         precision=None,
         suppress_small=None,
@@ -1409,16 +1412,13 @@ else:
             legacy=legacy,
         )
 
-
 def _array_str_scalar(x):
     # This wraps np.array_str for use as a format function in
     # MaskedFormat. We cannot use it directly as format functions
     # expect numpy scalars, while np.array_str expects an array.
     return np.array_str(np.array(x))
 
-
-@dispatched_function
-def array_str(a, max_line_width=None, precision=None, suppress_small=None):
+def _array_str_impl(a, max_line_width=None, precision=None, suppress_small=None):
     # Override to change special treatment of array scalars, since the numpy
     # code turns the masked array scalar into a regular array scalar.
     # By going through MaskedFormat, we can replace the string as needed.
@@ -1431,11 +1431,9 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
             # Following numpy._core.arrayprint._void_scalar_to_string
             if NUMPY_LT_2_1:
                 from numpy._core.arrayprint import _format_options
-
                 options = _format_options.copy()
             else:
                 from numpy._core.printoptions import format_options
-
                 options = format_options.get().copy()
 
             if options.get("formatter") is None:
@@ -1448,6 +1446,17 @@ def array_str(a, max_line_width=None, precision=None, suppress_small=None):
             )
 
     return array2string(a, max_line_width, precision, suppress_small, " ", "")
+
+# Dispatch the version with the correct signature for NumPy 2.4+
+if not NUMPY_LT_2_4:
+    @dispatched_function
+    def array_str(a, /, max_line_width=None, precision=None, suppress_small=None):
+        return _array_str_impl(a, max_line_width, precision, suppress_small)
+else:
+    @dispatched_function
+    def array_str(a, max_line_width=None, precision=None, suppress_small=None):
+        return _array_str_impl(a, max_line_width, precision, suppress_small)
+
 
 
 # For the nanfunctions, we just treat any nan as an additional mask.
@@ -1505,7 +1514,7 @@ for nanfuncname in _nplibnanfunctions.__all__:
 
 
 @dispatched_function
-def ediff1d(ary, to_end=None, to_begin=None):
+def _ediff1d_impl(ary, to_end=None, to_begin=None):
     from astropy.utils.masked import Masked
 
     # ediff1d works fine if ary is Masked, but not if it is not (and
@@ -1515,6 +1524,14 @@ def ediff1d(ary, to_end=None, to_begin=None):
 
     return np.ediff1d.__wrapped__(ary, to_end, to_begin), None, None
 
+if not NUMPY_LT_2_4:
+    @dispatched_function
+    def ediff1d(ary, /, to_end=None, to_begin=None):
+        return _ediff1d_impl(ary, to_end, to_begin)
+else:
+    @dispatched_function
+    def ediff1d(ary, to_end=None, to_begin=None):
+        return _ediff1d_impl(ary, to_end, to_begin)
 
 def _in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
     # Copy sorting implementation from _arraysetops_impl._in1d;
@@ -1552,31 +1569,51 @@ def _copy_of_mask(a):
 
 
 if NUMPY_LT_2_4:
-
     @dispatched_function
     def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         mask = _copy_of_mask(ar1).ravel()
         return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
+else:
+    @dispatched_function
+    def in1d(ar1, ar2, /, assume_unique=False, invert=False, *, kind=None):
+        mask = _copy_of_mask(ar1).ravel()
+        return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
+    
 
-
-@dispatched_function
-def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
+def _isin_impl(element, test_elements, assume_unique=False, invert=False, *, kind=None):
     element = np.asanyarray(element)
     result = _in1d(element, test_elements, assume_unique, invert, kind=kind)
     result.shape = element.shape
     return result, _copy_of_mask(element), None
 
+if not NUMPY_LT_2_4:
+    @dispatched_function
+    def isin(element, test_elements, /, assume_unique=False, invert=False, *, kind=None):
+        return _isin_impl(element, test_elements, assume_unique, invert, kind=kind)
+else:
+    @dispatched_function
+    def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
+        return _isin_impl(element, test_elements, assume_unique, invert, kind=kind)
 
-@dispatched_function
-def setdiff1d(ar1, ar2, assume_unique=False):
-    # Again, mostly just to avoid an asarray call.
+def _setdiff1d_impl(ar1, ar2, assume_unique=False):
     if assume_unique:
         ar1 = np.asanyarray(ar1).ravel()
     else:
         ar1 = np.unique(ar1)
         ar2 = np.unique(ar2)
-    return ar1[np.isin(ar1, ar2, assume_unique=True, invert=True)], None, None
+    # Note: we use the internal _isin_impl logic here
+    mask = _copy_of_mask(ar1)
+    res, _, _ = _isin_impl(ar1, ar2, assume_unique=True, invert=True)
+    return ar1[res], mask, None
 
+if not NUMPY_LT_2_4:
+    @dispatched_function
+    def setdiff1d(ar1, ar2, /, assume_unique=False):
+        return _setdiff1d_impl(ar1, ar2, assume_unique)
+else:
+    @dispatched_function
+    def setdiff1d(ar1, ar2, assume_unique=False):
+        return _setdiff1d_impl(ar1, ar2, assume_unique)
 
 # Add any dispatched or helper function that has a docstring to
 # __all__, so they will be typeset by sphinx. The logic is that for

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1573,47 +1573,24 @@ if NUMPY_LT_2_4:
     def in1d(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         mask = _copy_of_mask(ar1).ravel()
         return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
-else:
-    @dispatched_function
-    def in1d(ar1, ar2, /, assume_unique=False, invert=False, *, kind=None):
-        mask = _copy_of_mask(ar1).ravel()
-        return _in1d(ar1, ar2, assume_unique, invert, kind=kind), mask, None
-    
 
-def _isin_impl(element, test_elements, assume_unique=False, invert=False, *, kind=None):
+@dispatched_function
+def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
     element = np.asanyarray(element)
     result = _in1d(element, test_elements, assume_unique, invert, kind=kind)
     result.shape = element.shape
     return result, _copy_of_mask(element), None
 
-if not NUMPY_LT_2_4:
-    @dispatched_function
-    def isin(element, test_elements, /, assume_unique=False, invert=False, *, kind=None):
-        return _isin_impl(element, test_elements, assume_unique, invert, kind=kind)
-else:
-    @dispatched_function
-    def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
-        return _isin_impl(element, test_elements, assume_unique, invert, kind=kind)
 
-def _setdiff1d_impl(ar1, ar2, assume_unique=False):
+@dispatched_function
+def setdiff1d(ar1, ar2, assume_unique=False):
+    # Again, mostly just to avoid an asarray call.
     if assume_unique:
         ar1 = np.asanyarray(ar1).ravel()
     else:
         ar1 = np.unique(ar1)
         ar2 = np.unique(ar2)
-    # Note: we use the internal _isin_impl logic here
-    mask = _copy_of_mask(ar1)
-    res, _, _ = _isin_impl(ar1, ar2, assume_unique=True, invert=True)
-    return ar1[res], mask, None
-
-if not NUMPY_LT_2_4:
-    @dispatched_function
-    def setdiff1d(ar1, ar2, /, assume_unique=False):
-        return _setdiff1d_impl(ar1, ar2, assume_unique)
-else:
-    @dispatched_function
-    def setdiff1d(ar1, ar2, assume_unique=False):
-        return _setdiff1d_impl(ar1, ar2, assume_unique)
+    return ar1[np.isin(ar1, ar2, assume_unique=True, invert=True)], None, None
 
 # Add any dispatched or helper function that has a docstring to
 # __all__, so they will be typeset by sphinx. The logic is that for


### PR DESCRIPTION
## MAINT: Update function helpers for NumPy 2.4 parity and import resilience

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This pull request addresses compatibility issues with the upcoming **NumPy 2.4** release and refactors the internal dispatching registry in `astropy.units` to be more resilient.

Previously, `FUNCTION_HELPERS` used NumPy function objects as dictionary keys. This caused import-time failures if a function was removed or renamed in a newer version of NumPy. By switching to **string-based keys**, we ensure that `astropy.units` remains importable even if the underlying NumPy environment changes. Additionally, this PR updates function signatures to include the positional-only argument marker (`/`) where required for parity with NumPy 2.4.

**Summary of Changes:**

### `astropy.units`
* **Registry Refactor:** Updated `FUNCTION_HELPERS` in `quantity_helper/function_helpers.py` to use function names (strings) as keys (e.g., `np.sin` -> `"sin"`).
* **Dispatcher Update:** Modified `Quantity.__array_function__` in `quantity.py` to perform lookups using `function.__name__`.
* **NumPy 2.4 Parity:** Updated method signatures for reductions (like `sum`, `mean`, `std`) in `quantity.py` to include the positional-only `/` marker.

### `astropy.utils.masked`
* **Signature Updates:** Added positional-only markers to `array2string`, `array_str`, `ediff1d`, `in1d`, `isin`, and `setdiff1d` in `function_helpers.py`.
* **Code Maintenance:** Introduced internal `_impl` functions to reduce logic duplication across NumPy version branches.
* **Version Control:** Added `NUMPY_LT_2_4` constant in `core.py` for cleaner conditional logic.

**Scope of Future Changes:**
This PR focuses on the most critical function helpers. Further changes might be needed in `astropy/utils/masked/structured.py` once the CI results identify any remaining signature mismatches in structured array handling.
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19093 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
