### PR TITLE
ENH: Expose `MplQuantityConverter` and except arrays in `convert` and `default_units`

### DIFF
--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -14,7 +14,12 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates import Angle
-from astropy.visualization.units import quantity_support
+from astropy.visualization.units import MplQuantityConverter, quantity_support
+
+
+@pytest.fixture
+def converter_class() -> type[MplQuantityConverter]:
+    return MplQuantityConverter
 
 
 @pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
@@ -170,3 +175,58 @@ def test_override_axis_unit():
         ax.yaxis.set_units(u.cm)
         fig.canvas.draw()
         assert ax.yaxis.get_units() == u.cm
+
+
+@pytest.mark.parametrize(
+    ("format", "expected"),
+    [
+        pytest.param(None, "$\\mathrm{erg\\,s^{-1}\\,cm^{-2}}$", id="None"),
+        pytest.param("console", "erg s^-1 cm^-2", id="console"),
+    ],
+)
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
+def test_axisinfo_label(converter_class, format, expected):
+    result = converter_class.axisinfo(u.erg / (u.cm**2 * u.s), None, format).label
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("val", "expected"),
+    [
+        pytest.param(u.Quantity([1, 2, 3], u.m), np.array([1, 2, 3]), id="Quantity[m]"),
+        pytest.param(
+            u.Quantity([1, 2, 3], u.cm), np.array([0.01, 0.02, 0.03]), id="Quantity[cm]"
+        ),
+        pytest.param(
+            np.array([1 * u.m, 2 * u.m, 3 * u.m], dtype=object),
+            np.array([1, 2, 3]),
+            id="np_array",
+        ),
+    ],
+)
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
+def test_convert(converter_class, val, expected):
+    result = converter_class.convert(val, u.m, None)
+    assert all(result == expected)
+
+
+@pytest.mark.parametrize(
+    ("x", "expected"),
+    [
+        pytest.param(u.Quantity([1, 2, 3], u.m), u.m, id="Quantity[m]"),
+        pytest.param(
+            u.Quantity([1, 2, 3]),
+            u.dimensionless_unscaled,
+            id="Quantity[dimensionless]",
+        ),
+        pytest.param([1, 2, 3], None, id="scalar list"),
+        pytest.param(
+            np.array([1 * u.m, 2 * u.m, 3 * u.m], dtype=object), u.m, id="np array"
+        ),
+        pytest.param(np.array([], dtype=object), None, id="np array empty"),
+    ],
+)
+@pytest.mark.skipif(not HAS_PLT, reason="requires matplotlib")
+def test_default_units(converter_class, x, expected):
+    result = converter_class.default_units(x, None)
+    assert result == expected

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -104,16 +104,7 @@ class MplQuantityConverter(ConversionInterface, ContextDecorator):
 
             def rad_fn(x, pos=None):
                 n = int((x / np.pi) * 2.0 + 0.25)
