### PR TITLE
TST: run ufunc coverage test regardless scipy's availability

### DIFF
--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -99,15 +99,24 @@ class TestUfuncHelpers:
         all_q_ufuncs = qh.UNSUPPORTED_UFUNCS | set(qh.UFUNC_HELPERS.keys())
         # Check that every numpy ufunc is covered.
         assert all_np_ufuncs - all_q_ufuncs == set()
-        # Check that all ufuncs we cover come from numpy or erfa.
-        # (Since coverage for erfa is incomplete, we do not check
+        # Check all ufuncs we cover come from numpy, erfa, or scipy.
+        # (Since coverage for erfa and scipy are incomplete, we do not check
         # this the other way).
         all_erfa_ufuncs = {
             ufunc
             for ufunc in erfa_ufunc.__dict__.values()
             if isinstance(ufunc, np.ufunc)
         }
-        assert all_q_ufuncs - all_np_ufuncs - all_erfa_ufuncs == set()
+        if HAS_SCIPY:
+            import scipy.special as sps
+
+            all_sps_ufuncs = {
+                ufunc for ufunc in sps.__dict__.values() if isinstance(ufunc, np.ufunc)
+            }
+        else:
+            all_sps_ufuncs = set()
+
+        assert all_q_ufuncs - all_np_ufuncs - all_erfa_ufuncs - all_sps_ufuncs == set()
 
     @pytest.mark.skipif(
         HAS_SCIPY,


### PR DESCRIPTION
### Description
I initially wanted to see if I could make this test smarter by filtering out scipy functions instead of just skipping it entirely. I found I couldn't actually crash the test, so I'd like to try and see if this skipper is still needed in some condition covered in CI.

related to, yet surprisingly disjoint from #19390

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
