### PR TITLE
BLD/DEP: drop dangling build-time dependency on pyerfa

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ requires = ["setuptools>=77.0.0",
             "cython>=3.0.0, <4",
             "numpy>=2.0.0, <3",
             "extension-helpers>=1.4,<2",
-            "pyerfa>=2.0.1.3"]
+]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]


### PR DESCRIPTION
### Description
I don't know why `perfa` was originally declared as a build-time dependency but I couldn't find a need for it anywhere, and building the package locally suceeded, indicating that it is actually not used.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
