### PR TITLE
[internal] fix: minor spelling typos in comments

### DIFF
--- a/astropy/utils/xml/unescaper.py
+++ b/astropy/utils/xml/unescaper.py
@@ -6,7 +6,7 @@ from xml.sax import saxutils
 
 __all__ = ["unescape_all"]
 
-# This is D.I.Y.
+# This is DIY
 _bytes_entities = {
     b"&amp;": b"&",
     b"&lt;": b"<",


### PR DESCRIPTION
Fix minor spelling mistakes in internal code comments. No functional changes.
