### PR TITLE
Fix table indices serialization test failures on ARMv7 and improve coverage

### DIFF
--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -277,32 +277,7 @@ def represent_indices(tbl: Table, /) -> Table:
     automatically serializes column meta into YAML comments, while table meta is assumed
     to be FITS keyword files.
 
-    The format is most easily illustrated via the ECSV output in this example::
-
-      >>> from astropy.table import QTable
-      >>> import sys
-      >>> t = QTable()
-      >>> t["a"] = [2, 3, 1]
-      >>> t["b"] = [3, 5, 4]
-      >>> t.add_index("a")
-      >>> t.write(sys.stdout, format="ecsv", write_indices=True)
-      # %ECSV 1.0
-      # ---
-      # datatype:
-      # - {name: a, datatype: int64}
-      # - {name: b, datatype: int64}
-      # - {name: __index__, datatype: int64}
-      # meta: !!omap
-      # - __table_indices__:
-      #     indices:
-      #     - colnames: [a]
-      #       index_colname: __index__
-      #     primary_key: [a]
-      # schema: astropy-2.0
-      a b __index__
-      2 3 2
-      3 5 0
-      1 4 1
+    See the ``test_indices_serialization_*` tests in ``test_index.py`` for examples.
 
     Parameters
     ----------

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -21,6 +21,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from .test_table import SetupData
 
 available_engines = [BST, SortedArray]
+NATIVE_INT_NAME = np.array(0).dtype.name
 
 if HAS_SORTEDCONTAINERS:
     available_engines.append(SCEngine)
@@ -761,8 +762,8 @@ def test_indices_read_unknown_engine():
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - {name: a, datatype: int64}",
-        "# - {name: __index__, datatype: int64}",
+        f"# - {{name: a, datatype: {NATIVE_INT_NAME}}}",
+        f"# - {{name: __index__, datatype: {NATIVE_INT_NAME}}}",
         "# meta: !!omap",
         "# - __table_indices__:",
         "#     indices:",
@@ -800,8 +801,8 @@ def test_indices_serialization_unique_representation():
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - {name: a, datatype: int64}",
-        "# - {name: __index__, datatype: int64}",
+        f"# - {{name: a, datatype: {NATIVE_INT_NAME}}}",
+        f"# - {{name: __index__, datatype: {NATIVE_INT_NAME}}}",
         "# meta: !!omap",
         "# - __table_indices__:",
         "#     indices:",
@@ -834,8 +835,8 @@ def test_indices_serialization_representation_single(engine):
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - {name: a, datatype: int64}",
-        "# - {name: __index__, datatype: int64}",
+        f"# - {{name: a, datatype: {NATIVE_INT_NAME}}}",
+        f"# - {{name: __index__, datatype: {NATIVE_INT_NAME}}}",
         "# meta: !!omap",
         "# - __table_indices__:",
         "#     indices:",
@@ -872,10 +873,10 @@ def test_indices_serialization_representation_multiple():
         "# %ECSV 1.0",
         "# ---",
         "# datatype:",
-        "# - {name: a, datatype: int64}",
-        "# - {name: __index__1, datatype: int64}",
-        "# - {name: __index__, datatype: int64}",
-        "# - {name: __index__2, datatype: int64}",
+        f"# - {{name: a, datatype: {NATIVE_INT_NAME}}}",
+        f"# - {{name: __index__1, datatype: {NATIVE_INT_NAME}}}",
+        f"# - {{name: __index__, datatype: {NATIVE_INT_NAME}}}",
+        f"# - {{name: __index__2, datatype: {NATIVE_INT_NAME}}}",
         "# meta: !!omap",
         "# - __table_indices__:",
         "#     indices:",
@@ -891,6 +892,22 @@ def test_indices_serialization_representation_multiple():
         "2 3 1 1",
     ]
     assert out.getvalue().splitlines() == exp
+
+
+@pytest.mark.parametrize("dtype", [np.int16, np.float32, np.int64, np.float64])
+def test_indices_roundtrip_various_dtypes(dtype):
+    """Test that serialization round-trip works for various index dtypes."""
+    t = Table()
+    t["a"] = np.array([1, 3, 2], dtype=dtype)
+    t["b"] = np.array([5, 6, 7], dtype=dtype)
+    t.add_index("a")
+    t.add_index(["a", "b"])
+    out = io.StringIO()
+    t.write(out, format="ecsv", write_indices=True)
+    t2 = Table.read(out.getvalue(), format="ecsv")
+
+    assert_tables_equal(t, t2)
+    assert_indices_equal(t, t2, [("a",), ("a", "b")])
 
 
 @pytest.mark.parametrize("single_index", [True, False])
@@ -931,6 +948,11 @@ def test_indices_roundtrip_through_file(single_index, fmt, engine, tmp_path):
         # FITS does not round-trip the format
         t2["a"].format = "cxcsec"
 
+    assert_tables_equal(t, t2)
+    assert_indices_equal(t, t2, indices_colnames)
+
+
+def assert_indices_equal(t, t2, indices_colnames):
     assert len(t.indices) == len(t2.indices)
     assert t.primary_key == t2.primary_key
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to address fix test failures from #18703 on platforms like ARMv7 where `int64` is not the native integer type. It also expands test coverage to include creating indices with a variety of dtypes to stress the system a bit more.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #19632

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
