### PR TITLE
Backport PR #19610 to v7.2.x (TST: Add back ignoring socket warnings of yore)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,12 @@ filterwarnings = [
     # https://github.com/astropy/astropy/issues/18126
     "ignore:'_UnionGenericAlias' is deprecated and slated for removal in Python 3.17:DeprecationWarning", # not PYTHON_LT_3_14
     "ignore:The chararray class is deprecated and will be removed in a future release.:DeprecationWarning", # not NUMPY_LT_2_5
+    # Weird warning from the vectorized do_format in Angle.to_string. low numpy/python?
+    "ignore:invalid value encountered in do_format:RuntimeWarning",
+    # https://github.com/astropy/astropy/issues/19511
+    "ignore:Implicitly cleaning up <HTTPError 404:ResourceWarning",
+    "ignore:unclosed <socket:ResourceWarning",
+    "ignore:unclosed <ssl.SSLSocket:ResourceWarning",
 ]
 doctest_norecursedirs = [
     "*/setup_package.py",


### PR DESCRIPTION
### Description

Also contains a filter from #18986, which I guess isn't strictly needed on the backport branch, but doesn't hurt either, and makes future merge conflicts less likely.

Backport PR #19610 to v7.2.x

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
