### PR TITLE
Add write() method to VOTableFile as a wrapper around to_xml

### DIFF
--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -181,41 +181,6 @@ io_registry.register_writer("votable", Table, write_table_votable)
 io_registry.register_identifier("votable", Table, is_votable)
 
 
-def write_votable_file(input, output, **kwargs):
-    """
-    Write a VOTableFile object to an XML file.
-
-    Parameters
-    ----------
-    input : `~astropy.io.votable.tree.VOTableFile`
-        The VOTable to write out.
-
-    output : str or file-like
-        The filename or file object to write to.
-
-    **kwargs
-        Additional keyword arguments are passed on to
-        `~astropy.io.votable.tree.VOTableFile.to_xml`.
-    """
-    input.to_xml(output, **kwargs)
-
-
-class VOTableFileWrite(io_registry.UnifiedReadWrite):
-    """
-    Write this VOTableFile object to a file in VOTable format.
-    """
-
-    def __init__(self, instance, cls):
-        super().__init__(instance, cls, "write", registry=None)
-
-    def __call__(self, *args, **kwargs):
-        self.registry.write(self._instance, *args, **kwargs)
-
-
-io_registry.register_writer("votable", VOTableFile, write_votable_file)
-VOTableFile.write = io_registry.UnifiedReadWriteMethod(VOTableFileWrite)
-
-
 # VOTable with embedded/linked Parquet file #
 def write_table_votable_parquet(input, output, column_metadata, *, overwrite=False):
     """

--- a/astropy/io/votable/tests/test_tree.py
+++ b/astropy/io/votable/tests/test_tree.py
@@ -705,3 +705,6 @@ def test_votablefile_write(tmp_path):
     roundtripped = parse(str(out))
     assert roundtripped.params[0].name == "TestParam"
     assert roundtripped.infos[0].name == "TestInfo"
+
+    # format kwarg should be accepted and ignored for API compatibility
+    vot.write(str(out), format="votable")

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -4487,6 +4487,28 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                     for element in element_set:
                         element.to_xml(w, **kwargs)
 
+    def write(self, output, **kwargs):
+        """
+        Write the VOTable to a file.
+
+        This is a wrapper around
+        `~astropy.io.votable.tree.VOTableFile.to_xml` that accepts the same
+        ``output`` argument as `~astropy.table.Table.write`, allowing
+        `~astropy.io.votable.tree.VOTableFile` objects to be passed directly
+        to code that expects a ``write`` method with a compatible signature.
+
+        Parameters
+        ----------
+        output : str or file-like
+            Where to write the file. If a file-like object, must be writable.
+        **kwargs
+            Additional keyword arguments are passed on to
+            `~astropy.io.votable.tree.VOTableFile.to_xml`. The ``format``
+            keyword is accepted for API compatibility but ignored.
+        """
+        kwargs.pop("format", None)
+        self.to_xml(output, **kwargs)
+
     def iter_tables(self):
         """
         Iterates over all tables in the VOTable file in a "flat" way,

--- a/docs/changes/io.votable/19499.feature.rst
+++ b/docs/changes/io.votable/19499.feature.rst
@@ -1,1 +1,1 @@
-Added a ``write`` method to ``VOTableFile`` via the unified I/O framework.
+Added a ``write`` method to ``VOTableFile``.

--- a/docs/io/votable/index.rst
+++ b/docs/io/votable/index.rst
@@ -46,7 +46,7 @@ the :ref:`Unified I/O VOTable <table_io_votable>` section for details.
 
 To save a VOTable file, call the
 `~astropy.io.votable.tree.VOTableFile.to_xml` method, or equivalently
-use the unified I/O ``write`` method. Both accept either a string or
+the ``write`` convenience method. Both accept either a string or
 Unicode path, or a Python file-like object::
 
   votable.to_xml('output.xml')
@@ -57,9 +57,10 @@ Unicode path, or a Python file-like object::
 .. note::
 
   ``VOTableFile.write()`` serialises the existing ``VOTableFile`` object
-  as-is. This is different from ``Table.write(format='votable')``, which
-  converts an `~astropy.table.Table` into a new VOTable, a process that
-  does not preserve VOTable-specific metadata such as PARAMs and INFOs.
+  as-is, preserving all metadata including PARAMs and INFOs. This is
+  different from ``Table.write(format='votable')``, which converts an
+  `~astropy.table.Table` into a new VOTable and does not preserve
+  VOTable-specific metadata such as PARAMs and INFOs.
 
 There are a number of data storage formats supported by
 `astropy.io.votable`. The ``TABLEDATA`` format is XML-based and


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Adds a write method to VOTableFile via the unified I/O framework, allowing `votable_file.write("output.xml")` as an alternative to `votable_file.to_xml("output.xml")`

Motivated by [astropy/pyvo#734](https://github.com/astropy/pyvo/issues/734), where passing `VOTableFile` directly to the unified I/O layer is needed to preserve metadata (PARAMs, INFOs) that are lost when converting to `astropy.table.Table` first.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
