### PR TITLE
Fix setting of NULL values in logical FITS columns

### DIFF
--- a/astropy/io/fits/_logical_helpers.py
+++ b/astropy/io/fits/_logical_helpers.py
@@ -1,6 +1,49 @@
-"""Helpers for handling FITS logical (``'L'``) variable-length array data."""
+# Licensed under a 3-clause BSD style license
+
+"""
+Helpers for handling FITS logical (``'L'``) column data.
+"""
 
 import numpy as np
+
+
+def _logical_row_uses_byte_storage(row):
+    """Return True if a logical-column input needs |S1 storage to preserve NULL.
+
+    Triggers for |S1 byte arrays (produced by reading with
+    ``logical_as_bytes=True``), ``np.ma.MaskedArray`` input, and Python
+    lists/tuples containing ``None``.
+    """
+    if isinstance(row, np.ndarray) and row.dtype.kind == "S":
+        return True
+    if np.ma.isMaskedArray(row):
+        return True
+    if isinstance(row, (list, tuple)) and any(v is None for v in row):
+        return True
+    return False
+
+
+def _logical_row_to_byte_storage(row):
+    """Convert a logical-column input to |S1 bytes, mapping masked/None to NULL.
+
+    Accepts |S1 byte arrays (preserved verbatim), ``np.ma.MaskedArray``
+    of any shape, and Python lists/tuples containing ``None``.
+    """
+    if isinstance(row, np.ndarray) and row.dtype.kind == "S":
+        return np.asarray(row, dtype="S1")
+    if np.ma.isMaskedArray(row):
+        mask = np.ma.getmaskarray(row)
+        clean = np.asarray(row.filled(False), dtype=np.int8)
+    elif isinstance(row, (list, tuple)) and any(v is None for v in row):
+        mask = np.array([v is None for v in row])
+        clean = np.array([False if v is None else v for v in row], dtype=np.int8)
+    else:
+        mask = None
+        clean = np.array(row, dtype=np.int8)
+    bytes_arr = np.where(clean == 0, ord("F"), ord("T")).astype(np.int8)
+    if mask is not None:
+        bytes_arr[mask] = 0
+    return bytes_arr.view("S1")
 
 
 def _logical_to_fits_bytes(row):

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -18,6 +18,10 @@ from astropy.utils import lazyproperty
 from astropy.utils.compat import chararray, get_chararray
 from astropy.utils.exceptions import AstropyUserWarning
 
+from ._logical_helpers import (
+    _logical_row_to_byte_storage,
+    _logical_row_uses_byte_storage,
+)
 from .card import CARD_LENGTH, Card
 from .util import NotifierMixin, _convert_array, _is_int, cmp, encode_ascii
 from .verify import VerifyError, VerifyWarning
@@ -695,7 +699,33 @@ class Column(NotifierMixin):
         # input arrays can be just list or tuple, not required to be ndarray
         # does not include Object array because there is no guarantee
         # the elements in the object array are consistent.
+        # Detect logical L columns (both fixed-length and VLA), so the
+        # NULL-preservation pre-conversion below applies to both.
+        is_fixed_logical = getattr(self.format, "format", None) == "L"
+        is_vla_logical = getattr(self.format, "p_format", None) == "L"
+        is_logical = is_fixed_logical or is_vla_logical
+
+        # Whole-array ``np.ma.MaskedArray`` for a logical column: convert
+        # directly to |S1 with NULL at masked positions. This case skips
+        # the ``not isinstance(array, np.ndarray)`` branch below because
+        # MaskedArray is itself an ndarray subclass.
+        if array is not None and is_logical and np.ma.isMaskedArray(array):
+            array = _logical_row_to_byte_storage(array)
+
         if not isinstance(array, (np.ndarray, chararray, Delayed)):
