### PR TITLE
Simplify warning logic in SpectralCoord

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -573,30 +573,24 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             # accept plain quantities.
 
             def apply_velocity_frame_change(spectralcoord):
-                if (
-                    observer is not None
-                    and spectralcoord.observer is not None
-                    and spectralcoord.target is not None
-                ):
-                    return spectralcoord.with_observer_stationary_relative_to(observer)
+            if observer is None and spectralcoord.observer is None:
                 # When both observers are missing we silently skip the frame
                 # change since this is a common case and not worth warning
                 # about.
-                if observer is None and spectralcoord.observer is None:
-                    return spectralcoord
-                if observer is None:
-                    msg = "No observer defined on WCS"
-                elif spectralcoord.observer is None:
-                    msg = "No observer defined on SpectralCoord"
-                else:
-                    msg = "No target defined on SpectralCoord"
-                warnings.warn(
-                    f"{msg}, SpectralCoord "
-                    "will be converted without any velocity "
-                    "frame change",
-                    AstropyUserWarning,
-                )
                 return spectralcoord
+                
+            if observer is None:
+                msg = "No observer defined on WCS"
+            elif spectralcoord.observer is None:
+                msg = "No observer defined on SpectralCoord"
+            elif spectralcoord.target is None:
+                msg = "No target defined on SpectralCoord"
+            else:
+                return spectralcoord.with_observer_stationary_relative_to(observer)
+                
+            warnings.warn(f"{msg}, SpectralCoord will be converted without any velocity frame change", AstropyUserWarning)
+            
+            return spectralcoord
 
             if ctype == "ZOPT":
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -573,24 +573,29 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             # accept plain quantities.
 
             def apply_velocity_frame_change(spectralcoord):
-            if observer is None and spectralcoord.observer is None:
-                # When both observers are missing we silently skip the frame
-                # change since this is a common case and not worth warning
-                # about.
+                if observer is None and spectralcoord.observer is None:
+                    # When both observers are missing we silently skip the frame
+                    # change since this is a common case and not worth warning
+                    # about.
+                    return spectralcoord
+
+                if observer is None:
+                    msg = "No observer defined on WCS"
+                elif spectralcoord.observer is None:
+                    msg = "No observer defined on SpectralCoord"
+                elif spectralcoord.target is None:
+                    msg = "No target defined on SpectralCoord"
+                else:
+                    return spectralcoord.with_observer_stationary_relative_to(observer)
+
+                warnings.warn(
+                    f"{msg}, SpectralCoord "
+                    "will be converted without any velocity "
+                    "frame change",
+                    AstropyUserWarning,
+                )
+
                 return spectralcoord
-                
-            if observer is None:
-                msg = "No observer defined on WCS"
-            elif spectralcoord.observer is None:
-                msg = "No observer defined on SpectralCoord"
-            elif spectralcoord.target is None:
-                msg = "No target defined on SpectralCoord"
-            else:
-                return spectralcoord.with_observer_stationary_relative_to(observer)
-                
-            warnings.warn(f"{msg}, SpectralCoord will be converted without any velocity frame change", AstropyUserWarning)
-            
-            return spectralcoord
 
             if ctype == "ZOPT":
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -587,38 +587,37 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 def redshift_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent between WCS and SpectralCoord,
                     # if they are not the transformation doesn't make conceptual sense.
+
+                    # If both observers are missing we silently skip the frame
+                    # change since this is a common case and not worth warning
+                    # about. If exactly one observer is missing, or the target
+                    # is missing, we warn and skip the frame change.
+                    if observer is None and spectralcoord.observer is None:
+                        return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.0
                     if (
-                        observer is None
-                        or spectralcoord.observer is None
+                        (observer is None) != (spectralcoord.observer is None)
                         or spectralcoord.target is None
                     ):
