### PR TITLE
MNT: a couple QoL improvements to a dev helper script

### DIFF
--- a/scripts/check-lowest-resolved-tree.py
+++ b/scripts/check-lowest-resolved-tree.py
@@ -41,6 +41,13 @@ else:
 
 
 def generate_tree(debug: bool) -> str:
+    uv_lock = REPO_ROOT / "uv.lock"
+    uv_lock_content: bytes | None = None
+    uv_lock_st_mtime = 0.0
+    if uv_lock.exists():
+        uv_lock_content = uv_lock.read_bytes()
+        uv_lock_st_mtime = uv_lock.stat().st_mtime
+
     cp = run(
         [
             uv.find_uv_bin(),
@@ -52,6 +59,17 @@ def generate_tree(debug: bool) -> str:
         check=False,
         capture_output=True,
     )
+
+    assert uv_lock.exists()
+    if uv_lock.stat().st_mtime > uv_lock_st_mtime:
+        # uv.lock was created or modified: restore previous state
+        if uv_lock_content is None:
+            # created -> remove file entirely
+            uv_lock.unlink()
+        else:
+            # modified -> restore
+            uv_lock.write_bytes(uv_lock_content)
+
     if debug:
         print(cp.stderr.decode(), file=sys.stderr)
     if cp.returncode != 0:


### PR DESCRIPTION
### Description
This is a quick follow up to #19022, fixing a couple QoL defects I found in practice

- **MNT: allow ref file to be missing in `check-lowest-resolved-tree.py`**
- **MNT: ensure `uv.lock` is not overwritten by `check-lowest-resolved-tree.py`**

The second one helps any dev who wants to run the script *and* has a local `uv.lock` file (which at this point is probably just me, myself and I), and would become necessary if we also had a shared (version-tracked) version of it in the repo.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
