### PR TITLE
Fix : typos in inline comments in extern modules (no functional changes)

### DIFF
--- a/astropy/extern/configobj/validate.py
+++ b/astropy/extern/configobj/validate.py
@@ -944,7 +944,7 @@ def is_boolean(value):
         except KeyError:
             raise VdtTypeError(value)
     # we do an equality test rather than an identity test
-    # this ensures Python 2.2 compatibilty
+    # this ensures Python 2.2 compatibility
     # and allows 0 and 1 to represent True and False
     if value == False:
         return False
@@ -1231,7 +1231,7 @@ def force_list(value, min=None, max=None):
     trailing comma that turns a single value into a list.
 
     You can optionally specify the minimum and maximum number of members.
-    A minumum of greater than one will fail if the user only supplies a
+    A minimum of greater than one will fail if the user only supplies a
     string.
 
     >>> vtor.check('force_list', ())

--- a/astropy/extern/ply/ctokens.py
+++ b/astropy/extern/ply/ctokens.py
@@ -30,7 +30,7 @@ tokens = [
     # Ternary operator (?)
     'TERNARY',
 
-    # Delimeters ( ) [ ] { } , . ; :
+    # Delimiters ( ) [ ] { } , . ; :
     'LPAREN', 'RPAREN',
     'LBRACKET', 'RBRACKET',
     'LBRACE', 'RBRACE',

--- a/astropy/extern/ply/yacc.py
+++ b/astropy/extern/ply/yacc.py
@@ -1502,7 +1502,7 @@ class Grammar(object):
         self.Precedence   = {}      # Precedence rules for each terminal. Contains tuples of the
                                     # form ('right',level) or ('nonassoc', level) or ('left',level)
 
-        self.UsedPrecedence = set() # Precedence rules that were actually used by the grammer.
+        self.UsedPrecedence = set() # Precedence rules that were actually used by the grammar.
                                     # This is only used to provide error checking and to generate
                                     # a warning about unused precedence rules.
 


### PR DESCRIPTION
This PR corrects a few minor spelling mistakes in inline comments within the extern modules.

These changes are purely textual and do not affect any functionality or behavior.
