### PR TITLE
Make compressed fits files compatible with cfitsio funpack

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -75,7 +75,7 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         sudo apt-get update
-        sudo apt-get install language-pack-de tzdata
+        sudo apt-get install language-pack-de tzdata libcfitsio-dev -y
 
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox

--- a/.github/workflows/ci_cron_monthly.yml
+++ b/.github/workflows/ci_cron_monthly.yml
@@ -93,7 +93,8 @@ jobs:
                                   python3-setuptools-scm \
                                   python3-yaml \
                                   python3-venv \
-                                  python3-wheel
+                                  python3-wheel \
+                                  libcfitsio-dev
 
           run: |
             uname -a

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -168,7 +168,7 @@ jobs:
             apt-get install -q -y --no-install-recommends \
                                   git \
                                   g++ \
-                                  cfitsio-bin \
+                                  libcfitsio-dev \
                                   pkg-config \
                                   python3 \
                                   python3-erfa \

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -168,6 +168,7 @@ jobs:
             apt-get install -q -y --no-install-recommends \
                                   git \
                                   g++ \
+                                  cfitsio-bin \
                                   pkg-config \
                                   python3 \
                                   python3-erfa \

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -101,7 +101,6 @@ jobs:
               - tzdata
               - libbz2-dev
               - libcfitsio-dev
-              - cfitsio-bin
           toxargs: -v --develop
           posargs: -n=4 --run-slow
           cache-path: .tox

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -101,6 +101,7 @@ jobs:
               - tzdata
               - libbz2-dev
               - libcfitsio-dev
+              - cfitsio-bin
           toxargs: -v --develop
           posargs: -n=4 --run-slow
           cache-path: .tox
@@ -119,6 +120,9 @@ jobs:
 
         - name: Python 3.12 with all optional dependencies (MacOS X)
           macos: py312-test-alldeps
+          libraries:
+            brew:
+              - cfitsio
           posargs: --durations=50 --run-slow
           runs-on: macos-latest
           cache-path: .tox

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -61,7 +61,6 @@ import warnings
 
 import numpy as np
 
-from astropy.units.format import fits
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .diff import FITSDiff, HDUDiff
@@ -1169,20 +1168,20 @@ def pack(uncompressed_hdulist: HDUList, extension_quantizations: dict = None) ->
         hdulist = [primary_hdu, compressed_hdu]
 
     for hdu in uncompressed_hdulist[1:]:
-        if isinstance(hdu, fits.ImageHDU):
+        if isinstance(hdu, ImageHDU):
             if hdu.data is None:
                 data = None
             else:
                 data = np.ascontiguousarray(hdu.data)
             extname = hdu.header.get('EXTNAME')
             quantize_level = extension_quantizations.get(extname, 64)
-            compressed_hdu = fits.CompImageHDU(data=data, header=hdu.header,
-                                               quantize_level=quantize_level,
-                                               quantize_method=1)
+            compressed_hdu = CompImageHDU(data=data, header=hdu.header,
+                                          quantize_level=quantize_level,
+                                          quantize_method=1)
             hdulist.append(compressed_hdu)
         else:
             hdulist.append(hdu)
-    return fits.HDUList(hdulist)
+    return HDUList(hdulist)
 
 
 def _getext(filename, mode, *args, ext=None, extname=None, extver=None, **kwargs):

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1129,7 +1129,7 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
 
 
 def pack(
-    uncompressed_hdulist: HDUList, extension_quantizations: dict = None
+    uncompressed_hdulist: HDUList, extension_quantizations: dict | None = None
 ) -> HDUList:
     """
     Pack a FITS HDUList in an equivalent way to fpack from the cfitsio library.

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1097,11 +1097,7 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
         primary_hdu = PrimaryHDU(data=compressed_hdulist[0].data, header=compressed_hdulist[0].header)
     else:
         data_type = str(compressed_hdulist[1].data.dtype)
-        if 'int' == data_type[:3]:
-            data_type = 'u' + data_type
-            data = np.array(compressed_hdulist[1].data, getattr(np, data_type))
-        else:
-            data = compressed_hdulist[1].data
+        data = compressed_hdulist[1].data
         primary_hdu = PrimaryHDU(data=data, header=compressed_hdulist[1].header)
     hdulist = [primary_hdu]
     if move_1_to_0:
@@ -1114,11 +1110,7 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
                 data = hdu.data
             else:
                 data_type = str(hdu.data.dtype)
-                if 'int' == data_type[:3]:
-                    data_type = getattr(np, 'u' + data_type)
-                    data = np.array(hdu.data, data_type)
-                else:
-                    data = np.array(hdu.data, hdu.data.dtype)
+                data = np.array(hdu.data, hdu.data.dtype)
             hdulist.append(ImageHDU(data=data, header=hdu.header))
         elif isinstance(hdu, BinTableHDU):
             hdulist.append(BinTableHDU(data=hdu.data, header=hdu.header))

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -66,11 +66,10 @@ from astropy.utils.exceptions import AstropyUserWarning
 from .diff import FITSDiff, HDUDiff
 from .file import FILE_MODES, _File
 from .hdu.base import _BaseHDU, _ValidHDU
+from .hdu.compressed.compressed import CompImageHDU
 from .hdu.hdulist import HDUList, fitsopen
 from .hdu.image import ImageHDU, PrimaryHDU
 from .hdu.table import BinTableHDU
-from .hdu.compressed.compressed import CompImageHDU
-
 from .header import Header
 from .util import (
     _is_dask_array,
@@ -88,18 +87,26 @@ __all__ = [
     "getheader",
     "getval",
     "info",
+    "pack",
     "printdiff",
     "setval",
     "table_to_hdu",
     "tabledump",
     "tableload",
+    "unpack",
     "update",
     "writeto",
-    "pack",
-    "unpack"
 ]
 
-FITS_MANDATORY_KEYWORDS = ['SIMPLE', 'BITPIX', 'NAXIS', 'EXTEND', 'COMMENT', 'CHECKSUM', 'DATASUM']
+FITS_MANDATORY_KEYWORDS = [
+    "SIMPLE",
+    "BITPIX",
+    "NAXIS",
+    "EXTEND",
+    "COMMENT",
+    "CHECKSUM",
+    "DATASUM",
+]
 
 
 def getheader(filename, *args, **kwargs):
@@ -1094,7 +1101,9 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
             move_1_to_0 = False
             break
     if not move_1_to_0 or not isinstance(compressed_hdulist[1], CompImageHDU):
-        primary_hdu = PrimaryHDU(data=compressed_hdulist[0].data, header=compressed_hdulist[0].header)
+        primary_hdu = PrimaryHDU(
+            data=compressed_hdulist[0].data, header=compressed_hdulist[0].header
+        )
     else:
         data_type = str(compressed_hdulist[1].data.dtype)
         data = compressed_hdulist[1].data
@@ -1119,7 +1128,9 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
     return HDUList(hdulist)
 
 
-def pack(uncompressed_hdulist: HDUList, extension_quantizations: dict = None) -> HDUList:
+def pack(
+    uncompressed_hdulist: HDUList, extension_quantizations: dict = None
+) -> HDUList:
     """
     Pack a FITS HDUList in an equivalent way to fpack from the cfitsio library.
 
