### PR TITLE
Convolve: remove GIL

### DIFF
--- a/astropy/convolution/_convolve.pyx
+++ b/astropy/convolution/_convolve.pyx
@@ -24,18 +24,18 @@ def _convolveNd_c(np.ndarray result,
                   bool nan_interpolate,
                   bool embed_result_within_padded_region,
                   int n_threads):
-    # Cache attributes we need with the GIL before releasing it.
+    # Cache pointer/shape attributes under the GIL so we can release it
+    # around the C call. ``convolveNd_c`` is declared ``nogil`` in the C
+    # header, so this is safe; releasing the GIL lets threaded executors
+    # (dask, joblib threading backend, ...) run multiple convolutions in
+    # parallel instead of being serialised at the Python layer.
     cdef:
         np.float64_t * result_ptr = <np.float64_t*>np.PyArray_DATA(result)
-        const np.float64_t * array_ptr = <np.float64_t*>np.PyArray_DATA(array_to_convolve)
-        const unsigned ndim = array_to_convolve.ndim
-        const size_t * array_shape = <size_t*>array_to_convolve.shape
-        const np.float64_t * kernel_ptr = <np.float64_t*>np.PyArray_DATA(kernel)
-        const size_t * kernel_shape = <size_t*>kernel.shape
-    # convolveNd_c is declared nogil in the C header; release the GIL
-    # around the call so threaded executors (e.g. dask, joblib threading
-    # backend) can run multiple convolutions in parallel instead of being
-    # serialised at the Python layer.
+        np.float64_t * array_ptr = <np.float64_t*>np.PyArray_DATA(array_to_convolve)
+        unsigned ndim = array_to_convolve.ndim
+        size_t * array_shape = <size_t*>array_to_convolve.shape
+        np.float64_t * kernel_ptr = <np.float64_t*>np.PyArray_DATA(kernel)
+        size_t * kernel_shape = <size_t*>kernel.shape
     with nogil:
         convolveNd_c(
             result_ptr,

--- a/astropy/convolution/_convolve.pyx
+++ b/astropy/convolution/_convolve.pyx
@@ -24,14 +24,27 @@ def _convolveNd_c(np.ndarray result,
                   bool nan_interpolate,
                   bool embed_result_within_padded_region,
                   int n_threads):
-    convolveNd_c(
-        <np.float64_t*>np.PyArray_DATA(result),
-        <np.float64_t*>np.PyArray_DATA(array_to_convolve),
-        array_to_convolve.ndim,
-        <size_t*>array_to_convolve.shape,
-        <np.float64_t*>np.PyArray_DATA(kernel),
-        <size_t*>kernel.shape,
-        nan_interpolate,
-        embed_result_within_padded_region,
-        n_threads,
-    )
+    # Cache attributes we need with the GIL before releasing it.
+    cdef:
+        np.float64_t * result_ptr = <np.float64_t*>np.PyArray_DATA(result)
+        const np.float64_t * array_ptr = <np.float64_t*>np.PyArray_DATA(array_to_convolve)
+        const unsigned ndim = array_to_convolve.ndim
+        const size_t * array_shape = <size_t*>array_to_convolve.shape
+        const np.float64_t * kernel_ptr = <np.float64_t*>np.PyArray_DATA(kernel)
+        const size_t * kernel_shape = <size_t*>kernel.shape
+    # convolveNd_c is declared nogil in the C header; release the GIL
+    # around the call so threaded executors (e.g. dask, joblib threading
+    # backend) can run multiple convolutions in parallel instead of being
+    # serialised at the Python layer.
+    with nogil:
+        convolveNd_c(
+            result_ptr,
+            array_ptr,
+            ndim,
+            array_shape,
+            kernel_ptr,
+            kernel_shape,
+            nan_interpolate,
+            embed_result_within_padded_region,
+            n_threads,
+        )

--- a/docs/changes/convolution/19835.perf.rst
+++ b/docs/changes/convolution/19835.perf.rst
@@ -1,0 +1,4 @@
+``convolve()`` now releases the GIL around the underlying C call,
+restoring behaviour added in #3950 that was lost when the per-boundary
+Cython kernels were replaced with a single C backend in #7293. Threaded
+executors can again run multiple ``convolve`` calls in parallel.


### PR DESCRIPTION
This PR is supposed to prevent the convolve operation from acquiring a global lock.

@astrofrog I'd like your take on this, since my understanding of the cython code you wrote is very shallow and this change was AI-recommended.

This was motivated by an issue in spectral-cube where `dask` convolution along one dimension was going extremely slowly, and apparently that's caused by the current convolve holding the GIL unnecessarily. 