-                if n == 0:
-                    return "0"
-                elif n == 1:
-                    return "π/2"
-                elif n == 2:
-                    return "π"
-                elif n % 2 == 0:
-                    return f"{n // 2}π"
-                else:
-                    return f"{n}π/2"
+                return ("0", "π/2", "π")[n] if n < 3 else (f"{n // 2}π" if n % 2 == 0 else f"{n}π/2")
 
             return AxisInfo(
                 majloc=MultipleLocator(base=np.pi / 2),

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -83,9 +83,9 @@ class MplQuantityConverter(ConversionInterface, ContextDecorator):
     """Matplotlib converter for ``astropy.units.Quantity``.
 
     Registers itself to matplotlib as the converter for
-    `astropy.units.Quantity` when initialized. If used as a context manager,
+    ``astropy.units.Quantity`` when initialized. If used as a context manager,
     it will restore the original converter upon exit. Also see
-    ``quantity_support`` for a convenient way to use this converter
+    :meth:`quantity_support` for a convenient way to use this converter
     with an optional format for the ``axisinfo``.
     """
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ["MplQuantityConverter", "quantity_support"]
-
-import types
 from contextlib import ContextDecorator
 
 import numpy as np
@@ -10,28 +7,99 @@ import numpy as np
 from astropy import units as u
 from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
-if HAS_MATPLOTLIB:
-    from matplotlib.ticker import (
-        AutoLocator,
-        FormatStrFormatter,
-        FuncFormatter,
-        MultipleLocator,
-    )
-    from matplotlib.units import AxisInfo, ConversionInterface, registry
-else:  # Create mock-up classes to avoid import errors when matplotlib is not available.
+__all__ = ["MplQuantityConverter", "quantity_support"]
 
-    class MplMockUp:
+if HAS_MATPLOTLIB:
+    from matplotlib import ticker, units
+
+    class MplQuantityConverter(units.ConversionInterface, ContextDecorator):
+        """Matplotlib converter for ``astropy.units.Quantity``.
+
+        Registers itself to matplotlib as the converter for
+        ``astropy.units.Quantity`` when initialized. If used as a context manager,
+        it will restore the original converter upon exit. Also see
+        :meth:`quantity_support` for a convenient way to use this converter
+        with an optional format for the ``axisinfo``.
+        """
+
+        def __init__(self):
+            # Keep track of original converter in case the context manager is
+            # used in a nested way.
+            self._original_converter = {u.Quantity: units.registry.get(u.Quantity)}
+            units.registry[u.Quantity] = self
+
+        @staticmethod
+        def axisinfo(unit, axis, format=None):
+            if format is None:
+                format = _default_format
+            if unit == u.radian:
+
+                def rad_fn(x, pos=None):
+                    n = int((x / np.pi) * 2.0 + 0.25)
+                    if n < 3:
+                        return ("0", "π/2", "π")[n]
+                    elif n % 2 == 0:
+                        return f"{n // 2}π"
+                    else:
+                        return f"{n}π/2"
+
+                return units.AxisInfo(
+                    majloc=ticker.MultipleLocator(base=np.pi / 2),
+                    majfmt=ticker.FuncFormatter(rad_fn),
+                    label=unit.to_string(),
+                )
+            elif unit == u.degree:
+                return units.AxisInfo(
+                    majloc=ticker.AutoLocator(),
+                    majfmt=ticker.FormatStrFormatter("%g°"),
+                    label=unit.to_string(),
+                )
+            elif unit is not None:
+                return units.AxisInfo(label=unit.to_string(format))
+            return None
+
+        @staticmethod
+        def convert(val, unit, axis):
+            if isinstance(val, u.Quantity):
+                return val.to_value(unit)
+            elif (
+                all(
+                    hasattr(val, attr)
+                    for attr in ["__getitem__", "__iter__", "__len__"]
+                )
+                and len(val) > 0
+                and isinstance(val[0], u.Quantity)
+            ):
+                return [v.to_value(unit) for v in val]
+            else:
+                return val
+
+        @staticmethod
+        def default_units(x, axis):
+            if hasattr(x, "unit"):
+                return x.unit
+            elif (
+                all(hasattr(x, attr) for attr in ["__getitem__", "__iter__", "__len__"])
+                and len(x) > 0
+                and hasattr(x[0], "unit")
+            ):
+                return x[0].unit
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, type, value, tb):
+            if self._original_converter[u.Quantity] is None:
+                del units.registry[u.Quantity]
+            else:
+                units.registry[u.Quantity] = self._original_converter[u.Quantity]
+
+else:
+    # Create mock-up classes to avoid import errors when matplotlib is not available.
+    class MplQuantityConverter:
         def __init__(self, *args, **kwargs):
             raise ImportError("matplotlib is required in order to use this class.")
-
-    ConversionInterface = types.new_class("ConversionInterface", (MplMockUp,))
-    AxisInfo = types.new_class("AxisInfo", (MplMockUp,))
-    MultipleLocator = types.new_class("MultipleLocator", (MplMockUp,))
-    FuncFormatter = types.new_class("FuncFormatter", (MplMockUp,))
-    AutoLocator = types.new_class("AutoLocator", (MplMockUp,))
-    FormatStrFormatter = types.new_class("FormatStrFormatter", (MplMockUp,))
-
-    registry = {}
 
 
 __doctest_skip__ = ["quantity_support"]
@@ -78,84 +146,3 @@ def quantity_support(format=None):
             return MplQuantityConverter.axisinfo(unit, axis, format)
 
     return MplQuantityConverterFormatted()
