### PR TITLE
Fix the world axis components and classes cache in FITS WCS when equinox was NaN

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -397,13 +397,16 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         # it. We start off by defining a hash based on the attributes of the
         # WCS that matter here (we can't just use the WCS object as a hash since
         # it is mutable)
+        # NaN values must be normalized since NaN != NaN would otherwise
+        # defeat the cache comparison below.
+        equinox = self.wcs.equinox
         wcs_hash = (
             self.naxis,
             list(self.wcs.ctype),
             list(self.wcs.cunit),
             self.wcs.radesys,
             self.wcs.specsys,
-            self.wcs.equinox,
+            None if np.isnan(equinox) else equinox,
             self.wcs.dateobs,
             self.wcs.lng,
             self.wcs.lat,

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1691,3 +1691,13 @@ class TestMaskedData:
         x, y = self.wcs.world_to_pixel(coord)
         assert_array_equal(x.mask, coord.mask)
         assert_array_equal(y.mask, coord.mask)
+
+
+def test_components_and_classes_cache():
+    # Regression test for the components and classes cache never hitting
+    # when the equinox was undefined, because the NaN it contributed to the
+    # cache key compares unequal to itself
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    wcs.wcs.set()
+    assert wcs.world_axis_object_components is wcs.world_axis_object_components

--- a/docs/changes/wcs/19898.bugfix.rst
+++ b/docs/changes/wcs/19898.bugfix.rst
@@ -1,0 +1,1 @@
+Fix caching of ``wcs.world_axis_object_components`` and ``world_axis_object_classes`` in cases where the equinox was NaN


### PR DESCRIPTION
If equinox was NaN (the default value if no celestial frame), the cache was never hit since NaN != NaN


- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

