### PR TITLE
TST: Skip test_hub_proxy tests on OSX

### DIFF
--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import platform
+
 import pytest
 
 # By default, tests should not use the internet.
@@ -14,11 +16,13 @@ def setup_module(module):
     conf.use_internet = False
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 def test_SAMPHubProxy():
     """Test that SAMPHubProxy can be instantiated"""
     SAMPHubProxy()
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 @pytest.mark.slow
 def test_SAMPClient():
     """Test that SAMPClient can be instantiated"""
@@ -26,6 +30,7 @@ def test_SAMPClient():
     SAMPClient(proxy)
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 def test_SAMPIntegratedClient():
     """Test that SAMPIntegratedClient can be instantiated"""
     SAMPIntegratedClient()
@@ -40,6 +45,7 @@ def samp_hub():
     my_hub.stop()
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 @pytest.mark.filterwarnings("ignore:unclosed <socket:ResourceWarning")
 def test_SAMPIntegratedClient_notify_all(samp_hub):
     """Test that SAMP returns a warning if no receiver got the message."""
@@ -51,6 +57,7 @@ def test_SAMPIntegratedClient_notify_all(samp_hub):
     client.disconnect()
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 def test_reconnect(samp_hub):
     """Test that SAMPIntegratedClient can reconnect.
     This is a regression test for bug [#2673]

--- a/astropy/samp/tests/test_hub.py
+++ b/astropy/samp/tests/test_hub.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import platform
 import time
 
 import pytest
@@ -12,11 +13,13 @@ def setup_module(module):
     conf.use_internet = False
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 def test_SAMPHubServer():
     """Test that SAMPHub can be instantiated"""
     SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 @pytest.mark.slow
 def test_SAMPHubServer_run():
     """Test that SAMPHub can be run"""
@@ -26,6 +29,7 @@ def test_SAMPHubServer_run():
     hub.stop()
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 @pytest.mark.slow
 def test_SAMPHubServer_run_repeated():
     """

--- a/astropy/samp/tests/test_hub_proxy.py
+++ b/astropy/samp/tests/test_hub_proxy.py
@@ -1,3 +1,7 @@
+import platform
+
+import pytest
+
 from astropy.samp import conf
 from astropy.samp.hub import SAMPHubServer
 from astropy.samp.hub_proxy import SAMPHubProxy
@@ -7,6 +11,7 @@ def setup_module(module):
     conf.use_internet = False
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 class TestHubProxy:
     def setup_method(self, method):
         self.hub = SAMPHubServer(web_profile=False, mode="multiple", pool_size=1)
@@ -35,6 +40,7 @@ class TestHubProxy:
         self.proxy.unregister(result["samp.private-key"])
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 def test_custom_lockfile(tmp_path):
     lockfile = str(tmp_path / ".samptest")
 

--- a/astropy/samp/tests/test_hub_script.py
+++ b/astropy/samp/tests/test_hub_script.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import sys
 
 import pytest
@@ -20,6 +21,7 @@ def teardown_function(function):
     sys.argv = function.sys_argv_orig
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Takes too long on OSX")
 @pytest.mark.slow
 def test_hub_script(monkeypatch):
     mock_logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address OSX job taking way too long to complete. Larry narrowed it down to these SAMP tests. Given we are going to deprecate it soon in https://github.com/astropy/astropy/pull/19373 , it is easier to just skip them for OSX rather than fixing. Might be related:

* https://github.com/astropy/pyvo/issues/731

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
