### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -536,6 +536,19 @@ class InheritDocstrings(type):
                     if super_method is not None:
                         val.__doc__ = super_method.__doc__
                         break
+            elif (isinstance(val, property) and
+                  is_public_member(key) and
+                  val.fget is not None and
+                  val.fget.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_property = getattr(base, key, None)
+                    if super_property is not None:
+                        if isinstance(super_property, property):
+                            if super_property.fget is not None:
+                                val.fget.__doc__ = super_property.fget.__doc__
+                        else:
+                            val.fget.__doc__ = super_property.__doc__
+                        break
 
         super().__init__(name, bases, dct)
 


### PR DESCRIPTION
## Summary

Fixes the `InheritDocstrings` metaclass so it also handles properties, not just functions.

The issue was that `inspect.isfunction()` returns `False` for properties, so property docstrings were never inherited from base classes.

## Changes

**`astropy/utils/misc.py`**: Added an `elif` branch in `InheritDocstrings.__init__` that checks for `property` instances. When a subclass property's `fget` has no docstring, it inherits the docstring from the corresponding base class property's `fget`.

## Testing

Verified with the following test cases (all pass):
1. Property docstring is inherited from base class
2. Regular method docstring inheritance still works (no regression)
3. Property with an explicit docstring is NOT overwritten
4. Multiple inheritance follows MRO correctly for property docstrings