### PR TITLE
BUG: Fix missing goto fail in create_parser after ValueError in parse_times.c

### DIFF
--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -411,6 +411,7 @@ create_parser(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
         PyErr_SetString(PyExc_ValueError,
                         "Parameter array must have 7 entries"
                         "(year, month, day, hour, minute, integer second, fraction)");
+        goto fail;
     }
 
     gufunc = (PyUFuncObject *)PyUFunc_FromFuncAndDataAndSignature(

--- a/astropy/time/tests/test_fast_parser.py
+++ b/astropy/time/tests/test_fast_parser.py
@@ -153,3 +153,17 @@ def test_fast_large_arrays():
     assert t.size == 501
     with pytest.raises(ValueError, match="Input values did not match any"):
         Time(["parrot"] * 1000)
+
+
+def test_create_parser_invalid_pars_size():
+    """Regression test: create_parser must raise ValueError cleanly
+    for parameter arrays that don't have exactly 7 entries, without
+    continuing execution with an active exception (missing goto fail)."""
+    import numpy as np
+
+    from astropy.time import _parse_times
+
+    # 6 entries instead of required 7 - should raise ValueError cleanly
+    bad_pars = np.zeros(6, dtype=_parse_times.dt_pars)
+    with pytest.raises(ValueError, match="Parameter array must have 7 entries"):
+        _parse_times.create_parser(bad_pars)

--- a/docs/changes/time/19368.bugfix.rst
+++ b/docs/changes/time/19368.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed missing ``goto fail`` in ``create_parser`` in ``parse_times.c`` after setting a ``ValueError`` for invalid parameter array size, preventing execution from continuing with an exception already set.


### PR DESCRIPTION
## Summary

Fix missing `goto fail` in `create_parser` in `parse_times.c` after setting a `ValueError` for an invalid parameter array size.

Without this fix, execution continued past the error check and attempted to create and register a ufunc with an invalid parameter array, leaving an active exception set. This could produce a confusing `SystemError` instead of the intended `ValueError`.

## What changed

- Added `goto fail` immediately after `PyErr_SetString` in `create_parser` so cleanup runs correctly via the existing `fail:` label
- Added regression test `test_create_parser_invalid_pars_size` in `test_fast_parser.py`
- Added changelog entry `19361.bugfix.rst`

## Why this matters

This ensures invalid parser parameter arrays fail cleanly with `ValueError`, with proper C-level cleanup and no continuation under an already-set exception.

Fixes the control flow bug identified in `astropy/time/src/parse_times.c`.