### PR TITLE
Prevent XXE in SAMP XML-RPC communication

### DIFF
--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -19,7 +19,7 @@ from .constants import SAMP_STATUS_OK, __profile_version__
 from .errors import SAMPHubError, SAMPProxyError, SAMPProxyTimeoutError, SAMPWarning
 from .lockfile_helpers import create_lock_file, read_lockfile
 from .standard_profile import ThreadingXMLRPCServer
-from .utils import ServerProxyPool, _HubAsClient, internet_on
+from .utils import SAMPXXEServerProxy, ServerProxyPool, _HubAsClient, internet_on
 from .web_profile import WebProfileXMLRPCServer, web_profile_text_dialog
 
 __all__ = ["SAMPHubServer", "WebProfileDialog"]
@@ -744,7 +744,7 @@ class SAMPHubServer:
             server_proxy_pool = None
 
             server_proxy_pool = ServerProxyPool(
-                self._pool_size, xmlrpc.ServerProxy, xmlrpc_addr, allow_none=1
+                self._pool_size, SAMPXXEServerProxy, xmlrpc_addr, allow_none=1
             )
 
             public_id = self._private_keys[private_key][0]

--- a/astropy/samp/hub_proxy.py
+++ b/astropy/samp/hub_proxy.py
@@ -6,7 +6,7 @@ import xmlrpc.client as xmlrpc
 
 from .errors import SAMPHubError
 from .lockfile_helpers import get_main_running_hub
-from .utils import ServerProxyPool
+from .utils import SAMPXXEServerProxy, ServerProxyPool
 
 __all__ = ["SAMPHubProxy"]
 
@@ -65,7 +65,7 @@ class SAMPHubProxy:
             url = hub_params["samp.hub.xmlrpc.url"].replace("\\", "")
 
             self.proxy = ServerProxyPool(
-                pool_size, xmlrpc.ServerProxy, url, allow_none=1
+                pool_size, SAMPXXEServerProxy, url, allow_none=1
             )
 
             self.ping()

--- a/astropy/samp/lockfile_helpers.py
+++ b/astropy/samp/lockfile_helpers.py
@@ -17,6 +17,7 @@ from astropy import log
 from astropy.utils.data import get_readable_fileobj
 
 from .errors import SAMPHubError, SAMPWarning
+from .utils import SAMPXXEServerProxy
 
 
 def read_lockfile(lockfilename):
@@ -210,7 +211,7 @@ def check_running_hub(lockfilename):
 
     if "samp.hub.xmlrpc.url" in lockfiledict:
         try:
-            proxy = xmlrpc.ServerProxy(
+            proxy = SAMPXXEServerProxy(
                 lockfiledict["samp.hub.xmlrpc.url"].replace("\\", ""), allow_none=1
             )
             proxy.samp.hub.ping()

--- a/astropy/samp/standard_profile.py
+++ b/astropy/samp/standard_profile.py
@@ -10,6 +10,7 @@ from xmlrpc.server import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer
 
 from .constants import SAMP_ICON
 from .errors import SAMPWarning
+from .utils import safe_xmlrpc_loads
 
 __all__ = []
 
@@ -53,7 +54,7 @@ class SAMPSimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
                 size_remaining -= len(L[-1])
             data = b"".join(L)
 
-            params, method = xmlrpc.loads(data)
+            params, method = safe_xmlrpc_loads(data)
 
             if method == "samp.webhub.register":
                 params = list(params)

--- a/astropy/samp/tests/web_profile_test_helpers.py
+++ b/astropy/samp/tests/web_profile_test_helpers.py
@@ -7,7 +7,7 @@ from astropy.samp.errors import SAMPClientError, SAMPHubError
 from astropy.samp.hub import WebProfileDialog
 from astropy.samp.hub_proxy import SAMPHubProxy
 from astropy.samp.integrated_client import SAMPIntegratedClient
-from astropy.samp.utils import ServerProxyPool
+from astropy.samp.utils import SAMPXXEServerProxy, ServerProxyPool
 
 
 class AlwaysApproveWebProfileDialog(WebProfileDialog):
@@ -51,7 +51,7 @@ class SAMPWebHubProxy(SAMPHubProxy):
         try:
             self.proxy = ServerProxyPool(
                 pool_size,
-                xmlrpc.ServerProxy,
+                SAMPXXEServerProxy,
                 f"http://127.0.0.1:{web_port}",
                 allow_none=1,
             )

--- a/docs/changes/samp/19231.bugfix.rst
+++ b/docs/changes/samp/19231.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an XML External Entity (XXE) vulnerability in SAMP XML-RPC communication by disabling external entity resolution.


### PR DESCRIPTION
I implemented a safe XML-RPC unmarshaller and server proxy to prevent XXE vulnerabilities in the SAMP module. 

The standard `xmlrpc.client.loads` and `xmlrpc.client.ServerProxy` use the `xml.parsers.expat` parser, which by default can be vulnerable to external entity resolution. By subclassing `Unmarshaller` and explicitly setting `ExternalEntityRefHandler` to `None` on the underlying expat parser, I ensured that external entities are ignored without introducing any new dependencies like `defusedxml`.

I've updated the following files to use this new secure implementation:
- `standard_profile.py`: For handling incoming SAMP requests.
- `hub.py`, `hub_proxy.py`, and `lockfile_helpers.py`: For client-side communication with hubs.

Verified the fix with a standalone test script that attempts to resolve a local external entity. The entity was successfully ignored.

Fix https://github.com/astropy/astropy/issues/19220