### PR TITLE
TST: remove detailled logs for xfailed tests in `oldestdeps`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
     # so we don't need to deal with filtering anything triggered from dependencies
     # Other options replicate the static configuration from pyproject.toml, since they
     # would otherwise be shadowed by the env variable.
-    oldestdeps: PYTEST_ADDOPTS = -Wdefault -ra --doctest-rst --strict-config --strict-markers
+    oldestdeps: PYTEST_ADDOPTS = -Wdefault --doctest-rst --strict-config --strict-markers
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree


### PR DESCRIPTION
### Description
As pointed out by @mhvk, logging everything, including xfailures, makes logs practically unsearchable. This reduces the list of things to logs from "all" ('a'), to actually important stuff: (f)ails, (E)rrors, and (X)passes 

ref: https://docs.pytest.org/en/latest/reference/reference.html#cmdoption-r
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