@@ -1140,7 +1151,6 @@ def pack(uncompressed_hdulist: HDUList, extension_quantizations: dict = None) ->
     extension as is required for a binary table HDU, which is what it is
     stored as internally.
     """
-
     if extension_quantizations is None:
         extension_quantizations = {}
     if uncompressed_hdulist[0].data is None:
@@ -1152,11 +1162,14 @@ def pack(uncompressed_hdulist: HDUList, extension_quantizations: dict = None) ->
             data = None
         else:
             data = np.ascontiguousarray(uncompressed_hdulist[0].data)
-        extname = uncompressed_hdulist[0].header.get('EXTNAME')
+        extname = uncompressed_hdulist[0].header.get("EXTNAME")
         quantize_level = extension_quantizations.get(extname, 64)
-        compressed_hdu = CompImageHDU(data=data,
-                                      header=uncompressed_hdulist[0].header, quantize_level=quantize_level,
-                                      quantize_method=1)
+        compressed_hdu = CompImageHDU(
+            data=data,
+            header=uncompressed_hdulist[0].header,
+            quantize_level=quantize_level,
+            quantize_method=1,
+        )
         hdulist = [primary_hdu, compressed_hdu]
 
     for hdu in uncompressed_hdulist[1:]:
@@ -1165,11 +1178,14 @@ def pack(uncompressed_hdulist: HDUList, extension_quantizations: dict = None) ->
                 data = None
             else:
                 data = np.ascontiguousarray(hdu.data)
-            extname = hdu.header.get('EXTNAME')
+            extname = hdu.header.get("EXTNAME")
             quantize_level = extension_quantizations.get(extname, 64)
-            compressed_hdu = CompImageHDU(data=data, header=hdu.header,
-                                          quantize_level=quantize_level,
-                                          quantize_method=1)
+            compressed_hdu = CompImageHDU(
+                data=data,
+                header=hdu.header,
+                quantize_level=quantize_level,
+                quantize_method=1,
+            )
             hdulist.append(compressed_hdu)
         else:
             hdulist.append(hdu)

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -61,6 +61,7 @@ import warnings
 
 import numpy as np
 
+from astropy.units.format import fits
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .diff import FITSDiff, HDUDiff
@@ -69,6 +70,8 @@ from .hdu.base import _BaseHDU, _ValidHDU
 from .hdu.hdulist import HDUList, fitsopen
 from .hdu.image import ImageHDU, PrimaryHDU
 from .hdu.table import BinTableHDU
+from .hdu.compressed.compressed import CompImageHDU
+
 from .header import Header
 from .util import (
     _is_dask_array,
@@ -93,7 +96,11 @@ __all__ = [
     "tableload",
     "update",
     "writeto",
+    "pack",
+    "unpack"
 ]
+
+FITS_MANDATORY_KEYWORDS = ['SIMPLE', 'BITPIX', 'NAXIS', 'EXTEND', 'COMMENT', 'CHECKSUM', 'DATASUM']
 
 
 def getheader(filename, *args, **kwargs):
@@ -1053,6 +1060,129 @@ def tableload(datafile, cdfile, hfile=None):
 
 if isinstance(tableload.__doc__, str):
     tableload.__doc__ += BinTableHDU._tdump_file_format.replace("\n", "\n    ")
+
+
+def unpack(compressed_hdulist: HDUList) -> HDUList:
+    """
+    Unpack a compressed FITS HDUList in an equivalent way to funpack from
+    the cfitsio library.
+
+    Parameters
+    ----------
+    compressed_hdulist : `HDUList`
+        The compressed FITS HDUList to be unpacked.
+
+    Returns
+    -------
+    uncompressed_hdulist : `HDUList`
+        The uncompressed FITS HDUList.
+
+    Notes
+    -----
+    If the primary HDU of the uncompressed HDUList is an image HDU, then
+    fpacked file will have a primary header with only the manadatory header
+    keywords for a FITS file. In this case, we remove this and make the original primary HDU, the uncompressed HDU so the newly uncompressed
+    file matches the original. If there are other keywords, in the header
+    of the compressed file, then the next HDU was not the primary and we
+    decompress accordingly.
+    """
+    # If the primary fits header only has the mandatory keywords, then we throw away that extension
+    # and extension 1 gets moved to 0
+    # Otherwise, the primary HDU is kept
+    move_1_to_0 = True
+    for keyword in compressed_hdulist[0].header:
+        if keyword not in FITS_MANDATORY_KEYWORDS:
+            move_1_to_0 = False
+            break
+    if not move_1_to_0 or not isinstance(compressed_hdulist[1], CompImageHDU):
+        primary_hdu = PrimaryHDU(data=compressed_hdulist[0].data, header=compressed_hdulist[0].header)
+    else:
+        data_type = str(compressed_hdulist[1].data.dtype)
+        if 'int' == data_type[:3]:
+            data_type = 'u' + data_type
+            data = np.array(compressed_hdulist[1].data, getattr(np, data_type))
+        else:
+            data = compressed_hdulist[1].data
+        primary_hdu = PrimaryHDU(data=data, header=compressed_hdulist[1].header)
+    hdulist = [primary_hdu]
+    if move_1_to_0:
+        starting_extension = 2
+    else:
+        starting_extension = 1
+    for hdu in compressed_hdulist[starting_extension:]:
+        if isinstance(hdu, CompImageHDU):
+            if hdu.data is None:
+                data = hdu.data
+            else:
+                data_type = str(hdu.data.dtype)
+                if 'int' == data_type[:3]:
+                    data_type = getattr(np, 'u' + data_type)
+                    data = np.array(hdu.data, data_type)
+                else:
+                    data = np.array(hdu.data, hdu.data.dtype)
+            hdulist.append(ImageHDU(data=data, header=hdu.header))
+        elif isinstance(hdu, BinTableHDU):
+            hdulist.append(BinTableHDU(data=hdu.data, header=hdu.header))
+        else:
+            hdulist.append(ImageHDU(data=hdu.data, header=hdu.header))
+    return HDUList(hdulist)
+
+
+def pack(uncompressed_hdulist: HDUList, extension_quantizations: dict = None) -> HDUList:
+    """
+    Pack a FITS HDUList in an equivalent way to fpack from the cfitsio library.
+
+    Parameters
+    ----------
+    uncompressed_hdulist : `HDUList`
+        The uncompressed FITS HDUList to be packed.
+    extension_quantizations : dict, optional
+        A dictionary specifying the quantization levels for each extension.
+        The keys are the extension names (EXTNAME) and the values are the
+        quantization levels. If not provided, a default quantization level
+        of 64 is used for all extensions.
+
+    Notes
+    -----
+    If the primary HDU only has header data, then it will remain the primary
+    HDU. If the Primary HDU has image data, it will be moved to the first
+    extension as is required for a binary table HDU, which is what it is
+    stored as internally.
+    """
+
+    if extension_quantizations is None:
+        extension_quantizations = {}
+    if uncompressed_hdulist[0].data is None:
+        primary_hdu = PrimaryHDU(header=uncompressed_hdulist[0].header)
+        hdulist = [primary_hdu]
+    else:
+        primary_hdu = PrimaryHDU()
+        if uncompressed_hdulist[0].data is None:
+            data = None
+        else:
+            data = np.ascontiguousarray(uncompressed_hdulist[0].data)
+        extname = uncompressed_hdulist[0].header.get('EXTNAME')
+        quantize_level = extension_quantizations.get(extname, 64)
+        compressed_hdu = CompImageHDU(data=data,
+                                      header=uncompressed_hdulist[0].header, quantize_level=quantize_level,
+                                      quantize_method=1)
+        hdulist = [primary_hdu, compressed_hdu]
+
+    for hdu in uncompressed_hdulist[1:]:
+        if isinstance(hdu, fits.ImageHDU):
+            if hdu.data is None:
+                data = None
+            else:
+                data = np.ascontiguousarray(hdu.data)
+            extname = hdu.header.get('EXTNAME')
+            quantize_level = extension_quantizations.get(extname, 64)
+            compressed_hdu = fits.CompImageHDU(data=data, header=hdu.header,
+                                               quantize_level=quantize_level,
+                                               quantize_method=1)
+            hdulist.append(compressed_hdu)
+        else:
+            hdulist.append(hdu)
+    return fits.HDUList(hdulist)
 
 
 def _getext(filename, mode, *args, ext=None, extname=None, extver=None, **kwargs):

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1105,7 +1105,6 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
             data=compressed_hdulist[0].data, header=compressed_hdulist[0].header
         )
     else:
-        data_type = str(compressed_hdulist[1].data.dtype)
         data = compressed_hdulist[1].data
         primary_hdu = PrimaryHDU(data=data, header=compressed_hdulist[1].header)
     hdulist = [primary_hdu]
@@ -1115,16 +1114,15 @@ def unpack(compressed_hdulist: HDUList) -> HDUList:
         starting_extension = 1
     for hdu in compressed_hdulist[starting_extension:]:
         if isinstance(hdu, CompImageHDU):
+            # If the data has been lazy loaded, we need to actualize the data
+            # into an array.
             if hdu.data is None:
                 data = hdu.data
             else:
-                data_type = str(hdu.data.dtype)
                 data = np.array(hdu.data, hdu.data.dtype)
             hdulist.append(ImageHDU(data=data, header=hdu.header))
-        elif isinstance(hdu, BinTableHDU):
-            hdulist.append(BinTableHDU(data=hdu.data, header=hdu.header))
         else:
-            hdulist.append(ImageHDU(data=hdu.data, header=hdu.header))
+            hdulist.append(hdu.copy())
     return HDUList(hdulist)
 
 
@@ -1158,10 +1156,7 @@ def pack(
         hdulist = [primary_hdu]
     else:
         primary_hdu = PrimaryHDU()
-        if uncompressed_hdulist[0].data is None:
-            data = None
-        else:
-            data = np.ascontiguousarray(uncompressed_hdulist[0].data)
+        data = np.ascontiguousarray(uncompressed_hdulist[0].data)
         extname = uncompressed_hdulist[0].header.get("EXTNAME")
         quantize_level = extension_quantizations.get(extname, 64)
         compressed_hdu = CompImageHDU(

--- a/astropy/io/fits/hdu/compressed/compbintable.py
+++ b/astropy/io/fits/hdu/compressed/compbintable.py
@@ -1,4 +1,3 @@
-from astropy.io.fits.column import KEYWORD_TO_ATTRIBUTE
 from astropy.io.fits.hdu.table import BinTableHDU
 
 __all__ = ["_CompBinTableHDU"]

--- a/astropy/io/fits/hdu/compressed/compbintable.py
+++ b/astropy/io/fits/hdu/compressed/compbintable.py
@@ -1,3 +1,4 @@
+from astropy.io.fits.column import KEYWORD_TO_ATTRIBUTE
 from astropy.io.fits.hdu.table import BinTableHDU
 
 __all__ = ["_CompBinTableHDU"]

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -310,9 +310,7 @@ def _image_header_to_empty_bintable(
 
     # To ensure that the TFIELDS exists (and therefore the after="TFIELDS")
     # produces the correct ordering, we need to set it first, before TTYPE1
-    bintable.header.set(
-        "TFIELDS", 1, "number of fields in each row", after="GCOUNT"
-    )
+    bintable.header.set("TFIELDS", 1, "number of fields in each row", after="GCOUNT")
     # Set the label for the first column in the table
     bintable.header.set(
         "TTYPE1", "COMPRESSED_DATA", "label for field 1", after="TFIELDS"

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -308,8 +308,12 @@ def _image_header_to_empty_bintable(
     except (AttributeError, KeyError):
         naxis_comment = "dimension of original image"
 
+    # To ensure that the TFIELDS exists (and therefore the after="TFIELDS")
+    # produces the correct ordering, we need to set it first, before TTYPE1
+    bintable.header.set(
+        "TFIELDS", 1, "number of fields in each row", after="GCOUNT"
+    )
     # Set the label for the first column in the table
-
     bintable.header.set(
         "TTYPE1", "COMPRESSED_DATA", "label for field 1", after="TFIELDS"
     )
@@ -343,6 +347,9 @@ def _image_header_to_empty_bintable(
         # 'GZIP_COMPRESSED_DATA', 'ZSCALE', and 'ZZERO' columns (unless using
         # lossless compression, per CFITSIO)
         ncols = 4
+        bintable.header.set(
+            "TFIELDS", ncols, "number of fields in each row", after="GCOUNT"
+        )
 
         ttype2 = "GZIP_COMPRESSED_DATA"
 
@@ -385,7 +392,6 @@ def _image_header_to_empty_bintable(
         cols = ColDefs([col1, col2, col3, col4])
     else:
         # default table has just one 'COMPRESSED_DATA' column
-        ncols = 1
         after = "TFORM1"
 
         # Create the ColDefs object for the table
@@ -396,9 +402,7 @@ def _image_header_to_empty_bintable(
     # image HDU, the data type of the image data and the number of
     # dimensions in the image data array.
     bintable.header.set("NAXIS1", cols.dtype.itemsize, "width of table in bytes")
-    bintable.header.set(
-        "TFIELDS", ncols, "number of fields in each row", after="GCOUNT"
-    )
+
     bintable.header.set(
         "ZIMAGE", True, "extension contains compressed image", after=after
     )
@@ -583,6 +587,21 @@ def _image_header_to_empty_bintable(
             image_header.comments["SIMPLE"],
             before="ZBITPIX",
         )
+    # Only move the XTENSION card from the image header to the
+    # table header as ZTENSION card if this was not a primary header.
+    # There are cases when the skeleton header inherits the XTENSION card from
+    # the super class initialization and the SIMPLE card from the incoming header,
+    # so we want to protect against both existing simultanenously.
+    elif "XTENSION" in image_header:
+        # Since we only handle compressed IMAGEs, ZTENSION should
+        # always be IMAGE, even if the caller has passed in a header
+        # for some other type of extension.
+        bintable.header.set(
+            "ZTENSION",
+            "IMAGE",
+            image_header.comments["XTENSION"],
+            before="ZBITPIX",
+        )
 
     # Move EXTEND card from the image header to the
     # table header as ZEXTEND card.
@@ -600,20 +619,6 @@ def _image_header_to_empty_bintable(
             "ZBLOCKED",
             image_header["BLOCKED"],
             image_header.comments["BLOCKED"],
-        )
-
-    # Move XTENSION card from the image header to the
-    # table header as ZTENSION card.
-
-    # Since we only handle compressed IMAGEs, ZTENSION should
-    # always be IMAGE, even if the caller has passed in a header
-    # for some other type of extension.
-    if "XTENSION" in image_header:
-        bintable.header.set(
-            "ZTENSION",
-            "IMAGE",
-            image_header.comments["XTENSION"],
-            before="ZBITPIX",
         )
 
     # Move PCOUNT and GCOUNT cards from image header to the table

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -679,12 +679,14 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
 
     def _populate_table_keywords(self):
         """Populate the new table definition keywords from the header."""
+        after = "TFIELDS"
         for idx, column in enumerate(self.columns):
             for keyword, attr in KEYWORD_TO_ATTRIBUTE.items():
                 val = getattr(column, attr)
                 if val is not None:
                     keyword = keyword + str(idx + 1)
-                    self._header[keyword] = val
+                    self._header.set(keyword, val, after=after)
+                    after = keyword
 
 
 class TableHDU(_TableBaseHDU):

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -4,8 +4,12 @@ import io
 import os
 import pathlib
 import warnings
+import shutil
+import subprocess
+from itertools import batched
 
 import numpy as np
+from astropy.utils import data
 import pytest
 from numpy.testing import assert_array_equal
 
@@ -19,6 +23,8 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 from .conftest import FitsTestCase
 
+HAS_FUNPACK = shutil.which("funpack") is not None
+HAS_FPACK = shutil.which("fpack") is not None
 
 class TestConvenience(FitsTestCase):
     def test_resource_warning(self):
@@ -532,3 +538,209 @@ class TestConvenience(FitsTestCase):
         assert_array_equal(uplow["A"], ref)
         assert_array_equal(uplow["a"], ref)
         assert_array_equal(uplow.a, ref)
+
+    @pytest.fixture
+    def make_files_for_packing(self):
+        # Make random but reproducible data
+        np.random.seed(2305235)
+        data_header = fits.Header()
+        data_header['a'] = 'b'
+        data_header['c'] = 'd'
+        nx, ny = 512, 517
+        data_hdu = fits.PrimaryHDU(data=np.random.poisson(1000, size=(ny, nx)).astype(np.int32),
+                                   header=data_header)
+        data_hdu.add_checksum()
+
+        table = Table({'col1': ['foo', 'bar'], 'col2': ['test1', 'test2']})
+        table_hdu = fits.BinTableHDU(table)
+        table_hdu.add_checksum()
+
+        # Define 2 cases. One with the primary HDU having data, 
+        # and the second will only have a header
+        self.hdulist_pack1 = fits.HDUList([data_hdu, table_hdu])
+
+        # Case 2
+        primary_header = fits.Header()
+        primary_header['e'] = 'f'
+        primary_header['g'] = 'h'
+        primary_header['i'] = 'j'
+
+        primary_hdu = fits.PrimaryHDU(header=primary_header)
+        primary_hdu.add_checksum()
+
+        data_header = fits.Header()
+        data_header['k'] = 'l'
+        data_header['m'] = 'n'
+        nx, ny = 479, 492
+        data_hdu = fits.ImageHDU(data=np.random.poisson(1500, size=(ny, nx)).astype(np.int32), header=data_header)
+        data_hdu.add_checksum()
+
+        table = Table({'col1': ['foo', 'bar'], 'col2': ['test1', 'test2']})
+        table_hdu = fits.BinTableHDU(table)
+        table_hdu.add_checksum()
+
+        # This file should stay as the primary header, even in the
+        # compressed file
+        self.hdulist_pack2 = fits.HDUList([primary_hdu, data_hdu, table_hdu])
+
+    def test_pack_unpack_round_trip(self, make_files_for_packing):
+        # Test if fits files can round trip pack and unpack
+        packed_hdulist1 = fits.pack(self.hdulist_pack1)
+        unpacked_hdulist1 = fits.unpack(packed_hdulist1)
+        assert fits.FITSDiff(unpacked_hdulist1, self.hdulist_pack1).identical
+
+        packed_hdulist2 = fits.pack(self.hdulist_pack2)
+        unpacked_hdulist2 = fits.unpack(packed_hdulist2)
+        assert fits.FITSDiff(unpacked_hdulist2, self.hdulist_pack2).identical
+
+    @pytest.mark.skipif(not HAS_FUNPACK, reason="requires fpack binary from cfitsio")
+    def test_packed_funpack_compatability(self, make_files_for_packing):
+        # Test that pack creates files cfitsio funpack can unpack
+        for i in ['1', '2']:
+            packed_hdulist = fits.pack(getattr(self, f'hdulist_pack{i}'))
+            packed_filename = self.temp(f'packed{i}.fits.fz')
+            packed_hdulist.writeto(packed_filename, overwrite=True)
+            funpack_result = subprocess.run(
+                ["funpack", packed_filename],
+                capture_output=True,
+                text=True,
+            )
+            assert funpack_result.returncode == 0, f"funpack failed:\n{funpack_result.stderr}"
+            with fits.open(packed_filename.replace('.fz', '')) as unpacked_hdulist:
+                assert fits.FITSDiff(
+                    unpacked_hdulist,
+                    getattr(self, f'hdulist_pack{i}'),
+                    ignore_keywords=['CHECKSUM'],
+                    ignore_comments=['SIMPLE']
+                ).identical
+
+    @pytest.mark.skipif(not HAS_FPACK, reason="requires funpack binary from cfitsio")
+    def test_fpacked_unpack_compatability(self, make_files_for_packing):
+        # Test that unpack works on a cfitsio fpacked file
+        for i in ['1', '2']:
+            packed_filename = self.temp(f'packed{i}.fits')
+            getattr(self, f'hdulist_pack{i}').writeto(packed_filename, overwrite=True)
+            fpack_result = subprocess.run(
+                ["fpack", packed_filename],
+                capture_output=True,
+                text=True,
+            )
+            assert fpack_result.returncode == 0, f"fpack failed:\n{fpack_result.stderr}"
+            with fits.open(packed_filename + '.fz') as packed_hdulist:
+                unpacked_hdulist = fits.unpack(packed_hdulist)
+                assert fits.FITSDiff(
+                    unpacked_hdulist,
+                    getattr(self, f'hdulist_pack{i}'),
+                    ignore_keywords=['CHECKSUM'],
+                    ignore_comments=['SIMPLE']
+                ).identical
+
+    def test_packed_headers(self, make_files_for_packing):
+        # Test that the final packed headers are what we expect
+        expected_primary_headers = {
+            "1": [(b'SIMPLE', b'T'),
+                  (b'BITPIX', b'8'),
+                  (b'NAXIS', b'0'),
+                  (b'EXTEND', b'T')],
+            "2": [(b'SIMPLE', b'T'),
+                  (b'BITPIX', b'8'),
+                  (b'NAXIS', b'0'),
+                  (b'EXTEND', b'T'),
+                  (b'E', b"'f       '"),
+                  (b'G', b"'h       '"),
+                  (b'I', b"'j       '")]
+        }
+        expected_image_headers = {
+            '1': [(b'XTENSION', b"'BINTABLE'"),
+                  (b'BITPIX', b'8'),
+                  (b'NAXIS', b'2'),
+                  (b'NAXIS1', b'8'),
+                  (b'NAXIS2', b'517'),
+                  (b'PCOUNT', b'259822'),
+                  (b'GCOUNT', b'1'),
+                  (b'TFIELDS', b'1'),
+                  (b'TTYPE1', b"'COMPRESSED_DATA'"),
+                  (b'TFORM1', b"'1PB(511)'"),
+                  (b'ZIMAGE', b'T'),
+                  (b'ZSIMPLE', b'T'),
+                  (b'ZBITPIX', b'32'),
+                  (b'ZNAXIS', b'2'),
+                  (b'ZNAXIS1', b'512'),
+                  (b'ZNAXIS2', b'517'),
+                  (b'ZTILE1', b'512'),
+                  (b'ZTILE2', b'1'),
+                  (b'ZCMPTYPE', b"'RICE_1  '"),
+                  (b'ZNAME1', b"'BLOCKSIZE'"),
+                  (b'ZVAL1', b'32'),
+                  (b'ZNAME2', b"'BYTEPIX '"),
+                  (b'ZVAL2', b'4'),
+                  (b'EXTNAME', b"'COMPRESSED_IMAGE'"),
+                  (b'A', b"'b       '"),
+                  (b'C', b"'d       '")],
+            '2': [(b'XTENSION', b"'BINTABLE'"),
+                  (b'BITPIX', b'8'),
+                  (b'NAXIS', b'2'),
+                  (b'NAXIS1', b'8'),
+                  (b'NAXIS2', b'492'),
+                  (b'PCOUNT', b'239433'),
+                  (b'GCOUNT', b'1'),
+                  (b'TFIELDS', b'1'),
+                  (b'TTYPE1', b"'COMPRESSED_DATA'"),
+                  (b'TFORM1', b"'1PB(495)'"),
+                  (b'ZIMAGE', b'T'),
+                  (b'ZTENSION', b"'IMAGE   '"),
+                  (b'ZBITPIX', b'32'),
+                  (b'ZNAXIS', b'2'),
+                  (b'ZNAXIS1', b'479'),
+                  (b'ZNAXIS2', b'492'),
+                  (b'ZPCOUNT', b'0'),
+                  (b'ZGCOUNT', b'1'),
+                  (b'ZTILE1', b'479'),
+                  (b'ZTILE2', b'1'),
+                  (b'ZCMPTYPE', b"'RICE_1  '"),
+                  (b'ZNAME1', b"'BLOCKSIZE'"),
+                  (b'ZVAL1', b'32'),
+                  (b'ZNAME2', b"'BYTEPIX '"),
+                  (b'ZVAL2', b'4'),
+                  (b'EXTNAME', b"'COMPRESSED_IMAGE'"),
+                  (b'K', b"'l       '"),
+                  (b'M', b"'n       '")]
+        }
+
+        for i in ['1', '2']:
+            packed_hdulist = fits.pack(getattr(self, f'hdulist_pack{i}'))
+            packed_buffer = io.BytesIO()
+            packed_hdulist.writeto(packed_buffer)
+            packed_buffer.seek(0)
+            primary_header = _simple_str_header_parser(packed_buffer.read(2880))
+            assert primary_header == expected_primary_headers[i]
+            image_header = _simple_str_header_parser(packed_buffer.read(2880))
+            assert image_header == expected_image_headers[i]
+
+
+def _simple_str_header_parser(header_str):
+    """
+    A simple parser to check that the header on disk makes sense.
+    We throw away comments, checksum, and datasum keywords.
+    """
+    chunk_size = 80
+    header = []
+    for chunk in batched(header_str, chunk_size):
+        bytes_chunk = bytes(chunk)
+        if len(bytes_chunk.strip()) == 0:
+            continue
+        if bytes_chunk.startswith(b'COMMENT'):
+            continue
+        if bytes_chunk.strip() == b"END":
+            break
+        key_value = bytes_chunk.split(b'/')[0]
+        key, value = key_value.split(b'=', 1)
+        key = key.strip()
+        value = value.strip()
+        if key == b'CHECKSUM' or key == b'DATASUM':
+            continue
+        if key == b'ZHECKSUM' or key == b'ZDATASUM':
+            continue
+        header.append((key, value))
+
+    return header

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -6,7 +6,6 @@ import pathlib
 import shutil
 import subprocess
 import warnings
-from itertools import batched
 
 import numpy as np
 import pytest
@@ -609,6 +608,7 @@ class TestConvenience(FitsTestCase):
                 ["funpack", packed_filename],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             assert funpack_result.returncode == 0, (
                 f"funpack failed:\n{funpack_result.stderr}"
@@ -631,6 +631,7 @@ class TestConvenience(FitsTestCase):
                 ["fpack", packed_filename],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             assert fpack_result.returncode == 0, f"fpack failed:\n{fpack_result.stderr}"
             with fits.open(packed_filename + ".fz") as packed_hdulist:
@@ -740,7 +741,8 @@ def _simple_str_header_parser(header_str):
     """
     chunk_size = 80
     header = []
