### PR TITLE
TST: selectively ignore deprecation warnings for numpy.fix (deprecated in 2.5dev)

### DIFF
--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -859,6 +859,7 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_around(self):
         self.check(np.around)
 
+    @pytest.mark.filterwarnings("ignore:numpy.fix is deprecated:DeprecationWarning")
     def test_fix(self):
         self.check(np.fix)
 

--- a/astropy/utils/masked/tests/test_function_helpers.py
+++ b/astropy/utils/masked/tests/test_function_helpers.py
@@ -696,6 +696,7 @@ class TestMethodLikes(MaskedArraySetup):
 
 
 class TestUfuncLike(InvariantMaskTestSetup):
+    @pytest.mark.filterwarnings("ignore:numpy.fix is deprecated:DeprecationWarning")
     def test_fix(self):
         self.check(np.fix)
         # Check np.fix with out argument for completeness


### PR DESCRIPTION
### Description
xref https://github.com/numpy/numpy/pull/30644

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
