### PR TITLE
Dealing with deprecation of setting dtype in record arrays, and unitless times

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -37,7 +37,7 @@ from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_
 from astropy.io.fits.header import Header, _pad_length
 from astropy.io.fits.util import _is_int, _str_to_num, path_like
 from astropy.utils import lazyproperty
-from astropy.utils.compat import chararray
+from astropy.utils.compat import NUMPY_LT_2_5, chararray
 
 from .base import DELAYED, ExtensionHDU, _ValidHDU
 
@@ -208,7 +208,12 @@ class _TableLikeHDU(_ValidHDU):
     def _init_tbdata(self, data):
         columns = self.columns
 
-        data.dtype = data.dtype.newbyteorder(">")
+        if NUMPY_LT_2_5:
+            data.dtype = data.dtype.newbyteorder(">")
+        else:
+            # TODO: see if a a view is possible still; initial trial gives
+            # error in test_table.py::TestVLATables::test_empty_vla_raw_data.
+            np.ndarray._set_dtype(data, data.dtype.newbyteorder(">"))
 
         # hack to enable pseudo-uint support
         data._uint = self._uint
@@ -1517,11 +1522,20 @@ def _binary_table_byte_swap(data):
     for arr in reversed(to_swap):
         arr.byteswap(True)
 
-    data.dtype = np.dtype({"names": names, "formats": formats, "offsets": offsets})
+    new_dtype = np.dtype({"names": names, "formats": formats, "offsets": offsets})
+    if NUMPY_LT_2_5:
+        data.dtype = new_dtype
+    else:
+        # TODO: ensure self.data is never used with this context manager, so that
+        # a view here would work (and the second _set_dtype can be removed).
+        np.ndarray._set_dtype(data, new_dtype)
 
     yield data
 
     for arr in to_swap:
         arr.byteswap(True)
 
-    data.dtype = orig_dtype
+    if NUMPY_LT_2_5:
+        data.dtype = orig_dtype
+    else:
+        np.ndarray._set_dtype(data, orig_dtype)

--- a/astropy/table/_dataframes.py
+++ b/astropy/table/_dataframes.py
@@ -68,7 +68,7 @@ def _encode_mixins(tbl: Table) -> Table:
                 nat = np.timedelta64("NaT", "ns")
             else:
                 new_col = col.datetime64.copy()
-                nat = np.datetime64("NaT")
+                nat = np.datetime64("NaT", "ns")
             if col.masked:
                 new_col[col.mask] = nat
             tbl[col.info.name] = new_col

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1085,6 +1085,7 @@ class TestSubFormat:
             val = 730120.0
         else:
             # Ignore warnings from numpy for older matplotlib
+            # https://github.com/astropy/astropy/issues/19586
             if NUMPY_LT_2_5:
                 val = date2num(datetime.datetime(2000, 1, 1))
             else:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -5,6 +5,7 @@ import datetime
 import functools
 import gc
 import os
+import warnings
 from copy import deepcopy
 from decimal import Decimal, localcontext
 from io import StringIO
@@ -30,6 +31,7 @@ from astropy.time import (
     conf,
 )
 from astropy.utils import iers
+from astropy.utils.compat import NUMPY_LT_2_5
 from astropy.utils.compat.optional_deps import HAS_H5PY, HAS_PYTZ
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -1082,7 +1084,15 @@ class TestSubFormat:
             #   val = matplotlib.dates.date2num('2000-01-01')
             val = 730120.0
         else:
-            val = date2num(datetime.datetime(2000, 1, 1))
+            # Ignore warnings from numpy for older matplotlib
+            if NUMPY_LT_2_5:
+                val = date2num(datetime.datetime(2000, 1, 1))
+            else:
+                with warnings.catch_warnings(
+                    action="ignore", category=DeprecationWarning
+                ):
+                    val = date2num(datetime.datetime(2000, 1, 1))
+
         t = Time("2000-01-01 00:00:00", scale="utc")
         assert np.allclose(t.plot_date, val, atol=1e-5, rtol=0)
 


### PR DESCRIPTION
This PR aims to ensure astropy does not raise any numpy deprecation warnings.

Note that the numpy 2.5 change to add `_set_dtype = None` to `recarray` (EDIT: in https://github.com/numpy/numpy/pull/31293) means that in released versions of astropy, fits code will not work with numpy 2.5. I'll mention this upstream, though personally I feel people cannot simply expect to be able to upgrade to a newer numpy while sticking to an older astropy. Obviously, that does mean this should be backported.

@neutrinoceros - this PR includes your commit from #19578, to ensure we get all errors in one go.

Fixes #19579

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
