### PR TITLE
Add config option to show full vector columns using numpy print options

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -431,6 +431,7 @@ class TableFormatter:
             multidim1 = tuple(n - 1 for n in multidims)
             multidims_all_ones = np.prod(multidims) == 1
             multidims_has_zero = 0 in multidims
+            multidims_size = int(np.prod(multidims))
 
         i_dashes = None
         i_centers = []  # Line indexes where content should be centered
@@ -527,6 +528,13 @@ class TableFormatter:
                 elif multidims_has_zero:
                     # Any zero dimension means there is no data to print
                     return ""
+                elif (
+                    getattr(conf, "pprint_ndarray_max_size", 0) > 0
+                    and multidims_size <= conf.pprint_ndarray_max_size
+                ):
+                    # Delegate full ndarray formatting to numpy (respects
+                    # global numpy print options such as threshold, linewidth).
+                    return str(col[idx])
                 else:
                     left = format_func(col_format, col[(idx,) + multidim0])
                     right = format_func(col_format, col[(idx,) + multidim1])

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -50,6 +50,17 @@ __all__ = [
 ]
 
 
+class ConsoleConf:
+    #: If > 0, ndarray-valued table cells with total size ≤ this are
+    #: printed in full (using numpy's print options) instead of the
+    #: compact "first .. last" representation.  A value of 0 keeps the
+    #: existing compact behavior.
+    pprint_ndarray_max_size: int = 0
+
+
+conf = ConsoleConf()
+
+
 class _IPython:
     """Singleton class given access to IPython streams, etc."""
 


### PR DESCRIPTION
Add config option to show full vector columns using numpy print options
Solves - Control display of vector columns in TimeSeries #19116


Currently, vector-valued table columns always show "first .. last", which hides middle elements. This PR adds a config option to show full arrays for small vectors, using numpy's print options.

Changes:
- Added astropy.utils.console.conf.pprint_ndarray_max_size (default: 0, backward compatible)
- Modified table formatter to use numpy printing when enabled
- Added tests

Usage:thon
from astropy.utils import console
import numpy as np

console.conf.pprint_ndarray_max_size = 3
np.set_printoptions(threshold=np.inf)
Now 3-vectors show full [1 2 3] instead of "1 .. 3"