### PR TITLE
DOC: add examples for masked=False behavior in sigma_clip

### DIFF
--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -862,6 +862,26 @@ def sigma_clip(
 
     Note that along the other axis, no points would be clipped, as the
     standard deviation is higher.
+
+    The behavior of ``masked=False`` depends on whether ``axis`` is
+    specified. When ``axis=None`` (the default), clipped values are
+    *removed* from the output, so the returned array may be shorter
+    than the input::
+
+        >>> import numpy as np
+        >>> from astropy.stats import sigma_clip
+        >>> x = np.ones(10)
+        >>> x[5] = 1000.0
+        >>> clipped = sigma_clip(x, masked=False)
+        >>> len(clipped)  # shorter than input: outlier was removed
+        9
+
+    When ``axis`` is specified, clipped values are replaced with
+    ``np.nan`` instead::
+
+        >>> clipped_nan = sigma_clip(x, masked=False, axis=0)
+        >>> bool(np.isnan(clipped_nan[5]))  # outlier replaced with nan
+        True
     """
     sigclip = SigmaClip(
         sigma=sigma,


### PR DESCRIPTION
Closes #18495

The behavior of `sigma_clip` with `masked=False` depends on whether `axis` is specified, but this was only briefly mentioned in the Returns section and easy to overlook.

Added two small examples to the docstring to make the behavior clearer:
- when `axis=None`, clipped values are removed and the output array is shorter
- when `axis` is specified, clipped values are replaced with `nan`

Docs-only change.