### PR TITLE
STY: rewrite rtol=10e-2 in canonical 1e-1 form

### DIFF
--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -249,7 +249,7 @@ class TestLinearLSQFitter:
         fitter = LinearLSQFitter()
 
         fitted_model = fitter(initial_model, record.x, record.z)
-        assert_allclose(fitted_model.parameters, np.array(coeffs), rtol=10e-2)
+        assert_allclose(fitted_model.parameters, np.array(coeffs), rtol=1e-1)
 
     def test_linear_fit_model_set(self):
         """Tests fitting multiple models simultaneously."""


### PR DESCRIPTION


<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address the fact that I'm but a weak blob of thinking meat and that when I see 10e-2, I think 0.01. 

Spotted by the new bad-number-notation checker in pylint (see https://github.com/pylint-dev/pylint/pull/10425). It flags scientific-notation literals whose base falls outside [1, 1000). Happy to close this out if it's not worth the churn (or use 100e-3, or 0.1 instead).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
