### PR TITLE
Put serialized table indices into table meta instead of column meta

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -103,7 +103,7 @@ def _decode_mixins(tbl):
     info = meta.get_header_from_yaml(lines)
 
     # Add serialized column information to table meta for use in constructing mixins
-    tbl.meta["__serialized_columns__"] = info["meta"]["__serialized_columns__"]
+    tbl.meta.update(info["meta"])
 
     # Use the `datatype` attribute info to update column attributes that are
     # NOT already handled via standard FITS column keys (name, dtype, unit).
@@ -396,6 +396,7 @@ def _encode_mixins(tbl):
         )
         for col in tbl.itercols()
     )
+    info_lost |= "__table_indices__" in tbl.meta
 
     # Convert the table to one with no mixins, only Column objects.  This adds
     # meta data which is extracted with meta.get_yaml_from_table.  This ignores
@@ -423,19 +424,34 @@ def _encode_mixins(tbl):
     # the extra __serialized_columns__ key.  For FITS the table.meta is handled
     # by the native FITS connect code, so don't include that in the YAML
     # output.
-    ser_col = "__serialized_columns__"
+    ser_keys_default = {
+        "__serialized_columns__": {},
+        "__table_indices__": None,
+    }
 
     # encode_tbl might not have a __serialized_columns__ key if there were no mixins,
     # but machinery below expects it to be available, so just make an empty dict.
-    encode_tbl.meta.setdefault(ser_col, {})
+    for key, default in ser_keys_default.items():
+        if default is not None:
+            encode_tbl.meta.setdefault(key, default)
 
+    # Temporarily redefine encode_tbl.meta to have *only* the keys from
+    # ser_key_defaults. Use this to get the corresponding YAML header.
     tbl_meta_copy = encode_tbl.meta.copy()
     try:
-        encode_tbl.meta = {ser_col: encode_tbl.meta[ser_col]}
+        encode_tbl.meta = {
+            key: encode_tbl.meta[key]
+            for key in ser_keys_default
+            if key in encode_tbl.meta
+        }
         meta_yaml_lines = meta.get_yaml_from_table(encode_tbl)
     finally:
         encode_tbl.meta = tbl_meta_copy