-
-
-class MplQuantityConverter(ConversionInterface, ContextDecorator):
-    """Matplotlib converter for ``astropy.units.Quantity``.
-
-    Registers itself to matplotlib as the converter for
-    ``astropy.units.Quantity`` when initialized. If used as a context manager,
-    it will restore the original converter upon exit. Also see
-    :meth:`quantity_support` for a convenient way to use this converter
-    with an optional format for the ``axisinfo``.
-    """
-
-    def __init__(self):
-        # Keep track of original converter in case the context manager is
-        # used in a nested way.
-        self._original_converter = {u.Quantity: registry.get(u.Quantity)}
-        registry[u.Quantity] = self
-
-    @staticmethod
-    def axisinfo(unit, axis, format=None):
-        if format is None:
-            format = _default_format
-        if unit == u.radian:
-
-            def rad_fn(x, pos=None):
-                n = int((x / np.pi) * 2.0 + 0.25)
-                if n < 3:
-                    return ("0", "π/2", "π")[n]
-                elif n % 2 == 0:
-                    return f"{n // 2}π"
-                else:
-                    return f"{n}π/2"
-
-            return AxisInfo(
-                majloc=MultipleLocator(base=np.pi / 2),
-                majfmt=FuncFormatter(rad_fn),
-                label=unit.to_string(),
-            )
-        elif unit == u.degree:
-            return AxisInfo(
-                majloc=AutoLocator(),
-                majfmt=FormatStrFormatter("%g°"),
-                label=unit.to_string(),
-            )
-        elif unit is not None:
-            return AxisInfo(label=unit.to_string(format))
-        return None
-
-    @staticmethod
-    def convert(val, unit, axis):
-        if isinstance(val, u.Quantity):
-            return val.to_value(unit)
-        elif (
-            all(hasattr(val, attr) for attr in ["__getitem__", "__iter__", "__len__"])
-            and len(val) > 0
-            and isinstance(val[0], u.Quantity)
-        ):
-            return [v.to_value(unit) for v in val]
-        else:
-            return val
-
-    @staticmethod
-    def default_units(x, axis):
-        if hasattr(x, "unit"):
-            return x.unit
-        elif (
-            all(hasattr(x, attr) for attr in ["__getitem__", "__iter__", "__len__"])
-            and len(x) > 0
-            and hasattr(x[0], "unit")
-        ):
-            return x[0].unit
-        return None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, tb):
-        if self._original_converter[u.Quantity] is None:
-            del registry[u.Quantity]
-        else:
-            registry[u.Quantity] = self._original_converter[u.Quantity]

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+__all__ = ["MplQuantityConverter", "quantity_support"]
+
+import types
 from contextlib import ContextDecorator
 
 import numpy as np
@@ -31,7 +34,6 @@ else:  # Create mock-up classes to avoid import errors when matplotlib is not av
     registry = {}
 
 
-__all__ = ["MplQuantityConverter", "quantity_support"]
 __doctest_skip__ = ["quantity_support"]
 
 _default_format = "latex_inline"
@@ -63,7 +65,7 @@ def quantity_support(format=None):
 
     Parameters
     ----------
-    format : `astropy.units.format.Base` subclass or str
+    format : `astropy.units.format.Base` subclass or str or None, optional
         The name of a format or a formatter class.  If not
         provided, defaults to ``latex_inline``.
 
@@ -78,6 +80,15 @@ def quantity_support(format=None):
 
 
 class MplQuantityConverter(ConversionInterface, ContextDecorator):
+    """Matplotlib converter for ``astropy.units.Quantity``.
+
+    Registers itself to matplotlib as the converter for
+    `astropy.units.Quantity` when initialized. If used as a context manager,
+    it will restore the original converter upon exit. Also see
+    ``quantity_support`` for a convenient way to use this converter
+    with an optional format for the ``axisinfo``.
+    """
+
     def __init__(self):
         # Keep track of original converter in case the context manager is
         # used in a nested way.
@@ -92,7 +103,12 @@ class MplQuantityConverter(ConversionInterface, ContextDecorator):
 
             def rad_fn(x, pos=None):
                 n = int((x / np.pi) * 2.0 + 0.25)
-                return ("0", "π/2", "π")[n] if n < 3 else (f"{n // 2}π" if n % 2 == 0 else f"{n}π/2")
+                if n < 3:
+                    return ("0", "π/2", "π")[n]
+                elif n % 2 == 0:
+                    return f"{n // 2}π"
+                else:
+                    return f"{n}π/2"
 
             return AxisInfo(
                 majloc=MultipleLocator(base=np.pi / 2),

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -15,13 +15,12 @@ if HAS_MATPLOTLIB:
         MultipleLocator,
     )
     from matplotlib.units import AxisInfo, ConversionInterface, registry
