### PR TITLE
DOC: fix incorrect return type as documented in `get_(cache|config)_dir` docstrings

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -478,7 +478,7 @@ def get_config_dir_path(rootname: str = "astropy") -> Path:
 
     Returns
     -------
-    configdir : Path
+    pathlib.Path
         The absolute path to the configuration directory.
 
     """
@@ -494,7 +494,7 @@ def get_config_dir(rootname: str = "astropy") -> str:
 if get_config_dir_path.__doc__ is not None:
     # guard against PYTHONOPTIMIZE mode
     get_config_dir.__doc__ = cleandoc(
-        get_config_dir_path.__doc__
+        get_config_dir_path.__doc__.replace("pathlib.Path", "str")
         + """
     See Also
     --------
@@ -526,7 +526,7 @@ def get_cache_dir_path(rootname: str = "astropy") -> Path:
 
     Returns
     -------
-    cachedir : Path
+    pathlib.Path
         The absolute path to the cache directory.
 
     """
@@ -542,7 +542,7 @@ def get_cache_dir(rootname: str = "astropy") -> str:
 if get_cache_dir_path.__doc__ is not None:
     # guard against PYTHONOPTIMIZE mode
     get_cache_dir.__doc__ = cleandoc(
-        get_cache_dir_path.__doc__
+        get_cache_dir_path.__doc__.replace("pathlib.Path", "str")
         + """
     See Also
     --------


### PR DESCRIPTION
### Description
A more merge-friendly and backport version of #19606, but not a replacement; I still would like to refactor the entire mechanism to avoid `str.replace` as I'm doing here.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
