### PR TITLE
TST: leverage tox 4.33 support for PEP 508 environment markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ dev = [
     "astropy[typing]",
 ]
 dev_all = [
-    "tox>=4.22.0", # keep in sync with tox.minversion in tox.ini
+    "tox>=4.33.0", # keep in sync with tox.minversion in tox.ini
     "astropy[dev]",
     "astropy[test_all]",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist =
     codestyle
     stubtest
 requires =
+    tox >=4.33 # for PEP 508 environment markers # keep in sync with pyproject.toml
     tox-uv
-minversion = 4.22 # for dependency_groups # keep in sync with pyproject.toml
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
@@ -18,12 +18,9 @@ passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,IS_CRON,ARCH_ON_CI,PY_COLORS
 
 setenv =
     NUMPY_WARN_IF_NO_MEM_POLICY = 1
+    COVERAGE_CORE = sysmon; python_version >= '3.12'
     # For coverage, we need to pass extra options to the C compiler
     cov: CFLAGS = --coverage -fno-inline-functions -O0
-    # opt-in faster coverage when available (requires Python >= 3.12)
-    py312: COVERAGE_CORE=sysmon
-    py313: COVERAGE_CORE=sysmon
-    py313t: COVERAGE_CORE=sysmon
     py313t: PYTHON_GIL=0
     image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data
     !image: MPLFLAGS =


### PR DESCRIPTION
### Description
As a by product of working on #19115, I learned about a couple recent changes in tox:
- `minversion` is deprecated (`deps` should be used instead)
- PEP 508 environment markers are now supported, which allow us to eliminate some of the redundancy in our configuration

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
