### PR TITLE
fix: HTML writer now applies formats argument to cell values

### DIFF
--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -349,11 +349,13 @@ class HTML(core.BaseReader):
         cols = list(table.columns.values())
 
         self.data.header.cols = cols
+        self.data.cols = cols
 
         if isinstance(self.data.fill_values, tuple):
             self.data.fill_values = [self.data.fill_values]
 
         self.data._set_fill_values(cols)
+        self.data._set_col_formats()
 
         lines = []
 

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -717,6 +717,34 @@ def test_multi_column_write_table_html_fill_values_masked():
     assert buffer_output.getvalue() == buffer_expected.getvalue()
 
 
+def test_write_table_html_formats():
+    """
+    Test that the formats argument is applied when writing HTML tables.
+    """
+    buffer_output = StringIO()
+    t = Table([[1.234567], [8.9012345]], names=('a', 'b'))
+    ascii.write(t, buffer_output, formats={'a': '%.2f', 'b': '%.3f'},
+                format='html')
+    out = buffer_output.getvalue()
+    assert '1.23' in out
+    assert '8.901' in out
+    # Make sure full precision is not written
+    assert '1.234567' not in out
+    assert '8.9012345' not in out
+
+
+def test_write_table_html_formats_callable():
+    """
+    Test that callable formats are applied when writing HTML tables.
+    """
+    buffer_output = StringIO()
+    t = Table([[1.0], [2.0]], names=('a', 'b'))
+    ascii.write(t, buffer_output, formats={'a': lambda x: f'val={x:.1f}'},
+                format='html')
+    out = buffer_output.getvalue()
+    assert 'val=1.0' in out
+
+
 @pytest.mark.skipif('not HAS_BS4')
 def test_read_html_unicode():
     """


### PR DESCRIPTION
## Summary
- `astropy/io/ascii/html.py`의 HTML 라이터가 `formats` 인자를 무시하던 버그를 수정
- `write()` 메서드에 `self.data.cols = cols` 및 `self.data._set_col_formats()` 호출 추가
- CSV/RST 등 다른 포맷과 동일한 방식으로 `formats` 딕셔너리가 셀 값 포맷팅에 적용됨

## Changes
- `astropy/io/ascii/html.py`: `write()` 메서드에 `self.data.cols = cols` 할당과 `self.data._set_col_formats()` 호출 2줄 추가
- `astropy/io/ascii/tests/test_html.py`: `formats` 인자 동작을 검증하는 테스트 2개 추가

## Test Plan
- [ ] `pytest astropy/io/ascii/tests/test_html.py::test_write_table_html_formats` 실행 시 통과 (AC1: 문자열 포맷 스펙 적용 확인)
- [ ] `pytest astropy/io/ascii/tests/test_html.py::test_write_table_html_formats_callable` 실행 시 통과 (AC1: callable 포맷 적용 확인)
- [ ] `pytest astropy/io/ascii/tests/test_html.py` 전체 실행 시 기존 테스트 모두 통과 (AC3: 회귀 없음 확인)
- [ ] `ascii.write(t, formats={'col': '%.2f'}, format='html')` 출력 HTML에 포맷이 적용된 값이 포함됨 (AC2: 다른 포맷과 동일 방식)
- [ ] `ascii.write(t, formats={'col': '%.2f'}, format='csv')` 및 `format='html'` 동일 포맷 결과 확인 [Manual]

## Task
`swe-astropy__astropy-13453`

---
🤖 Generated by oh-my-agents