### PR TITLE
BUG: avoid deprecated shape mutation APIs in coordinates (2)

### DIFF
--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -315,7 +315,9 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None, get_velocity=True):
                     ):
                         body_p_or_v += p_or_v
 
-            body_posvel_bary.shape = body_posvel_bary.shape[:2] + jd1_shape
+            body_posvel_bary = np.reshape(
+                body_posvel_bary, body_posvel_bary.shape[:2] + jd1_shape
+            )
             body_pos_bary = CartesianRepresentation(
                 body_posvel_bary[0], unit=u.km, copy=False
             )


### PR DESCRIPTION
### Description
ref #19126
follow up to #19127
ported from #19184


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
