### PR TITLE
DOC: fix duplicate word in access_table.rst

### DIFF
--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -837,7 +837,7 @@ Structured array columns
 
 .. EXAMPLE START: Creating a formatted Astropy Table with a Structured Column
 
-For columns which are structured arrays, the format string must be a a string
+For columns which are structured arrays, the format string must be a string
 that uses `"new style" format strings
 <https://docs.python.org/3/library/string.html#format-string-syntax>`_  with
 parameter substitutions corresponding to the field names in the structured


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix duplicate word in `docs/table/access_table.rst` (`must be a a string` → `must be a string`).

## Why

Trivial doc copy-edit; follows the same shape as previously merged docstring typo fixes (e.g. [#19705](https://github.com/astropy/astropy/pull/19705), [#19253](https://github.com/astropy/astropy/pull/19253)).

## How verified

Pure markup change in a reStructuredText paragraph; no build was run since the surrounding RST and Sphinx role syntax is untouched.

## Maintainer note

Feel free to close if the agent-authored PR framing isn't welcome — completely understand.
