### PR TITLE
TST: autofixes for `PLW0108` (`unnecessary-lambda`)

### DIFF
--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -306,8 +306,8 @@ def test_htmlsplitter():
 @pytest.mark.parametrize(
     "get_table",
     [
-        lambda path: os.fspath(path),
-        lambda path: Path(path),
+        os.fspath,
+        Path,
         lambda path: Path(path).read_text(),
     ],
 )

--- a/astropy/io/registry/tests/test_registries.py
+++ b/astropy/io/registry/tests/test_registries.py
@@ -426,8 +426,8 @@ class TestUnifiedInputRegistry(TestUnifiedIORegistryBase):
     def test_register_readers_with_same_name_on_different_classes(self, registry):
         # No errors should be generated if the same name is registered for
         # different objects...but this failed under python3
-        registry.register_reader("test", EmptyData, lambda: EmptyData())
-        registry.register_reader("test", OtherEmptyData, lambda: OtherEmptyData())
+        registry.register_reader("test", EmptyData, EmptyData)
+        registry.register_reader("test", OtherEmptyData, OtherEmptyData)
         t = EmptyData.read(format="test", registry=registry)
         assert isinstance(t, EmptyData)
         tbl = OtherEmptyData.read(format="test", registry=registry)
@@ -1092,7 +1092,7 @@ def test_read_basic_table():
         list(zip([1, 2, 3], ["a", "b", "c"])), dtype=[("A", int), ("B", "|U1")]
     )
     try:
-        registry.register_reader("test", Table, lambda x: Table(x))
+        registry.register_reader("test", Table, Table)
     except Exception:
         pass
     else:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -411,7 +411,7 @@ def test_threaded_segfault(valid_urls):
 
     urls = list(islice(valid_urls, N_THREAD_HAMMER))
     with ThreadPoolExecutor(max_workers=len(urls)) as P:
-        list(P.map(lambda u: slurp_url(u), [u for (u, c) in urls]))
+        list(P.map(slurp_url, [u for (u, c) in urls]))
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")


### PR DESCRIPTION
### Description
ref #19261

Also note that the autofix for this rule is marked as [unsafe](https://docs.astral.sh/ruff/rules/unnecessary-lambda/#fix-safety) but I manually checked all of these substitutions and think they are actually safe.
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
