### PR TITLE
Adopt PEP 793 module export hooks for C extensions (keep PyInit for compatibility)

### DIFF
--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -412,18 +412,6 @@ static int module_clear(PyObject *m)
     return 0;
 }
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "tablewriter",
-    "Fast way to write VOTABLE TABLEDATA",
-    sizeof(struct module_state),
-    module_methods,
-    NULL,
-    module_traverse,
-    module_clear,
-    NULL
-};
-
 #if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_name, "tablewriter"},
@@ -442,6 +430,18 @@ PyMODEXPORT_FUNC PyModExport_tablewriter(void)
     return module_slots;
 }
 #else
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "tablewriter",
+    "Fast way to write VOTABLE TABLEDATA",
+    sizeof(struct module_state),
+    module_methods,
+    NULL,
+    module_traverse,
+    module_clear,
+    NULL
+};
+
 PyMODINIT_FUNC PyInit_tablewriter(void)
 {
     return PyModule_Create(&moduledef);

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -437,8 +437,7 @@ static PyModuleDef_Slot module_slots[] = {
 
 PyMODEXPORT_FUNC PyModExport_tablewriter(void);
 
-PyMODEXPORT_FUNC
-PyModExport_tablewriter(void)
+PyMODEXPORT_FUNC PyModExport_tablewriter(void)
 {
     return module_slots;
 }

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -424,6 +424,26 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_name, "tablewriter"},
+    {Py_mod_doc, "Fast way to write VOTABLE TABLEDATA"},
+    {Py_mod_state_size, (void *)sizeof(struct module_state)},
+    {Py_mod_methods, module_methods},
+    {Py_mod_state_traverse, (void *)module_traverse},
+    {Py_mod_state_clear, (void *)module_clear},
+    {0, NULL}
+};
+
+PyMODEXPORT_FUNC PyModExport_tablewriter(void);
+
+PyMODEXPORT_FUNC
+PyModExport_tablewriter(void)
+{
+    return module_slots;
+}
+#endif
+
 PyMODINIT_FUNC PyInit_tablewriter(void)
 {
     return PyModule_Create(&moduledef);

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -441,9 +441,9 @@ PyMODEXPORT_FUNC PyModExport_tablewriter(void)
 {
     return module_slots;
 }
-#endif
-
+#else
 PyMODINIT_FUNC PyInit_tablewriter(void)
 {
     return PyModule_Create(&moduledef);
 }
+#endif

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -38,8 +38,7 @@ static PyModuleDef_Slot module_slots[] = {
 
 PyMODEXPORT_FUNC PyModExport__fast_sigma_clip(void);
 
-PyMODEXPORT_FUNC
-PyModExport__fast_sigma_clip(void)
+PyMODEXPORT_FUNC PyModExport__fast_sigma_clip(void)
 {
     return module_slots;
 }

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -27,6 +27,24 @@ static PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
     }; \
     ob = PyModule_Create(&moduledef);
 
+#if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_name, "_fast_sigma_clip"},
+    {Py_mod_doc, module_docstring},
+    {Py_mod_state_size, (void *)-1},
+    {Py_mod_methods, module_methods},
+    {0, NULL}
+};
+
+PyMODEXPORT_FUNC PyModExport__fast_sigma_clip(void);
+
+PyMODEXPORT_FUNC
+PyModExport__fast_sigma_clip(void)
+{
+    return module_slots;
+}
+#endif
+
 MOD_INIT(_fast_sigma_clip)
 {
     PyObject *m, *d = NULL;

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -8,24 +8,28 @@
 
 /* Define docstrings */
 static char module_docstring[] = "Fast sigma clipping";
+#if !defined(PyMODEXPORT_FUNC) || !defined(Py_mod_name)
 static char _sigma_clip_fast_docstring[] = "Compute sigma clipping";
 
 /* Declare the C functions here. */
 static void _sigma_clip_fast(
     char **args, npy_intp const *dimensions, npy_intp const *steps, void *data
 );
+#endif
 
 /* Define the methods that will be available on the module. */
 static PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
 
 /* This is the function that is called on import. */
 
+#if !defined(PyMODEXPORT_FUNC) || !defined(Py_mod_name)
 #define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
 #define MOD_DEF(ob, name, doc, methods) \
     static struct PyModuleDef moduledef = { \
         PyModuleDef_HEAD_INIT, name, doc, -1, methods, NULL, NULL, NULL, NULL \
     }; \
     ob = PyModule_Create(&moduledef);
+#endif
 
 #if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
 static PyModuleDef_Slot module_slots[] = {
@@ -99,7 +103,7 @@ fail:
 }
 #endif
 
-
+#if !defined(PyMODEXPORT_FUNC) || !defined(Py_mod_name)
 static void _sigma_clip_fast(
     char **args, npy_intp const *dimensions, npy_intp const *steps, void *data
 )
@@ -198,3 +202,4 @@ static void _sigma_clip_fast(
         free((void *)mad_buffer);
     }
 }
