### PR TITLE
Bugfix for Parameter.value erroring if internal value state is None.

### DIFF
--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -353,7 +353,7 @@ class Parameter:
             else:
                 value = self._getter(self._internal_value)
 
-        if value.size == 1:
+        if value is not None and value.size == 1:
             # return scalar number as np.float64 object
             return np.float64(value.item())
 

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -1248,3 +1248,17 @@ def test_setter():
 
     for x, y in pars:
         np.testing.assert_almost_equal(model(x, y), (x + 1) ** 2 + (y - np.pi * 3) ** 2)
+
+
+def test_none_parameter():
+    """
+    When Parameter internal value is None, the value property should also be
+    NaN.
+
+    See issue #19188
+    """
+    param = Parameter()
+    # Internal value is None
+    assert param._value is None
+
+    assert np.isnan(param.value)

--- a/docs/changes/modeling/19189.bugfix.rst
+++ b/docs/changes/modeling/19189.bugfix.rst
@@ -1,0 +1,1 @@
+Bugfix for ``Parameter.value`` accessor when the parameter value has not been set yet.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes the access of `Parameter.value` when the parameter instance has not set its internal value. Currently this errors because it is expecting the internal value state to be a numpy array, but it can also be `None`. This adjusts the behavior to return a NaN value.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19188

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