-else:
+else:  # Create mock-up classes to avoid import errors when matplotlib is not available.
 
     class MplMockUp:
         def __init__(self, *args, **kwargs):
             raise ImportError("matplotlib is required in order to use this class.")
 
-    # Create mock-up classes to avoid import errors when matplotlib is not available.
     ConversionInterface = types.new_class("ConversionInterface", (MplMockUp,))
     AxisInfo = types.new_class("AxisInfo", (MplMockUp,))
     MultipleLocator = types.new_class("MultipleLocator", (MplMockUp,))

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -4,6 +4,45 @@ from contextlib import ContextDecorator
 
 import numpy as np
 
+from astropy import units as u
+from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
+
+if HAS_MATPLOTLIB:
+    from matplotlib.ticker import (
+        AutoLocator,
+        FormatStrFormatter,
+        FuncFormatter,
+        MultipleLocator,
+    )
+    from matplotlib.units import AxisInfo, ConversionInterface, registry
+else:
+
+    class MplMockUp:
+        def __init__(self, *args, **kwargs):
+            raise ImportError("matplotlib is required in order to use this class.")
+
+    # Create mock-up classes to avoid import errors when matplotlib is not available.
+    class ConversionInterface(MplMockUp):
+        pass
+
+    class AxisInfo(MplMockUp):
+        pass
+
+    class MultipleLocator(MplMockUp):
+        pass
+
+    class FuncFormatter(MplMockUp):
+        pass
+
+    class AutoLocator(MplMockUp):
+        pass
+
+    class FormatStrFormatter(MplMockUp):
+        pass
+
+    registry = {}
+
+
 __all__ = ["quantity_support"]
 __doctest_skip__ = ["quantity_support"]
 
