### PR TITLE
MNT: update dependency metadata in generate_ref_ast.py

### DIFF
--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -1,18 +1,11 @@
 # /// script
-# requires-python = ">=3.10, <3.13"
+# requires-python = ">=3.10"
 # dependencies = [
-#     "starlink-pyast==3.15.4",
-#     "numpy==1.26.4",
+#     "starlink-pyast>=4.0.0",
+#     "numpy",
 #     "astropy",
 # ]
 # ///
-# above are PEP 723 script metadata for later reference, but they are
-# insufficient to run the script: starlink-pyast doesn't have wheels or proper
-# build time requirements specifications.
-# It must be build from source and without isolation, for instance, as follows
-# pip install 'numpy==1.26.4' 'setuptools==74.1.2'
-# pip install 'starlink-pyast==3.15.4' --no-build-isolation
-# pip install astropy
 """
 This series of functions are used to generate the reference CSV files
 used by the accuracy tests.  Running this as a command-line script will


### PR DESCRIPTION
### Description
Follow up to #16976 now that the upstream blockers are resolved with `starlink-pyast` 4.0.0

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
