### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,9 +528,19 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
-                is_public_member(key) and
+            if (is_public_member(key) and
+                isinstance(val, property) and
                 val.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_val = base.__dict__.get(key)
+                    if isinstance(super_val, property) and super_val.__doc__ is not None:
+                        new_prop = property(val.fget, val.fset, val.fdel,
+                                            super_val.__doc__)
+                        setattr(cls, key, new_prop)
+                        break
+            elif (inspect.isfunction(val) and
+                  is_public_member(key) and
+                  val.__doc__ is None):
                 for base in cls.__mro__[1:]:
                     super_method = getattr(base, key, None)
                     if super_method is not None:


### PR DESCRIPTION
## Summary

Fixes the `InheritDocstrings` metaclass so it also inherits docstrings for properties, not just functions.

## Problem

`InheritDocstrings.__init__` used `inspect.isfunction(val)` to decide which class members should inherit docstrings. Since `inspect.isfunction` returns `False` for `property` objects, properties never had their docstrings inherited from base classes.

## Fix

Added an `isinstance(val, property)` check before the existing `inspect.isfunction` check. When a property with no docstring is found, we look up the MRO for a parent property with a docstring and create a new property with the inherited docstring via `setattr`.

Key details:
- Uses `base.__dict__` (not `getattr`) to look up the parent property, since `getattr` on a property invokes the getter instead of returning the descriptor.
- Creates a new `property(val.fget, val.fset, val.fdel, super_val.__doc__)` because property `__doc__` cannot always be set directly.
- Properties with their own explicit docstring are not overridden.
- Cross-type overrides (method -> property or vice versa) are handled correctly.

## Testing

Verified with standalone tests:
- Property docstring inherited from parent class
- Regular method docstring inheritance still works
- Property with explicit docstring is not overridden
- Multi-level property inheritance works correctly