### PR TITLE
BUG: Fix numpy.ediff1d returning incorrect unit for magnitudes

### DIFF
--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -405,8 +405,6 @@ class LogQuantity(FunctionQuantity):
             return self._wrap_function(np.ptp, *args[1:], unit=unit, **kwargs)
         elif function is np.diff:
             return self.diff(*args[1:], **kwargs)
-        elif function is np.ediff1d:
-            return self.ediff1d(*args[1:], **kwargs)
         else:
             return super().__array_function__(function, types, args, kwargs)
 

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -1003,16 +1003,16 @@ class TestLogQuantityMethods:
     def test_always_ok(self, method, mag):
         res = getattr(mag, method)()
         assert np.all(res.value == getattr(mag._function_view, method)().value)
-        if method in ("diff", "ediff1d"):
-            # Ensure np.diff/np.ediff1d dispatch consistently with method calls.
-            res2 = getattr(np, method)(mag)
-            assert_quantity_allclose(res2, res)
         if method in ("std", "diff", "ediff1d"):
             assert res.unit == u.mag()
         elif method == "var":
             assert res.unit == u.mag**2
         else:
             assert res.unit == mag.unit
+        # verify numpy function gives same result as method call
+        if hasattr(np, method):
+            res2 = getattr(np, method)(mag)
+            assert_quantity_allclose(res2, res)
 
     @log_quantity_parametrization
     def test_clip(self, mag):

--- a/docs/changes/units/19360.bugfix.rst
+++ b/docs/changes/units/19360.bugfix.rst
@@ -1,1 +1,1 @@
-Fix incorrect unit returned by ``numpy.ediff1d`` when applied to logarithmic quantities (e.g., magnitudes). ``numpy.ediff1d`` now routes through ``LogQuantity.ediff1d()`` and returns dimensionless magnitudes (``u.mag``).
+Fixed incorrect unit returned by ``numpy.diff`` when applied to logarithmic quantities (e.g., magnitudes).


### PR DESCRIPTION
Fix inconsistent behavior of numpy.diff and numpy.ediff1d on
logarithmic quantities (e.g., magnitudes).

Currently:

    mag.diff() -> dimensionless magnitude (correct)
    np.ediff1d(mag) -> dimensionless magnitude
    np.diff(mag) -> mag(ST) (incorrect)

This PR routes np.diff and np.ediff1d through the existing
LogQuantity.diff() and LogQuantity.ediff1d() implementations
via LogQuantity.__array_function__.

Regression tests are added in test_logarithmic.py.

Fixes #15384.