### PR TITLE
ENH: add a `ensure_exists` boolean option to cache and config path getters

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -19,7 +19,7 @@ from types import TracebackType
 from typing import (
     NewType,
     ParamSpec,
-    TypeAlias,
+    Protocol,
     TypedDict,
     assert_never,
     final,
@@ -41,7 +41,10 @@ __all__ = [
 ]
 
 P = ParamSpec("P")
-PathGetter: TypeAlias = Callable[[str], Path]
+
+
+class PathGetter(Protocol):
+    def __call__(self, p: str, /, *, ensure_exists: bool = False) -> Path: ...
 
 
 class _DirType(Enum):
@@ -456,7 +459,11 @@ def temporary_config_dir_path(
         yield tmp_path
 
 
-def get_config_dir_path(rootname: str = "astropy") -> Path:
+def get_config_dir_path(
+    rootname: str = "astropy",
+    *,
+    ensure_exists: bool = True,
+) -> Path:
     """
     Determines the configuration directory associated with a namespace and creates the
     directory if it doesn't exist.
@@ -476,6 +483,12 @@ def get_config_dir_path(rootname: str = "astropy") -> Path:
         Namespace associated with the directory. For example, for ``'pkgname'``,
         the directory would be ``$XDG_CONFIG_HOME/pkgname``. Default: ``'astropy'``
 
+    ensure_exists : bool, keyword-only, optional
+        Whether to create the directory (and its parents) if it's missing.
+        Default: True
+
+        .. versionadded:: 8.0.0
+
     Returns
     -------
     configdir : Path
@@ -483,12 +496,17 @@ def get_config_dir_path(rootname: str = "astropy") -> Path:
 
     """
     node = _finders.config.find_namespaced_node(rootname)
-    node.mkdir(parents=True, exist_ok=True)
+    if ensure_exists:
+        node.mkdir(parents=True, exist_ok=True)
     return node
 
 
-def get_config_dir(rootname: str = "astropy") -> str:
-    return str(get_config_dir_path(rootname))
+def get_config_dir(
+    rootname: str = "astropy",
+    *,
+    ensure_exists: bool = True,
+) -> str:
+    return str(get_config_dir_path(rootname, ensure_exists=ensure_exists))
 
 
 if get_config_dir_path.__doc__ is not None:
@@ -504,10 +522,14 @@ if get_config_dir_path.__doc__ is not None:
     )
 
 
-def get_cache_dir_path(rootname: str = "astropy") -> Path:
+def get_cache_dir_path(
+    rootname: str = "astropy",
+    *,
+    ensure_exists: bool = True,
+) -> Path:
     """
-    Determines the cache directory associated with a namespace and creates the
-    directory if it doesn't exist.
+    Determines the cache directory associated with a namespace and, optionally,
+    creates the directory if it doesn't exist.
 
     This directory is typically ``$XDG_CACHE_HOME/<namespace>``, but can be overwritten
     with the ``ASTROPY_CACHE_DIR`` environment variable, or with
@@ -524,6 +546,12 @@ def get_cache_dir_path(rootname: str = "astropy") -> Path:
         Namespace associated with the directory. For example, for ``'pkgname'``,
         the directory would be ``$XDG_CACHE_HOME/pkgname``. Default: ``'astropy'``
 
+    ensure_exists : bool, keyword-only, optional
+        Whether to create the directory (and its parents) if it's missing.
+        Default: True
+
+        .. versionadded:: 8.0.0
+
     Returns
     -------
     cachedir : Path
@@ -531,12 +559,17 @@ def get_cache_dir_path(rootname: str = "astropy") -> Path:
 
     """
     node = _finders.cache.find_namespaced_node(rootname)
-    node.mkdir(parents=True, exist_ok=True)
+    if ensure_exists:
+        node.mkdir(parents=True, exist_ok=True)
     return node
 
 
-def get_cache_dir(rootname: str = "astropy") -> str:
-    return str(get_cache_dir_path(rootname))
+def get_cache_dir(
+    rootname: str = "astropy",
+    *,
+    ensure_exists: bool = True,
+) -> str:
+    return str(get_cache_dir_path(rootname, ensure_exists=ensure_exists))
 
 
 if get_cache_dir_path.__doc__ is not None:

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -410,6 +410,23 @@ def test_set_temp_config(tmp_path, dirtype):
     assert configuration._cfgobjs == OLD_CONFIG
 
 
+@pytest.mark.parametrize("dirtype", _DirType)
+@pytest.mark.parametrize(
+    "create_kwargs",
+    [
+        pytest.param({}, id="implicit"),
+        pytest.param({"ensure_exists": True}, id="explicit"),
+    ],
+)
+def test_get_path_without_creation(dirtype: _DirType, create_kwargs, tmp_path):
+    with dirtype.legacy_context_manager(tmp_path) as tmp_dir:
+        assert not os.path.exists(tmp_dir)
+        dirtype.path_getter("astropy", ensure_exists=False)
+        assert not os.path.exists(tmp_dir)
+        dirtype.path_getter("astropy", **create_kwargs)
+        assert os.path.exists(tmp_dir)
+
+
 def test_set_temp_cache_resets_on_exception(tmp_path):
     """Test for regression of  bug #9704"""
     t = paths.get_cache_dir()

--- a/docs/changes/config/19616.feature.rst
+++ b/docs/changes/config/19616.feature.rst
@@ -1,2 +1,3 @@
 Add a ``ensure_exists`` boolean option to cache and config path getters, allowing
-callers to disable directory creation on discovery with ``ensure_exists=False`` .
+callers to disable directory creation on discovery with ``ensure_exists=False``.
+When False, callers should handle missing directory on their own.

--- a/docs/changes/config/19616.feature.rst
+++ b/docs/changes/config/19616.feature.rst
@@ -1,3 +1,3 @@
-Add a ``ensure_exists`` boolean option to cache and config path getters, allowing
+Added a ``ensure_exists`` boolean option to cache and config path getters, allowing
 callers to disable directory creation on discovery with ``ensure_exists=False``.
 When False, callers should handle missing directory on their own.

--- a/docs/changes/config/19616.feature.rst
+++ b/docs/changes/config/19616.feature.rst
@@ -1,0 +1,2 @@
+Add a ``ensure_exists`` boolean option to cache and config path getters, allowing
+callers to disable directory creation on discovery with ``ensure_exists=False`` .


### PR DESCRIPTION
### Description
In order to fix a minor test pollution issue (#19611), it'd be helpful to have public API allowing to discover a path without forcing creation.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
