### PR TITLE
coordinates: Fix binary I/O bug in TransformGraph.to_dot_graph

### DIFF
--- a/astropy/coordinates/tests/test_graph_to_dot_graph_io.py
+++ b/astropy/coordinates/tests/test_graph_to_dot_graph_io.py
@@ -1,0 +1,43 @@
+import subprocess
+
+
+class _FakePopen:
+    """
+    Simulate graphviz subprocess:
+    - If communicate() receives str (old buggy code), raise TypeError.
+    - If receives bytes (fixed code), return binary stdout (e.g. PNG).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.returncode = 0
+
+    def communicate(self, input=None):
+        if isinstance(input, str):
+            raise TypeError("a bytes-like object is required, not 'str'")
+        return (b"PNGDATA", b"")
+
+
+def test_to_dot_graph_binary_io_regression(tmp_path, monkeypatch):
+    """
+    This test FAILS on the old implementation because it calls:
+        communicate(dotgraph_str)
+    and/or writes bytes to a text file.
+
+    It PASSES after the minimal fix:
+        communicate(dotgraph.encode(...))
+        open(savefn, "wb").write(stdout_bytes)
+        decode stderr for error message
+    """
+    from astropy.coordinates.transformations.graph import TransformGraph
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+    g = TransformGraph()
+    out = tmp_path / "graph.png"
+
+    # Key: force subprocess branch (NOT the default "plain")
+    g.to_dot_graph(savefn=str(out), savelayout="dot", saveformat="png")
+
+    assert out.read_bytes() == b"PNGDATA"

--- a/astropy/coordinates/transformations/graph.py
+++ b/astropy/coordinates/transformations/graph.py
@@ -542,12 +542,16 @@ class TransformGraph:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                 )
-                stdout, stderr = proc.communicate(dotgraph)
+                stdout, stderr = proc.communicate(dotgraph.encode("utf-8"))
                 if proc.returncode != 0:
-                    raise OSError("problem running graphviz: \n" + stderr)
+                    raise OSError(
+                        "problem running graphviz:\n"
+                        + stderr.decode("utf-8", errors="replace")
+                    )
 
-                with open(savefn, "w") as f:
+                with open(savefn, "wb") as f:
                     f.write(stdout)
+
             else:
                 raise NotImplementedError(f'savelayout="{savelayout}" is not supported')
 

--- a/docs/changes/coordinates/19302.bugfix.rst
+++ b/docs/changes/coordinates/19302.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug in ``TransformGraph.to_dot_graph`` where Graphviz was called with
+a string input instead of bytes, which could raise a ``TypeError`` on some
+platforms. The output is now written in binary mode to correctly support
+non-text formats such as PNG and PDF.


### PR DESCRIPTION
### Description

This pull request fixes a bug in `astropy.coordinates.TransformGraph.to_dot_graph`
where the DOT graph string was passed to `subprocess.communicate()` as a Python
`str` while the subprocess was opened in binary mode. On some platforms this
raises a `TypeError`, causing graph generation with Graphviz to fail.

The fix ensures that the DOT input is encoded to UTF-8 bytes before being sent
to Graphviz, and that the resulting output is written in binary mode. This
also ensures correct handling of non-text output formats such as PNG and PDF.

