### PR TITLE
MNT: add inline comment for why `pull_request_target` isn't used in an unsafe fashion

### DIFF
--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types:
     - opened
+  # pull_request_target is only dangerous if combined with an explicit checkout
+  # of the opener's code, which it isn't here. See
+  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
     - opened


### PR DESCRIPTION
### Description
I keep forgetting exactly what is dangerous about this trigger and why it's okay that we use it here. Maybe with an inline comment it'll take less time for me to remember next time

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