+            # For logical columns, ``np.array`` would silently drop the
+            # mask of a ``np.ma.MaskedArray`` row and refuse to handle a
+            # row containing ``None``. Convert such inputs up front to
+            # |S1 byte arrays so the NULL information survives.
+            if array is not None and is_logical:
+                if any(_logical_row_uses_byte_storage(row) for row in array):
+                    # List of rows, some of which need byte storage
+                    array = [_logical_row_to_byte_storage(row) for row in array]
+                elif is_fixed_logical and any(v is None for v in array):
+                    # Fixed-length L (e.g. format='1L') with a flat list
+                    # of scalars containing ``None``; treat the whole
+                    # list as a single sequence with NULL at None.
+                    array = _logical_row_to_byte_storage(list(array))
             try:  # try to convert to a ndarray first
                 if array is not None:
                     array = np.array(array)
@@ -2249,14 +2279,15 @@ def _makep(array, descr_output, format, nrows=None):
         nrows = len(array)
 
     # Logical VLAs ('PL'/'QL') are stored in the _VLF as user-facing bool
-    # values. The FITS L wire format (ord('T')/ord('F')) is produced at
-    # heap-write time in FITS_rec._get_heap_data.
-    # If the input rows are already |S1 byte arrays (produced by reading
-    # with ``logical_as_bytes=True``), the bytes are preserved verbatim
-    # so NULL (b'\x00') survives a round-trip.
+    # values. The FITS L storage bytes (ord('T')/ord('F')) are written
+    # to the heap in FITS_rec._get_heap_data.
+    # Rows that need to carry NULL information (|S1 byte arrays from a
+    # ``logical_as_bytes=True`` read, ``np.ma.MaskedArray`` input, or a
+    # Python list/tuple containing ``None``) force the column to use
+    # |S1 storage so that NULL (b'\x00') survives the round-trip.
     is_logical = format.format == "L"
     is_logical_bytes = is_logical and any(
-        isinstance(row, np.ndarray) and row.dtype.kind == "S" for row in array
+        _logical_row_uses_byte_storage(row) for row in array
     )
     if is_logical:
         element_dtype = "S1" if is_logical_bytes else "b1"
@@ -2284,8 +2315,10 @@ def _makep(array, descr_output, format, nrows=None):
             data_output[idx] = get_chararray(encode_ascii(rowval), itemsize=1)
         elif is_logical_bytes:
             # |S1 byte input is preserved verbatim so NULL (b'\x00')
-            # survives a round-trip.
-            data_output[idx] = np.asarray(rowval, dtype="S1")
+            # survives a round-trip; ``np.ma.MaskedArray`` and lists
+            # containing ``None`` are converted to |S1 with NULL bytes
+            # at the masked / None positions.
+            data_output[idx] = _logical_row_to_byte_storage(rowval)
         elif is_logical:
             # Route through int8 first so non-numeric/non-bool inputs
             # (strings, None, ...) raise at write time, matching the

--- a/astropy/io/fits/tests/test_logical_helpers.py
+++ b/astropy/io/fits/tests/test_logical_helpers.py
@@ -1,13 +1,74 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 from astropy.io.fits._logical_helpers import (
     _detect_legacy_logical_vla_heap,
+    _logical_row_to_byte_storage,
+    _logical_row_uses_byte_storage,
     _logical_to_fits_bytes,
     _logical_vla_heap_has_null,
 )
