### PR TITLE
MNT: implicitly commit any changes from `update_astropy_iers_data_pin.yml`

### DIFF
--- a/.github/workflows/update_astropy_iers_data_pin.yml
+++ b/.github/workflows/update_astropy_iers_data_pin.yml
@@ -45,7 +45,7 @@ jobs:
         git config user.email github-actions@github.com
         BRANCH_NAME=update-astropy-iers-data-pin-$(date +"%s")
         git switch -c "$BRANCH_NAME"
-        git add pyproject.toml scripts/lowest-resolved-tree.txt
+        git add --update
         if ! git diff --cached --exit-code; then
           git commit -m "Update minimum required version of astropy-iers-data"
         fi


### PR DESCRIPTION
### Description
This reduces friction if for whatever reason, the exact list of files we *expect* this workflow to update changes again. Now the auto PR just includes *every* changes that result from running it.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
