### PR TITLE
Fix incorrect table::len warnings when reading non-astropy VOParquet files

### DIFF
--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -58,7 +58,12 @@ def parquet_identify(origin, filepath, fileobj, *args, **kwargs):
 
 
 def read_table_parquet(
-    input, include_names=None, exclude_names=None, schema_only=False, filters=None
+    input,
+    include_names=None,
+    exclude_names=None,
+    schema_only=False,
+    filters=None,
+    string_lengths=None,
 ):
     """
     Read a Table object from a Parquet file.
@@ -110,6 +115,11 @@ def read_table_parquet(
     filters : list [tuple] or list [list [tuple] ] or None, optional
         Rows which do not match the filter predicate will be removed from
         scanned data.  See `pyarrow.parquet.read_table()` for details.
+    string_lengths : dict [str, int or None], optional
+        A mapping from column name to fixed string length. When provided for
+        a column, we use that instead of scanning and we do not emit a warning.
+        If not supplied, the length is determined from ``table::len`` parquet
+        metadata if present, otherwise by scanning the data with a warning.
 
     Returns
     -------
@@ -242,6 +252,14 @@ def read_table_parquet(
         if md_name in md:
             # String/bytes length from header.
             strlen = int(md[md_name])
+        elif string_lengths is not None and name in string_lengths:
+            if string_lengths[name] is not None:
+                strlen = string_lengths[name]
+            else:
+                # Explicitly variable-length (arraysize="*"): use object dtype
+                # to match the VOTable reader and avoid fixed-width truncation.
+                dtype.append("object" if shape is None else ("object", shape))
+                continue
         elif schema_only:  # Find the maximum string length.
             # Choose an arbitrary string length since
             # are not reading in the table.
@@ -680,10 +698,28 @@ def read_parquet_votable(filename):
     # Create an empty Astropy table inheriting all the column metadata
     # information.
     vot_blob = io.BytesIO(parquet_custom_metadata[b"IVOA.VOTable-Parquet.content"])
-    empty_table_with_columns_and_metadata = Table.read(votable.parse(vot_blob))
+    parsed_vot = votable.parse(vot_blob)
+
+    empty_table_with_columns_and_metadata = Table.read(parsed_vot)
+
+    # Build a string-length map from the VOTable field declarations so that
+    # read_table_parquet does not need to scan or warn about missing table::len keys.
+    # TODO: VOTable 1.6 adds field.width (character count) for char columns.
+    #       Prefer that over arraysize (byte count) once 1.6 is in wide use.
+    fields = parsed_vot.resources[0].tables[0].fields
+    string_lengths = {}
+    for field in fields:
+        if field.datatype not in ("char", "unicodeChar"):
+            continue
+        col_name = field.ID or field.name
+        size_str = field.arraysize.rstrip("*")
+        # None signals variable-length (arraysize="*"): use object dtype.
+        string_lengths[col_name] = int(size_str) if size_str else None
 
     # Load the data from the parquet table using the Table.read() functionality
-    data_table_with_no_metadata = Table.read(filename, format="parquet")
+    data_table_with_no_metadata = Table.read(
+        filename, format="parquet", string_lengths=string_lengths
+    )
 
     # Stitch the two tables together to create final table
     return vstack([empty_table_with_columns_and_metadata, data_table_with_no_metadata])

--- a/astropy/io/misc/parquet.py
+++ b/astropy/io/misc/parquet.py
@@ -63,6 +63,7 @@ def read_table_parquet(
     exclude_names=None,
     schema_only=False,
     filters=None,
+    *,
     string_lengths=None,
 ):
     """

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -1,17 +1,23 @@
 import copy
+import warnings
 
 import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.io.misc.parquet import read_parquet_votable, write_parquet_votable
+from astropy.io.misc.parquet import (
+    read_parquet_votable,
+    read_table_parquet,
+    write_parquet_votable,
+)
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.misc import _NOT_OVERWRITING_MSG_MATCH
 
 # Skip all tests in this file if we cannot import pyarrow
-pyarrow = pytest.importorskip("pyarrow")
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
 
 
 number_of_objects = 10
@@ -59,8 +65,7 @@ def test_parquet_votable(tmp_path):
 
     write_parquet_votable(input_table, filename, metadata=column_metadata)
 