+
+
+class TestLogicalRowUsesByteStorage:
+    @pytest.mark.parametrize(
+        "row",
+        [
+            np.array([b"T", b"F"], dtype="S1"),
+            np.ma.masked_array([True, False], mask=[True, False]),
+            [True, None, False],
+            (None, True),
+        ],
+    )
+    def test_yes(self, row):
+        assert _logical_row_uses_byte_storage(row) is True
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            [True, False],
+            np.array([True, False]),
+            np.array([1, 0], dtype=np.int8),
+        ],
+    )
+    def test_no(self, row):
+        assert _logical_row_uses_byte_storage(row) is False
+
+
+class TestLogicalRowToByteStorage:
+    def test_preserves_S1_input_verbatim(self):
+        row = np.array([b"T", b"\x00", b"F"], dtype="S1")
+        out = _logical_row_to_byte_storage(row)
+        assert out.dtype == np.dtype("S1")
+        assert out.tobytes() == b"T\x00F"
+
+    def test_masked_array_writes_null_at_mask(self):
+        row = np.ma.masked_array([True, False, True], mask=[False, True, False])
+        out = _logical_row_to_byte_storage(row)
+        assert out.tobytes() == b"T\x00T"
+
+    def test_list_with_none_writes_null(self):
+        out = _logical_row_to_byte_storage([True, None, False])
+        assert out.tobytes() == b"T\x00F"
+
+    def test_pure_bool_list(self):
+        out = _logical_row_to_byte_storage([True, False, True])
+        assert out.tobytes() == b"TFT"
+
+    def test_2d_masked_array_preserves_shape(self):
+        # Whole-array MaskedArray (used for fixed-length L columns where
+        # the user passes an N-D MaskedArray rather than a list of rows).
+        ma = np.ma.masked_array(
+            [[False, False, True], [True, False, False]],
+            mask=[[True, False, False], [False, True, False]],
+        )
+        out = _logical_row_to_byte_storage(ma)
+        assert out.shape == (2, 3)
+        assert out[0].tobytes() == b"\x00FT"
+        assert out[1].tobytes() == b"T\x00F"
 
 
 class TestLogicalToFitsBytes:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2635,19 +2635,112 @@ class TestTableFunctions(FitsTestCase):
         [
             (["T", "F", "T"], ValueError),
             (["Y", "N"], ValueError),
-            ([None, False, True], TypeError),
         ],
     )
     def test_logical_vla_rejects_non_numeric_input(self, tmp_path, rowval, exc):
         """Logical VLA columns reject non-numeric / non-bool inputs at
         write time (matching the behavior of astropy <= 7.2.0). Without
-        this the new bool conversion would silently coerce strings/None:
+        this the new bool conversion would silently coerce strings:
         e.g. ``["T", "F", "T"]`` to ``[True, True, True]`` because
-        non-empty strings are truthy.
+        non-empty strings are truthy. Lists containing ``None`` are
+        accepted and produce NULL bytes; see
+        ``test_logical_vla_writes_null_from_masked_or_none``.
         """
         col = fits.Column(name="flag", format="PL()", array=[rowval])
         with pytest.raises(exc):
             fits.BinTableHDU.from_columns([col]).writeto(tmp_path / "bad.fits")
