### PR TITLE
TST: cleanup an unnecessary fixture in image tests

### DIFF
--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -15,7 +15,7 @@ from .test_images import BaseImageTests
 
 
 class TestDisplayWorldCoordinate(BaseImageTests):
-    def test_overlay_coords(self, ignore_matplotlibrc, tmp_path):
+    def test_overlay_coords(self, ignore_matplotlibrc):
         minus_sign = "\N{MINUS SIGN}" if mpl.rcParams["axes.unicode_minus"] else "-"
         wcs = WCS(self.msx_header)
 
@@ -25,9 +25,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs)
         fig.add_axes(ax)
 
-        # On some systems, fig.canvas.draw is not enough to force a draw, so we
-        # save to a temporary file.
-        fig.savefig(tmp_path / "test1.png")
+        # Force drawing
+        fig.canvas.draw()
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
@@ -51,9 +50,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         # main world coordinates.
         overlay[0].set_major_formatter("d.ddd")
 
-        # On some systems, fig.canvas.draw is not enough to force a draw, so we
-        # save to a temporary file.
-        fig.savefig(tmp_path / "test2.png")
+        # Force drawing
+        fig.canvas.draw()
 
         event4 = KeyEvent("test_pixel_coords", canvas, "w")
         fig.canvas.callbacks.process("key_press_event", event4)
@@ -70,9 +68,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         # main world coordinates.
         overlay[0].set_major_formatter("d.ddd")
 
-        # On some systems, fig.canvas.draw is not enough to force a draw, so we
-        # save to a temporary file.
-        fig.savefig(tmp_path / "test3.png")
+        # Force drawing
+        fig.canvas.draw()
 
         event5 = KeyEvent("test_pixel_coords", canvas, "w")
         fig.canvas.callbacks.process("key_press_event", event5)
@@ -89,9 +86,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         # main world coordinates.
         overlay[0].set_major_formatter("d.ddd")
 
-        # On some systems, fig.canvas.draw is not enough to force a draw, so we
-        # save to a temporary file.
-        fig.savefig(tmp_path / "test4.png")
+        # Force drawing
+        fig.canvas.draw()
 
         event6 = KeyEvent("test_pixel_coords", canvas, "w")
         fig.canvas.callbacks.process("key_press_event", event6)
@@ -102,7 +98,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
             string_world5 == f"267.652\xb0 {minus_sign}28\xb046'23\" (world, overlay 3)"
         )
 
-    def test_cube_coords(self, ignore_matplotlibrc, tmp_path):
+    def test_cube_coords(self, ignore_matplotlibrc):
         wcs = WCS(self.cube_header)
 
         fig = Figure(figsize=(4, 4))
@@ -111,9 +107,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs, slices=("y", 50, "x"))
         fig.add_axes(ax)
 
-        # On some systems, fig.canvas.draw is not enough to force a draw, so we
-        # save to a temporary file.
-        fig.savefig(tmp_path / "test.png")
+        # Force drawing
+        fig.canvas.draw()
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
@@ -125,7 +120,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         string_pixel = ax._display_world_coords(0.523412, 0.523412)
         assert string_pixel == "0.523412 0.523412 (pixel)"
 
-    def test_cube_coords_uncorr_slicing(self, ignore_matplotlibrc, tmp_path):
+    def test_cube_coords_uncorr_slicing(self, ignore_matplotlibrc):
         # Regression test for a bug that occurred with coordinate formatting if
         # some dimensions were uncorrelated and sliced out.
 
@@ -137,9 +132,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs, slices=("x", "y", 2))
         fig.add_axes(ax)
 
-        # On some systems, fig.canvas.draw is not enough to force a draw, so we
-        # save to a temporary file.
-        fig.savefig(tmp_path / "test.png")
+        # Force drawing
+        fig.canvas.draw()
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -71,7 +71,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_rectangular(self):
+    def test_update_clip_path_rectangular(self, tmp_path):
         fig = Figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
 
@@ -81,7 +81,9 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0.0, 2.0)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.canvas.draw()
+        # this should normally suffice, but currently doesn't (to be elucidated)
+        # fig.canvas.draw()
+        fig.savefig(tmp_path / "nothing")
 
         ax.imshow(np.zeros((12, 4)))
 

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -71,7 +71,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_rectangular(self, tmp_path):
+    def test_update_clip_path_rectangular(self):
         fig = Figure()
         ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect="equal")
 
@@ -81,7 +81,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0.0, 2.0)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(tmp_path / "nothing")
+        fig.canvas.draw()
 
         ax.imshow(np.zeros((12, 4)))
 
@@ -94,7 +94,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_nonrectangular(self, tmp_path):
+    def test_update_clip_path_nonrectangular(self):
         fig = Figure()
         ax = WCSAxes(
             fig, [0.1, 0.1, 0.8, 0.8], aspect="equal", frame_class=HexagonalFrame
@@ -106,7 +106,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0.0, 2.0)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(tmp_path / "nothing")
+        fig.canvas.draw()
 
         ax.imshow(np.zeros((12, 4)))
 
@@ -116,7 +116,7 @@ class TestFrame(BaseImageTests):
         return fig
 
     @figure_test
-    def test_update_clip_path_change_wcs(self, tmp_path):
+    def test_update_clip_path_change_wcs(self):
         # When WCS is changed, a new frame is created, so we need to make sure
         # that the path is carried over to the new frame.
 
