### PR TITLE
RFC: refactor docstring templating in config/paths.py

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -6,6 +6,7 @@ data/cache files used by Astropy should be placed.
 import os
 import re
 import shutil
+import sys
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, nullcontext
 from copy import deepcopy
@@ -464,37 +465,6 @@ def get_config_dir_path(
     *,
     ensure_exists: bool = True,
 ) -> Path:
-    """
-    Determines the configuration directory associated with a namespace and creates the
-    directory if it doesn't exist.
-
-    This directory is typically ``$XDG_CONFIG_HOME/<namespace>``, but can be overwritten
-    with the ``ASTROPY_CONFIG_DIR`` environment variable, or with
-    ``temporary_config_dir_path``.
-
-    .. versionchanged:: 8.0.0
-        In previous versions, the return value pointed to ``$HOME/.astropy/config`` by default.
-        A new environment variable ``ASTROPY_CONFIG_DIR`` is now supported.
-        Symlinks are no longer created in any situation.
-
-    Parameters
-    ----------
-    rootname : str, optional
-        Namespace associated with the directory. For example, for ``'pkgname'``,
-        the directory would be ``$XDG_CONFIG_HOME/pkgname``. Default: ``'astropy'``
-
-    ensure_exists : bool, keyword-only, optional
-        Whether to create the directory (and its parents) if it's missing.
-        Default: True
-
-        .. versionadded:: 8.0.0
-
-    Returns
-    -------
-    pathlib.Path
-        The absolute path to the configuration directory.
-
-    """
     node = _finders.config.find_namespaced_node(rootname)
     if ensure_exists:
         node.mkdir(parents=True, exist_ok=True)
