### PR TITLE
DOC: Remove unnecessary doctest-skip

### DIFF
--- a/docs/modeling/new-fitter.rst
+++ b/docs/modeling/new-fitter.rst
@@ -64,18 +64,14 @@ entry points can be found in `setuptools' documentation <https://setuptools.read
 Plugin fitters must to extend from the `~astropy.modeling.fitting.Fitter`
 base class. For the fitter to be discovered and inserted into
 `astropy.modeling.fitting` the entry points must be inserted into
-the `astropy.modeling` entry point group
-
-.. doctest-skip::
+the `astropy.modeling` entry point group::
 
     setup(
           # ...
           entry_points = {'astropy.modeling': 'PluginFitterName = fitter_module:PlugFitterClass'}
     )
 
-This would allow users to import the ``PlugFitterName`` through `astropy.modeling.fitting` by
-
-.. doctest-skip::
+This would allow users to import the ``PlugFitterName`` through `astropy.modeling.fitting` by::
 
     from astropy.modeling.fitting import PlugFitterName
 


### PR DESCRIPTION
from new fitter doc

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to close https://github.com/astropy/astropy/issues/19134

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
