### PR TITLE
ENH/BUG: avoid test pollution from data tests by making APIs resilient against missing cache directories

### DIFF
--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -148,7 +148,7 @@ def test_name_resolve_cache(tmp_path):
     target_name = "castor"
     (temp_cache_dir := tmp_path / "cache").mkdir()
     with paths.set_temp_cache(temp_cache_dir):
-        assert not get_cached_urls()  # sanity check
+        assert not get_cached_urls(on_missing="ignore")  # sanity check
         icrs = get_icrs_coordinates(target_name, cache=True)
         urls = get_cached_urls()
         assert len(urls) == 1

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -17,6 +17,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+import warnings
 import zipfile
 from collections.abc import Container, Generator, Iterable
 from contextlib import suppress
@@ -24,7 +25,7 @@ from importlib import import_module
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 from types import MappingProxyType
-from typing import Literal, overload
+from typing import Literal, assert_never, overload
 from warnings import warn
 
 import astropy_iers_data
@@ -1164,7 +1165,7 @@ def get_free_space_in_dir(path: str | os.PathLike[str], unit: UnitBase | bool = 
         If ``unit=False``, it is returned as plain integer (in bytes).
 
     """
-    if not (path := Path(path)).is_dir():
+    if (path := Path(path)).is_file():
         raise OSError(
             "Can only determine free space associated with directories, not files."
         )
@@ -1403,8 +1404,7 @@ def _download_file_from_source(
 
         if size is not None:
             check_free_space_in_dir(gettempdir(), size)
-            if cache:
-                dldir = _get_download_cache_loc(pkgname)
+            if cache and (dldir := _get_download_cache_loc(pkgname)).exists():
                 check_free_space_in_dir(dldir, size)
 
         # If a user has overridden sys.stdout it might not have the
@@ -1577,7 +1577,7 @@ def download_file(
 
     if cache:
         try:
-            dldir = _get_download_cache_loc(pkgname)
+            dldir = _get_download_cache_loc(pkgname, ensure_exists=True)
         except OSError as e:
             cache = False
             missing_cache = (
@@ -1661,6 +1661,8 @@ def download_file(
 def is_url_in_cache(
     url_key: str,
     pkgname: str = "astropy",
+    *,
+    on_missing: Literal["ignore", "warn", "error"] = "warn",
 ) -> bool:
     """Check if a download for ``url_key`` is in the cache.
 
@@ -1676,7 +1678,11 @@ def is_url_in_cache(
         The package name to use to locate the download cache. i.e. for
         ``pkgname='astropy'`` the default cache location is
         ``~/.cache/astropy``.
+    on_missing : 'ignore', 'warn', or 'error'
+        What to do if the cache directory doesn't exist.
+        Default: 'warn'
 
+        .. versionadded:: 8.0.0
 
     Returns
     -------
@@ -1688,9 +1694,8 @@ def is_url_in_cache(
     --------
     cache_contents : obtain a dictionary listing everything in the cache
     """
-    try:
-        dldir = _get_download_cache_loc(pkgname)
-    except OSError:
+    dldir = _get_download_cache_loc(pkgname, on_missing=on_missing)
+    if not dldir.exists():
         return False
     filename = dldir / _url_to_dirname(url_key) / "contents"
     return filename.exists()
@@ -1701,7 +1706,7 @@ def cache_total_size(
 ) -> int:
     """Return the total size in bytes of all files in the cache."""
     size = 0
-    dldir = _get_download_cache_loc(pkgname=pkgname)
+    dldir = _get_download_cache_loc(pkgname=pkgname, on_missing="ignore")
     for root, _, files in os.walk(dldir):
         size += sum(os.path.getsize(os.path.join(root, name)) for name in files)
     return size
@@ -1888,6 +1893,8 @@ def _deltemps():
 def clear_download_cache(
     hashorurl: str | None = None,
     pkgname: str = "astropy",
+    *,
+    on_missing: Literal["ignore", "warn", "error"] = "warn",
 ) -> None:
     """Clears the data file cache by deleting the local file(s).
 
@@ -1911,17 +1918,30 @@ def clear_download_cache(
         The package name to use to locate the download cache. i.e. for
         ``pkgname='astropy'`` the default cache location is
         ``~/.cache/astropy``.
+
+    on_missing : 'ignore', 'warn', or 'error'
+        What to do if the path requested for deletion doesn't exist.
+        Default: 'warn'
+
+        .. versionadded:: 8.0.0
     """
     try:
-        dldir = _get_download_cache_loc(pkgname)
-    except OSError as e:
-        # Problem arose when trying to open the cache
-        # Just a warning, though
-        msg = "Not clearing data cache - cache inaccessible due to "
-        estr = "" if len(e.args) < 1 else (": " + str(e))
-        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr), stacklevel=2)
-        return
-    try:
+        dldir = _get_download_cache_loc(pkgname, on_missing="ignore")
+        if not dldir.exists():
+            match on_missing:
+                case "ignore":
+                    pass
+                case "warn":
+                    warn(
+                        f"{dldir} does not exist",
+                        CacheMissingWarning,
+                        stacklevel=2,
+                    )
+                case "error":
+                    raise FileNotFoundError(f"no such file or directory {dldir}")
+                case _ as unreachable:
+                    assert_never(unreachable)
+            return
         if hashorurl is None:
             # Optional: delete old incompatible caches too
             _rmtree(dldir)
@@ -1930,7 +1950,7 @@ def clear_download_cache(
             _rmtree(filepath)
         else:
             # Not a URL, it should be either a filename or a hash
-            filepath = os.path.join(dldir, hashorurl)
+            filepath = dldir / hashorurl
             rp = os.path.relpath(filepath, dldir)
             if rp.startswith(".."):
                 raise RuntimeError(
@@ -1942,7 +1962,7 @@ def clear_download_cache(
                 # It's a filename not the hash of a URL
                 # so we want to zap the directory containing the
                 # files "url" and "contents"
-                filepath = os.path.join(dldir, d)
+                filepath = dldir / d
             if os.path.exists(filepath):
                 _rmtree(filepath)
             elif len(hashorurl) == 2 * hashlib.md5(
@@ -1958,8 +1978,13 @@ def clear_download_cache(
         warn(CacheMissingWarning(msg + e.__class__.__name__ + estr), stacklevel=2)
 
 
-def _get_download_cache_loc(pkgname: str = "astropy") -> Path:
-    """Finds the path to the cache directory and makes them if they don't exist.
+def _get_download_cache_loc(
+    pkgname: str = "astropy",
+    *,
+    ensure_exists: bool = False,
+    on_missing: Literal["ignore", "warn", "error"] = "warn",
+) -> Path:
+    """Finds the path to the cache directory.
 
     Parameters
     ----------
@@ -1968,32 +1993,49 @@ def _get_download_cache_loc(pkgname: str = "astropy") -> Path:
         ``pkgname='astropy'`` the default cache location is
         ``~/.cache/astropy``.
 
+    ensure_exists : bool, optional, keyword-only
+        Default: False
+
+    on_missing : 'ignore', 'warn', or 'error'
+        What to do if the download cache directory doesn't exist.
+        Default: 'warn'
+
+        .. versionadded:: 8.0.0
+
     Returns
     -------
     datadir : pathlib.Path
         The path to the data cache directory.
     """
-    try:
-        datadir = astropy.config.paths.get_cache_dir_path(
-            pkgname,
-            ensure_exists=False,
-        ).joinpath("download", "url")
+    dldir = astropy.config.paths.get_cache_dir_path(
+        pkgname,
+        ensure_exists=False,
+    ).joinpath("download", "url")
 
-        if not datadir.exists():
-            try:
-                datadir.mkdir(parents=True)
-            except OSError:
-                if not datadir.exists():
-                    raise
-        elif not datadir.is_dir():
-            raise OSError(f"Data cache directory {datadir} is not a directory")
+    if ensure_exists:
+        dldir.mkdir(parents=True, exist_ok=True)
 
-        return datadir
-    except OSError as e:
-        msg = "Remote data cache could not be accessed due to "
-        estr = "" if len(e.args) < 1 else (": " + str(e))
-        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr), stacklevel=2)
-        raise
+    if dldir.is_dir():
+        return dldir
+
+    if dldir.exists():
+        raise NotADirectoryError(f"Data cache directory {dldir} is not a directory")
+
+    match on_missing:
+        case "ignore":
+            pass
+        case "warn":
+            warnings.warn(
+                f"{dldir} does not exist",
+                CacheMissingWarning,
+                stacklevel=2,
+            )
+        case "error":
+            raise FileNotFoundError(f"No such file or directory {dldir}")
+        case _ as unreachable:
+            assert_never(unreachable)
+
+    return dldir
 
 
 def _url_to_dirname(url: str) -> str:
@@ -2007,9 +2049,6 @@ def _url_to_dirname(url: str) -> str:
         urlobj[2] = "/"
     url_c = urllib.parse.urlunsplit(urlobj)
     return hashlib.md5(url_c.encode("utf-8"), usedforsecurity=False).hexdigest()
-
-
-_NOTHING = MappingProxyType({})
 
 
 class CacheDamaged(ValueError):
@@ -2075,7 +2114,9 @@ def check_download_cache(
     """
     bad_files: str[Path] = set()
     messages: set[str] = set()
-    dldir = _get_download_cache_loc(pkgname=pkgname)
+    dldir = _get_download_cache_loc(pkgname=pkgname, on_missing="ignore")
+    if not dldir.exists():
+        return
     with os.scandir(dldir) as it:
         for entry in it:
             f = dldir.joinpath(entry.name).absolute()
@@ -2209,7 +2250,7 @@ def import_file_to_cache(
         Whether or not to replace an existing object in the cache, if one exists.
         If replacement is not requested but the object exists, silently pass.
     """
-    cache_dir = _get_download_cache_loc(pkgname=pkgname)
+    cache_dir = _get_download_cache_loc(pkgname=pkgname, ensure_exists=True)
     cache_dirname = _url_to_dirname(url_key)
     local_dirname = cache_dir / cache_dirname
     local_filename = local_dirname / "contents"
@@ -2243,6 +2284,8 @@ def import_file_to_cache(
 
 def get_cached_urls(
     pkgname: str = "astropy",
+    *,
+    on_missing: Literal["ignore", "warn", "error"] = "warn",
 ) -> list[str]:
     """
     Get the list of URLs in the cache. Especially useful for looking up what
@@ -2259,6 +2302,12 @@ def get_cached_urls(
         ``pkgname='astropy'`` the default cache location is
         ``~/.cache/astropy``.
 
+    on_missing : 'ignore', 'warn', or 'error'
+        What to do if the cache directory doesn't exist.
+        Default: 'warn'
+
+        .. versionadded:: 8.0.0
+
     Returns
     -------
     cached_urls : list
@@ -2268,10 +2317,14 @@ def get_cached_urls(
     --------
     cache_contents : obtain a dictionary listing everything in the cache
     """
-    return sorted(cache_contents(pkgname=pkgname).keys())
+    return sorted(cache_contents(pkgname=pkgname, on_missing=on_missing).keys())
 
 
-def cache_contents(pkgname: str = "astropy") -> MappingProxyType[str, str]:
+def cache_contents(
+    pkgname: str = "astropy",
+    *,
+    on_missing: Literal["ignore", "warn", "error"] = "warn",
+) -> MappingProxyType[str, str]:
     """Obtain a dict mapping cached URLs to filenames.
 
     This dictionary is a read-only snapshot of the state of the cache when this
@@ -2281,11 +2334,11 @@ def cache_contents(pkgname: str = "astropy") -> MappingProxyType[str, str]:
     busy with many running astropy processes, although the same issues apply to
     most functions in this module.
     """
+    dldir = _get_download_cache_loc(pkgname=pkgname, on_missing=on_missing)
+    if not dldir.exists():
+        return MappingProxyType({})
+
     r: dict[str, str] = {}
-    try:
-        dldir = _get_download_cache_loc(pkgname=pkgname)
-    except OSError:
-        return _NOTHING
     with os.scandir(dldir) as it:
         for entry in it:
             if entry.is_dir():
@@ -2380,7 +2433,11 @@ def import_download_cache(
             # but throughout this file.
             if urls is not None and url not in urls:
                 continue
-            if not update_cache and is_url_in_cache(url, pkgname=pkgname):
+            if (
+                not update_cache
+                and _get_download_cache_loc(pkgname, on_missing="ignore").exists()
+                and is_url_in_cache(url, pkgname=pkgname)
+            ):
                 continue
             f_temp_name = os.path.join(d, str(i))
             with z.open(zf) as f_zip, open(f_temp_name, "wb") as f_temp:

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1170,7 +1170,9 @@ class LeapSeconds(QTable):
         # already in cache.  The bools here indicate that the cache
         # should be used.
         trials = [
-            (f, True) for f in files if not urlparse(f).netloc or is_url_in_cache(f)
+            (f, True)
+            for f in files
+            if not urlparse(f).netloc or is_url_in_cache(f, on_missing="ignore")
         ]
         # If we are allowed to download, we try downloading new versions
         # if none of the above worked.

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -133,7 +133,8 @@ def invalid_urls(tmp_path):
 
 @pytest.fixture
 def temp_cache(tmp_path):
-    with paths.set_temp_cache(tmp_path):
+    with paths.set_temp_cache(tmp_path) as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "download", "url"))
         yield None
         check_download_cache()
 
@@ -302,40 +303,6 @@ def a_file(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
-def test_temp_cache(tmp_path):
-    dldir0 = _get_download_cache_loc()
-    check_download_cache()
-
-    with paths.set_temp_cache(tmp_path):
-        dldir1 = _get_download_cache_loc()
-        check_download_cache()
-        assert dldir1 != dldir0
-
-    dldir2 = _get_download_cache_loc()
-    check_download_cache()
-    assert dldir2 != dldir1
-    assert dldir2 == dldir0
-
-    # Check that things are okay even if we exit via an exception
-    class Special(Exception):
-        pass
-
-    try:
-        with paths.set_temp_cache(tmp_path):
-            dldir3 = _get_download_cache_loc()
-            check_download_cache()
-            assert dldir3 == dldir1
-            raise Special
-    except Special:
-        pass
-
-    dldir4 = _get_download_cache_loc()
-    check_download_cache()
-    assert dldir4 != dldir3
-    assert dldir4 == dldir0
-
-
-@pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("strategy", ["parallel", "sequential"])
 def test_download_with_sources_and_bogus_original(
     valid_urls, invalid_urls, temp_cache, strategy
@@ -499,7 +466,7 @@ def test_clear_download_multiple_references_doesnt_corrupt_storage(
         with NamedTemporaryFile("w", dir=tmp_path, delete=False) as f:
             f.write(content)
         url = url_to(f.name)
-        clear_download_cache(url)
+        clear_download_cache(url, on_missing="ignore")
         filename = download_file(url, cache=True)
         return url, filename
 
@@ -686,7 +653,7 @@ def test_download_cache_after_clear(tmp_path, temp_cache, valid_urls):
     testurl, contents = next(valid_urls)
     # Test issues raised in #4427 with clear_download_cache() without a URL,
     # followed by subsequent download.
-    download_dir = _get_download_cache_loc()
+    download_dir = _get_download_cache_loc(on_missing="ignore")
 
     fnout = download_file(testurl, cache=True)
     assert os.path.isfile(fnout)
@@ -716,11 +683,10 @@ def test_download_parallel_from_internet_works(temp_cache):
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 @pytest.mark.parametrize("method", [None, "spawn"])
-def test_download_parallel_fills_cache(tmp_path, valid_urls, method):
+def test_download_parallel_fills_cache(valid_urls, method):
     urls = []
-    # tmp_path is shared between many tests, and that can cause weird
-    # interactions if we set the temporary cache too directly
-    with paths.set_temp_cache(tmp_path):
+    with paths.temporary_cache_dir_path(namespace="astropy") as tmp_path:
+        tmp_path.joinpath("download", "url").mkdir(parents=True)
         for um, c in islice(valid_urls, FEW):
             assert not is_url_in_cache(um)
             urls.append((um, c))
@@ -733,7 +699,10 @@ def test_download_parallel_fills_cache(tmp_path, valid_urls, method):
         for r, (_, c) in zip(rs, urls):
             assert get_file_contents(r) == c
         check_download_cache()
-    assert not url_set.intersection(get_cached_urls())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", CacheMissingWarning)
+        new_urls = get_cached_urls()
+    assert not url_set.intersection(new_urls)
     check_download_cache()
 
 
@@ -841,7 +810,7 @@ def test_download_parallel_update(temp_cache, tmp_path):
         with open(fn, "w") as f:
             f.write(c)
         u = url_to(fn)
-        clear_download_cache(u)
+        clear_download_cache(u, on_missing="ignore")
         td.append((fn, u, c))
 
     r1 = download_files_in_parallel([u for (fn, u, c) in td])
@@ -1124,48 +1093,46 @@ def test_data_noastropy_fallback(monkeypatch):
     # astropy dir could not be accessed
     @classmethod
     def osraiser(cls, linkto, pkgname=None):
-        raise OSError()
+        raise OSError("mock os error")
 
     monkeypatch.setattr(paths._DirectoryFinder, "find_namespaced_node", osraiser)
 
     # make sure the config dir search fails
-    with pytest.raises(OSError):
+    with pytest.raises(OSError, match="^mock os error$"):
         paths.get_cache_dir(rootname="astropy")
 
-    with pytest.raises(OSError):
+    with pytest.raises(OSError, match="^mock os error$"):
         paths.get_cache_dir_path(rootname="astropy")
 
     with pytest.warns(CacheMissingWarning) as warning_lines:
         fnout = download_file(TESTURL, cache=True)
     n_warns = len(warning_lines)
 
-    partial_warn_msgs = ["remote data cache could not be accessed", "temporary file"]
+    allowed_warn_msgs = ["remote data cache could not be accessed", "temporary file"]
     if n_warns == 4:
-        partial_warn_msgs.extend(["socket", "socket"])
+        allowed_warn_msgs.extend(["socket", "socket"])
 
+    unexpected_warn_msgs: list[str] = []
     for wl in warning_lines:
-        cur_w = str(wl).lower()
-        for i, partial_msg in enumerate(partial_warn_msgs):
-            if partial_msg in cur_w:
-                del partial_warn_msgs[i]
+        msg = str(wl).lower()
+        for allowed in allowed_warn_msgs:
+            if allowed in msg:
                 break
-    assert len(partial_warn_msgs) == 0, (
-        f"Got some unexpected warnings: {partial_warn_msgs}"
-    )
+        else:
+            unexpected_warn_msgs.append(msg)
 
-    assert n_warns in (2, 4), f"Expected 2 or 4 warnings, got {n_warns}"
+    assert not unexpected_warn_msgs, (
+        f"Got some unexpected warnings: {unexpected_warn_msgs}"
+    )
 
     assert os.path.isfile(fnout)
 
     # clearing the cache should be a no-up that doesn't affect fnout
-    with pytest.warns(CacheMissingWarning) as record:
+    with pytest.warns(
+        CacheMissingWarning,
+        match="^Not clearing data from cache - problem arose OSError: mock os error$",
+    ):
         clear_download_cache(TESTURL)
-    assert len(record) == 2
-    assert (
-        record[0].message.args[0]
-        == "Remote data cache could not be accessed due to OSError"
-    )
-    assert "Not clearing data cache - cache inaccessible" in record[1].message.args[0]
     assert os.path.isfile(fnout)
 
     # now remove it so tests don't clutter up the temp dir this should get
@@ -1310,7 +1277,7 @@ def test_check_download_cache(tmp_path, temp_cache, valid_urls, invalid_urls):
     testurl2, testurl2_contents = next(valid_urls)
 
     zip_file_name = tmp_path / "the.zip"
-    clear_download_cache()
+    clear_download_cache(on_missing="ignore")
     assert not check_download_cache()
 
     download_file(testurl, cache=True)
@@ -1457,7 +1424,7 @@ def test_cache_size_changes_correctly_when_files_are_added_and_removed(
     temp_cache, valid_urls
 ):
     u, c = next(valid_urls)
-    clear_download_cache(u)
+    clear_download_cache(u, on_missing="ignore")
     s_i = cache_total_size()
     download_file(u, cache=True)
     assert cache_total_size() == s_i + len(c) + len(u.encode("utf-8"))
@@ -1526,12 +1493,16 @@ def test_download_file_schedules_deletion(valid_urls):
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
-def test_clear_download_cache_refuses_to_delete_outside_the_cache(tmp_path):
+def test_clear_download_cache_refuses_to_delete_outside_the_cache(tmp_path, temp_cache):
     fn = str(tmp_path / "file")
     with open(fn, "w") as f:
         f.write("content")
     assert os.path.exists(fn)
-    with pytest.raises(RuntimeError):
+
+    with pytest.raises(
+        RuntimeError,
+        match="attempted to use clear_download_cache on the path",
+    ):
         clear_download_cache(fn)
     assert os.path.exists(fn)
 
@@ -1607,31 +1578,42 @@ def test_cache_dir_is_actually_a_file(tmp_path: Path, valid_urls):
     to check what happens if any of the steps in the path is wrong somehow.
     """
 
-    def check_quietly_ignores_bogus_cache():
+    def check_quietly_ignores_bogus_cache(expect_file: bool = False) -> None:
         """We want a broken cache to produce a warning but then astropy should
         act like there isn't a cache.
         """
-        with pytest.warns(CacheMissingWarning):
+        if expect_file:
+            ctx = pytest.raises(OSError)
+            ctx2 = pytest.warns(CacheMissingWarning)
+            ctx3 = contextlib.nullcontext()
+            ctx4 = ctx
+        else:
+            ctx = pytest.warns(CacheMissingWarning)
+            ctx2 = contextlib.nullcontext()
+            ctx3 = ctx
+            ctx4 = contextlib.nullcontext()
+
+        with ctx:
             assert not get_cached_urls()
-        with pytest.warns(CacheMissingWarning):
+        with ctx:
             assert not is_url_in_cache("http://www.example.com/")
-        with pytest.warns(CacheMissingWarning):
+        with ctx:
             assert not cache_contents()
-        with pytest.warns(CacheMissingWarning):
+        with ctx3:
             u, c = next(valid_urls)
-            r = download_file(u, cache=True)
+            with ctx2:
+                r = download_file(u, cache=True)
             assert get_file_contents(r) == c
             # check the filename r appears in a warning message?
             # check r is added to the delete_at_exit list?
             # in fact should there be testing of the delete_at_exit mechanism,
             # as far as that is possible?
-        with pytest.warns(CacheMissingWarning):
+        with ctx:
             assert not is_url_in_cache(u)
-        with pytest.warns(CacheMissingWarning):
-            with pytest.raises(OSError):
-                check_download_cache()
+        with ctx4:
+            check_download_cache()
 
-    dldir = _get_download_cache_loc()
+    dldir = _get_download_cache_loc(ensure_exists=True)
     # set_temp_cache acts weird if it is pointed at a file (see below)
     # but we want to see what happens when the cache is pointed
     # at a file instead of a directory, so make a directory we can
@@ -1680,7 +1662,7 @@ def test_cache_dir_is_actually_a_file(tmp_path: Path, valid_urls):
     cd /= "url"
     cd.write_text(ct)
     with paths.set_temp_cache(tmp_path):
-        check_quietly_ignores_bogus_cache()
+        check_quietly_ignores_bogus_cache(expect_file=True)
     assert dldir == _get_download_cache_loc()
     assert cd.read_text() == ct
     cd.unlink()
@@ -2043,7 +2025,9 @@ def test_pkgname_isolation(temp_cache, valid_urls):
     a = str(uuid4())
 
     assert not get_cached_urls()
-    assert not get_cached_urls(pkgname=a)
+    with pytest.warns(CacheMissingWarning):
+        a_urls = get_cached_urls(pkgname=a)
+    assert not a_urls
 
     for u, _ in islice(valid_urls, FEW):
         download_file(u, cache=True, pkgname=a)
@@ -2101,11 +2085,17 @@ def test_pkgname_isolation(temp_cache, valid_urls):
 
     clear_download_cache(pkgname=a)
     assert len(get_cached_urls()) == FEW
-    assert not get_cached_urls(pkgname=a)
+    with pytest.warns(CacheMissingWarning):
+        a_urls = get_cached_urls(pkgname=a)
+    assert not a_urls
 
     clear_download_cache()
-    assert not get_cached_urls()
-    assert not get_cached_urls(pkgname=a)
+    with pytest.warns(CacheMissingWarning):
+        urls = get_cached_urls()
+    assert not urls
+    with pytest.warns(CacheMissingWarning):
+        a_urls = get_cached_urls(pkgname=a)
+    assert not a_urls
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
@@ -2114,7 +2104,9 @@ def test_transport_cache_via_zip(temp_cache, valid_urls):
     a = str(uuid4())
 
     assert not get_cached_urls()
-    assert not get_cached_urls(pkgname=a)
+    with pytest.warns(CacheMissingWarning):
+        a_urls = get_cached_urls(pkgname=a)
+    assert not a_urls
 
     for u, _ in islice(valid_urls, FEW):
         download_file(u, cache=True)
@@ -2149,7 +2141,9 @@ def test_download_parallel_respects_pkgname(temp_cache, valid_urls):
     a = str(uuid4())
 
     assert not get_cached_urls()
-    assert not get_cached_urls(pkgname=a)
+    with pytest.warns(CacheMissingWarning):
+        a_urls = get_cached_urls(pkgname=a)
+    assert not a_urls
 
     download_files_in_parallel([u for (u, c) in islice(valid_urls, FEW)], pkgname=a)
     assert not get_cached_urls()

--- a/docs/changes/utils/19650.feature.rst
+++ b/docs/changes/utils/19650.feature.rst
@@ -1,0 +1,3 @@
+``astropy.utils.data`` functions are now more resilient
+against a missing cache directory and avoid forcing its
+creation on call.


### PR DESCRIPTION
### Description
Follow up to #19631
close #19636

At the time of opening, I still have exactly one failing test locally, which is both responsible for the remaining bit of pollution I'm seeing (in the form of a test cache dir being created into the default, global location), and a victim of some *other* kind of pollution: it passes on its own but not when the entire test module is run. I have tools to track the latter down, but I'm opening this as a draft to allow myself to take a step back after a couple hours spent juggling with failures.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
