### PR TITLE
Backport PR #19592: Prevent creating compressed files with (u)int64 data (v7.2.x)

### DIFF
--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -5,11 +5,13 @@ the FITS 4 standard.
 """
 
 import sys
+import warnings
 from math import prod
 
 import numpy as np
 
 from astropy.io.fits.hdu.base import BITPIX2DTYPE
+from astropy.utils.exceptions import AstropyUserWarning
 
 from ._codecs import PLIO1, Gzip1, Gzip2, HCompress1, NoCompress, Rice1
 from ._quantization import DITHER_METHODS, QuantizationFailedException, Quantize
@@ -540,6 +542,26 @@ def compress_image_data(
     """
     if not isinstance(image_data, np.ndarray):
         raise TypeError("Image data must be a numpy.ndarray")
+
+    if (
+        compression_type in ("RICE_1", "PLIO_1")
+        and image_data.dtype.kind == "i"
+        and image_data.dtype.itemsize == 8
+    ):
+        new_dt = f"{image_data.dtype.byteorder}{image_data.dtype.kind}4"
+        try:
+            image_data = image_data.astype(new_dt, casting="same_value")
+            compressed_header["ZBITPIX"] = 32
+            warnings.warn(
+                f"{compression_type} compression doesn't support 64 integers, "
+                "data has been converted to 32 bits",
+                AstropyUserWarning,
+            )
+        except ValueError:
+            raise ValueError(
+                f"{compression_type} compression doesn't support 64 integers, "
+                "but data cannot be converted to 32 bits without overflow",
+            )
 
     _check_compressed_header(compressed_header)
 

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1481,7 +1481,7 @@ def test_reserved_keywords_stripped(tmp_path):
     #
     # See also https://github.com/astropy/astropy/issues/18067
 
-    data = np.arange(6).reshape((2, 3))
+    data = np.arange(6, dtype="int32").reshape((2, 3))
 
     hdu = fits.CompImageHDU(data)
     hdu.writeto(tmp_path / "compressed.fits")

--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -10,13 +10,15 @@ cfitsio.
 """
 
 import os
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
 
 from astropy.io import fits
+from astropy.utils.exceptions import AstropyUserWarning
 
-from .conftest import _expand, fitsio_param_to_astropy_param
+from .conftest import COMPRESSION_TYPES, _expand, fitsio_param_to_astropy_param
 
 # This is so that tox can force this file to be run, and not be silently
 # skipped on CI, but in all other test runs it's skipped if fitsio isn't present.
@@ -230,3 +232,50 @@ def test_compress(
 
     with fits.open(astropy_compressed_file_path) as hdul:
         np.testing.assert_allclose(data, hdul[1].data)
+
+
+@pytest.mark.parametrize(
+    "nbytes,overflow", [(2, False), (4, False), (8, False), (8, True)]
+)
+@pytest.mark.parametrize("compression_type", COMPRESSION_TYPES)
+def test_decompress_integers(nbytes, overflow, compression_type, tmp_path):
+    testfile = tmp_path / "test.fits.fz"
+    data = np.random.poisson(1000, size=(52, 57)).astype(f"i{nbytes}")
+    if overflow:
+        data += np.iinfo(np.int32).max
+    data_hdu = fits.PrimaryHDU(data=data)
+    compressed_hdu = fits.CompImageHDU(data=data, compression_type=compression_type)
+
+    if compression_type in ("RICE_1", "PLIO_1") and nbytes == 8:
+        test_func = pytest.raises if overflow else pytest.warns
+        ctx = test_func(
+            ValueError if overflow else AstropyUserWarning,
+            match=f"{compression_type} compression doesn't support 64 integers.*",
+        )
+        nbytes = 4
+    else:
+        ctx = nullcontext()
+
+    with ctx:
+        compressed_hdu.writeto(testfile)
+
+    if overflow:
+        # nothing more to test
+        return
+
+    with fits.open(testfile, disable_image_compression=True) as hdul:
+        assert hdul[1].header["ZCMPTYPE"] == compression_type
+        if compression_type == "RICE_1":
+            assert hdul[1].header["ZNAME2"] == "BYTEPIX"
+            assert hdul[1].header["ZVAL2"] == nbytes
+
+    with fits.open(testfile) as hdul:
+        np.testing.assert_array_equal(data, hdul[1].data)
+        assert hdul[1].data.dtype.kind == np.dtype(data.dtype).kind
+        assert hdul[1].data.dtype.itemsize == nbytes
+
+    if compression_type != "NOCOMPRESS" and nbytes != 8:
+        # fitsio does not support NOCOMPRESS or 64-bit data
+        fts = fitsio.FITS(testfile)
+        data2 = fts[1].read()
+        np.testing.assert_array_equal(data, data2)

--- a/docs/changes/io.fits/19592.bugfix.rst
+++ b/docs/changes/io.fits/19592.bugfix.rst
@@ -1,0 +1,3 @@
+Prevent creating RICE_1 or PLIO_1 compressed files with (u)int64 data. If
+possible without overflow data is converted to (u)int32, otherwise an error is
+raised.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport https://github.com/astropy/astropy/pull/19592 for v7.2.x because auto-backport failed.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
