### PR TITLE
fix "_POSIX_C_SOURCE redefined" error and warnings

### DIFF
--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -25,13 +25,13 @@
  */
 
 
+#include "convolve.h"
+
 #include <assert.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stddef.h>
-
-#include "convolve.h"
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/astropy/cosmology/_src/signature_deprecations.c
+++ b/astropy/cosmology/_src/signature_deprecations.c
@@ -3,8 +3,8 @@
 // MIT. see licenses/POSITIONAL_DEFAULTS.rst
 
 
-#include <stdio.h> // snprintf
 #include <Python.h>
+#include <stdio.h> // snprintf
 #include <structmember.h>
 
 #define SINCE_CHAR_SIZE 32

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -22,12 +22,12 @@
  *     library.
  ******************************************************************************/
 
+#include <Python.h>
 #include <stdio.h>
 #include <string.h> // memcpy
 #ifndef _MSC_VER
 #  include <unistd.h> // read
 #endif
-#include <Python.h>
 #include "structmember.h"
 
 #include "expat.h"

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -6,11 +6,10 @@
 #ifndef __PYUTIL_H__
 #define __PYUTIL_H__
 
+#include <Python.h>
 #include "util.h"
 
 #define PY_ARRAY_UNIQUE_SYMBOL astropy_wcs_numpy_api
-
-#include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -5,13 +5,12 @@
 
 #define NO_IMPORT_ARRAY
 
-#include <stdlib.h> // malloc, free
-#include <string.h> // memcpy
-
 /* util.h must be imported first */
 #include "astropy_wcs/pyutil.h"
-
 #include "astropy_wcs/docstrings.h"
+
+#include <stdlib.h> // malloc, free
+#include <string.h> // memcpy
 
 #include "wcsfix.h"
 #include "wcshdr.h"

--- a/astropy/wcs/src/str_list_proxy.c
+++ b/astropy/wcs/src/str_list_proxy.c
@@ -5,8 +5,8 @@
 
 #define NO_IMPORT_ARRAY
 
-#include <stdlib.h> // malloc, free
 #include "astropy_wcs/pyutil.h"
+#include <stdlib.h> // malloc, free
 
 /***************************************************************************
  * List-of-strings proxy object

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -5,9 +5,9 @@
 
 #define NO_IMPORT_ARRAY
 
-#include <string.h> // strncmp
 #include "astropy_wcs/pyutil.h"
 #include "astropy_wcs/str_list_proxy.h"
+#include <string.h> // strncmp
 
 /***************************************************************************
  * List-of-units proxy object

--- a/astropy/wcs/src/wcslib_celprm_wrap.c
+++ b/astropy/wcs/src/wcslib_celprm_wrap.c
@@ -1,10 +1,10 @@
 #define NO_IMPORT_ARRAY
 
-#include <stdlib.h> // calloc, malloc, free
-#include <string.h> // memcpy
-
 #include "astropy_wcs/wcslib_celprm_wrap.h"
 #include "astropy_wcs/wcslib_prjprm_wrap.h"
+
+#include <stdlib.h> // calloc, malloc, free
+#include <string.h> // memcpy
 
 #include <wcs.h>
 #include <wcsprintf.h>

--- a/astropy/wcs/src/wcslib_prjprm_wrap.c
+++ b/astropy/wcs/src/wcslib_prjprm_wrap.c
@@ -1,11 +1,11 @@
 #define NO_IMPORT_ARRAY
+#include "astropy_wcs/wcslib_celprm_wrap.h"
+#include "astropy_wcs/wcslib_prjprm_wrap.h"
+
 #include <math.h>
 #include <float.h>
 #include <stdlib.h> // calloc, malloc, free
 #include <string.h> // memcpy, strlen, strncpy
-
-#include "astropy_wcs/wcslib_celprm_wrap.h"
-#include "astropy_wcs/wcslib_prjprm_wrap.h"
 
 #include <wcs.h>
 #include <wcsprintf.h>

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -5,9 +5,6 @@
 
 #define NO_IMPORT_ARRAY
 
-#include <stdlib.h> // calloc, malloc, free
-#include <string.h> // memset, strlen, strncpy
-
 #include "astropy_wcs/wcslib_wrap.h"
 #include "astropy_wcs/wcslib_auxprm_wrap.h"
 #include "astropy_wcs/wcslib_prjprm_wrap.h"
@@ -17,6 +14,9 @@
 #include "astropy_wcs/wcslib_units_wrap.h"
 #include "astropy_wcs/unit_list_proxy.h"
 #include <structmember.h> /* from Python */
+
+#include <stdlib.h> // calloc, malloc, free
+#include <string.h> // memset, strlen, strncpy
 
 #include <wcs.h>
 #include <wcsfix.h>


### PR DESCRIPTION
Compile logs are full of
```
  .../3.14.2/include/python3.14/pyconfig.h:2007:9: warning: ‘_POSIX_C_SOURCE’ redefined
   2007 | #define _POSIX_C_SOURCE 200809L
        |         ^~~~~~~~~~~~~~~
```

warnings, and this causes a compilation error for `signature_deprecations.c` since it enforces `-Werror` (which now breaks compilation for me, probably following some gcc update?):
```
  creating /tmp/.../tmppg5jsirv.build-temp/astropy/cosmology/_src
  ccache /usr/bin/cc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=native -mtune=native -O3 -fPIC -I/home/.../.pyenv/versions/3.14.2/include/python3.14 -c astropy/cosmology/_src/signature_deprecations.c -o /tmp/.../tmppg5jsirv.build-temp/astropy/cosmology/_src/signature_deprecations.o -Werror -Wall
  In file included from /home/.../.pyenv/versions/3.14.2/include/python3.14/Python.h:14,
                   from astropy/cosmology/_src/signature_deprecations.c:7:
  /home/.../.pyenv/versions/3.14.2/include/python3.14/pyconfig.h:2007:9: error: ‘_POSIX_C_SOURCE’ redefined [-Werror]
   2007 | #define _POSIX_C_SOURCE 200809L
        |         ^~~~~~~~~~~~~~~
  In file included from /usr/include/bits/libc-header-start.h:33,
                   from /usr/include/stdio.h:28,
                   from astropy/cosmology/_src/signature_deprecations.c:6:
  /usr/include/features.h:319:10: note: this is the location of the previous definition
    319 | # define _POSIX_C_SOURCE        202405L
        |          ^~~~~~~~~~~~~~~
  cc1: all warnings being treated as errors
```

To fix this, `Python.h` should always be included first: 
- https://github.com/python/cpython/issues/61322
- https://docs.python.org/3/c-api/intro.html#include-files

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