-                        # Note that if observer and spectralcoord.observer are
-                        # both None, we don't emit any warning since this is
-                        # likely to be fine and is a very common use case. It
-                        # is more important to emit a warning if one has
-                        # observer information and the other does not.
-                        if not (observer is None and spectralcoord.observer is None):
-                            if observer is None:
-                                msg = "No observer defined on WCS"
-                            elif spectralcoord.observer is None:
-                                msg = "No observer defined on SpectralCoord"
-                            else:
-                                msg = "No target defined on SpectralCoord"
-                            warnings.warn(
-                                f"{msg}, SpectralCoord "
-                                "will be converted without any velocity "
-                                "frame change",
-                                AstropyUserWarning,
-                            )
-                        return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.0
-                    else:
-                        return (
-                            spectralcoord.with_observer_stationary_relative_to(
-                                observer
-                            ).to_value(u.m)
-                            / self.wcs.restwav
-                            - 1.0
+                        if observer is None:
+                            msg = "No observer defined on WCS"
+                        elif spectralcoord.observer is None:
+                            msg = "No observer defined on SpectralCoord"
+                        else:
+                            msg = "No target defined on SpectralCoord"
+                        warnings.warn(
+                            f"{msg}, SpectralCoord "
+                            "will be converted without any velocity "
+                            "frame change",
+                            AstropyUserWarning,
                         )
+                        return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.0
+                    return (
+                        spectralcoord.with_observer_stationary_relative_to(
+                            observer
+                        ).to_value(u.m)
+                        / self.wcs.restwav
+                        - 1.0
+                    )
 
                 classes["spectral"] = (u.Quantity, (), {}, spectralcoord_from_redshift)
                 components[self.wcs.spec] = ("spectral", 0, redshift_from_spectralcoord)
@@ -641,37 +640,36 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     # TODO: check target is consistent between WCS and SpectralCoord,
                     # if they are not the transformation doesn't make conceptual sense.
                     doppler_equiv = u.doppler_relativistic(self.wcs.restwav * u.m)
+
+                    # If both observers are missing we silently skip the frame
+                    # change since this is a common case and not worth warning
+                    # about. If exactly one observer is missing, or the target
+                    # is missing, we warn and skip the frame change.
+                    if observer is None and spectralcoord.observer is None:
+                        return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
                     if (
-                        observer is None
-                        or spectralcoord.observer is None
+                        (observer is None) != (spectralcoord.observer is None)
                         or spectralcoord.target is None
                     ):
-                        # Note that if observer and spectralcoord.observer are
-                        # both None, we don't emit any warning since this is
-                        # likely to be fine and is a very common use case. It
-                        # is more important to emit a warning if one has
-                        # observer information and the other does not.
-                        if not (observer is None and spectralcoord.observer is None):
-                            if observer is None:
-                                msg = "No observer defined on WCS"
-                            elif spectralcoord.observer is None:
-                                msg = "No observer defined on SpectralCoord"
-                            else:
-                                msg = "No target defined on SpectralCoord"
-                            warnings.warn(
-                                f"{msg}, SpectralCoord "
-                                "will be converted without any velocity "
-                                "frame change",
-                                AstropyUserWarning,
-                            )
-                        return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
-                    else:
-                        return (
-                            spectralcoord.with_observer_stationary_relative_to(
-                                observer
-                            ).to_value(u.m / u.s, doppler_equiv)
-                            / C_SI
+                        if observer is None:
+                            msg = "No observer defined on WCS"
+                        elif spectralcoord.observer is None:
+                            msg = "No observer defined on SpectralCoord"
+                        else:
+                            msg = "No target defined on SpectralCoord"
+                        warnings.warn(
+                            f"{msg}, SpectralCoord "
+                            "will be converted without any velocity "
+                            "frame change",
+                            AstropyUserWarning,
                         )
+                        return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
+                    return (
+                        spectralcoord.with_observer_stationary_relative_to(
+                            observer
+                        ).to_value(u.m / u.s, doppler_equiv)
+                        / C_SI
+                    )
 
                 classes["spectral"] = (u.Quantity, (), {}, spectralcoord_from_beta)
                 components[self.wcs.spec] = ("spectral", 0, beta_from_spectralcoord)
@@ -730,34 +728,33 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 def value_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent between WCS and SpectralCoord,
                     # if they are not the transformation doesn't make conceptual sense.
+
+                    # If both observers are missing we silently skip the frame
+                    # change since this is a common case and not worth warning
+                    # about. If exactly one observer is missing, or the target
+                    # is missing, we warn and skip the frame change.
+                    if observer is None and spectralcoord.observer is None:
+                        return spectralcoord.to_value(**kwargs)
                     if (
-                        observer is None
-                        or spectralcoord.observer is None
+                        (observer is None) != (spectralcoord.observer is None)
                         or spectralcoord.target is None
                     ):
-                        # Note that if observer and spectralcoord.observer are
-                        # both None, we don't emit any warning since this is
-                        # likely to be fine and is a very common use case. It
-                        # is more important to emit a warning if one has
-                        # observer information and the other does not.
-                        if not (observer is None and spectralcoord.observer is None):
-                            if observer is None:
-                                msg = "No observer defined on WCS"
-                            elif spectralcoord.observer is None:
-                                msg = "No observer defined on SpectralCoord"
-                            else:
-                                msg = "No target defined on SpectralCoord"
-                            warnings.warn(
-                                f"{msg}, SpectralCoord "
-                                "will be converted without any velocity "
-                                "frame change",
-                                AstropyUserWarning,
-                            )
+                        if observer is None:
+                            msg = "No observer defined on WCS"
+                        elif spectralcoord.observer is None:
+                            msg = "No observer defined on SpectralCoord"
+                        else:
+                            msg = "No target defined on SpectralCoord"
+                        warnings.warn(
+                            f"{msg}, SpectralCoord "
+                            "will be converted without any velocity "
+                            "frame change",
+                            AstropyUserWarning,
+                        )
                         return spectralcoord.to_value(**kwargs)
-                    else:
-                        return spectralcoord.with_observer_stationary_relative_to(
-                            observer
-                        ).to_value(**kwargs)
+                    return spectralcoord.with_observer_stationary_relative_to(
+                        observer
+                    ).to_value(**kwargs)
 
                 classes["spectral"] = (u.Quantity, (), {}, spectralcoord_from_value)
                 components[self.wcs.spec] = ("spectral", 0, value_from_spectralcoord)

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -572,6 +572,32 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             # of SpectralCoord - this is because we want to also be able to
             # accept plain quantities.
 
+            def apply_velocity_frame_change(spectralcoord):
+                if (
+                    observer is not None
+                    and spectralcoord.observer is not None
+                    and spectralcoord.target is not None
+                ):
+                    return spectralcoord.with_observer_stationary_relative_to(observer)
+                # When both observers are missing we silently skip the frame
+                # change since this is a common case and not worth warning
+                # about.
+                if observer is None and spectralcoord.observer is None:
+                    return spectralcoord
+                if observer is None:
+                    msg = "No observer defined on WCS"
+                elif spectralcoord.observer is None:
+                    msg = "No observer defined on SpectralCoord"
+                else:
+                    msg = "No target defined on SpectralCoord"
+                warnings.warn(
+                    f"{msg}, SpectralCoord "
+                    "will be converted without any velocity "
+                    "frame change",
+                    AstropyUserWarning,
+                )
+                return spectralcoord
+
             if ctype == "ZOPT":
 
                 def spectralcoord_from_redshift(redshift):
@@ -587,34 +613,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 def redshift_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent between WCS and SpectralCoord,
                     # if they are not the transformation doesn't make conceptual sense.
-
-                    # If both observers are missing we silently skip the frame
-                    # change since this is a common case and not worth warning
-                    # about. If exactly one observer is missing, or the target
-                    # is missing, we warn and skip the frame change.
-                    if observer is None and spectralcoord.observer is None:
-                        return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.0
-                    if (
-                        (observer is None) != (spectralcoord.observer is None)
-                        or spectralcoord.target is None
-                    ):
-                        if observer is None:
-                            msg = "No observer defined on WCS"
-                        elif spectralcoord.observer is None:
-                            msg = "No observer defined on SpectralCoord"
-                        else:
-                            msg = "No target defined on SpectralCoord"
-                        warnings.warn(
-                            f"{msg}, SpectralCoord "
-                            "will be converted without any velocity "
-                            "frame change",
-                            AstropyUserWarning,
-                        )
-                        return spectralcoord.to_value(u.m) / self.wcs.restwav - 1.0
                     return (
-                        spectralcoord.with_observer_stationary_relative_to(
-                            observer
-                        ).to_value(u.m)
+                        apply_velocity_frame_change(spectralcoord).to_value(u.m)
                         / self.wcs.restwav
                         - 1.0
                     )
@@ -640,34 +640,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     # TODO: check target is consistent between WCS and SpectralCoord,
                     # if they are not the transformation doesn't make conceptual sense.
                     doppler_equiv = u.doppler_relativistic(self.wcs.restwav * u.m)
-
-                    # If both observers are missing we silently skip the frame
-                    # change since this is a common case and not worth warning
-                    # about. If exactly one observer is missing, or the target
-                    # is missing, we warn and skip the frame change.
-                    if observer is None and spectralcoord.observer is None:
-                        return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
-                    if (
-                        (observer is None) != (spectralcoord.observer is None)
-                        or spectralcoord.target is None
-                    ):
-                        if observer is None:
-                            msg = "No observer defined on WCS"
-                        elif spectralcoord.observer is None:
-                            msg = "No observer defined on SpectralCoord"
-                        else:
-                            msg = "No target defined on SpectralCoord"
-                        warnings.warn(
-                            f"{msg}, SpectralCoord "
-                            "will be converted without any velocity "
-                            "frame change",
-                            AstropyUserWarning,
-                        )
-                        return spectralcoord.to_value(u.m / u.s, doppler_equiv) / C_SI
                     return (
-                        spectralcoord.with_observer_stationary_relative_to(
-                            observer
-                        ).to_value(u.m / u.s, doppler_equiv)
+                        apply_velocity_frame_change(spectralcoord).to_value(
+                            u.m / u.s, doppler_equiv
+                        )
                         / C_SI
                     )
 
@@ -728,33 +704,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 def value_from_spectralcoord(spectralcoord):
                     # TODO: check target is consistent between WCS and SpectralCoord,
                     # if they are not the transformation doesn't make conceptual sense.
-
-                    # If both observers are missing we silently skip the frame
-                    # change since this is a common case and not worth warning
-                    # about. If exactly one observer is missing, or the target
-                    # is missing, we warn and skip the frame change.
-                    if observer is None and spectralcoord.observer is None:
-                        return spectralcoord.to_value(**kwargs)
-                    if (
-                        (observer is None) != (spectralcoord.observer is None)
-                        or spectralcoord.target is None
-                    ):
-                        if observer is None:
-                            msg = "No observer defined on WCS"
-                        elif spectralcoord.observer is None:
-                            msg = "No observer defined on SpectralCoord"
-                        else:
-                            msg = "No target defined on SpectralCoord"
-                        warnings.warn(
-                            f"{msg}, SpectralCoord "
-                            "will be converted without any velocity "
-                            "frame change",
-                            AstropyUserWarning,
-                        )
-                        return spectralcoord.to_value(**kwargs)
-                    return spectralcoord.with_observer_stationary_relative_to(
-                        observer
-                    ).to_value(**kwargs)
+                    return apply_velocity_frame_change(spectralcoord).to_value(**kwargs)
 
                 classes["spectral"] = (u.Quantity, (), {}, spectralcoord_from_value)
                 components[self.wcs.spec] = ("spectral", 0, value_from_spectralcoord)


### PR DESCRIPTION
@mcara - prompted by your comment in https://github.com/astropy/astropy/pull/18902, I went one step further and actually modified the code to avoid repeating mostly the same code three times, and also switched to using ``!=`` as you suggested.

This doesn't change any API, it is just a cleanup, so it can go in after feature freeze.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
