### PR TITLE
TST: stop building wheels against dev build deps in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,7 @@ jobs:
       anaconda_user: astropy
       anaconda_package: astropy
       anaconda_keep_n_latest: 10
-
-      # For nightly wheels as well as when building with the 'Build all wheels' label, we disable
-      # the build isolation and explicitly install the latest developer version of numpy as well as
-      # the latest stable versions of all other build-time dependencies.
-      # KEEP IN SYNC WITH [build-system] from pyproject.toml
       env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip install -U --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple setuptools>=77.0.0 setuptools_scm cython numpy>=0.0.dev0 extension-helpers pyerfa') || '' }}'
-        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'build; args: --no-isolation') || 'build' }}'
         EXTENSION_HELPERS_PY_LIMITED_API: 'cp311'
 
       test_extras: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ volint = "astropy.io.votable.volint:main"
 wcslint = "astropy.wcs.wcslint:main"
 
 [build-system]
-# keep in sync with .github/workflows/publish.yml
 requires = ["setuptools>=77.0.0",
             "setuptools_scm>=8.0.0",
             "cython>=3.0.0, <4",


### PR DESCRIPTION
### Description
This is basically the same as #19426, only taken to its logical conclusion by also removing the cruft that stops being useful.
close #19426
close #19422

for context, this scheme was implemented in https://github.com/astropy/astropy/pull/15524 in order to improve testing of numpy 2.0 as it was being developed. I don't think we need it anymore.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
