### PR TITLE
TST: upgrade Allowed Failures job to CPython 3.14

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -150,8 +150,8 @@ jobs:
           - language-pack-de
           - tzdata
       envs: |
-        - name: (Allowed Failure) Python 3.13 with remote data and dev version of key dependencies
-          linux: py313-test-devdeps
+        - name: (Allowed Failure) Python 3.14 with remote data and dev version of key dependencies
+          linux: py314-test-devdeps
           posargs: --remote-data=any --verbose
 
   stub_tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,9 @@ filterwarnings = [
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
     # Weird warning from the vectorized do_format in Angle.to_string. low numpy/python?
     "ignore:invalid value encountered in do_format:RuntimeWarning",
+    # https://github.com/astropy/astropy/issues/19511
+    "ignore:Implicitly cleaning up <HTTPError 404:ResourceWarning",
+    "ignore:unclosed <socket.socket:ResourceWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
### Description
I don't know of any blockers against this.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
