### PR TITLE
TST: upgrade free-threaded weekly job to CPython 3.14t

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -70,10 +70,13 @@ jobs:
             python: '3.14'
             toxenv: py314-test-devpytest
 
-          - name: Python 3.13t (free-threading) with recommended dependencies
+          - name: Python 3.14t (free-threading) with recommended dependencies
             os: ubuntu-latest
-            python: '3.13t'
-            toxenv: py313t-test-recdeps
+            python: '3.14t'
+            toxenv: py314t-test-recdeps
+            PYTHON_GIL: 0
+            # https://github.com/astropy/astropy/issues/19205
+            PYTHON_CONTEXT_AWARE_WARNINGS: 0
 
           - name: Documentation link check
             os: ubuntu-latest
@@ -103,6 +106,9 @@ jobs:
       run: python -m pip install --upgrade tox
     - name: Run tests
       run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
+      env:
+        PYTHON_GIL: ${{ matrix.PYTHON_GIL }}
+        PYTHON_CONTEXT_AWARE_WARNINGS: ${{ matrix.PYTHON_CONTEXT_AWARE_WARNINGS }}
 
 
   tests_more_architectures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,313t,314,dev}-test{,-recdeps,-docdeps,-alldeps,-oldestdeps,-devdeps,-devpytest,-predeps,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,314,314t,dev}-test{,-recdeps,-docdeps,-alldeps,-oldestdeps,-devdeps,-devpytest,-predeps,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -14,7 +14,7 @@ minversion = 4.22 # for dependency_groups # keep in sync with pyproject.toml
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
-passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI,PY_COLORS
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI,PY_COLORS,PYTHON_GIL,PYTHON_CONTEXT_AWARE_WARNINGS
 
 setenv =
     NUMPY_WARN_IF_NO_MEM_POLICY = 1


### PR DESCRIPTION
### Description
taken out of #18186
experimental at the time of opening. Last time this was tried, about 800 tests (seemingly all using `pytest.warns`) failed with some variation of `Failed: DID NOT WARN.` I do not know off hand a reason to expect 3.14t to behave differently than 3.13t with respect to warnings, but maybe that's a side effect of setting `PYTHON_GIL=0`. Any way, I'll dig into this.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
