### PR TITLE
BUG: add support for new internal ufuncs in numpy 2.5 (`np._core.imag` and `np._core.real`)

### DIFF
--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -18,6 +18,7 @@ from astropy.utils.compat.numpycompat import (
     NUMPY_LT_2_1,
     NUMPY_LT_2_2,
     NUMPY_LT_2_3,
+    NUMPY_LT_2_5,
 )
 
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
@@ -454,6 +455,9 @@ invariant_ufuncs = (
     np.trunc,
     np.positive,
 )
+if not NUMPY_LT_2_5:
+    invariant_ufuncs += (np_umath.imag, np_umath.real)
+
 for ufunc in invariant_ufuncs:
     UFUNC_HELPERS[ufunc] = helper_invariant
 


### PR DESCRIPTION
### Description
Close #19504

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
