### PR TITLE
table: FutureWarning when adding structured np.ndarray to Table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1243,6 +1243,11 @@ class Table:
         # mixin class
         if (not isinstance(data, Column) and not data_is_mixin
                 and isinstance(data, np.ndarray) and len(data.dtype) > 1):
+            warnings.warn(
+                "Adding a structured np.ndarray to a Table is deprecated and will "
+                "be changed in version 5.2. Instead wrap the data in a Column with "
+                "``col = Column(data)`` and add that to the Table.",
+                FutureWarning, stacklevel=4)
             data = data.view(NdarrayMixin)
             data_is_mixin = True
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -6,6 +6,8 @@ import copy
 import pickle
 from io import StringIO
 
+import warnings
+
 import pytest
 import numpy as np
 
@@ -758,6 +760,43 @@ def test_ndarray_mixin():
         "     (2, 'b')    (20, 'bb')   (200., 'rbb')   2 .. 3",
         "     (3, 'c')    (30, 'cc')   (300., 'rcc')   4 .. 5",
         "     (4, 'd')    (40, 'dd')   (400., 'rdd')   6 .. 7"]
+
+
+def test_structured_ndarray_deprecation_warning_message():
+    """Regression test for #13236: FutureWarning message guides users to the fix.
+
+    The message must mention Column wrapping so users know how to silence it.
+    """
+    a = np.array([(1, 'x'), (2, 'y')], dtype=[('f0', 'i4'), ('f1', 'U1')])
+    with pytest.warns(FutureWarning, match=r'col = Column\(data\)') as record:
+        Table([a], names=['a'])
+    assert 'version 5.2' in str(record[0].message)
+
+
+def test_structured_ndarray_column_wrapper_no_warning():
+    """Regression test for #13236: wrapping in Column() suppresses the deprecation.
+
+    The recommended workaround must not emit any FutureWarning.
+    """
+    a = np.array([(1, 'x'), (2, 'y')], dtype=[('f0', 'i4'), ('f1', 'U1')])
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', FutureWarning)
+        t = Table([Column(a)], names=['a'])
+    assert isinstance(t['a'], Column)
+
+
+def test_ndarray_mixin_view_no_warning():
+    """Regression test for #13236: an NdarrayMixin view does not trigger deprecation.
+
+    Only raw structured ndarrays should warn; an explicit NdarrayMixin is already
+    in the correct form.
+    """
+    a = np.array([(1, 'x'), (2, 'y')], dtype=[('f0', 'i4'), ('f1', 'U1')])
+    mixin = a.view(NdarrayMixin)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', FutureWarning)
+        t = Table([mixin], names=['a'])
+    assert isinstance(t['a'], NdarrayMixin)
 
 
 def test_possible_string_format_functions():

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -712,9 +712,10 @@ def test_ndarray_mixin():
     d = np.arange(8, dtype='i8').reshape(4, 2).view(NdarrayMixin)
 
     # Add one during initialization and the next as a new column.
-    t = Table([a], names=['a'])
-    t['b'] = b
-    t['c'] = c
+    with pytest.warns(FutureWarning, match='Adding a structured np.ndarray to a Table'):
+        t = Table([a], names=['a'])
+        t['b'] = b
+        t['c'] = c
     t['d'] = d
 
     assert isinstance(t['a'], NdarrayMixin)


### PR DESCRIPTION
## Summary
- `Table.__setitem__` 내부에서 구조화된 `np.ndarray`를 `NdarrayMixin`으로 자동 변환하는 코드 블록에 `FutureWarning` 추가
- 경고 메시지에 `Column`으로 감싸서 사용하는 방법과 버전 5.2에서 동작이 변경될 것임을 안내
- 기존 `test_ndarray_mixin` 테스트를 `pytest.warns` 컨텍스트로 업데이트하고 3개의 회귀 테스트 추가

## Changes
- `astropy/table/table.py`: 구조화된 `np.ndarray` 감지 블록에 `FutureWarning` 추가
- `astropy/table/tests/test_mixin.py`: 기존 테스트를 `pytest.warns`로 래핑하고, 메시지 내용·Column 래핑 무경고·NdarrayMixin 무경고를 검증하는 회귀 테스트 3개 추가

## Test Plan
- [ ] `pytest astropy/table/tests/test_mixin.py::test_ndarray_mixin` 실행 시 통과 (AC1: FutureWarning 발생 확인)
- [ ] `pytest astropy/table/tests/test_mixin.py::test_structured_ndarray_deprecation_warning_message` 실행 시 통과 — 경고 메시지에 `col = Column(data)`와 `version 5.2` 포함 여부 검증 (AC2)
- [ ] `pytest astropy/table/tests/test_mixin.py::test_structured_ndarray_column_wrapper_no_warning` 실행 시 통과 — `Column(data)` 사용 시 경고 없음 검증
- [ ] `pytest astropy/table/tests/test_mixin.py::test_ndarray_mixin_view_no_warning` 실행 시 통과 — 명시적 `NdarrayMixin` view는 경고 없음 검증
- [ ] `pytest astropy/table/tests/test_mixin.py` 전체 통과

## Task
`swe-astropy__astropy-13236`

---
🤖 Generated by oh-my-agents