### PR TITLE
Added round-tripping stress test for compression against fitsio for all different int types

### DIFF
--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -543,9 +543,23 @@ def compress_image_data(
     if not isinstance(image_data, np.ndarray):
         raise TypeError("Image data must be a numpy.ndarray")
 
+    # PLIO_1 encodes only non-negative integers, but astropy stores unsigned
+    # FITS data via the BZERO=2**(N-1) convention which produces negative
+    # values for the lower half of the range. Reject unsigned multi-byte
+    # input to avoid corrupted writes.
+    if (
+        compression_type == "PLIO_1"
+        and image_data.dtype.kind == "u"
+        and image_data.dtype.itemsize >= 2
+    ):
+        raise ValueError(
+            "PLIO_1 compression does not support unsigned integers "
+            "larger than 8 bits"
+        )
+
     if (
         compression_type in ("RICE_1", "PLIO_1")
-        and image_data.dtype.kind == "i"
+        and image_data.dtype.kind in ("i", "u")
         and image_data.dtype.itemsize == 8
     ):
         new_dt = f"{image_data.dtype.byteorder}{image_data.dtype.kind}4"
@@ -562,20 +576,6 @@ def compress_image_data(
                 f"{compression_type} compression doesn't support 64 integers, "
                 "but data cannot be converted to 32 bits without overflow",
             )
-
-    # PLIO_1 encodes only non-negative integers, but astropy stores unsigned
-    # FITS data via the BZERO=2**(N-1) convention which produces negative
-    # values for the lower half of the range. Reject unsigned multi-byte
-    # input to avoid corrupted writes.
-    if (
-        compression_type == "PLIO_1"
-        and image_data.dtype.kind == "u"
-        and image_data.dtype.itemsize >= 2
-    ):
-        raise ValueError(
-            "PLIO_1 compression does not support unsigned integers "
-            "larger than 8 bits"
-        )
 
     _check_compressed_header(compressed_header)
 
@@ -601,7 +601,12 @@ def compress_image_data(
         tile_data = image_data[tile_slices]
 
         if tile_data.dtype.kind == "u":
-            if tile_data.dtype.itemsize == 4:
+            if tile_data.dtype.itemsize == 8:
+                # Subtract 2**63 in wrap-around uint64 arithmetic, then
+                # reinterpret the bits as int64. This is equivalent to flipping
+                # the high bit and matches the FITS BZERO=2**63 convention.
+                tile_data = (tile_data - np.uint64(2**63)).view(np.int64)
+            elif tile_data.dtype.itemsize == 4:
                 tile_data = (tile_data.astype(np.int64) - 2**31).astype(np.int32)
             elif tile_data.dtype.itemsize == 2:
                 tile_data = (tile_data.astype(np.int32) - 2**15).astype(np.int16)

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -558,7 +558,7 @@ def compress_image_data(
         )
 
     if (
-        compression_type in ("RICE_1", "PLIO_1")
+        compression_type in ("RICE_1", "PLIO_1", "HCOMPRESS_1")
         and image_data.dtype.kind in ("i", "u")
         and image_data.dtype.itemsize == 8
     ):

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -563,6 +563,20 @@ def compress_image_data(
                 "but data cannot be converted to 32 bits without overflow",
             )
 
+    # PLIO_1 encodes only non-negative integers, but astropy stores unsigned
+    # FITS data via the BZERO=2**(N-1) convention which produces negative
+    # values for the lower half of the range. Reject unsigned multi-byte
+    # input to avoid corrupted writes.
+    if (
+        compression_type == "PLIO_1"
+        and image_data.dtype.kind == "u"
+        and image_data.dtype.itemsize >= 2
+    ):
+        raise ValueError(
+            "PLIO_1 compression does not support unsigned integers "
+            "larger than 8 bits"
+        )
+
     _check_compressed_header(compressed_header)
 
     # TODO: This implementation is memory inefficient as it generates all the

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -553,8 +553,7 @@ def compress_image_data(
         and image_data.dtype.itemsize >= 2
     ):
         raise ValueError(
-            "PLIO_1 compression does not support unsigned integers "
-            "larger than 8 bits"
+            "PLIO_1 compression does not support unsigned integers larger than 8 bits"
         )
 
     if (
@@ -565,7 +564,9 @@ def compress_image_data(
         # numpy's same_value check does not byteswap before comparing values,
         # so non-native source data silently truncates instead of raising.
         # Convert source to native byte order first.
-        native_source = image_data.astype(image_data.dtype.newbyteorder("="), copy=False)
+        native_source = image_data.astype(
+            image_data.dtype.newbyteorder("="), copy=False
+        )
         new_dt = f"{image_data.dtype.kind}4"
         try:
             image_data = native_source.astype(new_dt, casting="same_value")

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -571,6 +571,11 @@ def compress_image_data(
         try:
             image_data = native_source.astype(new_dt, casting="same_value")
             compressed_header["ZBITPIX"] = 32
+            if image_data.dtype.kind == "u":
+                # The input image header carries BZERO=2**63 for the original
+                # uint64 storage; after converting to uint32 the offset must
+                # be 2**31 so the FITS reader reconstructs the right values.
+                compressed_header["BZERO"] = 2**31
             warnings.warn(
                 f"{compression_type} compression doesn't support 64 integers, "
                 "data has been converted to 32 bits",

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -562,9 +562,13 @@ def compress_image_data(
         and image_data.dtype.kind in ("i", "u")
         and image_data.dtype.itemsize == 8
     ):
-        new_dt = f"{image_data.dtype.byteorder}{image_data.dtype.kind}4"
+        # numpy's same_value check does not byteswap before comparing values,
+        # so non-native source data silently truncates instead of raising.
+        # Convert source to native byte order first.
+        native_source = image_data.astype(image_data.dtype.newbyteorder("="), copy=False)
+        new_dt = f"{image_data.dtype.kind}4"
         try:
-            image_data = image_data.astype(new_dt, casting="same_value")
+            image_data = native_source.astype(new_dt, casting="same_value")
             compressed_header["ZBITPIX"] = 32
             warnings.warn(
                 f"{compression_type} compression doesn't support 64 integers, "

--- a/astropy/io/fits/hdu/compressed/tests/conftest.py
+++ b/astropy/io/fits/hdu/compressed/tests/conftest.py
@@ -38,7 +38,10 @@ def _expand(*params):
 
 ALL_INTEGER_DTYPES = [
     "".join(ele)
-    for ele in _expand([("<", ">"), ("i",), ("2", "4")], [("<", ">"), ("u",), ("1",)])
+    for ele in _expand(
+        [("<", ">"), ("i",), ("2", "4")],
+        [("<", ">"), ("u",), ("1", "2", "4")],
+    )
 ]
 ALL_FLOAT_DTYPES = ["".join(ele) for ele in _expand([("<", ">"), ("f",), ("4", "8")])]
 

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -380,9 +380,7 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
         and np_dtype.kind in ("i", "u")
         and np_dtype.itemsize == 8
     ) or (
-        compression_type == "PLIO_1"
-        and np_dtype.kind == "i"
-        and np_dtype.itemsize == 8
+        compression_type == "PLIO_1" and np_dtype.kind == "i" and np_dtype.itemsize == 8
     ):
         with pytest.raises(
             ValueError,
@@ -407,11 +405,7 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
     # unsigned itemsize >= 2; cfitsio raises only for itemsize >= 4 and
     # segfaults on itemsize == 2 with full-range data, so the cross-check
     # only runs for the 4/8-byte cases.
-    if (
-        compression_type == "PLIO_1"
-        and np_dtype.kind == "u"
-        and np_dtype.itemsize >= 2
-    ):
+    if compression_type == "PLIO_1" and np_dtype.kind == "u" and np_dtype.itemsize >= 2:
         with pytest.raises(
             ValueError,
             match=r"PLIO_1 compression does not support unsigned integers",

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -267,16 +267,22 @@ def test_compress(
         np.testing.assert_allclose(data, hdul[1].data, rtol=rtol, atol=atol)
 
 
+@pytest.mark.parametrize("kind", ["i", "u"])
 @pytest.mark.parametrize(
     "nbytes,overflow", [(2, False), (4, False), (8, False), (8, True)]
 )
 @pytest.mark.parametrize("compression_type", COMPRESSION_TYPES)
-def test_decompress_integers(nbytes, overflow, compression_type, tmp_path):
+def test_decompress_integers(nbytes, overflow, compression_type, kind, tmp_path):
+    if kind == "u" and compression_type == "PLIO_1" and nbytes >= 2:
+        pytest.skip(
+            "PLIO_1 cannot encode unsigned multi-byte integers (covered elsewhere)"
+        )
 
     testfile = tmp_path / "test.fits.fz"
-    data = np.random.poisson(1000, size=(52, 57)).astype(f"i{nbytes}")
+    data = np.random.poisson(1000, size=(52, 57)).astype(f"{kind}{nbytes}")
     if overflow:
-        data += np.iinfo(np.int32).max
+        # push past the 32-bit limit so the conversion fallback fails
+        data += np.iinfo(np.int32).max if kind == "i" else np.uint64(2**32)
     data_hdu = fits.PrimaryHDU(data=data)
     compressed_hdu = fits.CompImageHDU(data=data, compression_type=compression_type)
 

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -133,6 +133,15 @@ def fitsio_compressed_file_path(
         # fitsio fails with a compression error
         pytest.xfail("fitsio fails to write these")
 
+    if (
+        compression_type == "PLIO_1"
+        and np.dtype(dtype).kind == "u"
+        and np.dtype(dtype).itemsize >= 2
+    ):
+        # PLIO can't represent the BZERO-shifted unsigned values; cfitsio
+        # rejects 4/8-byte cases outright and segfaults on 2-byte ones.
+        pytest.xfail("PLIO_1 cannot encode unsigned multi-byte integers")
+
     if compression_type == "NOCOMPRESS":
         pytest.xfail("fitsio does not support NOCOMPRESS")
 
@@ -166,6 +175,13 @@ def astropy_compressed_file_path(
 ):
     compression_type, param, dtype = comp_param_dtype
     original_data = base_original_data.astype(dtype)
+
+    if (
+        compression_type == "PLIO_1"
+        and np.dtype(dtype).kind == "u"
+        and np.dtype(dtype).itemsize >= 2
+    ):
+        pytest.xfail("PLIO_1 cannot encode unsigned multi-byte integers")
 
     tmp_path = tmp_path_factory.mktemp("astropy")
     filename = tmp_path / f"{compression_type}_{dtype}.fits"
@@ -365,7 +381,32 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
             hdu.writeto(astropy_path)
         return
 
-    # PLIO_1 only encodes non-negative integers up to 2**24 - 1.
+    # PLIO_1 cannot encode unsigned multi-byte integers because the FITS
+    # BZERO=2**(N-1) offset astropy applies to unsigned data produces negative
+    # values that PLIO rejects. Astropy raises a clean ValueError for all
+    # unsigned itemsize >= 2; cfitsio raises only for itemsize >= 4 and
+    # segfaults on itemsize == 2 with full-range data, so the cross-check
+    # only runs for the 4/8-byte cases.
+    if (
+        compression_type == "PLIO_1"
+        and np_dtype.kind == "u"
+        and np_dtype.itemsize >= 2
+    ):
+        with pytest.raises(
+            ValueError,
+            match=r"PLIO_1 compression does not support unsigned integers",
+        ):
+            hdu.writeto(astropy_path)
+        if np_dtype.itemsize >= 4:
+            with pytest.raises(
+                ValueError,
+                match=r"Unsigned 4/8-byte integers currently not allowed",
+            ):
+                with fitsio.FITS(tmp_path / "fitsio.fits", "rw") as fts:
+                    fts.write(data, compress=compression_type)
+        return
+
+    # PLIO_1 also can't encode signed values outside [0, 2**24 - 1].
     if compression_type == "PLIO_1" and (info.min < 0 or info.max > 2**24 - 1):
         with pytest.raises(
             ValueError,

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -364,10 +364,15 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
     astropy_path = tmp_path / "astropy.fits"
     hdu = fits.CompImageHDU(data=data, compression_type=compression_type)
 
-    # Signed 64-bit data with full-range sentinels overflows the int32
-    # conversion that RICE_1 and PLIO_1 fall back to.
+    # 64-bit integer data with full-range sentinels overflows the 32-bit
+    # conversion that RICE_1 falls back to. (PLIO_1 + i8 also lands here;
+    # PLIO_1 + u8 is caught by the unsigned-multi-byte rejection below.)
     if (
-        compression_type in ("RICE_1", "PLIO_1")
+        compression_type == "RICE_1"
+        and np_dtype.kind in ("i", "u")
+        and np_dtype.itemsize == 8
+    ) or (
+        compression_type == "PLIO_1"
         and np_dtype.kind == "i"
         and np_dtype.itemsize == 8
     ):

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -129,6 +129,12 @@ def fitsio_compressed_file_path(
     ):
         pytest.xfail("fitsio won't write these")
 
+    if compression_type == "HCOMPRESS_1" and "u2" in dtype:
+        # cfitsio's HCOMPRESS encoder underestimates the output buffer size
+        # for uint16 data on certain tile configurations, raising "encode:
+        # output buffer too small". astropy's encoder handles the same combos.
+        pytest.xfail("cfitsio HCOMPRESS encoder buffer-size bug for uint16 input")
+
     if compression_type == "PLIO_1" and "f" in dtype:
         # fitsio fails with a compression error
         pytest.xfail("fitsio fails to write these")

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -440,7 +440,13 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
         np.testing.assert_array_equal(rt, data)
 
     # fitsio doesn't support NOCOMPRESS, so the cross-checks stop here.
-    if compression_type == "NOCOMPRESS":
+    # cfitsio also refuses to read or write GZIP-compressed 64-bit integer
+    # images even though the FITS Tile Compression Convention permits them,
+    # so astropy's standard-compliant output cannot be cross-validated for
+    # those combinations.
+    if compression_type == "NOCOMPRESS" or (
+        compression_type in ("GZIP_1", "GZIP_2") and np_dtype.itemsize == 8
+    ):
         return
 
     # 3. fitsio reads astropy's compressed file.

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -274,7 +274,7 @@ def test_decompress_integers(nbytes, overflow, compression_type, tmp_path):
     data_hdu = fits.PrimaryHDU(data=data)
     compressed_hdu = fits.CompImageHDU(data=data, compression_type=compression_type)
 
-    if compression_type in ("RICE_1", "PLIO_1") and nbytes == 8:
+    if compression_type in ("RICE_1", "PLIO_1", "HCOMPRESS_1") and nbytes == 8:
         test_func = pytest.raises if overflow else pytest.warns
         ctx = test_func(
             ValueError if overflow else AstropyUserWarning,
@@ -365,10 +365,12 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
     hdu = fits.CompImageHDU(data=data, compression_type=compression_type)
 
     # 64-bit integer data with full-range sentinels overflows the 32-bit
-    # conversion that RICE_1 falls back to. (PLIO_1 + i8 also lands here;
-    # PLIO_1 + u8 is caught by the unsigned-multi-byte rejection below.)
+    # conversion that RICE_1 and HCOMPRESS_1 fall back to. (PLIO_1 + i8 also
+    # lands here; PLIO_1 + u8 is caught by the unsigned-multi-byte rejection
+    # below.) For these combos cfitsio also rejects the input outright, so
+    # cross-check that fitsio raises too.
     if (
-        compression_type == "RICE_1"
+        compression_type in ("RICE_1", "HCOMPRESS_1")
         and np_dtype.kind in ("i", "u")
         and np_dtype.itemsize == 8
     ) or (
@@ -384,6 +386,13 @@ def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
             ),
         ):
             hdu.writeto(astropy_path)
+        if compression_type == "HCOMPRESS_1":
+            with pytest.raises(
+                OSError,
+                match=r"writing T(U)?LONGLONG to compressed image is not supported",
+            ):
+                with fitsio.FITS(tmp_path / "fitsio.fits", "rw") as fts:
+                    fts.write(data, compress=compression_type)
         return
 
     # PLIO_1 cannot encode unsigned multi-byte integers because the FITS

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 from astropy.io import fits
+from astropy.utils import NumpyRNGContext
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .conftest import COMPRESSION_TYPES, _expand, fitsio_param_to_astropy_param
@@ -290,3 +291,116 @@ def test_decompress_integers(nbytes, overflow, compression_type, tmp_path):
         fts = fitsio.FITS(testfile)
         data2 = fts[1].read()
         np.testing.assert_array_equal(data, data2)
+
+
+INTEGER_DTYPES_FULL_RANGE = [
+    "<i2",
+    ">i2",
+    "<i4",
+    ">i4",
+    "<i8",
+    ">i8",
+    "<u1",
+    ">u1",
+    "<u2",
+    ">u2",
+    "<u4",
+    ">u4",
+    "<u8",
+    ">u8",
+]
+
+
+def _full_range_integer_data(dtype, shape=(32, 32)):
+    info = np.iinfo(dtype)
+    sentinels = np.array(
+        [
+            info.min,
+            info.min + 1,
+            -1 if info.min < 0 else 0,
+            0,
+            1,
+            info.max - 1,
+            info.max,
+        ],
+        dtype=dtype,
+    )
+    with NumpyRNGContext(0):
+        data = np.random.randint(
+            info.min,
+            info.max + 1,
+            size=shape,
+            dtype=dtype.lstrip("<>"),
+        ).astype(dtype)
+    data.ravel()[: sentinels.size] = sentinels
+    return data
+
+
+@pytest.mark.parametrize("dtype", INTEGER_DTYPES_FULL_RANGE)
+@pytest.mark.parametrize("compression_type", COMPRESSION_TYPES)
+def test_integer_full_range_roundtrip(compression_type, dtype, tmp_path):
+    """Cross-check exact round-tripping of boundary-spanning integer data
+    between astropy and fitsio for every standard FITS integer dtype and
+    every compression algorithm that supports it."""
+    data = _full_range_integer_data(dtype)
+    np_dtype = np.dtype(dtype)
+    info = np.iinfo(dtype)
+    astropy_path = tmp_path / "astropy.fits"
+    hdu = fits.CompImageHDU(data=data, compression_type=compression_type)
+
+    # Signed 64-bit data with full-range sentinels overflows the int32
+    # conversion that RICE_1 and PLIO_1 fall back to.
+    if (
+        compression_type in ("RICE_1", "PLIO_1")
+        and np_dtype.kind == "i"
+        and np_dtype.itemsize == 8
+    ):
+        with pytest.raises(
+            ValueError,
+            match=(
+                f"{compression_type} compression doesn't support 64 integers, "
+                "but data cannot be converted to 32 bits without overflow"
+            ),
+        ):
+            hdu.writeto(astropy_path)
+        return
+
+    # PLIO_1 only encodes non-negative integers up to 2**24 - 1.
+    if compression_type == "PLIO_1" and (info.min < 0 or info.max > 2**24 - 1):
+        with pytest.raises(
+            ValueError,
+            match=r"data out of range for PLIO compression",
+        ):
+            hdu.writeto(astropy_path)
+        return
+
+    # 1. astropy writes a compressed file.
+    hdu.writeto(astropy_path)
+
+    # 2. astropy reads its own compressed file.
+    with fits.open(astropy_path) as hdul:
+        rt = hdul[1].data
+        assert rt.dtype.kind == np_dtype.kind
+        assert rt.dtype.itemsize == np_dtype.itemsize
+        np.testing.assert_array_equal(rt, data)
+
+    # fitsio doesn't support NOCOMPRESS, so the cross-checks stop here.
+    if compression_type == "NOCOMPRESS":
+        return
+
+    # 3. fitsio reads astropy's compressed file.
+    with fitsio.FITS(astropy_path) as fts:
+        rt_fitsio = fts[1].read()
+        assert rt_fitsio.dtype.kind == np_dtype.kind
+        assert rt_fitsio.dtype.itemsize == np_dtype.itemsize
+        np.testing.assert_array_equal(rt_fitsio, data)
+
+    # 4. astropy reads a file fitsio compressed.
+    fitsio_path = tmp_path / "fitsio.fits"
+    with fitsio.FITS(fitsio_path, "rw") as fts:
+        fts.write(data, compress=compression_type)
+    with fits.open(fitsio_path) as hdul:
+        rt_astropy = hdul[1].data
+        assert rt_astropy.dtype.kind == np_dtype.kind
+        assert rt_astropy.dtype.itemsize == np_dtype.itemsize
+        np.testing.assert_array_equal(rt_astropy, data)

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -203,6 +203,8 @@ def test_roundtrip_high_D(
         np.count_nonzero(np.array(shape[:2]) % tile_shape[:2]) != 0
     ):
         pytest.xfail("HCOMPRESS requires 2D tiles.")
+    if compression_type == "PLIO_1" and np.dtype(dtype).kind == "u" and np.dtype(dtype).itemsize >= 2:
+        pytest.xfail("PLIO_1 cannot encode unsigned multi-byte integers")
     random = numpy_rng.uniform(high=255, size=shape)
     # Set first value to be exactly zero as zero values require special treatment
     # for SUBTRACTIVE_DITHER_2

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -203,7 +203,11 @@ def test_roundtrip_high_D(
         np.count_nonzero(np.array(shape[:2]) % tile_shape[:2]) != 0
     ):
         pytest.xfail("HCOMPRESS requires 2D tiles.")
-    if compression_type == "PLIO_1" and np.dtype(dtype).kind == "u" and np.dtype(dtype).itemsize >= 2:
+    if (
+        compression_type == "PLIO_1"
+        and np.dtype(dtype).kind == "u"
+        and np.dtype(dtype).itemsize >= 2
+    ):
         pytest.xfail("PLIO_1 cannot encode unsigned multi-byte integers")
     random = numpy_rng.uniform(high=255, size=shape)
     # Set first value to be exactly zero as zero values require special treatment

--- a/docs/changes/io.fits/19670.bugfix.rst
+++ b/docs/changes/io.fits/19670.bugfix.rst
@@ -1,0 +1,8 @@
+Fix a bug that caused uint64 data to be silently shifted by 2**63 when
+round-tripping through compressed FITS files (the FITS BZERO=2**63 offset was
+missing at compression time but still applied on read). Extend the existing
+RICE_1 and PLIO_1 64-bit-to-32-bit conversion fallback to also cover uint64
+input and HCOMPRESS_1, and fix big-endian 64-bit input being silently truncated
+by the conversion check instead of raising. Reject PLIO_1 with unsigned
+multi-byte input outright, since the BZERO convention used to store unsigned
+FITS data produces negative values that PLIO cannot encode.

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -597,3 +597,106 @@ describes the possible options for constructing a :class:`CompImageHDU` object.
 
 ..
   EXAMPLE END
+
+
+Supported Integer Data Types
+----------------------------
+
+Not every compression algorithm can be used with every integer data type. The
+table below summarizes which combinations work, including the cases where
+``astropy`` accepts the input only when the values lie within a more
+restricted range.
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Compression
+     - ``int16``
+     - ``int32``
+     - ``int64``
+     - ``uint8``
+     - ``uint16``
+     - ``uint32``
+     - ``uint64``
+   * - ``GZIP_1``
+     - ✅
+     - ✅
+     - ⚠️ [1]_
+     - ✅
+     - ✅
+     - ✅
+     - ⚠️ [1]_
+   * - ``GZIP_2``
+     - ✅
+     - ✅
+     - ⚠️ [1]_
+     - ✅
+     - ✅
+     - ✅
+     - ⚠️ [1]_
+   * - ``RICE_1``
+     - ✅
+     - ✅
+     - 🟡 [2]_
+     - ✅
+     - ✅
+     - ✅
+     - 🟡 [2]_
+   * - ``HCOMPRESS_1``
+     - ✅
+     - ✅
+     - 🟡 [2]_
+     - ✅
+     - ✅
+     - ✅
+     - 🟡 [2]_
+   * - ``PLIO_1``
+     - 🟡 [3]_
+     - 🟡 [3]_
+     - 🟡 [2]_ [3]_
+     - ✅
+     - ❌ [4]_
+     - ❌ [4]_
+     - ❌ [4]_
+   * - ``NOCOMPRESS``
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+     - ✅
+
+Legend:
+
+* ✅ Full support: any value within the type's range round-trips losslessly.
+* 🟡 Partial support: works only when input values satisfy the numeric
+  restriction in the corresponding footnote; a ``ValueError`` is raised
+  otherwise.
+* ⚠️ Caveat: round-trips correctly within ``astropy``, but the resulting
+  file may not be readable by other FITS libraries (see footnote).
+* ❌ Not supported: writing the data raises a ``ValueError``.
+
+.. [1] ``astropy`` writes a standards-compliant file, but ``cfitsio`` and
+   tools built on top of it (including ``funpack``, ``fitsio``, and DS9) do
+   not currently support reading 64-bit integer images compressed with
+   ``GZIP_1`` or ``GZIP_2``. The file round-trips correctly when read by
+   ``astropy`` itself.
+
+.. [2] 64-bit integer input is converted to a 32-bit type on write. The
+   conversion succeeds only if every input value fits in the corresponding
+   32-bit range: ``[-2**31, 2**31 - 1]`` for signed and ``[0, 2**32 - 1]``
+   for unsigned. Otherwise a ``ValueError`` is raised. When the conversion
+   succeeds an ``AstropyUserWarning`` is emitted to signal the precision
+   change.
+
+.. [3] ``PLIO_1`` is designed for pixel masks and supports only non-negative
+   integer values up to ``2**24 - 1`` (``16777215``). Negative values or
+   values above this limit cause a ``ValueError`` at write time. For
+   ``int64`` input both this restriction and the 32-bit conversion in
+   footnote [2]_ apply.
+
+.. [4] ``PLIO_1`` cannot store unsigned 16-, 32-, or 64-bit integers. Use
+   ``RICE_1``, ``HCOMPRESS_1``, ``GZIP_1``, or ``GZIP_2`` for unsigned data
+   that does not fit in ``uint8``.


### PR DESCRIPTION
This started off as a continuation of https://github.com/astropy/astropy/pull/19592 - here I've added a round-tripping test against fitsio to make sure that all dtypes we say we support are supported. At the moment 64 of the tests pass, and 20 fail, so I'll be working on trying to fix the bugs or explicitly disabling cases that we can't support.

I will add Extra CI at some point, but no point wasting CPU until the main CI passes.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
