### PR TITLE
Add MultiNorm to the nitpick exceptions

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -45,6 +45,7 @@ py:obj Bbox
 py:obj Transform
 py:obj Figure
 py:obj AbstractPathEffect
+py:obj MultiNorm
 py:obj N
 py:obj masked
 


### PR DESCRIPTION
This should hopefully fix the RTD warnings