### PR TITLE
DOC/TST: `console` and `unicode` formatting support roundtrip

### DIFF
--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -402,6 +402,7 @@ class TestRoundtripGeneric(RoundtripBase):
     )
     def test_roundtrip(self, unit):
         self.check_roundtrip(unit)
+        self.check_roundtrip(unit, output_format="console")
         self.check_roundtrip(unit, output_format="unicode")
         self.check_roundtrip_decompose(unit)
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -363,15 +363,15 @@ def test_ogip_negative_powers(string):
 
 
 class RoundtripBase:
-    def check_roundtrip(self, unit, output_format=None):
+    def check_roundtrip(self, unit, output_format=None, **kwargs):
         if output_format is None:
             output_format = self.format_.name
-        s = unit.to_string(output_format, deprecations="silent")
+        s = unit.to_string(output_format, deprecations="silent", **kwargs)
         if s in self.format_._deprecated_units:
             with pytest.raises(UnitsError, match="deprecated"):
-                unit.to_string(output_format, deprecations="raise")
+                unit.to_string(output_format, deprecations="raise", **kwargs)
             with pytest.warns(UnitsWarning, match="deprecated"):
-                assert unit.to_string(output_format) == s
+                assert unit.to_string(output_format, **kwargs) == s
             with pytest.warns(UnitsWarning, match="deprecated") as w:
                 a = Unit(s, format=self.format_)
             assert len(w) == 1
@@ -405,6 +405,12 @@ class TestRoundtripGeneric(RoundtripBase):
         self.check_roundtrip(unit, output_format="console")
         self.check_roundtrip(unit, output_format="unicode")
         self.check_roundtrip_decompose(unit)
+
+    @pytest.mark.parametrize("fraction", [None, "inline"])
+    @pytest.mark.parametrize("output_format", [None, "console", "unicode"])
+    def test_composite_roundtrip(self, output_format, fraction):
+        fluxunit = u.erg / (u.cm**2 * u.s)
+        self.check_roundtrip(fluxunit, output_format=output_format, fraction=fraction)
 
 
 class TestRoundtripVOUnit(RoundtripBase):

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -204,6 +204,36 @@ formats:
     `Office of Guest Investigator Programs (OGIP)
     <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`_.
 
+  - ``"console"``: Writes a representation of the unit useful for
+    display in a text console::
+
+      >>> print(fluxunit.to_string('console'))
+       erg s^-1 cm^-2
+
+    It is also possible to use a fraction, either on a single line,
+
+      >>> print(fluxunit.to_string('console', fraction='inline'))
+      erg / (s cm^2)
+
+    or using a multiline representation:
+
+      >>> print(fluxunit.to_string('console', fraction='multiline'))
+       erg
+      ------
+      s cm^2
+
+  - ``"unicode"``: Same as ``"console"``, except uses Unicode
+    characters::
+
+      >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸ m² kg s⁻²
+      >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸ m² kg / s²
+      >>> print(u.Ry.decompose().to_string('unicode', fraction='multiline'))  # doctest: +FLOAT_CMP
+                      m² kg
+      2.1798724×10⁻¹⁸ ─────
+                       s²
+
 `astropy.units` is also able to write, but not read, units in the
 following formats:
 
@@ -238,36 +268,6 @@ following formats:
     .. math::
 
        \mathrm{erg\,s^{-1}\,cm^{-2}}
-
-  - ``"console"``: Writes a representation of the unit useful for
-    display in a text console::
-
-      >>> print(fluxunit.to_string('console'))
-       erg s^-1 cm^-2
-
-    It is also possible to use a fraction, either on a single line,
-
-      >>> print(fluxunit.to_string('console', fraction='inline'))
-      erg / (s cm^2)
-
-    or using a multiline representation:
-
-      >>> print(fluxunit.to_string('console', fraction='multiline'))
-       erg
-      ------
-      s cm^2
-
-  - ``"unicode"``: Same as ``"console"``, except uses Unicode
-    characters::
-
-      >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
-      2.1798724×10⁻¹⁸ m² kg s⁻²
-      >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
-      2.1798724×10⁻¹⁸ m² kg / s²
-      >>> print(u.Ry.decompose().to_string('unicode', fraction='multiline'))  # doctest: +FLOAT_CMP
-                      m² kg
-      2.1798724×10⁻¹⁸ ─────
-                       s²
 
 .. _astropy-units-format-unrecognized:
 

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -257,13 +257,9 @@ parsing depends on the format, see details below:
       ------
       s cm^2
 
