### PR TITLE
API: avoid creating cache directories on discovery

### DIFF
--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -620,11 +620,13 @@ def get_config(packageormod=None, reload=False, rootname=None):
     cobj = _cfgobjs.get(pkgname)
 
     if cobj is None or reload:
+        cfgfile = str(
+            get_config_dir_path(rootname, ensure_exists=False)
+            .joinpath(pkgname)
+            .with_suffix(".cfg")
+        )
         try:
-            cobj = configobj.ConfigObj(
-                str((get_config_dir_path(rootname) / pkgname).with_suffix(".cfg")),
-                interpolation=False,
-            )
+            cobj = configobj.ConfigObj(cfgfile, interpolation=False)
         except OSError:
             # This can happen when HOME is not set
             cobj = configobj.ConfigObj(interpolation=False)
@@ -698,6 +700,7 @@ def generate_config(pkgname="astropy", filename=None, verbose=False):
 
     with contextlib.ExitStack() as stack:
         if isinstance(filename, (str, os.PathLike)):
+            Path(filename).parent.mkdir(parents=True, exist_ok=True)
             fp = stack.enter_context(open(filename, "w"))
         else:
             # assume it's a file object, or io.StringIO
@@ -818,13 +821,14 @@ def create_config_file(pkg, rootname="astropy", overwrite=False):
     doupdate = True
 
     # if the file already exists, check that it has not been modified
-    if cfgfn is not None and cfgfn.is_file():
+    if cfgfn.is_file():
         with open(cfgfn, encoding="latin-1") as fd:
             content = fd.read()
 
         doupdate = is_unedited_config_file(content, template_content)
 
     if doupdate or overwrite:
+        cfgfn.parent.mkdir(parents=True, exist_ok=True)
         with open(cfgfn, "w", encoding="latin-1") as fw:
             fw.write(template_content)
         log.info(f"The configuration file has been successfully written to {cfgfn}")

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1938,7 +1938,10 @@ def _get_download_cache_loc(pkgname="astropy"):
         The path to the data cache directory.
     """
     try:
-        datadir = astropy.config.paths.get_cache_dir_path(pkgname) / "download" / "url"
+        datadir = astropy.config.paths.get_cache_dir_path(
+            pkgname,
+            ensure_exists=False,
+        ).joinpath("download", "url")
 
         if not datadir.exists():
             try:

--- a/docs/changes/utils/19631.api.rst
+++ b/docs/changes/utils/19631.api.rst
@@ -1,0 +1,3 @@
+Cache directories are not created on discovery anymore. Meaning some functions
+that only retrieve a file or directory by name and without populating ig won't
+guarantee that the path returned already exists.


### PR DESCRIPTION
### Description
This resolves remaining pollution with (empty) cache and config directories being created at the user level from a test session.
Closes #19611
Note that none of the problems this solve were caused by #19575
I'm marking this as a breaking change, although I'm really unsure anyone really relies on the behavior being changed here: cache directories are *still* being created when they are actually needed. This branch only avoids creating them the instant paths are being discovered.

I'm opening this including a first, temporary commit, that acts as a safe guard and helped discovering where pollution happened. It is not meant to be merged, or even work on windows. But, short of changing the default of `ensure_exists` to `False`, which is probably much more impactful of a breaking change, this is the best I can come up with to verify that I wiped all problems in CI.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
