### PR TITLE
BUG: ensure thread safety in `set_temp_(cache|config)` context managers

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from functools import partial, wraps
 from inspect import cleandoc
 from pathlib import Path
+from threading import RLock
 from types import TracebackType
 from typing import Literal, ParamSpec
 from warnings import warn
@@ -25,8 +26,13 @@ __all__ = [
     "set_temp_config",
 ]
 
-
 P = ParamSpec("P")
+
+# Any number of threads may call any combination of set_temp_cache and set_temp_config,
+# in any order. Hence they need to share a single lock (otherwise deadlocks would be possible).
+# In particular, the possibility of nesting more than one instance of each context imposes
+# the use of a re-entrant lock (RLock).
+_PATHS_LOCK = RLock()
 
 
 def get_config_dir_path(rootname: str = "astropy") -> Path:
@@ -131,14 +137,16 @@ class _SetTempPath:
 
         self._path = path
         self._delete = delete
-        self._prev_path = self.__class__._temp_path
 
     def __enter__(self) -> str:
-        self.__class__._temp_path = self._path
+        _PATHS_LOCK.acquire()
+        self._prev_path = self.__class__._temp_path
         try:
+            self.__class__._temp_path = self._path
             return str(self.__class__._get_dir_path(rootname="astropy"))
         except Exception:
             self.__class__._temp_path = self._prev_path