-    del encode_tbl.meta[ser_col]
+
+    # Remove those special keys so that later FITS doesn't try to put them into normal
+    # HEADER keys.
+    for key in ser_keys_default:
+        encode_tbl.meta.pop(key, None)
 
     if "comments" not in encode_tbl.meta:
         encode_tbl.meta["comments"] = []

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -381,9 +381,19 @@ def read_table_fits(
     return _decode_mixins(t)
 
 
-def _encode_mixins(tbl):
-    """Encode a Table ``tbl`` that may have mixin columns to a Table with only
-    astropy Columns + appropriate meta-data to allow subsequent decoding.
+def _encode_mixins(tbl: Table) -> Table:
+    """Encode Table ``tbl`` to a Table with only astropy Columns + appropriate meta.
+
+    This handles:
+    - Mixin columns
+    - Columns with meta that cannot be directly stored to FITS
+    - Table with indices, where it is assumed that tbl.meta["__table_indices__"] is set
+      upstream in the Table connect code.
+
+    This function serializes that information appropriately and puts it into the
+    returned (new) table meta as "comments": list[str].
+
+    If none of the above situations apply the original table is returned.
     """
     # Determine if information will be lost without serializing meta.  This is hardcoded
     # to the set difference between column info attributes and what FITS can store
@@ -419,11 +429,11 @@ def _encode_mixins(tbl):
         meta_copy = deepcopy(tbl.meta)
         encode_tbl = Table(tbl.columns, meta=meta_copy, copy=False)
 
-    # Get the YAML serialization of information describing the table columns.
-    # This is reusing ECSV code that combined existing table.meta with with
-    # the extra __serialized_columns__ key.  For FITS the table.meta is handled
-    # by the native FITS connect code, so don't include that in the YAML
-    # output.
+    # Get the YAML serialization of information describing the table columns as well as
+    # (optionally) information on table indices. This is reusing ECSV code that combined
+    # existing table.meta with the extra __serialized_columns__ key.  For FITS the
+    # table.meta is handled by the native FITS connect code, so don't include that in
+    # the YAML output.
     ser_keys_default = {
         "__serialized_columns__": {},
         "__table_indices__": None,

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -349,18 +349,12 @@ def represent_indices(tbl: Table, /) -> Table:
             index_info["engine"] = type(index.data).__name__
         if index.data.unique:
             index_info["unique"] = True
-        if len(tbl.indices) > 1 and index.id == tbl.primary_key:
-            index_info["primary"] = True
 
         indices_info.append(index_info)
 
-    for index_info in indices_info:
-        # Store the index information on the first column in the index. This is somewhat
-        # arbitrary but eliminates duplication of index_info for multi-column indices.
-        col = tbl_out[index_info["colnames"][0]]
-        if col.info.meta is None:
-            col.info.meta = {}
-        col_meta_indices = col.info.meta.setdefault("__indices__", [])
-        col_meta_indices.append(index_info)
+        tbl_out.meta["__table_indices__"] = {
+            "primary_key": list(tbl.primary_key),
+            "indices": indices_info,
+        }
 
     return tbl_out

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -289,14 +289,15 @@ def represent_indices(tbl: Table, /) -> Table:
       # %ECSV 1.0
       # ---
       # datatype:
-      # - name: a
-      #   datatype: int64
-      #   meta: !!omap
-      #   - __indices__:
-      #     - colnames: [a]
-      #       index_colname: __index__
+      # - {name: a, datatype: int64}
       # - {name: b, datatype: int64}
       # - {name: __index__, datatype: int64}
+      # meta: !!omap
+      # - __table_indices__:
+      #     indices:
+      #     - colnames: [a]
+      #       index_colname: __index__
+      #     primary_key: [a]
       # schema: astropy-2.0
       a b __index__
       2 3 2

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -157,32 +157,23 @@ def construct_indices(tbl: Table) -> None:
     tbl : Table
         Table in which to create indices (in-place).
     """
-    indices: list[SlicedIndex] = []
-
-    primary_key = None
-    row_index_colnames = set()
-    for col in tbl.itercols():
-        if not col.info.meta or "__indices__" not in col.info.meta:
-            continue
-
-        for index_info in col.info.meta["__indices__"]:
-            if index_info.get("primary"):
-                primary_key = tuple(index_info["colnames"])
-            indices.append(construct_sliced_index(tbl, index_info))
-            row_index_colnames.add(index_info["index_colname"])
-
-    # No indices, do nothing
-    if not indices:
+    # No action if there are no indices defined in table meta. Otherwise get the
+    # table indices meta and pop that key off of meta.
+    if (indices_meta := tbl.meta.pop("__table_indices__", None)) is None:
         return
 
-    if primary_key is None:
-        primary_key = indices[0].id
+    indices: list[SlicedIndex] = []
+    row_index_colnames = set()
+
+    primary_key = tuple(indices_meta["primary_key"])
+    for index_info in indices_meta["indices"]:
+        indices.append(construct_sliced_index(tbl, index_info))
+        row_index_colnames.add(index_info["index_colname"])
 
     for index in indices:
-        # Add index to table by adding to each column indices and clean up column meta.
+        # Add index to table by adding to each column indices
         for colname in index.id:
             tbl[colname].info.indices.append(index)
-            tbl[colname].info.meta.pop("__indices__", None)
 
     tbl.primary_key = primary_key
     tbl.remove_columns(row_index_colnames)

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -761,15 +761,16 @@ def test_indices_read_unknown_engine():
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - name: a",
-        "#   datatype: int64",
-        "#   meta: !!omap",
-        "#   - __indices__:",
+        "# - {name: a, datatype: int64}",
+        "# - {name: __index__, datatype: int64}",
+        "# meta: !!omap",
+        "# - __table_indices__:",
+        "#     indices:",
         "#     - colnames: [a]",
         "#       engine: Foo",
         "#       index_colname: __index__",
-        "#       unique: false",
-        "# - {name: __index__, datatype: int64}",
+        "#       unique: true",
+        "#     primary_key: [a]",
         "# schema: astropy-2.0",
         "a __index__",
         "1 0",
@@ -895,7 +896,7 @@ def test_indices_serialization_representation_multiple():
 @pytest.mark.parametrize("single_index", [True, False])
 @pytest.mark.parametrize("engine", [SortedArray, SCEngine])
 @pytest.mark.parametrize("fmt", ["fits", "ecsv", "hdf5"])
-def test_roundtrip_through_file(single_index, fmt, engine, tmp_path):
+def test_indices_roundtrip_through_file(single_index, fmt, engine, tmp_path):
     if single_index and fmt != "ecsv":
         # Save a few compute cycles, since single_index is really impacting just the
         # serialization data and the engine and fmt don't matter.
@@ -903,6 +904,9 @@ def test_roundtrip_through_file(single_index, fmt, engine, tmp_path):
 
     if not HAS_H5PY and fmt == "hdf5":
         pytest.skip("hdf5 tests require h5py")
+
+    if fmt == "fits":
+        pytest.xfail("fits not yet supported")
 
     t = QTable()
     t["a"] = Time([1, 3, 2, 2], format="cxcsec")

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -864,28 +864,30 @@ def test_indices_serialization_representation_multiple():
     t.add_index("a")
     out = io.StringIO()
     t.write(out, format="ecsv", write_indices=True)
-    assert out.getvalue().splitlines() == [
+
+    exp = [
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - name: a",
-        "#   datatype: int64",
-        "#   meta: !!omap",
-        "#   - __indices__:",
-        "#     - colnames: [a, __index__1]",
-        "#       index_colname: __index__",
-        "#       primary: true",
-        "#     - colnames: [a]",
-        "#       index_colname: __index__2",
+        "# - {name: a, datatype: int64}",
         "# - {name: __index__1, datatype: int64}",
         "# - {name: __index__, datatype: int64}",
         "# - {name: __index__2, datatype: int64}",
+        "# meta: !!omap",
+        "# - __table_indices__:",
+        "#     indices:",
+        "#     - colnames: [a, __index__1]",
+        "#       row_index_colname: __index__",
+        "#     - colnames: [a]",
+        "#       row_index_colname: __index__2",
+        "#     primary_key: [a, __index__1]",
         "# schema: astropy-2.0",
         "a __index__1 __index__ __index__2",
         "1 5 0 0",
         "3 4 2 2",
         "2 3 1 1",
     ]
+    assert out.getvalue().splitlines() == exp
 
 
 @pytest.mark.parametrize("single_index", [True, False])

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -799,14 +799,15 @@ def test_indices_serialization_unique_representation():
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - name: a",
-        "#   datatype: int64",
-        "#   meta: !!omap",
-        "#   - __indices__:",
+        "# - {name: a, datatype: int64}",
+        "# - {name: __index__, datatype: int64}",
+        "# meta: !!omap",
+        "# - __table_indices__:",
+        "#     indices:",
         "#     - colnames: [a]",
         "#       index_colname: __index__",
         "#       unique: true",
-        "# - {name: __index__, datatype: int64}",
+        "#     primary_key: [a]",
         "# schema: astropy-2.0",
         "a __index__",
         "1 0",
@@ -828,28 +829,29 @@ def test_indices_serialization_representation_single(engine):
     t.add_index("a", engine=engine)
     out = io.StringIO()
     t.write(out, format="ecsv", write_indices=True)
-    exp_1 = [
+    exp = [
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - name: a",
-        "#   datatype: int64",
-        "#   meta: !!omap",
-        "#   - __indices__:",
-        "#     - colnames: [a]",
-    ]
-    # `engine` is included in YAML only for non-default case
-    exp_2 = [] if engine is SortedArray else ["#       engine: SCEngine"]
-    exp_3 = [
-        "#       index_colname: __index__",
+        "# - {name: a, datatype: int64}",
         "# - {name: __index__, datatype: int64}",
+        "# meta: !!omap",
+        "# - __table_indices__:",
+        "#     indices:",
+        "#     - colnames: [a]",
+        "#       index_colname: __index__",
+        "#     primary_key: [a]",
         "# schema: astropy-2.0",
         "a __index__",
         "1 0",
         "3 2",
         "2 1",
     ]
-    assert out.getvalue().splitlines() == exp_1 + exp_2 + exp_3
+
+    if engine is SCEngine:
+        exp.insert(9, "#       engine: SCEngine")
+
+    assert out.getvalue().splitlines() == exp
 
 
 def test_indices_serialization_representation_multiple():
@@ -877,9 +879,9 @@ def test_indices_serialization_representation_multiple():
         "# - __table_indices__:",
         "#     indices:",
         "#     - colnames: [a, __index__1]",
-        "#       row_index_colname: __index__",
+        "#       index_colname: __index__",
         "#     - colnames: [a]",
-        "#       row_index_colname: __index__2",
+        "#       index_colname: __index__2",
         "#     primary_key: [a, __index__1]",
         "# schema: astropy-2.0",
         "a __index__1 __index__ __index__2",

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -905,9 +905,6 @@ def test_indices_roundtrip_through_file(single_index, fmt, engine, tmp_path):
     if not HAS_H5PY and fmt == "hdf5":
         pytest.skip("hdf5 tests require h5py")
 
-    if fmt == "fits":
-        pytest.xfail("fits not yet supported")
-
     t = QTable()
     t["a"] = Time([1, 3, 2, 2], format="cxcsec")
     t["b"] = [3, 2, 2, 1]


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address a conceptual concern in #18703 where the table indices were being stored in column meta data. This was largely driven by implementation details of the FITS table writer that were incompatible with such table meta data. It was recognized that storing the indices meta on table meta makes more sense and we would like to get this approach locked into the API for 8.0.

This PR moves the table indices meta into the table meta and puts in special-case handling to the FITS connect code to allow this. This results in COMMENT keys like below:
```
COMMENT --BEGIN-ASTROPY-SERIALIZED-COLUMNS--                                    
COMMENT datatype:                                                               
COMMENT - {name: a, unit: m, datatype: float64}                                 
COMMENT - {name: b, datatype: int64}                                            
COMMENT - {name: __index__, datatype: int64}                                    
COMMENT meta: !!omap                                                            
COMMENT - __serialized_columns__:                                               
COMMENT     a:                                                                  
COMMENT       __class__: astropy.units.quantity.Quantity                        
COMMENT       unit: !astropy.units.Unit {unit: m}                               
COMMENT       value: !astropy.table.SerializedColumn {name: a}                  
COMMENT - __table_indices__:                                                    
COMMENT     indices:                                                            
COMMENT     - colnames: [a]                                                     
COMMENT       index_colname: __index__                                          
COMMENT     primary_key: [a]                                                    
COMMENT --END-ASTROPY-SERIALIZED-COLUMNS--    
```

The implementation could likely be improved, in particular eventually generalizing the concept to allow other table meta to get serialized in FITS. However, this appears to work correctly and there is nothing that leaks out of these internals and cannot be improved later. 

Given the proximity to the feature freeze it is requested that reviews focus strictly on critical issues that impact code correctness. Please open issues for any other non-critical changes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>

<!-- Optional opt-out -->

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

cc: @mhvk @neutrinoceros 
