### PR TITLE
Fix `AttributeError` when pickling unbound `DataInfo` instances

### DIFF
--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -376,10 +376,16 @@ that temporary object is now lost.  Instead force a permanent reference (e.g.
             raise TypeError("info must be set with a DataInfo instance")
 
     def __getstate__(self):
-        return self._attrs
+        # If this is an unbound descriptor, _attrs is uninitialized, so
+        # return None to indicate no state for it.
+        return getattr(self, "_attrs", None)
 
     def __setstate__(self, state):
-        self._attrs = state
+        # Only assign _attrs if state is not None. This prevents _attrs
+        # from being set to None when unpickling an object that did not
+        # originally have _attrs initialized.
+        if state is not None:
+            self._attrs = state
 
     def _represent_as_dict(self, attrs=None):
         """Get the values for the parent ``attrs`` and return as a dict. This

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pickle
+
 import numpy as np
 import pytest
 
@@ -8,7 +10,7 @@ from astropy.coordinates import SkyCoord
 from astropy.table import QTable
 from astropy.table.index import SlicedIndex
 from astropy.time import Time
-from astropy.utils.data_info import dtype_info_name
+from astropy.utils.data_info import DataInfo, dtype_info_name
 
 STRING_TYPE_NAMES = {(True, "S"): "bytes", (True, "U"): "str"}
 
@@ -106,3 +108,10 @@ def test_setting_info_name_to_with_invalid_type():
     qt["a"] = [1, 2] * u.m
     with pytest.raises(TypeError, match="Expected a str value, got 1 with type int"):
         qt["a"].info.name = 1
+
+
+def test_pickle_unbound_data_info():
+    """Test that an unbound DataInfo object can be pickled."""
+    di = DataInfo()
+    di_rt = pickle.loads(pickle.dumps(di))
+    assert isinstance(di_rt, DataInfo)

--- a/docs/changes/utils/19141.bugfix.rst
+++ b/docs/changes/utils/19141.bugfix.rst
@@ -1,0 +1,1 @@
+``AttributeError`` will no longer occur when attempting to pickle an unbound ``DataInfo`` instance.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address an `AttributeError` that occurs when attempting to pickle an unbound `DataInfo` instance, which lacks an `_attrs` attribute. This bug was identified in #16352, but was never fully resolved. I have added the fix suggested by @Jerry-Ma and a regression test based on @mhvk's test case.

Example of fixed behavior:
```python
import pickle
from astropy.utils.data_info import DataInfo
di = DataInfo()
# Previously raised AttributeError: 'DataInfo' object has no attribute '_attrs'
pickle.dumps(di)
```
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
