### PR TITLE
DEP: add a temporary constraint on pandas (<3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -866,6 +866,9 @@ constraint-dependencies = [
 
     # see https://github.com/astropy/astropy/issues/18292
     "array-api-strict<2.4 ; python_version<'3.12'",
+
+    # https://github.com/astropy/astropy/issues/19651
+    "pandas<3"
 ]
 
 # uv sync's default behavior includes the 'dev' group.


### PR DESCRIPTION
### Description
A more lightweight alternative to #19653

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
