### PR TITLE
Fix a couple of pickle-related issues in WCS

### DIFF
--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -172,8 +172,33 @@ def test_alt_wcskey():
     assert w2.wcs.alt == "A"
 
 
-def test_preserve_units():
-    w = wcs.WCS(naxis=2, preserve_units=True)
-    assert w._preserve_units is True
+@pytest.mark.parametrize("preserve_units", [False, True])
+def test_preserve_units(preserve_units):
+    # Use non-SI units so that the world coordinates returned by
+    # ``wcs_pix2world`` differ between ``preserve_units=True`` (arcsec) and
+    # ``preserve_units=False`` (converted to deg). This ensures the pickle
+    # round-trip is exercising the actual transformation behavior, not just
+    # the stored flag.
+    header = fits.Header.fromstring(
+        "WCSAXES = 2\n"
+        "CTYPE1  = 'RA---TAN'\n"
+        "CTYPE2  = 'DEC--TAN'\n"
+        "CUNIT1  = 'arcsec'\n"
+        "CUNIT2  = 'arcsec'\n"
+        "CRVAL1  = 4\n"
+        "CRVAL2  = 6\n"
+        "CRPIX1  = 1\n"
+        "CRPIX2  = 1\n"
+        "CDELT1  = 4\n"
+        "CDELT2  = 2\n",
+        sep="\n",
+    )
+    w = wcs.WCS(header, preserve_units=preserve_units)
+    assert w._preserve_units is preserve_units
+
+    coords = np.array([[1.0, 2.0], [3.0, 4.0]])
+    expected = w.wcs_pix2world(coords, 0)
+
     w2 = pickle.loads(pickle.dumps(w))
-    assert w2._preserve_units is True
+    assert w2._preserve_units is preserve_units
+    assert_array_almost_equal(w2.wcs_pix2world(coords, 0), expected)

--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -170,3 +170,10 @@ def test_alt_wcskey():
     w2 = pickle.loads(pickle.dumps(w))
 
     assert w2.wcs.alt == "A"
+
+
+def test_preserve_units():
+    w = wcs.WCS(naxis=2, preserve_units=True)
+    assert w._preserve_units is True
+    w2 = pickle.loads(pickle.dumps(w))
+    assert w2._preserve_units is True

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3352,7 +3352,13 @@ reduce these to 2 dimensions using the naxis kwarg.
         buffer = io.BytesIO()
         hdulist.writeto(buffer)
 
-        dct = self.__dict__.copy()
+        # Exclude lazily-populated caches: they are pure functions of the
+        # WCS state, so unpickling can regenerate them on demand. Keeping
+        # them out of the pickle avoids bloating the payload and prevents
+        # non-picklable cache contents (e.g. closures) from breaking pickle.
+        dct = {
+            k: v for k, v in self.__dict__.items() if not k.endswith("_cache")
+        }
         dct["_alt_wcskey"] = self.wcs.alt
 
         return (

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -529,6 +529,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
         self._init_kwargs = {
             "keysel": copy.copy(keysel),
             "colsel": copy.copy(colsel),
+            "preserve_units": preserve_units,
         }
 
         if header is None:

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3357,9 +3357,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         # WCS state, so unpickling can regenerate them on demand. Keeping
         # them out of the pickle avoids bloating the payload and prevents
         # non-picklable cache contents (e.g. closures) from breaking pickle.
-        dct = {
-            k: v for k, v in self.__dict__.items() if not k.endswith("_cache")
-        }
+        dct = {k: v for k, v in self.__dict__.items() if not k.endswith("_cache")}
         dct["_alt_wcskey"] = self.wcs.alt
 
         return (

--- a/docs/changes/wcs/19591.bugfix.rst
+++ b/docs/changes/wcs/19591.bugfix.rst
@@ -1,0 +1,9 @@
+Lazily-populated caches on a ``WCS`` (such as the internal
+``world_axis_object_components``/``world_axis_object_classes`` cache) are no
+longer included in the pickled state. They are regenerated on demand after
+unpickling, which keeps pickling robust even when a cache entry holds a
+non-picklable value.
+
+Fixed a bug where the ``preserve_units`` option passed to the ``WCS``
+constructor was silently reset to ``False`` when a ``WCS`` object was pickled
+and unpickled.


### PR DESCRIPTION
This fixes two issues:

* If a WCS was pickled, ``preserve_units`` was not correctly preserved
* The ``_components_and_classes_cache`` attribute should not be pickled - which matters if it contains e.g. ``lambda`` expressions, see e.g. https://github.com/astropy/astropy/pull/19506/changes#r3074879519