### PR TITLE
Reject in-place unit conversion on Quantity views

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1180,6 +1180,15 @@ class Quantity(np.ndarray):
             # In principle, in-place might be possible.
             return NotImplemented
 
+        # Do not allow in-place conversion if this is a view of another
+        # Quantity, since that would change the data in the original without
+        # updating its unit.
+        if isinstance(self.base, Quantity) and not is_effectively_unity(factor):
+            raise ValueError(
+                "cannot do in-place unit conversion on a Quantity view; "
+                "use `q = q << unit` or `q = q.to(unit)` instead"
+            )
+
         view = self.view(np.ndarray)
         try:
             view *= factor  # operates on view

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -772,6 +772,79 @@ def test_regression_12964():
     assert x.dtype == np.float64
 
 
+def test_ilshift_rejects_views():
+    # In-place conversion on a view would corrupt the original's data.
+    a = u.Quantity([1.0], u.Mpc)
+    b = a.view(u.Quantity)
+
+    with pytest.raises(ValueError, match="cannot do in-place unit conversion"):
+        b <<= u.kpc
+
+    # Original unchanged
+    assert a.unit == u.Mpc
+    assert a.value[0] == 1.0
+
+    # Slices are also views
+    d = u.Quantity([1.0, 2.0, 3.0], u.Mpc)
+    e = d[1:]
+    with pytest.raises(ValueError, match="cannot do in-place unit conversion"):
+        e <<= u.kpc
+
+    # Non-view quantities still work
+    c = u.Quantity([1.0], u.Mpc)
+    c <<= u.kpc
+    assert c.unit == u.kpc
+    assert c.value[0] == 1000.0
+
+
+def test_ilshift_noop_on_views():
+    # No-op conversions (factor=1) are allowed on views since data is unchanged.
+    a = u.Quantity([1.0], u.Mpc)
+    b = a.view(u.Quantity)
+
+    b <<= u.Mpc
+    assert b.unit == u.Mpc
+    assert b.value[0] == 1.0
+    assert a.value[0] == 1.0
+
+    # Equivalent units
+    c = u.Quantity([1.0], u.m)
+    d = c.view(u.Quantity)
+    d <<= u.meter
+    assert d.unit == u.meter
+    assert d.value[0] == 1.0
+
+
+def test_ilshift_chained_views():
+    # Chained views should also be rejected.
+    a = u.Quantity([1.0], u.Mpc)
+    b = a.view(u.Quantity)
+    c = b.view(u.Quantity)
+
+    with pytest.raises(ValueError, match="cannot do in-place unit conversion"):
+        c <<= u.kpc
+
+    assert a.value[0] == 1.0
+    assert b.value[0] == 1.0
+    assert c.value[0] == 1.0
+
+
+def test_ilshift_on_original_with_views():
+    # Known limitation: we cannot detect when the original is mutated
+    # while views exist. This test documents the current behavior.
+    a = u.Quantity([1.0], u.Mpc)
+    b = a.view(u.Quantity)
+
+    # This goes through because a.base is not a Quantity
+    a <<= u.kpc
+
+    assert a.unit == u.kpc
+    assert a.value[0] == 1000.0
+    # b is now inconsistent: its data changed but unit did not
+    assert b.unit == u.Mpc
+    assert b.value[0] == 1000.0  # data was modified through shared buffer
+
+
 def test_quantity_value_views():
     q1 = u.Quantity([1.0, 2.0], unit=u.meter)
     # views if the unit is the same.

--- a/docs/changes/units/19620.bugfix.rst
+++ b/docs/changes/units/19620.bugfix.rst
@@ -1,0 +1,1 @@
+In-place unit conversion (``<<=``) on Quantity views now raises ``ValueError`` to prevent silent data corruption.


### PR DESCRIPTION
### Description

  Rejects in-place unit conversion (`<<=`) on Quantity views to prevent silent data corruption.

  When a Quantity view exists and is mutated via `<<=`, the underlying data changes but the original's unit is not updated, leaving it in an inconsistent state. This change raises a `ValueError` when attempting in-place conversion on a view, directing users to use `q = q << unit` or `q = q.to(unit)` instead.

  No-op conversions (factor=1) are still allowed on views since no data is mutated.

  Known limitation: We can only detect when a view is being mutated (protecting the original). The reverse case—mutating the original while views exist—cannot be detected without tracking all references.

  Fixes #19605

  - [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.