### PR TITLE
DOC: Remove warning in SpectralCoord introduction

### DIFF
--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -138,15 +138,13 @@ class SpectralCoord(SpectralQuantity):
     """
     A spectral coordinate with its corresponding unit.
 
-    .. note:: The |SpectralCoord| class is new in Astropy v4.1 and should be
-              considered experimental at this time. Note that we do not fully
-              support cases where the observer and target are moving
-              relativistically relative to each other, so care should be taken
-              in those cases. It is possible that there will be API changes in
-              future versions of Astropy based on user feedback. If you have
-              specific ideas for how it might be improved, please  let us know
-              on the |astropy-dev mailing list| or at
-              http://feedback.astropy.org.
+    .. note::
+        The |SpectralCoord| class at this time does not fully support cases where the
+        observer and target are moving relativistically relative to each other, so care
+        should be taken in those cases. The behavior of instances of multiple spectral values
+        combined with multiple target frames as an N * M dimensional |SpectralCoord|
+        has also not yet been finalised. It is possible that there will be API changes in future
+        versions of Astropy based on user feedback.
 
     Parameters
     ----------

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -3,6 +3,13 @@
 Using the SpectralCoord Class
 *****************************
 
+.. warning::
+
+    The |SpectralCoord| class does not fully support cases
+    where the observer and target are moving relativistically relative to each
+    other, so care should be taken in those cases. It is possible that there
+    will be API changes in future versions of Astropy based on user feedback.
+
 The |SpectralCoord| class provides an interface for representing and
 transforming spectral coordinates such as frequencies, wavelengths, and photon
 energies, as well as equivalent Doppler velocities. While the plain |Quantity|

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -6,7 +6,7 @@ Using the SpectralCoord Class
 .. warning::
 
     The |SpectralCoord| class does not fully support cases
-    where the way multiple spectral values and multiple target frames are combined,
+    where multiple spectral values and multiple target frames are combined,
     so care should be taken in those cases. It is possible that there
     will be API changes in future versions of Astropy based on user feedback.
 

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -3,16 +3,6 @@
 Using the SpectralCoord Class
 *****************************
 
-.. warning::
-
-    The |SpectralCoord| class is new in Astropy v4.1 and should be considered
-    experimental at this time. Note that we do not fully support cases
-    where the observer and target are moving relativistically relative to each
-    other, so care should be taken in those cases. It is possible that there
-    will be API changes in future versions of Astropy based on user feedback. If
-    you have specific ideas for how it might be improved, please  let us know on
-    the |astropy-dev mailing list| or at http://feedback.astropy.org.
-
 The |SpectralCoord| class provides an interface for representing and
 transforming spectral coordinates such as frequencies, wavelengths, and photon
 energies, as well as equivalent Doppler velocities. While the plain |Quantity|

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -5,10 +5,12 @@ Using the SpectralCoord Class
 
 .. warning::
 
-    The |SpectralCoord| class does not fully support cases
-    where multiple spectral values and multiple target frames are combined,
-    so care should be taken in those cases. It is possible that there
-    will be API changes in future versions of Astropy based on user feedback.
+    The |SpectralCoord| class at this time does not fully support cases where the
+    observer and target are moving relativistically relative to each other, so care
+    should be taken in those cases. The behavior of instances of multiple spectral values
+    combined with multiple target frames as an N * M dimensional |SpectralCoord|
+    has also not yet been finalised. It is possible that there will be API changes in future
+    versions of Astropy based on user feedback.
 
 The |SpectralCoord| class provides an interface for representing and
 transforming spectral coordinates such as frequencies, wavelengths, and photon

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -6,8 +6,8 @@ Using the SpectralCoord Class
 .. warning::
 
     The |SpectralCoord| class does not fully support cases
-    where the observer and target are moving relativistically relative to each
-    other, so care should be taken in those cases. It is possible that there
+    where the way multiple spectral values and multiple target frames are combined,
+    so care should be taken in those cases. It is possible that there
     will be API changes in future versions of Astropy based on user feedback.
 
 The |SpectralCoord| class provides an interface for representing and


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

Surely SpectralCoord is no longer considered experimental by now?

* https://astropy--19608.org.readthedocs.build/en/19608/coordinates/spectralcoord.html
* https://astropy--19608.org.readthedocs.build/en/19608/api/astropy.coordinates.SpectralCoord.html#astropy.coordinates.SpectralCoord

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
