### PR TITLE
DEV: Auto-update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,12 +55,12 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.22.0
+    rev: v1.24.0
     hooks:
     - id: zizmor
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args: ["--write-changes"]
@@ -68,14 +68,14 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.10
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/scientific-python/cookie
-    rev: 2025.11.21
+    rev: 2026.04.04
     hooks:
       - id: sp-repo-review
 
@@ -107,7 +107,7 @@ repos:
         exclude: "(licenses/|docs/_build/|.*parsetab.py|astropy/extern/)"
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v21.1.2'
+    rev: 'v22.1.3'
     hooks:
       - id: clang-format
         files: \.(c|h)$

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10550,7 +10550,7 @@ astropy.coordinates
 - Slicing and reshaping of ``SkyCoord`` and coordinate frames no longer passes
   the new object through ``__init__``, but directly sets attributes on a new
   instance. This speeds up those methods by an order of magnitude, but means
-  that any customization done in ``__init__`` is by-passed. [#6941]
+  that any customization done in ``__init__`` is bypassed. [#6941]
 
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -130,7 +130,7 @@ class Constant(Quantity, metaclass=ConstantMeta):
                 raise TypeError(f"{cls} requires a reference.")
         name_lower = name.lower()
         instances = cls._registry.setdefault(name_lower, {})
-        # By-pass Quantity initialization, since units may not yet be
+        # Bypass Quantity initialization, since units may not yet be
         # initialized here, and we store the unit in string form.
         inst = np.array(value).view(cls)
 

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -337,8 +337,9 @@ FORCE_INLINE void convolve1d(
 
                 if (nan_interpolate) // compile time constant
                 {
-                    if (bot ==
-                        0) { // This should prob be np.isclose(kernel_sum, 0, atol=normalization_zero_tol)
+                    if (
+                        bot == 0
+                    ) { // This should prob be np.isclose(kernel_sum, 0, atol=normalization_zero_tol)
                         result[result_index] = f[i];
                     }
                     else {
@@ -471,8 +472,9 @@ FORCE_INLINE void convolve2d(
 
                         if (nan_interpolate) // compile time constant
                         {
-                            if (bot ==
-                                0) { // This should prob be np.isclose(kernel_sum, 0, atol=normalization_zero_tol)
+                            if (
+                                bot == 0
+                            ) { // This should prob be np.isclose(kernel_sum, 0, atol=normalization_zero_tol)
                                 result[result_index] = f[result_cursor + j];
                             }
                             else {
@@ -605,7 +607,9 @@ FORCE_INLINE void convolve3d(
                                                     for (kk = 0; kk < nkz; ++kk) {
                                                         val = f[f_cursor + kk];
                                                         ker = g[g_cursor - kk];
-                                                        if (nan_interpolate) // compile time constant
+                                                        if (
+                                                            nan_interpolate
+                                                        ) // compile time constant
                                                         {
                                                             if (!isnan(val)) {
                                                                 top += val * ker;
@@ -633,8 +637,9 @@ FORCE_INLINE void convolve3d(
 
                                 if (nan_interpolate) // compile time constant
                                 {
-                                    if (bot ==
-                                        0) { // This should prob be np.isclose(kernel_sum, 0, atol=normalization_zero_tol)
+                                    if (
+                                        bot == 0
+                                    ) { // This should prob be np.isclose(kernel_sum, 0, atol=normalization_zero_tol)
                                         result[result_index] = f[array_cursor + k];
                                     }
                                     else {

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -383,8 +383,9 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
                 if ((c == ' ' || c == '\t') && self->strip_whitespace_fields) {
                     break;
                 }
-                else if (!self->strip_whitespace_lines && self->comment != 0 &&
-                         c == self->comment) {
+                else if (
+                    !self->strip_whitespace_lines && self->comment != 0 && c == self->comment
+                ) {
                     // Comment line, not caught earlier because of no stripping
                     self->state = COMMENT;
                     break;


### PR DESCRIPTION
Closes #19532.

Updates:

- [github.com/zizmorcore/zizmor-pre-commit: v1.22.0 → v1.24.0](https://github.com/zizmorcore/zizmor-pre-commit/compare/v1.22.0...v1.24.0)
- [github.com/codespell-project/codespell: v2.4.1 → v2.4.2](https://github.com/codespell-project/codespell/compare/v2.4.1...v2.4.2)
- [github.com/astral-sh/ruff-pre-commit: v0.15.4 → v0.15.10](https://github.com/astral-sh/ruff-pre-commit/compare/v0.15.4...v0.15.10)
- [github.com/scientific-python/cookie: 2025.11.21 → 2026.04.04](https://github.com/scientific-python/cookie/compare/2025.11.21...2026.04.04)
- [github.com/pre-commit/mirrors-clang-format: v21.1.2 → v22.1.3](https://github.com/pre-commit/mirrors-clang-format/compare/v21.1.2...v22.1.3)