### PR TITLE
EXP: exclude numpy 2.4.3 from build-env solutions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=2.0",
+    "numpy==2.4.2",
     "pyerfa>=2.0.1.3",  # for >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2026.2.23.0.48.33",
     "PyYAML>=6.0.0",


### PR DESCRIPTION
### Description
This is an exploratory PR to check wether my current suspucion is correct.
ref #19422


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