+
+    def test_logical_vla_writes_null_from_masked_or_none(self, tmp_path):
+        """Masked positions in an ``np.ma.MaskedArray`` row, and ``None``
+        entries in a list/tuple row, are written as NULL bytes (b'\\x00')
+        to the heap of a logical VLA column. ``logical_as_bytes=True``
+        on read exposes the raw bytes so the round-trip is verifiable.
+        """
+        col = fits.Column(
+            name="flag",
+            format="PL()",
+            array=[
+                np.ma.masked_array([False, False, True], mask=[True, False, False]),
+                [None, False, True],
+            ],
+        )
+        out_path = tmp_path / "vla_null_write.fits"
+        fits.BinTableHDU.from_columns([col]).writeto(out_path)
+
+        with fits.open(out_path, logical_as_bytes=True) as hdul:
+            d = hdul[1].data["flag"]
+            assert d[0].dtype == np.dtype("S1")
+            assert d[0].tobytes() == b"\x00FT"
+            assert d[1].tobytes() == b"\x00FT"
+
+    def test_logical_vla_writes_mixed_null_and_plain_rows(self, tmp_path):
+        """When the column array mixes rows that carry NULL information
+        (``np.ma.MaskedArray`` or list-with-``None``) with rows that
+        don't, the column switches to |S1 storage and the plain rows
+        are converted alongside the NULL-carrying ones without losing
+        their bool values.
+        """
+        col = fits.Column(
+            name="flag",
+            format="PL()",
+            array=[
+                np.ma.masked_array([False, False, True], mask=[True, False, False]),
+                [True, False, True],
+            ],
+        )
+        out_path = tmp_path / "vla_mixed.fits"
+        fits.BinTableHDU.from_columns([col]).writeto(out_path)
+
+        with fits.open(out_path, logical_as_bytes=True) as hdul:
+            d = hdul[1].data["flag"]
+            assert d[0].tobytes() == b"\x00FT"
+            assert d[1].tobytes() == b"TFT"
+
+    def test_logical_fixed_writes_null_from_masked_or_none(self, tmp_path):
+        """Same NULL-preservation works for fixed-length logical columns.
+        Three input shapes are accepted: a list of rows where some rows
+        are ``np.ma.MaskedArray`` or contain ``None``; a whole-array
+        ``np.ma.MaskedArray`` of shape (nrows, repeat); and (for
+        ``format='1L'``) a flat list of scalars with ``None``.
+        """
+        # Case 1: list with MaskedArray row + list-with-None row
+        col = fits.Column(
+            name="flag",
+            format="3L",
+            array=[
+                np.ma.masked_array([False, False, True], mask=[True, False, False]),
+                [None, False, True],
+            ],
+        )
+        path1 = tmp_path / "fixed_list.fits"
+        fits.BinTableHDU.from_columns([col]).writeto(path1)
+        with fits.open(path1, logical_as_bytes=True) as hdul:
+            d = hdul[1].data["flag"]
+            assert d[0].tobytes() == b"\x00FT"
+            assert d[1].tobytes() == b"\x00FT"
+
+        # Case 2: whole-array MaskedArray of shape (nrows, repeat)
+        ma = np.ma.masked_array(
+            [[False, False, True], [True, False, False]],
+            mask=[[True, False, False], [False, True, False]],
+        )
+        col = fits.Column(name="flag", format="3L", array=ma)
+        path2 = tmp_path / "fixed_ma.fits"
+        fits.BinTableHDU.from_columns([col]).writeto(path2)
+        with fits.open(path2, logical_as_bytes=True) as hdul:
+            d = hdul[1].data["flag"]
+            assert d[0].tobytes() == b"\x00FT"
+            assert d[1].tobytes() == b"T\x00F"
+
+        # Case 3: format='1L' flat list with None at outer level
+        col = fits.Column(name="flag", format="1L", array=[True, None, False])
+        path3 = tmp_path / "fixed_1L.fits"
+        fits.BinTableHDU.from_columns([col]).writeto(path3)
+        with fits.open(path3, logical_as_bytes=True) as hdul:
+            d = hdul[1].data["flag"]
+            assert d[0].tobytes() == b"T"
+            assert d[1].tobytes() == b"\x00"
+            assert d[2].tobytes() == b"F"
 
     def test_logical_vla_as_bytes(self):
         """``logical_as_bytes=True`` exposes the raw FITS L wire bytes

--- a/docs/changes/io.fits/19694.bugfix.rst
+++ b/docs/changes/io.fits/19694.bugfix.rst
@@ -1,0 +1,5 @@
+Logical (``'L'``) columns now accept ``np.ma.MaskedArray`` input and
+Python lists/tuples containing ``None`` on write, with masked /
+``None`` positions written to the heap as the FITS NULL byte
+(``b'\x00'``). This applies to both fixed-length and variable-length
+logical columns.


### PR DESCRIPTION
While it is possible to set logical column to byte string arrays (e.g. ``np.array([b"F", b"\x00", b"T"]``), things silently fail or error when trying to pass python ``None`` or masked arrays - e.g. using:

```python
col6 = fits.Column(name="f", format="PL", array=[[None, False, True]])
```

as mentioned in https://github.com/astropy/astropy/issues/18755.

For example when trying to pass a list with True/False/None:

```python
In [1]: import numpy as np

In [2]: from astropy.io import fits

In [3]: col = fits.Column(name="flag", format="PL", array=[[None, False, True]])

In [4]: fits.BinTableHDU.from_columns([col]).writeto("/tmp/case1.fits", overwrite=True)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 fits.BinTableHDU.from_columns([col]).writeto("/tmp/case1.fits", overwrite=True)

File ~/Code/Astropy/astropy/astropy/io/fits/hdu/table.py:156, in _TableLikeHDU.from_columns(cls, columns, header, nrows, fill, character_as_bytes, logical_as_bytes, **kwargs)
     98 """
     99 Given either a `ColDefs` object, a sequence of `Column` objects,
    100 or another table HDU or table data (a `FITS_rec` or multi-field
   (...)    153 ``__init__`` may also be passed in as keyword arguments.
    154 """
    155 coldefs = cls._columns_type(columns)
--> 156 data = FITS_rec.from_columns(
    157     coldefs,
    158     nrows=nrows,
    159     fill=fill,
    160     character_as_bytes=character_as_bytes,
    161     logical_as_bytes=logical_as_bytes,
    162 )
    163 hdu = cls(
    164     data=data,
    165     header=header,
   (...)    168     **kwargs,
    169 )
    170 coldefs._add_listener(hdu)

File ~/Code/Astropy/astropy/astropy/io/fits/fitsrec.py:412, in FITS_rec.from_columns(cls, columns, nrows, fill, character_as_bytes, logical_as_bytes)
    410         continue
    411 elif isinstance(recformat, _FormatP):
--> 412     data._cache_field(name, _makep(inarr, field, recformat, nrows=nrows))
    413     continue
    414 # TODO: Find a better way of determining that the column is meant
    415 # to be FITS L formatted

File ~/Code/Astropy/astropy/astropy/io/fits/column.py:2295, in _makep(array, descr_output, format, nrows)
   2288     data_output[idx] = np.asarray(rowval, dtype="S1")
   2289 elif is_logical:
   2290     # Route through int8 first so non-numeric/non-bool inputs
   2291     # (strings, None, ...) raise at write time, matching the
   2292     # behavior of astropy <= 7.2.0; bypassing this and using
   2293     # ``astype(bool)`` directly would silently coerce e.g.
   2294     # ``["T", "F"]`` to ``[True, True]``.
-> 2295     data_output[idx] = np.array(rowval, dtype=np.int8).astype(bool, copy=False)
   2296 else:
   2297     data_output[idx] = np.array(rowval, dtype=format.dtype)

TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

Or a masked array, which would make sense:

```python
In [5]: col = fits.Column(name="flag", format="PL", array=[np.ma.masked_array([False, False, True], mask=[True, False, False])])

In [6]: fits.BinTableHDU.from_columns([col]).writeto("/tmp/case2.fits", overwrite=True)

In [7]: fits.open("/tmp/case2.fits", logical_as_bytes=True)[1].data["flag"][0].tobytes()
Out[7]: b'FFT'
```

With this PR, both cases are now handled correctly:

```python
In [1]: import numpy as np

In [2]: from astropy.io import fits
^[[A
In [3]: col = fits.Column(name="flag", format="PL", array=[[None, False, True]])

In [4]: fits.BinTableHDU.from_columns([col]).writeto("/tmp/case1.fits", overwrite=True)

In [5]: fits.open("/tmp/case1.fits", logical_as_bytes=True)[1].data["flag"][0].tobytes()
Out[5]: b'\x00FT'

In [6]: col = fits.Column(name="flag", format="PL", array=[np.ma.masked_array([False, False, True], mask=[True, False, False])])

In [7]: fits.BinTableHDU.from_columns([col]).writeto("/tmp/case2.fits", overwrite=True)

In [8]: fits.open("/tmp/case2.fits", logical_as_bytes=True)[1].data["flag"][0].tobytes()
Out[8]: b'\x00FT'
```

This fix applies to both the VLAs and fixed L columns. 

@saimn - do you agree this is desirable? If so, I'm flexible as to whether we call this a bugfix or a feature - I'd lean towards bugfix to avoid people running into issues in the 8.0.x branch, but I'm happy to defer to your call.

This shouldn't be backported to v7.2.x, only v8.0.x.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