@@ -509,55 +479,11 @@ def get_config_dir(
     return str(get_config_dir_path(rootname, ensure_exists=ensure_exists))
 
 
-if get_config_dir_path.__doc__ is not None:
-    # guard against PYTHONOPTIMIZE mode
-    get_config_dir.__doc__ = cleandoc(
-        get_config_dir_path.__doc__.replace("pathlib.Path", "str")
-        + """
-    See Also
-    --------
-    get_config_dir_path : same as this function, except that the return value is a pathlib.Path
-
-    """
-    )
-
-
 def get_cache_dir_path(
     rootname: str = "astropy",
     *,
     ensure_exists: bool = True,
 ) -> Path:
-    """
-    Determines the cache directory associated with a namespace and, optionally,
-    creates the directory if it doesn't exist.
-
-    This directory is typically ``$XDG_CACHE_HOME/<namespace>``, but can be overwritten
-    with the ``ASTROPY_CACHE_DIR`` environment variable, or with
-    :func:`temporary_cache_dir_path`.
-
-    .. versionchanged:: 8.0.0
-        In previous versions, the return value pointed to ``$HOME/.astropy/cache`` by default.
-        A new environment variable ``ASTROPY_CACHE_DIR`` is now supported.
-        Symlinks are no longer created in any situation.
-
-    Parameters
-    ----------
-    rootname : str, optional
-        Namespace associated with the directory. For example, for ``'pkgname'``,
-        the directory would be ``$XDG_CACHE_HOME/pkgname``. Default: ``'astropy'``
-
-    ensure_exists : bool, keyword-only, optional
-        Whether to create the directory (and its parents) if it's missing.
-        Default: True
-
-        .. versionadded:: 8.0.0
-
-    Returns
-    -------
-    pathlib.Path
-        The absolute path to the cache directory.
-
-    """
     node = _finders.cache.find_namespaced_node(rootname)
     if ensure_exists:
         node.mkdir(parents=True, exist_ok=True)
@@ -572,16 +498,93 @@ def get_cache_dir(
     return str(get_cache_dir_path(rootname, ensure_exists=ensure_exists))
 
 
-if get_cache_dir_path.__doc__ is not None:
-    # guard against PYTHONOPTIMIZE mode
-    get_cache_dir.__doc__ = cleandoc(
-        get_cache_dir_path.__doc__.replace("pathlib.Path", "str")
-        + """
-    See Also
-    --------
-    get_cache_dir_path : same as this function, except that the return value is a pathlib.Path
+if sys.flags.optimize < 2:
+    # with PYTHONOPTIMIZE=2, docstrings are stripped from everywhere,
+    # so don't add them dynamically in that case
 
-    """
+    _base_get_config_doc = """\
+        Determines the configuration directory associated with a namespace and creates the
+        directory if it doesn't exist.
+
+        This directory is typically ``$XDG_CONFIG_HOME/<namespace>``, but can be overwritten
+        with the ``ASTROPY_CONFIG_DIR`` environment variable, or with
+        ``temporary_config_dir_path``.
+
+        .. versionchanged:: 8.0.0
+            In previous versions, the return value pointed to ``$HOME/.astropy/config`` by default.
+            A new environment variable ``ASTROPY_CONFIG_DIR`` is now supported.
+            Symlinks are no longer created in any situation.
+
+        Parameters
+        ----------
+        rootname : str, optional
+            Namespace associated with the directory. For example, for ``'pkgname'``,
+            the directory would be ``$XDG_CONFIG_HOME/pkgname``. Default: ``'astropy'``
+
+        ensure_exists : bool, keyword-only, optional
+            Whether to create the directory (and its parents) if it's missing.
+            Default: True
+
+            .. versionadded:: 8.0.0
+        """
+    _base_get_cache_doc = """\
+        Determines the cache directory associated with a namespace and, optionally,
+        creates the directory if it doesn't exist.
+
+        This directory is typically ``$XDG_CACHE_HOME/<namespace>``, but can be overwritten
+        with the ``ASTROPY_CACHE_DIR`` environment variable, or with
+        :func:`temporary_cache_dir_path`.
+
+        .. versionchanged:: 8.0.0
+            In previous versions, the return value pointed to ``$HOME/.astropy/cache`` by default.
+            A new environment variable ``ASTROPY_CACHE_DIR`` is now supported.
+            Symlinks are no longer created in any situation.
+
+        Parameters
+        ----------
+        rootname : str, optional
+            Namespace associated with the directory. For example, for ``'pkgname'``,
+            the directory would be ``$XDG_CACHE_HOME/pkgname``. Default: ``'astropy'``
+
+        ensure_exists : bool, keyword-only, optional
+            Whether to create the directory (and its parents) if it's missing.
+            Default: True
+
+            .. versionadded:: 8.0.0
+        """
+    _ret_section = """
+        Returns
+        -------
+        {rettype}
+            The absolute path to the {dirtype} directory.
+        """
+
+    get_config_dir_path.__doc__ = cleandoc(
+        _base_get_config_doc + _ret_section.format(rettype="Path", dirtype="cache")
+    )
+
+    get_config_dir.__doc__ = cleandoc(
+        _base_get_config_doc
+        + _ret_section.format(rettype="str", dirtype="cache")
+        + """
+        See Also
+        --------
+        get_config_dir_path : same as this function, except that the return value is a pathlib.Path
+        """
+    )
+
+    get_cache_dir_path.__doc__ = cleandoc(
+        _base_get_cache_doc + _ret_section.format(rettype="Path", dirtype="cache")
+    )
+
+    get_cache_dir.__doc__ = cleandoc(
+        _base_get_cache_doc
+        + _ret_section.format(rettype="str", dirtype="cache")
+        + """
+        See Also
+        --------
+        get_cache_dir_path : same as this function, except that the return value is a pathlib.Path
+        """
     )
 
 


### PR DESCRIPTION
### Description

The problem was initially reported in https://github.com/astropy/astropy/pull/19575#issuecomment-4335222710, but exists on main. I'm opening this separate PR so that it can be backported.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
