### PR TITLE
table: avoid an eval

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -251,7 +251,7 @@ def _convert_sequence_data_to_array(data, dtype=None):
     # a copy of `data` in the common case where there are no masked elements.
     def contains_ma_masked(values, ndim):
         if ndim == 1:
-            return any(value is np.ma.masked for value in values)
+            return any(value is np_ma_masked for value in values)
         return any(contains_ma_masked(value, ndim - 1) for value in values)
 
     has_masked = contains_ma_masked(data, np_data.ndim)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -247,22 +247,14 @@ def _convert_sequence_data_to_array(data, dtype=None):
 
     # Now we need to determine if there is an np.ma.masked anywhere in input data.
 
-    # Make a statement like below to look for np.ma.masked in a nested sequence.
-    # Because np.array(data) succeeded we know that `data` has a regular N-d
-    # structure. Find ma_masked:
-    #   any(any(any(d2 is ma_masked for d2 in d1) for d1 in d0) for d0 in data)
-    # Using this eval avoids creating a copy of `data` in the more-usual case of
-    # no masked elements.
-    any_statement = "d0 is ma_masked"
-    for ii in reversed(range(np_data.ndim)):
-        if ii == 0:
-            any_statement = f"any({any_statement} for d0 in data)"
-        elif ii == np_data.ndim - 1:
-            any_statement = f"any(d{ii} is ma_masked for d{ii} in d{ii - 1})"
-        else:
-            any_statement = f"any({any_statement} for d{ii} in d{ii - 1})"
-    context = {"ma_masked": np.ma.masked, "data": data}
-    has_masked = eval(any_statement, context)
+    # Look for np.ma.masked in the regular N-d nested sequence without creating
+    # a copy of `data` in the common case where there are no masked elements.
+    def contains_ma_masked(values, ndim):
+        if ndim == 1:
+            return any(value is np.ma.masked for value in values)
+        return any(contains_ma_masked(value, ndim - 1) for value in values)
+
+    has_masked = contains_ma_masked(data, np_data.ndim)
 
     # If there are any masks then explicitly change each one to a fill value and
     # set a mask boolean array. If not has_masked then we're done.

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -168,11 +168,17 @@ def _contains_ma_masked(
 
     This does not create a copy of `data`.
     """
-    if ndim == 0:
-        return values is np_ma_masked
-    if ndim == 1:
-        return any(value is np_ma_masked for value in values)
-    return any(_contains_ma_masked(value, ndim - 1, np_ma_masked) for value in values)
+    match ndim:
+        case int(neg) if neg < 0:
+            raise AssertionError
+        case 0:
+            return values is np_ma_masked
+        case 1:
+            return any(value is np_ma_masked for value in values)
+        case _:
+            return any(
+                _contains_ma_masked(value, ndim - 1, np_ma_masked) for value in values
+            )
 
 
 def _convert_sequence_data_to_array(data, dtype=None):

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -440,6 +440,11 @@ class TestColumn:
         assert c.shape == (1, 2)
         assert np.all(c[0].mask == [True, False])
 
+    def test_masked_multidim_nested_list(self):
+        c = table.MaskedColumn([[1, np.ma.masked], [3, 4]])
+        assert c.shape == (2, 2)
+        assert np.all(c.mask == [[False, True], [False, False]])
+
     def test_insert_masked_multidim(self):
         c = table.MaskedColumn([[1, 2], [3, 4]], name="a", dtype=int)
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_array_equal
 
 from astropy import table, time
 from astropy import units as u
+from astropy.table.column import _convert_sequence_data_to_array
 from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_0
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
@@ -441,7 +442,8 @@ class TestColumn:
         assert np.all(c[0].mask == [True, False])
 
     def test_masked_multidim_nested_list(self):
-        c = table.MaskedColumn([[1, np.ma.masked], [3, 4]])
+        data = [[1, np.ma.masked], [3, 4]]
+        c = _convert_sequence_data_to_array(data)
         assert c.shape == (2, 2)
         assert np.all(c.mask == [[False, True], [False, False]])
 


### PR DESCRIPTION
I noticed this eval and worked with GH Copilot a bit to try to avoid it. 

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
