### PR TITLE
Backport PR 19199 onto v7.2.x (API,BUG: support user dtypes in table columns)

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -1008,7 +1008,7 @@ def get_descrs(arrays, col_name_map):
 
         # Output dtype is the superset of all dtypes in in_arrays
         try:
-            dtype = common_dtype(in_cols)
+            dtype = result_type(in_cols)
         except TableMergeError as tme:
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
@@ -1030,7 +1030,7 @@ def get_descrs(arrays, col_name_map):
     return out_descrs
 
 
-def common_dtype(cols):
+def result_type(cols):
     """
     Use numpy to find the common dtype for a list of columns.
 
@@ -1038,7 +1038,7 @@ def common_dtype(cols):
     np.bool_, np.object_, np.number, np.character, np.void
     """
     try:
-        return metadata.common_dtype(cols)
+        return metadata.utils.result_type(cols)
     except metadata.MergeConflictError as err:
         tme = TableMergeError(f"Columns have incompatible types {err._incompat_types}")
         tme._incompat_types = err._incompat_types
@@ -1085,7 +1085,7 @@ def _get_join_sort_idxs(keys, left, right):
             sort_right[sort_key] = right_sort_col
 
             # Build up dtypes for the structured array that gets sorted.
-            dtype_str = common_dtype([left_sort_col, right_sort_col])
+            dtype_str = result_type([left_sort_col, right_sort_col])
             sort_keys_dtypes.append((sort_key, dtype_str))
             ii += 1
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from astropy import table
 from astropy import units as u
@@ -33,7 +34,7 @@ from astropy.timeseries import TimeSeries
 from astropy.units.quantity import Quantity
 from astropy.utils import metadata
 from astropy.utils.compat import NUMPY_LT_2_0
-from astropy.utils.compat.optional_deps import HAS_SCIPY
+from astropy.utils.compat.optional_deps import HAS_NUMPY_QUADDTYPE, HAS_SCIPY
 from astropy.utils.masked import Masked
 from astropy.utils.metadata import MergeConflictError
 
@@ -2625,3 +2626,16 @@ def test_empty_skycoord_vstack():
     table2 = table.vstack([table1, table1])  # Used to fail.
     assert len(table2) == 0
     assert isinstance(table2["foo"], SkyCoord)
+
+
+@pytest.mark.skipif(not HAS_NUMPY_QUADDTYPE, reason="Tests QuadDtype")
+def test_user_dtype_vstack():
+    # Regression test for gh-19197
+    from numpy_quaddtype import QuadPrecDType
+
+    c = Column([1, 2], dtype=QuadPrecDType()) + 1e-25
+    t = Table([c], names=["c"])
+    t2 = table.vstack([t, t])  # This used to fail
+    assert t2["c"].dtype == c.dtype
+    assert_array_equal(t2[:2]["c"], c)
+    assert_array_equal(t2[2:]["c"], c)

--- a/astropy/utils/compat/optional_deps.py
+++ b/astropy/utils/compat/optional_deps.py
@@ -32,6 +32,7 @@ _optional_deps = [
     "matplotlib",
     "mpmath",
     "narwhals",
+    "numpy_quaddtype",
     "pandas",
     "PIL",
     "polars",

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -738,7 +738,7 @@ class BaseColumnInfo(DataInfo):
             )
 
         # Output dtype is the superset of all dtypes in in_cols
-        out["dtype"] = metadata.common_dtype(cols)
+        out["dtype"] = metadata.utils.result_type(cols)
 
         # Make sure all input shapes are the same
         uniq_shapes = {col.shape[1:] for col in cols}

--- a/astropy/utils/metadata/merge.py
+++ b/astropy/utils/metadata/merge.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import numpy as np
 
 from .exceptions import MergeConflictError, MergeConflictWarning
-from .utils import common_dtype
+from .utils import result_type
 
 __all__ = [
     "MERGE_STRATEGIES",
@@ -130,7 +130,7 @@ class MergeNpConcatenate(MergeStrategy):
     @classmethod
     def merge(cls, left, right):
         left, right = np.asanyarray(left), np.asanyarray(right)
-        common_dtype([left, right])  # Ensure left and right have compatible dtype
+        result_type([left, right])  # Ensure left and right have compatible dtype
         return np.concatenate([left, right])
 
 

--- a/docs/changes/table/19199.bugfix.rst
+++ b/docs/changes/table/19199.bugfix.rst
@@ -1,0 +1,2 @@
+Tables can now be joined and stacked also if they contain columns with
+user-defined data types such as ``QuadPrecDtype``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ test_all = [
     "sgp4>=2.3",
     "array-api-strict>=1.0",
     "array-api-strict<2.4;python_version<'3.12'",  # PYTHON_LT_3_12
+    "numpy-quaddtype>=1.0",
 ]
 typing = [
     "pandas-stubs>=2.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,7 @@ deps =
     devdeps-!noscipy: sgp4>=2.3
     devdeps-!noscipy: array-api-strict>=1.0
     py311-devdeps-!noscipy: array-api-strict<2.4
+    devdeps-!noscipy: numpy-quaddtype>=1.0
 
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed.
 # test_all does not work here due to upstream bug https://github.com/tox-dev/tox/issues/3433


### PR DESCRIPTION
Backport of https://github.com/astropy/astropy/pull/19199 onto v7.2.x

API,BUG: support user dtypes in table columns

(cherry picked from commit 66a32acd10b97c1bac63b0e1abd826f692246216)

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
