### PR TITLE
Remove datas from codespell ignore-words-list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -713,7 +713,7 @@ ignore-words-list = """
     ans,
     clen,
     coo,
-    datas,
+
     ded,
     dum,
     fo,


### PR DESCRIPTION
Good day,

This PR removes datas from the codespell ignore-words-list in pyproject.toml. The word datas is a valid technical term referring to multiple datasets or data arrays, particularly common in scientific computing contexts.

This addresses the issue raised in #14185 regarding false positives in the codespell configuration.

Changes:
- Removed datas from ignore-words-list in pyproject.toml

The word datas appears legitimately throughout the codebase (e.g., CHANGES.rst: floating point dataset, multiple dataset) and should not be flagged as a misspelling.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if theres anything to adjust.

Warmly,
RoomWithOutRoof