### PR TITLE
[internal] Fix minor typos in test comments

### DIFF
--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -1247,7 +1247,7 @@ def test_uninterpolated_nan_regions(boundary, normalize_kernel):
     # Test case: kernel.shape > NaN_region.shape
     nan_centroid = np.full(
         (kernel.shape[0] - 1, kernel.shape[1] - 1), np.nan
-    )  # 1 smaller than kerenel
+    )  # 1 smaller than kernel
     image = np.pad(
         nan_centroid, pad_width=kernel.shape[0] * 2, mode="constant", constant_values=1
     )

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1271,7 +1271,7 @@ def test_two_argument_useage_non_nddata_first_arg(meth):
     # Call add on the class (not the instance)
     ndd3 = getattr(NDDataArithmetic, meth)(data1, data2)
 
-    # Compare it with the instance-useage and two identical NDData-like
+    # Compare it with the instance-usage and two identical NDData-like
     # classes:
     ndd1 = NDDataArithmetic(data1)
     ndd2 = NDDataArithmetic(data2)

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -60,7 +60,7 @@ def test_median_absolute_deviation():
 
 
 def test_median_absolute_deviation_masked():
-    # Based on the changes introduces in #4658
+    # Based on the changes introduced in #4658
 
     # normal masked arrays without masked values are handled like normal
     # numpy arrays

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -669,7 +669,7 @@ def test_mad_std():
 
     # We now check this again but with the axis= keyword set since at the time
     # of writing this test this relies on a fast C implementation in which we
-    # have re-inplemented mad_std.
+    # have re-implemented mad_std.
 
     result_std = sigma_clip(
         array,


### PR DESCRIPTION
Fixes a few spelling mistakes in test comments. No functional changes.