### PR TITLE
CI: simplify monthly builds

### DIFF
--- a/.github/workflows/ci_cron_monthly.yml
+++ b/.github/workflows/ci_cron_monthly.yml
@@ -83,6 +83,7 @@ jobs:
                                   git \
                                   g++ \
                                   pkg-config \
+                                  cython3 \
                                   python3 \
                                   python3-erfa \
                                   python3-extension-helpers \
@@ -99,9 +100,6 @@ jobs:
             echo "LONG_BIT="$(getconf LONG_BIT)
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            # cython and pyerfa versions in ubuntu repos are too old currently
-            pip install -U cython setuptools packaging
-            pip install -U --no-build-isolation pyerfa
             pip install -v --no-build-isolation -e .[test]
             pip list
             python3 -m pytest --strict-markers --pyargs astropy -m "not hypothesis"


### PR DESCRIPTION
### Description
As far as I can tell the comment justifying that we used Cython and pyerfa from PyPI instead of system packages in this env isn't true anymore. Let's see if CI agrees.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
