### PR TITLE
units: add neperian logarithm to logarithmic units

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -379,7 +379,7 @@ class _GenericParserMixin(_ParsingFormatMixin):
             if p[1] == "sqrt":
                 p[0] = p[3] ** 0.5
                 return
-            elif p[1] in ("mag", "dB", "dex"):
+            elif p[1] in ("mag", "dB", "dex", "ln"):
                 try:
                     function_unit = cls._validate_unit(p[1])
                 except KeyError:

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -20,6 +20,8 @@ __all__ = [
     "DecibelUnit",
     "Dex",
     "DexUnit",
+    "Ln",
+    "LnUnit",
     "LogQuantity",
     "LogUnit",
     "MagUnit",
@@ -212,6 +214,48 @@ class DecibelUnit(LogUnit):
     @property
     def _quantity_class(self):
         return Decibel
+
+
+class LnUnit(LogUnit):
+    """Neperian logarithmic physical units expressed in neperian log.
+
+    Parameters
+    ----------
+    physical_unit : `~astropy.units.Unit` or `string`
+        Unit that is encapsulated within the magnitude function unit.
+        If not given, dimensionless.
+
+    function_unit :  `~astropy.units.Unit` or `string`
+        By default, this is ``ln``, but this allows one to use an equivalent
+        unit such as ``0.5 ln``.
+    """
+
+    @cached_property
+    def _default_function_unit(self):
+        from .units import ln
+
+        return ln
+
+    @property
+    def _quantity_class(self):
+        return Ln
+
+    def from_physical(self, x):
+        """Transformation from value in physical to value in neperian logarithmic units.
+        Used in equivalency.
+        """
+        # Local import to avoid circular dependency.
+        from .units import ln
+
+        return ln.to(self._function_unit, np.log(x))
+
+    def to_physical(self, x):
+        """Transformation from value in neperian logarithmic to value in physical units.
+        Used in equivalency.
+        """
+        from .units import ln
+
+        return np.exp(self._function_unit.to(ln, x))
 
 
 class LogQuantity(FunctionQuantity):
@@ -429,3 +473,7 @@ class Decibel(LogQuantity):
 
 class Magnitude(LogQuantity):
     _unit_class = MagUnit
+
+
+class Ln(LogQuantity):
+    _unit_class = LnUnit

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -17,7 +17,7 @@ import unicodedata
 from astropy.units import photometric
 from astropy.units.core import CompositeUnit, UnitBase, _add_prefixes
 
-from .logarithmic import DecibelUnit, DexUnit, MagUnit
+from .logarithmic import DecibelUnit, DexUnit, LnUnit, MagUnit
 from .mixin import IrreducibleFunctionUnit, RegularFunctionUnit
 
 __all__: list[str] = []  #  Units are added at the end
@@ -42,6 +42,9 @@ dB = RegularFunctionUnit(
     doc="Decibel: ten per base 10 logarithmic unit",
 )
 dB._function_unit_class = DecibelUnit
+
+ln = IrreducibleFunctionUnit(["ln"], namespace=_ns, doc="ln: Neperian logarithmic unit")
+ln._function_unit_class = LnUnit
 
 mag = RegularFunctionUnit(
     ["mag"],

--- a/astropy/units/tests/test_docgen.py
+++ b/astropy/units/tests/test_docgen.py
@@ -115,22 +115,22 @@ def test_unit_definition_module_function_units_summary():
     from astropy.units.function import units
 
     entries = units.__doc__.split("\n\n")
-    assert len(entries) == 14
-    assert entries[8] == "\n".join(
+    assert len(entries) == 15
+    assert entries[9] == "\n".join(
         (
             ".. list-table:: Available Magnitude Units",
             "   :header-rows: 1",
             "   :widths: 10 50 10",
         )
     )
-    assert entries[9] == "\n".join(
+    assert entries[10] == "\n".join(
         (
             "   * - Unit",
             "     - Description",
             "     - Represents",
         )
     )
-    assert entries[12] == "\n".join(
+    assert entries[13] == "\n".join(
         (
             "   * - ``M_bol``",
             "     - Absolute bolometric magnitude: M_bol=0 corresponds to :math:`\\mathrm{3.0128 \\times 10^{28}\\,W}`",


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Add the ability to use Neperian log as units.
- Added: `LnUnit(LogUnit)` and `Ln(LogQuantity)` and `ln` for the unit.
- Use the existing LogUnit, by providing the correct `from_physical` and `to_physical`.
- Extended the parser to support `Unit('ln(m)')`

Due to the insertions of the entries in the doc generated, I modified the values inside test_docgen.

I tried to extend the tests by adding a minimal testing class. I used the existing tests when possible. 


<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
