### PR TITLE
DOC: fix spelling mistakes in comments

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1235,7 +1235,7 @@ def _try_url_open(
 
     # Always try first with a secure connection
     # _build_urlopener uses lru_cache, so the ssl_context argument must be
-    # converted to a hashshable type (a set of 2-tuples)
+    # converted to a hashable type (a set of 2-tuples)
     ssl_context = frozenset(ssl_context.items() if ssl_context else [])
     urlopener = _build_urlopener(
         ftp_tls=ftp_tls, ssl_context=ssl_context, allow_insecure=False

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -2417,7 +2417,7 @@ RADESYS = 'ICRS'               / Equatorial coordinate system
     def test_no_scaling_if_no_unit_changes(self):
         # This checks that if a WCS doesn't actually have units changing in
         # WCSLIB, that we aren't using the unit scaling machinery with scales
-        # all set to 1 since this would have an unecessary impact on performance.
+        # all set to 1 since this would have an unnecessary impact on performance.
 
         simple_wcs = wcs.WCS(naxis=3, preserve_units=True)
         simple_wcs.wcs.ctype = "RA---TAN", "DEC--TAN", "FREQ"


### PR DESCRIPTION
This PR corrects two minor spelling mistakes found in code comments.

The changes are limited strictly to comments and do not modify any code logic, behavior, or tests.