+#endif

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -42,8 +42,7 @@ PyMODEXPORT_FUNC PyModExport__fast_sigma_clip(void)
 {
     return module_slots;
 }
-#endif
-
+#else
 MOD_INIT(_fast_sigma_clip)
 {
     PyObject *m, *d = NULL;
@@ -98,6 +97,7 @@ fail:
     Py_XDECREF(d);
     return NULL;
 }
+#endif
 
 
 static void _sigma_clip_fast(

--- a/astropy/stats/src/fast_sigma_clip.c
+++ b/astropy/stats/src/fast_sigma_clip.c
@@ -8,29 +8,11 @@
 
 /* Define docstrings */
 static char module_docstring[] = "Fast sigma clipping";
-#if !defined(PyMODEXPORT_FUNC) || !defined(Py_mod_name)
-static char _sigma_clip_fast_docstring[] = "Compute sigma clipping";
-
-/* Declare the C functions here. */
-static void _sigma_clip_fast(
-    char **args, npy_intp const *dimensions, npy_intp const *steps, void *data
-);
-#endif
 
 /* Define the methods that will be available on the module. */
 static PyMethodDef module_methods[] = {{NULL, NULL, 0, NULL}};
 
 /* This is the function that is called on import. */
-
-#if !defined(PyMODEXPORT_FUNC) || !defined(Py_mod_name)
-#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
-#define MOD_DEF(ob, name, doc, methods) \
-    static struct PyModuleDef moduledef = { \
-        PyModuleDef_HEAD_INIT, name, doc, -1, methods, NULL, NULL, NULL, NULL \
-    }; \
-    ob = PyModule_Create(&moduledef);
-#endif
-
 #if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_name, "_fast_sigma_clip"},
@@ -47,6 +29,20 @@ PyMODEXPORT_FUNC PyModExport__fast_sigma_clip(void)
     return module_slots;
 }
 #else
+static char _sigma_clip_fast_docstring[] = "Compute sigma clipping";
+
+/* Declare the C functions here. */
+static void _sigma_clip_fast(
+    char **args, npy_intp const *dimensions, npy_intp const *steps, void *data
+);
+
+#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+#define MOD_DEF(ob, name, doc, methods) \
+    static struct PyModuleDef moduledef = { \
+        PyModuleDef_HEAD_INIT, name, doc, -1, methods, NULL, NULL, NULL, NULL \
+    }; \
+    ob = PyModule_Create(&moduledef);
+
 MOD_INIT(_fast_sigma_clip)
 {
     PyObject *m, *d = NULL;
@@ -101,9 +97,7 @@ fail:
     Py_XDECREF(d);
     return NULL;
 }
-#endif
 
