### PR TITLE
MAINT: cleanup config as there is a new release for dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -156,12 +156,9 @@ setenv =
     predeps: UV_INDEX_STRATEGY = unsafe-best-match # match pip's behavior
 
 commands =
-    # Need to install it here otherwise UV throws a hissy fit about it requiring sphinx>=9 and refuses to install the version from github
-    # Remove github url when newer than 0.1.2 is released
-    predeps: uv pip install git+https://github.com/missinglinkelectronics/sphinxcontrib-globalsubs@f4a340d5b7506aca9dcc914e9bd96d60d0d36865
-
-    # predeps: Override sphinx max pin in sphinx-design
-    predeps: uv pip install sphinx -U --pre --no-deps
+    # predeps: Override sphinx max pin in sphinx-design;
+    # we need to reinstall sphinxcontrib-globalsubs, too as it either sphinx<9 or >=9
+    predeps: uv pip install sphinx sphinxcontrib-globalsubs -U --pre
     {list_dependencies_command}
     sphinx-build \
     predeps: -W \


### PR DESCRIPTION
This PR cleansup previous workarounds from https://github.com/astropy/astropy/pull/19092 as there is in fact a [new release](https://github.com/missinglinkelectronics/sphinxcontrib-globalsubs/issues/8) for the docs dependency (but it doesn't get picked up properly as the env resolution is still stuck with older sphinx by default.


