### PR TITLE
DEP: bump lower bound on `packaging` from `22.0` to `25.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pyerfa>=2.0.1.3",  # for >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2026.1.26.0.43.56",
     "PyYAML>=6.0.0",
-    "packaging>=22.0.0",
+    "packaging>=25.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Description
Fixes #19288

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
