### PR TITLE
DEP/TST: add missing lower bound on direct test dependency hypothesis (v7.2.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ all = [
 # The base set of test-time dependencies.
 test = [
     "coverage>=6.4.4",
+    "hypothesis>=6.84.0",
     "pre-commit>=2.9.3", # lower bound is not tested beyond installation
     "pytest>=8.0.0",
     "pytest-doctestplus>=1.4.0",


### PR DESCRIPTION
### Description
Hopefully resolves #19234
Incidentally, partially backports #18896

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
