### PR TITLE
TST: Add direct tests for join_inner in table/_np_utils Cython extension

### DIFF
--- a/astropy/table/tests/test_np_utils.py
+++ b/astropy/table/tests/test_np_utils.py
@@ -58,6 +58,8 @@ def _check_n_out_unique(n_out, join_type, left_keys, right_keys, expected=None):
     NOTE: This logic is only mathematically valid when all keys within both
     the left and right arrays are strictly unique.
     """
+    if len(set(left_keys)) < len(left_keys) or len(set(right_keys)) < len(right_keys):
+        raise AssertionError
     match join_type:
         case 0:  # inner
             n = len(set(left_keys).intersection(right_keys))


### PR DESCRIPTION
Part of GSoC 2026 proposal: Hardening Astropy's Core Stability 
This PR adds direct tests for the `join_inner` function in `astropy/table/_np_utils.pyx`, bypassing the public `astropy.table.join()` API to test the compiled Cython interface directly.

`join_inner()` is the single function exposed by this extension and is the core index-computation engine for all table join operations in astropy. It currently has zero standalone test coverage, it is only exercised indirectly through the public API.

## Tests cover

* All four join types: inner (0), outer (1), left (2), right (3)
* Cartesian product expansion for duplicate keys (the n×m case)
* Output array length consistency (`len(left_out) == n_out` for all join types)
* Mask array length consistency (`len(left_mask) == n_out` for all join types)
* Edge cases: single row match, no overlap, 100-key scaling test

The helper `_make_join_inputs()` reproduces the exact index-preparation that `operations.py` performs before calling `join_inner()`, keeping the tests fully self-contained with no dependency on the public API.