### PR TITLE
Fix testing pickle protocol versions in table unit tests

### DIFF
--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -18,7 +18,7 @@ def test_pickle_column(protocol):
         unit="cm",
         meta={"a": 1},
     )
-    cs = pickle.dumps(c)
+    cs = pickle.dumps(c, protocol=protocol)
     cp = pickle.loads(cs)
     assert np.all(cp == c)
     assert cp.attrs_equal(c)
@@ -38,7 +38,7 @@ def test_pickle_masked_column(protocol):
     c.mask[1] = True
     c.fill_value = -99
 
-    cs = pickle.dumps(c)
+    cs = pickle.dumps(c, protocol=protocol)
     cp = pickle.loads(cs)
 
     assert np.all(cp._data == c._data)
@@ -54,7 +54,7 @@ def test_pickle_multidimensional_column(protocol):
 
     a = np.zeros((3, 2))
     c = Column(a, name="a")
-    cs = pickle.dumps(c)
+    cs = pickle.dumps(c, protocol=protocol)
     cp = pickle.loads(cs)
 
     assert np.all(c == cp)
@@ -87,7 +87,7 @@ def test_pickle_table(protocol):
         t["d"] = Time(["2001-01-02T12:34:56", "2001-02-03T00:01:02"])
         t["e"] = SkyCoord([125.0, 180.0] * deg, [-45.0, 36.5] * deg)
 
-        ts = pickle.dumps(t)
+        ts = pickle.dumps(t, protocol=protocol)
         tp = pickle.loads(ts)
 
         assert tp.__class__ is table_class
@@ -129,7 +129,7 @@ def test_pickle_masked_table(protocol):
     t["a"].mask[1] = True
     t["a"].fill_value = -99
 
-    ts = pickle.dumps(t)
+    ts = pickle.dumps(t, protocol=protocol)
     tp = pickle.loads(ts)
 
     for colname in ("a", "b"):
@@ -148,7 +148,7 @@ def test_pickle_indexed_table(protocol):
     t = simple_table()
     t.add_index("a")
     t.add_index(["a", "b"])
-    ts = pickle.dumps(t)
+    ts = pickle.dumps(t, protocol=protocol)
     tp = pickle.loads(ts)
 
     assert len(t.indices) == len(tp.indices)

--- a/docs/changes/table/19153.bugfix.rst
+++ b/docs/changes/table/19153.bugfix.rst
@@ -1,0 +1,1 @@
+``astropy.table`` unit tests for pickling now test all appropriate pickle protocol versions instead of only the default.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

The `table` unit tests for pickling currently iterate through multiple pickle protocol versions with a fixture, but the `pickle.dumps()` call inside the tests does not actually use this protocol. Currently, only the default protocol is being tested. I updated the tests to explicitly pass the `protocol` argument from the fixture.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