-    for chunk in batched(header_str, chunk_size):
+    for i in range(0, len(header_str), chunk_size):
+        chunk = header_str[i : i + chunk_size]
         bytes_chunk = bytes(chunk)
         if len(bytes_chunk.strip()) == 0:
             continue

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -3,13 +3,12 @@
 import io
 import os
 import pathlib
-import warnings
 import shutil
 import subprocess
+import warnings
 from itertools import batched
 
 import numpy as np
-from astropy.utils import data
 import pytest
 from numpy.testing import assert_array_equal
 
@@ -25,6 +24,7 @@ from .conftest import FitsTestCase
 
 HAS_FUNPACK = shutil.which("funpack") is not None
 HAS_FPACK = shutil.which("fpack") is not None
+
 
 class TestConvenience(FitsTestCase):
     def test_resource_warning(self):
@@ -544,38 +544,43 @@ class TestConvenience(FitsTestCase):
         # Make random but reproducible data
         np.random.seed(2305235)
         data_header = fits.Header()
-        data_header['a'] = 'b'
-        data_header['c'] = 'd'
+        data_header["a"] = "b"
+        data_header["c"] = "d"
         nx, ny = 512, 517
-        data_hdu = fits.PrimaryHDU(data=np.random.poisson(1000, size=(ny, nx)).astype(np.int32),
-                                   header=data_header)
+        data_hdu = fits.PrimaryHDU(
+            data=np.random.poisson(1000, size=(ny, nx)).astype(np.int32),
+            header=data_header,
+        )
         data_hdu.add_checksum()
 
