### PR TITLE
MAINT: move np.average to subclass safe for numpy>=2.4.1

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -48,6 +48,7 @@ from astropy.utils.compat import (
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
     NUMPY_LT_2_4,
+    NUMPY_LT_2_4_1,
 )
 
 if NUMPY_LT_2_0:
@@ -142,6 +143,8 @@ if not NUMPY_LT_2_0:
     SUBCLASS_SAFE_FUNCTIONS |= {np.trapezoid}
 if not NUMPY_LT_2_1:
     SUBCLASS_SAFE_FUNCTIONS |= {np.unstack, np.cumulative_prod, np.cumulative_sum}
+if not NUMPY_LT_2_4_1:
+    SUBCLASS_SAFE_FUNCTIONS |= {np.average}
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others
@@ -467,29 +470,27 @@ def _quantities2arrays(*args, unit_from_first=False):
     return arrays, q.unit
 
 
-@function_helper
-def average(a, axis=None, weights=None, returned=False, *, keepdims=np._NoValue):
-    # This override should no longer be needed once
-    # https://github.com/numpy/numpy/pull/30522 is merged (likely for
-    # "not NUMPY_LT_2_4_1").
+if NUMPY_LT_2_4_1:
 
-    a_value, a_unit = (_a := _as_quantity(a)).value, _a.unit
-    w_value, w_unit = (
-        (None, dimensionless_unscaled)
-        if weights is None
-        else ((_w := _as_quantity(weights)).value, _w.unit)
-    )
-    return (
-        (a_value,),
-        {
-            "axis": axis,
-            "weights": w_value,
-            "returned": returned,
-            "keepdims": keepdims,
-        },
-        ((a_unit, w_unit) if returned else a_unit),
-        None,
-    )
+    @function_helper
+    def average(a, axis=None, weights=None, returned=False, *, keepdims=np._NoValue):
+        a_value, a_unit = (_a := _as_quantity(a)).value, _a.unit
+        w_value, w_unit = (
+            (None, dimensionless_unscaled)
+            if weights is None
+            else ((_w := _as_quantity(weights)).value, _w.unit)
+        )
+        return (
+            (a_value,),
+            {
+                "axis": axis,
+                "weights": w_value,
+                "returned": returned,
+                "keepdims": keepdims,
+            },
+            ((a_unit, w_unit) if returned else a_unit),
+            None,
+        )
 
 
 def _iterable_helper(*args, out=None, **kwargs):

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -16,6 +16,7 @@ __all__ = [
     "NUMPY_LT_2_2",
     "NUMPY_LT_2_3",
     "NUMPY_LT_2_4",
+    "NUMPY_LT_2_4_1",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -27,6 +28,7 @@ NUMPY_LT_2_1 = not minversion(np, "2.1.0.dev")
 NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
 NUMPY_LT_2_4 = not minversion(np, "2.4.0.dev0")
+NUMPY_LT_2_4_1 = not minversion(np, "2.4.1.dev0")
 
 
 COPY_IF_NEEDED = False if NUMPY_LT_2_0 else None


### PR DESCRIPTION
This is a follow-up on #19055, removing the work-around for numpy>=2.4.1, since that will have my fix on the numpy side, 
https://github.com/numpy/numpy/pull/30522, https://github.com/numpy/numpy/pull/30523

This should only be merged once devdeps passes - which will likely require a rerun a few days from now, when the numpy nighties have updated. Since this is just an optimization, no need to backport, I think.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
