### PR TITLE
DOC: Update broken ILRS link in satellites.rst (#19112)

### DIFF
--- a/docs/coordinates/satellites.rst
+++ b/docs/coordinates/satellites.rst
@@ -4,7 +4,7 @@ Working with Earth Satellites Using Astropy Coordinates
 *******************************************************
 This document discusses Two-Line Element ephemerides and the True Equator, Mean Equinox frame.
 For satellite ephemerides given directly in geocentric ITRS coordinates
-(e.g. `ILRS ephemeris format <https://ilrs.gsfc.nasa.gov/data_and_products/formats/cpf.html>`_)
+(e.g. `ILRS ephemeris format <https://ilrs.gsfc.nasa.gov/data_and_products/formats/consolidated_prediction_format.html>`_)
 please see the example transform to `~astropy.coordinates.AltAz` below starting with
 the geocentric ITRS coordinate frame.
 


### PR DESCRIPTION
This PR fixes the broken ILRS ephemeris link in the coordinates documentation as requested in #19112.
Changes:
Updated the link in docs/coordinates/satellites.rst from the timed-out cpf.html to the current consolidated_prediction_format.html page.
Testing:
Manually verified that the new URL correctly redirects to the International Laser Ranging Service (ILRS) format specifications page.

@astropy-bot add no-changelog-entry-needed