### PR TITLE
Fix AttributeError when printing deepcopy of masked Table and add reg…

### DIFF
--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -505,7 +505,8 @@ class TableFormatter:
             or _possible_string_format_functions
         )
         auto_format_func = get_auto_format_func(col, pssf)
-        format_func = col.info._format_funcs.get(col_format, auto_format_func)
+        format_funcs = getattr(col.info, "_format_funcs", {})
+        format_func = format_funcs.get(col_format, auto_format_func)
 
         if n_rows > max_lines:
             if show_length is None:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1642,6 +1642,24 @@ def test_copy_protocol():
     _assert_copies(t, t3)
 
 
+def test_masked_table_deepcopy_print_regression():
+    """
+       Regression test for issue #19408 where deepcopy of masked Table
+    raised AttributeError when printing.
+    """
+    from copy import deepcopy
+
+    from astropy.table import Table
+
+    t1 = Table([(1, 2)], names=("a"), masked=True)
+    t2 = deepcopy(t1)
+
+    # Ensure printing the deepcopy does not raise an exception
+    output = str(t2)
+
+    assert "a" in output
+
+
 def test_disallow_inequality_comparisons():
     """
     Regression test for #828 - disallow comparison operators on whole Table

--- a/docs/changes/table/19412.bugfix.rst
+++ b/docs/changes/table/19412.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an AttributeError when printing a deepcopy of a masked Table.


### PR DESCRIPTION
…ression test

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request fixes an AttributeError that occurs when printing a
deepcopy of a masked Table.

The error happens because `_format_funcs` may be missing on
MaskedColumnInfo objects created via deepcopy. The table printing
logic expects this attribute to exist and raises an AttributeError
when it is absent.

This patch safely accesses `_format_funcs` using getattr to prevent
the crash.

A regression test has been added to ensure deepcopy of a masked Table
can be printed without raising an exception.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19408

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
