### PR TITLE
DEP: update minimal requirement for sgp4 to 2.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -746,7 +746,7 @@ no-build-package = [
     "polars",
     "requests",
     "scipy",
-    "sgp4",
+    # "sgp4", # https://github.com/brandon-rhodes/python-sgp4/pull/150
 
     # via jsonschema v4.0.1 via asdf v2.15.0 via asdf-astropy v0.8.0
     "pyrsistent", # can be removed once we drop asdf-astropy<=0.8 https://github.com/astropy/asdf-astropy/pull/297


### PR DESCRIPTION
### Description
sgp4 2.2 is a 6 y.o. version, that we are not actually testing against: because we have so far required binary installs for this package, the oldest version we can actually claim to support is 2.22
On the other hand, as of writing this, the latest version (2.25) doesn't have `cp314` wheels, making the requirement on binary installs essentially impossible to satisfy for a dev env on the latest Python, so I think it should be (temporarily) relaxed.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
