### PR TITLE
PoC: Generic-based Physical Type hints for Quantity

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -10,6 +10,7 @@ import numbers
 import operator
 import re
 import warnings
+from typing import Generic, TypeVar
 from collections.abc import Collection
 from fractions import Fraction
 from typing import ClassVar, Self
@@ -245,8 +246,10 @@ class QuantityInfo(QuantityInfoBase):
         """
         return [self._parent]
 
+# This represents the Physical Type (Length, Time, etc.)
+D = TypeVar("D")
 
-class Quantity(np.ndarray):
+class Quantity(np.ndarray, Generic[D]):
     """A `~astropy.units.Quantity` represents a number with some associated unit.
 
     See also: https://docs.astropy.org/en/stable/units/quantity.html
@@ -2263,3 +2266,8 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         raise UnitsError("'rtol' should be dimensionless")
 
     return actual.value, desired.value, rtol.value, atol.value
+
+# Simple classes to satisfy Mypy
+class Length: pass
+class Time: pass
+class Mass: pass


### PR DESCRIPTION
This is a Proof of Concept (PoC) exploring the Generic approach for Quantity as discussed in #19034.
By inheriting from Generic[D], we allow static type checkers to see the physical dimension of a Quantity. Locally, this successfully catches unit mismatches that Annotated currently misses:

<img width="1297" height="43" alt="Screenshot 2026-01-14 011201" src="https://github.com/user-attachments/assets/f243a348-0c10-4890-8eea-1186f097c404" />

This implementation avoids using unit instances as types, addressing the concern that "units are not types".
