### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -536,6 +536,14 @@ class InheritDocstrings(type):
                     if super_method is not None:
                         val.__doc__ = super_method.__doc__
                         break
+            elif (isinstance(val, property) and
+                  is_public_member(key) and
+                  val.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_property = getattr(base, key, None)
+                    if super_property is not None:
+                        val.__doc__ = super_property.__doc__
+                        break
 
         super().__init__(name, bases, dct)
 


### PR DESCRIPTION
## Summary

Fixes the `InheritDocstrings` metaclass so it also handles `property` objects, not just functions.

## Problem

The `InheritDocstrings` metaclass in `astropy/utils/misc.py` uses `inspect.isfunction()` to check class members, which returns `False` for properties. This means property docstrings are never inherited from base classes.

## Fix

Added an `elif` branch that checks `isinstance(val, property)` and, when the property has no docstring (`val.__doc__ is None`), inherits the docstring from the corresponding base class property.

## Testing

Verified with standalone tests covering:
1. Property docstring inheritance works
2. Function docstring inheritance still works (no regression)
3. Properties with their own docstrings are not overwritten
4. Write-only properties (fget is None) don't crash
5. Private members are still skipped
6. Multi-level inheritance works

Fixes #7166