### PR TITLE
RFC: use dedicated type pathlib.Path for internal objects in astropy.utils.data

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -19,6 +19,7 @@ import urllib.parse
 import urllib.request
 import zipfile
 from collections.abc import Container, Generator, Iterable
+from contextlib import suppress
 from importlib import import_module
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
@@ -1133,19 +1134,23 @@ def _find_hash_fn(
 
 
 @overload
-def get_free_space_in_dir(path: str, unit: Literal[False]) -> int: ...
+def get_free_space_in_dir(
+    path: str | os.PathLike[str], unit: Literal[False]
+) -> int: ...
 @overload
-def get_free_space_in_dir(path: str, unit: UnitBase | Literal[True]) -> Quantity: ...
+def get_free_space_in_dir(
+    path: str | os.PathLike[str], unit: UnitBase | Literal[True]
+) -> Quantity: ...
 
 
-def get_free_space_in_dir(path, unit: UnitBase | bool = False):
+def get_free_space_in_dir(path: str | os.PathLike[str], unit: UnitBase | bool = False):
     """
     Given a path to a directory, returns the amount of free space
     on that filesystem.
 
     Parameters
     ----------
-    path : str
+    path : str, os.PathLike
         The path to a directory.
 
     unit : bool or `~astropy.units.Unit`
@@ -1159,7 +1164,7 @@ def get_free_space_in_dir(path, unit: UnitBase | bool = False):
         If ``unit=False``, it is returned as plain integer (in bytes).
 
     """
-    if not os.path.isdir(path):
+    if not (path := Path(path)).is_dir():
         raise OSError(
             "Can only determine free space associated with directories, not files."
         )
@@ -1342,7 +1347,7 @@ def _download_file_from_source(
     ftp_tls=None,
     ssl_context=None,
     allow_insecure: bool = False,
-) -> str:
+) -> Path:
     from astropy.utils.console import ProgressBarOrSpinner
 
     if not conf.allow_internet:
