### PR TITLE
Fix MaskedNDArray mask preservation during pickling

### DIFF
--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -706,6 +706,15 @@ class MaskedNDArray(Masked, np.ndarray, base_cls=np.ndarray, data_cls=np.ndarray
                 ) from None
 
         return result
+    
+    def __reduce__(self):
+        pickled_state = super().__reduce__()
+        new_state = pickled_state[2] + (self._mask,)
+        return (pickled_state[0], pickled_state[1], new_state)
+    
+    def __setstate__(self, state):
+        super().__setstate__(state[:-1])
+        self._set_mask(state[-1])
 
     def __array_finalize__(self, obj):
         # If we're a new object or viewing an ndarray, nothing has to be done.

--- a/astropy/utils/masked/tests/test_pickle.py
+++ b/astropy/utils/masked/tests/test_pickle.py
@@ -8,7 +8,7 @@ import pytest
 import astropy.units as u
 from astropy.coordinates import Angle, Latitude, Longitude
 from astropy.units import Quantity
-from astropy.utils.masked import Masked
+from astropy.utils.masked import Masked, MaskedNDArray
 
 
 @pytest.mark.parametrize(
@@ -20,6 +20,7 @@ from astropy.utils.masked import Masked
         Longitude([1, 2, 3], u.deg),
     ],
 )
+
 def test_masked_pickle(data):
     mask = [True, False, False]
     m = Masked(data, mask=mask)
@@ -35,3 +36,14 @@ def test_masked_pickle(data):
     assert m.unit == m2.unit
     assert type(m) is type(m2)
     assert type(m.info) is type(m2.info)
+
+def test_masked_ndarray_pickle_preserves_mask():
+    data = MaskedNDArray([1, 2, 3], mask=[True, False, False])
+
+    result = pickle.loads(pickle.dumps(data))
+
+    np.testing.assert_array_equal(result.unmasked, data.unmasked)
+    np.testing.assert_array_equal(result.mask, data.mask)
+    assert type(result) is type(data)
+    
+


### PR DESCRIPTION
Fixes an issue where MaskedNDArray objects lost their mask after being pickled and unpickled.

This PR:

adds a regression test for MaskedNDArray pickle round-tripping
preserves _mask state during pickling via __reduce__
restores the mask during unpickling via __setstate__

Closes #19154
