### PR TITLE
TST: upgrade Stable CI jobs to CPython 3.13

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -93,8 +93,8 @@ jobs:
           cache-path: .tox
           cache-key: mindeps-${{ github.ref_name }}
 
-        - name: Python 3.12 in Parallel with all optional dependencies
-          linux: py312-test-alldeps-fitsio
+        - name: Python 3.13 in Parallel with all optional dependencies
+          linux: py313-test-alldeps-fitsio
           libraries:
             apt:
               - language-pack-fr
@@ -111,22 +111,21 @@ jobs:
           posargs: --remote-data=astropy
           coverage: codecov
 
-        - name: Python 3.12 with all optional dependencies (Windows)
-          windows: py312-test-alldeps
+        - name: Python 3.13 with all optional dependencies (Windows)
+          windows: py313-test-alldeps
           posargs: --durations=50
           cache-path: .tox
           cache-key: alldeps-windows-${{ github.ref_name }}
 
-        - name: Python 3.12 with all optional dependencies (MacOS X)
-          macos: py312-test-alldeps
+        - name: Python 3.13 with all optional dependencies (MacOS X)
+          macos: py313-test-alldeps
           posargs: --durations=50 --run-slow
           runs-on: macos-latest
           cache-path: .tox
           cache-key: alldeps-macos-${{ github.ref_name }}
 
-        # FIXME: Add aarch64 to name when bump Python version.
-        - name: Python 3.11 Double test (Run tests twice)
-          linux: py311-test-double
+        - name: Python 3.13 aarch64, Run tests twice
+          linux: py313-test-double
           runs-on: ubuntu-24.04-arm
           posargs: -n=4
           setenv: |


### PR DESCRIPTION
### Description
This seems overdue. Last time I checked, we did this once a year and at the same time as we bumped our minimal requirement on Python itself, but I think this approach isn't appropriate now that astropy is abi3-compliant and there's much less of a motivation for aggressively bumping the requirement. Meanwhile, CPython 3.13 has been stable for almost 18 months now, so I think it's very safe to use it as our primary version in CI.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