-        table = Table({'col1': ['foo', 'bar'], 'col2': ['test1', 'test2']})
+        table = Table({"col1": ["foo", "bar"], "col2": ["test1", "test2"]})
         table_hdu = fits.BinTableHDU(table)
         table_hdu.add_checksum()
 
-        # Define 2 cases. One with the primary HDU having data, 
+        # Define 2 cases. One with the primary HDU having data,
         # and the second will only have a header
         self.hdulist_pack1 = fits.HDUList([data_hdu, table_hdu])
 
         # Case 2
         primary_header = fits.Header()
-        primary_header['e'] = 'f'
-        primary_header['g'] = 'h'
-        primary_header['i'] = 'j'
+        primary_header["e"] = "f"
+        primary_header["g"] = "h"
+        primary_header["i"] = "j"
 
         primary_hdu = fits.PrimaryHDU(header=primary_header)
         primary_hdu.add_checksum()
 
         data_header = fits.Header()
-        data_header['k'] = 'l'
-        data_header['m'] = 'n'
+        data_header["k"] = "l"
+        data_header["m"] = "n"
         nx, ny = 479, 492
-        data_hdu = fits.ImageHDU(data=np.random.poisson(1500, size=(ny, nx)).astype(np.int32), header=data_header)
+        data_hdu = fits.ImageHDU(
+            data=np.random.poisson(1500, size=(ny, nx)).astype(np.int32),
+            header=data_header,
+        )
         data_hdu.add_checksum()
 
