### PR TITLE
MNT: auto-add 'dependencies' labels to automated iers-data upgrades

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,8 @@
+dependencies:
+- any:
+  - head-branch:
+    - '^update-astropy-iers-data-pin-\d+$'
+
 Docs:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
### Description
Just noticed this oversight this morning.
I don't know if this needs to be backported for it to work on all branches, so I'll start with assuming it doesn't.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
