### PR TITLE
Remove instruction to close/open PR for credit update PRs

### DIFF
--- a/.github/workflows/update_credits.md
+++ b/.github/workflows/update_credits.md
@@ -3,7 +3,6 @@ This is an automated update of the credits for the core package.
 Checklist:
 
 * [ ] Apply backport labels to any active backport branches
-* [ ] Close and re-open this pull request to trigger the CI
 * [ ] Check the resulting docs/credits.rst, and update the .mailmap file for any duplicates or missing names
 * [ ] If you update .mailmap, re-run:
 


### PR DESCRIPTION
This isn't needed since CI does run correctly