-        table = Table({'col1': ['foo', 'bar'], 'col2': ['test1', 'test2']})
+        table = Table({"col1": ["foo", "bar"], "col2": ["test1", "test2"]})
         table_hdu = fits.BinTableHDU(table)
         table_hdu.add_checksum()
 
@@ -596,119 +601,129 @@ class TestConvenience(FitsTestCase):
     @pytest.mark.skipif(not HAS_FUNPACK, reason="requires fpack binary from cfitsio")
     def test_packed_funpack_compatability(self, make_files_for_packing):
         # Test that pack creates files cfitsio funpack can unpack
-        for i in ['1', '2']:
-            packed_hdulist = fits.pack(getattr(self, f'hdulist_pack{i}'))
-            packed_filename = self.temp(f'packed{i}.fits.fz')
+        for i in ["1", "2"]:
+            packed_hdulist = fits.pack(getattr(self, f"hdulist_pack{i}"))
+            packed_filename = self.temp(f"packed{i}.fits.fz")
             packed_hdulist.writeto(packed_filename, overwrite=True)
             funpack_result = subprocess.run(
                 ["funpack", packed_filename],
                 capture_output=True,
                 text=True,
             )
-            assert funpack_result.returncode == 0, f"funpack failed:\n{funpack_result.stderr}"
-            with fits.open(packed_filename.replace('.fz', '')) as unpacked_hdulist:
+            assert funpack_result.returncode == 0, (
+                f"funpack failed:\n{funpack_result.stderr}"
+            )
+            with fits.open(packed_filename.replace(".fz", "")) as unpacked_hdulist:
                 assert fits.FITSDiff(
                     unpacked_hdulist,
-                    getattr(self, f'hdulist_pack{i}'),
-                    ignore_keywords=['CHECKSUM'],
-                    ignore_comments=['SIMPLE']
+                    getattr(self, f"hdulist_pack{i}"),
+                    ignore_keywords=["CHECKSUM"],
+                    ignore_comments=["SIMPLE"],
                 ).identical
 
     @pytest.mark.skipif(not HAS_FPACK, reason="requires funpack binary from cfitsio")
     def test_fpacked_unpack_compatability(self, make_files_for_packing):
         # Test that unpack works on a cfitsio fpacked file
