### PR TITLE
TST: mock `XDG_*_HOME` env vars *alongside* `ASTROPY_*_DIR`, preventing test pollution when namespaces other than 'astropy' are exercised

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -105,14 +105,14 @@ def ignore_config_paths_global_state(monkeypatch, tmp_path_factory):
 
 @pytest.fixture(scope="session", autouse=True)
 def _session_level_cache_dir(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("cache_")
-    os.environ["ASTROPY_CACHE_DIR"] = str(tmp_path)
+    os.environ["ASTROPY_CACHE_DIR"] = str(tmp_path_factory.mktemp("astropy_cache_"))
+    os.environ["XDG_CACHE_HOME"] = str(tmp_path_factory.mktemp("xdg_cache_"))
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _session_level_config_dir(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("config_")
-    os.environ["ASTROPY_CONFIG_DIR"] = str(tmp_path)
+    os.environ["ASTROPY_CONFIG_DIR"] = str(tmp_path_factory.mktemp("astropy_config_"))
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path_factory.mktemp("xdg_config_"))
 
 
 def pytest_configure(config):

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -19,14 +19,14 @@ import pytest
 
 @pytest.fixture(scope="session", autouse=True)
 def _session_level_cache_dir(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("cache_")
-    os.environ["ASTROPY_CACHE_DIR"] = str(tmp_path)
+    os.environ["ASTROPY_CACHE_DIR"] = str(tmp_path_factory.mktemp("astropy_cache_"))
+    os.environ["XDG_CACHE_HOME"] = str(tmp_path_factory.mktemp("xdg_cache_"))
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _session_level_config_dir(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("config_")
-    os.environ["ASTROPY_CONFIG_DIR"] = str(tmp_path)
+    os.environ["ASTROPY_CONFIG_DIR"] = str(tmp_path_factory.mktemp("astropy_config_"))
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path_factory.mktemp("xdg_config_"))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Description
Partially address the test pollution issue reported in #19702. The other subissue is already addressed in #19650
A changelog is not needed (I think) because the bug was not shipped yet.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
