### PR TITLE
WHL: use `uv` for faster env resolution/installation in wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,7 @@ markers = [
 ]
 
 [tool.cibuildwheel]
+build-frontend = "build[uv]"
 # We disable testing for the following wheels:
 # - MuslLinux (tests hang non-deterministically)
 test-skip = "*-musllinux_x86_64"


### PR DESCRIPTION
### Description
Replaces `pip` with `uv pip` under the hood. The only visible difference should be a slight performance improvement.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