-        for i in ['1', '2']:
-            packed_filename = self.temp(f'packed{i}.fits')
-            getattr(self, f'hdulist_pack{i}').writeto(packed_filename, overwrite=True)
+        for i in ["1", "2"]:
+            packed_filename = self.temp(f"packed{i}.fits")
+            getattr(self, f"hdulist_pack{i}").writeto(packed_filename, overwrite=True)
             fpack_result = subprocess.run(
                 ["fpack", packed_filename],
                 capture_output=True,
                 text=True,
             )
             assert fpack_result.returncode == 0, f"fpack failed:\n{fpack_result.stderr}"
-            with fits.open(packed_filename + '.fz') as packed_hdulist:
+            with fits.open(packed_filename + ".fz") as packed_hdulist:
                 unpacked_hdulist = fits.unpack(packed_hdulist)
                 assert fits.FITSDiff(
                     unpacked_hdulist,
-                    getattr(self, f'hdulist_pack{i}'),
-                    ignore_keywords=['CHECKSUM'],
-                    ignore_comments=['SIMPLE']
+                    getattr(self, f"hdulist_pack{i}"),
+                    ignore_keywords=["CHECKSUM"],
+                    ignore_comments=["SIMPLE"],
                 ).identical
 
     def test_packed_headers(self, make_files_for_packing):
         # Test that the final packed headers are what we expect
         expected_primary_headers = {
-            "1": [(b'SIMPLE', b'T'),
-                  (b'BITPIX', b'8'),
-                  (b'NAXIS', b'0'),
-                  (b'EXTEND', b'T')],
-            "2": [(b'SIMPLE', b'T'),
-                  (b'BITPIX', b'8'),
-                  (b'NAXIS', b'0'),
-                  (b'EXTEND', b'T'),
-                  (b'E', b"'f       '"),
-                  (b'G', b"'h       '"),
-                  (b'I', b"'j       '")]
+            "1": [
+                (b"SIMPLE", b"T"),
+                (b"BITPIX", b"8"),
+                (b"NAXIS", b"0"),
+                (b"EXTEND", b"T"),
+            ],
+            "2": [
+                (b"SIMPLE", b"T"),
+                (b"BITPIX", b"8"),
+                (b"NAXIS", b"0"),
+                (b"EXTEND", b"T"),
+                (b"E", b"'f       '"),
+                (b"G", b"'h       '"),
+                (b"I", b"'j       '"),
+            ],
         }
         expected_image_headers = {
-            '1': [(b'XTENSION', b"'BINTABLE'"),
-                  (b'BITPIX', b'8'),
-                  (b'NAXIS', b'2'),
-                  (b'NAXIS1', b'8'),
-                  (b'NAXIS2', b'517'),
-                  (b'PCOUNT', b'259822'),
-                  (b'GCOUNT', b'1'),
-                  (b'TFIELDS', b'1'),
-                  (b'TTYPE1', b"'COMPRESSED_DATA'"),
-                  (b'TFORM1', b"'1PB(511)'"),
-                  (b'ZIMAGE', b'T'),
-                  (b'ZSIMPLE', b'T'),
-                  (b'ZBITPIX', b'32'),
-                  (b'ZNAXIS', b'2'),
-                  (b'ZNAXIS1', b'512'),
-                  (b'ZNAXIS2', b'517'),
-                  (b'ZTILE1', b'512'),
-                  (b'ZTILE2', b'1'),
-                  (b'ZCMPTYPE', b"'RICE_1  '"),
-                  (b'ZNAME1', b"'BLOCKSIZE'"),
-                  (b'ZVAL1', b'32'),
-                  (b'ZNAME2', b"'BYTEPIX '"),
-                  (b'ZVAL2', b'4'),
-                  (b'EXTNAME', b"'COMPRESSED_IMAGE'"),
-                  (b'A', b"'b       '"),
-                  (b'C', b"'d       '")],
-            '2': [(b'XTENSION', b"'BINTABLE'"),
-                  (b'BITPIX', b'8'),
-                  (b'NAXIS', b'2'),
-                  (b'NAXIS1', b'8'),
-                  (b'NAXIS2', b'492'),
-                  (b'PCOUNT', b'239433'),
-                  (b'GCOUNT', b'1'),
-                  (b'TFIELDS', b'1'),
-                  (b'TTYPE1', b"'COMPRESSED_DATA'"),
-                  (b'TFORM1', b"'1PB(495)'"),
-                  (b'ZIMAGE', b'T'),
-                  (b'ZTENSION', b"'IMAGE   '"),
-                  (b'ZBITPIX', b'32'),
-                  (b'ZNAXIS', b'2'),
-                  (b'ZNAXIS1', b'479'),
-                  (b'ZNAXIS2', b'492'),
-                  (b'ZPCOUNT', b'0'),
-                  (b'ZGCOUNT', b'1'),
-                  (b'ZTILE1', b'479'),
-                  (b'ZTILE2', b'1'),
-                  (b'ZCMPTYPE', b"'RICE_1  '"),
-                  (b'ZNAME1', b"'BLOCKSIZE'"),
-                  (b'ZVAL1', b'32'),
-                  (b'ZNAME2', b"'BYTEPIX '"),
-                  (b'ZVAL2', b'4'),
-                  (b'EXTNAME', b"'COMPRESSED_IMAGE'"),
-                  (b'K', b"'l       '"),
-                  (b'M', b"'n       '")]
+            "1": [
+                (b"XTENSION", b"'BINTABLE'"),
+                (b"BITPIX", b"8"),
+                (b"NAXIS", b"2"),
+                (b"NAXIS1", b"8"),
+                (b"NAXIS2", b"517"),
+                (b"PCOUNT", b"259822"),
+                (b"GCOUNT", b"1"),
+                (b"TFIELDS", b"1"),
+                (b"TTYPE1", b"'COMPRESSED_DATA'"),
+                (b"TFORM1", b"'1PB(511)'"),
+                (b"ZIMAGE", b"T"),
+                (b"ZSIMPLE", b"T"),
+                (b"ZBITPIX", b"32"),
+                (b"ZNAXIS", b"2"),
+                (b"ZNAXIS1", b"512"),
+                (b"ZNAXIS2", b"517"),
+                (b"ZTILE1", b"512"),
+                (b"ZTILE2", b"1"),
+                (b"ZCMPTYPE", b"'RICE_1  '"),
+                (b"ZNAME1", b"'BLOCKSIZE'"),
+                (b"ZVAL1", b"32"),
+                (b"ZNAME2", b"'BYTEPIX '"),
+                (b"ZVAL2", b"4"),
+                (b"EXTNAME", b"'COMPRESSED_IMAGE'"),
+                (b"A", b"'b       '"),
+                (b"C", b"'d       '"),
+            ],
+            "2": [
+                (b"XTENSION", b"'BINTABLE'"),
+                (b"BITPIX", b"8"),
+                (b"NAXIS", b"2"),
+                (b"NAXIS1", b"8"),
+                (b"NAXIS2", b"492"),
+                (b"PCOUNT", b"239433"),
+                (b"GCOUNT", b"1"),
+                (b"TFIELDS", b"1"),
+                (b"TTYPE1", b"'COMPRESSED_DATA'"),
+                (b"TFORM1", b"'1PB(495)'"),
+                (b"ZIMAGE", b"T"),
+                (b"ZTENSION", b"'IMAGE   '"),
+                (b"ZBITPIX", b"32"),
+                (b"ZNAXIS", b"2"),
+                (b"ZNAXIS1", b"479"),
+                (b"ZNAXIS2", b"492"),
+                (b"ZPCOUNT", b"0"),
+                (b"ZGCOUNT", b"1"),
+                (b"ZTILE1", b"479"),
+                (b"ZTILE2", b"1"),
+                (b"ZCMPTYPE", b"'RICE_1  '"),
+                (b"ZNAME1", b"'BLOCKSIZE'"),
+                (b"ZVAL1", b"32"),
+                (b"ZNAME2", b"'BYTEPIX '"),
+                (b"ZVAL2", b"4"),
+                (b"EXTNAME", b"'COMPRESSED_IMAGE'"),
+                (b"K", b"'l       '"),
+                (b"M", b"'n       '"),
+            ],
         }
 
