### PR TITLE
TST: fix a logic flaw in a pytest fixture

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -45,7 +45,7 @@ def fast_thread_switching():
     This makes it easier to provoke race conditions.
     """
     old = sys.getswitchinterval()
-    sys.setswitchinterval(1e-6)
+    sys.setswitchinterval(min(old, 1e-6))
     yield
     sys.setswitchinterval(old)
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -44,7 +44,7 @@ def fast_thread_switching():
     This makes it easier to provoke race conditions.
     """
     old = sys.getswitchinterval()
-    sys.setswitchinterval(1e-6)
+    sys.setswitchinterval(min(old, 1e-6))
     yield
     sys.setswitchinterval(old)
 


### PR DESCRIPTION
### Description
Technically this is a fix to a logic flaw (we should not update the switching frequency _unconditionally_), but not worth backporting; it's merely theoritical.


- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
