### PR TITLE
TST: avoid refering to astropy's own version in `minversion`'s doctest

### DIFF
--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -105,8 +105,8 @@ def minversion(module: ModuleType | str, version: str, inclusive: bool = True) -
 
     Examples
     --------
-    >>> import astropy
-    >>> minversion(astropy, '0.4.4')
+    >>> import numpy
+    >>> minversion(numpy, '1.21.0')
     True
     """
     if inspect.ismodule(module):


### PR DESCRIPTION
### Description
This is another, hopefully less controversial solution to the problem I tried to resolve in #19027

Rationale:
this test can single-handedly cause the entire test suite to fail if everything's working correctly *but* astropy was built from a shallow clone, with none of the git tags attached, resulting in it's version number to be seen as `0.0.0` at runtime. I don't think this failure mode is particularily useful or desired. Making the test about any other package solves the problem. Numpy is the obvious candidate for replacement as our single most crucial dependency, which we can safely assume will never go away.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
