### PR TITLE
DEP: relax lower bound on numpy-quaddtype from `>=1.0.0` to `>=0.2.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,14 @@ test_all = [
     "sgp4>=2.3",
     "array-api-strict>=1.0",
     "array-api-strict<2.4;python_version<'3.12'",  # PYTHON_LT_3_12
-    "numpy-quaddtype>=1.0",
+
+    # 0.2.2 works on *some* platforms we support, though not all
+    # 1.0.0 would be a more universal lower bound, but it also
+    # requires numpy>=2.4. Because dependency trees are resolved
+    # with *all* extras and groups (whether they are to be installed or not),
+    # and we want to preserve the ability to test against NUMPY_LT_2_4,
+    # we effectively cannot upgrade this lower bound until we drop NUMPY_LT_2_4
+    "numpy-quaddtype>=0.2.2",
 ]
 typing = [
     "pandas-stubs>=2.0.2",

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ deps =
     devdeps-!noscipy: skyfield>=1.20
     devdeps-!noscipy: sgp4>=2.3
     devdeps-!noscipy: array-api-strict>=1.0
-    devdeps-!noscipy: numpy-quaddtype>=1.0
+    devdeps-!noscipy: numpy-quaddtype>=0.2.2
 
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed.
 # test_all does not work here due to upstream bug https://github.com/tox-dev/tox/issues/3433


### PR DESCRIPTION
### Description
Fixes #19278. What remains to be seen is whether this survives CI.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
