### PR TITLE
DEP: replace test dependency on `pytest-astropy` with the subset of *its* dependency tree we actually use

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -78,6 +78,30 @@ def ignore_config_paths_global_state(monkeypatch, tmp_path_factory):
         yield
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="run slow tests",
+    )
+    parser.addoption(
+        "--run-hugemem",
+        action="store_true",
+        default=False,
+        help="run memory intensive tests",
+    )
+    parser.addoption(
+        "-R",
+        nargs="?",
+        const="any",
+        default="none",
+        help="run tests with online data, requires pytest-remotedata",
+        dest="remote_data",
+        choices=["astropy", "any", "github", "none"],
+    )
+
+
 def pytest_configure(config):
     # Ensure number of columns and lines is deterministic for testing
     from astropy import conf
@@ -135,6 +159,8 @@ def pytest_configure(config):
             threads_per_worker = max(max_threads // int(xdist_worker_count), 1)
             threadpool_limits(threads_per_worker)
 
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "hugemem: mark test as using a lot of memory")
     config.addinivalue_line(
         "markers",
         "only_optimized_interpreter: mark a test as skipped if the interpreter is not running with -OO flags",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,10 @@ test = [
     "coverage>=7.2.0",
     "hypothesis>=6.84.0",
     "pytest>=8.0.1",
-    "pytest-doctestplus>=1.4.0",
     "pytest-astropy-header>=0.2.1",
-    "pytest-astropy>=0.11.0",
+    "pytest-cov>=2.3.1",
+    "pytest-doctestplus>=1.4.0",
+    "pytest-remotedata>=0.4.1",
     "pytest-xdist>=3.6.0",
     "threadpoolctl>=3.0.0",
 ]


### PR DESCRIPTION
### Description
Close #18783
I need to check how this behaves if `pytest-astropy` is installed anyway.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
