### PR TITLE
Vendored private API from narwhals

### DIFF
--- a/astropy/table/_dataframes.py
+++ b/astropy/table/_dataframes.py
@@ -204,8 +204,14 @@ def to_df(
 
     backend_impl = _get_backend_impl(backend)
 
-    # Using private API while narwhals-dev/narwhals#3150 is not merged
-    if not nw._utils.is_eager_allowed(backend_impl):
+    # Ensure eager-compatible backend
+    if backend_impl not in {
+        nw.Implementation.CUDF,
+        nw.Implementation.MODIN,
+        nw.Implementation.PANDAS,
+        nw.Implementation.POLARS,
+        nw.Implementation.PYARROW,
+    }:
         raise ValueError("Must export to eager compatible DataFrame")
 
     # Handle index argument


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

In #18435 we used a private Narhwals API with the hope that it might be exposed in the long run. As narwhals-dev/narwhals#3150 is now closed as not planned I have vendored the relevant code as suggested in narwhals-dev/narwhals#3149. This ensures more stability on the Astropy side. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
