### PR TITLE
Remove unused nditer fallback code in io/fits

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -594,23 +594,9 @@ def _array_to_file_like(arr, fileobj):
         else:
             return
 
-    if hasattr(np, "nditer"):
-        # nditer version for non-contiguous arrays
-        for item in np.nditer(arr, order="C"):
-            fileobj.write(item.tobytes())
-    else:
-        # Slower version for Numpy versions without nditer;
-        # The problem with flatiter is it doesn't preserve the original
-        # byteorder
-        byteorder = arr.dtype.byteorder
-        if (sys.byteorder == "little" and byteorder == ">") or (
-            sys.byteorder == "big" and byteorder == "<"
-        ):
-            for item in arr.flat:
-                fileobj.write(item.byteswap().tobytes())
-        else:
-            for item in arr.flat:
-                fileobj.write(item.tobytes())
+    # nditer version for non-contiguous arrays
+    for item in np.nditer(arr, order="C"):
+        fileobj.write(item.tobytes())
 
 
 def _write_string(f, s):


### PR DESCRIPTION
## Description

``np.nditer`` has existed since numpy 1.6, so this is no longer needed

Not sure that we need a changelog entry since this is just removing unused code. However, maybe worth backporting since it's a trivial change (but I don't mind either way).

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
