### PR TITLE
MNT: Refactor itertools.product in test_units.py

### DIFF
--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Regression tests for the units package."""
 
-import itertools
 import operator
 import pickle
 from contextlib import nullcontext
@@ -583,10 +582,10 @@ def test_compose_no_duplicates():
     assert len(composed) == 1
 
 
-@pytest.mark.parametrize(
-    "dtype", tuple(map("".join, itertools.product("<>", "if", "48")))
-)
-def test_endian_independence(dtype):
+@pytest.mark.parametrize("endian", ["<", ">"])
+@pytest.mark.parametrize("kind", ["i", "f"])
+@pytest.mark.parametrize("size", ["4", "8"])
+def test_endian_independence(endian, kind, size):
     """
     Regression test for #744
 
@@ -594,6 +593,7 @@ def test_endian_independence(dtype):
     converted because the dtype is '>f4', not 'float32', and the code was
     looking for the strings 'float' or 'int'.
     """
+    dtype = endian + kind + size
     x = np.array([1, 2, 3], dtype=dtype)
     assert u.m.to(u.cm, x).tolist() == [100.0, 200.0, 300.0]
 


### PR DESCRIPTION
This PR refactors the test_endian_independence function in astropy/units/tests/test_units.py as part of #18110. 
Changes:
Replaced the complex itertools.product and map call with stacked @pytest.mark.parametrize decorators.
Removed import itertools from the file as it is no longer needed.

Testing:
Verified locally that all 390 tests in test_units.py pass, including the 8 generated test cases for this specific function.