### PR TITLE
Avoid NaN <-> UNDEFINED conversions in astropy.wcs to improve thread-safety

### DIFF
--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -109,7 +109,6 @@ copy_array_to_c_int(
 int
 is_null(/*@null@*/ void *);
 
-typedef void (*value_fixer_t)(double*, unsigned int);
 
 /* DEPRECATED (GH-16409): the wcsprm struct is now stored canonically in
  * WCSLIB's native UNDEFINED form, with NaN<->UNDEFINED translation done at the

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -242,6 +242,25 @@ set_double(
     PyObject* value,
     double* dest);
 
+/* WCSParameterArray: a writeable ndarray subclass that exposes a wcsprm
+ * double array with UNDEFINED<->NaN translation and writes element
+ * assignments back into the owning struct (GH-16409).  Used ONLY for the
+ * auxiliary fields that WCSLIB represents with the UNDEFINED sentinel
+ * (obsgeo, crder, csyer, cperi, czphs, mjdref).  The core linear parameters
+ * (crpix/crval/cdelt/pc/cd/crota) are never UNDEFINED in WCSLIB, so they are
+ * exposed as ordinary writeable views with no translation (see
+ * get_double_array below) -- this keeps live-view semantics and makes a
+ * user-supplied NaN propagate honestly instead of becoming a sentinel. */
+/*@null@*/ PyObject*
+WCSParameterArray_New(
+    PyObject* owner,
+    int ndims,
+    const npy_intp* dims,
+    double* value);
+
+int _setup_wcsparameter_array_type(PyObject* m);
+
+/* Core/derived double arrays: plain writeable view, no UNDEFINED translation. */
 /*@null@*/ static INLINE PyObject*
 get_double_array(
     /*@unused@*/ const char* propname,
@@ -264,8 +283,29 @@ get_double_array_readonly(
   return ArrayReadOnlyProxy_New(owner, ndims, dims, NPY_DOUBLE, value);
 }
 
+/* Auxiliary UNDEFINED-capable double arrays: translating write-back array. */
+/*@null@*/ static INLINE PyObject*
+get_double_array_undefined(
+    /*@unused@*/ const char* propname,
+    double* value,
+    int ndims,
+    const npy_intp* dims,
+    /*@shared@*/ PyObject* owner) {
+
+  return WCSParameterArray_New(owner, ndims, dims, value);
+}
+
 int
 set_double_array(
+    const char* propname,
+    PyObject* value,
+    int ndims,
+    const npy_intp* dims,
+    double* dest);
+
+/* As set_double_array, but translates NaN -> WCSLIB UNDEFINED (aux fields). */
+int
+set_double_array_undefined(
     const char* propname,
     PyObject* value,
     int ndims,

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -114,7 +114,8 @@ is_null(/*@null@*/ void *);
  * WCSLIB's native UNDEFINED form, with NaN<->UNDEFINED translation done at the
  * Python attribute boundary, so no in-place conversion is ever needed.  These
  * two functions are now no-ops, retained only for C-API (AstropyWcs_API slots
- * 1 and 2) backwards compatibility; do not call them in new code. */
+ * 1 and 2) backwards compatibility; the exported slots emit a
+ * DeprecationWarning when called.  Do not call them in new code. */
 void
 wcsprm_c2python(
     /*@null@*/ struct wcsprm* x);

--- a/astropy/wcs/include/astropy_wcs/pyutil.h
+++ b/astropy/wcs/include/astropy_wcs/pyutil.h
@@ -111,6 +111,11 @@ is_null(/*@null@*/ void *);
 
 typedef void (*value_fixer_t)(double*, unsigned int);
 
+/* DEPRECATED (GH-16409): the wcsprm struct is now stored canonically in
+ * WCSLIB's native UNDEFINED form, with NaN<->UNDEFINED translation done at the
+ * Python attribute boundary, so no in-place conversion is ever needed.  These
+ * two functions are now no-ops, retained only for C-API (AstropyWcs_API slots
+ * 1 and 2) backwards compatibility; do not call them in new code. */
 void
 wcsprm_c2python(
     /*@null@*/ struct wcsprm* x);
@@ -223,6 +228,11 @@ get_double(
     const char* propname,
     double value) {
 
+  /* The struct stores values in WCSLIB's native UNDEFINED form (GH-16409);
+   * present undefined scalars to Python as NaN. */
+  if (undefined(value)) {
+    return PyFloat_FromDouble((double)NPY_NAN);
+  }
   return PyFloat_FromDouble(value);
 }
 

--- a/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
@@ -42,6 +42,6 @@ int _update_wtbarr_from_hdulist(PyObject *hdulist, struct wtbarr *wtb);
 
 void _set_wtbarr_callback(PyObject* callback);
 
-int Wcsprm_cset(Wcsprm* self, const int convert);
+int Wcsprm_cset(Wcsprm* self);
 
 #endif

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -310,6 +310,7 @@ def get_extensions():
         "docstrings.c",
         "pipeline.c",
         "pyutil.c",
+        "wcsparam_array.c",
         "astropy_wcs.c",
         "astropy_wcs_api.c",
         "sip.c",

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -877,6 +877,7 @@ PyInit__wcs(void)
   if (_setup_api(m)                 ||
       _setup_str_list_proxy_type(m) ||
       _setup_unit_list_proxy_type(m)||
+      _setup_wcsparameter_array_type(m) ||
       _setup_wcsprm_type(m)         ||
       _setup_auxprm_type(m)         ||
       _setup_prjprm_type(m)         ||

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -257,7 +257,7 @@ Wcs_all_pix2world(
   // under the GIL here (short-circuited by wcsenq on subsequent calls) we
   // can safely drop the wcsprm_python2c / wcsprm_c2python round-trip from
   // around pipeline_all_pixel2world.
-  if (Wcsprm_cset(((Wcsprm*)(self->py_wcsprm)), 1)) {
+  if (Wcsprm_cset(((Wcsprm*)(self->py_wcsprm)))) {
     return NULL;
   }
 

--- a/astropy/wcs/src/astropy_wcs_api.c
+++ b/astropy/wcs/src/astropy_wcs_api.c
@@ -12,9 +12,13 @@ AstropyWcs_GetCVersion(void) {
  *
  * Of the symbols exported through the AstropyWcs_API function-pointer table
  * (and discoverable by downstream C/Cython code via astropy.wcs.get_include()),
- * only six are known to be used by a downstream package (drizzlepac):
- * wcsprm_python2c, wcsprm_c2python, pipeline_all_pixel2world, wcss2p, wcsprt
- * and wcslib_get_error_message.  wcsp2s is also kept, for symmetry with wcss2p.
+ * only four remain supported: pipeline_all_pixel2world, wcss2p, wcsprt and
+ * wcslib_get_error_message.  wcsp2s is also kept, for symmetry with wcss2p.
+ * wcsprm_python2c and wcsprm_c2python, although used by a downstream package
+ * (drizzlepac), are deprecated as well: the wcsprm struct is now stored
+ * canonically in WCSLIB's native UNDEFINED form, so the conversions they used
+ * to perform are no longer needed and both functions are no-ops (see
+ * pyutil.c).
  *
  * The remaining members are deprecated.  Rather than remove them (which would
  * break the ABI and the table layout that the REVISION check relies on), each
@@ -37,6 +41,20 @@ AstropyWcs_GetCVersion(void) {
 #define ASTROPY_WCS_DEPRECATE(name)                                     \
   DEPRECATE(name " is a deprecated part of the public astropy.wcs C "   \
                  "API and will be removed in a future version of astropy")
+
+/* pyutil.h */
+
+static void
+deprecated_wcsprm_python2c(struct wcsprm* x) {
+  ASTROPY_WCS_DEPRECATE("wcsprm_python2c");
+  wcsprm_python2c(x);
+}
+
+static void
+deprecated_wcsprm_c2python(struct wcsprm* x) {
+  ASTROPY_WCS_DEPRECATE("wcsprm_c2python");
+  wcsprm_c2python(x);
+}
 
 /* distortion.h */
 
@@ -200,8 +218,8 @@ deprecated_wcsprintf_buf(void) {
 void* AstropyWcs_API[] = {
   /*  0 */ (void *)AstropyWcs_GetCVersion,
   /* pyutil.h */
-  /*  1 */ (void *)wcsprm_python2c,
-  /*  2 */ (void *)wcsprm_c2python,
+  /*  1 */ (void *)deprecated_wcsprm_python2c,
+  /*  2 */ (void *)deprecated_wcsprm_c2python,
   /* distortion.h */
   /*  3 */ (void *)deprecated_distortion_lookup_t_init,
   /*  4 */ (void *)deprecated_distortion_lookup_t_free,

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -508,17 +508,12 @@ _set_double_array(
     }
   }
 
+  copy_array_to_c_double(value_array, dest);
   if (to_undefined) {
     /* Auxiliary UNDEFINED-capable field: translate NaN -> UNDEFINED. */
-    npy_intp n = PyArray_SIZE(value_array);
-    const double* src = (const double*)PyArray_DATA(value_array);
-    for (npy_intp j = 0; j < n; ++j) {
-      dest[j] = npy_isnan(src[j]) ? UNDEFINED : src[j];
-    }
-  } else {
-    /* Core/derived field: stored verbatim (NaN stays NaN). */
-    copy_array_to_c_double(value_array, dest);
+    nan2undefined(dest, (unsigned int)PyArray_SIZE(value_array));
   }
+  /* else: core/derived field, stored verbatim (NaN stays NaN). */
 
   Py_DECREF(value_array);
 

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -471,7 +471,7 @@ set_double(
 
 /* get_double_array is inlined */
 
-int
+static int
 _set_double_array(
     const char* propname,
     PyObject* value,

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -158,7 +158,8 @@ is_null(
 
    These two functions are retained as no-ops only because they are part of
    astropy's exported WCS C API (see astropy_wcs_api.c).  They no longer
-   mutate the struct.
+   mutate the struct, and the exported table slots are deprecated and emit a
+   DeprecationWarning when called.
 */
 
 void

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -472,12 +472,13 @@ set_double(
 /* get_double_array is inlined */
 
 int
-set_double_array(
+_set_double_array(
     const char* propname,
     PyObject* value,
     int ndims,
     const npy_intp* dims,
-    double* dest) {
+    double* dest,
+    int to_undefined) {
 
   PyArrayObject* value_array = NULL;
   npy_int        i           = 0;
@@ -507,11 +508,41 @@ set_double_array(
     }
   }
 
-  copy_array_to_c_double(value_array, dest);
+  if (to_undefined) {
+    /* Auxiliary UNDEFINED-capable field: translate NaN -> UNDEFINED. */
+    npy_intp n = PyArray_SIZE(value_array);
+    const double* src = (const double*)PyArray_DATA(value_array);
+    for (npy_intp j = 0; j < n; ++j) {
+      dest[j] = npy_isnan(src[j]) ? UNDEFINED : src[j];
+    }
+  } else {
+    /* Core/derived field: stored verbatim (NaN stays NaN). */
+    copy_array_to_c_double(value_array, dest);
+  }
 
   Py_DECREF(value_array);
 
   return 0;
+}
+
+int
+set_double_array(
+    const char* propname,
+    PyObject* value,
+    int ndims,
+    const npy_intp* dims,
+    double* dest) {
+  return _set_double_array(propname, value, ndims, dims, dest, 0);
+}
+
+int
+set_double_array_undefined(
+    const char* propname,
+    PyObject* value,
+    int ndims,
+    const npy_intp* dims,
+    double* dest) {
+  return _set_double_array(propname, value, ndims, dims, dest, 1);
 }
 
 int

--- a/astropy/wcs/src/pyutil.c
+++ b/astropy/wcs/src/pyutil.c
@@ -147,77 +147,30 @@ is_null(
 }
 
 /* wcslib represents undefined values using its own special constant,
-   UNDEFINED.  To be consistent with the Pythonic way of doing things,
-   it's nicer to represent undefined values using NaN.  Unfortunately,
-   in order to get nice mutable arrays in Python, Python must be able
-   to edit the wcsprm values directly.  The solution is to store NaNs
-   in the struct "canonically", but convert those NaNs to/from
-   UNDEFINED around every call into a wcslib function.  It's not as
-   computationally expensive as it sounds, as all these arrays are
-   quite small.
+   UNDEFINED, and to be consistent with NumPy/Python we expose them as NaN.
+
+   Historically the struct was stored "canonically" in NaN form and these two
+   functions flipped the whole struct to/from UNDEFINED in place around every
+   wcslib call.  That in-place flip of a shared struct is not thread-safe
+   (GH-16409).  The struct is now stored canonically in wcslib's native
+   UNDEFINED form, and the NaN<->UNDEFINED translation happens at the Python
+   attribute boundary (the getters/setters and WCSParameterArray) instead.
+
+   These two functions are retained as no-ops only because they are part of
+   astropy's exported WCS C API (see astropy_wcs_api.c).  They no longer
+   mutate the struct.
 */
-
-static INLINE void
-wcsprm_fix_values(
-    struct wcsprm* x,
-    value_fixer_t value_fixer) {
-
-  unsigned int naxis = (unsigned int)x->naxis;
-
-  value_fixer(x->cd, naxis * naxis);
-  value_fixer(x->cdelt, naxis);
-  value_fixer(x->crder, naxis);
-  value_fixer(x->crota, naxis);
-  value_fixer(x->crpix, naxis);
-  value_fixer(x->crval, naxis);
-  value_fixer(x->csyer, naxis);
-  value_fixer(&x->equinox, 1);
-  value_fixer(&x->latpole, 1);
-  value_fixer(&x->lonpole, 1);
-  value_fixer(&x->mjdavg, 1);
-  value_fixer(&x->mjdobs, 1);
-  value_fixer(x->obsgeo, 6);
-  value_fixer(&x->cel.phi0, 1);
-  value_fixer(&x->restfrq, 1);
-  value_fixer(&x->restwav, 1);
-  value_fixer(&x->cel.theta0, 1);
-  value_fixer(&x->velangl, 1);
-  value_fixer(&x->velosys, 1);
-  value_fixer(&x->zsource, 1);
-  value_fixer(x->czphs, naxis);
-  value_fixer(x->cperi, naxis);
-  value_fixer(x->mjdref, 2);
-  value_fixer(&x->mjdbeg, 1);
-  value_fixer(&x->mjdend, 1);
-  value_fixer(&x->jepoch, 1);
-  value_fixer(&x->bepoch, 1);
-  value_fixer(&x->tstart, 1);
-  value_fixer(&x->tstop, 1);
-  value_fixer(&x->xposure, 1);
-  value_fixer(&x->timsyer, 1);
-  value_fixer(&x->timrder, 1);
-  value_fixer(&x->timedel, 1);
-  value_fixer(&x->timepixr, 1);
-  value_fixer(&x->timeoffs, 1);
-  value_fixer(&x->telapse, 1);
-}
 
 void
 wcsprm_c2python(
     /*@null@*/ struct wcsprm* x) {
-
-  if (x != NULL) {
-    wcsprm_fix_values(x, &undefined2nan);
-  }
+  (void)x;
 }
 
 void
 wcsprm_python2c(
     /*@null@*/ struct wcsprm* x) {
-
-  if (x != NULL) {
-    wcsprm_fix_values(x, &nan2undefined);
-  }
+  (void)x;
 }
 
 /***************************************************************************
@@ -505,13 +458,15 @@ set_double(
     return -1;
   }
 
-  *dest = PyFloat_AsDouble(value);
+  double v = PyFloat_AsDouble(value);
 
-  if (PyErr_Occurred()) {
+  if (v == -1.0 && PyErr_Occurred()) {
     return -1;
-  } else {
-    return 0;
   }
+
+  /* Store NaN as WCSLIB's native UNDEFINED (GH-16409). */
+  *dest = npy_isnan(v) ? UNDEFINED : v;
+  return 0;
 }
 
 /* get_double_array is inlined */

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -355,7 +355,7 @@ int _update_wtbarr_from_hdulist(PyObject *hdulist, struct wtbarr *wtb) {
  */
 
 int
-Wcsprm_cset(Wcsprm* self, const int convert);
+Wcsprm_cset(Wcsprm* self);
 
 static INLINE void
 note_change(Wcsprm* self) {
@@ -474,7 +474,7 @@ Wcsprm_init(
 
     self->x.alt[0] = key[0];
 
-    if (Wcsprm_cset(self, 0)) {
+    if (Wcsprm_cset(self)) {
       return -1;
     }
 
@@ -736,7 +736,7 @@ Wcsprm_copy(
 
 
   if (status == 0) {
-    if (Wcsprm_cset(copy, 0)) {
+    if (Wcsprm_cset(copy)) {
       Py_XDECREF((PyObject*)copy);
       return NULL;
     }
@@ -1269,7 +1269,7 @@ Wcsprm_get_cdelt_func(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -1296,7 +1296,7 @@ Wcsprm_get_pc_func(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -1361,7 +1361,7 @@ static PyObject*
 Wcsprm_is_unity(
     Wcsprm* self) {
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -1484,7 +1484,7 @@ Wcsprm_mix(
    * wcs->flag == WCSSET so that wcsmix below does not invoke wcsset
    * itself, allowing the wcsprm_python2c / wcsprm_c2python round-trip
    * to be dropped. */
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     goto exit;
   }
 
@@ -1624,7 +1624,7 @@ Wcsprm_p2s(
   // itself -- with wcsset moved out of the parallel region, wcsp2s is
   // read-only on the wcsprm struct, and the wcsprm_python2c /
   // wcsprm_c2python round-trip can be dropped.
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -1820,7 +1820,7 @@ Wcsprm_s2p(
   // itself, allowing the wcsprm_python2c / wcsprm_c2python round-trip to
   // be dropped.
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -1955,8 +1955,7 @@ Wcsprm_s2p(
 
 int
 Wcsprm_cset(
-    Wcsprm* self,
-    const int convert) {
+    Wcsprm* self) {
 
   int status = 0;
 
@@ -2008,7 +2007,7 @@ Wcsprm_cset(
 Wcsprm_set(
     Wcsprm* self) {
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -2067,7 +2066,7 @@ Wcsprm_print_contents(
      we can assume we won't have thread conflicts */
   wcsprintf_set(NULL);
 
-  if (Wcsprm_cset(self, 0)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -2147,7 +2146,7 @@ Wcsprm___str__(
      we can assume we won't have thread conflicts */
   wcsprintf_set(NULL);
 
-  if (Wcsprm_cset(self, 0)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -2374,7 +2373,7 @@ Wcsprm_sub(
     check_unit_changes(py_dest_wcs);
 
 }
-  if (Wcsprm_cset(py_dest_wcs, 0)) {
+  if (Wcsprm_cset(py_dest_wcs)) {
     status = -1;
     goto exit;
   }
@@ -2568,7 +2567,7 @@ Wcsprm_get_axis_types(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -3381,7 +3380,7 @@ Wcsprm_get_imgpix_matrix(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -3422,7 +3421,7 @@ Wcsprm_get_lat(
     Wcsprm* self,
     /*@unused@*/ void* closure) {
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -3462,7 +3461,7 @@ Wcsprm_get_lattyp(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -3474,7 +3473,7 @@ Wcsprm_get_lng(
     Wcsprm* self,
     /*@unused@*/ void* closure) {
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -3490,7 +3489,7 @@ Wcsprm_get_lngtyp(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 
@@ -4168,7 +4167,7 @@ Wcsprm_get_piximg_matrix(
     return NULL;
   }
 
-  if (Wcsprm_cset(self, 1)) {
+  if (Wcsprm_cset(self)) {
     return NULL;
   }
 

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -2591,7 +2591,7 @@ Wcsprm_set_bepoch(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.bepoch = (double)NPY_NAN;
+    self->x.bepoch = UNDEFINED;
     return 0;
   }
 
@@ -3362,7 +3362,7 @@ Wcsprm_set_equinox(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) { /* deletion */
-    self->x.equinox = (double)NPY_NAN;
+    self->x.equinox = UNDEFINED;
     return 0;
   }
 
@@ -3408,7 +3408,7 @@ Wcsprm_set_jepoch(
   note_change(self);
 
   if (value == NULL) {
-    self->x.jepoch = (double)NPY_NAN;
+    self->x.jepoch = UNDEFINED;
     return 0;
   }
 
@@ -3513,7 +3513,7 @@ Wcsprm_set_lonpole(
   note_change(self);
 
   if (value == NULL) {
-    self->x.lonpole = (double)NPY_NAN;
+    self->x.lonpole = UNDEFINED;
     return 0;
   }
 
@@ -3535,7 +3535,7 @@ Wcsprm_set_mjdavg(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.mjdavg = (double)NPY_NAN;
+    self->x.mjdavg = UNDEFINED;
     return 0;
   }
 
@@ -3557,7 +3557,7 @@ Wcsprm_set_mjdbeg(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.mjdbeg = (double)NPY_NAN;
+    self->x.mjdbeg = UNDEFINED;
     return 0;
   }
 
@@ -3579,7 +3579,7 @@ Wcsprm_set_mjdend(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.mjdend = (double)NPY_NAN;
+    self->x.mjdend = UNDEFINED;
     return 0;
   }
 
@@ -3603,7 +3603,7 @@ Wcsprm_set_mjdobs(
   note_change(self);
 
   if (value == NULL) {
-    self->x.mjdobs = (double)NPY_NAN;
+    self->x.mjdobs = UNDEFINED;
     return 0;
   }
 
@@ -3629,8 +3629,8 @@ Wcsprm_set_mjdref(
   npy_intp size = 2;
 
   if (value == NULL) {
-    self->x.mjdref[0] = NPY_NAN;
-    self->x.mjdref[1] = NPY_NAN;
+    self->x.mjdref[0] = UNDEFINED;
+    self->x.mjdref[1] = UNDEFINED;
     return 0;
   }
   return set_double_array_undefined("mjdref", value, 1, &size, self->x.mjdref);
@@ -3777,7 +3777,7 @@ Wcsprm_set_tstart(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.tstart = (double)NPY_NAN;
+    self->x.tstart = UNDEFINED;
     return 0;
   }
 
@@ -3799,7 +3799,7 @@ Wcsprm_set_tstop(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.tstop = (double)NPY_NAN;
+    self->x.tstop = UNDEFINED;
     return 0;
   }
 
@@ -3821,7 +3821,7 @@ Wcsprm_set_telapse(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.telapse = (double)NPY_NAN;
+    self->x.telapse = UNDEFINED;
     return 0;
   }
 
@@ -3843,7 +3843,7 @@ Wcsprm_set_timeoffs(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.timeoffs = (double)NPY_NAN;
+    self->x.timeoffs = UNDEFINED;
     return 0;
   }
 
@@ -3865,7 +3865,7 @@ Wcsprm_set_timsyer(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.timsyer = (double)NPY_NAN;
+    self->x.timsyer = UNDEFINED;
     return 0;
   }
 
@@ -3887,7 +3887,7 @@ Wcsprm_set_timrder(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.timrder = (double)NPY_NAN;
+    self->x.timrder = UNDEFINED;
     return 0;
   }
 
@@ -3909,7 +3909,7 @@ Wcsprm_set_timedel(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.timedel = (double)NPY_NAN;
+    self->x.timedel = UNDEFINED;
     return 0;
   }
 
@@ -3931,7 +3931,7 @@ Wcsprm_set_timepixr(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.timepixr = (double)NPY_NAN;
+    self->x.timepixr = UNDEFINED;
     return 0;
   }
 
@@ -3978,7 +3978,7 @@ Wcsprm_set_xposure(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) {
-    self->x.xposure = (double)NPY_NAN;
+    self->x.xposure = UNDEFINED;
     return 0;
   }
 
@@ -4045,12 +4045,12 @@ Wcsprm_set_obsgeo(
   }
 
   if (value == NULL) {
-    self->x.obsgeo[0] = NPY_NAN;
-    self->x.obsgeo[1] = NPY_NAN;
-    self->x.obsgeo[2] = NPY_NAN;
-    self->x.obsgeo[3] = NPY_NAN;
-    self->x.obsgeo[4] = NPY_NAN;
-    self->x.obsgeo[5] = NPY_NAN;
+    self->x.obsgeo[0] = UNDEFINED;
+    self->x.obsgeo[1] = UNDEFINED;
+    self->x.obsgeo[2] = UNDEFINED;
+    self->x.obsgeo[3] = UNDEFINED;
+    self->x.obsgeo[4] = UNDEFINED;
+    self->x.obsgeo[5] = UNDEFINED;
     return 0;
   }
 
@@ -4149,7 +4149,7 @@ Wcsprm_set_phi0(
   note_change(self);
 
   if (value == NULL) {
-    self->x.cel.phi0 = (double)NPY_NAN;
+    self->x.cel.phi0 = UNDEFINED;
     return 0;
   }
 
@@ -4218,7 +4218,7 @@ Wcsprm_set_restfrq(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) { /* deletion */
-    self->x.restfrq = (double)NPY_NAN;
+    self->x.restfrq = UNDEFINED;
     return 0;
   }
 
@@ -4242,7 +4242,7 @@ Wcsprm_set_restwav(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) { /* deletion */
-    self->x.restwav = (double)NPY_NAN;
+    self->x.restwav = UNDEFINED;
     return 0;
   }
 
@@ -4385,7 +4385,7 @@ Wcsprm_set_theta0(
   note_change(self);
 
   if (value == NULL) {
-    self->x.cel.theta0 = (double)NPY_NAN;
+    self->x.cel.theta0 = UNDEFINED;
     return 0;
   }
 
@@ -4407,7 +4407,7 @@ Wcsprm_set_velangl(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) { /* deletion */
-    self->x.velangl = (double)NPY_NAN;
+    self->x.velangl = UNDEFINED;
     return 0;
   }
 
@@ -4429,7 +4429,7 @@ Wcsprm_set_velosys(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) { /* deletion */
-    self->x.velosys = (double)NPY_NAN;
+    self->x.velosys = UNDEFINED;
     return 0;
   }
 
@@ -4498,7 +4498,7 @@ Wcsprm_set_zsource(
     /*@unused@*/ void* closure) {
 
   if (value == NULL) { /* deletion */
-    self->x.zsource = (double)NPY_NAN;
+    self->x.zsource = UNDEFINED;
     return 0;
   }
 

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -2838,7 +2838,7 @@ Wcsprm_get_crder(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return get_double_array("crder", self->x.crder, 1, &naxis, (PyObject*)self);
+  return get_double_array_undefined("crder", self->x.crder, 1, &naxis, (PyObject*)self);
 }
 
 static int
@@ -2855,7 +2855,7 @@ Wcsprm_set_crder(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return set_double_array("crder", value, 1, &naxis, self->x.crder);
+  return set_double_array_undefined("crder", value, 1, &naxis, self->x.crder);
 }
 
 /*@null@*/ static PyObject*
@@ -3011,7 +3011,7 @@ Wcsprm_get_csyer(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return get_double_array("csyer", self->x.csyer, 1, &naxis, (PyObject*)self);
+  return get_double_array_undefined("csyer", self->x.csyer, 1, &naxis, (PyObject*)self);
 }
 
 static int
@@ -3028,7 +3028,7 @@ Wcsprm_set_csyer(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return set_double_array("csyer", value, 1, &naxis, self->x.csyer);
+  return set_double_array_undefined("csyer", value, 1, &naxis, self->x.csyer);
 }
 
 /*@null@*/ static PyObject*
@@ -3167,7 +3167,7 @@ Wcsprm_get_czphs(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return get_double_array("czphs", self->x.czphs, 1, &naxis, (PyObject*)self);
+  return get_double_array_undefined("czphs", self->x.czphs, 1, &naxis, (PyObject*)self);
 }
 
 static int
@@ -3184,7 +3184,7 @@ Wcsprm_set_czphs(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return set_double_array("czphs", value, 1, &naxis, self->x.czphs);
+  return set_double_array_undefined("czphs", value, 1, &naxis, self->x.czphs);
 }
 
 /*@null@*/ static PyObject*
@@ -3200,7 +3200,7 @@ Wcsprm_get_cperi(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return get_double_array("cperi", self->x.cperi, 1, &naxis, (PyObject*)self);
+  return get_double_array_undefined("cperi", self->x.cperi, 1, &naxis, (PyObject*)self);
 }
 
 static int
@@ -3217,7 +3217,7 @@ Wcsprm_set_cperi(
 
   naxis = (Py_ssize_t)self->x.naxis;
 
-  return set_double_array("cperi", value, 1, &naxis, self->x.cperi);
+  return set_double_array_undefined("cperi", value, 1, &naxis, self->x.cperi);
 }
 
 /*@null@*/ static PyObject*
@@ -3618,7 +3618,7 @@ Wcsprm_get_mjdref(
 
   npy_intp size = 2;
 
-  return get_double_array("mjdref", self->x.mjdref, 1, &size, (PyObject*)self);
+  return get_double_array_undefined("mjdref", self->x.mjdref, 1, &size, (PyObject*)self);
 }
 
 static int
@@ -3634,7 +3634,7 @@ Wcsprm_set_mjdref(
     self->x.mjdref[1] = NPY_NAN;
     return 0;
   }
-  return set_double_array("mjdref", value, 1, &size, self->x.mjdref);
+  return set_double_array_undefined("mjdref", value, 1, &size, self->x.mjdref);
 }
 
 
@@ -4030,7 +4030,7 @@ Wcsprm_get_obsgeo(
     return NULL;
   }
 
-  return get_double_array("obsgeo", self->x.obsgeo, 1, &size, (PyObject*)self);
+  return get_double_array_undefined("obsgeo", self->x.obsgeo, 1, &size, (PyObject*)self);
 }
 
 static int
@@ -4055,7 +4055,7 @@ Wcsprm_set_obsgeo(
     return 0;
   }
 
-  return set_double_array("obsgeo", value, 1, &size, self->x.obsgeo);
+  return set_double_array_undefined("obsgeo", value, 1, &size, self->x.obsgeo);
 }
 
 /*@null@*/ static PyObject*

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -477,7 +477,6 @@ Wcsprm_init(
     if (Wcsprm_cset(self, 0)) {
       return -1;
     }
-    wcsprm_c2python(&self->x);
 
     return 0;
   } else { /* header != NULL */
@@ -657,7 +656,6 @@ Wcsprm_init(
     }
 
     note_change(self);
-    wcsprm_c2python(&self->x);
     wcsvfree(&nwcs, &wcs);
     return 0;
   }
@@ -688,7 +686,6 @@ Wcsprm_bounds_check(
       bounds |= 1;
   }
 
-  wcsprm_python2c(&self->x);
   wcsbchk(&self->x, bounds);
 
   Py_RETURN_NONE;
@@ -709,9 +706,7 @@ Wcsprm_copy(
 
   wcsini(0, self->x.naxis, &copy->x);
 
-  wcsprm_python2c(&self->x);
   status = wcscopy(1, &self->x, &copy->x);
-  wcsprm_c2python(&self->x);
 
   // Also copy over any information related to preserving units
 
@@ -746,7 +741,6 @@ Wcsprm_copy(
       return NULL;
     }
 
-    wcsprm_c2python(&copy->x);
     return (PyObject*)copy;
   } else {
     Py_XDECREF((PyObject*)copy);
@@ -936,7 +930,6 @@ Wcsprm_find_all_wcs(
     }
 
     subresult->x.flag = 0;
-    wcsprm_c2python(&subresult->x);
   }
 
   wcsvfree(&nwcs, &wcs);
@@ -949,9 +942,7 @@ Wcsprm_cdfix(
 
   int status = 0;
 
-  wcsprm_python2c(&self->x);
   status = cdfix(&self->x);
-  wcsprm_c2python(&self->x);
 
   if (status == -1 || status == 0) {
     return PyLong_FromLong((long)status);
@@ -967,9 +958,7 @@ Wcsprm_celfix(
 
   int status = 0;
 
-  wcsprm_python2c(&self->x);
   status = celfix(&self->x);
-  wcsprm_c2python(&self->x);
 
   if (status == -1 || status == 0) {
     return PyLong_FromLong((long)status);
@@ -1000,11 +989,7 @@ Wcsprm_compare(
   }
 
 
-  wcsprm_python2c(&self->x);
-  wcsprm_python2c(&other->x);
   status = wcscompare(cmp, tolerance, &self->x, &other->x, &equal);
-  wcsprm_c2python(&self->x);
-  wcsprm_c2python(&other->x);
 
   if (status) {
     wcserr_fix_to_python_exc(self->x.err);
@@ -1054,9 +1039,7 @@ Wcsprm_cylfix(
     naxis = (int*)PyArray_DATA(naxis_array);
   }
 
-  wcsprm_python2c(&self->x);
   status = cylfix(naxis, &self->x);
-  wcsprm_c2python(&self->x);
 
   Py_XDECREF((PyObject*)naxis_array);
 
@@ -1074,9 +1057,7 @@ Wcsprm_datfix(
 
   int status = 0;
 
-  wcsprm_python2c(&self->x);
   status = datfix(&self->x);
-  wcsprm_c2python(&self->x);
 
   if (status == -1 || status == 0) {
     return PyLong_FromLong((long)status);
@@ -1239,9 +1220,7 @@ Wcsprm_fix(
 
   initialize_preserve_units(self);
 
-  wcsprm_python2c(&self->x);
   wcsfixi(ctrl, naxis, &self->x, stat, err);
-  wcsprm_c2python(&self->x);
 
   check_unit_changes(self);
 
@@ -2009,9 +1988,7 @@ Wcsprm_cset(
 
   initialize_preserve_units(self);
 
-  if (convert) wcsprm_python2c(&self->x);
   status = wcsset(&self->x);
-  if (convert) wcsprm_c2python(&self->x);
 
   check_unit_changes(self);
 
@@ -2090,9 +2067,7 @@ Wcsprm_print_contents(
      we can assume we won't have thread conflicts */
   wcsprintf_set(NULL);
 
-  wcsprm_python2c(&self->x);
   if (Wcsprm_cset(self, 0)) {
-    wcsprm_c2python(&self->x);
     return NULL;
   }
 
@@ -2102,7 +2077,6 @@ if (self->unit_scaling != NULL) {
     Wcsprm_dealloc(copy);
   } else {
     wcsprt(&self->x);
-    wcsprm_c2python(&self->x);
   }
 
   printf("%s", wcsprintf_buf());
@@ -2118,9 +2092,7 @@ Wcsprm_spcfix(
 
   int status = 0;
 
-  wcsprm_python2c(&self->x);
   status = spcfix(&self->x);
-  wcsprm_c2python(&self->x);
 
   if (status == -1 || status == 0) {
     return PyLong_FromLong((long)status);
@@ -2156,9 +2128,7 @@ Wcsprm_sptr(
 
   strncpy(ctype, py_ctype, 9);
 
-  wcsprm_python2c(&self->x);
   status = wcssptr(&self->x, &i, ctype);
-  wcsprm_c2python(&self->x);
 
   if (status == 0) {
     Py_INCREF(Py_None);
@@ -2177,9 +2147,7 @@ Wcsprm___str__(
      we can assume we won't have thread conflicts */
   wcsprintf_set(NULL);
 
-  wcsprm_python2c(&self->x);
   if (Wcsprm_cset(self, 0)) {
-    wcsprm_c2python(&self->x);
     return NULL;
   }
 
@@ -2189,7 +2157,6 @@ Wcsprm___str__(
     Wcsprm_dealloc(copy);
   } else {
     wcsprt(&self->x);
-    wcsprm_c2python(&self->x);
   }
 
   return PyUnicode_FromString(wcsprintf_buf());
@@ -2207,13 +2174,9 @@ PyObject *Wcsprm_richcompare(PyObject *a, PyObject *b, int op) {
     ax = &((Wcsprm *)a)->x;
     bx = &((Wcsprm *)b)->x;
 
-    wcsprm_python2c(ax);
-    wcsprm_python2c(bx);
     status = wcscompare(
         WCSCOMPARE_ANCILLARY, 0.0,
         ax, bx, &equal);
-    wcsprm_c2python(ax);
-    wcsprm_c2python(bx);
 
     if (status == 0) {
       if (op == Py_NE) {
@@ -2377,9 +2340,7 @@ Wcsprm_sub(
     goto exit;
   }
 
-  wcsprm_python2c(&self->x);
   status = wcssub(1, &self->x, &nsub, axes, &py_dest_wcs->x);
-  wcsprm_c2python(&self->x);
 
   // At this point, we need to copy over any relevant preserve_units
   // information, but we need to be careful since axes may have been removed or
@@ -2417,7 +2378,6 @@ Wcsprm_sub(
     status = -1;
     goto exit;
   }
-  wcsprm_c2python(&py_dest_wcs->x);
 
   if (status != 0) {
     goto exit;
@@ -2484,7 +2444,6 @@ Wcsprm_to_header(
 
     Wcsprm* copy = Wcsprm_copy_with_patched_units(self);
 
-    wcsprm_python2c(&copy->x);
     status = wcshdo(relax, &copy->x, &nkeyrec, &header);
 
     if (status != 0) {
@@ -2497,9 +2456,7 @@ Wcsprm_to_header(
 
   } else {
 
-    wcsprm_python2c(&self->x);
     status = wcshdo(relax, &self->x, &nkeyrec, &header);
-    wcsprm_c2python(&self->x);
 
     if (status != 0) {
       wcs_to_python_exc(&(self->x));

--- a/astropy/wcs/src/wcsparam_array.c
+++ b/astropy/wcs/src/wcsparam_array.c
@@ -20,6 +20,7 @@
 #include "astropy_wcs/wcslib_wrap.h"  /* for the Wcsprm struct (write-back) */
 
 #include <stdlib.h>  /* malloc, free */
+#include <string.h>  /* memcpy */
 
 /* Write-back context for an auxiliary WCSParameterArray.  It is carried on the
  * array's base object as a PyCapsule rather than a custom C type, because a
@@ -87,10 +88,9 @@ WCSParameterArray_ass_subscript(PyObject* self, PyObject* key, PyObject* value) 
   /* Then sync the whole (small) buffer back into the wcsprm field,
    * translating NaN -> UNDEFINED. */
   if (wb != NULL) {
-    const double* src = (const double*)PyArray_DATA((PyArrayObject*)self);
-    for (npy_intp i = 0; i < wb->nelem; ++i) {
-      wb->dest[i] = npy_isnan(src[i]) ? UNDEFINED : src[i];
-    }
+    memcpy(wb->dest, PyArray_DATA((PyArrayObject*)self),
+           (size_t)wb->nelem * sizeof(double));
+    nan2undefined(wb->dest, (unsigned int)wb->nelem);
     /* Equivalent to note_change(): force a wcsset on next use. */
     ((Wcsprm*)wb->parent)->x.flag = 0;
   }
@@ -134,42 +134,28 @@ _setup_wcsparameter_array_type(PyObject* m) {
   return PyModule_AddObjectRef(m, "WCSParameterArray", WCSParameterArray_Type);
 }
 
-static PyObject*
-new_double_array(PyTypeObject* subtype, int ndims, const npy_intp* dims,
-                 double* value, npy_intp* nelem_out) {
+/*@null@*/ PyObject*
+WCSParameterArray_New(PyObject* owner, int ndims,
+                      const npy_intp* dims, double* value) {
   npy_intp nelem = 1;
   for (int i = 0; i < ndims; ++i) {
     nelem *= dims[i];
   }
+
   /* data == NULL here, so the flags argument is interpreted by NumPy as a
    * boolean Fortran-order flag -- pass 0 for C order (NOT
    * NPY_ARRAY_C_CONTIGUOUS, whose nonzero value would request Fortran order
    * and transpose 2-D fields like pc/cd). */
   PyObject* arr = PyArray_NewFromDescr(
-      subtype, PyArray_DescrFromType(NPY_DOUBLE), ndims, (npy_intp*)dims,
-      NULL, NULL, 0, NULL);
+      (PyTypeObject*)WCSParameterArray_Type, PyArray_DescrFromType(NPY_DOUBLE),
+      ndims, (npy_intp*)dims, NULL, NULL, 0, NULL);
   if (arr == NULL) {
     return NULL;
   }
-  double* d = (double*)PyArray_DATA((PyArrayObject*)arr);
-  for (npy_intp i = 0; i < nelem; ++i) {
-    d[i] = undefined(value[i]) ? (double)NPY_NAN : value[i];
-  }
-  if (nelem_out) {
-    *nelem_out = nelem;
-  }
-  return arr;
-}
 
-/*@null@*/ PyObject*
-WCSParameterArray_New(PyObject* owner, int ndims,
-                      const npy_intp* dims, double* value) {
-  npy_intp nelem = 0;
-  PyObject* arr = new_double_array((PyTypeObject*)WCSParameterArray_Type, ndims,
-                                   dims, value, &nelem);
-  if (arr == NULL) {
-    return NULL;
-  }
+  /* Expose a copy with UNDEFINED translated to NaN. */
+  memcpy(PyArray_DATA((PyArrayObject*)arr), value, (size_t)nelem * sizeof(double));
+  undefined2nan((double*)PyArray_DATA((PyArrayObject*)arr), (unsigned int)nelem);
 
   WCSParamWriteback* wb = (WCSParamWriteback*)malloc(sizeof(WCSParamWriteback));
   if (wb == NULL) {

--- a/astropy/wcs/src/wcsparam_array.c
+++ b/astropy/wcs/src/wcsparam_array.c
@@ -1,0 +1,199 @@
+/*
+ WCSParameterArray: a NumPy ndarray subclass used to expose the auxiliary
+ wcsprm array parameters that WCSLIB represents with its UNDEFINED sentinel
+ (obsgeo, crder, csyer, cperi, czphs, mjdref).  It holds a copy of the field
+ with UNDEFINED translated to NaN, and writes element assignments back into the
+ owning wcsprm field translating NaN -> UNDEFINED (GH-16409).
+
+ It is a heap type (PyType_FromSpecWithBases) that delegates to ndarray's slots
+ via PyType_GetSlot, with the write-back context carried on a PyCapsule, so the
+ whole thing is compatible with the limited C API / abi3 builds.
+
+ The core/derived array parameters (crpix, crval, cdelt, pc, cd, ...) are NOT
+ exposed this way -- WCSLIB never treats them as UNDEFINED, so they are plain
+ writeable views (see get_double_array in pyutil.h).
+*/
+
+#define NO_IMPORT_ARRAY
+
+#include "astropy_wcs/pyutil.h"
+#include "astropy_wcs/wcslib_wrap.h"  /* for the Wcsprm struct (write-back) */
+
+#include <stdlib.h>  /* malloc, free */
+
+/* Write-back context for an auxiliary WCSParameterArray.  It is carried on the
+ * array's base object as a PyCapsule rather than a custom C type, because a
+ * capsule is fully compatible with the limited C API / abi3 builds (a static
+ * PyTypeObject is not). */
+typedef struct {
+  PyObject*   parent;    /* owning Wcsprm, holds a reference */
+  double*     dest;      /* &parent->x.<field> */
+  npy_intp    nelem;
+} WCSParamWriteback;
+
+static const char* const WCSPARAM_CAPSULE_NAME = "astropy.wcs._wcsparam_writeback";
+
+static void
+wcsparam_writeback_destructor(PyObject* capsule) {
+  WCSParamWriteback* wb =
+      (WCSParamWriteback*)PyCapsule_GetPointer(capsule, WCSPARAM_CAPSULE_NAME);
+  if (wb != NULL) {
+    Py_XDECREF(wb->parent);
+    free(wb);
+  }
+}
+
+/* Created at setup via PyType_FromSpecWithBases so the whole subclass works
+ * under the limited API.  ndarray's own subscript slots are fetched with
+ * PyType_GetSlot and delegated to. */
+static PyObject*     WCSParameterArray_Type = NULL;
+static binaryfunc    ndarray_subscript = NULL;
+static objobjargproc ndarray_ass_subscript = NULL;
+
+/* Read indexing decays to a plain ndarray, so a slice or element of an
+ * auxiliary array is an ordinary array and downstream code (e.g.
+ * astropy.units) never has to handle the subclass -- which also means the
+ * subclass needs no instance __dict__. */
+static PyObject*
+WCSParameterArray_subscript(PyObject* self, PyObject* key) {
+  PyObject* result = ndarray_subscript(self, key);
+  if (result != NULL && PyArray_Check(result) &&
+      Py_TYPE(result) == (PyTypeObject*)WCSParameterArray_Type) {
+    PyObject* plain = PyArray_View((PyArrayObject*)result, NULL, &PyArray_Type);
+    Py_DECREF(result);
+    return plain;
+  }
+  return result;
+}
+
+static int
+WCSParameterArray_ass_subscript(PyObject* self, PyObject* key, PyObject* value) {
+  PyObject* base = PyArray_BASE((PyArrayObject*)self);
+  WCSParamWriteback* wb = NULL;
+  if (base != NULL && PyCapsule_IsValid(base, WCSPARAM_CAPSULE_NAME)) {
+    wb = (WCSParamWriteback*)PyCapsule_GetPointer(base, WCSPARAM_CAPSULE_NAME);
+  }
+
+  /* Only the interceptable assignment paths (a[i]=, a[:]=) reach here; writes
+   * that bypass __setitem__ (np.fill_diagonal, a.flat[i]=, a+=) are not synced
+   * back.  Making every write path safe would mean returning read-only arrays
+   * and steering users to whole-attribute assignment -- left to a follow-up. */
+
+  /* Perform the normal ndarray assignment first (NaN is allowed). */
+  if (ndarray_ass_subscript(self, key, value) != 0) {
+    return -1;
+  }
+
+  /* Then sync the whole (small) buffer back into the wcsprm field,
+   * translating NaN -> UNDEFINED. */
+  if (wb != NULL) {
+    const double* src = (const double*)PyArray_DATA((PyArrayObject*)self);
+    for (npy_intp i = 0; i < wb->nelem; ++i) {
+      wb->dest[i] = npy_isnan(src[i]) ? UNDEFINED : src[i];
+    }
+    /* Equivalent to note_change(): force a wcsset on next use. */
+    ((Wcsprm*)wb->parent)->x.flag = 0;
+  }
+  return 0;
+}
+
+static PyType_Slot WCSParameterArray_slots[] = {
+  {Py_mp_subscript, (void*)WCSParameterArray_subscript},
+  {Py_mp_ass_subscript, (void*)WCSParameterArray_ass_subscript},
+  {0, NULL}
+};
+
+static PyType_Spec WCSParameterArray_spec = {
+  "astropy.wcs.WCSParameterArray",
+  0,  /* basicsize == 0 inherits from the base type (ndarray) */
+  0,  /* itemsize */
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  WCSParameterArray_slots
+};
+
+int
+_setup_wcsparameter_array_type(PyObject* m) {
+  ndarray_subscript =
+      (binaryfunc)PyType_GetSlot(&PyArray_Type, Py_mp_subscript);
+  ndarray_ass_subscript =
+      (objobjargproc)PyType_GetSlot(&PyArray_Type, Py_mp_ass_subscript);
+  if (ndarray_subscript == NULL || ndarray_ass_subscript == NULL) {
+    return -1;
+  }
+
+  PyObject* bases = PyTuple_Pack(1, (PyObject*)&PyArray_Type);
+  if (bases == NULL) {
+    return -1;
+  }
+  WCSParameterArray_Type =
+      PyType_FromSpecWithBases(&WCSParameterArray_spec, bases);
+  Py_DECREF(bases);
+  if (WCSParameterArray_Type == NULL) {
+    return -1;
+  }
+  return PyModule_AddObjectRef(m, "WCSParameterArray", WCSParameterArray_Type);
+}
+
+static PyObject*
+new_double_array(PyTypeObject* subtype, int ndims, const npy_intp* dims,
+                 double* value, npy_intp* nelem_out) {
+  npy_intp nelem = 1;
+  for (int i = 0; i < ndims; ++i) {
+    nelem *= dims[i];
+  }
+  /* data == NULL here, so the flags argument is interpreted by NumPy as a
+   * boolean Fortran-order flag -- pass 0 for C order (NOT
+   * NPY_ARRAY_C_CONTIGUOUS, whose nonzero value would request Fortran order
+   * and transpose 2-D fields like pc/cd). */
+  PyObject* arr = PyArray_NewFromDescr(
+      subtype, PyArray_DescrFromType(NPY_DOUBLE), ndims, (npy_intp*)dims,
+      NULL, NULL, 0, NULL);
+  if (arr == NULL) {
+    return NULL;
+  }
+  double* d = (double*)PyArray_DATA((PyArrayObject*)arr);
+  for (npy_intp i = 0; i < nelem; ++i) {
+    d[i] = undefined(value[i]) ? (double)NPY_NAN : value[i];
+  }
+  if (nelem_out) {
+    *nelem_out = nelem;
+  }
+  return arr;
+}
+
+/*@null@*/ PyObject*
+WCSParameterArray_New(PyObject* owner, int ndims,
+                      const npy_intp* dims, double* value) {
+  npy_intp nelem = 0;
+  PyObject* arr = new_double_array((PyTypeObject*)WCSParameterArray_Type, ndims,
+                                   dims, value, &nelem);
+  if (arr == NULL) {
+    return NULL;
+  }
+
+  WCSParamWriteback* wb = (WCSParamWriteback*)malloc(sizeof(WCSParamWriteback));
+  if (wb == NULL) {
+    Py_DECREF(arr);
+    return PyErr_NoMemory();
+  }
+  Py_INCREF(owner);
+  wb->parent = owner;
+  wb->dest = value;
+  wb->nelem = nelem;
+
+  PyObject* capsule = PyCapsule_New(wb, WCSPARAM_CAPSULE_NAME,
+                                    wcsparam_writeback_destructor);
+  if (capsule == NULL) {
+    Py_DECREF(owner);
+    free(wb);
+    Py_DECREF(arr);
+    return NULL;
+  }
+  /* SetBaseObject steals the capsule reference on success. */
+  if (PyArray_SetBaseObject((PyArrayObject*)arr, capsule) < 0) {
+    Py_DECREF(capsule);  /* runs the destructor: DECREF owner + free wb */
+    Py_DECREF(arr);
+    return NULL;
+  }
+  return arr;
+}

--- a/astropy/wcs/src/wcsparam_array.c
+++ b/astropy/wcs/src/wcsparam_array.c
@@ -75,10 +75,31 @@ WCSParameterArray_ass_subscript(PyObject* self, PyObject* key, PyObject* value) 
     wb = (WCSParamWriteback*)PyCapsule_GetPointer(base, WCSPARAM_CAPSULE_NAME);
   }
 
-  /* Only the interceptable assignment paths (a[i]=, a[:]=) reach here; writes
-   * that bypass __setitem__ (np.fill_diagonal, a.flat[i]=, a+=) are not synced
-   * back.  Making every write path safe would mean returning read-only arrays
-   * and steering users to whole-attribute assignment -- left to a follow-up. */
+  /* Anything that goes through __setitem__ reaches here and IS synced back,
+   * including element-wise augmented assignment, because the interpreter
+   * expands it into a __setitem__ store:
+   *
+   *     wcs.wcs.obsgeo[i] = x        ->  obsgeo.__setitem__(i, x)
+   *     wcs.wcs.obsgeo[i] += x       ->  obsgeo.__setitem__(i, obsgeo[i] + x)
+   *     wcs.wcs.obsgeo[:] = x        ->  obsgeo.__setitem__(slice, x)
+   *
+   * What is NOT synced back are writes that mutate the array buffer without
+   * ever calling __setitem__ on it, e.g. np.fill_diagonal(arr, ...),
+   * arr.flat[i] = x, or an in-place op on a *saved* reference to the whole
+   * array (`arr = wcs.wcs.obsgeo; arr += x`, which is arr.__iadd__(x): it
+   * mutates only the detached copy, with no __setitem__ and no attribute
+   * store back onto the WCS).  Note that `wcs.wcs.obsgeo += x` -- augmenting
+   * the attribute itself rather than a saved reference -- does sync, because
+   * it ends in the attribute setter.  Making every buffer-write path safe
+   * would mean returning read-only arrays and steering users to
+   * whole-attribute assignment -- left to a follow-up.
+   *
+   * The write-back below (memcpy + nan2undefined + flag reset) is also a
+   * non-atomic read-modify-write of the shared struct, so two threads writing
+   * to the *same* field concurrently can clobber each other.  That is no worse
+   * than any other concurrent mutation of a shared object -- mutating a WCS
+   * from multiple threads is the caller's responsibility; this PR only makes
+   * concurrent *readers* safe. */
 
   /* Perform the normal ndarray assignment first (NaN is allowed). */
   if (ndarray_ass_subscript(self, key, value) != 0) {
@@ -107,12 +128,14 @@ static PyType_Spec WCSParameterArray_spec = {
   "astropy.wcs.WCSParameterArray",
   0,  /* basicsize == 0 inherits from the base type (ndarray) */
   0,  /* itemsize */
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  Py_TPFLAGS_DEFAULT,  /* not BASETYPE: the type is sealed, no further subclassing */
   WCSParameterArray_slots
 };
 
 int
 _setup_wcsparameter_array_type(PyObject* m) {
+  /* PyType_GetSlot has accepted static types (such as NumPy's PyArray_Type)
+   * since Python 3.10, i.e. on every version astropy supports (>= 3.11). */
   ndarray_subscript =
       (binaryfunc)PyType_GetSlot(&PyArray_Type, Py_mp_subscript);
   ndarray_ass_subscript =
@@ -157,6 +180,11 @@ WCSParameterArray_New(PyObject* owner, int ndims,
   memcpy(PyArray_DATA((PyArrayObject*)arr), value, (size_t)nelem * sizeof(double));
   undefined2nan((double*)PyArray_DATA((PyArrayObject*)arr), (unsigned int)nelem);
 
+  /* wb->dest points into the owning wcsprm's arrays.  The capsule below holds
+   * a reference to the parent, so it cannot be freed while this array is alive;
+   * however, re-initialising the same Wcsprm in place (Wcsprm.__init__ on an
+   * existing object, which wcsfree/wcsini's the dynamic arrays) would leave
+   * dest dangling.  That is the same hazard plain array views already have. */
   WCSParamWriteback* wb = (WCSParamWriteback*)malloc(sizeof(WCSParamWriteback));
   if (wb == NULL) {
     Py_DECREF(arr);
@@ -170,6 +198,9 @@ WCSParameterArray_New(PyObject* owner, int ndims,
   PyObject* capsule = PyCapsule_New(wb, WCSPARAM_CAPSULE_NAME,
                                     wcsparam_writeback_destructor);
   if (capsule == NULL) {
+    /* The capsule was never created, so its destructor will not run; undo the
+     * INCREF and free wb by hand, mirroring what the destructor would do.  Do
+     * NOT also call the destructor here, or owner would be double-freed. */
     Py_DECREF(owner);
     free(wb);
     Py_DECREF(arr);

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -133,7 +133,7 @@ def test_error_message(wcsapi_test):
 
 
 def test_roundtrip(wcsapi_test):
-    # Slots 1, 2, 20, 21: wcsprm_python2c, wcsprm_c2python, wcsp2s and wcss2p.
+    # Slots 20, 21: wcsp2s and wcss2p.
     w = _make_wcs()
     x, y = 200.0, 150.0
     rx, ry = wcsapi_test.roundtrip(w.wcs, x, y)
@@ -181,3 +181,18 @@ def test_get_include_missing_headers(monkeypatch):
     monkeypatch.setattr("os.path.exists", lambda path: False)
     with pytest.raises(NoWcslibHeadersError, match="system installation of WCSLIB"):
         get_include()
+
+
+def test_deprecated_conversion_slots_warn(wcsapi_test):
+    # Slots 1 and 2: wcsprm_python2c and wcsprm_c2python are deprecated no-ops
+    # now that the wcsprm struct is stored canonically in WCSLIB form, but
+    # calling wcsp2s bracketed by them (as drizzlepac does) still works.
+    w = _make_wcs()
+    with pytest.warns(DeprecationWarning) as record:
+        wx, wy = wcsapi_test.call_conversions(w.wcs, 200.0, 150.0)
+    messages = [str(r.message) for r in record]
+    assert any("wcsprm_python2c" in m for m in messages)
+    assert any("wcsprm_c2python" in m for m in messages)
+    ((ex, ey),) = w.wcs.p2s([[200.0, 150.0]], 1)["world"]
+    assert wx == pytest.approx(ex, abs=1e-9)
+    assert wy == pytest.approx(ey, abs=1e-9)

--- a/astropy/wcs/tests/extension/wcsapi_test.c
+++ b/astropy/wcs/tests/extension/wcsapi_test.c
@@ -3,7 +3,7 @@
  function-pointer table (discoverable from astropy.wcs.get_include()).  This is
  the same entry point a downstream package such as drizzlepac uses.  The module
  provides one Python-callable function per member, or group of members, of the
- table that astropy still supports, plus one that calls a deprecated member.
+ table that astropy still supports, plus some that call deprecated members.
 */
 
 #include "Python.h"
@@ -29,9 +29,10 @@ get_error_message(PyObject* self, PyObject* arg) {
     return PyUnicode_FromString(msg == NULL ? "" : msg);
 }
 
-/* Slots 1, 2, 20, 21: bracket wcsp2s / wcss2p with the wcsprm_python2c /
-   wcsprm_c2python pair (exactly as drizzlepac does) and round-trip a single
-   two-dimensional coordinate through pixel -> world -> pixel. */
+/* Slots 20, 21: round-trip a single two-dimensional coordinate through
+   pixel -> world -> pixel with wcsp2s / wcss2p.  The wcsprm struct is stored
+   canonically in WCSLIB form, so no conversion calls are needed around the
+   transforms. */
 static PyObject*
 roundtrip(PyObject* self, PyObject* args) {
     PyObject* wcsprm_obj;
@@ -50,10 +51,8 @@ roundtrip(PyObject* self, PyObject* args) {
     pixcrd[0] = x;
     pixcrd[1] = y;
 
-    wcsprm_python2c(w);
     s1 = wcsp2s(w, 1, 2, pixcrd, imgcrd, phi, theta, world, stat);
     s2 = wcss2p(w, 1, 2, world, phi, theta, imgcrd, pix2, stat);
-    wcsprm_c2python(w);
 
     if (s1 != 0 || s2 != 0) {
         PyErr_Format(PyExc_RuntimeError,
@@ -109,6 +108,37 @@ call_deprecated(PyObject* self, PyObject* args) {
     Py_RETURN_NONE;
 }
 
+/* Slots 1 and 2: the deprecated wcsprm_python2c / wcsprm_c2python conversion
+   pair, called around wcsp2s exactly as drizzlepac does. */
+static PyObject*
+call_conversions(PyObject* self, PyObject* args) {
+    PyObject* wcsprm_obj;
+    double x, y;
+    struct wcsprm* w;
+    double pixcrd[2], imgcrd[2], world[2];
+    double phi[1], theta[1];
+    int stat[1];
+    int status;
+
+    if (!PyArg_ParseTuple(args, "Odd", &wcsprm_obj, &x, &y)) {
+        return NULL;
+    }
+    w = &((Wcsprm*)wcsprm_obj)->x;
+
+    pixcrd[0] = x;
+    pixcrd[1] = y;
+
+    wcsprm_python2c(w);
+    status = wcsp2s(w, 1, 2, pixcrd, imgcrd, phi, theta, world, stat);
+    wcsprm_c2python(w);
+
+    if (status != 0) {
+        PyErr_Format(PyExc_RuntimeError, "wcsp2s failed (status=%d)", status);
+        return NULL;
+    }
+    return Py_BuildValue("(dd)", world[0], world[1]);
+}
+
 static PyMethodDef module_methods[] = {
     {"get_c_version", get_c_version, METH_NOARGS, ""},
     {"get_error_message", get_error_message, METH_O, ""},
@@ -116,6 +146,7 @@ static PyMethodDef module_methods[] = {
     {"print_wcsprm", print_wcsprm, METH_O, ""},
     {"all_pix2world", all_pix2world, METH_VARARGS, ""},
     {"call_deprecated", call_deprecated, METH_NOARGS, ""},
+    {"call_conversions", call_conversions, METH_VARARGS, ""},
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -2855,3 +2855,38 @@ def test_thread_safe_conversions():
         results = pool.map(round_trip_transform, (pixel,) * 8)
         for pixel2 in results:
             assert_allclose(pixel, pixel2, atol=1e-7)
+
+
+def test_nan_in_core_param_propagates():
+    # Core linear parameters (crval/crpix/cdelt/pc/...) are not UNDEFINED-capable
+    # in WCSLIB, so a user-supplied NaN is passed straight through rather than
+    # turned into the UNDEFINED sentinel (which would surface as ~9.9e107). See
+    # GH-16409 / the "Much better!" example in the PR description.
+    w = wcs.WCS(naxis=2)
+    w.wcs.crval[1] = np.nan
+    result = w.wcs_pix2world(1, 2, 0)
+    assert np.isnan(result[1])
+
+
+def test_to_header_concurrent_consistency():
+    # Regression for the in-place NaN<->UNDEFINED conversion of the shared
+    # struct: calling to_header() on one shared WCS from many threads must
+    # always produce the single correct header, never a torn one containing
+    # "NAN" cards. This has real teeth only on a free-threaded interpreter; on
+    # a GIL build it still exercises the path and can never fail spuriously.
+    w = wcs.WCS(naxis=2)
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    w.wcs.crval = [10.0, 20.0]
+    w.wcs.crpix = [256.0, 256.0]
+    w.wcs.cdelt = [-1e-3, 1e-3]
+    w.wcs.set()
+    reference = w.wcs.to_header()
+
+    def make_headers(_):
+        return {w.wcs.to_header() for _ in range(200)}
+
+    with ThreadPool(8) as pool:
+        seen = set().union(*pool.map(make_headers, range(8)))
+
+    assert seen == {reference}
+    assert not any("NAN" in h.upper() for h in seen)

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -1247,3 +1247,39 @@ def test_array_keys(key):
         setattr(w, key, ["foo", "bar"])
     with pytest.raises(ValueError):
         setattr(w, key, "foo")
+
+
+def test_wcsparameterarray_behaviour():
+    # The six UNDEFINED-capable auxiliary arrays are exposed through the
+    # WCSParameterArray subclass, which translates NaN <-> UNDEFINED and writes
+    # element assignments back into the wcsprm struct (GH-16409).
+    w = _wcs.Wcsprm()
+    assert isinstance(w.obsgeo, np.ndarray)
+
+    w.obsgeo = [1, 2, 3, 4, 5, 6]
+    # In-place element assignment is written back to the struct...
+    w.obsgeo[5] = 60
+    assert w.obsgeo[5] == 60
+    # ...including NaN, which round-trips through the UNDEFINED sentinel.
+    w.obsgeo[4] = np.nan
+    assert np.isnan(w.obsgeo[4])
+    assert_array_equal(w.obsgeo[:4], [1, 2, 3, 4])
+
+    # Reads decay to a plain ndarray so downstream code never sees the subclass.
+    assert type(w.obsgeo[:3]) is np.ndarray
+    assert type(w.obsgeo[0:0]) is np.ndarray
+
+
+def test_deleting_undefined_field_omits_from_header():
+    # Regression (GH-16409): deleting an UNDEFINED-capable field must store the
+    # WCSLIB UNDEFINED sentinel, not NaN -- otherwise the field leaks into the
+    # header as "... = NAN" instead of being omitted.  The getter maps both
+    # UNDEFINED and NaN back to NaN, so this can only be observed via to_header.
+    w = _wcs.Wcsprm()
+    w.equinox = 2000.0
+    w.mjdref = [1.0, 2.0]
+    w.obsgeo = [1, 2, 3, 4, 5, 6]
+    del w.equinox
+    del w.mjdref
+    del w.obsgeo
+    assert "NAN" not in w.to_header().upper()

--- a/docs/changes/wcs/19862.bugfix.rst
+++ b/docs/changes/wcs/19862.bugfix.rst
@@ -1,0 +1,16 @@
+Improved the thread safety of ``astropy.wcs`` by storing the underlying WCSLIB
+parameter struct in WCSLIB's native representation instead of converting it in
+place to and from a NaN-based representation around every WCSLIB call. The
+in-place mutation of the shared struct during coordinate transforms and
+attribute access could produce incorrect results when a single ``WCS`` object
+was used concurrently from multiple threads. Setting a core linear parameter
+(``crpix``, ``crval``, ``cdelt``, ``pc`` or ``cd``) to NaN now also propagates
+as NaN through the transforms, rather than being turned into a sentinel that
+yielded an incorrect finite result. The ``wcsprm_python2c`` and
+``wcsprm_c2python`` functions in the public C API, which used to perform these
+conversions, are now deprecated no-ops and emit a ``DeprecationWarning`` when
+called through the function-pointer table. Note that, as before, an array
+previously returned by one of the auxiliary parameters (``obsgeo``, ``crder``,
+``csyer``, ``cperi``, ``czphs`` or ``mjdref``) is a snapshot: it is not updated
+if that parameter is subsequently changed through the ``WCS`` object, and is
+left dangling if the ``WCS`` is re-initialised in place.


### PR DESCRIPTION
_sorry I know this PR description is long but I wrote it all by hand, it is not an AI slop grenade 😆_ 

### Motivation

This PR is part of a series (hopefully one of the last such PRs) that aims to clean up some of the C-level code in astropy.wcs in order to make it thread-safe. One of the thread-unsafe things we do in astropy.wcs is to constantly call ``wcsprm_python2c`` and ``wcsprm_c2python`` to change values from being NaN (Python-side) to UNDEFINED (a special sentinel value in the C code) and back. But mutating the WCS is thread-unsafe and while one thread may be modifying the ``Wcsprm`` object to be in Python convention, the other might be doing an operation expecting it to be in C convention. Here is an example of buggy behavior with ``to_header()``:

```python
import concurrent.futures
from astropy.wcs import WCS

wcs = WCS(naxis=2)
wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
wcs.wcs.crval, wcs.wcs.crpix, wcs.wcs.cdelt = [10, 20], [256, 256], [-1e-3, 1e-3]
wcs.wcs.set()


def headers(_):
    return {wcs.wcs.to_header() for _ in range(500)}  # shared WCS, 500 calls


with concurrent.futures.ThreadPoolExecutor(8) as ex:
    seen = set().union(*ex.map(headers, range(8)))

print(
    f"distinct headers: {len(seen)} (want 1); "
    f"with NAN: {sum('NAN' in h.upper() for h in seen)} (want 0)"
)

print(next((h for h in seen if "NAN" in h.upper()), "").strip()[:300])
```

You can run this with:

```
PYTHON_GIL=0 uv run --python 3.14t --with numpy --with astropy mwe2.py
```

The output is:

```
distinct headers: 46 (want 1); with NAN: 45 (want 0)
WCSAXES =                    2 / Number of coordinate axes
CRPIX1  =                256.0 / Pixel coordinate of reference point
CRPIX2  =                256.0 / Pixel coordinate of reference point
CDELT1  =               -0.001 / [deg] Coordinate increment at reference point
...
RADESYS = 'ICRS'               / Equatorial coordinate system
EQUINOX =                NAN.0 / [yr] Equinox of equatorial coordinates
COMMENT  WCS header keyrecords produced by WCSLIB 8.4 
```

There are 46 different header outputs (as in, 46 different variants of the above header), and as you can see above, some of the values are ``NAN.0``.

What's happening here is that one of the threads is making a header (in the C code) while the other thread had converted some of the values to NaN (for Python). I tried to fix most of these issues in other PRs with non-free-threaded Python by making sure we only release the GIL in safe places, but these issues are going to become more common with free-threaded Python since the GIL is never there (as you can see above).

There are a number of other examples of similar bugs, which fundamentally come down to the fact we keep modifying the ``Wcsprm`` in-place. The ideal solution is to simply get rid of these back and forth conversions, which is what this PR does.

### Approach

The general approach of this PR is to instead always store the WCS with UNDEFINED values (where these are needed) and convert WCS parameter values from NaN to UNDEFINED (where needed) on-the-fly in the getters and setters for ``Wcsprm``. For scalars, this is easy. For array values, it's also easy to support e.g.

```python
wcs.wcs.obsgeo = [1, 2, 3, 4, 5, np.nan]
```

and have this translate to ``[1, 2, 3, 4, 5, UNDEFINED]`` in the C layer, but where it gets trickier is supporting:

```python
wcs.wcs.obsgeo[5] = np.nan
```

i.e. modify single elements of the arrays. This doesn't go through the setter, it just uses the getter for the parameter then uses Numpy to modify the underlying buffer directly, so we can't detect if a user does this kind of operation easily. In order to properly support this, we therefore need a thin Numpy array subclass which can deal with the conversion on-the-fly including on individual elements as above (which this PR includes). The way this array subclass works is that when the getter for e.g. ``wcs.wcs.obsgeo`` is called, we make an instance of the subclass with a buffer which is a copy of the original one in the WCS but with undefined values changed to NaNs, and then when a value is set via ``__setitem__`` on the array, we update the subclass's buffer but then *also* update the WCS's buffer, converting NaN -> UNDEFINED.

### Limitations

There is one limitation I am aware of - since we make a copy of the buffer when creating the numpy subclass instance, this won't work:

```
>>> wcs.wcs.obsgeo = (1, 2, 3, 4, 5, 6)
>>> arr = wcs.wcs.obsgeo
>>> wcs.wcs.obsgeo[1] = np.nan
>>> arr
[1, 2, 3, 4, 5, 6]
```

that is, because the subclass has a copy of the buffer, that buffer won't be updated if the contents of the WCS change through some other mechanism. However, doing e.g. arr[1] = np.nan will work though. So it's just the corner case of getting the array and then modifying it in-place using the original ``wcs`` path and then expecting the array 'reference' to see an updated value that won't work.

### Primary array parameters

The limitation above is not perfect, but we can limit its impact. I realized while working on all this that WCSLIB only cares about UNDEFINED values in some parameters, but not all. For example, WCSLIB does not do anything special with UNDEFINED values in ``wcs.wcs.crval``, and in fact this can lead to weird issues - the following is on main:

```python
In [4]: import numpy as np

In [5]: from astropy.wcs import WCS

In [6]: wcs = WCS(naxis=2)

In [8]: wcs.wcs.crval[1] = np.nan

In [9]: wcs.wcs_pix2world(1, 2, 0)
Out[9]: [array(2.), array(9.87654321e+107)]
```

For such fields, since WCSLIB doesn't look for the sentinel value, it would actually be better to actually have the C parameters also set to NaN, not the UNDEFINED sentinel value. So in this PR, the approach of having the wrapper numpy class is *only* done for array-like parameters for which WCSLIB actually cares about UNDEFINED values - and there are only six:

* ``WCS.wcs.obsgeo``
* ``WCS.wcs.crder``
* ``WCS.wcs.csyer``
* ``WCS.wcs.cperi``
* ``WCS.wcs.czphs``
* ``WCS.wcs.mjdref``

For e.g. ``WCS.wcs.crval``, in this PR we *don't* use the Numpy array subclass, and we let the NaN values through. This actually then produces less weird results for the above example:

```python
In [2]: import numpy as np

In [3]: from astropy.wcs import WCS

In [4]: wcs = WCS(naxis=2)

In [5]: wcs.wcs.crval[1] = np.nan

In [6]: wcs.wcs_pix2world(1, 2, 0)
Out[6]: [array(2.), array(nan)]
```

Much better!

### Summary

* This PR gets rid of all the calls to ``wcsprm_python2c`` and ``wcsprm_c2python``
* For scalar parameters, we convert between NaN and UNDEFINED in the getters and setters
* For most array parameters (all those for which WCSLIB doesn't look for UNDEFINED), we don't do anything, and pass NaN values through which leads to improved behavior
* For the six array parameters listed above, we use the Numpy subclass, called ``WCSParameterArray``. This subclass is where most of the complexity is here, so I've put it in its own file to try and keep the diff of all the other files simpler.
* The only downside of all this is that for the corner case of trying to get a reference to one of these six parameters and then modifying the parameter in-place using the ``WCS`` object, the reference will not also be updated - to me this is a very small corner case which I very much doubt will matter in practice
* We could actually deprecate modifying the arrays in-place for the six parameter values which would allow the Numpy subclass approach to be a temporary solution, and in the long term we'd get rid of it and just return read-only arrays for parameters in which UNDEFINED is special, so one would need to do e.g.

```
wcs.wcs.obsgeo = [...]
```

rather than setting individual elements in-place. We could do this deprecation in a follow-up PR though if we like that idea.


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

