### PR TITLE
BUG: avoid mutation of shape attibutes (utils.masked)

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -741,13 +741,13 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
     @shape.setter
     def shape(self, shape):
         old_shape = self.shape
-        self._mask.shape = shape
+        self._mask = np.reshape(self._mask, shape)
         # Reshape array proper in try/except just in case some broadcasting
         # or so causes it to fail.
         try:
             super(MaskedNDArray, type(self)).shape.__set__(self, shape)
         except Exception as exc:
-            self._mask.shape = old_shape
+            self._mask = np.reshape(self._mask, old_shape)
             # Given that the mask reshaping succeeded, the only logical
             # reason for an exception is something like a broadcast error in
             # in __array_finalize__, or a different memory ordering between

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1426,8 +1426,10 @@ if NUMPY_LT_2_4:
 @dispatched_function
 def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
     element = np.asanyarray(element)
-    result = _in1d(element, test_elements, assume_unique, invert, kind=kind)
-    result.shape = element.shape
+    result = np.reshape(
+        _in1d(element, test_elements, assume_unique, invert, kind=kind),
+        element.shape,
+    )
     return result, _copy_of_mask(element), None
 
 


### PR DESCRIPTION
### Description
ref #19126

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
