### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
+            if ((inspect.isfunction(val) or isinstance(val, property)) and
                 is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:


### PR DESCRIPTION
## Summary

The InheritDocstrings metaclass uses inspect.isfunction() to determine which class members should inherit docstrings from base classes. However, inspect.isfunction() returns False for properties, so properties never had their docstrings inherited.

## Fix

Added isinstance(val, property) check alongside the existing inspect.isfunction(val) check so that properties without docstrings also inherit from their base class.

## Testing

Verified with standalone tests confirming:
- Property docstrings are now inherited from base classes
- Regular method docstring inheritance still works
- Properties with their own docstrings are NOT overwritten
- Private members are correctly skipped