### PR TITLE
BUG: a avoid deprecation warning from numpy.char.chararray (table)

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1148,7 +1148,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     def tolist(self):
         if self.dtype.kind == "S":
-            return np.char.chararray.decode(self, encoding="utf-8").tolist()
+            return np.char.decode(self, encoding="utf-8").tolist()
         else:
             return super().tolist()
 


### PR DESCRIPTION
### Description
ref #19216

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