-    with pytest.warns(AstropyUserWarning, match="No table::len"):
-        loaded_table = read_parquet_votable(filename)
+    loaded_table = read_parquet_votable(filename)
 
     # Compare data content, but not metadata (input had none)
     assert np.all(input_table == loaded_table)
@@ -81,8 +86,7 @@ def test_parquet_votable_input_column_unit(overwrite_metadata, tmp_path):
         overwrite_metadata=overwrite_metadata,
     )
 
-    with pytest.warns(AstropyUserWarning, match="No table::len"):
-        loaded_table = read_parquet_votable(filename)
+    loaded_table = read_parquet_votable(filename)
 
     # Compare data content
     assert np.all(modified_input == loaded_table)
@@ -102,8 +106,7 @@ def test_parquet_votable_input_column_metadata(tmp_path):
     modified_input["mass"].meta["foo"] = "bar"
     write_parquet_votable(modified_input, filename, metadata=column_metadata)
 
-    with pytest.warns(AstropyUserWarning, match="No table::len"):
-        loaded_table = read_parquet_votable(filename)
+    loaded_table = read_parquet_votable(filename)
 
     assert "foo" in loaded_table["mass"].meta
     assert loaded_table["mass"].meta["foo"] == "bar"
@@ -118,8 +121,7 @@ def test_parquet_votable_input_metadata(tmp_path):
     modified_input.meta["table_foo"] = "table_bar"
     write_parquet_votable(modified_input, filename, metadata=column_metadata)
 
-    with pytest.warns(AstropyUserWarning, match="No table::len"):
-        loaded_table = read_parquet_votable(filename)
+    loaded_table = read_parquet_votable(filename)
 
     assert "table_foo" in loaded_table.meta
     assert loaded_table.meta["table_foo"] == "table_bar"
@@ -133,6 +135,11 @@ def test_compare_parquet_votable(tmp_path):
 
     with pytest.warns(AstropyUserWarning, match="No table::len"):
         parquet_table = Table.read(filename, format="parquet")
+
+    # VOParquet read derives string lengths from the embedded VOTable XML,
+    # so no warning should be emitted.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
         parquet_votable = Table.read(filename, format="parquet.votable")
 
     assert len(parquet_table["sfr"].meta) == 0
@@ -198,3 +205,134 @@ def test_read_write_existing(tmp_path):
 
     with pytest.raises(OSError, match=_NOT_OVERWRITING_MSG_MATCH):
         write_parquet_votable(input_table, filename, metadata=column_metadata)
