### PR TITLE
TST: fix portability issue with new serialization tests

### DIFF
--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -281,9 +281,10 @@ def represent_indices(tbl: Table, /) -> Table:
 
       >>> from astropy.table import QTable
       >>> import sys
+      >>> import numpy as np
       >>> t = QTable()
-      >>> t["a"] = [2, 3, 1]
-      >>> t["b"] = [3, 5, 4]
+      >>> t["a"] = np.array([2, 3, 1], dtype="int64")
+      >>> t["b"] = np.array([3, 5, 4], dtype="int64")
       >>> t.add_index("a")
       >>> t.write(sys.stdout, format="ecsv", write_indices=True)
       # %ECSV 1.0

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -792,7 +792,7 @@ def test_indices_read_unknown_engine():
 
 def test_indices_serialization_unique_representation():
     t = Table()
-    t["a"] = [1, 3, 2]
+    t["a"] = np.array([1, 3, 2], dtype="int64")
     t.add_index("a", unique=True)
     out = io.StringIO()
     t.write(out, format="ecsv", write_indices=True)
@@ -826,7 +826,7 @@ def test_indices_serialization_representation_single(engine):
     The `primary` key is not included in this case.
     """
     t = Table()
-    t["a"] = [1, 3, 2]
+    t["a"] = np.array([1, 3, 2], dtype="int64")
     t.add_index("a", engine=engine)
     out = io.StringIO()
     t.write(out, format="ecsv", write_indices=True)
@@ -861,7 +861,7 @@ def test_indices_serialization_representation_multiple():
     This includes the `primary` key and a collision.
     """
     t = Table()
-    t["a"] = [1, 3, 2]
+    t["a"] = np.array([1, 3, 2], dtype="int64")
     t["__index__1"] = [5, 4, 3]
     t.add_index(["a", "__index__1"])
     t.add_index("a")


### PR DESCRIPTION
### Description
Fixes #19632
follow up to #18703

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