@@ -39,9 +78,6 @@ def quantity_support(format="latex_inline"):
         provided, defaults to ``latex_inline``.
 
     """
-    from matplotlib import ticker, units
-
-    from astropy import units as u
 
     def rad_fn(x, pos=None):
         n = int((x / np.pi) * 2.0 + 0.25)
@@ -56,29 +92,29 @@ def quantity_support(format="latex_inline"):
         else:
             return f"{n}π/2"
 
-    class MplQuantityConverter(units.ConversionInterface, ContextDecorator):
+    class MplQuantityConverter(ConversionInterface, ContextDecorator):
         def __init__(self):
             # Keep track of original converter in case the context manager is
             # used in a nested way.
-            self._original_converter = {u.Quantity: units.registry.get(u.Quantity)}
-            units.registry[u.Quantity] = self
+            self._original_converter = {u.Quantity: registry.get(u.Quantity)}
+            registry[u.Quantity] = self
 
         @staticmethod
         def axisinfo(unit, axis):
             if unit == u.radian:
-                return units.AxisInfo(
-                    majloc=ticker.MultipleLocator(base=np.pi / 2),
-                    majfmt=ticker.FuncFormatter(rad_fn),
+                return AxisInfo(
+                    majloc=MultipleLocator(base=np.pi / 2),
+                    majfmt=FuncFormatter(rad_fn),
                     label=unit.to_string(),
                 )
             elif unit == u.degree:
-                return units.AxisInfo(
-                    majloc=ticker.AutoLocator(),
-                    majfmt=ticker.FormatStrFormatter("%g°"),
+                return AxisInfo(
+                    majloc=AutoLocator(),
+                    majfmt=FormatStrFormatter("%g°"),
                     label=unit.to_string(),
                 )
             elif unit is not None:
-                return units.AxisInfo(label=unit.to_string(format))
+                return AxisInfo(label=unit.to_string(format))
             return None
 
         @staticmethod
@@ -101,8 +137,8 @@ def quantity_support(format="latex_inline"):
 
         def __exit__(self, type, value, tb):
             if self._original_converter[u.Quantity] is None:
-                del units.registry[u.Quantity]
+                del registry[u.Quantity]
             else:
-                units.registry[u.Quantity] = self._original_converter[u.Quantity]
+                registry[u.Quantity] = self._original_converter[u.Quantity]
 
     return MplQuantityConverter()

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -9,6 +9,10 @@ from astropy.utils.compat.optional_deps import HAS_MATPLOTLIB
 
 __all__ = ["MplQuantityConverter", "quantity_support"]
 
+__doctest_skip__ = ["quantity_support"]
+
+_default_format = "latex_inline"
+
 if HAS_MATPLOTLIB:
     from matplotlib import ticker, units
 
@@ -96,15 +100,10 @@ if HAS_MATPLOTLIB:
                 units.registry[u.Quantity] = self._original_converter[u.Quantity]
 
 else:
-    # Create mock-up classes to avoid import errors when matplotlib is not available.
+    # Create mock-up class to avoid import errors when matplotlib is not available.
     class MplQuantityConverter:
         def __init__(self, *args, **kwargs):
             raise ImportError("matplotlib is required in order to use this class.")
-
-
-__doctest_skip__ = ["quantity_support"]
-
-_default_format = "latex_inline"
 
 
 def quantity_support(format=None):

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -34,6 +34,19 @@ if HAS_MATPLOTLIB:
 
         @staticmethod
         def axisinfo(unit, axis, format=None):
+            """Return a :class:`matplotlib.units.AxisInfo` for *unit* and *axis*.                                                                          
+ 
+            Parameters                                                                                                                                     
+            ----------                                                                                                                                   
+            unit : `~astropy.units.UnitBase`
+                The unit to format the axis for.                                                                                                           
+            axis : `matplotlib.axis.Axis`
+                The matplotlib axis being formatted.                                                                                                       
+            format : `astropy.units.format.Base` subclass or str or None, optional                                                                         
+                The name of a format or a formatter class used to render the
+                axis label.  If `None`, the module-level default                                                                                           
+                (``"latex_inline"``) is used.                                                                                                              
+            """
             if format is None:
                 format = _default_format
             if unit == u.radian:

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -34,18 +34,18 @@ if HAS_MATPLOTLIB:
 
         @staticmethod
         def axisinfo(unit, axis, format=None):
-            """Return a :class:`matplotlib.units.AxisInfo` for *unit* and *axis*.                                                                          
- 
-            Parameters                                                                                                                                     
-            ----------                                                                                                                                   
+            """Return a :class:`matplotlib.units.AxisInfo` for *unit* and *axis*.
+
+            Parameters
+            ----------
             unit : `~astropy.units.UnitBase`
-                The unit to format the axis for.                                                                                                           
+                The unit to format the axis for.
             axis : `matplotlib.axis.Axis`
-                The matplotlib axis being formatted.                                                                                                       
-            format : `astropy.units.format.Base` subclass or str or None, optional                                                                         
+                The matplotlib axis being formatted.
+            format : `astropy.units.format.Base` subclass or str or None, optional
                 The name of a format or a formatter class used to render the
-                axis label.  If `None`, the module-level default                                                                                           
-                (``"latex_inline"``) is used.                                                                                                              
+                axis label.  If `None`, the module-level default
+                (``"latex_inline"``) is used.
             """
             if format is None:
                 format = _default_format

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -43,11 +43,13 @@ else:
     registry = {}
 
 
-__all__ = ["quantity_support"]
+__all__ = ["MplQuantityConverter", "quantity_support"]
 __doctest_skip__ = ["quantity_support"]
 
+_default_format = "latex_inline"
 
-def quantity_support(format="latex_inline"):
+
+def quantity_support(format=None):
     """
     Enable support for plotting `astropy.units.Quantity` instances in
     matplotlib.
@@ -79,66 +81,75 @@ def quantity_support(format="latex_inline"):
 
     """
 
-    def rad_fn(x, pos=None):
-        n = int((x / np.pi) * 2.0 + 0.25)
-        if n == 0:
-            return "0"
-        elif n == 1:
-            return "π/2"
-        elif n == 2:
-            return "π"
-        elif n % 2 == 0:
-            return f"{n // 2}π"
-        else:
-            return f"{n}π/2"
-
-    class MplQuantityConverter(ConversionInterface, ContextDecorator):
-        def __init__(self):
-            # Keep track of original converter in case the context manager is
-            # used in a nested way.
-            self._original_converter = {u.Quantity: registry.get(u.Quantity)}
-            registry[u.Quantity] = self
-
+    class MplQuantityConverterFormatted(MplQuantityConverter):
         @staticmethod
         def axisinfo(unit, axis):
-            if unit == u.radian:
-                return AxisInfo(
-                    majloc=MultipleLocator(base=np.pi / 2),
-                    majfmt=FuncFormatter(rad_fn),
-                    label=unit.to_string(),
-                )
-            elif unit == u.degree:
-                return AxisInfo(
-                    majloc=AutoLocator(),
-                    majfmt=FormatStrFormatter("%g°"),
-                    label=unit.to_string(),
-                )
-            elif unit is not None:
-                return AxisInfo(label=unit.to_string(format))
-            return None
+            return MplQuantityConverter.axisinfo(unit, axis, format)
 
