### PR TITLE
BUG: fix pickling of SigmaClip when Bottleneck is installed

### DIFF
--- a/astropy/stats/nanfunctions.py
+++ b/astropy/stats/nanfunctions.py
@@ -101,29 +101,38 @@ if HAS_BOTTLENECK:
         nanvar=np.nanvar,
     )
 
-    def _dtype_dispatch(func_name):
-        # dispatch to bottleneck or numpy depending on the input array dtype
-        # this is done to workaround known accuracy bugs in bottleneck
-        # affecting float32 calculations
-        # see https://github.com/pydata/bottleneck/issues/379
-        # see https://github.com/pydata/bottleneck/issues/462
-        # see https://github.com/astropy/astropy/issues/17185
-        # see https://github.com/astropy/astropy/issues/11492
-        def wrapped(*args, **kwargs):
-            if args[0].dtype.str[1:] == "f8":
-                return bn_funcs[func_name](*args, **kwargs)
+    class _DtypeDispatch:
+        """Picklable dispatcher that routes to bottleneck or numpy based on dtype.
+
+        Using a class instead of a closure ensures instances can be pickled,
+        which is required for pickling objects that store these functions as
+        attributes (e.g., SigmaClip._cenfunc_parsed).
+
+        Bottleneck is only used for float64 (f8) arrays to work around known
+        accuracy bugs affecting float32 calculations:
+        - https://github.com/pydata/bottleneck/issues/379
+        - https://github.com/pydata/bottleneck/issues/462
+        - https://github.com/astropy/astropy/issues/17185
+        - https://github.com/astropy/astropy/issues/11492
+        """
+
+        def __init__(self, func_name):
+            self.func_name = func_name
+
+        def __call__(self, *args, **kwargs):
+            dt = args[0].dtype
+            if dt.kind == "f" and dt.itemsize == 8:
+                return bn_funcs[self.func_name](*args, **kwargs)
             else:
-                return np_funcs[func_name](*args, **kwargs)
+                return np_funcs[self.func_name](*args, **kwargs)
 
-        return wrapped
-
-    nansum = _dtype_dispatch("nansum")
-    nanmin = _dtype_dispatch("nanmin")
-    nanmax = _dtype_dispatch("nanmax")
-    nanmean = _dtype_dispatch("nanmean")
-    nanmedian = _dtype_dispatch("nanmedian")
-    nanstd = _dtype_dispatch("nanstd")
-    nanvar = _dtype_dispatch("nanvar")
+    nansum = _DtypeDispatch("nansum")
+    nanmin = _DtypeDispatch("nanmin")
+    nanmax = _DtypeDispatch("nanmax")
+    nanmean = _DtypeDispatch("nanmean")
+    nanmedian = _DtypeDispatch("nanmedian")
+    nanstd = _DtypeDispatch("nanstd")
+    nanvar = _DtypeDispatch("nanvar")
 
 else:
     nansum = np.nansum

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pickle
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
@@ -721,3 +723,18 @@ def test_propagation_of_mask():
     y = np.ma.masked_where(x > 1, x)
 
     assert_allclose(sigma_clipped_stats(y, grow=1), (1, 1, 0))
+
+
+def test_sigmaclip_pickle():
+    """Regression test for gh-19343: SigmaClip cannot be pickled
+    when Bottleneck is installed."""
+
+    sigclip = SigmaClip(sigma=3.0, maxiters=5)
+    restored = pickle.loads(pickle.dumps(sigclip))
+    assert restored.sigma == sigclip.sigma
+    assert restored.maxiters == sigclip.maxiters
+    # verify the restored object still works correctly
+    data = np.ma.array([1, 2, 3, 100, 4, 5])
+    result = restored(data)
+    expected = sigclip(data)
+    np.testing.assert_array_equal(result, expected)

--- a/docs/changes/stats/19372.bugfix.rst
+++ b/docs/changes/stats/19372.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed pickling of ``SigmaClip`` objects when Bottleneck is installed. ``_dtype_dispatch`` returned a local closure which cannot be pickled; replaced with a picklable ``_DtypeDispatch`` class.


### PR DESCRIPTION
Fixes #19343

When Bottleneck is installed, `SigmaClip` could fail to pickle because `_dtype_dispatch` returned a local closure, which Python cannot pickle. Since these functions are stored on the `SigmaClip` instance (`_cenfunc_parsed` and `_stdfunc_parsed`), pickling the object raised an `AttributeError`.

Replaced the closure with a small `_DtypeDispatch` class that performs the same dtype-based dispatch but is picklable. A regression test was also added to ensure that `SigmaClip` objects can be pickled correctly.