### PR TITLE
TST: drop redundant `--strict-markers` pytest flag in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -122,10 +122,10 @@ commands =
     # docdeps-predeps: Override sphinx max pin in sphinx-design
     docdeps-predeps: uv pip install sphinx -U --pre --no-deps
     {list_dependencies_command}
-    !cov-!double: pytest --strict-markers --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
-    cov-!double: pytest --strict-markers --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
+    !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
 
-    double: pytest --keep-duplicates --strict-markers --pyargs astropy {toxinidir}/docs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    double: pytest --keep-duplicates --pyargs astropy {toxinidir}/docs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
 
 pip_pre =
     devdeps: true


### PR DESCRIPTION
### Description
This flag is already configured as addopted (i.e. always on) in `pyproject.toml`

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
