### PR TITLE
Add WorldAxisMetadata Protocol for high-level WCS conversion helpers

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -19,8 +19,8 @@ __all__ = [
 
 _WorldAxisComponent = tuple[str, str | int, str | Callable[[Any], Any]]
 _WorldAxisClass = (
-    tuple[type | str, tuple[Any, ...], dict[str, Any]]
-    | tuple[type | str, tuple[Any, ...], dict[str, Any], Callable[..., Any]]
+    tuple[type[Any] | str, tuple[Any, ...], dict[str, Any]]
+    | tuple[type[Any] | str, tuple[Any, ...], dict[str, Any], Callable[..., Any]]
 )
 
 
@@ -161,7 +161,7 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
 
 def high_level_objects_to_values(
     *world_objects: Any, low_level_wcs: _WorldAxisMetadata
-) -> list:
+) -> list[float | int | np.ndarray]:
     """
     Convert the input high level object to low level values.
 
@@ -307,7 +307,7 @@ def high_level_objects_to_values(
 
 def values_to_high_level_objects(
     *world_values: ArrayLike, low_level_wcs: _WorldAxisMetadata
-) -> list:
+) -> list[Any]:
     """
     Convert low level values into high level objects.
 

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -1,9 +1,11 @@
 import abc
 import numbers
 from collections import OrderedDict, defaultdict
-from typing import Protocol
+from collections.abc import Callable
+from typing import Any, Protocol
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 from .utils import deserialize_class
 
@@ -15,7 +17,14 @@ __all__ = [
 ]
 
 
-class _WorldAxisMetadata(Protocol):  # noqa: PYI046
+_WorldAxisComponent = tuple[str, str | int, str | Callable[[Any], Any]]
+_WorldAxisClass = (
+    tuple[type | str, tuple[Any, ...], dict[str, Any]]
+    | tuple[type | str, tuple[Any, ...], dict[str, Any], Callable[..., Any]]
+)
+
+
+class _WorldAxisMetadata(Protocol):
     """
     Structural-subtyping interface for the world axis metadata used by
     `high_level_objects_to_values` and `values_to_high_level_objects`.
@@ -26,8 +35,8 @@ class _WorldAxisMetadata(Protocol):  # noqa: PYI046
     is recognised when present and otherwise treated as ``False``.
     """
 
-    world_axis_object_classes: dict
-    world_axis_object_components: list
+    world_axis_object_classes: dict[str, _WorldAxisClass]
+    world_axis_object_components: list[_WorldAxisComponent]
 
 
 def rec_getattr(obj, att):
@@ -150,7 +159,9 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
             )
 
 
-def high_level_objects_to_values(*world_objects, low_level_wcs):
+def high_level_objects_to_values(
+    *world_objects: Any, low_level_wcs: _WorldAxisMetadata
+) -> list:
     """
     Convert the input high level object to low level values.
 
@@ -294,7 +305,9 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
     return world
 
 
-def values_to_high_level_objects(*world_values, low_level_wcs):
+def values_to_high_level_objects(
+    *world_values: ArrayLike, low_level_wcs: _WorldAxisMetadata
+) -> list:
     """
     Convert low level values into high level objects.
 
@@ -307,7 +320,7 @@ def values_to_high_level_objects(*world_values, low_level_wcs):
 
     Parameters
     ----------
-    *world_values : scalar or `~numpy.ndarray`
+    *world_values : `~numpy.typing.ArrayLike`
         Low level, "values" representations of the world coordinates.
 
     low_level_wcs : `.BaseLowLevelWCS` or object

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -1,6 +1,7 @@
 import abc
 import numbers
 from collections import OrderedDict, defaultdict
+from typing import Protocol
 
 import numpy as np
 
@@ -12,6 +13,21 @@ __all__ = [
     "high_level_objects_to_values",
     "values_to_high_level_objects",
 ]
+
+
+class _WorldAxisMetadata(Protocol):  # noqa: PYI046
+    """
+    Structural-subtyping interface for the world axis metadata used by
+    `high_level_objects_to_values` and `values_to_high_level_objects`.
+
+    Any object exposing the two attributes below is accepted as the
+    ``low_level_wcs`` argument of those functions; this includes any
+    `BaseLowLevelWCS` instance. The optional ``serialized_classes`` attribute
+    is recognised when present and otherwise treated as ``False``.
+    """
+
+    world_axis_object_classes: dict
+    world_axis_object_components: list
 
 
 def rec_getattr(obj, att):
@@ -148,7 +164,7 @@ def high_level_objects_to_values(*world_objects, low_level_wcs):
 
     Parameters
     ----------
-    *world_objects : object
+    *world_objects : `~astropy.coordinates.SkyCoord`, `~astropy.units.Quantity`, etc.
         High level coordinate objects.
 
     low_level_wcs : `.BaseLowLevelWCS` or object
@@ -291,7 +307,7 @@ def values_to_high_level_objects(*world_values, low_level_wcs):
 
     Parameters
     ----------
-    *world_values : object
+    *world_values : scalar or `~numpy.ndarray`
         Low level, "values" representations of the world coordinates.
 
     low_level_wcs : `.BaseLowLevelWCS` or object


### PR DESCRIPTION
@neutrinoceros - I'm still new to typing, so let me know whether this is what you had in mind or not, or if I'm doing this wrong. Should we be exposing WorldAxisMetadata through ``__all__``?

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
