### PR TITLE
MNT: fixup update-credits script

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -214,6 +214,8 @@ Julien Woillez               <jwoillez@gmail.com> <jwoillez@gmail.org>
 Jurien Huisman               <huisman@strw.leidenuniv.nl>
 Kacper Kowalik               <xarthisius.kk@gmail.com>
 Kacper Kowalik               <xarthisius.kk@gmail.com> <xarthisius@gentoo.org>
+Kacper Rutkowski             <kk.rutkowski@student.uw.edu.pl>
+Kacper Rutkowski             <kk.rutkowski@student.uw.edu.pl> <kacper@localhost.localdomain>
 Kang Wang                    <kangqiwang@outlook.com>
 Karan Grover                 <karan@karan-HP-Pavilion-dm4-Notebook-PC.(none)>
 Kartavay Verma               <vermakartavay25@gmail.com>

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -288,9 +288,11 @@ Core Package Contributors
 * JP Maia
 * Juan Luis Cano Rodríguez
 * Juanjo Bazán
+* Julian Harbeck
 * Julien Woillez
 * Jurien Huisman
 * Kacper Kowalik
+* Kacper Rutkowski
 * Kang Wang
 * Karan Grover
 * Karl Gordon
@@ -341,6 +343,7 @@ Core Package Contributors
 * M\. Atakan Gürkan
 * M\. S\. R\. Dinesh
 * Mabry Cervin
+* Macdara Ó Murchú
 * Madhura Parikh
 * Magali Mebsout
 * maggiesam

--- a/scripts/update-credits.py
+++ b/scripts/update-credits.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
+import re
 import subprocess
 import sys
 import unicodedata
@@ -20,11 +21,21 @@ Other Credits
 # of the project which are not captured by git. This should likely not
 # need to be updated again.
 
-MANUAL_ADDITIONS = (
-    "Paul Barrett",
-    "Chris Hanley",
-    "JC Hsu",
-    "James Taylor",
+MANUAL_ADDITIONS = frozenset(
+    {
+        "Paul Barrett",
+        "Chris Hanley",
+        "JC Hsu",
+        "James Taylor",
+    }
+)
+
+# Names that are manually excluded
+
+MANUAL_EXCLUSIONS = frozenset(
+    {
+        "Matthias Bussonnier",  # per request
+    }
 )
 
 
@@ -37,13 +48,25 @@ def sorting_key(x: str, /) -> str:
     return remove_accents(x.lower())
 
 
+SHORTLOG_LINE_REGEXP = re.compile(r"^\s*\d+\s+(?P<name>.+) <(?P<email>.+@.+)>$")
+
+
 # Get the full list of contributors - this takes into account the .mailmap
-names = subprocess.check_output(["git", "shortlog", "-sne", "HEAD"]).splitlines()
+def names_from_logs() -> set[str]:
+    cp = subprocess.run(
+        ["git", "shortlog", "-sne", "HEAD"], check=True, capture_output=True
+    )
+    if cp.returncode != 0:
+        print("Failed to parse git logs", file=sys.stderr)
+        raise SystemExit(1)
+    lines = cp.stdout.decode().splitlines()
+    matches = [SHORTLOG_LINE_REGEXP.match(L) for L in lines]
+    return {m.group("name") for m in matches if m is not None}
+
 
 # Extract the names from each line, and sort in a case-insensitive way
 names = sorted(
-    [name.decode("utf-8").split("\t")[1].split("<")[0].strip() for name in names]
-    + list(MANUAL_ADDITIONS),
+    (names_from_logs() - MANUAL_EXCLUSIONS) | MANUAL_ADDITIONS,
     key=sorting_key,
 )
 


### PR DESCRIPTION
### Description
Close #19654
The trick was to use sets for everything until they were properly combined (and sorted into a list of unique names)

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
