### PR TITLE
TST: require tox>=4.37 and clean up moot workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ dev = [
     "astropy[typing]",
 ]
 dev_all = [
-    "tox>=4.33.0", # keep in sync with tox.minversion in tox.ini
+    "tox>=4.37.0", # keep in sync with tox.minversion in tox.ini
     "astropy[dev]",
     "astropy[test_all]",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     codestyle
     stubtest
 requires =
-    tox >=4.33 # for PEP 508 environment markers # keep in sync with pyproject.toml
+    tox >=4.37 # keep in sync with pyproject.toml
     tox-uv
 
 [testenv]
@@ -98,21 +98,12 @@ deps =
     devpytest: git+https://github.com/matplotlib/pytest-mpl.git
     devpytest: git+https://github.com/astropy/pytest-astropy.git
 
-    # Duplicates test_all in pyproject.toml due to upstream bug
-    # https://github.com/tox-dev/tox/issues/3433
-    # But we cannot use alldeps because it messed up oldest-deps pins.
-    devdeps-!noscipy: objgraph>=1.6.0
-    devdeps-!noscipy: skyfield>=1.20
-    devdeps-!noscipy: sgp4>=2.3
-    devdeps-!noscipy: array-api-strict>=1.0
-    devdeps-!noscipy: numpy-quaddtype>=0.2.2
-
 # The following indicates which [project.optional-dependencies] from pyproject.toml will be installed.
-# test_all does not work here due to upstream bug https://github.com/tox-dev/tox/issues/3433
 extras =
     test: test
     recdeps: recommended
     alldeps, docdeps: all
+    devdeps-!noscipy: test_all
     docdeps: docs
 
 dependency-groups =


### PR DESCRIPTION
### Description
follow up to #17900
The issue linked in the comment has been closed in recent versions of tox. This is an attempt to clean the temporary workaround we used.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
