### PR TITLE
Backport PR 19158 to branch v7.2.x (BUG/TST: avoid (or accept) NumPy deprecation warnings for mutating shape attributes in utils.masked)

### DIFF
--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -24,6 +24,7 @@ else:
     import numpy._core as np_core
     from numpy.lib._function_base_impl import _quantile_is_valid, _ureduce
 
+from astropy.utils.compat import NUMPY_LT_2_5
 
 # This module should not really be imported, but we define __all__
 # such that sphinx can typeset the functions with docstrings.
@@ -1563,7 +1564,10 @@ if NUMPY_LT_2_4:
 def isin(element, test_elements, assume_unique=False, invert=False, *, kind=None):
     element = np.asanyarray(element)
     result = _in1d(element, test_elements, assume_unique, invert, kind=kind)
-    result.shape = element.shape
+    if NUMPY_LT_2_5:
+        result.shape = element.shape
+    else:
+        result._set_shape(element.shape)
     return result, _copy_of_mask(element), None
 
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Longitude
 from astropy.units import Quantity
-from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_2, NUMPY_LT_2_3
+from astropy.utils.compat import NUMPY_LT_2_0, NUMPY_LT_2_1, NUMPY_LT_2_2, NUMPY_LT_2_3
 from astropy.utils.compat.optional_deps import HAS_PLT
 from astropy.utils.masked import Masked, MaskedNDArray
 
@@ -304,8 +304,11 @@ class TestMaskedNDArraySubclassCreation:
 
     def test_viewing_independent_shape(self):
         mms = Masked(self.a, mask=self.m)
-        mms2 = mms.view()
-        mms2.shape = mms2.shape[::-1]
+        if NUMPY_LT_2_1:
+            mms2 = mms.view()
+            mms2.shape = mms2.shape[::-1]
+        else:
+            mms2 = np.reshape(mms, mms.shape[::-1], copy=False)
         assert mms2.shape == mms.shape[::-1]
         assert mms2.mask.shape == mms.shape[::-1]
         # This should not affect the original array!
@@ -563,14 +566,21 @@ class TestMaskedArrayShaping(MaskedArraySetup):
         assert_array_equal(ma_reshape.mask, expected_mask)
 
     def test_shape_setting(self):
-        ma_reshape = self.ma.copy()
-        ma_reshape.shape = (6,)
+        if NUMPY_LT_2_1:
+            ma_reshape = self.ma.copy()
+            ma_reshape.shape = (6,)
+        else:
+            ma_reshape = np.reshape(self.ma, (6,), copy=True)
+
         expected_data = self.a.reshape((6,))
         expected_mask = self.mask_a.reshape((6,))
         assert ma_reshape.shape == expected_data.shape
         assert_array_equal(ma_reshape.unmasked, expected_data)
         assert_array_equal(ma_reshape.mask, expected_mask)
 
+    @pytest.mark.filterwarnings(
+        "default:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning"
+    )
     def test_shape_setting_failure(self):
         ma = self.ma.copy()
         with pytest.raises(ValueError, match="cannot reshape"):


### PR DESCRIPTION
### Description
Manual backport for #19158

(cherry picked from commit 7cc5a2c0c7bb0fd0ecf89bbf12315184c89a4d94)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
