### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
+            if ((inspect.isfunction(val) or isinstance(val, property)) and
                 is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:


### PR DESCRIPTION
## Summary

Fixes #7166 — The `InheritDocstrings` metaclass didn't work for properties because it used `inspect.isfunction()` which returns `False` for property objects.

## Fix

Added `isinstance(val, property)` check alongside the existing `inspect.isfunction(val)` check in the `InheritDocstrings.__init__` method.

## Testing

Verified with a standalone test that exercises the fixed metaclass logic:

```python
class A(metaclass=InheritDocstrings):
    @property
    def my_prop(self):
        'Property docstring'
        return 42

class B(A):
    @property
    def my_prop(self):
        return 43

assert B.my_prop.__doc__ == 'Property docstring'  # PASSES
```

Also confirmed:
- Function docstring inheritance still works as before
- Properties with explicit docstrings are NOT overridden
- Private members are still skipped