### PR TITLE
Add dask to `docs` list for pip installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ docs = [
     "Jinja2>=3.1.3",
     "sphinxcontrib-globalsubs >= 0.1.1",
     "matplotlib>=3.9.1",  # https://github.com/matplotlib/matplotlib/issues/28234
-    "dask",
+    "dask[dataframe]>=2024.8.0", # keep in sync with dependency-groups.dataframe
 ]
 # These group together all the dependencies needed for developing in Astropy.
 dev = [
@@ -197,7 +197,7 @@ dataframe = [
     "pandas>=2.2.2",
     "polars>=1.0.0",
     "duckdb>=1.1.0",
-    "dask[dataframe]>=2024.8.0"
+    "dask[dataframe]>=2024.8.0", # keep in sync with other declarations
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
[skip ci] 

fixes #19323

Since we don't do `pip install ".[docs]" on CI, I've tested this locally and I'm skipping CI here.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
