### PR TITLE
Add clang-format commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -49,3 +49,5 @@ fa2df9f32e5c041d74f7d1ef3d5a188c521cbc79
 d2165fa02c1a2d79f4a6cb69a5cebeee0b073033
 # DOC: Moved dev docs around
 f5a1738f32d4920ac853c7c0ec6c941ccec47555
+# clang-format for most sub-packages except astropy.wcs
+933e3e6eadff215165c838fd91c21e8615d0cf88


### PR DESCRIPTION
Follow-up to https://github.com/astropy/astropy/pull/18674

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
