### PR TITLE
DEPR: deprecate setting `Column.dtype`, following numpy 2.5.0 (dev)

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -12,6 +12,7 @@ from astropy.units import Quantity, StructuredUnit, Unit
 from astropy.utils.compat import NUMPY_LT_2_5
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.metadata import MetaData
 from astropy.utils.misc import dtype_bytes_or_chars
 
@@ -1273,6 +1274,15 @@ class Column(BaseColumn):
                 "cannot set mask value to a column in non-masked Table"
             )
         if not NUMPY_LT_2_5 and item == "dtype":
+            warnings.warn(
+                "Setting the Column dtype attribute is deprecated since astropy 8.0.0 "
+                "and it will stop working in a future version. "
+                "As an alternative, you can create a view with a new dtype via "
+                "column.view(dtype=new_dtype). This follows a similar "
+                "deprecation in numpy 2.5.0.",
+                AstropyDeprecationWarning,
+                stacklevel=2,
+            )
             self._set_dtype(value)
         else:
             super().__setattr__(item, value)

--- a/docs/changes/table/19542.api.rst
+++ b/docs/changes/table/19542.api.rst
@@ -1,0 +1,5 @@
+Setting the ``Column.dtype`` attribute is now deprecated since mutating
+an array is unsafe if an array is shared, especially by multiple
+threads.  As an alternative, you can create a view with a new dtype
+via ``column.view(dtype=new_dtype)``. This follows a similar
+deprecation in numpy 2.5.0.


### PR DESCRIPTION
### Description
Follow up to #19540
This isn't ready yet: when running the test suite with numpy dev + pandas, I'm hitting the warning in places it's not expected, so it's turned into an error. At the time of opening I'm not sure yet wether this needs to be addressed on our side or in pandas.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
