### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -536,6 +536,17 @@ class InheritDocstrings(type):
                     if super_method is not None:
                         val.__doc__ = super_method.__doc__
                         break
+            elif (isinstance(val, property) and
+                  is_public_member(key) and
+                  val.fget is not None and
+                  val.fget.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_property = base.__dict__.get(key)
+                    if (isinstance(super_property, property) and
+                            super_property.fget is not None and
+                            super_property.fget.__doc__ is not None):
+                        val.fget.__doc__ = super_property.fget.__doc__
+                        break
 
         super().__init__(name, bases, dct)
 


### PR DESCRIPTION
## Summary

Fix the `InheritDocstrings` metaclass so it also inherits docstrings for properties, not just functions.

Fixes #7166

## Problem

The `InheritDocstrings` metaclass in `astropy/utils/misc.py` uses `inspect.isfunction()` to check class members, which returns `False` for `property` objects. This means properties defined in subclasses never inherit docstrings from their base class counterparts.

## Solution

Added an `elif` branch in `InheritDocstrings.__init__` that checks for `property` instances. When a property's `fget` has no docstring (`fget.__doc__ is None`), it walks the MRO to find a base class property with the same name and copies the `fget.__doc__` from it.

Key details:
- Uses `base.__dict__.get(key)` instead of `getattr(base, key)` to avoid invoking the descriptor protocol
- Only copies docstrings from base properties that are also `property` instances with non-None `fget.__doc__`
- Does not overwrite properties that already have their own docstring

## Testing

Verified with a standalone test script:
- Property docstring inheritance works (subclass property without docstring inherits from base)
- Function docstring inheritance still works (existing behavior preserved)
- Properties with their own docstrings are not overwritten
- Multi-level inheritance works (grandchild inherits through parent chain)

## Files Changed

- `astropy/utils/misc.py` — Added property handling in `InheritDocstrings.__init__`