### PR TITLE
ENH: always annotate exceptions with requested url in `astropy.utils.data.download_file`

### DIFF
--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -358,12 +358,12 @@ def test_ephemeris_non_existing_url(monkeypatch):
         raise HTTPError(code=404, msg="Not Found", fp=None, hdrs=None, url="")
 
     monkeypatch.setattr("urllib.request.OpenerDirector.open", request_invalid_url)
-    with pytest.raises(HTTPError, match="^HTTP Error 404: Not Found$"):
-        get_body(
-            "earth",
-            time=Time("1960-01-12 00:00"),
-            ephemeris="https://www.astropy.org/path/to/nonexisting/file.bsp",
-        )
+    url = "https://www.astropy.org/path/to/nonexisting/file.bsp"
+    with pytest.raises(
+        HTTPError,
+        match=f"^HTTP Error 404: Not Found\nrequested URL: {url}$",
+    ):
+        get_body("earth", time=Time("1960-01-12 00:00"), ephemeris=url)
 
 
 @pytest.mark.skipif(not HAS_JPLEPHEM, reason="requires jplephem")
@@ -372,7 +372,10 @@ def test_ephemeris_non_existing_url(monkeypatch):
     [
         pytest.param(
             "de001",
-            pytest.raises(HTTPError, match="^HTTP Error 404: Not Found$"),
+            pytest.raises(
+                HTTPError,
+                match="^HTTP Error 404: Not Found\nrequested URL: https://",
+            ),
             marks=pytest.mark.remote_data,
             id="non_existing_JPL_ephemeris_version",
         ),

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1579,18 +1579,8 @@ def download_file(
             # Success!
             break
 
-        except urllib.error.URLError as e:
-            # errno 8 is from SSL "EOF occurred in violation of protocol"
-            if (
-                hasattr(e, "reason")
-                and hasattr(e.reason, "errno")
-                and e.reason.errno == 8
-            ):
-                e.reason.strerror = f"{e.reason.strerror}. requested URL: {remote_url}"
-                e.reason.args = (e.reason.errno, e.reason.strerror)
-            errors[source_url] = e
-
-        except TimeoutError as e:
+        except (urllib.error.URLError, TimeoutError) as e:
+            e.add_note(f"requested URL: {remote_url}")
             errors[source_url] = e
 
     else:  # No success

--- a/docs/changes/utils/19701.feature.rst
+++ b/docs/changes/utils/19701.feature.rst
@@ -1,0 +1,2 @@
+Always annotate exceptions with requested url in
+``astropy.utils.data.download_file``.


### PR DESCRIPTION
### Description
This is clearer, shorter, and more generally useful

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
