### PR TITLE
TST: updating spectral conversion test

### DIFF
--- a/astropy/coordinates/tests/test_spectral_quantity.py
+++ b/astropy/coordinates/tests/test_spectral_quantity.py
@@ -6,8 +6,8 @@ from astropy import units as u
 from astropy.coordinates.spectral_quantity import SpectralQuantity
 from astropy.tests.helper import assert_quantity_allclose
 
-SPECTRAL_UNITS = (u.GHz, u.micron, u.keV, (1 / u.nm).unit, u.km / u.s)
-SPECTRAL_UNITS_NO_VELOCITY = (u.GHz, u.micron, u.keV, (1 / u.nm).unit)
+SPECTRAL_UNITS = (u.GHz, u.micron, u.keV, u.nm**-1, u.km / u.s)
+SPECTRAL_UNITS_NO_VELOCITY = (u.GHz, u.micron, u.keV, u.nm**-1)
 
 
 class TestSpectralQuantity:


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull requests updates  test_spectral_converstion by adding a SPECTRAL_UNITS_NO_VELOCITY constant and updating the parameter to use itertools.permutations as suggested in https://github.com/astropy/astropy/pull/18859/changes#r2511111840.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #18895 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
