### PR TITLE
MNT: Upgrade to CFITSIO 4.6.4

### DIFF
--- a/astropy/io/fits/hdu/compressed/src/compression.c
+++ b/astropy/io/fits/hdu/compressed/src/compression.c
@@ -425,18 +425,19 @@ static PyObject *decompress_hcompress_1_c(PyObject *self, PyObject *args)
 
         compressed_values = (unsigned char *)str;
 
-    dbytes = malloc((size_t)nx * ny * bytepix);
+    int na = nx * ny * bytepix;
+    dbytes = malloc((size_t)na);
 
     if (bytepix == 4) {
         decompressed_values_int = (int *)dbytes;
         fits_hdecompress(
-            compressed_values, smooth, decompressed_values_int, &ny, &nx, &scale, &status
+            compressed_values, smooth, decompressed_values_int, na, &ny, &nx, &scale, &status
         );
     }
     else {
         decompressed_values_longlong = (long long *)dbytes;
         fits_hdecompress64(
-            compressed_values, smooth, decompressed_values_longlong, &ny, &nx, &scale, &status
+            compressed_values, smooth, decompressed_values_longlong, na, &ny, &nx, &scale, &status
         );
     }
 

--- a/astropy/io/fits/hdu/compressed/src/fits_hdecompress.h
+++ b/astropy/io/fits/hdu/compressed/src/fits_hdecompress.h
@@ -1,8 +1,8 @@
 typedef long long LONGLONG;
 
 int fits_hdecompress(
-    unsigned char *input, int smooth, int *a, int *ny, int *nx, int *scale, int *status
+    unsigned char *input, int smooth, int *a, int na, int *ny, int *nx, int *scale, int *status
 );
 int fits_hdecompress64(
-    unsigned char *input, int smooth, LONGLONG *a, int *ny, int *nx, int *scale, int *status
+    unsigned char *input, int smooth, LONGLONG *a, int na, int *ny, int *nx, int *scale, int *status
 );

--- a/cextern/README.rst
+++ b/cextern/README.rst
@@ -5,3 +5,9 @@ This directory contains C libraries included with Astropy. Note that only C
 libraries without python-specific code  should be included in this directory.
 Cython or C code intended for use with Astropy or wrapper code should be in
 the Astropy source tree.
+
+CFITSIO
+-------
+The cfitsio directory only contains the small subset of files from CFITSIO which are
+required for the astropy.io.fits.hdu.compressed._tiled_compression package. All files are
+copied verbatim from CFITSIO and can easily be updated if needed.

--- a/cextern/cfitsio/ChangeLog
+++ b/cextern/cfitsio/ChangeLog
@@ -1,4 +1,30 @@
                    Log of Changes Made to CFITSIO
+                   
+Version 4.6.4 - Apr 2026
+
+  - This release includes patches to security vulnerabilities.  We 
+    strongly encourage this upgrade, particularly for those running 
+    CFITSIO in web accessible applications.
+    
+    Our thanks to A. Denkiewicz, J.B. Ferreira, S.A. Vives, 
+    Otis0408 and K.B. de Pouqueville for their help with this. 
+
+  - Input files iter_image.fits and vari.fits added for use in 
+    iter_image and iter_var example programs. (R. Mathar)
+    New configure/build options --enable-iterprogs for 'configure', 
+    and -DITERPROGS=ON for CMAKE.
+
+  - Absolute paths for installation directories now supported in 
+    CMAKE builds.
+
+  - Bug fixes for edge cases involving lossless compression of int-type
+    images, and for float-types that cannot undergo lossy compression. 
+    (M. Becker)
+
+  - Bug fix for case of switching between HDUs of lossless and quantized
+    compression.  (J. Bosch)
+
+  - Bug fix for applying histogram binning to image extensions.
 
 Version 4.6.3 - Sep 2025
 