@@ -129,7 +129,7 @@ class TestFrame(BaseImageTests):
         ax.set_ylim(0.0, 2.0)
 
         # Force drawing, which freezes the clip path returned by WCSAxes
-        fig.savefig(tmp_path / "nothing")
+        fig.canvas.draw()
 
         ax.reset_wcs()
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -43,7 +43,7 @@ def test_grid_regression(ignore_matplotlibrc):
     WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
 
 
-def test_format_coord_regression(ignore_matplotlibrc, tmp_path):
+def test_format_coord_regression(ignore_matplotlibrc):
     # Regression test for a bug that meant that if format_coord was called by
     # Matplotlib before the axes were drawn, an error occurred.
     fig = Figure(figsize=(3, 3))
@@ -52,7 +52,8 @@ def test_format_coord_regression(ignore_matplotlibrc, tmp_path):
     assert ax.format_coord(10, 10) == ""
     assert ax.coords[0].format_coord(10) == ""
     assert ax.coords[1].format_coord(10) == ""
-    fig.savefig(tmp_path / "nothing")
+    # Force drawing
+    fig.canvas.draw()
     assert ax.format_coord(10, 10) == "10.0 10.0 (world)"
     assert ax.coords[0].format_coord(10) == "10.0"
     assert ax.coords[1].format_coord(10) == "10.0"
@@ -80,7 +81,7 @@ COORDSYS= 'icrs    '
 
 
 @pytest.mark.parametrize("grid_type", ["lines", "contours"])
-def test_no_numpy_warnings(ignore_matplotlibrc, tmp_path, grid_type):
+def test_no_numpy_warnings(ignore_matplotlibrc, grid_type):
     fig = Figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS(TARGET_HEADER))
     ax.imshow(np.zeros((100, 200)))
@@ -105,7 +106,8 @@ def test_no_numpy_warnings(ignore_matplotlibrc, tmp_path, grid_type):
         warnings.filterwarnings(
             "ignore", message=r".*PY_SSIZE_T_CLEAN will be required.*"
         )
-        fig.savefig(tmp_path / "test.png")
+        # Force drawing
+        fig.canvas.draw()
 
 
 def test_invalid_frame_overlay(ignore_matplotlibrc):
@@ -197,7 +199,7 @@ CRPIX3  =                241.0
 )
 
 
-def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
+def test_slicing_warnings(ignore_matplotlibrc):
     # Regression test to make sure that no warnings are emitted by the tick
     # locator for the sliced axis when slicing a cube.
 
@@ -215,7 +217,7 @@ def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
         # https://github.com/astropy/astropy/issues/9690
         warnings.filterwarnings("ignore", message=r".*PY_SSIZE_T_CLEAN.*")
         fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 1))
-        fig.savefig(tmp_path / "test.png")
+        fig.canvas.draw()
 
     # Angle case
 
@@ -226,7 +228,7 @@ def test_slicing_warnings(ignore_matplotlibrc, tmp_path):
         warnings.filterwarnings("ignore", message=r".*PY_SSIZE_T_CLEAN.*")
         fig.clear()
         fig.add_subplot(1, 1, 1, projection=wcs3d, slices=("x", "y", 2))
-        fig.savefig(tmp_path / "test.png")
+        fig.canvas.draw()
 
 
 @pytest.fixture
@@ -250,7 +252,7 @@ def test_plt_xlabel_ylabel(tmp_path):
     plt.savefig(tmp_path / "test.png")
 
 
-def test_grid_type_contours_transform(tmp_path):
+def test_grid_type_contours_transform():
     # Regression test for a bug that caused grid_type='contours' to not work
     # with custom transforms
 
@@ -273,7 +275,8 @@ def test_grid_type_contours_transform(tmp_path):
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], transform=transform, coord_meta=coord_meta)
     fig.add_axes(ax)
     ax.grid(grid_type="contours")
-    fig.savefig(tmp_path / "test.png")
+    # Force drawing
+    fig.canvas.draw()
 
 
 @pytest.mark.usefixtures("tmp_plt_figure")
@@ -473,7 +476,7 @@ def test_time_wcs(time_spectral_wcs_2d):
 
 
 @pytest.mark.skipif(TEX_UNAVAILABLE, reason="TeX is unavailable")
-def test_simplify_labels_usetex(ignore_matplotlibrc, tmp_path):
+def test_simplify_labels_usetex(ignore_matplotlibrc):
     """Regression test for https://github.com/astropy/astropy/issues/8004."""
     mpl.rc("text", usetex=True)
 
@@ -503,7 +506,7 @@ def test_simplify_labels_usetex(ignore_matplotlibrc, tmp_path):
     ax.coords[1].set_ticks(spacing=30 * u.deg)
     ax.grid()
 
-    fig.savefig(tmp_path / "plot.png")
+    fig.canvas.draw()
 
 
 @pytest.mark.parametrize(
@@ -607,12 +610,12 @@ def test_wcs_type_transform_regression():
     ax.get_transform(sliced_wcs)
 
 
-def test_multiple_draws_grid_contours(tmp_path):
+def test_multiple_draws_grid_contours():
     fig = Figure()
     ax = fig.add_subplot(1, 1, 1, projection=WCS())
     ax.grid(color="black", grid_type="contours")
-    fig.savefig(tmp_path / "plot.png")
-    fig.savefig(tmp_path / "plot.png")
+    fig.canvas.draw()
+    fig.canvas.draw()
 
 
 def test_get_coord_range_nan_regression():


### PR DESCRIPTION
### Description
Follow up to #19484


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