-        for i in ['1', '2']:
-            packed_hdulist = fits.pack(getattr(self, f'hdulist_pack{i}'))
+        for i in ["1", "2"]:
+            packed_hdulist = fits.pack(getattr(self, f"hdulist_pack{i}"))
             packed_buffer = io.BytesIO()
             packed_hdulist.writeto(packed_buffer)
             packed_buffer.seek(0)
@@ -729,17 +744,17 @@ def _simple_str_header_parser(header_str):
         bytes_chunk = bytes(chunk)
         if len(bytes_chunk.strip()) == 0:
             continue
-        if bytes_chunk.startswith(b'COMMENT'):
+        if bytes_chunk.startswith(b"COMMENT"):
             continue
         if bytes_chunk.strip() == b"END":
             break
-        key_value = bytes_chunk.split(b'/')[0]
-        key, value = key_value.split(b'=', 1)
+        key_value = bytes_chunk.split(b"/")[0]
+        key, value = key_value.split(b"=", 1)
         key = key.strip()
         value = value.strip()
-        if key == b'CHECKSUM' or key == b'DATASUM':
+        if key == b"CHECKSUM" or key == b"DATASUM":
             continue
-        if key == b'ZHECKSUM' or key == b'ZDATASUM':
+        if key == b"ZHECKSUM" or key == b"ZDATASUM":
             continue
         header.append((key, value))
 

--- a/docs/changes/io.fits/19582.feature.rst
+++ b/docs/changes/io.fits/19582.feature.rst
@@ -1,0 +1,1 @@
+Added ``astropy.io.fits.pack`` and ``astropy.io.fits.unpack`` which are convenience functions that operate on a full HDUList object to compress or uncompress the full file in analogous way to ``fpack`` and ``funpack`` which are provided by the cfitsio library.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
This PR fixes a bug when a fits HDU is compressed, it can have both the ZSIMPLE and ZTENSION keywords by default. This leads to having both SIMPLE AND XTENSION keywords when cfitsio tries to unpack the file, which is not a valid FITS file. I also cleaned up the order of the output header keywords, keeping TFIELDS with the other TTYPE and TFORM keywords.

I also added some convenience functions that act as fpack and funpack on an HDULIst object, wrapping the compression for each individual HDU. 

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19577 

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
