### PR TITLE
Added missing .clang-format for cextern/

### DIFF
--- a/cextern/.clang-format
+++ b/cextern/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
This was an oversight in https://github.com/astropy/astropy/pull/19476 - with this we shouldn't need to exclude cextern in the pre-commit config.