### PR TITLE
Backport PR #19347: Update publish workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_and_publish:
-    # This does the actual wheel building and publishing as part of the cron job
+  build:
+    # This does the actual wheel building as part of the cron job
     # or if triggered manually via the workflow dispatch, or for a tag.
     permissions:
       contents: none
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@d9b81a07e789d1b1921ab5fe33de2ddcbbd02c3f  # v2.3.0
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@a138926f6e4f9667d1306c24f24f5bdcaa01fbab # v2.5.0
     if: |
       github.repository == 'astropy/astropy' && (
         startsWith(github.ref, 'refs/tags/v') ||
@@ -36,8 +36,9 @@ jobs:
       )
     with:
 
-      # We upload to PyPI for all tags starting with v but not ones ending in .dev
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && (github.event_name == 'push') }}
+      # We use trusted publishing so the upload is handled in a separate job below
+      upload_to_pypi: false
+      save_artifacts: true
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
       anaconda_user: astropy
       anaconda_package: astropy
@@ -78,5 +79,23 @@ jobs:
         - cp3*-win_arm64
 
     secrets:
-      pypi_token: ${{ secrets.pypi_token }}
       anaconda_token: ${{ secrets.anaconda_token }}
+
+  upload:
+    # Upload to PyPI using trusted publishing for all tags starting with v but not ones ending in .dev
+    if: startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && github.event_name == 'push'
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/docs/changes/19347.other.rst
+++ b/docs/changes/19347.other.rst
@@ -1,0 +1,1 @@
+Publishing files to PyPI is now done using the Trusted Publisher mechanism (https://docs.pypi.org/trusted-publishers/).


### PR DESCRIPTION
Manual backport of https://github.com/astropy/astropy/pull/19347 - was just a small conflict with versions for the publish workflow.