### PR TITLE
BUG: prefer arrays views instead of mutating array dtypes in place

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1517,11 +1517,7 @@ def _binary_table_byte_swap(data):
     for arr in reversed(to_swap):
         arr.byteswap(True)
 
-    data.dtype = np.dtype({"names": names, "formats": formats, "offsets": offsets})
-
-    yield data
+    yield data.astype({"names": names, "formats": formats, "offsets": offsets})
 
     for arr in to_swap:
         arr.byteswap(True)
-
-    data.dtype = orig_dtype


### PR DESCRIPTION
### Description

This is in line with #19540, and addresses some (not all) deprecation warnings that were previously not seen on numpy dev (2.5 has been a moving target).
The reason I'm not trying to be exhaustive in my fix right now is twofold:
- I'm seeing an unusual number of failures (about 700)
- I'm also hitting a segfault (presumably from numpy), that prevents me from testing everything thoroughly

Of course I'll open more detailed reports where due (unless someone else beats me to it), but I only have limited time tonight.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
