### PR TITLE
Draft: Add Power Spectra to .cosmology

### DIFF
--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -13,6 +13,7 @@ __all__ = (  #  noqa: RUF100, RUF022
     "units",
     "traits",
     "io",
+    "spectra",
     # Core
     "Cosmology",
     "CosmologyError",
@@ -66,6 +67,15 @@ from ._src.flrw import (
 )
 from ._src.funcs import cosmology_equal, z_at_value
 from ._src.parameter import Parameter
+from ._src.spectra import (
+    PowerSpectrum,
+    AnalyticalPowerSpectrum,
+    ScaleInvariantSpectrum,
+    PowerLawSpectrum,
+    RunningPowerLawSpectrum,
+    LogOscillationSpectrum,
+    BrokenPowerLawSpectrum,
+)
 from .realizations import available, default_cosmology
 
 

--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -48,14 +48,12 @@ __all__ = (  #  noqa: RUF100, RUF022
     "Planck15",
     "Planck18",
     # Spectra
+    "PowerSpectrum",
     "ScaleInvariantSpectrum",
     "PowerLawSpectrum",
-    "RunningPowerLawSpectrum",
-    "LogOscillationSpectrum",
-    "BrokenPowerLawSpectrum",
 )
 
-from . import io, realizations, traits, units
+from . import io, realizations, spectra, traits, units
 from ._src.core import Cosmology, CosmologyError, FlatCosmologyMixin
 from ._src.flrw import (
     FLRW,
@@ -73,16 +71,8 @@ from ._src.flrw import (
 )
 from ._src.funcs import cosmology_equal, z_at_value
 from ._src.parameter import Parameter
-from ._src.spectra import (
-    PowerSpectrum,
-    AnalyticalPowerSpectrum,
-    ScaleInvariantSpectrum,
-    PowerLawSpectrum,
-    RunningPowerLawSpectrum,
-    LogOscillationSpectrum,
-    BrokenPowerLawSpectrum,
-)
 from .realizations import available, default_cosmology
+from .spectra import PowerLawSpectrum, PowerSpectrum, ScaleInvariantSpectrum
 
 
 def __getattr__(name: str) -> Cosmology:

--- a/astropy/cosmology/__init__.py
+++ b/astropy/cosmology/__init__.py
@@ -47,6 +47,12 @@ __all__ = (  #  noqa: RUF100, RUF022
     "Planck13",
     "Planck15",
     "Planck18",
+    # Spectra
+    "ScaleInvariantSpectrum",
+    "PowerLawSpectrum",
+    "RunningPowerLawSpectrum",
+    "LogOscillationSpectrum",
+    "BrokenPowerLawSpectrum",
 )
 
 from . import io, realizations, traits, units

--- a/astropy/cosmology/_src/spectra.py
+++ b/astropy/cosmology/_src/spectra.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from numbers import Integral, Real
+from typing import Any
+
+import numpy as np
+
+
+def _window_tophat(x: np.ndarray) -> np.ndarray:
+    """Fourier-space spherical top-hat window.
+
+    W(x) = 3 (sin x - x cos x) / x^3
+    """
+    out = np.ones_like(x, dtype=float)
+    m = x != 0.0
+    xm = x[m]
+    out[m] = 3.0 * (np.sin(xm) - xm * np.cos(xm)) / (xm * xm * xm)
+    return out
+
+
+def _as_float_array(x: Any, *, name: str) -> np.ndarray:
+    """Convert input to a float ndarray and require positivity.
+
+    Args:
+        x: Input value(s).
+        name: Name used in error messages.
+
+    Returns
+    -------
+        Float ndarray view/copy of `x`.
+
+    Raises
+    ------
+        ValueError: If any element is <= 0.
+    """
+    arr = np.asarray(x, dtype=float)
+    if np.any(arr <= 0.0):
+        msg = f"All {name} values must be positive."
+        raise ValueError(msg)
+    return arr
+
+
+class PowerSpectrum(ABC):
+    """
+    Abstract base class for power spectrum models.
+
+    Subclasses implement `_compute_spectrum(k)` and `_compute_integral(x)`.
+
+    The public call `ps(k)` evaluates the spectrum with:
+        - an overall prefactor `prefactor = 1 / (2*pi)^ndims`
+        - an optional multiplicative `scale`
+        - an optional Gaussian cutoff exp(-(k/k_cutoff)^2)
+
+    Notes
+    -----
+        The `integrate(x)` method is intentionally *not* multiplied by the
+        prefactor again. Subclasses should define integrals in terms of the
+        evaluated spectrum `self(k)` where appropriate.
+    """
+
+    def __init__(
+        self,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        """Initialize the spectrum model.
+
+        Args:
+            ndims: Dimensionality used to define the prefactor
+                `prefactor = 1 / (2*pi)^ndims`.
+            scale: Optional multiplicative scale applied to the spectrum.
+                Defaults to 1.0.
+            k_cutoff: Optional Gaussian cutoff scale. If provided, the spectrum
+                is multiplied by exp(-(k/k_cutoff)^2).
+        """
+        self.ndims = int(ndims)
+        self.scale = 1.0 if scale is None else float(scale)
+        self.k_cutoff = None if k_cutoff is None else float(k_cutoff)
+
+        self.prefactor = 1.0 / (2.0 * np.pi) ** self.ndims
+        self.spectrum_type: str | None = None
+
+        # integration defaults
+        self.k_min = 1.0e-5
+        self.k_max = 1.0e2
+        self.nk = 4096
+
+    @abstractmethod
+    def _compute_spectrum(self, k: Any) -> Any:
+        """Compute the spectrum P(k) without prefactor/scale/cutoff.
+
+        Args:
+            k: Wavenumber(s).
+
+        Returns
+        -------
+            Spectrum values with the same shape as `k`.
+        """
+        raise NotImplementedError
+
+    def _cutoff_multiplier(self, k: Any) -> Any:
+        """
+        Compute Gaussian cutoff multiplier for the given k.
+
+        Args:
+            k: Wavenumber(s).
+
+        Returns
+        -------
+            exp(-(k/k_cutoff)^2) evaluated elementwise, or 1 if no cutoff.
+        """
+        if self.k_cutoff is None:
+            return 1.0
+
+        k_arr = np.asarray(k, dtype=float)
+        return np.exp(-(k_arr * k_arr) / (self.k_cutoff * self.k_cutoff))
+
+    def __call__(self, k: Any) -> Any:
+        """
+        Evaluate the spectrum at wavenumber(s) k.
+
+        Args:
+            k: Wavenumber(s).
+
+        Returns
+        -------
+            Evaluated spectrum including prefactor, scale, and optional cutoff.
+        """
+        base = self._compute_spectrum(k)
+        cutoff = self._cutoff_multiplier(k)
+        return self.scale * self.prefactor * base * cutoff
+
+    def integrate(self, R: Any) -> Any:
+        """Compute sigma(R) using a spherical top-hat window."""
+        R_arr = np.asarray(R, dtype=float)
+
+        if np.any(R_arr <= 0):
+            msg = "R must be positive."
+            raise ValueError(msg)
+
+        k = np.logspace(np.log10(self.k_min), np.log10(self.k_max), self.nk)
+        Pk = np.asarray(self(k), dtype=float)
+
+        k_col = k[:, None]
+        R_row = np.atleast_1d(R_arr)[None, :]
+
+        W = _window_tophat(k_col * R_row)
+
+        integrand = (k_col * k_col) * Pk[:, None] * (W * W)
+
+        sigma2 = (1.0 / (2.0 * np.pi * np.pi)) * np.trapezoid(integrand, k, axis=0)
+        sigma = np.sqrt(sigma2)
+
+        if np.ndim(R) == 0:
+            return float(sigma[0])
+
+        return sigma
+
+
+class AnalyticalPowerSpectrum(PowerSpectrum):
+    """Base class for analytical (closed-form) power spectra."""
+
+    def __init__(
+        self,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        """Initialize an analytical spectrum model.
+
+        Args:
+            ndims: Dimensionality used to define the prefactor.
+            scale: Optional multiplicative scale applied to the spectrum.
+            k_cutoff: Optional Gaussian cutoff scale.
+        """
+        super().__init__(ndims=ndims, scale=scale, k_cutoff=k_cutoff)
+        self.spectrum_type = "analytical"
+
+
+class ScaleInvariantSpectrum(AnalyticalPowerSpectrum):
+    """
+    Harrison-Zel'dovich (scale-invariant) primordial spectrum.
+
+    This spectrum is the strictly scale-invariant primordial curvature spectrum:
+
+        P(k) = A_s.
+
+    Args:
+        A_s: Amplitude (dimensionless).
+        ndims: Dimensionality used by the base prefactor.
+        scale: Optional multiplicative scale applied to the evaluated spectrum.
+        k_cutoff: Optional Gaussian cutoff scale applied to the evaluated spectrum.
+
+    References
+    ----------
+        Planck Collaboration, *Planck 2018 results. VI. Cosmological parameters*,
+        arXiv:1807.06209 (2018). Parameter conventions and typical amplitudes.
+    """
+
+    def __init__(
+        self,
+        A_s: Real = 2.1e-9,
+        *,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        super().__init__(
+            ndims=ndims,
+            scale=scale,
+            k_cutoff=k_cutoff,
+        )
+        self.A_s = float(A_s)
+
+    def _compute_spectrum(self, k: Any) -> Any:
+        k_arr = _as_float_array(k, name="k")
+        out = np.full_like(k_arr, self.A_s, dtype=float)
+
+        if np.ndim(k) == 0:
+            return float(out.item())
+
+        return out
+
+
+class PowerLawSpectrum(AnalyticalPowerSpectrum):
+    r"""Primordial power-law curvature spectrum.
+
+    Implements the standard primordial (inflationary) power-law form:
+
+        P(k) = A_s * (k / k_pivot)^(n_s - 1).
+
+    Args:
+        A_s: Primordial curvature amplitude at the pivot scale (dimensionless).
+        n_s: Scalar spectral index.
+        k_pivot: Pivot scale in the same units as k. Must be positive.
+        ndims: Dimensionality used by the base prefactor `1 / (2*pi)^ndims`.
+        scale: Optional multiplicative scale applied to the evaluated spectrum.
+        k_cutoff: Optional Gaussian cutoff scale applied to the evaluated spectrum.
+
+    Notes
+    -----
+        The common defaults `A_s=2.1e-9`, `n_s=0.965`, and `k_pivot=0.05` are
+        consistent with Planck 2018 base-ΛCDM conventions (A_s defined at
+        k = 0.05 Mpc^-1) and typical best-fit values.
+
+    References
+    ----------
+        Planck Collaboration, *Planck 2018 results. VI. Cosmological parameters*,
+        arXiv:1807.06209 (2018). (See parameter definitions: A_s at k=0.05 Mpc^-1,
+        and reported n_s ≈ 0.965.)
+    """
+
+    def __init__(
+        self,
+        A_s: Real = 2.1e-9,
+        n_s: Real = 0.965,
+        k_pivot: Real = 0.05,
+        *,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        if k_pivot <= 0:
+            msg = "k_pivot must be positive."
+            raise ValueError(msg)
+
+        super().__init__(ndims=ndims, scale=scale, k_cutoff=k_cutoff)
+        self.A_s = float(A_s)
+        self.n_s = float(n_s)
+        self.k_pivot = float(k_pivot)
+
+    def _compute_spectrum(self, k: Any) -> Any:
+        k_arr = _as_float_array(k, name="k")
+        out = self.A_s * (k_arr / self.k_pivot) ** (self.n_s - 1.0)
+
+        if np.ndim(k) == 0:
+            return float(out.item())
+
+        return out
+
+
+class RunningPowerLawSpectrum(AnalyticalPowerSpectrum):
+    r"""
+    Primordial power spectrum with running of the tilt.
+
+    Uses the common expansion:
+        ln P(k) = ln A_s + (n_s - 1) ln(k/k_pivot) + 0.5 * alpha_s [ln(k/k_pivot)]^2.
+
+    Equivalently:
+        P(k) = A_s * exp((n_s - 1)L + 0.5*alpha_s*L^2),  L = ln(k/k_pivot).
+
+    Args:
+        A_s: Amplitude at k_pivot.
+        n_s: Scalar tilt at k_pivot.
+        alpha_s: Running dn_s/dlnk at k_pivot.
+        k_pivot: Pivot scale (same units as k). Must be positive.
+        ndims: Dimensionality used by the base prefactor.
+        scale: Optional multiplicative scale applied to the evaluated spectrum.
+        k_cutoff: Optional Gaussian cutoff scale.
+
+    References
+    ----------
+        Planck Collaboration, *Planck 2018 results. VI. Cosmological parameters*,
+        arXiv:1807.06209 (2018). (Standard parameterization and constraints on
+        running in common extensions.)
+    """
+
+    def __init__(
+        self,
+        A_s: Real = 2.1e-9,
+        n_s: Real = 0.965,
+        alpha_s: Real = 0.0,
+        k_pivot: Real = 0.05,
+        *,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        if k_pivot <= 0:
+            msg = "k_pivot must be positive."
+            raise ValueError(msg)
+
+        super().__init__(ndims=ndims, scale=scale, k_cutoff=k_cutoff)
+        self.A_s = float(A_s)
+        self.n_s = float(n_s)
+        self.alpha_s = float(alpha_s)
+        self.k_pivot = float(k_pivot)
+
+    def _compute_spectrum(self, k: Any) -> Any:
+        k_arr = _as_float_array(k, name="k")
+        L = np.log(k_arr / self.k_pivot)
+        out = np.exp(
+            np.log(self.A_s) + (self.n_s - 1.0) * L + 0.5 * self.alpha_s * (L * L)
+        )
+
+        if np.ndim(k) == 0:
+            return float(out.item())
+
+        return out
+
+
+class LogOscillationSpectrum(AnalyticalPowerSpectrum):
+    r"""Power-law spectrum with a log-oscillatory feature.
+
+    P(k) = P_pl(k) * [1 + A_osc * sin(omega * ln(k/k_pivot) + phi)],
+
+    where P_pl(k) is the underlying power-law.
+
+    Args:
+        A_s: Power-law amplitude at k_pivot.
+        n_s: Power-law tilt.
+        k_pivot: Pivot scale.
+        A_osc: Oscillation amplitude (non-negative).
+        omega: Oscillation frequency in log-k.
+        phi: Phase in radians.
+        ndims: Dimensionality used by the base prefactor.
+        scale: Optional multiplicative scale applied to the evaluated spectrum.
+        k_cutoff: Optional Gaussian cutoff scale.
+
+    Notes
+    -----
+        For physical positivity of P(k), typically require A_osc << 1
+        (since 1 + A_osc*sin(...) can become negative if A_osc > 1).
+
+    References
+    ----------
+        Planck Collaboration, *Planck 2018 results. VI. Cosmological parameters*,
+        arXiv:1807.06209 (2018). (Underlying power-law primordial convention.)
+    """
+
+    def __init__(
+        self,
+        A_s: Real = 2.1e-9,
+        n_s: Real = 0.965,
+        k_pivot: Real = 0.05,
+        *,
+        A_osc: Real = 0.0,
+        omega: Real = 0.0,
+        phi: Real = 0.0,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        if k_pivot <= 0:
+            msg = "k_pivot must be positive."
+            raise ValueError(msg)
+        if A_osc < 0:
+            msg = "A_osc must be non-negative."
+            raise ValueError(msg)
+
+        super().__init__(
+            ndims=ndims,
+            scale=scale,
+            k_cutoff=k_cutoff,
+        )
+
+        self.A_s = float(A_s)
+        self.n_s = float(n_s)
+        self.k_pivot = float(k_pivot)
+        self.A_osc = float(A_osc)
+        self.omega = float(omega)
+        self.phi = float(phi)
+
+    def _compute_spectrum(self, k: Any) -> Any:
+        k_arr = _as_float_array(k, name="k")
+        pl = self.A_s * (k_arr / self.k_pivot) ** (self.n_s - 1.0)
+
+        if self.A_osc == 0.0 or self.omega == 0.0:
+            out = pl
+        else:
+            L = np.log(k_arr / self.k_pivot)
+            out = pl * (1.0 + self.A_osc * np.sin(self.omega * L + self.phi))
+
+        if np.ndim(k) == 0:
+            return float(out.item())
+
+        return out
+
+
+class BrokenPowerLawSpectrum(AnalyticalPowerSpectrum):
+    r"""
+    Broken power-law spectrum with a smooth transition.
+
+    This is a phenomenological form often used for “knee” spectra:
+
+        P(k) = A * (k/k_break)^n1 * [1 + (k/k_break)^(1/s)]^{s(n2-n1)},
+
+    where `s = smooth` controls the sharpness of the transition.
+
+    Args:
+        A: Amplitude scale.
+        k_break: Break scale (same units as k). Must be positive.
+        n1: Low-k slope exponent.
+        n2: High-k slope exponent.
+        smooth: Smoothness parameter (>0). Smaller -> sharper.
+        ndims: Dimensionality used by the base prefactor.
+        scale: Optional multiplicative scale applied to the evaluated spectrum.
+        k_cutoff: Optional Gaussian cutoff scale.
+
+    Notes
+    -----
+        The implementation uses a log-form evaluation for stability.
+
+    References
+    ----------
+        (Phenomenological; used broadly across cosmology/SGWB fitting. No single
+        canonical source. If you have a target application (PTA, strings,
+        phase transitions), we should cite that specific literature.)
+    """
+
+    def __init__(
+        self,
+        A: Real = 1.0,
+        k_break: Real = 1.0,
+        n1: Real = 0.0,
+        n2: Real = -3.0,
+        *,
+        smooth: Real = 0.1,
+        ndims: Integral = 3,
+        scale: Real | None = None,
+        k_cutoff: Real | None = None,
+    ) -> None:
+        if k_break <= 0:
+            msg = "k_break must be positive."
+            raise ValueError(msg)
+        if smooth <= 0:
+            msg = "smooth must be positive."
+            raise ValueError(msg)
+
+        super().__init__(ndims=ndims, scale=scale, k_cutoff=k_cutoff)
+        self.A = float(A)
+        self.k_break = float(k_break)
+        self.n1 = float(n1)
+        self.n2 = float(n2)
+        self.smooth = float(smooth)
+
+    def _compute_spectrum(self, k: Any) -> Any:
+        k_arr = _as_float_array(k, name="k")
+        x = k_arr / self.k_break
+
+        lnP = np.log(self.A) + self.n1 * np.log(x)
+        ln_fac = self.smooth * (self.n2 - self.n1) * np.log1p(x ** (1.0 / self.smooth))
+        out = np.exp(lnP + ln_fac)
+
+        if np.ndim(k) == 0:
+            return float(out.item())
+
+        return out

--- a/astropy/cosmology/_src/spectra.py
+++ b/astropy/cosmology/_src/spectra.py
@@ -1,13 +1,24 @@
-from __future__ import annotations
+"""Power Spectrum models and utilities."""
+
+__all__ = (
+    "AnalyticalPowerSpectrum",
+    "BrokenPowerLawSpectrum",
+    "LogOscillationSpectrum",
+    "PowerLawSpectrum",
+    "PowerSpectrum",
+    "RunningPowerLawSpectrum",
+    "ScaleInvariantSpectrum",
+)
 
 from abc import ABC, abstractmethod
 from numbers import Integral, Real
 from typing import Any
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 
 
-def _window_tophat(x: np.ndarray) -> np.ndarray:
+def _window_tophat(x: ArrayLike, /) -> NDArray[np.floating]:
     """Fourier-space spherical top-hat window.
 
     W(x) = 3 (sin x - x cos x) / x^3
@@ -140,7 +151,7 @@ class PowerSpectrum(ABC):
             msg = "R must be positive."
             raise ValueError(msg)
 
-        k = np.logspace(np.log10(self.k_min), np.log10(self.k_max), self.nk)
+        k = np.geomspace(self.k_min, self.k_max, self.nk)
         Pk = np.asarray(self(k), dtype=float)
 
         k_col = k[:, None]

--- a/astropy/cosmology/_src/spectra.py
+++ b/astropy/cosmology/_src/spectra.py
@@ -18,7 +18,7 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 
-def _window_tophat(x: ArrayLike, /) -> NDArray[np.floating]:
+def window_tophat(x: ArrayLike, /) -> NDArray[np.floating]:
     """Fourier-space spherical top-hat window.
 
     W(x) = 3 (sin x - x cos x) / x^3
@@ -143,8 +143,15 @@ class PowerSpectrum(ABC):
         cutoff = self._cutoff_multiplier(k)
         return self.scale * self.prefactor * base * cutoff
 
-    def integrate(self, R: Any) -> Any:
-        """Compute sigma(R) using a spherical top-hat window."""
+    def integrate(
+        self,
+        R: Any,
+        window_func: Any = window_tophat,
+    ) -> Any:
+        """
+        Compute sigma(R) using a window function (spherical top-hat by 
+        default).
+        """
         R_arr = np.asarray(R, dtype=float)
 
         if np.any(R_arr <= 0):
@@ -157,7 +164,7 @@ class PowerSpectrum(ABC):
         k_col = k[:, None]
         R_row = np.atleast_1d(R_arr)[None, :]
 
-        W = _window_tophat(k_col * R_row)
+        W = window_func(k_col * R_row)
 
         integrand = (k_col * k_col) * Pk[:, None] * (W * W)
 

--- a/astropy/cosmology/_src/spectra.py
+++ b/astropy/cosmology/_src/spectra.py
@@ -31,7 +31,8 @@ def window_tophat(x: ArrayLike, /) -> NDArray[np.floating]:
 
 
 def _as_float_array(x: Any, *, name: str) -> np.ndarray:
-    """Convert input to a float ndarray and require positivity.
+    """
+    Convert input to a float ndarray and require positivity.
 
     Args:
         x: Input value(s).
@@ -65,9 +66,8 @@ class PowerSpectrum(ABC):
 
     Notes
     -----
-        The `integrate(x)` method is intentionally *not* multiplied by the
-        prefactor again. Subclasses should define integrals in terms of the
-        evaluated spectrum `self(k)` where appropriate.
+        The `_compute_spectrum(k)` method is not defined by this class. 
+        Subclasses should define their implementations of this method.
     """
 
     def __init__(
@@ -100,7 +100,8 @@ class PowerSpectrum(ABC):
 
     @abstractmethod
     def _compute_spectrum(self, k: Any) -> Any:
-        """Compute the spectrum P(k) without prefactor/scale/cutoff.
+        """
+        Compute the spectrum P(k) without prefactor / scale / cutoff.
 
         Args:
             k: Wavenumber(s).
@@ -186,7 +187,8 @@ class AnalyticalPowerSpectrum(PowerSpectrum):
         scale: Real | None = None,
         k_cutoff: Real | None = None,
     ) -> None:
-        """Initialize an analytical spectrum model.
+        """
+        Initialize an analytical spectrum model.
 
         Args:
             ndims: Dimensionality used to define the prefactor.

--- a/astropy/cosmology/spectra.py
+++ b/astropy/cosmology/spectra.py
@@ -1,81 +1,16 @@
-from abc import ABC, abstractmethod
-from numbers import Integral, Real
-import numpy as np
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module contains implementations of several power spectra for cosmology.
+"""
 
+__all__ = (
+    "ScaleInvariantSpectrum",
+    "PowerLawSpectrum",
+    "RunningPowerLawSpectrum",
+    "LogOscillationSpectrum",
+    "BrokenPowerLawSpectrum",
+)
 
-class PowerSpectrum(ABC):
-    """
-    Abstract base class for power spectrum computations.
-
-    Attributes:
-    scale (float): Scale factor for the spectrum.
-    k_cutoff (float): Cutoff value for the wave number.
-    spectrum_type (str): Type of the spectrum.
-    """
-
-    def __init__(
-        self,
-        ndims: Integral = 3,
-        scale: Real = None,
-        k_cutoff: Real = None,
-    ) -> None:
-        """
-        Initializes the PowerSpectrum with the given scale and k_cutoff.
-
-        Args:
-            scale (float, optional): Scale factor for the spectrum. Defaults to 1.0.
-            k_cutoff (float, optional): Cutoff value for the wave number.
-        """
-        self.ndims = ndims
-        self.scale = scale if scale is not None else 1.
-        self.k_cutoff = k_cutoff
-        self.spectrum_type = None
-        self.f = 1 / (2 * np.pi)**self.ndims
-
-    @abstractmethod
-    def _compute_spectrum(self) -> None:
-        """
-        Abstract method to compute the power spectrum.
-
-        Args:
-            k (float): Wave number.
-
-        Raises:
-            NotImplementedError: If the method is not overridden by a subclass.
-        """
-        raise NotImplementedError("Method must be overriden by child.")
-    
-    @abstractmethod
-    def _compute_integral(self):
-        raise NotImplementedError("Method must be overriden by child.")
-
-    def _compute_cutoff(self, k: Real) -> Real:
-        """
-        Computes the cutoff function for a given wave number.
-
-        Args:
-            k (float): Wave number.
-
-        Returns:
-            float: Cutoff modifier.
-        """
-        return np.exp(- k * k / (self.k_cutoff * self.k_cutoff))
-
-    def __call__(self, k) -> Real:
-        """
-        Evaluates the power spectrum with or without the cutoff.
-
-        Args:
-            k (float): Wave number.
-
-        Returns:
-            float: Evaluated power spectrum.
-        """
-        if self.k_cutoff is None:
-            return self.f * self._compute_spectrum(k)
-        else:
-            return self.f * self._compute_spectrum(k) * self._compute_cutoff(k)
-    
-    def integrate(self, k) -> Real:
-        return self.f * self._compute_integral(k)
-    
+def __dir__():
+    """Directory, including lazily-imported objects."""
+    return __all__

--- a/astropy/cosmology/spectra.py
+++ b/astropy/cosmology/spectra.py
@@ -4,13 +4,21 @@ This module contains implementations of several power spectra for cosmology.
 """
 
 __all__ = (
-    "ScaleInvariantSpectrum",
-    "PowerLawSpectrum",
-    "RunningPowerLawSpectrum",
-    "LogOscillationSpectrum",
+    "AnalyticalPowerSpectrum",
     "BrokenPowerLawSpectrum",
+    "LogOscillationSpectrum",
+    "PowerLawSpectrum",
+    "PowerSpectrum",
+    "RunningPowerLawSpectrum",
+    "ScaleInvariantSpectrum",
 )
 
-def __dir__():
-    """Directory, including lazily-imported objects."""
-    return __all__
+from ._src.spectra import (
+    AnalyticalPowerSpectrum,
+    BrokenPowerLawSpectrum,
+    LogOscillationSpectrum,
+    PowerLawSpectrum,
+    PowerSpectrum,
+    RunningPowerLawSpectrum,
+    ScaleInvariantSpectrum,
+)

--- a/astropy/cosmology/spectra.py
+++ b/astropy/cosmology/spectra.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod
+from numbers import Integral, Real
+import numpy as np
+
+
+class PowerSpectrum(ABC):
+    """
+    Abstract base class for power spectrum computations.
+
+    Attributes:
+    scale (float): Scale factor for the spectrum.
+    k_cutoff (float): Cutoff value for the wave number.
+    spectrum_type (str): Type of the spectrum.
+    """
+
+    def __init__(
+        self,
+        ndims: Integral = 3,
+        scale: Real = None,
+        k_cutoff: Real = None,
+    ) -> None:
+        """
+        Initializes the PowerSpectrum with the given scale and k_cutoff.
+
+        Args:
+            scale (float, optional): Scale factor for the spectrum. Defaults to 1.0.
+            k_cutoff (float, optional): Cutoff value for the wave number.
+        """
+        self.ndims = ndims
+        self.scale = scale if scale is not None else 1.
+        self.k_cutoff = k_cutoff
+        self.spectrum_type = None
+        self.f = 1 / (2 * np.pi)**self.ndims
+
+    @abstractmethod
+    def _compute_spectrum(self) -> None:
+        """
+        Abstract method to compute the power spectrum.
+
+        Args:
+            k (float): Wave number.
+
+        Raises:
+            NotImplementedError: If the method is not overridden by a subclass.
+        """
+        raise NotImplementedError("Method must be overriden by child.")
+    
+    @abstractmethod
+    def _compute_integral(self):
+        raise NotImplementedError("Method must be overriden by child.")
+
+    def _compute_cutoff(self, k: Real) -> Real:
+        """
+        Computes the cutoff function for a given wave number.
+
+        Args:
+            k (float): Wave number.
+
+        Returns:
+            float: Cutoff modifier.
+        """
+        return np.exp(- k * k / (self.k_cutoff * self.k_cutoff))
+
+    def __call__(self, k) -> Real:
+        """
+        Evaluates the power spectrum with or without the cutoff.
+
+        Args:
+            k (float): Wave number.
+
+        Returns:
+            float: Evaluated power spectrum.
+        """
+        if self.k_cutoff is None:
+            return self.f * self._compute_spectrum(k)
+        else:
+            return self.f * self._compute_spectrum(k) * self._compute_cutoff(k)
+    
+    def integrate(self, k) -> Real:
+        return self.f * self._compute_integral(k)
+    

--- a/docs/changes/cosmology/19321.feature.rst
+++ b/docs/changes/cosmology/19321.feature.rst
@@ -1,0 +1,1 @@
+Add analytical primordial power spectra classes (scale-invariant, power-law, running, log-oscillatory, broken power-law) to ``astropy.cosmology`` and supporting infrastructure.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


## Add analytical cosmological power spectra to `astropy.cosmology`

This MR introduces a small framework for **analytical primordial power spectra**
and several reference implementations.

The goal is to provide lightweight analytical models commonly used in:
- pedagogical examples
- testing pipelines
- analytical cosmology workflows

## Summary of Changes

New module:
```
astropy/cosmology/power_spectra.py
```

New classes:

- `AnalyticalPowerSpectrum` (base class)
- `ScaleInvariantSpectrum`
- `PowerLawSpectrum`
- `RunningPowerLawSpectrum`
- `LogOscillationSpectrum`
- `BrokenPowerLawSpectrum`

These provide callable objects:

```python
spec = PowerLawSpectrum(A_s=2.1e-9, n_s=0.965)
Pk = spec(k)
```

All implementations are:
- NumPy-only dependable
- scalar/array compatible

## Demonstration

```
import numpy as np
import matplotlib.pyplot as plt

from astropy.cosmology import (
    BrokenPowerLawSpectrum,
    LogOscillationSpectrum,
    PowerLawSpectrum,
    RunningPowerLawSpectrum,
    ScaleInvariantSpectrum,
)

def demo_spectrum(
    spec,
    *,
    k_min=1e-4,
    k_max=1e1,
    nk=2000,
    title=None,
):
    """Plot P(k) for a spectrum instance on a log-spaced k grid."""
    k = np.logspace(np.log10(k_min), np.log10(k_max), nk)
    pk = spec(k)

    fig = plt.figure()
    ax = fig.add_subplot(111)
    ax.loglog(k, pk)

    ax.set_xlabel("k")
    ax.set_ylabel("P(k)")
    ax.set_title(title if title is not None else spec.__class__.__name__)
    ax.grid(True, which="both")
    plt.show()

spec = ScaleInvariantSpectrum(A_s=2.1e-9)
demo_spectrum(spec, title="ScaleInvariantSpectrum: P(k)=A_s")

spec = PowerLawSpectrum(A_s=2.1e-9, n_s=0.965, k_pivot=0.05)
demo_spectrum(spec, title="PowerLawSpectrum")

spec = RunningPowerLawSpectrum(A_s=2.1e-9, n_s=0.965, alpha_s=-0.005, k_pivot=0.05)
demo_spectrum(spec, title="RunningPowerLawSpectrum (alpha_s=-0.005)")

spec = LogOscillationSpectrum(
    A_s=2.1e-9,
    n_s=0.965,
    k_pivot=0.05,
    A_osc=0.05,
    omega=10.0,
    phi=0.0,
)
demo_spectrum(spec, title="LogOscillationSpectrum (A_osc=0.05, omega=10)")

spec = BrokenPowerLawSpectrum(
    A=1.0,
    k_break=0.1,
    n1=1.0,
    n2=-3.0,
    smooth=0.1,
)
demo_spectrum(spec, title="BrokenPowerLawSpectrum (k_break=0.1, n1=1, n2=-3)")

# cut-off demonstration
spec_no_cut = PowerLawSpectrum(A_s=2.1e-9, n_s=0.965, k_pivot=0.05)
spec_cut = PowerLawSpectrum(A_s=2.1e-9, n_s=0.965, k_pivot=0.05, k_cutoff=1.0)

k = np.logspace(-4, 2, 2000)
pk0 = spec_no_cut(k)
pkc = spec_cut(k)

fig = plt.figure()
ax = fig.add_subplot(111)
ax.loglog(k, pk0, label="no cutoff")
ax.loglog(k, pkc, label="k_cutoff=1.0")
ax.set_xlabel("k")
ax.set_ylabel("P(k)")
ax.set_title("Gaussian cutoff effect")
ax.grid(True, which="both")
ax.legend()
plt.show()
```