### PR TITLE
TST: exclude packages newer than a week old from resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -745,6 +745,9 @@ ignore-words-list = """
 """
 
 [tool.uv]
+# always allow arbitrarily new versions of astropy-iers-data
+exclude-newer-package = { "astropy-iers-data" = false }
+
 # never build the following packages from source. Prefer more recent versions
 # with binary distributions even with --resolution=lowest[-direct]
 no-build-package = [

--- a/scripts/check-lowest-resolved-tree.py
+++ b/scripts/check-lowest-resolved-tree.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "uv==0.10.2",
+#     "uv==0.11.13",
 # ]
 # ///
 
@@ -53,6 +53,7 @@ def generate_tree(debug: bool) -> str:
             uv.find_uv_bin(),
             "tree",
             "--resolution=lowest",
+            "--exclude-newer=P7D",
             "--all-groups",
             "--universal",
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
     stubtest
 requires =
     tox >=4.33 # for PEP 508 environment markers # keep in sync with pyproject.toml
-    tox-uv
+    tox-uv >= 1.35 # for cache proper invalidation on UV_* env vars changes
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI
@@ -28,6 +28,7 @@ setenv =
     clocale: LC_ALL = C
     devdeps: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     mpldev: UV_INDEX = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    !devdeps-!mpldev-!predeps-!devpytest: UV_EXCLUDE_NEWER = P7D
     devdeps, mpldev, predeps, devpytest: UV_INDEX_STRATEGY = unsafe-best-match # match pip's behavior
     fitsio: ASTROPY_ALWAYS_TEST_FITSIO = true
     # on oldestdeps, we let warnings be warnings (-Wdefault) instead of treated-as-errors,


### PR DESCRIPTION
### Description
Only allow packages to get in regular CI jobs after a cooldown period of a week, which should be more than enough time for upstream to address breaches in the style of [llmlite](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/).

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
