### PR TITLE
STY: reformat lambda expressions with ruff 0.15

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -966,10 +966,10 @@ class _ValidHDU(_BaseHDU, _Verify):
 
         self.req_cards(firstkey, 0, None, firstval, option, errs)
         self.req_cards(
-            "BITPIX", 1, lambda v: (_is_int(v) and is_valid(v)), 8, option, errs
+            "BITPIX", 1, lambda v: _is_int(v) and is_valid(v), 8, option, errs
         )
         self.req_cards(
-            "NAXIS", 2, lambda v: (_is_int(v) and 0 <= v <= 999), 0, option, errs
+            "NAXIS", 2, lambda v: _is_int(v) and 0 <= v <= 999, 0, option, errs
         )
 
         naxis = self._header.get("NAXIS", 0)
@@ -979,7 +979,7 @@ class _ValidHDU(_BaseHDU, _Verify):
                 self.req_cards(
                     key,
                     ax,
-                    lambda v: (_is_int(v) and v >= 0),
+                    lambda v: _is_int(v) and v >= 0,
                     _extract_number(self._header[key], default=1),
                     option,
                     errs,
@@ -1546,10 +1546,10 @@ class ExtensionHDU(_ValidHDU):
         # Verify location and value of mandatory keywords.
         naxis = self._header.get("NAXIS", 0)
         self.req_cards(
-            "PCOUNT", naxis + 3, lambda v: (_is_int(v) and v >= 0), 0, option, errs
+            "PCOUNT", naxis + 3, lambda v: _is_int(v) and v >= 0, 0, option, errs
         )
         self.req_cards(
-            "GCOUNT", naxis + 4, lambda v: (_is_int(v) and v == 1), 1, option, errs
+            "GCOUNT", naxis + 4, lambda v: _is_int(v) and v == 1, 1, option, errs
         )
 
         return errs

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -508,16 +508,16 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
         # Verify locations and values of mandatory keywords.
         self.req_cards(
-            "NAXIS", 2, lambda v: (_is_int(v) and 1 <= v <= 999), 1, option, errs
+            "NAXIS", 2, lambda v: _is_int(v) and 1 <= v <= 999, 1, option, errs
         )
-        self.req_cards("NAXIS1", 3, lambda v: (_is_int(v) and v == 0), 0, option, errs)
+        self.req_cards("NAXIS1", 3, lambda v: _is_int(v) and v == 0, 0, option, errs)
 
         after = self._header["NAXIS"] + 3
         pos = lambda x: x >= after
 
         self.req_cards("GCOUNT", pos, _is_int, 1, option, errs)
         self.req_cards("PCOUNT", pos, _is_int, 0, option, errs)
-        self.req_cards("GROUPS", pos, lambda v: (v is True), True, option, errs)
+        self.req_cards("GROUPS", pos, lambda v: v is True, True, option, errs)
         return errs
 
     def _calculate_datasum(self):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1267,7 +1267,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         # ExtensionHDU._verify, however ExtensionHDU._verify allows PCOUNT
         # to be >= 0, so we need to check it here
         self.req_cards(
-            "PCOUNT", naxis + 3, lambda v: (_is_int(v) and v == 0), 0, option, errs
+            "PCOUNT", naxis + 3, lambda v: _is_int(v) and v == 0, 0, option, errs
         )
         return errs
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -532,12 +532,12 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                     )
                 )
 
-            self.req_cards("NAXIS", None, lambda v: (v == 2), 2, option, errs)
-            self.req_cards("BITPIX", None, lambda v: (v == 8), 8, option, errs)
+            self.req_cards("NAXIS", None, lambda v: v == 2, 2, option, errs)
+            self.req_cards("BITPIX", None, lambda v: v == 8, 8, option, errs)
             self.req_cards(
                 "TFIELDS",
                 7,
-                lambda v: (_is_int(v) and v >= 0 and v <= 999),
+                lambda v: _is_int(v) and v >= 0 and v <= 999,
                 0,
                 option,
                 errs,
@@ -787,7 +787,7 @@ class TableHDU(_TableBaseHDU):
         `TableHDU` verify method.
         """
         errs = super()._verify(option=option)
-        self.req_cards("PCOUNT", None, lambda v: (v == 0), 0, option, errs)
+        self.req_cards("PCOUNT", None, lambda v: v == 0, 0, option, errs)
         tfields = self._header["TFIELDS"]
         for idx in range(tfields):
             self.req_cards("TBCOL" + str(idx + 1), None, _is_int, None, option, errs)


### PR DESCRIPTION
### Description
ref #19261
This is a rare instance of `ruff format`'s new style being backward compatible, so might as well reformat ahead of the auto-upgrade.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
