### PR TITLE
MNT: fix pre-commit exclude regexp

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autofix_prs: false
   autoupdate_schedule: 'monthly'
 
-exclude: "^cextern/*"
+exclude: "^cextern"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
### Description
Fixes #19487

Follow-up of https://github.com/astropy/astropy/pull/19476

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
