### PR TITLE
Fix InheritDocstrings metaclass to work with properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -536,6 +536,21 @@ class InheritDocstrings(type):
                     if super_method is not None:
                         val.__doc__ = super_method.__doc__
                         break
+            elif (isinstance(val, property) and
+                  is_public_member(key) and
+                  val.fget is not None and
+                  val.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_property = getattr(base, key, None)
+                    if super_property is not None:
+                        if isinstance(super_property, property) and super_property.__doc__ is not None:
+                            # Properties cache __doc__ at creation time,
+                            # so we need to replace the property with a
+                            # new one that has the inherited docstring.
+                            setattr(cls, key, property(
+                                val.fget, val.fset, val.fdel,
+                                super_property.__doc__))
+                        break
 
         super().__init__(name, bases, dct)
 

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -89,6 +89,22 @@ def test_inherit_docstrings():
         assert Subclass.__call__.__doc__ == "FOO"
 
 
+def test_inherit_docstrings_property():
+    class Base(metaclass=misc.InheritDocstrings):
+        @property
+        def foo(self):
+            "FOO"
+            pass
+
+    class Subclass(Base):
+        @property
+        def foo(self):
+            pass
+
+    if Base.foo.__doc__ is not None:
+        assert Subclass.foo.__doc__ == "FOO"
+
+
 def test_set_locale():
     # First, test if the required locales are available
     current = locale.setlocale(locale.LC_ALL)


### PR DESCRIPTION
## Summary

The `InheritDocstrings` metaclass uses `inspect.isfunction()` to identify members that should inherit docstrings from base classes. However, `inspect.isfunction()` returns `False` for properties, so property docstrings were never inherited.

This adds an `elif` branch that handles properties by checking `isinstance(val, property)`. When a property has no docstring (`val.__doc__ is None`), it looks up the MRO for a base class property with a docstring and creates a new property with the inherited docstring.

Properties cache their `__doc__` at creation time from `fget.__doc__`, so we cannot simply set `fget.__doc__` after the fact. Instead, we replace the property on the class with a new `property()` that has the inherited docstring passed via the `doc` parameter.

Uses `super_property.__doc__` (not `super_property.fget.__doc__`) as the source for the inherited docstring, which correctly handles multi-level inheritance where intermediate classes also went through this metaclass.

## Changes

- `astropy/utils/misc.py`: Added property handling in `InheritDocstrings.__init__`
- `astropy/utils/tests/test_misc.py`: Added `test_inherit_docstrings_property` test

## Testing

Verified with 7 test scenarios run via `python3 -c` (full astropy pytest requires C extension build):

1. **Basic property docstring inheritance** -- subclass property inherits base class property docstring
2. **Existing property docstrings preserved** -- subclass property with its own docstring is not overridden
3. **Multi-level inheritance** -- grandchild class inherits docstring through intermediate class
4. **Private properties not inherited** -- properties starting with `_` are skipped (matches existing behavior for functions)
5. **Properties with setters** -- setter/deleter are preserved when property is replaced
6. **Explicit doc parameter preserved** -- `property(fget, doc='...')` is not overridden
7. **Function inheritance regression** -- original function docstring inheritance still works

All 7 tests pass.