### PR TITLE
MNT: don't autolabel edits to `pyproject.toml` as `installation`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -65,7 +65,6 @@ installation:
   - any-glob-to-any-file:
     - docs/install.rst
     - MANIFEST.in
-    - pyproject.toml
     - setup.py
 
 Release:


### PR DESCRIPTION
### Description
we use `pyproject.toml` as the configuration file for most our tooling, so I find myself removing this label manually more often than I even need it applied.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
