### PR TITLE
Revert "CLN: clean up remnants of unused and partially undefined tox env (recdeps)"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{311,312,313,313t,314,dev}-test{,-docdeps,-alldeps,-oldestdeps,-devdeps,-devpytest,-predeps,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
+    py{311,312,313,313t,314,dev}-test{,-recdeps,-docdeps,-alldeps,-oldestdeps,-devdeps,-devpytest,-predeps,-mpl380}{,-cov}{,-clocale}{,-fitsio}{,-noscipy}
     # Only these two exact tox environments have corresponding figure hash files.
     py311-test-image-mpl380-cov
     py311-test-image-mpldev-cov
@@ -50,6 +50,7 @@ changedir = .tmp/{envname}
 #
 description =
     run tests
+    recdeps: with recommended optional dependencies
     docdeps: with documentation dependencies
     alldeps: with all optional and test dependencies
     devdeps: with the latest developer version of key dependencies
@@ -110,6 +111,7 @@ deps =
 # test_all does not work here due to upstream bug https://github.com/tox-dev/tox/issues/3433
 extras =
     test: test
+    recdeps: recommended
     alldeps, docdeps: all
     docdeps: docs
 


### PR DESCRIPTION
Reverts astropy/astropy#19326
We (myself and reviewers) missed that this factor was actually used in weekly cron. The PR should not have been merged, but now the best thing to do is reverting. Sorry about that !