### PR TITLE
BUG: add missing stacklevel arguments in warnings emitted from astropy.utils.data APIs

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1077,6 +1077,7 @@ def get_pkg_data_path(*path, package=None):
                     f"use astropy.utils.iers.{_IERS_DATA_REDIRECTS[filename][0]} "
                     "instead.",
                     AstropyDeprecationWarning,
+                    stacklevel=2,
                 )
                 return _IERS_DATA_REDIRECTS[filename][1]
 
@@ -1288,7 +1289,7 @@ def _try_url_open(
                 raise urllib.error.URLError(msg)
             else:
                 msg += ". Re-trying with allow_insecure=True."
-                warn(msg, AstropyWarning)
+                warn(msg, AstropyWarning, stacklevel=2)
                 # Try again with a new urlopener allowing insecure connections
                 urlopener = _build_urlopener(
                     ftp_tls=ftp_tls, ssl_context=ssl_context, allow_insecure=True
@@ -1626,7 +1627,7 @@ def download_file(
         # FIXME: other kinds of cache problem can occur?
 
     if missing_cache:
-        warn(CacheMissingWarning(missing_cache, f_name))
+        warn(CacheMissingWarning(missing_cache, f_name), stacklevel=2)
     if conf.delete_temporary_downloads_at_exit:
         _tempfilestodel.append(f_name)
     return os.path.abspath(f_name)
@@ -1792,6 +1793,7 @@ def download_files_in_parallel(
             'it will be set to ``"update"``. You may need to manually remove '
             "the cached files with clear_download_cache() afterwards.",
             AstropyWarning,
+            stacklevel=2,
         )
         cache = "update"
 
@@ -1884,7 +1886,7 @@ def clear_download_cache(hashorurl=None, pkgname="astropy"):
         # Just a warning, though
         msg = "Not clearing data cache - cache inaccessible due to "
         estr = "" if len(e.args) < 1 else (": " + str(e))
-        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr), stacklevel=2)
         return
     try:
         if hashorurl is None:
@@ -1920,7 +1922,7 @@ def clear_download_cache(hashorurl=None, pkgname="astropy"):
     except OSError as e:
         msg = "Not clearing data from cache - problem arose "
         estr = "" if len(e.args) < 1 else (": " + str(e))
-        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr), stacklevel=2)
 
 
 def _get_download_cache_loc(pkgname: str = "astropy") -> Path:
@@ -1957,7 +1959,7 @@ def _get_download_cache_loc(pkgname: str = "astropy") -> Path:
     except OSError as e:
         msg = "Remote data cache could not be accessed due to "
         estr = "" if len(e.args) < 1 else (": " + str(e))
-        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr), stacklevel=2)
         raise
 
 
@@ -2095,12 +2097,13 @@ def _rmtree(path, replace=None):
                     f"Unable to remove directory {path} because a file in it "
                     "is in use and you are on Windows",
                     path,
-                )
+                ),
+                stacklevel=2,
             )
             raise
         except OSError as e:
             if e.errno == errno.EXDEV:
-                warn(e.strerror, AstropyWarning)
+                warn(e.strerror or "", AstropyWarning, stacklevel=2)
                 shutil.move(path, os.path.join(d, "to-zap"))
             else:
                 raise
@@ -2116,7 +2119,7 @@ def _rmtree(path, replace=None):
                     # already there, fine
                     pass
                 elif e.errno == errno.EXDEV:
-                    warn(e.strerror, AstropyWarning)
+                    warn(e.strerror or "", AstropyWarning, stacklevel=2)
                     shutil.move(replace, path)
                 else:
                     raise

--- a/docs/changes/utils/19700.bugfix.rst
+++ b/docs/changes/utils/19700.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing ``stacklevel`` arguments in warnings emitted from ``astropy.utils.data`` APIs


### PR DESCRIPTION
### Description
In a couple cases, I also ensured type-safety in the `message` arguments, where `OSError.strerror` was passed, which can be `None`, while `warnings.warn` strictly expects a `str`.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
