### PR TITLE
Fix description of TDB-TT offset and location

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1142,12 +1142,11 @@ scale along with the auto-download feature::
     request ``UT1-UTC`` for times beyond the range of IERS table data then the
     nearest available values will be provided.
 
-In the case of the TDB to TT offset, most users need only provide the ``lon``
-and ``lat`` values when creating the |Time| object. If the
+In the case of the TDB to TT offset, most users need only provide the
+``location`` when creating the |Time| object. If the
 :attr:`~astropy.time.Time.delta_tdb_tt` attribute is not explicitly set, then
 the |PyERFA| routine `erfa.dtdb` will be used to compute the TDB to TT
-offset. Note that if ``lon`` and ``lat`` are not explicitly initialized,
-values of 0.0 degrees for both will be used.
+offset. If ``location`` is not specified, the center of the Earth is assumed.
 
 Example
 ~~~~~~~


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This PR fixes the `Time` documentation pertaining to the TDB-TT offset and `location`, specifically that the default location is geocenter (fixed in #11134)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
