### PR TITLE
BUG: avoid deprecated interface for mutating shape attibutes (uncertainty)

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -13,6 +13,7 @@ from numpy.lib.array_utils import normalize_axis_index
 
 from astropy import stats
 from astropy import units as u
+from astropy.utils.compat import NUMPY_LT_2_5
 
 from .function_helpers import FUNCTION_HELPERS
 
@@ -94,7 +95,10 @@ class Distribution:
         # Set our new structured dtype.
         structured.dtype = new_dtype
         # Get rid of trailing dimension of 1.
-        structured.shape = samples.shape[:-1]
+        if NUMPY_LT_2_5:
+            structured.shape = samples.shape[:-1]
+        else:
+            structured._set_shape(samples.shape[:-1])
 
         # Now view as the Distribution subclass, and finalize based on the
         # original samples (e.g., to set the unit for QuantityDistribution).

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -17,6 +17,7 @@ __all__ = [
     "NUMPY_LT_2_3",
     "NUMPY_LT_2_4",
     "NUMPY_LT_2_4_1",
+    "NUMPY_LT_2_5",
 ]
 
 # TODO: It might also be nice to have aliases to these named for specific
@@ -27,6 +28,7 @@ NUMPY_LT_2_2 = not minversion(np, "2.2.0.dev0")
 NUMPY_LT_2_3 = not minversion(np, "2.3.0.dev0")
 NUMPY_LT_2_4 = not minversion(np, "2.4.0.dev0")
 NUMPY_LT_2_4_1 = not minversion(np, "2.4.1.dev0")
+NUMPY_LT_2_5 = not minversion(np, "2.5.0.dev0")
 
 
 def __getattr__(attr):


### PR DESCRIPTION
### Description
ref #19126

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
