### PR TITLE
Fix SortedArray index range query dropping duplicate rows

### DIFF
--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -93,7 +93,7 @@ class SortedArray:
 
     def find_pos(self, key, data, exact=False):
         """
-        Return the index of the largest key in data greater than or
+        Return the index of the first key in data greater than or
         equal to the given key, data pair.
 
         Parameters
@@ -197,7 +197,8 @@ class SortedArray:
             return self.find_pos(key, 0)
 
         def bisect_right(key):
-            # Position just past the last entry whose key is == ``key``.
+            # Position of the first entry whose key is > ``key`` (i.e. just
+            # past the last entry equal to ``key``).
             if self.unique:
                 pos = self.find_pos(key, 0)
                 if pos < n and tuple(col[pos] for col in self.cols) == key:

--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -190,27 +190,39 @@ class SortedArray:
             argument corresponds to an inclusive lower bound,
             and the second argument to an inclusive upper bound.
         """
-        # Find initial positions for lower and upper bounds. Just like a slice object,
-        # None values for `lower` or `upper` correspond to no bound in that direction.
-        lower_pos = 0 if lower is None else self.find_pos(lower, 0)
-        upper_pos = len(self.row_index) if upper is None else self.find_pos(upper, 0)
+        n = len(self.row_index)
 
-        if lower_pos == len(self.row_index):
-            return []
+        def bisect_left(key):
+            # Position of the first entry whose key is >= ``key``.
+            return self.find_pos(key, 0)
 
-        lower_bound = tuple(col[lower_pos] for col in self.cols)
-        if not bounds[0] and lower_bound == lower:
-            lower_pos += 1  # data[lower_pos] > lower
+        def bisect_right(key):
+            # Position just past the last entry whose key is == ``key``.
+            if self.unique:
+                pos = self.find_pos(key, 0)
+                if pos < n and tuple(col[pos] for col in self.cols) == key:
+                    pos += 1
+                return pos
+            # For a non-unique index the stored keys include the row number, so
+            # searching with a row number larger than any real row lands just
+            # past the last entry equal to ``key`` (and thus past all duplicates).
+            return self.find_pos(key, n)
 
-        # data[lower_pos] >= lower
-        # data[upper_pos] >= upper
-        if upper_pos < len(self.row_index):
-            upper_bound = tuple(col[upper_pos] for col in self.cols)
-            if not bounds[1] and upper_bound == upper:
-                upper_pos -= 1  # data[upper_pos] < upper
-            elif upper_bound > upper:
-                upper_pos -= 1  # data[upper_pos] <= upper
-        return self.row_index[lower_pos : upper_pos + 1]
+        # Compute a half-open range [lower_pos, upper_pos). Just like a slice
+        # object, a None value for `lower` or `upper` means no bound in that
+        # direction. Using bisect_left/bisect_right ensures all entries that
+        # share a value with an inclusive bound are included, even duplicates.
+        if lower is None:
+            lower_pos = 0
+        else:
+            lower_pos = bisect_left(lower) if bounds[0] else bisect_right(lower)
+
+        if upper is None:
+            upper_pos = n
+        else:
+            upper_pos = bisect_right(upper) if bounds[1] else bisect_left(upper)
+
+        return self.row_index[lower_pos:upper_pos]
 
     def remove(self, key: tuple, data: int) -> bool:
         """

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -1133,11 +1133,11 @@ def test_loc_range_with_duplicate_index_values(engine, table_type):
     row, so e.g. ``t.loc[1:2]`` silently dropped all but one of the ``2`` rows.
     """
     t = table_type()
-    t["a"] = [1, 2, 2, 2, 3]
-    t["b"] = [10, 20, 21, 22, 30]
+    t["a"] = [3, 2, 2, 3, 1, 2]
+    t["b"] = [30, 20, 21, 31, 10, 22]
     t.add_index("a", engine=engine)
 
     assert sorted(t.loc[1:2]["b"].tolist()) == [10, 20, 21, 22]
     assert sorted(t.loc[2:2]["b"].tolist()) == [20, 21, 22]
-    assert sorted(t.loc[2:3]["b"].tolist()) == [20, 21, 22, 30]
-    assert sorted(t.loc[:]["b"].tolist()) == [10, 20, 21, 22, 30]
+    assert sorted(t.loc[2:3]["b"].tolist()) == [20, 21, 22, 30, 31]
+    assert sorted(t.loc[:]["b"].tolist()) == [10, 20, 21, 22, 30, 31]

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -1122,3 +1122,22 @@ def test_index_not_corrupted_on_failed_row_assignment(engine):
     # No ghost entry for the attempted new value
     with pytest.raises(KeyError):
         t.loc[99]
+
+
+@pytest.mark.parametrize("table_type", [Table, QTable])
+def test_loc_range_with_duplicate_index_values(engine, table_type):
+    """Regression test: a range query must return every row whose value equals
+    an inclusive bound, even when that value is duplicated in the index.
+
+    The default ``SortedArray`` engine previously kept only the first matching
+    row, so e.g. ``t.loc[1:2]`` silently dropped all but one of the ``2`` rows.
+    """
+    t = table_type()
+    t["a"] = [1, 2, 2, 2, 3]
+    t["b"] = [10, 20, 21, 22, 30]
+    t.add_index("a", engine=engine)
+
+    assert sorted(t.loc[1:2]["b"].tolist()) == [10, 20, 21, 22]
+    assert sorted(t.loc[2:2]["b"].tolist()) == [20, 21, 22]
+    assert sorted(t.loc[2:3]["b"].tolist()) == [20, 21, 22, 30]
+    assert sorted(t.loc[:]["b"].tolist()) == [10, 20, 21, 22, 30]

--- a/docs/changes/table/19903.bugfix.rst
+++ b/docs/changes/table/19903.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug where a ``Table.loc[]`` range query using the default
+``SortedArray`` index engine silently dropped rows when the upper bound
+matched a value that appears more than once in the indexed column.


### PR DESCRIPTION
Fixes #19902.

`Table.loc[lower:upper]` on the default `SortedArray` engine dropped rows when the upper bound matched a duplicated index value. The upper position was computed with `find_pos(upper, 0)`, which points at the *first* entry equal to the bound, so an inclusive query kept only the first of several equal rows:

```python
t = Table()
t["a"] = [1, 2, 2, 2, 3]
t.add_index("a")
t.loc[1:2]   # returned 2 rows, should return 4
```

This rewrites `range()` as a half-open `[lower_pos, upper_pos)` slice using bisect-left / bisect-right semantics, so every row matching an inclusive bound is included, duplicates and all. `BST` and `SCEngine` already returned the correct rows.

Added a regression test parametrized over all index engines (the other two act as an oracle for the fixed `SortedArray`).
