### PR TITLE
CLN: clean up remnants of unused and partially undefined tox env (recdeps)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,313t,314,dev}-test{,-recdeps,-docdeps,-alldeps,-oldestdeps,-devdeps,-devpytest,-predeps,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,314,dev}-test{,-docdeps,-alldeps,-oldestdeps,-devdeps,-devpytest,-predeps,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -50,7 +50,6 @@ changedir = .tmp/{envname}
 #
 description =
     run tests
-    recdeps: with recommended optional dependencies
     docdeps: with documentation dependencies
     alldeps: with all optional and test dependencies
     devdeps: with the latest developer version of key dependencies
@@ -111,7 +110,6 @@ deps =
 # test_all does not work here due to upstream bug https://github.com/tox-dev/tox/issues/3433
 extras =
     test: test
-    recdeps: recommended
     alldeps, docdeps: all
     docdeps: docs
 


### PR DESCRIPTION
### Description
Follow up to #17900 which intended to remove this factor.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
