### PR TITLE
DOC: clarify scipy.special compatibility with Quantity objects

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -354,6 +354,11 @@ class Quantity(np.ndarray):
 
     Unless the ``dtype`` argument is explicitly specified, integer
     or (non-Quantity) object inputs are converted to `float` by default.
+
+    Some functions from ``scipy.special`` do not currently support
+    `~astropy.units.Quantity` inputs directly. In such cases, users may
+    need to convert quantities to plain values using ``.value`` before
+    passing them to these functions.
     """
 
     # Need to set a class-level default for _equivalencies, or


### PR DESCRIPTION
Fixes #6390

Close #19390 

Adds a note to the Quantity documentation clarifying that some
scipy.special functions do not support Quantity inputs directly.
Users may need to convert quantities using `.value`.