+
+
+def _write_voparquet(path, data, votable_xml):
+    """Write a minimal VOParquet file using pyarrow directly.
+
+    This bypasses astropy's writer to simulate a TAP service producing
+    a VOParquet file without the table::len metadata.
+    """
+    pa_table = pa.table(data)
+    metadata = {
+        b"IVOA.VOTable-Parquet.version": b"1.0",
+        b"IVOA.VOTable-Parquet.content": votable_xml.encode(),
+    }
+    pq.write_table(pa_table.replace_schema_metadata(metadata), path)
+
+
+def test_read_parquet_votable_no_warning(tmp_path):
+    """Reading a VOParquet file must not emit table::len warnings."""
+    filename = tmp_path / "test.parq"
+    write_parquet_votable(input_table, filename, metadata=column_metadata)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
+        Table.read(filename, format="parquet.votable")
+
+
+def test_read_parquet_votable_string_dtype_from_arraysize(tmp_path):
+    """String column dtype must use arraysize from the VOTable XML, not scanned data."""
+    votable_xml = (
+        "<?xml version='1.0' encoding='utf-8'?>"
+        '<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">'
+        '<RESOURCE type="results"><TABLE>'
+        '<FIELD name="band" ID="band" datatype="char" arraysize="20"/>'
+        "</TABLE></RESOURCE></VOTABLE>"
+    )
+    filename = tmp_path / "test.parq"
+    _write_voparquet(
+        filename, {"band": pa.array(["r", "g", "i"], type=pa.string())}, votable_xml
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
+        loaded = Table.read(filename, format="parquet.votable")
+
+    assert loaded["band"].dtype == np.dtype("U20")
+
+
+def test_read_parquet_votable_variable_arraysize(tmp_path):
+    """Variable-length string columns (arraysize='*') use object dtype without warning."""
+    votable_xml = (
+        "<?xml version='1.0' encoding='utf-8'?>"
+        '<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">'
+        '<RESOURCE type="results"><TABLE>'
+        '<FIELD name="label" ID="label" datatype="char" arraysize="*"/>'
+        "</TABLE></RESOURCE></VOTABLE>"
+    )
+    filename = tmp_path / "test.parq"
+    _write_voparquet(
+        filename,
+        {"label": pa.array(["short", "a longer label"], type=pa.string())},
+        votable_xml,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
+        loaded = Table.read(filename, format="parquet.votable")
+
+    assert loaded["label"].dtype == np.dtype("object")
+    assert list(loaded["label"]) == ["short", "a longer label"]
+
+
+def test_read_parquet_votable_scalar_char(tmp_path):
+    """Scalar char columns (no arraysize) get width 1 per VOTable spec."""
+    votable_xml = (
+        "<?xml version='1.0' encoding='utf-8'?>"
+        '<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">'
+        '<RESOURCE type="results"><TABLE>'
+        '<FIELD name="flag" ID="flag" datatype="char"/>'
+        "</TABLE></RESOURCE></VOTABLE>"
+    )
+    filename = tmp_path / "test.parq"
+    _write_voparquet(
+        filename, {"flag": pa.array(["a", "b", "c"], type=pa.string())}, votable_xml
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
+        loaded = Table.read(filename, format="parquet.votable")
+
+    assert loaded["flag"].dtype == np.dtype("U1")
+
+
+def test_read_table_parquet_string_still_warns(tmp_path):
+    """Plain parquet files without table::len metadata still warn."""
+    filename = tmp_path / "test.parq"
+    # Write with pyarrow directly, as astropy's own writer adds table::len
+    pq.write_table(
+        pa.table({"col": pa.array(["foo", "bar"], type=pa.string())}), filename
+    )
+
+    with pytest.warns(AstropyUserWarning, match="No table::len"):
+        Table.read(filename, format="parquet")
+
+
+def test_read_table_parquet_string_lengths_parameter(tmp_path):
+    """string_lengths parameter suppresses the warning and sets the correct dtype."""
+    filename = tmp_path / "test.parq"
+    pq.write_table(pa.table({"band": pa.array(["r", "g"], type=pa.string())}), filename)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
+        loaded = read_table_parquet(filename, string_lengths={"band": 20})
+
+    assert loaded["band"].dtype == np.dtype("U20")
+
+
+def test_read_table_parquet_string_lengths_schema_only(tmp_path):
+    """string_lengths=None sentinel yields object dtype in schema_only mode without warning."""
+    filename = tmp_path / "test.parq"
+    pq.write_table(
+        pa.table({"label": pa.array(["short", "longer"], type=pa.string())}), filename
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", AstropyUserWarning)
+        schema_table = read_table_parquet(
+            filename, schema_only=True, string_lengths={"label": None}
+        )
+
+    assert len(schema_table) == 0
+    assert schema_table["label"].dtype == np.dtype("object")

--- a/astropy/io/misc/tests/test_parquet_votable.py
+++ b/astropy/io/misc/tests/test_parquet_votable.py
@@ -137,9 +137,9 @@ def test_compare_parquet_votable(tmp_path):
         parquet_table = Table.read(filename, format="parquet")
 
     # VOParquet read derives string lengths from the embedded VOTable XML,
-    # so no warning should be emitted.
+    # so no table::len warning should be emitted.
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         parquet_votable = Table.read(filename, format="parquet.votable")
 
     assert len(parquet_table["sfr"].meta) == 0
@@ -227,7 +227,7 @@ def test_read_parquet_votable_no_warning(tmp_path):
     write_parquet_votable(input_table, filename, metadata=column_metadata)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         Table.read(filename, format="parquet.votable")
 
 
@@ -246,7 +246,7 @@ def test_read_parquet_votable_string_dtype_from_arraysize(tmp_path):
     )
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         loaded = Table.read(filename, format="parquet.votable")
 
     assert loaded["band"].dtype == np.dtype("U20")
@@ -269,7 +269,7 @@ def test_read_parquet_votable_variable_arraysize(tmp_path):
     )
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         loaded = Table.read(filename, format="parquet.votable")
 
     assert loaded["label"].dtype == np.dtype("object")
@@ -291,7 +291,7 @@ def test_read_parquet_votable_scalar_char(tmp_path):
     )
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         loaded = Table.read(filename, format="parquet.votable")
 
     assert loaded["flag"].dtype == np.dtype("U1")
@@ -315,7 +315,7 @@ def test_read_table_parquet_string_lengths_parameter(tmp_path):
     pq.write_table(pa.table({"band": pa.array(["r", "g"], type=pa.string())}), filename)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         loaded = read_table_parquet(filename, string_lengths={"band": 20})
 
     assert loaded["band"].dtype == np.dtype("U20")
@@ -329,7 +329,7 @@ def test_read_table_parquet_string_lengths_schema_only(tmp_path):
     )
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error", AstropyUserWarning)
+        warnings.filterwarnings("error", "No table::len", AstropyUserWarning)
         schema_table = read_table_parquet(
             filename, schema_only=True, string_lengths={"label": None}
         )

