### PR TITLE
Fix InheritDocstrings metaclass to work with properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
+            if ((inspect.isfunction(val) or isinstance(val, property)) and
                 is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:


### PR DESCRIPTION
## Fix

The `InheritDocstrings` metaclass used `inspect.isfunction()` to identify class members whose docstrings should be inherited. However, `inspect.isfunction()` returns `False` for properties, so properties never had their docstrings inherited from base classes.

**Change:** Added `isinstance(val, property)` check alongside the existing `inspect.isfunction(val)` check in `astropy/utils/misc.py`, so that properties also inherit docstrings from parent classes when they don't have their own.

Fixes #7166