-        @staticmethod
-        def convert(val, unit, axis):
-            if isinstance(val, u.Quantity):
-                return val.to_value(unit)
-            elif isinstance(val, list) and val and isinstance(val[0], u.Quantity):
-                return [v.to_value(unit) for v in val]
-            else:
-                return val
+    return MplQuantityConverterFormatted()
 
-        @staticmethod
-        def default_units(x, axis):
-            if hasattr(x, "unit"):
-                return x.unit
-            return None
 
-        def __enter__(self):
-            return self
+class MplQuantityConverter(ConversionInterface, ContextDecorator):
+    def __init__(self):
+        # Keep track of original converter in case the context manager is
+        # used in a nested way.
+        self._original_converter = {u.Quantity: registry.get(u.Quantity)}
+        registry[u.Quantity] = self
 
-        def __exit__(self, type, value, tb):
-            if self._original_converter[u.Quantity] is None:
-                del registry[u.Quantity]
-            else:
-                registry[u.Quantity] = self._original_converter[u.Quantity]
+    @staticmethod
+    def axisinfo(unit, axis, format=None):
+        if not format:
+            format = _default_format
+        if unit == u.radian:
 
-    return MplQuantityConverter()
+            def rad_fn(x, pos=None):
+                n = int((x / np.pi) * 2.0 + 0.25)
+                if n == 0:
+                    return "0"
+                elif n == 1:
+                    return "π/2"
+                elif n == 2:
+                    return "π"
+                elif n % 2 == 0:
+                    return f"{n // 2}π"
+                else:
+                    return f"{n}π/2"
+
+            return AxisInfo(
+                majloc=MultipleLocator(base=np.pi / 2),
+                majfmt=FuncFormatter(rad_fn),
+                label=unit.to_string(),
+            )
+        elif unit == u.degree:
+            return AxisInfo(
+                majloc=AutoLocator(),
+                majfmt=FormatStrFormatter("%g°"),
+                label=unit.to_string(),
+            )
+        elif unit is not None:
+            return AxisInfo(label=unit.to_string(format))
+        return None
+
+    @staticmethod
+    def convert(val, unit, axis):
+        if isinstance(val, u.Quantity):
+            return val.to_value(unit)
+        elif isinstance(val, list) and val and isinstance(val[0], u.Quantity):
+            return [v.to_value(unit) for v in val]
+        else:
+            return val
+
+    @staticmethod
+    def default_units(x, axis):
+        if hasattr(x, "unit"):
+            return x.unit
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        if self._original_converter[u.Quantity] is None:
+            del registry[u.Quantity]
+        else:
+            registry[u.Quantity] = self._original_converter[u.Quantity]

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -108,7 +108,7 @@ else:
 
 def quantity_support(format=None):
     """
-    Enable support for plotting `astropy.units.Quantity` instances in
+    Enable support for plotting :class:`astropy.units.Quantity` instances in
     matplotlib.
 
     May be (optionally) used with a ``with`` statement.
@@ -119,9 +119,9 @@ def quantity_support(format=None):
       >>> with visualization.quantity_support():
       ...     fig, ax = plt.subplots()
       ...     ax.plot([1, 2, 3] * u.m)
-      [...]
+      ...  # doctest: +ELLIPSIS
       ...     ax.plot([101, 125, 150] * u.cm)
-      [...]
+      ...  # doctest: +ELLIPSIS
       ...     ax.yaxis.set_units(u.km)
       ...     plt.draw()
 
@@ -132,7 +132,7 @@ def quantity_support(format=None):
 
     Parameters
     ----------
-    format : `astropy.units.format.Base` subclass or str or None, optional
+    format : :class:`astropy.units.format.Base` subclass or str or None, optional
         The name of a format or a formatter class.  If not
         provided, defaults to ``latex_inline``.
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -22,23 +22,12 @@ else:
             raise ImportError("matplotlib is required in order to use this class.")
 
     # Create mock-up classes to avoid import errors when matplotlib is not available.
-    class ConversionInterface(MplMockUp):
-        pass
-
-    class AxisInfo(MplMockUp):
-        pass
-
-    class MultipleLocator(MplMockUp):
-        pass
-
-    class FuncFormatter(MplMockUp):
-        pass
-
-    class AutoLocator(MplMockUp):
-        pass
-
-    class FormatStrFormatter(MplMockUp):
-        pass
+    ConversionInterface = types.new_class("ConversionInterface", (MplMockUp,))
+    AxisInfo = types.new_class("AxisInfo", (MplMockUp,))
+    MultipleLocator = types.new_class("MultipleLocator", (MplMockUp,))
+    FuncFormatter = types.new_class("FuncFormatter", (MplMockUp,))
+    AutoLocator = types.new_class("AutoLocator", (MplMockUp,))
+    FormatStrFormatter = types.new_class("FormatStrFormatter", (MplMockUp,))
 
     registry = {}
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -72,6 +72,7 @@ def quantity_support(format=None):
     """
 
     class MplQuantityConverterFormatted(MplQuantityConverter):
