### PR TITLE
fix: separability_matrix 중첩 CompoundModel에서 올바른 행렬 반환

### DIFF
--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -242,7 +242,7 @@ def _cstack(left, right):
         cright = _coord_matrix(right, 'right', noutp)
     else:
         cright = np.zeros((noutp, right.shape[1]))
-        cright[-right.shape[0]:, -right.shape[1]:] = 1
+        cright[-right.shape[0]:, -right.shape[1]:] = right
 
     return np.hstack([cleft, cright])
 

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -13,6 +13,7 @@ from astropy.modeling.models import Mapping
 from astropy.modeling.separable import (_coord_matrix, is_separable, _cdot,
                                         _cstack, _arith_oper, separability_matrix)
 from astropy.modeling.core import ModelDefinitionError
+from astropy.modeling.models import Pix2Sky_TAN, Linear1D
 
 
 sh1 = models.Shift(1, name='shift1')
@@ -133,6 +134,46 @@ def test_arith_oper():
 def test_separable(compound_model, result):
     assert_allclose(is_separable(compound_model), result[0])
     assert_allclose(separability_matrix(compound_model), result[1])
+
+
+def test_nested_compound_model_separability():
+    """Regression test for nested CompoundModel separability (issue #12907).
+
+    Nested compound models like `A & (B & C)` must produce the same correct
+    block-diagonal separability matrix as the flat equivalent `A & B & C`.
+    """
+    tan = Pix2Sky_TAN()
+    lin1 = Linear1D(10)
+    lin2 = Linear1D(5)
+
+    # Nested: tan & (lin1 & lin2)
+    nested = tan & (lin1 & lin2)
+    # Flat (left-associative): (tan & lin1) & lin2
+    flat = tan & lin1 & lin2
+
+    expected = np.array([
+        [True,  True,  False, False],
+        [True,  True,  False, False],
+        [False, False, True,  False],
+        [False, False, False, True],
+    ])
+
+    assert_allclose(separability_matrix(nested), expected)
+    assert_allclose(separability_matrix(flat), expected)
+
+    # Nested with Rotation2D and Shift models
+    nested_rot = rot & (sh1 & sh2)
+    flat_rot = rot & sh1 & sh2
+
+    expected_rot = np.array([
+        [True,  True,  False, False],
+        [True,  True,  False, False],
+        [False, False, True,  False],
+        [False, False, False, True],
+    ])
+
+    assert_allclose(separability_matrix(nested_rot), expected_rot)
+    assert_allclose(separability_matrix(flat_rot), expected_rot)
 
 
 def test_custom_model_separable():


### PR DESCRIPTION
## Summary
- `_cstack` 함수에서 중첩된 CompoundModel의 separability 정보가 손실되는 버그 수정
- 우측 피연산자가 이미 행렬 형태일 때, `1`로 덮어쓰지 않고 실제 행렬 값(`right`)을 보존하도록 수정
- 중첩된 `&` 연산자 조합에 대한 회귀 테스트 추가

## Changes
- `astropy/modeling/separable.py`: `_cstack`에서 `cright[-right.shape[0]:, -right.shape[1]:] = 1` → `= right` 로 변경 (1줄 수정)
- `astropy/modeling/tests/test_separable.py`: `test_separability_matrix_nested_compound_model` 회귀 테스트 추가

## Test Plan
- [ ] `pytest astropy/modeling/tests/test_separable.py::test_separability_matrix_nested_compound_model` 실행 시 통과 (AC1)
- [ ] `separability_matrix(Pix2Sky_TAN() & (Linear1D(10) & Linear1D(5)))` 결과가 올바른 대각 블록 행렬 반환 검증 (AC1)
- [ ] `separability_matrix(Shift(1) & (Shift(2) & Shift(3)))` 결과가 `eye(3)` (완전 분리 가능) 임을 확인 (AC1)
- [ ] `pytest astropy/modeling/tests/test_separable.py` 전체 실행 시 기존 테스트 모두 통과 (AC2 - 비중첩 모델 동작 유지)
- [ ] `pytest astropy/modeling/` 실행 시 modeling 모듈 전체 회귀 없음 (AC2)

## Task
`swe-astropy__astropy-12907`

---
🤖 Generated by oh-my-agents