### PR TITLE
Reject logarithmic units with a non-default scale in Quantity

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,7 +20,13 @@ from astropy import config as _config
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy.utils.exceptions import AstropyWarning
 
-from .core import Unit, UnitBase, dimensionless_unscaled, get_current_unit_registry
+from .core import (
+    Unit,
+    UnitBase,
+    UnrecognizedUnit,
+    dimensionless_unscaled,
+    get_current_unit_registry,
+)
 from .errors import UnitConversionError, UnitsError, UnitTypeError
 from .format import Base, Latex
 from .quantity_helper import can_have_arbitrary_unit, check_output, converters_and_unit
@@ -860,12 +866,19 @@ class Quantity(np.ndarray):
             else:
                 # Trying to go through a string ensures that, e.g., Magnitudes with
                 # dimensionless physical unit become Quantity with units of mag.
-                unit = Unit(str(unit), parse_strict="silent")
-                if not isinstance(unit, (UnitBase, StructuredUnit)):
+                parsed = Unit(str(unit), parse_strict="silent")
+                # ``parse_strict="silent"`` turns an unparseable string into an
+                # ``UnrecognizedUnit`` (which is a ``UnitBase``), so a function
+                # unit with a non-default scale like ``2 mag(m)`` would otherwise
+                # slip through. Reject it like any other non-normal unit.
+                if not isinstance(parsed, (UnitBase, StructuredUnit)) or isinstance(
+                    parsed, UnrecognizedUnit
+                ):
                     raise UnitTypeError(
                         f"{self.__class__.__name__} instances require normal units, "
                         f"not {unit.__class__} instances."
                     )
+                unit = parsed
 
         self._unit = unit
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -867,7 +867,7 @@ class Quantity(np.ndarray):
                 # Trying to go through a string ensures that, e.g., Magnitudes with
                 # dimensionless physical unit become Quantity with units of mag.
                 parsed = Unit(str(unit), parse_strict="silent")
-                # ``parse_strict="silent"`` turns an unparseable string into an
+                # ``parse_strict="silent"`` turns an unparsable string into an
                 # ``UnrecognizedUnit`` (which is a ``UnitBase``), so a function
                 # unit with a non-default scale like ``2 mag(m)`` would otherwise
                 # slip through. Reject it like any other non-normal unit.

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -614,6 +614,17 @@ class TestLogQuantityCreation:
         q = u.Quantity(1.0, lu, subok=True)
         assert type(q) is lu._quantity_class
 
+    @pytest.mark.parametrize(
+        "lq", [u.Magnitude(5.0 * u.m), u.Magnitude(5.0 * u.m, 2 * u.mag)]
+    )
+    def test_quantity_from_logquantity_rejected(self, lq):
+        """A plain Quantity cannot be initialized from a logarithmic quantity,
+        including one with a non-default function unit like ``2 mag``; see
+        issue #19867.
+        """
+        with pytest.raises(u.UnitTypeError, match="require normal units"):
+            u.Quantity(lq)
+
 
 def test_conversion_to_and_from_physical_quantities():
     """Ensures we can convert from regular quantities."""

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -625,6 +625,19 @@ class TestLogQuantityCreation:
         with pytest.raises(u.UnitTypeError, match="require normal units"):
             u.Quantity(lq)
 
+    @pytest.mark.parametrize(
+        "lq, expected_unit",
+        [(u.Magnitude(5.0), u.mag), (u.Dex(5.0), u.dex), (u.Decibel(5.0), u.dB)],
+    )
+    def test_quantity_from_dimensionless_logquantity(self, lq, expected_unit):
+        """A dimensionless logarithmic quantity still converts to a Quantity in
+        the corresponding unit (mag/dex/dB).
+        """
+        q = u.Quantity(lq)
+        assert type(q) is u.Quantity
+        assert q.unit == expected_unit
+        assert q.value == 5.0
+
 
 def test_conversion_to_and_from_physical_quantities():
     """Ensures we can convert from regular quantities."""

--- a/docs/changes/units/19892.bugfix.rst
+++ b/docs/changes/units/19892.bugfix.rst
@@ -1,0 +1,3 @@
+Initializing a ``Quantity`` from a logarithmic quantity whose function unit has a
+non-default scale (e.g. ``Magnitude(5.0 * u.m, 2 * u.mag)``) now correctly raises
+``UnitTypeError`` instead of silently producing a nonsensical unit.


### PR DESCRIPTION
Fixes #19867.

Initializing a `Quantity` with a logarithmic unit is meant to fail:

```python
>>> u.Quantity(u.Magnitude(5.0 * u.m))
UnitTypeError: Quantity instances require normal units, not MagUnit instances.
```

but with a non-default function unit it silently succeeded:

```python
>>> u.Quantity(u.Magnitude(5.0 * u.m, 2 * u.mag))
<Quantity -0.87371251 2 mag(m)>
```

`Quantity._set_unit` routes a non-`UnitBase` unit through `Unit(str(unit), parse_strict="silent")` so that, e.g., a dimensionless `Magnitude` becomes a `Quantity` in `mag`. For `mag(m)` the round-trip yields a `MagUnit`, which the existing guard rejects. For `2 mag(m)` the string `"2 mag(m)"` does not parse, and `parse_strict="silent"` turns it into an `UnrecognizedUnit` — which *is* a `UnitBase`, so it slipped through.

The fix also rejects an `UnrecognizedUnit` result, so the non-default-scale case raises `UnitTypeError` like the default one. The intended conversions (dimensionless `Magnitude`/`Dex`/`Decibel` → `Quantity` in `mag`/`dex`/`dB`) still work, and `Quantity(..., subok=True)` is unaffected.

Regression test parametrizes the default and non-default function-unit cases in `TestLogQuantityCreation`; the non-default case fails without the change.