### PR TITLE
DOC/TYP: fix incorrect return type on an internal function

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -19,6 +19,7 @@ import urllib.parse
 import urllib.request
 import zipfile
 from importlib import import_module
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
 from types import MappingProxyType
 from warnings import warn
@@ -1922,7 +1923,7 @@ def clear_download_cache(hashorurl=None, pkgname="astropy"):
         warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
 
 
-def _get_download_cache_loc(pkgname="astropy"):
+def _get_download_cache_loc(pkgname: str = "astropy") -> Path:
     """Finds the path to the cache directory and makes them if they don't exist.
 
     Parameters
@@ -1934,7 +1935,7 @@ def _get_download_cache_loc(pkgname="astropy"):
 
     Returns
     -------
-    datadir : str
+    datadir : pathlib.Path
         The path to the data cache directory.
     """
     try:


### PR DESCRIPTION
### Description
Not technically a bug (the incorrect docstring had no effect), but adding a type annotation helps fixing *other* bugs in call sites.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