+            _PATHS_LOCK.release()
             raise
 
     def __exit__(
@@ -147,10 +155,13 @@ class _SetTempPath:
         value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self.__class__._temp_path = self._prev_path
+        try:
+            self.__class__._temp_path = self._prev_path
 
-        if self._delete and self._path is not None:
-            shutil.rmtree(self._path)
+            if self._delete and self._path is not None:
+                shutil.rmtree(self._path)
+        finally:
+            _PATHS_LOCK.release()
 
     def __call__(self, func: Callable[P, object]) -> Callable[P, None]:
         """Implements use as a decorator."""
@@ -269,6 +280,9 @@ class set_temp_config(_SetTempPath):
     This may also be used as a decorator on a function to set the config path
     just within that function.
 
+    Thread safety is guaranteed since astropy 7.2.1, but concurrency isn't:
+    only a single thread at a time may execute code within this context.
+
     Parameters
     ----------
     path : str, optional
@@ -294,9 +308,24 @@ class set_temp_config(_SetTempPath):
         # config file (e.g., iers.conf.auto_download=False for our tests).
         from .configuration import _cfgobjs
 
-        self._cfgobjs_copy = _cfgobjs.copy()
-        _cfgobjs.clear()
-        return super().__enter__()
+        _PATHS_LOCK.acquire()
+
+        try:
+            _cfgobjs_copy = _cfgobjs.copy()
+        except Exception:
+            _PATHS_LOCK.release()
+            raise
+
+        self._cfgobjs_copy = _cfgobjs_copy
+
+        try:
+            _cfgobjs.clear()
+            return super().__enter__()
+        except Exception:
+            _cfgobjs.update(self._cfgobjs_copy)
+            del self._cfgobjs_copy
+            _PATHS_LOCK.release()
+            raise
 
     def __exit__(
         self,
@@ -304,12 +333,15 @@ class set_temp_config(_SetTempPath):
         value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        from .configuration import _cfgobjs
+        try:
+            from .configuration import _cfgobjs
 
-        _cfgobjs.clear()
-        _cfgobjs.update(self._cfgobjs_copy)
-        del self._cfgobjs_copy
-        super().__exit__(type, value, tb)
+            _cfgobjs.clear()
+            _cfgobjs.update(self._cfgobjs_copy)
+            del self._cfgobjs_copy
+            super().__exit__(type, value, tb)
+        finally:
+            _PATHS_LOCK.release()
 
 
 class set_temp_cache(_SetTempPath):
@@ -324,6 +356,9 @@ class set_temp_cache(_SetTempPath):
 
     This may also be used as a decorator on a function to set the cache path
     just within that function.
+
+    Thread safety is guaranteed since astropy 7.2.1, but concurrency isn't:
+    only a single thread at a time may execute code within this context.
 
     Parameters
     ----------

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from functools import partial, wraps
 from inspect import cleandoc
 from pathlib import Path
+from threading import RLock
 from types import TracebackType
 from typing import Literal, ParamSpec
 from warnings import warn
@@ -25,8 +26,13 @@ __all__ = [
     "set_temp_config",
 ]
 
-
 P = ParamSpec("P")
+
+# Any number of threads may call any combination of set_temp_cache and set_temp_config,
+# in any order. Hence they need to share a single lock (otherwise deadlocks would be possible).
+# In particular, the possibility of nesting more than one instance of each context imposes
+# the use of a re-entrant lock (RLock).
+_PATHS_MUTEX = RLock()
 
 
 def get_config_dir_path(rootname: str = "astropy") -> Path:
@@ -134,11 +140,17 @@ class _SetTempPath:
         self._prev_path = self.__class__._temp_path
 
     def __enter__(self) -> str:
-        self.__class__._temp_path = self._path
+        _PATHS_MUTEX.acquire()
+        try:
+            self.__class__._temp_path = self._path
+        except Exception:
+            _PATHS_MUTEX.release()
+            raise
         try:
             return str(self.__class__._get_dir_path(rootname="astropy"))
         except Exception:
             self.__class__._temp_path = self._prev_path
+            _PATHS_MUTEX.release()
             raise
 
     def __exit__(
@@ -147,10 +159,13 @@ class _SetTempPath:
         value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self.__class__._temp_path = self._prev_path
+        try:
+            self.__class__._temp_path = self._prev_path
 
-        if self._delete and self._path is not None:
-            shutil.rmtree(self._path)
+            if self._delete and self._path is not None:
+                shutil.rmtree(self._path)
+        finally:
+            _PATHS_MUTEX.release()
 
     def __call__(self, func: Callable[P, object]) -> Callable[P, None]:
         """Implements use as a decorator."""
@@ -269,6 +284,9 @@ class set_temp_config(_SetTempPath):
     This may also be used as a decorator on a function to set the config path
     just within that function.
 
+    Thread safety is guaranteed since astropy 7.2.1, but concurrency isn't:
+    only a single thread at a time may execute code within this context.
+
     Parameters
     ----------
     path : str, optional
@@ -292,11 +310,17 @@ class set_temp_config(_SetTempPath):
         # cached config objects.  We do keep the cache, since some of it
         # may have been set programmatically rather than be stored in the
         # config file (e.g., iers.conf.auto_download=False for our tests).
-        from .configuration import _cfgobjs
+        _PATHS_MUTEX.acquire()
 
-        self._cfgobjs_copy = _cfgobjs.copy()
-        _cfgobjs.clear()
-        return super().__enter__()
+        try:
+            from .configuration import _cfgobjs
+
+            self._cfgobjs_copy = _cfgobjs.copy()
+            _cfgobjs.clear()
+            return super().__enter__()
+        except Exception:
+            _PATHS_MUTEX.release()
+            raise
 
     def __exit__(
         self,
@@ -304,12 +328,15 @@ class set_temp_config(_SetTempPath):
         value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        from .configuration import _cfgobjs
+        try:
+            from .configuration import _cfgobjs
 
-        _cfgobjs.clear()
-        _cfgobjs.update(self._cfgobjs_copy)
-        del self._cfgobjs_copy
-        super().__exit__(type, value, tb)
+            _cfgobjs.clear()
+            _cfgobjs.update(self._cfgobjs_copy)
+            del self._cfgobjs_copy
+            super().__exit__(type, value, tb)
+        finally:
+            _PATHS_MUTEX.release()
 
 
 class set_temp_cache(_SetTempPath):
@@ -324,6 +351,9 @@ class set_temp_cache(_SetTempPath):
 
     This may also be used as a decorator on a function to set the cache path
     just within that function.
+
+    Thread safety is guaranteed since astropy 7.2.1, but concurrency isn't:
+    only a single thread at a time may execute code within this context.
 
     Parameters
     ----------

--- a/astropy/config/tests/test_concurrency.py
+++ b/astropy/config/tests/test_concurrency.py
@@ -1,0 +1,149 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from threading import Barrier
+from typing import Generic, TypeAlias, TypeVar
+from uuid import uuid4
+
+import pytest
+
+from astropy.config import (
+    get_cache_dir_path,
+    get_config_dir_path,
+    set_temp_cache,
+    set_temp_config,
+)
+from astropy.config.paths import _SetTempPath
+
+N_THREADS = 10
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class Result(Generic[T]):
+    actual: T
+    expected: T
+
+    def match(self) -> bool:
+        return self.actual == self.expected
+
+
+PathGetter: TypeAlias = Callable[[], Path]
+
+
+def getter_from_manager(cm: type[_SetTempPath]) -> PathGetter:
+    # this is functionally equivalent to an immutable dict
+    # it could be refactored into a frozendict when Python 3.14 is unsupported
+    if cm is set_temp_cache:
+        return get_cache_dir_path
+    elif cm is set_temp_config:
+        return get_config_dir_path
+    else:
+        raise ValueError
+
+
+def closure_base(
+    ctx_manager: type[_SetTempPath],
+    *,
+    directory: Path,
+    barrier: Barrier,
+) -> Result[Path]:
+    local_path = directory / str(uuid4())
+    local_path.mkdir()
+    getter = getter_from_manager(ctx_manager)
+
+    barrier.wait()
+    with ctx_manager(local_path):
+        res = getter()
+
+    return Result(actual=res, expected=local_path / "astropy")
+
+
+def assert_valid_results(results: list[Result[T]]) -> None:
+    __tracebackhide__ = True
+    assert len(results) == N_THREADS
+    assert len(set(results)) == N_THREADS
+    assert all(r.match() for r in results)
+
+
+@pytest.mark.parametrize("ctx_manager", [set_temp_cache, set_temp_config])
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
+def test_set_temp_dir(ctx_manager, tmp_path):
+    closure = partial(
+        closure_base,
+        ctx_manager,
+        directory=tmp_path,
+        barrier=Barrier(N_THREADS),
+    )
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [executor.submit(closure) for _ in range(N_THREADS)]
+
+    assert_valid_results([f.result() for f in futures])
+
+
+@pytest.mark.parametrize(
+    "cm_out, cm_in",
+    [
+        pytest.param(set_temp_cache, set_temp_cache, id="cache-cache"),
+        pytest.param(set_temp_cache, set_temp_config, id="cache-config"),
+        pytest.param(set_temp_config, set_temp_cache, id="config-cache"),
+        pytest.param(set_temp_config, set_temp_config, id="config-config"),
+    ],
+)
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
+def test_nesting(cm_out: type[_SetTempPath], cm_in: type[_SetTempPath], tmp_path: Path):
+    # check that nesting doesn't deadlock
+    barrier = Barrier(N_THREADS)
+    getter_out = getter_from_manager(cm_out)
+    getter_in = getter_from_manager(cm_in)
+
+    def closure() -> Result[tuple[Path, Path, Path, Path]]:
+        local_path_1 = tmp_path / str(uuid4())
+        local_path_1.mkdir()
+        local_path_2 = tmp_path / str(uuid4())
+        local_path_2.mkdir()
+
+        barrier.wait()
+        with cm_out(local_path_1):
+            res0 = getter_out()
+            with cm_in(local_path_2):
+                res1 = getter_in()
+                res2 = getter_out()
+            res3 = getter_out()
+        return Result(
+            actual=(res0, res1, res2, res3),
+            expected=(
+                local_path_1 / "astropy",
+                local_path_2 / "astropy",
+                (local_path_1 if cm_in != cm_out else local_path_2) / "astropy",
+                local_path_1 / "astropy",
+            ),
+        )
+
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [executor.submit(closure) for _ in range(N_THREADS)]
+
+    assert_valid_results([f.result() for f in futures])
+
+
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
+def test_mixed_settings(tmp_path):
+    barrier = Barrier(N_THREADS)
+
+    cache_setter = partial(
+        closure_base, set_temp_cache, directory=tmp_path, barrier=barrier
+    )
+    config_setter = partial(
+        closure_base, set_temp_config, directory=tmp_path, barrier=barrier
+    )
+
+    closures = [cache_setter if n % 2 else config_setter for n in range(N_THREADS)]
+    with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+        futures = [executor.submit(c) for c in closures]
+
+    assert_valid_results([f.result() for f in futures])

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -8,7 +8,6 @@ import sys
 from contextlib import nullcontext
 from inspect import cleandoc
 from pathlib import Path
-from threading import Lock
 
 import pytest
 
@@ -17,31 +16,6 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 OLD_CONFIG = {}
-
-_IGNORE_CONFIG_PATHS_GLOBAL_STATE_LOCK = Lock()
-
-
-@pytest.fixture
-def ignore_config_paths_global_state(monkeypatch, tmp_path_factory):
-    # ignore global state of the test session
-    # and preserve thread safety across all users of this fixture
-    with _IGNORE_CONFIG_PATHS_GLOBAL_STATE_LOCK:
-        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-
-        monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)
-        monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
-
-        # also mock $HOME as it's part of the global state taken into account
-        # for path detection
-        mock_home_dir = tmp_path_factory.mktemp("MOCK_HOME")
-
-        def mock_home():
-            return mock_home_dir
-
-        monkeypatch.setattr(Path, "home", mock_home)
-
-        yield
 
 
 def setup_module():

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import warnings
 from pathlib import Path
+from threading import Lock
 
 try:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
@@ -47,6 +48,34 @@ def fast_thread_switching():
     sys.setswitchinterval(1e-6)
     yield
     sys.setswitchinterval(old)
+
+
+_IGNORE_CONFIG_PATHS_GLOBAL_STATE_LOCK = Lock()
+
+
+@pytest.fixture
+def ignore_config_paths_global_state(monkeypatch, tmp_path_factory):
+    from astropy.config import set_temp_cache, set_temp_config
+
+    # ignore global state of the test session
+    # and preserve thread safety across all users of this fixture
+    with _IGNORE_CONFIG_PATHS_GLOBAL_STATE_LOCK:
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        monkeypatch.setattr(set_temp_cache, "_temp_path", None)
+        monkeypatch.setattr(set_temp_config, "_temp_path", None)
+
+        # also mock $HOME as it's part of the global state taken into account
+        # for path detection
+        mock_home_dir = tmp_path_factory.mktemp("MOCK_HOME")
+
+        def mock_home():
+            return mock_home_dir
+
+        monkeypatch.setattr(Path, "home", mock_home)
+
+        yield
 
 
 def pytest_configure(config):

--- a/docs/changes/config/19559.bugfix.rst
+++ b/docs/changes/config/19559.bugfix.rst
@@ -1,0 +1,2 @@
+Disabling thread concurrency within ``set_temp_cache`` and ``set_temp_config``
+context managers, ensuring thread safety.

--- a/docs/changes/config/19559.bugfix.rst
+++ b/docs/changes/config/19559.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure thread safety in ``set_temp_cache`` and ``set_temp_config``
+context managers


### PR DESCRIPTION
### Description
While working on #18964, I realized that these context managers where obviously not thread safe as they relying on mutations to global state.
Because they are public API, I don't think it's possible to put the genie back in the bottle now and so we must compose with this global+mutable state, and the only thing to do is hence to add locking to it.
Furthermore, because we have to allow any number of threads to call any combination of these context managers in any order, they need to share a single lock (otherwise deadlocks would be possible). In particular, the possibility of nesting more than one instance of each context imposes the use of a re-entrant lock (`RLock`).
I've added multiple tests that all fail seemingly 100% of the time on my machine so I'm confident they capture the bugs and don't think we need special jobs to run them as stress tests.


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
