### PR TITLE
API: strip_spaces is now True by default

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -125,7 +125,7 @@ def read_table_fits(
     character_as_bytes=True,
     unit_parse_strict="warn",
     mask_invalid=True,
-    strip_spaces=False,
+    strip_spaces=True,
     use_fsspec=None,
     fsspec_kwargs=None,
 ):
@@ -183,9 +183,12 @@ def read_table_fits(
         penalty of doing this masking step. The masking is always deactivated
         when using ``memmap=True`` (see above).
     strip_spaces : bool, optional
-        Strip trailing whitespace in string columns, default is False and will be
-        changed to True in the next major release. This is deactivated when
-        using ``memmap=True`` (see above).
+        Strip trailing whitespace in string columns, default is True.
+        This is deactivated when using ``memmap=True`` (see above).
+
+        .. version-changed:: 8.0
+            The default is now `True` when ``memmap=False``.
+
     use_fsspec : bool, optional
         Use `fsspec.open` to open the file? Defaults to `False` unless
         ``name`` starts with the Amazon S3 storage prefix ``s3://`` or the

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -336,14 +336,15 @@ class TestSingleTable:
     @pytest.mark.parametrize("character_as_bytes", (False, True))
     def test_strip_spaces(self, tmp_path, character_as_bytes):
         filename = get_pkg_data_filename("data/tb.fits")
-        t = Table.read(
-            filename, character_as_bytes=character_as_bytes, strip_spaces=True
-        )
+        t = Table.read(filename, character_as_bytes=character_as_bytes)
         assert t["c2"].tolist() == ["abc", "xy"]
 
-        t = Table.read(filename, character_as_bytes=character_as_bytes)
+        t = Table.read(
+            filename, character_as_bytes=character_as_bytes, strip_spaces=False
+        )
         assert t["c2"].tolist() == ["abc", "xy "]
 
+        # strip_spaces automatically deactivated when memmap is enabled.
         t = Table.read(filename, character_as_bytes=character_as_bytes, memmap=True)
         assert t["c2"].tolist() == ["abc", "xy "]
         del t

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -732,7 +732,7 @@ def test_masking_regression_1795():
     Regression test for #1795 - this bug originally caused columns where TNULL
     was not defined to have their first element masked.
     """
-    t = Table.read(get_pkg_data_filename("data/tb.fits"))
+    t = Table.read(get_pkg_data_filename("data/tb.fits"), strip_spaces=False)
     assert np.all(t["c1"].mask == np.array([False, False]))
     assert not hasattr(t["c2"], "mask")
     assert not hasattr(t["c3"], "mask")

--- a/docs/changes/io.fits/19638.api.rst
+++ b/docs/changes/io.fits/19638.api.rst
@@ -1,0 +1,2 @@
+The ``strip_spaces`` option in ``Table.read`` to strip trailing whitespaces in
+string columns is now True by default. Set it to False to keep the old behavior.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to make default strip_spaces True unless memmap=True then it is set to False regardless.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #17864 

Follow-up of #17777

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
