### PR TITLE
Fix InheritDocstrings metaclass to work with properties

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -528,7 +528,7 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
+            if ((inspect.isfunction(val) or isinstance(val, property)) and
                 is_public_member(key) and
                 val.__doc__ is None):
                 for base in cls.__mro__[1:]:


### PR DESCRIPTION
## Summary

Fixes the `InheritDocstrings` metaclass so it also handles properties, not just functions.

## Problem

The `InheritDocstrings` metaclass in `astropy/utils/misc.py` used `inspect.isfunction(val)` to check whether a class member should inherit its docstring. However, `inspect.isfunction()` returns `False` for `property` objects, so properties never had their docstrings inherited from base classes.

## Fix

Added `isinstance(val, property)` as an additional check alongside `inspect.isfunction(val)` on line 531 of `astropy/utils/misc.py`.

## Testing

Verified with a standalone test that:
- Properties without docstrings correctly inherit from the base class
- Regular functions still inherit docstrings as before
- Properties with their own docstrings are not overridden