### PR TITLE
DEP: move a constraint on array-api-strict from tox.ini to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -845,4 +845,7 @@ constraint-dependencies = [
     # via dask
     "toolz>=0.12.0", # can be removed once dask<=2025.11.0 is dropped
     "cloudpickle>=2.1.0", # can be removed once dask<2024.8.1 is dropped
+
+    # see https://github.com/astropy/astropy/issues/18292
+    "array-api-strict<2.4 ; python_version<'3.12'",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,6 @@ deps =
     devdeps-!noscipy: skyfield>=1.20
     devdeps-!noscipy: sgp4>=2.3
     devdeps-!noscipy: array-api-strict>=1.0
-    py311-devdeps-!noscipy: array-api-strict<2.4
     devdeps-!noscipy: numpy-quaddtype>=1.0
 
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed.


### PR DESCRIPTION
### Description
Follow up to #18293 now that we have a centralized place to store similar constraints.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
