### PR TITLE
MNT: sort runtime dependencies alphabetically to stabilize auto upgrades to astropy-iers-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,11 @@ keywords = [
     "ascii",
 ]
 dependencies = [
-    "numpy>=2.0",
-    "pyerfa>=2.0.1.3",  # for >=2.0.1.7, adjust structured_units.rst and doctest-requires
     "astropy-iers-data>=0.2026.3.16.0.53.33",
-    "PyYAML>=6.0.0",
+    "numpy>=2.0",
     "packaging>=25.0",
+    "pyerfa>=2.0.1.3",  # for >=2.0.1.7, adjust structured_units.rst and doctest-requires
+    "PyYAML>=6.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Description

originally discussed in https://github.com/astropy/astropy/pull/19456#issuecomment-4083411250

quoting the relevant part here for convenience:
> `uv add` [will] preserve alphabetical order if the list is already sorted

this avoids manual editing of auto PRs as we've seen in https://github.com/astropy/astropy/pull/19461


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