--- a/docs/changes/io.misc/19817.bugfix.1.rst
+++ b/docs/changes/io.misc/19817.bugfix.1.rst
@@ -1,0 +1,2 @@
+String column widths are now derived from the ``arraysize`` attributes of
+the VOTable ``<FIELD>`` elements when reading VOParquet files.

--- a/docs/changes/io.misc/19817.bugfix.rst
+++ b/docs/changes/io.misc/19817.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``read_parquet_votable`` emitting ``table::len`` warnings when
+reading IVOA-conformant VOParquet files from non-astropy writers.
+String column widths are now derived from the ``arraysize`` attributes of
+the VOTable ``<FIELD>`` elements.

--- a/docs/changes/io.misc/19817.bugfix.rst
+++ b/docs/changes/io.misc/19817.bugfix.rst
@@ -1,4 +1,2 @@
 Fixed ``read_parquet_votable`` emitting ``table::len`` warnings when
 reading IVOA-conformant VOParquet files from non-astropy writers.
-String column widths are now derived from the ``arraysize`` attributes of
-the VOTable ``<FIELD>`` elements.


### PR DESCRIPTION
### Description

This pull request fixes a bug where `read_parquet_votable` incorrectly emits `AstropyUserWarning` messages for every string column when reading VOParquet files produced by non-astropy writers (e.g. TAP services).

`read_parquet_votable` delegates the raw data load to `read_table_parquet` via `Table.read(filename, format="parquet")`. That code path looks for `table::len::<name>` keys in the Parquet file metadata to determine string column widths. Those keys are an astropy-private convention written only by `write_parquet_table`, but not part of the IVOA VOTable-in-Parquet specification. 

So conformant VOParquet files not produced by astropy will not include these keys, leading to warnings incorrectly being fired for any such files.

The fix here adds a `string_lengths` parameter to `read_table_parquet` that lets callers supply column widths directly, bypassing the `table::len` lookup and the associated scans & warnings. 

`read_parquet_votable` uses this parameter by extracting the widths from the  `arraysize` attributes of the `<FIELD>` elements in the embedded VOTable XML,  as that information should always be present in every conformant VOParquet file.


Fixes #19783

---

### Changes

**`astropy/io/misc/parquet.py`**

- `read_table_parquet`: new `string_lengths: dict[str, int | None] | None` parameter. When a column name is present in the dict, the value is used as the string width (`None` means variable-length).  The `table::len` metadata lookup and scan/warning are only reached when the column is absent from `string_lengths`.
- `read_parquet_votable`: parses the embedded VOTable XML, builds a complete `string_lengths` dict from `<FIELD arraysize="...">` attributes, and passes it to the `Table.read(filename, format="parquet")` call.

**`astropy/io/misc/tests/test_parquet_votable.py`**

- Added `_write_voparquet` helper that writes a minimal VOParquet file using
  pyarrow directly, simulating a TAP service (no `table::len` written).
- New tests covering various cases.
- Updated `test_compare_parquet_votable` to assert that VOParquet reads never
  emit the warning (plain parquet reads still do).
