### PR TITLE
Extract logical-VLA helpers to dedicated private module

### DIFF
--- a/astropy/io/fits/_logical_helpers.py
+++ b/astropy/io/fits/_logical_helpers.py
@@ -1,0 +1,74 @@
+"""Helpers for handling FITS logical (``'L'``) variable-length array data."""
+
+import numpy as np
+
+
+def _logical_to_fits_bytes(row):
+    """Convert a logical-VLA row to its FITS L wire-format bytes.
+
+    Returns an int8 array containing ord('T') / ord('F'). Bool inputs map
+    to T/F; numeric inputs treat zero as False and non-zero as True.
+    Bytes input (|S1, e.g. from reading with ``logical_as_bytes=True``)
+    is viewed as int8 verbatim so that NULL (b'\\x00') survives.
+    """
+    arr = np.asarray(row)
+    if arr.dtype.kind == "S":
+        return arr.view(np.int8)
+    if arr.dtype == bool:
+        return np.where(arr, ord("T"), ord("F")).astype(np.int8)
+    return np.where(arr == 0, ord("F"), ord("T")).astype(np.int8)
+
+
+def _logical_vla_heap_has_null(raw_data, field, heap_offset):
+    """Return True if the heap unambiguously contains NULL bytes.
+
+    Used to decide whether to warn that NULL values would be silently
+    converted to False when reading a logical VLA column without
+    ``logical_as_bytes=True``. To avoid a misleading warning on an
+    all-zero heap (which under the FITS standard means all-NULL but
+    under the astropy <= 7.2.0 legacy encoding means all-False), this
+    requires both a 0x00 byte AND at least one ord('T') / ord('F')
+    byte. The legacy-detection heuristic in
+    ``_detect_legacy_logical_vla_heap`` separately catches files with
+    a 0x01 byte; the only case this still treats as ambiguous is a
+    heap containing nothing but 0x00, where the read value (``False``)
+    is correct under either interpretation.
+    """
+    has_null = False
+    has_tf = False
+    for idx in range(len(field)):
+        offset = int(field[idx, 1]) + heap_offset
+        count = int(field[idx, 0])
+        if not count:
+            continue
+        chunk = raw_data[offset : offset + count]
+        if not has_null and (chunk == 0).any():
+            has_null = True
+        if not has_tf and ((chunk == ord("T")) | (chunk == ord("F"))).any():
+            has_tf = True
+        if has_null and has_tf:
+            return True
+    return False
+
+
+def _detect_legacy_logical_vla_heap(raw_data, field, heap_offset):
+    """Heuristically detect a logical VLA column written by astropy <= 7.2.0.
+
+    astropy <= 7.2.0 stored bool VLA values as 0x00/0x01 bytes instead of the
+    FITS L wire format ord('T') (0x54) / ord('F') (0x46). A column is
+    classified as legacy when its heap region contains the byte 0x01 and no
+    bytes other than 0x00 / 0x01 (those values cannot occur in a correctly
+    written L column, where only 0x00, 0x46, 0x54 are valid). Heaps
+    containing only 0x00 are ambiguous but indistinguishable in either
+    interpretation.
+    """
+    bufs = []
+    for idx in range(len(field)):
+        offset = int(field[idx, 1]) + heap_offset
+        count = int(field[idx, 0])
+        if count:
+            bufs.append(raw_data[offset : offset + count].view(np.uint8))
+    if not bufs:
+        return False
+    unique = np.unique(np.concatenate(bufs))
+    return bool(np.all(unique <= 1)) and 1 in unique

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -12,6 +12,11 @@ from astropy.utils import lazyproperty
 from astropy.utils.compat import chararray, get_chararray
 from astropy.utils.exceptions import AstropyUserWarning
 
