### PR TITLE
ENH: fallback to legacy default paths if they exist

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -208,6 +208,9 @@ class _DirectoryFinder:
             xdg=_Envvar(spec=_SpecSource.XDG, dirtype=self.dirtype),
         )
 
+    def legacy_default_base_node(self, namespace: str) -> Path:
+        return Path.home() / f".{namespace}" / self.dirtype.as_str()
+
     def default_base_node(self) -> Path:
         # default to a XDG-compliant scheme
         return Path.home() / f".{self.dirtype.as_str()}"
@@ -240,7 +243,21 @@ class _DirectoryFinder:
         return replace(de, base_node=self.default_base_node())
 
     def find_namespaced_node(self, namespace: str) -> Path:
-        return self.find_directory_elements(namespace).join()
+        legacy_node = self.legacy_default_base_node(namespace)
+        preferred_node = self.find_directory_elements(namespace).join()
+        if legacy_node.is_dir() and not preferred_node.exists():
+            # backward compatibility
+            # legacy_node is checked more strictly, because we only need to bridge the
+            # gap for previously supported cases
+            return legacy_node
+        else:
+            # we intentionally let through some possibly invalid state,
+            # like a file occupying the preferred node, where we expect a directory,
+            # The core reason is that there'll always be a difference between the time
+            # we look up the location and the time we actually use it, so it's
+            # impossible to make the look up perfectly safe. In turn, the responsibility
+            # to raise an exception falls on the function that'll actually try use it.
+            return preferred_node
 
 
 class _TempDirKwargs(TypedDict):

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -427,6 +427,19 @@ def test_get_path_without_creation(dirtype: _DirType, create_kwargs, tmp_path):
         assert os.path.exists(tmp_dir)
 
 
+@pytest.mark.parametrize("dirtype", _DirType)
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
+def test_fallback_to_legacy_dir_if_found(dirtype):
+    df = _DirectoryFinder(dirtype)
+    namespace = str(uuid4())
+    node = df.find_namespaced_node(namespace)
+    legacy_node = df.legacy_default_base_node(namespace)
+    assert node != legacy_node
+
+    legacy_node.mkdir(parents=True)
+    assert df.find_namespaced_node(namespace) == legacy_node
+
+
 def test_set_temp_cache_resets_on_exception(tmp_path):
     """Test for regression of  bug #9704"""
     t = paths.get_cache_dir()

--- a/docs/whatsnew/8.0.rst
+++ b/docs/whatsnew/8.0.rst
@@ -180,6 +180,8 @@ Cache and configuration directories now adhere to the XDG specification
 by default. For example, the default cache location was changed from
 ``$HOME/.astropy/cache`` to ``$XDG_CACHE_HOME/astropy``, where
 ``XDG_CACHE_HOME`` itself defaults to ``$HOME/.cache``.
+Legacy cache and configuration default locations are still silently selected
+if present and in case the new default locations do not exist.
 
 In addition, temporary directories set through ``set_temp_cache``
 or ``set_temp_config`` will now not be symlinked to default locations.


### PR DESCRIPTION
### Description
Follow up to #19575
goes hand-in-hand with #19616, which will allow us to ensure that new default paths are not created by accident, so we can be confident that if found, they are actively used, and we don't need to emit a noisy warning here.
The missing piece to finish #19611 will be to actually ensure this condition is met, and it'll require #19616

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
