### PR TITLE
TST/BUG: prevent test pollution in two config tests

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2043,6 +2043,7 @@ def test_check_download_cache_works_if_fake_readonly(fake_readonly_cache):
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_pkgname_isolation(temp_cache, valid_urls):
     a = str(uuid4())
 
@@ -2113,6 +2114,7 @@ def test_pkgname_isolation(temp_cache, valid_urls):
 
 
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
+@pytest.mark.usefixtures("ignore_config_paths_global_state")
 def test_transport_cache_via_zip(temp_cache, valid_urls):
     a = str(uuid4())
 


### PR DESCRIPTION
### Description
Extracted from #19650. This is trivially correct and immediately useful, while the rest of the PR is a bit harder to converge.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
