### PR TITLE
Backport PR 19656 to v7.2.x (DEP: add a temporary constraint on pandas (<3))

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -771,4 +771,7 @@ required-environments = [
 constraint-dependencies = [
     "asdf>=2.12.0",
     "asdf-coordinates-schemas>=0.2.0",
+
+    # https://github.com/astropy/astropy/issues/19651
+    "pandas<3"
 ]


### PR DESCRIPTION
### Description
Manual backport for #19656 
I'm *assuming* the true fix (#19658) cannot be backported instead, for reasons I listed in https://github.com/astropy/astropy/pull/19658#pullrequestreview-4227087379

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
