### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
+            if ((inspect.isfunction(val) or isinstance(val, property)) and
                 is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:


### PR DESCRIPTION
## Summary

Fixes #7166 - The `InheritDocstrings` metaclass didn't work for properties because it only checked `inspect.isfunction(val)`, which returns `False` for property objects.

## Fix

Added `isinstance(val, property)` check alongside the existing `inspect.isfunction(val)` check in `astropy/utils/misc.py`.

The single-line change:
```python
# Before
if (inspect.isfunction(val) and ...

# After  
if ((inspect.isfunction(val) or isinstance(val, property)) and ...
```

## Testing

Verified with a standalone test:
```python
class A(metaclass=InheritDocstrings):
    @property
    def my_prop(self):
        'Property docstring from A'
        return 42

class B(A):
    @property
    def my_prop(self):
        return 43

assert B.my_prop.__doc__ == 'Property docstring from A'  # PASS
```

Also confirmed that properties with explicit docstrings are not overridden, and that regular method docstring inheritance still works as before.