### PR TITLE
BUG: use non-deprecated numpy APIs to override dtype of a base column

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
+from astropy.utils.compat import NUMPY_LT_2_5
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -1264,7 +1265,10 @@ class Column(BaseColumn):
             raise AttributeError(
                 "cannot set mask value to a column in non-masked Table"
             )
-        super().__setattr__(item, value)
+        if not NUMPY_LT_2_5 and item == "dtype":
+            self._set_dtype(value)
+        else:
+            super().__setattr__(item, value)
 
         if item == "unit" and issubclass(self.dtype.type, np.number):
             try:


### PR DESCRIPTION
### Description
fixes an upcoming incompatibity that shows up in our tests suite with numpy dev + pandas
xref: https://github.com/numpy/numpy/pull/29575

The change isn't in nightlies yet so this would likely fail devdeps at the time of opening. I'll undraft when it's ready.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
