### PR TITLE
MNT: sign myself up to watch edits to dev `scripts` dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,7 @@ docs/time                   @taldcroft
 docs/visualization          @astrofrog      @larrybradley
 docs/wcs                    @mcara
 
+scripts/*                   @neutrinoceros
 pyproject.toml              @neutrinoceros
 setup.py                    @neutrinoceros
 MANIFEST.in                 @neutrinoceros


### PR DESCRIPTION
### Description
These scripts have their own dependency metadata so it feels in line with watching `pyproject.toml`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
