### PR TITLE
Fix InheritDocstrings metaclass to work for properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
+            if ((inspect.isfunction(val) or isinstance(val, property)) and
                 is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:


### PR DESCRIPTION
## Summary

Fixes #7166 - The `InheritDocstrings` metaclass didn't work for properties because it used `inspect.isfunction()` which returns `False` for property objects.

## Fix

Added `isinstance(val, property)` check alongside the existing `inspect.isfunction(val)` check in `astropy/utils/misc.py`, so that properties with no docstring will inherit the docstring from the base class, just like regular methods.

## Testing

Verified with a standalone test:

```python
from astropy.utils.misc import InheritDocstrings

class A(metaclass=InheritDocstrings):
    @property
    def wiggle(self):
        'Wiggle the thingamajig'
        pass

class B(A):
    @property
    def wiggle(self):
        pass

assert B.wiggle.__doc__ == 'Wiggle the thingamajig'  # passes
```

Also confirmed that regular function docstring inheritance still works correctly.