### PR TITLE
DOC: Add versionchanged note for astropy config API change

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -11,10 +11,12 @@ The ``astropy`` configuration system is designed to give users control of
 various parameters used in ``astropy`` or affiliated packages without delving
 into the source code to make those changes.
 
-.. note::
-    * Before version 4.3 the configuration file was created by default
-      when importing ``astropy``. Its existence was required, which is
-      no longer the case.
+.. versionchanged:: 4.3
+   The configuration file is no longer created automatically when importing
+   ``astropy``. Users now need to explicitly create it using
+   :func:`astropy.config.create_config_file`.
+
+
 
 Getting Started
 ===============


### PR DESCRIPTION
This PR replaces a plain note with a proper ``versionchanged:: 4.3`` directive
to document the API change where the Astropy configuration file is no longer
created automatically on import.

This addresses part of #8651.
