### PR TITLE
TST: avoid a deprecation warning from numpy 2.5 (datetime64 without and explicit unit)

### DIFF
--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -359,7 +359,7 @@ def test_all_formats(format_, masked_cls, masked_array_type):
 
 
 def test_datetime64_with_nat():
-    dt64 = np.array(["nat", "2001-02-03", "2001-02-04"], dtype="datetime64")
+    dt64 = np.array(["nat", "2001-02-03", "2001-02-04"], dtype="datetime64[ns]")
     mdt64 = Masked(dt64, mask=[False, True, False])
     t = Time(mdt64)
     assert t.masked


### PR DESCRIPTION
### Description
xref https://github.com/numpy/numpy/pull/31213


<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
