### PR TITLE
TYP: add ``scipy-stubs`` as ``typing`` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ test_all = [
 ]
 typing = [
     "pandas-stubs>=2.0.2",
+    "scipy-stubs>=1.14.1.6",
     "narwhals>=1.42.0" # keep in sync with dependency-groups.dataframe
 ]
 docs = [


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Hi there! I noticed that astropy uses SciPy [quite a lot](https://github.com/search?q=repo%3Aastropy%2Fastropy%20scipy&type=code), and that you're also serious about static typing, so I figured that you might also be interested in adding [`scipy-stubs`](https://github.com/scipy/scipy-stubs/) alongside `pandas-stubs` under the `typing` dependency group :)

At the earliest it supports SciPy 1.14.1, while astropy currently supports `scipy>=1.13`. But considering that `scipy-stubs` isn't a dependency, I was hoping that wouldn't be a deal-breaker here.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
