### PR TITLE
DOC: simplify instructions for generating new hash libraries

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -738,21 +738,8 @@ New hash libraries
 ------------------
 
 When adding a new tox environment for image testing, such as for a new Matplotlib
-or Python version, the tests will fail as the hash library does not exist yet. To
-generate it, you should run the tests the first time with::
-
-    tox -e <envname> -- --mpl-generate-hash-library=astropy/tests/figures/<envname>.json
-
-for example::
-
-    tox -e py311-test-image-mpl380-cov -- --mpl-generate-hash-library=astropy/tests/figures/py311-test-image-mpl380-cov.json
-
-Then add and commit the new JSON file and try running the tests again. The tests
-may fail in the continuous integration if e.g. the freetype version does not
-match or if you generated the JSON file on a Mac or Windows machine - if that is
-the case, follow the instructions in `Failing tests`_ to update the hashes.
-
-As an alternative to generating the JSON file above, you can also simply copy a
+or Python version, the tests will fail as the hash library does not exist yet.
+Instead of generating it from scratch, you can simply copy a
 previous version of the JSON file and update any failing hashes as described
 in `Failing tests`_.
 


### PR DESCRIPTION
### Description
I think this section is needlessly complicated and somewhat misleading: generating hashes locally is not generally safe and seeing differences in CI is the norm rather than the exception. In practice we're always using the *secondary* workflow to get there, so we may as well drop the other one entirely.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
