### PR TITLE
TST: add tests for _convolveNd_c (from convolution sub-package) C extension

### DIFF
--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -132,6 +132,7 @@ def test_embed_true_returns_expected_padded_output(image, kernel, expected):
     npt.assert_allclose(result, expected)
 
 
+# fmt: off
 @pytest.mark.parametrize(
     ("image", "kernel", "expected"),
     [
@@ -164,22 +165,28 @@ def test_embed_true_returns_expected_padded_output(image, kernel, expected):
             id="2d",
         ),
         pytest.param(
-            np.ones((3, 3, 3), dtype=np.float64),
-            np.ones((3, 3, 3), dtype=np.float64),
-            np.full((3, 3, 3), np.nan, dtype=np.float64),
+            np.array(
+                [
+                    [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+                    [[1.0, 1.0, 1.0], [1.0, np.nan, 1.0], [1.0, 1.0, 1.0]],
+                    [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+                ],
+                dtype=np.float64,
+            ),
+           np.ones((3, 3, 3), dtype=np.float64)
+,
+           np.full((3, 3, 3), np.nan, dtype=np.float64),
             id="3d",
         ),
     ],
 )
 def test_nan_without_interpolation_matches_expected_values(image, kernel, expected):
     """Without NaN interpolation, any NaN in the window should propagate to the output."""
-    if image.ndim == 3:
-        image = image.copy()
-        image[1, 1, 1] = np.nan
 
     result = _run_extension_with_zero_padding(image, kernel)
 
     npt.assert_allclose(result, expected, equal_nan=True)
+# fmt: on
 
 
 @pytest.mark.parametrize(

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -4,21 +4,17 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-
+from functools import partial
 from astropy.convolution._convolve import _convolveNd_c
 
 
-# these helprer functions preprocess the inputs before passing to the extension
-def _as_float64_c_contiguous(array):
-    """Return a C-contiguous ``float64`` array for the extension call."""
-    return np.ascontiguousarray(array, dtype=np.float64)
 
+_as_float64_c_contiguous = partial(np.ascontiguousarray, dtype = 'float64')
+# these helprer functions preprocess the inputs before passing to the extension
 
 def _pad_for_direct_call(image, kernel):
     """Pad an image the same way with half-kernel width."""
-    pad_width = tuple((size // 2, size // 2) for size in kernel.shape)
-    padded = np.pad(image, pad_width, mode="constant", constant_values=0.0)
-    return _as_float64_c_contiguous(padded)
+    return np.pad(image, pad_width=tuple((size // 2, size // 2) for size in kernel.shape))
 
 
 def _allocate_result(image, padded_image, embed):

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -182,7 +182,7 @@ def test_embed_true_returns_expected_padded_output(image, kernel, expected):
     npt.assert_allclose(result, expected)
 
 
-# fmt: off
+# fmt:off
 @pytest.mark.parametrize(
     ("image", "kernel", "expected"),
     [
@@ -223,29 +223,30 @@ def test_embed_true_returns_expected_padded_output(image, kernel, expected):
                 ],
                 dtype=np.float64,
             ),
-           np.ones((3, 3, 3), dtype=np.float64)
-,
-           np.full((3, 3, 3), np.nan, dtype=np.float64),
+            np.ones((3, 3, 3), dtype=np.float64),
+            np.full((3, 3, 3), np.nan, dtype=np.float64),
             id="3d",
         ),
     ],
 )
 def test_nan_without_interpolation_matches_expected_values(image, kernel, expected):
-    """Without NaN interpolation, any NaN in the window propagates.
-
-    Example:
-
-    for padded ``image = [0, 1, nan, 1, 0]`` and ``kernel = [1, 1, 1]``,
-    ``_convolveNd_c`` yields ``result = [nan, nan, nan]`` because each
-    output window contains the ``nan`` term and the extension
-    intentionally does not skip NaN values unless
-    ``nan_interpolate=True``.
     """
+    When ``nan_interpolate=False``, a ``NaN`` in the input window makes the
+    corresponding output ``NaN``.
 
+    In these test cases the kernel size is 3 along every axis, so the kernel radius
+    is 1. Therefore, a ``NaN`` at input index ``i`` contaminates output centers
+    within an offset of 1 along each axis: in 1D, outputs ``i-1``, ``i``, and
+    ``i+1``; analogously in 2D and 3D.
+
+    More generally, for an odd-sized kernel of size ``n``, the kernel radius is
+    ``n // 2``, so ``NaN`` values propagate to output centers within that radius.
+
+    """
     result = _run_extension_with_zero_padding(image, kernel)
 
     npt.assert_allclose(result, expected, equal_nan=True)
-# fmt: on
+# fmt:on
 
 
 @pytest.mark.parametrize(

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -1,20 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
+from functools import partial
+
 import numpy as np
 import numpy.testing as npt
 import pytest
-from functools import partial
+
 from astropy.convolution._convolve import _convolveNd_c
 
+_as_float64_c_contiguous = partial(np.ascontiguousarray, dtype="float64")
 
 
-_as_float64_c_contiguous = partial(np.ascontiguousarray, dtype = 'float64')
-# these helprer functions preprocess the inputs before passing to the extension
-
+# these helper functions preprocess the inputs before passing to the extension
 def _pad_for_direct_call(image, kernel):
     """Pad an image the same way with half-kernel width."""
-    return np.pad(image, pad_width=tuple((size // 2, size // 2) for size in kernel.shape))
+    return np.pad(
+        image, pad_width=tuple((size // 2, size // 2) for size in kernel.shape)
+    )
 
 
 def _allocate_result(image, padded_image, embed):

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -181,7 +181,16 @@ def test_embed_true_returns_expected_padded_output(image, kernel, expected):
     ],
 )
 def test_nan_without_interpolation_matches_expected_values(image, kernel, expected):
-    """Without NaN interpolation, any NaN in the window should propagate to the output."""
+    """Without NaN interpolation, any NaN in the window propagates.
+
+    Example:
+
+    for padded ``image = [0, 1, nan, 1, 0]`` and ``kernel = [1, 1, 1]``,
+    ``_convolveNd_c`` yields ``result = [nan, nan, nan]`` because each
+    output window contains the ``nan`` term and the extension
+    intentionally does not skip NaN values unless
+    ``nan_interpolate=True``.
+    """
 
     result = _run_extension_with_zero_padding(image, kernel)
 

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -1,39 +1,26 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from functools import partial
-
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 from astropy.convolution._convolve import _convolveNd_c
 
-_as_float64_c_contiguous = partial(np.ascontiguousarray, dtype="float64")
 
-
-# these helper functions preprocess the inputs before passing to the extension
-def _pad_for_direct_call(image, kernel):
-    """Pad an image the same way with half-kernel width."""
-    return np.pad(
-        image, pad_width=tuple((size // 2, size // 2) for size in kernel.shape)
+def _run_extension_with_zero_padding(
+    image, kernel, *, nan_interpolate=False, embed=False, n_threads=1
+):
+    """Call ``_convolveNd_c`` with a zero-padded input."""
+    image = np.ascontiguousarray(image, dtype=np.float64)
+    kernel = np.ascontiguousarray(kernel, dtype=np.float64)
+    pad_width = tuple((size // 2, size // 2) for size in kernel.shape)
+    padded_image = np.pad(
+        image,
+        pad_width=pad_width,
     )
-
-
-def _allocate_result(image, padded_image, embed):
-    """Allocate the result buffer with the shape expected by the C code."""
-
-    shape = padded_image.shape if embed else image.shape
-    return np.zeros(shape, dtype=np.float64, order="C")
-
-
-def _call_direct(image, kernel, *, nan_interpolate=False, embed=False, n_threads=1):
-    """Prepare inputs and call ``_convolveNd_c`` directly."""
-
-    image = _as_float64_c_contiguous(image)
-    kernel = _as_float64_c_contiguous(kernel)
-    padded_image = _pad_for_direct_call(image, kernel)
-    result = _allocate_result(image, padded_image, embed)
+    result_shape = padded_image.shape if embed else image.shape
+    result = np.zeros(result_shape, dtype=np.float64, order="C")
 
     _convolveNd_c(
         result,
@@ -47,86 +34,54 @@ def _call_direct(image, kernel, *, nan_interpolate=False, embed=False, n_threads
     return result
 
 
-def _trim_padding(embedded_result, kernel):
-    """Remove the outer padding region from an embedded result array after convolution."""
-
-    slices = []
-    for size in kernel.shape:
-        width = size // 2
-        slices.append(slice(width, -width if width else None))
-    return embedded_result[tuple(slices)]
-
-
-# this function acts as the oracle, a reference against which the outputs of the _convolveNd_c will be validated
-def _reference_direct_convolution(image, kernel, *, nan_interpolate=False, embed=False):
-    """Pure NumPy reference for the direct extension contract."""
-    image = _as_float64_c_contiguous(image)
-    kernel = _as_float64_c_contiguous(kernel)
-    padded_image = _pad_for_direct_call(image, kernel)
-    flipped_kernel = kernel[tuple(slice(None, None, -1) for _ in range(kernel.ndim))]
-    pad_width = tuple(size // 2 for size in kernel.shape)
-    result = _allocate_result(image, padded_image, embed)
-
-    for image_index in np.ndindex(image.shape):
-        padded_index = tuple(index + pad for index, pad in zip(image_index, pad_width))
-
-        window_slices = tuple(
-            slice(
-                padded_index[axis] - pad_width[axis],
-                padded_index[axis] - pad_width[axis] + kernel.shape[axis],
-            )
-            for axis in range(image.ndim)
-        )
-        window = padded_image[window_slices]
-
-        if nan_interpolate:
-            valid = ~np.isnan(window)
-            if np.any(valid):
-                top = np.sum(window[valid] * flipped_kernel[valid])
-                bot = np.sum(flipped_kernel[valid])
-            else:
-                top = 0.0
-                bot = 0.0
-
-            # The C code copies the center input value when the effective
-            # kernel weight sum is exactly zero.
-            if bot == 0.0:
-                value = padded_image[padded_index]
-            else:
-                value = top / bot
-        else:
-            value = np.sum(window * flipped_kernel)
-
-        result_index = padded_index if embed else image_index
-        result[result_index] = value
-
-    return result
-
-
 @pytest.mark.parametrize(
-    ("image", "kernel"),
+    ("image", "kernel", "expected"),
     [
         pytest.param(
-            np.array([10.0, 20.0, 30.0, 40.0, 50.0]),
-            np.array([1.0, 2.0, 1.0]),
+            np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            np.array([1.0, 0.0, -1.0], dtype=np.float64),
+            np.array([2.0, 2.0, -2.0], dtype=np.float64),
             id="1d",
         ),
         pytest.param(
-            np.arange(1.0, 17.0).reshape(4, 4),
-            np.array([[0.0, 1.0, 0.0], [1.0, 2.0, 1.0], [0.0, 1.0, 0.0]]),
+            np.arange(1.0, 10.0, dtype=np.float64).reshape(3, 3),
+            np.ones((3, 3), dtype=np.float64),
+            np.array(
+                [
+                    [12.0, 21.0, 16.0],
+                    [27.0, 45.0, 33.0],
+                    [24.0, 39.0, 28.0],
+                ],
+                dtype=np.float64,
+            ),
             id="2d",
         ),
         pytest.param(
-            np.arange(1.0, 65.0).reshape(4, 4, 4),
+            np.arange(1.0, 28.0, dtype=np.float64).reshape(3, 3, 3),
             np.ones((3, 3, 3), dtype=np.float64),
+            np.array(
+                [
+                    [[60.0, 96.0, 68.0], [108.0, 171.0, 120.0], [84.0, 132.0, 92.0]],
+                    [
+                        [144.0, 225.0, 156.0],
+                        [243.0, 378.0, 261.0],
+                        [180.0, 279.0, 192.0],
+                    ],
+                    [
+                        [132.0, 204.0, 140.0],
+                        [216.0, 333.0, 228.0],
+                        [156.0, 240.0, 164.0],
+                    ],
+                ],
+                dtype=np.float64,
+            ),
             id="3d",
         ),
     ],
 )
-def test_dispatch_paths_match_reference_without_nan_interpolation(image, kernel):
-    """Each dispatch path(1D, 2D, 3D) should agree with the NumPy reference result."""
-    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
-    expected = _reference_direct_convolution(
+def test_zero_padded_convolution_matches_expected_values(image, kernel, expected):
+    """Small representative inputs should produce the expected output values."""
+    result = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=False,
@@ -137,200 +92,185 @@ def test_dispatch_paths_match_reference_without_nan_interpolation(image, kernel)
 
 
 def test_asymmetric_kernel_is_flipped_before_multiplication():
-    """The direct extension should perform convolution, not correlation."""
-    image = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-    kernel = np.array([1.0, 2.0, 3.0])
+    """The extension should perform convolution, not correlation."""
+    image = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64)
+    kernel = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 
-    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
+    result = _run_extension_with_zero_padding(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=False,
+    )
+    expected = np.array([4.0, 10.0, 16.0, 22.0, 22.0], dtype=np.float64)
 
-    # ``convolve.c`` flips the kernel, so [1, 2, 3] is applied as [3, 2, 1].
-    expected = np.array([4.0, 10.0, 16.0, 22.0, 22.0])
     npt.assert_allclose(result, expected)
 
 
 @pytest.mark.parametrize(
-    ("image", "kernel"),
+    ("image", "kernel", "expected"),
     [
         pytest.param(
-            np.array([3.0, 7.0, 2.0, 9.0]), np.array([1.0, 2.0, 1.0]), id="1d"
+            np.array([3.0, 7.0, 2.0, 9.0], dtype=np.float64),
+            np.array([1.0, 2.0, 1.0], dtype=np.float64),
+            np.array([0.0, 13.0, 19.0, 20.0, 20.0, 0.0], dtype=np.float64),
+            id="1d",
         ),
         pytest.param(
-            np.arange(1.0, 10.0).reshape(3, 3),
+            np.arange(1.0, 10.0, dtype=np.float64).reshape(3, 3),
             np.ones((3, 3), dtype=np.float64),
+            np.array(
+                [
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 12.0, 21.0, 16.0, 0.0],
+                    [0.0, 27.0, 45.0, 33.0, 0.0],
+                    [0.0, 24.0, 39.0, 28.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                ],
+                dtype=np.float64,
+            ),
             id="2d",
-        ),
-        pytest.param(
-            np.arange(1.0, 28.0).reshape(3, 3, 3),
-            np.ones((3, 3, 3), dtype=np.float64),
-            id="3d",
         ),
     ],
 )
-def test_embed_true_matches_embed_false_in_inner_region_and_leaves_border_zero(
-    image, kernel
-):
-    """Embedded results should land in the padded coordinates and nowhere else."""
-    embedded = _call_direct(image, kernel, nan_interpolate=False, embed=True)
-    non_embedded = _call_direct(image, kernel, nan_interpolate=False, embed=False)
-
-    # The inner region should be exactly the same data we get from embed=False.
-    npt.assert_allclose(_trim_padding(embedded, kernel), non_embedded)
-
-    # The C loop only writes valid image coordinates, so the outer border should
-    # still contain the zeros from the initial result allocation.
-    inner_slices = tuple(
-        slice(size // 2, -(size // 2) if size // 2 else None) for size in kernel.shape
+def test_embed_true_returns_expected_padded_output(image, kernel, expected):
+    """With ``embed=True``, the result is written into the interior of the padded output."""
+    result = _run_extension_with_zero_padding(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=True,
     )
-    padding_mask = np.ones(embedded.shape, dtype=bool)
-    padding_mask[inner_slices] = False
-    npt.assert_array_equal(embedded[padding_mask], 0.0)
+
+    npt.assert_allclose(result, expected)
 
 
 @pytest.mark.parametrize(
-    ("image", "kernel", "probe_index"),
+    ("image", "kernel", "expected"),
     [
-        pytest.param(np.array([1.0, np.nan, 3.0, 4.0, 5.0]), np.ones(3), (0,), id="1d"),
+        pytest.param(
+            np.array([1.0, np.nan, 3.0, 4.0, 5.0], dtype=np.float64),
+            np.ones(3, dtype=np.float64),
+            np.array([np.nan, np.nan, np.nan, 12.0, 9.0], dtype=np.float64),
+            id="1d",
+        ),
         pytest.param(
             np.array(
                 [
-                    [1.0, 2.0, 3.0, 4.0, 5.0],
-                    [6.0, 7.0, 8.0, 9.0, 10.0],
-                    [11.0, 12.0, np.nan, 14.0, 15.0],
-                    [16.0, 17.0, 18.0, 19.0, 20.0],
-                    [21.0, 22.0, 23.0, 24.0, 25.0],
-                ]
+                    [1.0, 2.0, 3.0, 4.0],
+                    [5.0, np.nan, 7.0, 8.0],
+                    [9.0, 10.0, 11.0, 12.0],
+                    [13.0, 14.0, 15.0, 16.0],
+                ],
+                dtype=np.float64,
             ),
-            np.ones((3, 3)),
-            (2, 2),
+            np.ones((3, 3), dtype=np.float64),
+            np.array(
+                [
+                    [np.nan, np.nan, np.nan, 22.0],
+                    [np.nan, np.nan, np.nan, 45.0],
+                    [np.nan, np.nan, np.nan, 69.0],
+                    [46.0, 72.0, 78.0, 54.0],
+                ],
+                dtype=np.float64,
+            ),
             id="2d",
         ),
         pytest.param(
-            np.ones((5, 5, 5), dtype=np.float64),
             np.ones((3, 3, 3), dtype=np.float64),
-            (2, 2, 2),
+            np.ones((3, 3, 3), dtype=np.float64),
+            np.full((3, 3, 3), np.nan, dtype=np.float64),
             id="3d",
         ),
     ],
 )
-def test_nan_propagates_when_nan_interpolation_is_disabled(image, kernel, probe_index):
-    """Without NaN interpolation, any NaN in the window should poison the sum."""
+def test_nan_without_interpolation_matches_expected_values(image, kernel, expected):
+    """Without NaN interpolation, any NaN in the window should propagate to the output."""
     if image.ndim == 3:
         image = image.copy()
-        image[2, 2, 2] = np.nan
+        image[1, 1, 1] = np.nan
 
-    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
-    expected = _reference_direct_convolution(
+    result = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=False,
         embed=False,
     )
 
-    assert np.isnan(result[probe_index])
     npt.assert_allclose(result, expected, equal_nan=True)
 
 
 @pytest.mark.parametrize(
-    ("image", "kernel", "probe_index"),
+    ("image", "kernel", "expected"),
     [
-        pytest.param(np.array([1.0, 1.0, np.nan, 1.0, 1.0]), np.ones(3), (2,), id="1d"),
         pytest.param(
-            np.ones((5, 5), dtype=np.float64),
-            np.ones((3, 3), dtype=np.float64),
-            (2, 2),
-            id="2d",
+            np.array([1.0, 1.0, np.nan, 1.0, 1.0], dtype=np.float64),
+            np.ones(3, dtype=np.float64),
+            np.array([2.0 / 3.0, 1.0, 1.0, 1.0, 2.0 / 3.0], dtype=np.float64),
+            id="1d",
         ),
         pytest.param(
-            np.ones((5, 5, 5), dtype=np.float64),
-            np.ones((3, 3, 3), dtype=np.float64),
-            (2, 2, 2),
-            id="3d",
+            np.array(
+                [
+                    [1.0, 1.0, 1.0],
+                    [1.0, np.nan, 1.0],
+                    [1.0, 1.0, 1.0],
+                ],
+                dtype=np.float64,
+            ),
+            np.ones((3, 3), dtype=np.float64),
+            np.array(
+                [
+                    [0.375, 0.625, 0.375],
+                    [0.625, 1.0, 0.625],
+                    [0.375, 0.625, 0.375],
+                ],
+                dtype=np.float64,
+            ),
+            id="2d",
         ),
     ],
 )
-def test_nan_interpolation_skips_nan_values_and_renormalizes(
-    image, kernel, probe_index
-):
-    """With NaN interpolation enabled, valid neighbors should be reweighted."""
-    image = image.copy()
-    image[probe_index] = np.nan
-
-    result = _call_direct(image, kernel, nan_interpolate=True, embed=False)
-    expected = _reference_direct_convolution(
+def test_nan_interpolation_matches_expected_values(image, kernel, expected):
+    """With NaN interpolation enabled, valid neighbors are reweighted."""
+    result = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=True,
         embed=False,
     )
 
-    # A window of ones with one missing value should still evaluate to 1.0.
-    assert result[probe_index] == pytest.approx(1.0)
-    npt.assert_allclose(result, expected, equal_nan=True)
+    npt.assert_allclose(result, expected)
 
 
 def test_all_nan_window_copies_the_center_nan_value():
-    """An all-NaN window should fall back to the center input value."""
-    image = np.array([1.0, np.nan, np.nan, np.nan, 5.0])
+    """An all-NaN window should copy the center value back into the result."""
+    image = np.array([1.0, np.nan, np.nan, np.nan, 5.0], dtype=np.float64)
     kernel = np.ones(3, dtype=np.float64)
 
-    result = _call_direct(image, kernel, nan_interpolate=True, embed=False)
-    expected = _reference_direct_convolution(
+    result = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=True,
         embed=False,
     )
+    expected = np.array([0.5, 1.0, np.nan, 5.0, 2.5], dtype=np.float64)
 
-    # The center window is [nan, nan, nan], so ``bot`` becomes zero and the
-    # C code copies the center value, which is also NaN in this case.
-    assert np.isnan(result[2])
     npt.assert_allclose(result, expected, equal_nan=True)
 
 
 def test_zero_effective_weight_sum_copies_the_center_input_value():
-    """The ``bot == 0`` fallback should also work when valid pixels remain."""
-    image = np.array([5.0, np.nan, 20.0, 30.0, 40.0])
-    kernel = np.array([1.0, -1.0, 0.0])
+    """A zero effective kernel sum should copy the center input value."""
+    image = np.array([5.0, np.nan, 20.0, 30.0, 40.0], dtype=np.float64)
+    kernel = np.array([1.0, -1.0, 0.0], dtype=np.float64)
 
-    result = _call_direct(image, kernel, nan_interpolate=True, embed=False)
-    expected = _reference_direct_convolution(
+    result = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=True,
         embed=False,
     )
-
-    # At index 2 the valid weights sum to zero after the NaN is skipped, so the
-    # extension should copy the center input value instead of dividing by zero.
-    assert result[2] == pytest.approx(20.0)
-    npt.assert_allclose(result, expected, equal_nan=True)
-
-
-@pytest.mark.parametrize(
-    ("image", "kernel"),
-    [
-        pytest.param(np.array([1.0, 2.0, 3.0]), np.array([1.0, 0.0, -1.0]), id="1d"),
-        pytest.param(
-            np.arange(1.0, 10.0).reshape(3, 3),
-            np.ones((3, 3), dtype=np.float64),
-            id="2d",
-        ),
-        pytest.param(
-            np.arange(1.0, 28.0).reshape(3, 3, 3),
-            np.ones((3, 3, 3), dtype=np.float64),
-            id="3d",
-        ),
-    ],
-)
-def test_smallest_valid_input_shape_still_computes(image, kernel):
-    """Images that are just large enough for the kernel should still work."""
-    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
-    expected = _reference_direct_convolution(
-        image,
-        kernel,
-        nan_interpolate=False,
-        embed=False,
-    )
+    expected = np.array([5.0, 20.0, 20.0, 30.0, 40.0], dtype=np.float64)
 
     npt.assert_allclose(result, expected)
 
@@ -338,14 +278,18 @@ def test_smallest_valid_input_shape_still_computes(image, kernel):
 @pytest.mark.parametrize(
     ("image", "kernel"),
     [
-        pytest.param(np.linspace(1.0, 9.0, 9), np.array([1.0, 2.0, 1.0]), id="1d"),
         pytest.param(
-            np.arange(1.0, 101.0).reshape(10, 10),
+            np.linspace(1.0, 9.0, 9, dtype=np.float64),
+            np.array([1.0, 2.0, 1.0], dtype=np.float64),
+            id="1d",
+        ),
+        pytest.param(
+            np.arange(1.0, 101.0, dtype=np.float64).reshape(10, 10),
             np.ones((3, 3), dtype=np.float64),
             id="2d",
         ),
         pytest.param(
-            np.arange(1.0, 513.0).reshape(8, 8, 8),
+            np.arange(1.0, 513.0, dtype=np.float64).reshape(8, 8, 8),
             np.ones((3, 3, 3), dtype=np.float64),
             id="3d",
         ),
@@ -353,14 +297,14 @@ def test_smallest_valid_input_shape_still_computes(image, kernel):
 )
 def test_multi_threaded_results_match_single_threaded(image, kernel):
     """Changing ``n_threads`` should not change the numerical result."""
-    single_thread = _call_direct(
+    single_thread = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=False,
         embed=False,
         n_threads=1,
     )
-    multi_thread = _call_direct(
+    multi_thread = _run_extension_with_zero_padding(
         image,
         kernel,
         nan_interpolate=False,

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -86,16 +86,66 @@ def test_zero_padded_convolution_matches_expected_values(image, kernel, expected
     npt.assert_allclose(result, expected)
 
 
-def test_asymmetric_kernel_is_flipped_before_multiplication():
-    """The extension should perform convolution, not correlation."""
-
-    image = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64)
-    kernel = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-
+@pytest.mark.parametrize(
+    ("image", "kernel", "expected"),
+    [
+        pytest.param(
+            np.arange(1.0, 6.0, dtype=np.float64),
+            np.arange(1.0, 4.0, dtype=np.float64),
+            np.array([4.0, 10.0, 16.0, 22.0, 22.0], dtype=np.float64),
+            id="1d",
+        ),
+        pytest.param(
+            np.arange(1.0, 26.0, dtype=np.float64).reshape(5, 5),
+            np.arange(1.0, 10.0, dtype=np.float64).reshape(3, 3),
+            np.array(
+                [
+                    [32.0, 68.0, 89.0, 110.0, 96.0],
+                    [114.0, 219.0, 264.0, 309.0, 252.0],
+                    [249.0, 444.0, 489.0, 534.0, 417.0],
+                    [384.0, 669.0, 714.0, 759.0, 582.0],
+                    [440.0, 734.0, 773.0, 812.0, 600.0],
+                ],
+                dtype=np.float64,
+            ),
+            id="2d",
+        ),
+        pytest.param(
+            np.arange(1.0, 28.0, dtype=np.float64).reshape(3, 3, 3),
+            np.arange(1.0, 28.0, dtype=np.float64).reshape(3, 3, 3),
+            np.array(
+                [
+                    [
+                        [268.0, 490.0, 396.0],
+                        [654.0, 1140.0, 882.0],
+                        [700.0, 1174.0, 876.0],
+                    ],
+                    [
+                        [1050.0, 1788.0, 1350.0],
+                        [2196.0, 3654.0, 2700.0],
+                        [2022.0, 3300.0, 2394.0],
+                    ],
+                    [
+                        [1996.0, 3190.0, 2268.0],
+                        [3570.0, 5676.0, 4014.0],
+                        [2860.0, 4522.0, 3180.0],
+                    ],
+                ],
+                dtype=np.float64,
+            ),
+            id="3d",
+        ),
+    ],
+)
+def test_asymmetric_kernel_is_flipped_correctly(image, kernel, expected):
+    """
+    Kernel flip is fundamental to convolution. The extension should flip
+    the kernel correctly to compute the correct output. For a symmetric
+    kernel like ``[1, 1, 1]`` the flip does not matter since it reads the
+    same in both directions, but for an asymmetric kernel like ``[1, 2, 3]``
+    the flip changes the output .
+    """
     result = _run_extension_with_zero_padding(image, kernel)
-
-    expected = np.array([4.0, 10.0, 16.0, 22.0, 22.0], dtype=np.float64)
-
     npt.assert_allclose(result, expected)
 
 

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -1,0 +1,372 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from astropy.convolution._convolve import _convolveNd_c
+
+
+# these helprer functions preprocess the inputs before passing to the extension
+def _as_float64_c_contiguous(array):
+    """Return a C-contiguous ``float64`` array for the extension call."""
+    return np.ascontiguousarray(array, dtype=np.float64)
+
+
+def _pad_for_direct_call(image, kernel):
+    """Pad an image the same way with half-kernel width."""
+    pad_width = tuple((size // 2, size // 2) for size in kernel.shape)
+    padded = np.pad(image, pad_width, mode="constant", constant_values=0.0)
+    return _as_float64_c_contiguous(padded)
+
+
+def _allocate_result(image, padded_image, embed):
+    """Allocate the result buffer with the shape expected by the C code."""
+
+    shape = padded_image.shape if embed else image.shape
+    return np.zeros(shape, dtype=np.float64, order="C")
+
+
+def _call_direct(image, kernel, *, nan_interpolate=False, embed=False, n_threads=1):
+    """Prepare inputs and call ``_convolveNd_c`` directly."""
+
+    image = _as_float64_c_contiguous(image)
+    kernel = _as_float64_c_contiguous(kernel)
+    padded_image = _pad_for_direct_call(image, kernel)
+    result = _allocate_result(image, padded_image, embed)
+
+    _convolveNd_c(
+        result,
+        padded_image,
+        kernel,
+        nan_interpolate,
+        embed,
+        n_threads,
+    )
+
+    return result
+
+
+def _trim_padding(embedded_result, kernel):
+    """Remove the outer padding region from an embedded result array after convolution."""
+
+    slices = []
+    for size in kernel.shape:
+        width = size // 2
+        slices.append(slice(width, -width if width else None))
+    return embedded_result[tuple(slices)]
+
+
+# this function acts as the oracle, a reference against which the outputs of the _convolveNd_c will be validated
+def _reference_direct_convolution(image, kernel, *, nan_interpolate=False, embed=False):
+    """Pure NumPy reference for the direct extension contract."""
+    image = _as_float64_c_contiguous(image)
+    kernel = _as_float64_c_contiguous(kernel)
+    padded_image = _pad_for_direct_call(image, kernel)
+    flipped_kernel = kernel[tuple(slice(None, None, -1) for _ in range(kernel.ndim))]
+    pad_width = tuple(size // 2 for size in kernel.shape)
+    result = _allocate_result(image, padded_image, embed)
+
+    for image_index in np.ndindex(image.shape):
+        padded_index = tuple(index + pad for index, pad in zip(image_index, pad_width))
+
+        window_slices = tuple(
+            slice(
+                padded_index[axis] - pad_width[axis],
+                padded_index[axis] - pad_width[axis] + kernel.shape[axis],
+            )
+            for axis in range(image.ndim)
+        )
+        window = padded_image[window_slices]
+
+        if nan_interpolate:
+            valid = ~np.isnan(window)
+            if np.any(valid):
+                top = np.sum(window[valid] * flipped_kernel[valid])
+                bot = np.sum(flipped_kernel[valid])
+            else:
+                top = 0.0
+                bot = 0.0
+
+            # The C code copies the center input value when the effective
+            # kernel weight sum is exactly zero.
+            if bot == 0.0:
+                value = padded_image[padded_index]
+            else:
+                value = top / bot
+        else:
+            value = np.sum(window * flipped_kernel)
+
+        result_index = padded_index if embed else image_index
+        result[result_index] = value
+
+    return result
+
+
+@pytest.mark.parametrize(
+    ("image", "kernel"),
+    [
+        pytest.param(
+            np.array([10.0, 20.0, 30.0, 40.0, 50.0]),
+            np.array([1.0, 2.0, 1.0]),
+            id="1d",
+        ),
+        pytest.param(
+            np.arange(1.0, 17.0).reshape(4, 4),
+            np.array([[0.0, 1.0, 0.0], [1.0, 2.0, 1.0], [0.0, 1.0, 0.0]]),
+            id="2d",
+        ),
+        pytest.param(
+            np.arange(1.0, 65.0).reshape(4, 4, 4),
+            np.ones((3, 3, 3), dtype=np.float64),
+            id="3d",
+        ),
+    ],
+)
+def test_dispatch_paths_match_reference_without_nan_interpolation(image, kernel):
+    """Each dispatch path(1D, 2D, 3D) should agree with the NumPy reference result."""
+    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
+    expected = _reference_direct_convolution(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=False,
+    )
+
+    npt.assert_allclose(result, expected)
+
+
+def test_asymmetric_kernel_is_flipped_before_multiplication():
+    """The direct extension should perform convolution, not correlation."""
+    image = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    kernel = np.array([1.0, 2.0, 3.0])
+
+    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
+
+    # ``convolve.c`` flips the kernel, so [1, 2, 3] is applied as [3, 2, 1].
+    expected = np.array([4.0, 10.0, 16.0, 22.0, 22.0])
+    npt.assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("image", "kernel"),
+    [
+        pytest.param(
+            np.array([3.0, 7.0, 2.0, 9.0]), np.array([1.0, 2.0, 1.0]), id="1d"
+        ),
+        pytest.param(
+            np.arange(1.0, 10.0).reshape(3, 3),
+            np.ones((3, 3), dtype=np.float64),
+            id="2d",
+        ),
+        pytest.param(
+            np.arange(1.0, 28.0).reshape(3, 3, 3),
+            np.ones((3, 3, 3), dtype=np.float64),
+            id="3d",
+        ),
+    ],
+)
+def test_embed_true_matches_embed_false_in_inner_region_and_leaves_border_zero(
+    image, kernel
+):
+    """Embedded results should land in the padded coordinates and nowhere else."""
+    embedded = _call_direct(image, kernel, nan_interpolate=False, embed=True)
+    non_embedded = _call_direct(image, kernel, nan_interpolate=False, embed=False)
+
+    # The inner region should be exactly the same data we get from embed=False.
+    npt.assert_allclose(_trim_padding(embedded, kernel), non_embedded)
+
+    # The C loop only writes valid image coordinates, so the outer border should
+    # still contain the zeros from the initial result allocation.
+    inner_slices = tuple(
+        slice(size // 2, -(size // 2) if size // 2 else None) for size in kernel.shape
+    )
+    padding_mask = np.ones(embedded.shape, dtype=bool)
+    padding_mask[inner_slices] = False
+    npt.assert_array_equal(embedded[padding_mask], 0.0)
+
+
+@pytest.mark.parametrize(
+    ("image", "kernel", "probe_index"),
+    [
+        pytest.param(np.array([1.0, np.nan, 3.0, 4.0, 5.0]), np.ones(3), (0,), id="1d"),
+        pytest.param(
+            np.array(
+                [
+                    [1.0, 2.0, 3.0, 4.0, 5.0],
+                    [6.0, 7.0, 8.0, 9.0, 10.0],
+                    [11.0, 12.0, np.nan, 14.0, 15.0],
+                    [16.0, 17.0, 18.0, 19.0, 20.0],
+                    [21.0, 22.0, 23.0, 24.0, 25.0],
+                ]
+            ),
+            np.ones((3, 3)),
+            (2, 2),
+            id="2d",
+        ),
+        pytest.param(
+            np.ones((5, 5, 5), dtype=np.float64),
+            np.ones((3, 3, 3), dtype=np.float64),
+            (2, 2, 2),
+            id="3d",
+        ),
+    ],
+)
+def test_nan_propagates_when_nan_interpolation_is_disabled(image, kernel, probe_index):
+    """Without NaN interpolation, any NaN in the window should poison the sum."""
+    if image.ndim == 3:
+        image = image.copy()
+        image[2, 2, 2] = np.nan
+
+    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
+    expected = _reference_direct_convolution(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=False,
+    )
+
+    assert np.isnan(result[probe_index])
+    npt.assert_allclose(result, expected, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    ("image", "kernel", "probe_index"),
+    [
+        pytest.param(np.array([1.0, 1.0, np.nan, 1.0, 1.0]), np.ones(3), (2,), id="1d"),
+        pytest.param(
+            np.ones((5, 5), dtype=np.float64),
+            np.ones((3, 3), dtype=np.float64),
+            (2, 2),
+            id="2d",
+        ),
+        pytest.param(
+            np.ones((5, 5, 5), dtype=np.float64),
+            np.ones((3, 3, 3), dtype=np.float64),
+            (2, 2, 2),
+            id="3d",
+        ),
+    ],
+)
+def test_nan_interpolation_skips_nan_values_and_renormalizes(
+    image, kernel, probe_index
+):
+    """With NaN interpolation enabled, valid neighbors should be reweighted."""
+    image = image.copy()
+    image[probe_index] = np.nan
+
+    result = _call_direct(image, kernel, nan_interpolate=True, embed=False)
+    expected = _reference_direct_convolution(
+        image,
+        kernel,
+        nan_interpolate=True,
+        embed=False,
+    )
+
+    # A window of ones with one missing value should still evaluate to 1.0.
+    assert result[probe_index] == pytest.approx(1.0)
+    npt.assert_allclose(result, expected, equal_nan=True)
+
+
+def test_all_nan_window_copies_the_center_nan_value():
+    """An all-NaN window should fall back to the center input value."""
+    image = np.array([1.0, np.nan, np.nan, np.nan, 5.0])
+    kernel = np.ones(3, dtype=np.float64)
+
+    result = _call_direct(image, kernel, nan_interpolate=True, embed=False)
+    expected = _reference_direct_convolution(
+        image,
+        kernel,
+        nan_interpolate=True,
+        embed=False,
+    )
+
+    # The center window is [nan, nan, nan], so ``bot`` becomes zero and the
+    # C code copies the center value, which is also NaN in this case.
+    assert np.isnan(result[2])
+    npt.assert_allclose(result, expected, equal_nan=True)
+
+
+def test_zero_effective_weight_sum_copies_the_center_input_value():
+    """The ``bot == 0`` fallback should also work when valid pixels remain."""
+    image = np.array([5.0, np.nan, 20.0, 30.0, 40.0])
+    kernel = np.array([1.0, -1.0, 0.0])
+
+    result = _call_direct(image, kernel, nan_interpolate=True, embed=False)
+    expected = _reference_direct_convolution(
+        image,
+        kernel,
+        nan_interpolate=True,
+        embed=False,
+    )
+
+    # At index 2 the valid weights sum to zero after the NaN is skipped, so the
+    # extension should copy the center input value instead of dividing by zero.
+    assert result[2] == pytest.approx(20.0)
+    npt.assert_allclose(result, expected, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    ("image", "kernel"),
+    [
+        pytest.param(np.array([1.0, 2.0, 3.0]), np.array([1.0, 0.0, -1.0]), id="1d"),
+        pytest.param(
+            np.arange(1.0, 10.0).reshape(3, 3),
+            np.ones((3, 3), dtype=np.float64),
+            id="2d",
+        ),
+        pytest.param(
+            np.arange(1.0, 28.0).reshape(3, 3, 3),
+            np.ones((3, 3, 3), dtype=np.float64),
+            id="3d",
+        ),
+    ],
+)
+def test_smallest_valid_input_shape_still_computes(image, kernel):
+    """Images that are just large enough for the kernel should still work."""
+    result = _call_direct(image, kernel, nan_interpolate=False, embed=False)
+    expected = _reference_direct_convolution(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=False,
+    )
+
+    npt.assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("image", "kernel"),
+    [
+        pytest.param(np.linspace(1.0, 9.0, 9), np.array([1.0, 2.0, 1.0]), id="1d"),
+        pytest.param(
+            np.arange(1.0, 101.0).reshape(10, 10),
+            np.ones((3, 3), dtype=np.float64),
+            id="2d",
+        ),
+        pytest.param(
+            np.arange(1.0, 513.0).reshape(8, 8, 8),
+            np.ones((3, 3, 3), dtype=np.float64),
+            id="3d",
+        ),
+    ],
+)
+def test_multi_threaded_results_match_single_threaded(image, kernel):
+    """Changing ``n_threads`` should not change the numerical result."""
+    single_thread = _call_direct(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=False,
+        n_threads=1,
+    )
+    multi_thread = _call_direct(
+        image,
+        kernel,
+        nan_interpolate=False,
+        embed=False,
+        n_threads=4,
+    )
+
+    npt.assert_allclose(single_thread, multi_thread)

--- a/astropy/convolution/tests/test_extension_convolve_nd_c.py
+++ b/astropy/convolution/tests/test_extension_convolve_nd_c.py
@@ -81,27 +81,19 @@ def _run_extension_with_zero_padding(
 )
 def test_zero_padded_convolution_matches_expected_values(image, kernel, expected):
     """Small representative inputs should produce the expected output values."""
-    result = _run_extension_with_zero_padding(
-        image,
-        kernel,
-        nan_interpolate=False,
-        embed=False,
-    )
+    result = _run_extension_with_zero_padding(image, kernel)
 
     npt.assert_allclose(result, expected)
 
 
 def test_asymmetric_kernel_is_flipped_before_multiplication():
     """The extension should perform convolution, not correlation."""
+
     image = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64)
     kernel = np.array([1.0, 2.0, 3.0], dtype=np.float64)
 
-    result = _run_extension_with_zero_padding(
-        image,
-        kernel,
-        nan_interpolate=False,
-        embed=False,
-    )
+    result = _run_extension_with_zero_padding(image, kernel)
+
     expected = np.array([4.0, 10.0, 16.0, 22.0, 22.0], dtype=np.float64)
 
     npt.assert_allclose(result, expected)
@@ -135,12 +127,7 @@ def test_asymmetric_kernel_is_flipped_before_multiplication():
 )
 def test_embed_true_returns_expected_padded_output(image, kernel, expected):
     """With ``embed=True``, the result is written into the interior of the padded output."""
-    result = _run_extension_with_zero_padding(
-        image,
-        kernel,
-        nan_interpolate=False,
-        embed=True,
-    )
+    result = _run_extension_with_zero_padding(image, kernel, embed=True)
 
     npt.assert_allclose(result, expected)
 
@@ -190,12 +177,7 @@ def test_nan_without_interpolation_matches_expected_values(image, kernel, expect
         image = image.copy()
         image[1, 1, 1] = np.nan
 
-    result = _run_extension_with_zero_padding(
-        image,
-        kernel,
-        nan_interpolate=False,
-        embed=False,
-    )
+    result = _run_extension_with_zero_padding(image, kernel)
 
     npt.assert_allclose(result, expected, equal_nan=True)
 
@@ -237,14 +219,13 @@ def test_nan_interpolation_matches_expected_values(image, kernel, expected):
         image,
         kernel,
         nan_interpolate=True,
-        embed=False,
     )
 
     npt.assert_allclose(result, expected)
 
 
 def test_all_nan_window_copies_the_center_nan_value():
-    """An all-NaN window should copy the center value back into the result."""
+    """An all-NaN window should copy the center value back into the result when nan_interpolate is enabled."""
     image = np.array([1.0, np.nan, np.nan, np.nan, 5.0], dtype=np.float64)
     kernel = np.ones(3, dtype=np.float64)
 
@@ -252,7 +233,6 @@ def test_all_nan_window_copies_the_center_nan_value():
         image,
         kernel,
         nan_interpolate=True,
-        embed=False,
     )
     expected = np.array([0.5, 1.0, np.nan, 5.0, 2.5], dtype=np.float64)
 
@@ -260,7 +240,8 @@ def test_all_nan_window_copies_the_center_nan_value():
 
 
 def test_zero_effective_weight_sum_copies_the_center_input_value():
-    """A zero effective kernel sum should copy the center input value."""
+    """A zero effective kernel sum should copy the center input value when nan_interpolation is enabled."""
+
     image = np.array([5.0, np.nan, 20.0, 30.0, 40.0], dtype=np.float64)
     kernel = np.array([1.0, -1.0, 0.0], dtype=np.float64)
 
@@ -268,7 +249,6 @@ def test_zero_effective_weight_sum_copies_the_center_input_value():
         image,
         kernel,
         nan_interpolate=True,
-        embed=False,
     )
     expected = np.array([5.0, 20.0, 20.0, 30.0, 40.0], dtype=np.float64)
 
@@ -300,15 +280,11 @@ def test_multi_threaded_results_match_single_threaded(image, kernel):
     single_thread = _run_extension_with_zero_padding(
         image,
         kernel,
-        nan_interpolate=False,
-        embed=False,
         n_threads=1,
     )
     multi_thread = _run_extension_with_zero_padding(
         image,
         kernel,
-        nan_interpolate=False,
-        embed=False,
         n_threads=4,
     )
 


### PR DESCRIPTION
### Description
This PR adds direct tests for the `_convolveNd_c` C extension in the convolution 
subpackage as part of my GSoC 2026 interest in improving low-level test coverage.

Currently no tests target this extension directly , only the public Python API (`convolve.py`)  for this is tested.

UPDATE:

  I’ve updated the file to simplify the approach:

  - removed the Python reference/oracle helper
  - replaced it with explicit expected values for small representative cases
  - renamed the helper to make the zero-padding setup explicit
  - removed the extra trimming helper and made the embed=True expectation explicit in the test
  - made dtype=np.float64 explicit throughout


### Testing
`pytest astropy/convolution/tests/test_extension_convolve_nd_c.py -v`

cc @neutrinoceros @astrofrog @nstarman 