### PR TITLE
Fix incorrect `Py_XDECREF/Py_DECREF` call on stolen reference after `PyList_SetItem` failure

### DIFF
--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -735,7 +735,6 @@ get_pscards(
     }
 
     if (PyList_SetItem(result, i, subresult)) {
-      Py_DECREF(subresult);
       Py_DECREF(result);
       return NULL;
     }
@@ -846,7 +845,6 @@ get_pvcards(
     }
 
     if (PyList_SetItem(result, i, subresult)) {
-      Py_DECREF(subresult);
       Py_DECREF(result);
       return NULL;
     }

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -930,7 +930,6 @@ PyWcsprm_find_all_wcs(
     }
 
     if (PyList_SetItem(result, i, (PyObject *)subresult) == -1) {
-      Py_DECREF(subresult);
       Py_DECREF(result);
       wcsvfree(&nwcs, &wcs);
       return NULL;
@@ -4305,7 +4304,6 @@ PyWcsprm_get_tab(
     }
 
     if (PyList_SetItem(result, i, subresult) == -1) {
-      Py_DECREF(subresult);
       Py_DECREF(result);
       return NULL;
     }
@@ -4657,7 +4655,6 @@ int add_prj_codes(PyObject* module)
     for (k = 0; k < prj_ncode; k++) {
         code = PyUnicode_FromString(prj_codes[k]);
         if (PyList_SetItem(list, k, code)) {
-            Py_DECREF(code);
             Py_DECREF(list);
             return -1;
         }


### PR DESCRIPTION
Close #19718