### PR TITLE
TST: Fix MaskedNDArray shape test failures

### DIFF
--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -573,7 +573,7 @@ class TestMaskedArrayShaping(MaskedArraySetup):
 
     def test_shape_setting_failure(self):
         ma = self.ma.copy()
-        with pytest.raises(ValueError, match="cannot reshape"):
+        with pytest.raises(AttributeError, match="Incompatible shape"):
             ma.shape = (5,)
 
         assert ma.shape == self.ma.shape
@@ -581,7 +581,7 @@ class TestMaskedArrayShaping(MaskedArraySetup):
 
         # Here, mask can be reshaped but array cannot.
         ma2 = Masked(np.broadcast_to([[1.0], [2.0]], self.a.shape), mask=self.mask_a)
-        with pytest.raises(AttributeError, match="ncompatible shape"):
+        with pytest.raises(AttributeError, match="Incompatible shape"):#typo-fixed
             ma2.shape = (6,)
 
         assert ma2.shape == self.ma.shape
@@ -591,12 +591,11 @@ class TestMaskedArrayShaping(MaskedArraySetup):
         ma3 = Masked(
             self.a.copy(), mask=np.broadcast_to([[True], [False]], self.mask_a.shape)
         )
-        with pytest.raises(AttributeError, match="ncompatible shape"):
-            ma3.shape = (6,)
+        with pytest.raises(AttributeError, match="Incompatible shape"):#typo-fixed
+            ma3.shape = (5,)
 
         assert ma3.shape == self.ma.shape
         assert ma3.mask.shape == self.ma.shape
-
     def test_ravel(self):
         ma_ravel = self.ma.ravel()
         expected_data = self.a.ravel()


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