+from ._logical_helpers import (
+    _detect_legacy_logical_vla_heap,
+    _logical_to_fits_bytes,
+    _logical_vla_heap_has_null,
+)
 from .column import (
     _VLF,
     ASCII2NUMPY,
@@ -1465,76 +1470,6 @@ class FITS_rec(np.recarray):
         column_lists = [self[name].tolist() for name in self.columns.names]
 
         return [list(row) for row in zip(*column_lists)]
-
-
-def _logical_to_fits_bytes(row):
-    """Convert a logical-VLA row to its FITS L wire-format bytes.
-
-    Returns an int8 array containing ord('T') / ord('F'). Bool inputs map
-    to T/F; numeric inputs treat zero as False and non-zero as True.
-    Bytes input (|S1, e.g. from reading with ``logical_as_bytes=True``)
-    is viewed as int8 verbatim so that NULL (b'\\x00') survives.
-    """
-    arr = np.asarray(row)
-    if arr.dtype.kind == "S":
-        return arr.view(np.int8)
-    if arr.dtype == bool:
-        return np.where(arr, ord("T"), ord("F")).astype(np.int8)
-    return np.where(arr == 0, ord("F"), ord("T")).astype(np.int8)
-
-
-def _logical_vla_heap_has_null(raw_data, field, heap_offset):
-    """Return True if the heap unambiguously contains NULL bytes.
-
-    Used to decide whether to warn that NULL values would be silently
-    converted to False when reading a logical VLA column without
-    ``logical_as_bytes=True``. To avoid a misleading warning on an
-    all-zero heap (which under the FITS standard means all-NULL but
-    under the astropy <= 7.2.0 legacy encoding means all-False), this
-    requires both a 0x00 byte AND at least one ord('T') / ord('F')
-    byte. The legacy-detection heuristic in
-    ``_detect_legacy_logical_vla_heap`` separately catches files with
-    a 0x01 byte; the only case this still treats as ambiguous is a
-    heap containing nothing but 0x00, where the read value (``False``)
-    is correct under either interpretation.
-    """
-    has_null = False
-    has_tf = False
-    for idx in range(len(field)):
-        offset = int(field[idx, 1]) + heap_offset
-        count = int(field[idx, 0])
-        if not count:
-            continue
-        chunk = raw_data[offset : offset + count]
-        if not has_null and (chunk == 0).any():
-            has_null = True
-        if not has_tf and ((chunk == ord("T")) | (chunk == ord("F"))).any():
-            has_tf = True
-        if has_null and has_tf:
-            return True
-    return False
-
-
-def _detect_legacy_logical_vla_heap(raw_data, field, heap_offset):
-    """Heuristically detect a logical VLA column written by astropy <= 7.2.0.
-
-    astropy <= 7.2.0 stored bool VLA values as 0x00/0x01 bytes instead of the
-    FITS L wire format ord('T') (0x54) / ord('F') (0x46). A column is
-    classified as legacy when its heap region contains the byte 0x01 and no
-    bytes other than 0x00 / 0x01 — those values cannot occur in a correctly
-    written L column (only 0x00, 0x46, 0x54 are valid). Heaps containing
-    only 0x00 are ambiguous but indistinguishable in either interpretation.
-    """
-    bufs = []
-    for idx in range(len(field)):
-        offset = int(field[idx, 1]) + heap_offset
-        count = int(field[idx, 0])
-        if count:
-            bufs.append(raw_data[offset : offset + count].view(np.uint8))
-    if not bufs:
-        return False
-    unique = np.unique(np.concatenate(bufs))
-    return bool(np.all(unique <= 1)) and 1 in unique
 
 
 def _get_recarray_field(array, key):

--- a/astropy/io/fits/tests/test_logical_helpers.py
+++ b/astropy/io/fits/tests/test_logical_helpers.py
@@ -1,0 +1,84 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from astropy.io.fits._logical_helpers import (
+    _detect_legacy_logical_vla_heap,
+    _logical_to_fits_bytes,
+    _logical_vla_heap_has_null,
+)
+
+
+class TestLogicalToFitsBytes:
+    def test_S1_viewed_as_int8(self):
+        row = np.array([b"T", b"\x00", b"F"], dtype="S1")
+        out = _logical_to_fits_bytes(row)
+        assert out.dtype == np.int8
+        assert_array_equal(out, [ord("T"), 0, ord("F")])
+
+    def test_bool_input(self):
+        out = _logical_to_fits_bytes(np.array([True, False, True]))
+        assert_array_equal(out, [ord("T"), ord("F"), ord("T")])
+
+    def test_numeric_nonzero_is_true(self):
+        out = _logical_to_fits_bytes(np.array([0, 1, -3, 7]))
+        assert_array_equal(out, [ord("F"), ord("T"), ord("T"), ord("T")])
+
+
+class TestLogicalVlaHeapHasNull:
+    @staticmethod
+    def _heap(rows):
+        """Build a (raw_data, field, heap_offset) triple from per-row bytes."""
+        offsets, counts, blob = [], [], b""
+        for r in rows:
+            offsets.append(len(blob))
+            counts.append(len(r))
+            blob += r
+        field = np.array(list(zip(counts, offsets)), dtype=np.int64)
+        raw_data = np.frombuffer(blob, dtype=np.uint8)
+        return raw_data, field, 0
+
+    def test_mixed_null_and_tf(self):
+        raw, field, off = self._heap([b"T\x00F", b"T"])
+        assert _logical_vla_heap_has_null(raw, field, off) is True
+
+    def test_only_nulls_is_ambiguous(self):
+        # All-zero heap could be all-NULL or pre-fix all-False; not flagged.
+        raw, field, off = self._heap([b"\x00\x00", b"\x00"])
+        assert _logical_vla_heap_has_null(raw, field, off) is False
+
+    def test_only_tf_no_null(self):
+        raw, field, off = self._heap([b"TF", b"FT"])
+        assert _logical_vla_heap_has_null(raw, field, off) is False
+
+    def test_empty_rows_skipped(self):
+        raw, field, off = self._heap([b"", b"T\x00"])
+        assert _logical_vla_heap_has_null(raw, field, off) is True
+
+
+class TestDetectLegacyLogicalVlaHeap:
+    @staticmethod
+    def _heap(blob):
+        raw_data = np.frombuffer(blob, dtype=np.uint8)
+        field = np.array([[len(blob), 0]], dtype=np.int64)
+        return raw_data, field, 0
+
+    def test_legacy_zeros_and_ones(self):
+        raw, field, off = self._heap(b"\x00\x01\x01\x00")
+        assert _detect_legacy_logical_vla_heap(raw, field, off) is True
+
+    def test_modern_TF_bytes_not_legacy(self):
+        raw, field, off = self._heap(b"TFT\x00")
+        assert _detect_legacy_logical_vla_heap(raw, field, off) is False
+
+    def test_all_zero_not_legacy_no_anchor(self):
+        # Without a 0x01 anchor we cannot distinguish all-NULL from all-False;
+        # the function returns False so the modern decoder runs.
+        raw, field, off = self._heap(b"\x00\x00\x00")
+        assert _detect_legacy_logical_vla_heap(raw, field, off) is False
+
+    def test_no_rows_returns_false(self):
+        raw = np.empty(0, dtype=np.uint8)
+        field = np.empty((0, 2), dtype=np.int64)
+        assert _detect_legacy_logical_vla_heap(raw, field, 0) is False


### PR DESCRIPTION
This is just moving private code around in preparation for another PR which will fix some more issues with the logical-VLA columns. This also adds unit tests for the logical helpers.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
