### PR TITLE
BUG: Replace assert with RuntimeError in units/quantity_helper/function_helpers.py

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -530,7 +530,13 @@ def unwrap_arange_args(*, start_or_stop, stop_, step_):
             pass
 
     # purely defensive programming
-    assert stop is not None, "Please report this."
+    if stop is None:
+        raise RuntimeError(
+            "Unexpected internal state in unwrap_arange_args: "
+            "'stop' is None after argument parsing. "
+            "Please report this at "
+            "https://github.com/astropy/astropy/issues"
+        )
     return start, stop, step
 
 
@@ -539,7 +545,13 @@ def wrap_arange_args(*, start, stop, step, expected_out_unit):
     # this is needed because start_or_stop *must* be passed as positional
 
     # purely defensive programming
-    assert stop is not None, "Please report this."
+    if stop is None:
+        raise RuntimeError(
+            "Unexpected internal state in wrap_arange_args: "
+            "'stop' is None before argument reconstruction. "
+            "Please report this at "
+            "https://github.com/astropy/astropy/issues"
+        )
 
     match start, stop:
         case (None, _):
@@ -556,9 +568,21 @@ def wrap_arange_args(*, start, stop, step, expected_out_unit):
     # expected unit, which we guarantee should be stop's
     args_rev, out_unit = _quantities2arrays(*qty_args[::-1])
     if expected_out_unit is not UNIT_FROM_LIKE_ARG:
-        assert out_unit == expected_out_unit
+        if out_unit != expected_out_unit:
+            raise RuntimeError(
+                f"Unit mismatch after conversion: expected "
+                f"{expected_out_unit!r} but got {out_unit!r}. "
+                "Please report this at "
+                "https://github.com/astropy/astropy/issues"
+            )
     if hasattr(stop, "unit"):
-        assert out_unit == stop.unit
+        if out_unit != stop.unit:
+            raise RuntimeError(
+                f"Unit mismatch: converted output unit {out_unit!r} "
+                f"does not match stop.unit {stop.unit!r}. "
+                "Please report this at "
+                "https://github.com/astropy/astropy/issues"
+            )
 
     # reverse args again to restore initial order
     args = args_rev[::-1]

--- a/astropy/units/tests/test_quantity_helpers.py
+++ b/astropy/units/tests/test_quantity_helpers.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from astropy import units as u
+from astropy.units.quantity_helper import function_helpers as fh
 
 
 @pytest.mark.parametrize(
@@ -32,3 +33,88 @@ def test_allclose_isclose():
     c = [90, 200] * u.cm
     assert not u.allclose(a, c)
     assert not np.all(u.isclose(a, c))
+
+
+def test_unwrap_arange_args_stop_none_raises_runtimeerror_not_asserts():
+    """
+    Regression: production assert replaced with explicit exception.
+    Under `python -O`, assert statements are silently removed,
+    making this validation disappear.
+    """
+    start, stop, step = fh.unwrap_arange_args(start_or_stop=1, stop_=None, step_=2)
+    assert start is None
+    assert stop == 1
+    assert step == 2
+
+    with pytest.raises(RuntimeError, match="unwrap_arange_args"):
+        fh.unwrap_arange_args(start_or_stop=None, stop_=None, step_=1)
+
+
+def test_wrap_arange_args_stop_none_raises_runtimeerror_not_asserts():
+    """
+    Regression: production assert replaced with explicit exception.
+    Under `python -O`, assert statements are silently removed,
+    making this validation disappear.
+    """
+    args, kwargs = fh.wrap_arange_args(
+        start=None,
+        stop=5 * u.m,
+        step=1,
+        expected_out_unit=fh.UNIT_FROM_LIKE_ARG,
+    )
+    assert args == (np.float64(5.0),)
+    assert kwargs == {}
+
+    with pytest.raises(RuntimeError, match="wrap_arange_args"):
+        fh.wrap_arange_args(
+            start=None,
+            stop=None,
+            step=1,
+            expected_out_unit=fh.UNIT_FROM_LIKE_ARG,
+        )
+
+
+def test_wrap_arange_args_expected_out_unit_mismatch_raises_runtimeerror_not_asserts(
+    monkeypatch,
+):
+    """
+    Regression: production assert replaced with explicit exception.
+    Under `python -O`, assert statements are silently removed,
+    making this validation disappear.
+    """
+
+    def fake_quantities2arrays(*args):
+        return args, u.m
+
+    monkeypatch.setattr(fh, "_quantities2arrays", fake_quantities2arrays)
+
+    with pytest.raises(RuntimeError, match="Unit mismatch after conversion"):
+        fh.wrap_arange_args(
+            start=None,
+            stop=5 * u.m,
+            step=1,
+            expected_out_unit=u.s,
+        )
+
+
+def test_wrap_arange_args_stop_unit_mismatch_raises_runtimeerror_not_asserts(
+    monkeypatch,
+):
+    """
+    Regression: production assert replaced with explicit exception.
+    Under `python -O`, assert statements are silently removed,
+    making this validation disappear.
+    """
+
+    def fake_quantities2arrays(*args):
+        return args, u.s
+
+    monkeypatch.setattr(fh, "_quantities2arrays", fake_quantities2arrays)
+
+    with pytest.raises(RuntimeError, match="does not match stop.unit"):
+        fh.wrap_arange_args(
+            start=None,
+            stop=5 * u.m,
+            step=1,
+            expected_out_unit=fh.UNIT_FROM_LIKE_ARG,
+        )

--- a/docs/changes/units/19359.bugfix.rst
+++ b/docs/changes/units/19359.bugfix.rst
@@ -1,0 +1,6 @@
+Replace internal ``assert`` statements in
+``astropy.units.quantity_helper.function_helpers`` with explicit
+``RuntimeError`` exceptions. Previously, running Python with the
+``-O`` optimization flag would silently remove these checks,
+potentially causing unit mismatches or corrupt internal state
+to propagate without any error being raised.


### PR DESCRIPTION
## Summary

Replace 4 production `assert` statements in `astropy/units/quantity_helper/function_helpers.py` with explicit `RuntimeError` exceptions.

## Root Cause

Python's `-O` flag silently removes all `assert` statements. In production code this means:

- `assert stop is not None` disappears → `None` propagates silently downstream
- `assert out_unit == expected_out_unit` disappears → wrong unit silently returned to user with no error

## Demonstration

Before (disappears silently under `python -O`):

    assert stop is not None, "Please report this."

After (always raises regardless of optimization flag):

    if stop is None:
        raise RuntimeError(
            "Unexpected internal state in unwrap_arange_args: "
            "'stop' is None after argument parsing. "
            "Please report this at "
            "https://github.com/astropy/astropy/issues"
        )

Verified locally:

    $ python -O -c "..."
    PASS: RuntimeError raised even under -O

## Changes

- `astropy/units/quantity_helper/function_helpers.py` — 4 asserts replaced with RuntimeError
- `astropy/units/tests/test_quantity_helpers.py` — 4 regression tests added
- `docs/changes/units/19360.bugfix.rst` — changelog entry added

## Related PRs

- Similar fix in `utils/shapes.py`: #19351
- Similar fix in `table/_dataframes.py`: #19358