### PR TITLE
DOC: Remove dead link for barycorr reference

### DIFF
--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -572,7 +572,7 @@ radial velocity and :math:`v_b` is the barycentric correction returned by
 the barycentric correction in this way leads to errors of order 3 m/s.
 
 The barycentric correction in `~astropy.coordinates.SkyCoord.radial_velocity_correction` is consistent
-with the `IDL implementation <https://astroutils.astronomy.ohio-state.edu/exofast/barycorr.html>`_ of
+with the IDL implementation of
 the Wright & Eastmann (2014) paper to a level of 10 mm/s for a source at
 infinite distance. We do not include the Shapiro delay nor the light
 travel time correction from equation 28 of that paper. The neglected terms


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

A relliable source informed me that https://astroutils.astronomy.ohio-state.edu/exofast/barycorr.html will be retired permanently. There is no replacement.

The Extra CI label is really only for linkcheck job. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
