### PR TITLE
CI: opt-into upcoming default node.js 24 on emulated archs

### DIFF
--- a/.github/workflows/ci_cron_monthly.yml
+++ b/.github/workflows/ci_cron_monthly.yml
@@ -28,6 +28,8 @@ concurrency:
 env:
   IS_CRON: 'true'
   PY_COLORS: "1"
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -28,6 +28,8 @@ concurrency:
 env:
   IS_CRON: 'true'
   PY_COLORS: "1"
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description
This is in response to the following warning we've been seeing on emulated archs
```
node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```
opting into the next default now will both silence the warning and check wether everything on the toolchain is actually compatible already.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