-#if !defined(PyMODEXPORT_FUNC) || !defined(Py_mod_name)
 static void _sigma_clip_fast(
     char **args, npy_intp const *dimensions, npy_intp const *steps, void *data
 )

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -492,6 +492,24 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_name, "parse_times"},
+    {Py_mod_doc, (char *)MODULE_DOCSTRING},
+    {Py_mod_state_size, (void *)-1},
+    {Py_mod_methods, parse_times_methods},
+    {0, NULL}
+};
+
+PyMODEXPORT_FUNC PyModExport__parse_times(void);
+
+PyMODEXPORT_FUNC
+PyModExport__parse_times(void)
+{
+    return module_slots;
+}
+#endif
+
 /* Initialization function for the module */
 PyMODINIT_FUNC PyInit__parse_times(void)
 {

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -503,8 +503,7 @@ static PyModuleDef_Slot module_slots[] = {
 
 PyMODEXPORT_FUNC PyModExport__parse_times(void);
 
-PyMODEXPORT_FUNC
-PyModExport__parse_times(void)
+PyMODEXPORT_FUNC PyModExport__parse_times(void)
 {
     return module_slots;
 }

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -480,18 +480,6 @@ static PyMethodDef parse_times_methods[] = {
     {NULL, NULL, 0, NULL} /* Sentinel */
 };
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "parse_times",
-    MODULE_DOCSTRING,
-    -1,
-    parse_times_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
 #if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_name, "parse_times"},
@@ -508,6 +496,18 @@ PyMODEXPORT_FUNC PyModExport__parse_times(void)
     return module_slots;
 }
 #else
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "parse_times",
+    MODULE_DOCSTRING,
+    -1,
+    parse_times_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
 /* Initialization function for the module */
 PyMODINIT_FUNC PyInit__parse_times(void)
 {

--- a/astropy/time/src/parse_times.c
+++ b/astropy/time/src/parse_times.c
@@ -507,8 +507,7 @@ PyMODEXPORT_FUNC PyModExport__parse_times(void)
 {
     return module_slots;
 }
-#endif
-
+#else
 /* Initialization function for the module */
 PyMODINIT_FUNC PyInit__parse_times(void)
 {
@@ -584,3 +583,4 @@ decref:
     Py_XDECREF((PyObject *)dt_ymdhms);
     return m;
 }
+#endif

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1339,6 +1339,26 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
+static PyModuleDef_Slot module_slots[] = {
+    {Py_mod_name, "_iterparser"},
+    {Py_mod_doc, "Fast XML parser"},
+    {Py_mod_state_size, (void *)sizeof(struct module_state)},
+    {Py_mod_methods, module_methods},
+    {Py_mod_state_traverse, (void *)module_traverse},
+    {Py_mod_state_clear, (void *)module_clear},
+    {0, NULL}
+};
+
+PyMODEXPORT_FUNC PyModExport__iterparser(void);
+
+PyMODEXPORT_FUNC
+PyModExport__iterparser(void)
+{
+    return module_slots;
+}
+#endif
+
 PyMODINIT_FUNC PyInit__iterparser(void)
 {
     PyObject *m;

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1327,18 +1327,6 @@ static int module_clear(PyObject *m)
     return 0;
 }
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_iterparser",
-    "Fast XML parser",
-    sizeof(struct module_state),
-    module_methods,
-    NULL,
-    module_traverse,
-    module_clear,
-    NULL
-};
-
 #if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_name, "_iterparser"},
@@ -1357,6 +1345,18 @@ PyMODEXPORT_FUNC PyModExport__iterparser(void)
     return module_slots;
 }
 #else
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_iterparser",
+    "Fast XML parser",
+    sizeof(struct module_state),
+    module_methods,
+    NULL,
+    module_traverse,
+    module_clear,
+    NULL
+};
+
 PyMODINIT_FUNC PyInit__iterparser(void)
 {
     PyObject *m;

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1356,8 +1356,7 @@ PyMODEXPORT_FUNC PyModExport__iterparser(void)
 {
     return module_slots;
 }
-#endif
-
+#else
 PyMODINIT_FUNC PyInit__iterparser(void)
 {
     PyObject *m;
@@ -1376,3 +1375,4 @@ PyMODINIT_FUNC PyInit__iterparser(void)
 
     return m;
 }
+#endif

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1352,8 +1352,7 @@ static PyModuleDef_Slot module_slots[] = {
 
 PyMODEXPORT_FUNC PyModExport__iterparser(void);
 
-PyMODEXPORT_FUNC
-PyModExport__iterparser(void)
+PyMODEXPORT_FUNC PyModExport__iterparser(void)
 {
     return module_slots;
 }

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -830,6 +830,23 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
+static PyModuleDef_Slot module_slots[] = {
+  {Py_mod_name, "_wcs"},
+  {Py_mod_state_size, (void *)sizeof(struct module_state)},
+  {Py_mod_methods, module_methods},
+  {0, NULL}
+};
+
+PyMODEXPORT_FUNC PyModExport__wcs(void);
+
+PyMODEXPORT_FUNC
+PyModExport__wcs(void)
+{
+  return module_slots;
+}
+#endif
+
 PyMODINIT_FUNC
 PyInit__wcs(void)
 

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -818,18 +818,6 @@ struct module_state {
 #endif
 };
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_wcs",
-    NULL,
-    sizeof(struct module_state),
-    module_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
 #if defined(PyMODEXPORT_FUNC) && defined(Py_mod_name)
 static PyModuleDef_Slot module_slots[] = {
   {Py_mod_name, "_wcs"},
@@ -846,6 +834,18 @@ PyModExport__wcs(void)
   return module_slots;
 }
 #else
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_wcs",
+    NULL,
+    sizeof(struct module_state),
+    module_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
 PyMODINIT_FUNC
 PyInit__wcs(void)
 

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -845,8 +845,7 @@ PyModExport__wcs(void)
 {
   return module_slots;
 }
-#endif
-
+#else
 PyMODINIT_FUNC
 PyInit__wcs(void)
 
@@ -906,3 +905,4 @@ PyInit__wcs(void)
 
   return m;
 }
+#endif

--- a/docs/changes/19482.other.rst
+++ b/docs/changes/19482.other.rst
@@ -1,1 +1,1 @@
-Refactored several C extension sources for Python 3.15 and ``Limited API`` (PEP 793) compatibility across ``io.votable``, ``wcs``, ``time``, ``utils``, and ``stats`` without changing public behavior.
+Ensure PEP 793 compliance in C extension modules for CPython 3.15+ .

--- a/docs/changes/19482.other.rst
+++ b/docs/changes/19482.other.rst
@@ -1,0 +1,1 @@
+Refactored several C extension sources for Python 3.15 and ``Limited API`` (PEP 793) compatibility across ``io.votable``, ``wcs``, ``time``, ``utils``, and ``stats`` without changing public behavior.


### PR DESCRIPTION

This PR adds PEP 793-style module export hooks (PyModExport_*) to Astropy C extensions that currently define modules via PyModuleDef_HEAD_INIT. 

What changed
Added guarded slot-based module export definitions in:

- io/votable/src/tablewriter.c
- stats/src/fast_sigma_clip.c
- time/src/parse_times.c
- utils/xml/src/iterparse.c
- wcs/src/astropy_wcs.c

fixes #19478 

do let's me know if I am misssing something. I am quite new to the code base

