### PR TITLE
nddata: skip INFO log in CCDData.read when unit matches BUNIT

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -768,10 +768,25 @@ def fits_ccddata_reader(
                         "file before reading it."
                     )
             else:
-                log.info(
-                    f"using the unit {unit} passed to the FITS reader instead "
-                    f"of the unit {fits_unit_string} in the FITS file."
-                )
+                # Only log when the units actually differ. If the user passed
+                # the same unit that is already in the header, there is nothing
+                # to warn about.
+                try:
+                    kifus = CCDData.known_invalid_fits_unit_strings
+                    fits_unit_string_for_compare = fits_unit_string
+                    if fits_unit_string_for_compare in kifus:
+                        fits_unit_string_for_compare = kifus[
+                            fits_unit_string_for_compare
+                        ]
+                    fits_unit_parsed = u.Unit(fits_unit_string_for_compare)
+                    units_match = u.Unit(unit) == fits_unit_parsed
+                except (ValueError, TypeError):
+                    units_match = False
+                if not units_match:
+                    log.info(
+                        f"using the unit {unit} passed to the FITS reader instead "
+                        f"of the unit {fits_unit_string} in the FITS file."
+                    )
 
         use_unit = unit or fits_unit_string
         hdr, wcs = _generate_wcs_and_update_header(hdr)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -633,6 +633,17 @@ def test_infol_logged_if_unit_in_fits_header(tmp_path):
         assert explicit_unit_name in log_list[0].message
 
 
+def test_no_log_when_unit_matches_fits_header(tmp_path):
+    # create_ccd_data uses u.adu, so BUNIT will be 'adu' in the written file.
+    ccd_data = create_ccd_data()
+    tmpfile = str(tmp_path / "temp.fits")
+    ccd_data.write(tmpfile)
+    log.setLevel("INFO")
+    with log.log_to_list() as log_list:
+        _ = CCDData.read(tmpfile, unit="adu")
+        assert len(log_list) == 0
+
+
 def test_wcs_attribute(tmp_path):
     """
     Check that WCS attribute gets added to header, and that if a CCDData


### PR DESCRIPTION
## Summary

Fixes #13539.

When `CCDData.read` is called with an explicit `unit` argument and the FITS file already has a `BUNIT` header keyword, an INFO log message is always emitted — even when the two units are identical. This is noisy and confusing since there is nothing being overridden.

**Change:** Before logging, parse `BUNIT` into a `u.Unit` and compare it with the provided unit. Only emit the message when they differ.

## Changes

- `astropy/nddata/ccddata.py`: Added unit comparison in the `else` branch of the `fits_unit_string` block. Reuses `known_invalid_fits_unit_strings` for the comparison the same way the `unit is None` branch does. Falls back to logging if the BUNIT string cannot be parsed.
- `astropy/nddata/tests/test_ccddata.py`: Added `test_no_log_when_unit_matches_fits_header` to assert no log entries are produced when the provided unit equals the header unit.

## Test plan

- [ ] `python -m pytest astropy/nddata/tests/test_ccddata.py::test_infol_logged_if_unit_in_fits_header` — existing test, still passes (different units still log)
- [ ] `python -m pytest astropy/nddata/tests/test_ccddata.py::test_no_log_when_unit_matches_fits_header` — new test, passes (matching units produce no log)
- [ ] `python -m pytest astropy/nddata/tests/test_ccddata.py` — full suite, 107 passed