### PR TITLE
Use READTHEDOCS_VERSION to build per-version html_baseurl

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,8 +249,17 @@ html_copy_source = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + "doc"
 
-# Set canonical URL from the Read the Docs Domain
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+# Set canonical URL from the Read the Docs Domain. RTD always sets
+# READTHEDOCS_CANONICAL_URL to the stable URL regardless of the build version,
+# so we reconstruct the per-version base URL using READTHEDOCS_VERSION.
+_rtd_canonical = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+_rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+if _rtd_canonical and _rtd_version:
+    html_baseurl = (
+        "/".join(_rtd_canonical.rstrip("/").split("/")[:-1]) + f"/{_rtd_version}/"
+    )
+else:
+    html_baseurl = _rtd_canonical
 
 
 def _custom_edit_url(


### PR DESCRIPTION
Fixes #19855.

`html_baseurl` was being set directly from `READTHEDOCS_CANONICAL_URL`, but RTD always sets that env var to the stable URL regardless of the build being run. Sphinx bakes the base URL into the search index, so every search result on /en/latest/ was linking back to /en/stable/.

This reconstructs the per-version base URL from the canonical URL and `READTHEDOCS_VERSION`, falling back to the canonical URL when either env var is missing (e.g. local builds).

Per @pllim: no changelog needed; the CI changelog check will fail but a maintainer label fixes that.

Needs an RTD preview build to verify — the change can't be confirmed locally.