### PR TITLE
TST: Ensure that Latitude([lon, lon]) raises

### DIFF
--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -783,6 +783,10 @@ def test_lon_as_lat():
         lat = Latitude([20], "deg")
         lat[0] = lon
 
+    # Also check list of longitudes (regression test for gh-11757).
+    with pytest.raises(TypeError, match="cannot be created from"):
+        Latitude([lon, lon])
+
     # Check we can work around the Lat vs Long checks by casting explicitly to Angle.
     lat = Latitude(Angle(lon))
     assert lat.value == 10.0


### PR DESCRIPTION
This pull request adds a test to ensure that initializing a latitude from a list of longitudes will fail. This was an issue #11757 in older versions of astropy, but was fixed as a side effect of #17132 in 6.1.5 onwards. This PR just adds a test to ensure we do not regress.

Note to reviewer(s): in principle, it might be nice to rewrite the whole test, separating out different cases, and indeed explicitly test the reverse too. But I don't have the time right now, and thought something is better than nothing. I'd suggest to just merge and leave clean-up for another time, but feel free to push additions.

In a similar vein of avoiding unnecessary work, I felt there is no need for a changelog entry (would have to have been done for 6.1.5), or to backport (since the code is already correct anyway).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #11757

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
