### PR TITLE
BUG: future-proof `np.timedelta64` invocations

### DIFF
--- a/astropy/table/_dataframes.py
+++ b/astropy/table/_dataframes.py
@@ -65,7 +65,7 @@ def _encode_mixins(tbl: Table) -> Table:
         for col in time_cols:
             if isinstance(col, TimeDelta):
                 new_col = (col.sec * 1e9).astype("timedelta64[ns]")
-                nat = np.timedelta64("NaT")
+                nat = np.timedelta64("NaT", "ns")
             else:
                 new_col = col.datetime64.copy()
                 nat = np.datetime64("NaT")


### PR DESCRIPTION
### Description

xref https://github.com/numpy/numpy/pull/29619

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