+        # Override to pass on `format`
         @staticmethod
         def axisinfo(unit, axis):
             return MplQuantityConverter.axisinfo(unit, axis, format)
@@ -97,7 +98,7 @@ class MplQuantityConverter(ConversionInterface, ContextDecorator):
 
     @staticmethod
     def axisinfo(unit, axis, format=None):
-        if not format:
+        if format is None:
             format = _default_format
         if unit == u.radian:
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -70,7 +70,7 @@ if HAS_MATPLOTLIB:
                 and len(val) > 0
                 and isinstance(val[0], u.Quantity)
             ):
-                return [v.to_value(unit) for v in val]
+                return np.array([v.to_value(unit) for v in val])
             else:
                 return val
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -134,7 +134,11 @@ class MplQuantityConverter(ConversionInterface, ContextDecorator):
     def convert(val, unit, axis):
         if isinstance(val, u.Quantity):
             return val.to_value(unit)
-        elif isinstance(val, list) and val and isinstance(val[0], u.Quantity):
+        elif (
+            all(hasattr(val, attr) for attr in ["__getitem__", "__iter__", "__len__"])
+            and len(val) > 0
+            and isinstance(val[0], u.Quantity)
+        ):
             return [v.to_value(unit) for v in val]
         else:
             return val
@@ -143,6 +147,12 @@ class MplQuantityConverter(ConversionInterface, ContextDecorator):
     def default_units(x, axis):
         if hasattr(x, "unit"):
             return x.unit
+        elif (
+            all(hasattr(x, attr) for attr in ["__getitem__", "__iter__", "__len__"])
+            and len(x) > 0
+            and hasattr(x[0], "unit")
+        ):
+            return x[0].unit
         return None
 
     def __enter__(self):

--- a/docs/changes/visualization/19539.feature.rst
+++ b/docs/changes/visualization/19539.feature.rst
@@ -1,0 +1,2 @@
+Expose ``MplQuantityConverter`` class in ``astropy.visualization`` and
+except numpy arrays in its ``convert`` and ``default_units`` methods.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request exposes `MplQuantityConverter` within `astropy.visualization` and makes its methods `convert` and `default_units` a bit more flexible in regards to their inputs, specifically allowing `np.ndarray` objects with `object` dtype.

Implementation details:
- Moved `MplQuantityConverter` ouside of `quantity_support` function.
- Create subclass of `MplQuantityConverter` inside of `quantity_support` to keep the possibility to set `format` for `axisinfo`:
    - `MplQuantityConverter.axisinfo` has new argument `format` which defaults to `_default_format` aka `"latex_inline"`
    - The class of the object returned from `quantity_support` now has the name `MplQuantityConverterFormatted` instead of `MplQuantityConverter`
- `MplQuantityConverter` and `_default_format` are now also exposed in `astropy.visualizations` because of `from .units import *` in its `__init__.py` file (could be changed to explicit import, if that is not preferred), but only added `MplQuantityConverter` to `__all__`, because the other is considered to be an internal variable.
- `rad_fn` now inside of `MplQuantityConverter.axisinfo` as it is only needed there.
- `MplQuantityConverter.convert` and `MplQuantityConverter.default_units` are a bit more flexible.
- Moved imports of `matplotlib` classes outside of the function and therefore adopted pattern with mockup classes from `astropy.visualization.mpl_normalize,py` if `matplotlib` is not available.

I think it also makes sense to add some tests for this, but I first want to clarify if the functionality itself is fine.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19523 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