-    The ``"console"`` format can also be parsed back to a |Unit| object, but
-    this is only supported for the default and ``fraction="inline"`` format and
-    not the ``fraction="multiline"`` format. Exemplary the ``"inline"``
-    representation can be parsed back to the ```fluxunit``:
-
-      >>> u.Unit("erg / (s cm^2)") == fluxunit
-      True
+    The ``"console"`` format is not meant to be parsed back to |Unit| objects, even
+    though it does generally work as long as no scale factors are present and one
+    does not use ``fraction="multiline"``.
 
   - ``"unicode"``: Same as ``"console"``, except uses Unicode
     characters::

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -204,38 +204,8 @@ formats:
     `Office of Guest Investigator Programs (OGIP)
     <https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/general/ogip_93_001/>`_.
 
-  - ``"console"``: Writes a representation of the unit useful for
-    display in a text console::
-
-      >>> print(fluxunit.to_string('console'))
-       erg s^-1 cm^-2
-
-    It is also possible to use a fraction, either on a single line,
-
-      >>> print(fluxunit.to_string('console', fraction='inline'))
-      erg / (s cm^2)
-
-    or using a multiline representation:
-
-      >>> print(fluxunit.to_string('console', fraction='multiline'))
-       erg
-      ------
-      s cm^2
-
-  - ``"unicode"``: Same as ``"console"``, except uses Unicode
-    characters::
-
-      >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
-      2.1798724×10⁻¹⁸ m² kg s⁻²
-      >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
-      2.1798724×10⁻¹⁸ m² kg / s²
-      >>> print(u.Ry.decompose().to_string('unicode', fraction='multiline'))  # doctest: +FLOAT_CMP
-                      m² kg
-      2.1798724×10⁻¹⁸ ─────
-                       s²
-
-`astropy.units` is also able to write, but not read, units in the
-following formats:
+`astropy.units` is also able to write units in the following formats, but
+parsing depends on the format, see details below:
 
   - ``"latex"``: Writes units out using LaTeX math syntax using the
     `IAU Style Manual
@@ -268,6 +238,44 @@ following formats:
     .. math::
 
        \mathrm{erg\,s^{-1}\,cm^{-2}}
+
+  - ``"console"``: Writes a representation of the unit useful for
+    display in a text console::
+
+      >>> print(fluxunit.to_string('console'))
+       erg s^-1 cm^-2
+
+    It is also possible to use a fraction, either on a single line,
+
+      >>> print(fluxunit.to_string('console', fraction='inline'))
+      erg / (s cm^2)
+
+    or using a multiline representation:
+
+      >>> print(fluxunit.to_string('console', fraction='multiline'))
+       erg
+      ------
+      s cm^2
+
+    The ``"console"`` format can also be parsed back to a |Unit| object, but
+    this is only supported for the default and ``fraction="inline"`` format and
+    not the ``fraction="multiline"`` format. Exemplary the ``"inline"``
+    representation can be parsed back to the ```fluxunit``:
+
+      >>> u.Unit("erg / (s cm^2)") == fluxunit
+      True
+
+  - ``"unicode"``: Same as ``"console"``, except uses Unicode
+    characters::
+
+      >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸ m² kg s⁻²
+      >>> print(u.Ry.decompose().to_string('unicode', fraction=True))  # doctest: +FLOAT_CMP
+      2.1798724×10⁻¹⁸ m² kg / s²
+      >>> print(u.Ry.decompose().to_string('unicode', fraction='multiline'))  # doctest: +FLOAT_CMP
+                      m² kg
+      2.1798724×10⁻¹⁸ ─────
+                       s²
 
 .. _astropy-units-format-unrecognized:
 

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -261,8 +261,8 @@ parsing depends on the format, see details below:
     though it does generally work as long as no scale factors are present and one
     does not use ``fraction="multiline"``.
 
-  - ``"unicode"``: Same as ``"console"``, except uses Unicode
-    characters::
+- ``"unicode"``: Same as ``"console"``, except uses Unicode characters.
+Similar restrictions for parsing the output back apply::
 
       >>> print(u.Ry.decompose().to_string('unicode'))  # doctest: +FLOAT_CMP
       2.1798724×10⁻¹⁸ m² kg s⁻²


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request just moves the `console` and `unicode` sections in the [Built-In Formats](https://docs.astropy.org/en/latest/units/format.html#built-in-formats) section of `Units and Quantities/String Representations of Units and Quantities` and adds a test. Previously they both were listed as able to write, but not read, so not supporting a round trip like `u.Unit(unit.to_string(format="console"))`. `unicode` seems to be fixed since #11827 (thanks @dhomeier), but for `console` I did not find the PR on the spot, nevertheless it seems to work since the added test works.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
