### PR TITLE
Don't log when passed unit matches FITS BUNIT

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -768,10 +768,15 @@ def fits_ccddata_reader(
                         "file before reading it."
                     )
             else:
-                log.info(
-                    f"using the unit {unit} passed to the FITS reader instead "
-                    f"of the unit {fits_unit_string} in the FITS file."
-                )
+                try:
+                    fits_unit_parsed = u.Unit(fits_unit_string)
+                except ValueError:
+                    fits_unit_parsed = None
+                if fits_unit_parsed is None or fits_unit_parsed != u.Unit(unit):
+                    log.info(
+                        f"using the unit {unit} passed to the FITS reader instead "
+                        f"of the unit {fits_unit_string} in the FITS file."
+                    )
 
         use_unit = unit or fits_unit_string
         hdr, wcs = _generate_wcs_and_update_header(hdr)

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -768,11 +768,7 @@ def fits_ccddata_reader(
                         "file before reading it."
                     )
             else:
-                try:
-                    fits_unit_parsed = u.Unit(fits_unit_string)
-                except ValueError:
-                    fits_unit_parsed = None
-                if fits_unit_parsed is None or fits_unit_parsed != u.Unit(unit):
+                if str(unit) != str(fits_unit_string):
                     log.info(
                         f"using the unit {unit} passed to the FITS reader instead "
                         f"of the unit {fits_unit_string} in the FITS file."

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -633,6 +633,18 @@ def test_infol_logged_if_unit_in_fits_header(tmp_path):
         assert explicit_unit_name in log_list[0].message
 
 
+def test_no_log_if_unit_matches_bunit(tmp_path):
+    # Regression test for https://github.com/astropy/astropy/issues/13539
+    # No log should be emitted when the passed unit matches BUNIT in the file.
+    ccd_data = create_ccd_data()  # unit=adu, BUNIT written as "adu"
+    tmpfile = str(tmp_path / "temp.fits")
+    ccd_data.write(tmpfile)
+    log.setLevel("INFO")
+    with log.log_to_list() as log_list:
+        _ = CCDData.read(tmpfile, unit="adu")
+        assert len(log_list) == 0
+
+
 def test_wcs_attribute(tmp_path):
     """
     Check that WCS attribute gets added to header, and that if a CCDData

--- a/docs/changes/nddata/13539.bugfix.rst
+++ b/docs/changes/nddata/13539.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``CCDData.read`` logging a spurious info message when the unit passed by the caller matches the ``BUNIT`` value in the FITS header.

--- a/docs/changes/nddata/13539.bugfix.rst
+++ b/docs/changes/nddata/13539.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``CCDData.read`` logging a spurious info message when the unit passed by the caller matches the ``BUNIT`` value in the FITS header.

--- a/docs/changes/nddata/19389.bugfix.rst
+++ b/docs/changes/nddata/19389.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed \CCDData.read\ logging a spurious info message when the unit passed by the caller matches the \BUNIT\ value in the FITS header.
+Fixed ``CCDData.read()`` logging a spurious info message when the unit passed by the caller matches the BUNIT value in the FITS header.

--- a/docs/changes/nddata/19389.bugfix.rst
+++ b/docs/changes/nddata/19389.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed \CCDData.read\ logging a spurious info message when the unit passed by the caller matches the \BUNIT\ value in the FITS header.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

### Description

Don't log when passed unit matches FITS BUNIT

`CCDData.read` logs an info message whenever a `unit` argument is passed alongside a FITS file that has a `BUNIT` header, even when they match. This is noisy when users explicitly pass the unit to confirm what's already in the file.

The log now only fires when the two units actually differ.

Fixes #13539


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