--- a/cextern/cfitsio/lib/fits_hdecompress.c
+++ b/cextern/cfitsio/lib/fits_hdecompress.c
@@ -35,6 +35,7 @@ The following modifications have been made to the original code:
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include "fitsio2.h"
 
 /* WDP added test to see if min and max are already defined */
@@ -47,8 +48,8 @@ The following modifications have been made to the original code:
 
 static long nextchar;
 
-static int decode(unsigned char *infile, int *a, int *nx, int *ny, int *scale);
-static int decode64(unsigned char *infile, LONGLONG *a, int *nx, int *ny, int *scale);
+static int decode(unsigned char *infile, int *a, int na, int *nx, int *ny, int *scale);
+static int decode64(unsigned char *infile, LONGLONG *a, int na, int *nx, int *ny, int *scale);
 static int hinv(int a[], int nx, int ny, int smooth ,int scale);
 static int hinv64(LONGLONG a[], int nx, int ny, int smooth ,int scale);
 static void undigitize(int a[], int nx, int ny, int scale);
@@ -81,7 +82,7 @@ static void read_bdirect64(unsigned char *infile, LONGLONG a[], int n, int nqx, 
 static int  input_huffman(unsigned char *infile);
 
 /* ---------------------------------------------------------------------- */
-int fits_hdecompress(unsigned char *input, int smooth, int *a, int *ny, int *nx, 
+int fits_hdecompress(unsigned char *input, int smooth, int *a, int na, int *ny, int *nx, 
                      int *scale, int *status)
 {
   /* 
@@ -104,7 +105,7 @@ int stat;
 	/* decode the input array */
 
         FFLOCK;  /* decode uses the nextchar global variable */
-	stat = decode(input, a, nx, ny, scale);
+	stat = decode(input, a, na, nx, ny, scale);
         FFUNLOCK;
 
         *status = stat;
@@ -124,7 +125,7 @@ int stat;
   return(*status);
 }
 /* ---------------------------------------------------------------------- */
-int fits_hdecompress64(unsigned char *input, int smooth, LONGLONG *a, int *ny, int *nx, 
+int fits_hdecompress64(unsigned char *input, int smooth, LONGLONG *a, int na, int *ny, int *nx, 
                      int *scale, int *status)
 {
   /* 
@@ -147,7 +148,7 @@ int fits_hdecompress64(unsigned char *input, int smooth, LONGLONG *a, int *ny, i
 	/* decode the input array */
 
         FFLOCK;  /* decode uses the nextchar global variable */
-	stat = decode64(input, a, nx, ny, scale);
+	stat = decode64(input, a, na, nx, ny, scale);
         FFUNLOCK;
 
         *status = stat;
@@ -1041,11 +1042,12 @@ LONGLONG *p, scale64;
 static char code_magic[2] = { (char)0xDD, (char)0x99 };
 
 /*  ############################################################################  */
-static int decode(unsigned char *infile, int *a, int *nx, int *ny, int *scale)
+static int decode(unsigned char *infile, int *a, int na, int *nx, int *ny, int *scale)
 /*
 char *infile;				 input file							
-int  *a;				 address of output array [nx][ny]		
-int  *nx,*ny;				 size of output array					
+int  *a;				 address of output array [nx][ny]
+int  na;		                 size allocated for output array
+int  *nx,*ny;				 dimensions of image					
 int  *scale;				 scale factor for digitization		
 */
 {
@@ -1073,6 +1075,15 @@ char tmagic[2];
 	*ny =readint(infile);				/* y size of image			*/
 	*scale=readint(infile);				/* scale factor for digitization	*/
 	
+        if ((*nx) > INT_MAX/(*ny)) {
+                ffpmsg("numerical overflow during decompression");
+                return(DATA_DECOMPRESSION_ERR);
+        }
+        if ((*nx)*(*ny) > na) {
+                ffpmsg("wrong allocation size during decompression");
+		return(DATA_DECOMPRESSION_ERR);
+        }
+        
 	/* sum of all pixels	*/
 	sumall=readlonglong(infile);
 	/* # bits in quadrants	*/
@@ -1087,11 +1098,12 @@ char tmagic[2];
 	return(stat);
 }
 /*  ############################################################################  */
-static int decode64(unsigned char *infile, LONGLONG *a, int *nx, int *ny, int *scale)
+static int decode64(unsigned char *infile, LONGLONG *a, int na, int *nx, int *ny, int *scale)
 /*
 char *infile;				 input file							
-LONGLONG  *a;				 address of output array [nx][ny]		
-int  *nx,*ny;				 size of output array					
+LONGLONG  *a;				 address of output array [nx][ny]
+int  na;                                 size allocated for output array		
+int  *nx,*ny;				 dimensions of image					
 int  *scale;				 scale factor for digitization		
 */
 {
@@ -1119,6 +1131,15 @@ char tmagic[2];
 	*ny =readint(infile);				/* y size of image			*/
 	*scale=readint(infile);				/* scale factor for digitization	*/
 	
+        if ((*nx) > INT_MAX/(*ny)) {
+                ffpmsg("numerical overflow during decompression");
+                return(DATA_DECOMPRESSION_ERR);
+        }
+        if ((*nx)*(*ny) > na) {
+                ffpmsg("wrong allocation size during decompression");
+		return(DATA_DECOMPRESSION_ERR);
+        }
+        
 	/* sum of all pixels	*/
 	sumall=readlonglong(infile);
 	/* # bits in quadrants	*/

--- a/cextern/trim_cfitsio.sh
+++ b/cextern/trim_cfitsio.sh
@@ -22,16 +22,15 @@ mv cfitsio/pliocomp.c cfitsio/lib/
 mv cfitsio/quantize.c cfitsio/lib/
 mv cfitsio/ricecomp.c cfitsio/lib/
 
+rm -f cfitsio/.gitattributes
+rm -f cfitsio/.gitignore
 rm -f cfitsio/README
 rm -f cfitsio/INSTALL
 rm -f cfitsio/configure
 rm -f cfitsio/install-sh
-rm -f cfitsio/docs/*.tex
-rm -f cfitsio/docs/*.ps
-rm -f cfitsio/docs/*.pdf
-rm -f cfitsio/docs/*.doc
-rm -f cfitsio/docs/*.toc
-rm -f cfitsio/docs/*.odt
+rm -f cfitsio/run-testprog
+rm -rf cfitsio/.github
+rm -rf cfitsio/docs/
 rm -rf cfitsio/[^L]*.*
 rm -rf cfitsio/utilities
 rm -rf cfitsio/cmake

--- a/docs/changes/19662.other.rst
+++ b/docs/changes/19662.other.rst
@@ -1,0 +1,1 @@
+Updated the bundled CFITSIO library to 4.6.4.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

New CFITSIO release found.

Version: 4.6.4 (Apr 2026)

#### Change log

Version 4.6.4 - Apr 2026

  - This release includes patches to security vulnerabilities.  We  strongly encourage this upgrade, particularly for those running CFITSIO in web accessible applications.
    
    Our thanks to A. Denkiewicz, J.B. Ferreira, S.A. Vives, Otis0408 and K.B. de Pouqueville for their help with this. 

  - Input files iter_image.fits and vari.fits added for use in iter_image and iter_var example programs. (R. Mathar)
    New configure/build options --enable-iterprogs for 'configure', and -DITERPROGS=ON for CMAKE.

  - Absolute paths for installation directories now supported in CMAKE builds.

  - Bug fixes for edge cases involving lossless compression of int-type images, and for float-types that cannot undergo lossy compression. (M. Becker)

  - Bug fix for case of switching between HDUs of lossless and quantized compression.  (J. Bosch)

  - Bug fix for applying histogram binning to image extensions.

(For complete change log information, see https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/docs/changes.txt .)

<!-- Optional opt-out -->

Last update was https://github.com/astropy/astropy/pull/18689

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