@@ -1418,6 +1423,7 @@ def _download_file_from_source(
             with NamedTemporaryFile(
                 prefix=f"astropy-download-{os.getpid()}-", delete=False
             ) as f:
+                fp = Path(f.name)
                 try:
                     bytes_read = 0
                     block = remote.read(conf.download_block_size)
@@ -1439,13 +1445,10 @@ def _download_file_from_source(
                             content=None,
                         )
                 except BaseException:
-                    if os.path.exists(f.name):
-                        try:
-                            os.remove(f.name)
-                        except OSError:
-                            pass
+                    with suppress(PermissionError):
+                        fp.unlink()
                     raise
-    return f.name
+    return fp
 
 
 def download_file(
@@ -1591,9 +1594,9 @@ def download_file(
                     "otherwise use a boolean"
                 )
             else:
-                filename = os.path.join(dldir, _url_to_dirname(url_key), "contents")
-                if os.path.exists(filename):
-                    return os.path.abspath(filename)
+                filename = dldir / _url_to_dirname(url_key) / "contents"
+                if filename.exists():
+                    return str(filename.absolute())
 
     errors = {}
     for source_url in sources:
@@ -1634,7 +1637,7 @@ def download_file(
         try:
             return import_file_to_cache(
                 url_key,
-                f_name,
+                str(f_name),
                 remove_original=True,
                 replace=(cache == "update"),
                 pkgname=pkgname,
@@ -1689,8 +1692,8 @@ def is_url_in_cache(
         dldir = _get_download_cache_loc(pkgname)
     except OSError:
         return False
-    filename = os.path.join(dldir, _url_to_dirname(url_key), "contents")
-    return os.path.exists(filename)
+    filename = dldir / _url_to_dirname(url_key) / "contents"
+    return filename.exists()
 
 
 def cache_total_size(
@@ -1858,7 +1861,7 @@ def download_files_in_parallel(
 
 # This is used by download_file and _deltemps to determine the files to delete
 # when the interpreter exits
-_tempfilestodel = []
+_tempfilestodel: list[Path] = []
 
 
 @atexit.register
@@ -1866,14 +1869,14 @@ def _deltemps():
     if _tempfilestodel is not None:
         while len(_tempfilestodel) > 0:
             fn = _tempfilestodel.pop()
-            if os.path.isfile(fn):
+            if fn.is_file():
                 try:
-                    os.remove(fn)
+                    fn.unlink()
                 except OSError:
                     # oh well we tried
                     # could be held open by some process, on Windows
                     pass
-            elif os.path.isdir(fn):
+            elif fn.is_dir():
                 try:
                     shutil.rmtree(fn)
                 except OSError:
@@ -1923,7 +1926,7 @@ def clear_download_cache(
             # Optional: delete old incompatible caches too
             _rmtree(dldir)
         elif _is_url(hashorurl):
-            filepath = os.path.join(dldir, _url_to_dirname(hashorurl))
+            filepath = dldir / _url_to_dirname(hashorurl)
             _rmtree(filepath)
         else:
             # Not a URL, it should be either a filename or a hash
@@ -2015,7 +2018,13 @@ class CacheDamaged(ValueError):
     whichever is not None, should resolve this particular problem.
     """
 
-    def __init__(self, *args, bad_urls=None, bad_files=None, **kwargs):
+    def __init__(
+        self,
+        *args: object,
+        bad_urls: list[str] | None = None,
+        bad_files: list[Path] | None = None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.bad_urls = bad_urls if bad_urls is not None else []
         self.bad_files = bad_files if bad_files is not None else []
@@ -2064,12 +2073,12 @@ def check_download_cache(
         :func:`clear_download_cache` to resolve, or may indicate some kind of
         misconfiguration.
     """
-    bad_files = set()
-    messages = set()
+    bad_files: str[Path] = set()
+    messages: set[str] = set()
     dldir = _get_download_cache_loc(pkgname=pkgname)
     with os.scandir(dldir) as it:
         for entry in it:
-            f = os.path.abspath(os.path.join(dldir, entry.name))
+            f = dldir.joinpath(entry.name).absolute()
             if entry.name.startswith("rmtree-"):
                 if f not in _tempfilestodel:
                     bad_files.add(f)
@@ -2078,12 +2087,12 @@ def check_download_cache(
                 for sf in os.listdir(f):
                     if sf in ["url", "contents"]:
                         continue
-                    sf = os.path.join(f, sf)
+                    sf = f / sf
                     bad_files.add(sf)
                     messages.add(f"Unexpected file f{sf}")
-                urlf = os.path.join(f, "url")
+                urlf = f / "url"
                 url = None
-                if not os.path.isfile(urlf):
+                if not urlf.is_file():
                     bad_files.add(urlf)
                     messages.add(f"Problem with URL file f{urlf}")
                 else:
@@ -2099,7 +2108,7 @@ def check_download_cache(
                                 f"URL hashes to {hashname} but is stored in"
                                 f" {entry.name}"
                             )
-                if not os.path.isfile(os.path.join(f, "contents")):
+                if not f.joinpath("contents").is_file():
                     bad_files.add(f)
                     if url is None:
                         messages.add(f"Hash {entry.name} is missing contents")
@@ -2111,7 +2120,7 @@ def check_download_cache(
                 bad_files.add(f)
                 messages.add(f"Left-over non-directory {f} in cache")
     if bad_files:
-        raise CacheDamaged("\n".join(messages), bad_files=bad_files)
+        raise CacheDamaged("\n".join(messages), bad_files=sorted(bad_files))
 
 
 def _rmtree(
@@ -2202,17 +2211,17 @@ def import_file_to_cache(
     """
     cache_dir = _get_download_cache_loc(pkgname=pkgname)
     cache_dirname = _url_to_dirname(url_key)
-    local_dirname = os.path.join(cache_dir, cache_dirname)
-    local_filename = os.path.join(local_dirname, "contents")
+    local_dirname = cache_dir / cache_dirname
+    local_filename = local_dirname / "contents"
     with TemporaryDirectory(
         prefix="temp_dir", dir=cache_dir, ignore_cleanup_errors=True
     ) as temp_dir:
-        temp_filename = os.path.join(temp_dir, "contents")
+        temp_path = Path(temp_dir)
+        temp_filename = temp_path / "contents"
         # Make sure we're on the same filesystem
         # This will raise an exception if the url_key doesn't turn into a valid filename
         shutil.copy(filename, temp_filename)
-        with open(os.path.join(temp_dir, "url"), "w", encoding="utf-8") as f:
-            f.write(url_key)
+        temp_path.joinpath("url").write_text(url_key, encoding="utf-8")
         if replace:
             _rmtree(local_dirname, replace=temp_dir)
         else:
@@ -2280,10 +2289,8 @@ def cache_contents(pkgname: str = "astropy") -> MappingProxyType[str, str]:
     with os.scandir(dldir) as it:
         for entry in it:
             if entry.is_dir():
-                url = get_file_contents(
-                    os.path.join(dldir, entry.name, "url"), encoding="utf-8"
-                )
-                r[url] = os.path.abspath(os.path.join(dldir, entry.name, "contents"))
+                url = get_file_contents(dldir / entry.name / "url", encoding="utf-8")
+                r[str(url)] = str(dldir.joinpath(entry.name, "contents").absolute())
     return MappingProxyType(r)
 
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1521,7 +1521,7 @@ def test_download_file_local_directory(tmp_path):
 def test_download_file_schedules_deletion(valid_urls):
     u, c = next(valid_urls)
     f = download_file(u)
-    assert f in _tempfilestodel
+    assert Path(f) in _tempfilestodel
     # how to test deletion actually occurs?
 
 
@@ -1541,7 +1541,7 @@ def test_check_download_cache_finds_bogus_entries(temp_cache, valid_urls):
     u, c = next(valid_urls)
     download_file(u, cache=True)
     dldir = _get_download_cache_loc()
-    bf = os.path.abspath(os.path.join(dldir, "bogus"))
+    bf = dldir.joinpath("bogus").absolute()
     with open(bf, "w") as f:
         f.write("bogus file that exists")
     with pytest.raises(CacheDamaged) as e:
@@ -1553,10 +1553,9 @@ def test_check_download_cache_finds_bogus_entries(temp_cache, valid_urls):
 @pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
 def test_check_download_cache_finds_bogus_subentries(temp_cache, valid_urls):
     u, c = next(valid_urls)
-    f = download_file(u, cache=True)
-    bf = os.path.abspath(os.path.join(os.path.dirname(f), "bogus"))
-    with open(bf, "w") as f:
-        f.write("bogus file that exists")
+    f = Path(download_file(u, cache=True))
+    bf = f.parent.joinpath("bogus").absolute()
+    bf.write_text("bogus file that exists")
     with pytest.raises(CacheDamaged) as e:
         check_download_cache()
     assert bf in e.value.bad_files
@@ -1569,28 +1568,24 @@ def test_check_download_cache_cleanup(temp_cache, valid_urls):
     fn = download_file(u, cache=True)
     dldir = _get_download_cache_loc()
 
-    bf1 = os.path.abspath(os.path.join(dldir, "bogus1"))
-    with open(bf1, "w") as f:
-        f.write("bogus file that exists")
+    bf1 = dldir.joinpath("bogus1").absolute()
+    bf1.write_text("bogus file that exists")
 
-    bf2 = os.path.abspath(os.path.join(os.path.dirname(fn), "bogus2"))
-    with open(bf2, "w") as f:
-        f.write("other bogus file that exists")
+    bf2 = Path(fn).parent.joinpath("bogus2").absolute()
+    bf2.write_text("other bogus file that exists")
 
-    bf3 = os.path.abspath(os.path.join(dldir, "contents"))
-    with open(bf3, "w") as f:
-        f.write("awkwardly-named bogus file that exists")
+    bf3 = dldir.joinpath("contents").absolute()
+    bf3.write_text("awkwardly-named bogus file that exists")
 
-    u2, c2 = next(valid_urls)
-    f2 = download_file(u, cache=True)
-    os.unlink(f2)
-    bf4 = os.path.dirname(f2)
+    f2 = Path(download_file(u, cache=True))
+    f2.unlink()
+    bf4 = f2.parent
 
     with pytest.raises(CacheDamaged) as e:
         check_download_cache()
     assert set(e.value.bad_files) == {bf1, bf2, bf3, bf4}
     for bf in e.value.bad_files:
-        clear_download_cache(bf)
+        clear_download_cache(str(bf))
     # download cache will be checked on exit
 
 


### PR DESCRIPTION
### Description
This is a refactor with no user-observable changes. It's helpful to use a dedicated type for paths internally so, in particular for private functions' return types, and I'm using this to debug #19650. This is the isolated, self contained version of this.
~At the time of opening, this is based off #19681~

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
