### PR TITLE
Added quotes around tox paths so that it works with directories that have a space in their name.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     # For coverage, we need to pass extra options to the C compiler
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     py313t: PYTHON_GIL=0
-    image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/astropy/tests/figures/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data
+    image: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path="{toxinidir}/results" --mpl-hash-library="{toxinidir}/astropy/tests/figures/{envname}.json" --mpl-baseline-path=https://raw.githubusercontent.com/astropy/astropy-figure-tests/astropy-main/figures/{envname}/ --remote-data
     !image: MPLFLAGS =
     clocale: LC_CTYPE = C.ascii
     clocale: LC_ALL = C
@@ -122,10 +122,10 @@ commands =
     # docdeps-predeps: Override sphinx max pin in sphinx-design
     docdeps-predeps: uv pip install sphinx -U --pre --no-deps
     {list_dependencies_command}
-    !cov-!double: pytest --strict-markers --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
-    cov-!double: pytest --strict-markers --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml {posargs}
+    !cov-!double: pytest --strict-markers --pyargs astropy "{toxinidir}/docs" {env:MPLFLAGS} {posargs}
+    cov-!double: pytest --strict-markers --pyargs astropy "{toxinidir}/docs" {env:MPLFLAGS} --cov astropy --cov-config="{toxinidir}/pyproject.toml" --cov-report xml:"{toxinidir}/coverage.xml" {posargs}
 
-    double: pytest --keep-duplicates --strict-markers --pyargs astropy {toxinidir}/docs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    double: pytest --keep-duplicates --strict-markers --pyargs astropy "{toxinidir}/docs" astropy "{toxinidir}/docs" {env:MPLFLAGS} {posargs}
 
 pip_pre =
     devdeps: true
@@ -224,4 +224,4 @@ commands =
                 --hidden-import pytest_remotedata.plugin \
                 --hidden-import pytest_doctestplus.plugin \
                 --hidden-import pytest_mpl.plugin
-    ./run_astropy_tests --astropy-root {toxinidir}
+    ./run_astropy_tests --astropy-root "{toxinidir}"


### PR DESCRIPTION

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This PR add quotes in the tox calls so that folders with spaces in their names (e.g. created by dropbox) are valid paths to run tox testing.
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
