### PR TITLE
DOC: migrate RTD python image from mambaforge (deprecated) to miniforge

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-25.11"
   jobs:
     post_checkout:
       - git fetch --unshallow || true


### PR DESCRIPTION
### Description
[mambaforge is deprecated](https://github.com/readthedocs/readthedocs.org/issues/11690), let's try moving to a more recent miniforge image (Python 3.13)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
