### PR TITLE
Fix reading empty (no-column) tables with the new ECSV reader

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -231,13 +231,20 @@ def test_write_read_roundtrip(format_engine):
                 assert np.all(t[name] == t2[name])
 
 
-def test_write_read_roundtrip_empty_table(tmp_path):
+def test_write_read_roundtrip_empty_table(tmp_path, format_engine):
+    # A table with no columns has no CSV data section, so every reader must
+    # round-trip it from the header alone.
     # see https://github.com/astropy/astropy/issues/13191
+    # and https://github.com/astropy/astropy/issues/19895 (meta-only, "ecsv" engines)
     sfile = tmp_path / "x.ecsv"
-    Table().write(sfile)
-    t = Table.read(sfile)
-    assert len(t) == 0
-    assert len(t.colnames) == 0
+    t = Table()
+    t.meta["foo"] = 1
+    t.meta["bar"] = "example"
+    t.write(sfile, **patch_format_write(format_engine))
+    t2 = Table.read(sfile, **format_engine)
+    assert len(t2) == 0
+    assert len(t2.colnames) == 0
+    assert t2.meta == t.meta
 
 
 def test_bad_delimiter():

--- a/astropy/io/misc/ecsv.py
+++ b/astropy/io/misc/ecsv.py
@@ -741,6 +741,12 @@ def read_data(
     """
     from astropy.table import Table
 
+    # A table with no columns has no CSV data section to read: the comment
+    # lines that follow the header would otherwise be misparsed as the CSV
+    # data header (see #19895). Return an empty table immediately.
+    if not header.cols:
+        return Table()
+
     engine = ECSVEngine.engines[engine_name]()
 
     # Get the engine-specific kwargs for reading the CSV data.
@@ -1213,12 +1219,6 @@ def read_ecsv(
 
     # Read the ECSV header from the input.
     header = read_header(input_file, encoding=encoding)
-
-    # A table with no columns has no CSV data section to read: the comment
-    # lines that follow the header would otherwise be misparsed as the CSV
-    # data header (see #19895). Return an empty table immediately.
-    if not header.cols:
-        return Table()
 
     # Read the CSV data from the input starting at the line after the header. This
     # includes handling that is particular to the engine.

--- a/astropy/io/misc/ecsv.py
+++ b/astropy/io/misc/ecsv.py
@@ -741,13 +741,6 @@ def read_data(
     """
     from astropy.table import Table
 
-    # A table with no columns has no CSV data section to read: the comment lines
-    # that follow the header would otherwise be misparsed as the CSV data header
-    # (see #19895). Return an empty table; the caller rebuilds it from the header
-    # metadata alone.
-    if not header.cols:
-        return Table()
-
     engine = ECSVEngine.engines[engine_name]()
 
     # Get the engine-specific kwargs for reading the CSV data.
@@ -1220,6 +1213,12 @@ def read_ecsv(
 
     # Read the ECSV header from the input.
     header = read_header(input_file, encoding=encoding)
+
+    # A table with no columns has no CSV data section to read: the comment
+    # lines that follow the header would otherwise be misparsed as the CSV
+    # data header (see #19895). Return an empty table immediately.
+    if not header.cols:
+        return Table()
 
     # Read the CSV data from the input starting at the line after the header. This
     # includes handling that is particular to the engine.

--- a/astropy/io/misc/ecsv.py
+++ b/astropy/io/misc/ecsv.py
@@ -741,6 +741,13 @@ def read_data(
     """
     from astropy.table import Table
 
+    # A table with no columns has no CSV data section to read: the comment lines
+    # that follow the header would otherwise be misparsed as the CSV data header
+    # (see #19895). Return an empty table; the caller rebuilds it from the header
+    # metadata alone.
+    if not header.cols:
+        return Table()
+
     engine = ECSVEngine.engines[engine_name]()
 
     # Get the engine-specific kwargs for reading the CSV data.
@@ -1214,22 +1221,15 @@ def read_ecsv(
     # Read the ECSV header from the input.
     header = read_header(input_file, encoding=encoding)
 
-    # A table with no columns has no CSV data section (not even a header line of
-    # column names), so skip reading data and build an empty table from the header
-    # metadata alone. Attempting to read the data otherwise misinterprets the
-    # remaining comment lines as the CSV header (see #19895).
-    if header.cols:
-        # Read the CSV data from the input starting at the line after the header.
-        # This includes handling that is particular to the engine.
-        data_raw = read_data(
-            input_file,
-            header,
-            null_values=null_values,
-            encoding=encoding,
-            engine_name=engine,
-        )
-    else:
-        data_raw = {}
+    # Read the CSV data from the input starting at the line after the header. This
+    # includes handling that is particular to the engine.
+    data_raw = read_data(
+        input_file,
+        header,
+        null_values=null_values,
+        encoding=encoding,
+        engine_name=engine,
+    )
 
     # Convert the column data to the appropriate numpy dtype. This is mostly concerned
     # with JSON-encoded data but also handles cases like pyarrow not supporting float16.

--- a/astropy/io/misc/ecsv.py
+++ b/astropy/io/misc/ecsv.py
@@ -1214,15 +1214,22 @@ def read_ecsv(
     # Read the ECSV header from the input.
     header = read_header(input_file, encoding=encoding)
 
-    # Read the CSV data from the input starting at the line after the header. This
-    # includes handling that is particular to the engine.
-    data_raw = read_data(
-        input_file,
-        header,
-        null_values=null_values,
-        encoding=encoding,
-        engine_name=engine,
-    )
+    # A table with no columns has no CSV data section (not even a header line of
+    # column names), so skip reading data and build an empty table from the header
+    # metadata alone. Attempting to read the data otherwise misinterprets the
+    # remaining comment lines as the CSV header (see #19895).
+    if header.cols:
+        # Read the CSV data from the input starting at the line after the header.
+        # This includes handling that is particular to the engine.
+        data_raw = read_data(
+            input_file,
+            header,
+            null_values=null_values,
+            encoding=encoding,
+            engine_name=engine,
+        )
+    else:
+        data_raw = {}
 
     # Convert the column data to the appropriate numpy dtype. This is mostly concerned
     # with JSON-encoded data but also handles cases like pyarrow not supporting float16.

--- a/docs/changes/io.misc/19909.bugfix.rst
+++ b/docs/changes/io.misc/19909.bugfix.rst
@@ -1,3 +1,3 @@
-Fixed the new ``format="ecsv"`` reader raising ``InconsistentTableError`` when
-reading an empty table that has no columns. Such tables are now read from the
-header metadata alone, matching the legacy ``format="ascii.ecsv"`` reader.
+Fixed the ``format="ecsv"`` ECSV reader to correctly read an empty table that has
+no columns. Previously this was raising an ``InconsistentTableError``. The legacy
+``format="ascii.ecsv"`` ECSV reader was already handling this case correctly.

--- a/docs/changes/io.misc/19909.bugfix.rst
+++ b/docs/changes/io.misc/19909.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed the new ``format="ecsv"`` reader raising ``InconsistentTableError`` when
+reading an empty table that has no columns. Such tables are now read from the
+header metadata alone, matching the legacy ``format="ascii.ecsv"`` reader.


### PR DESCRIPTION
Fixes #19895.

The new `format="ecsv"` reader (`astropy.io.misc.ecsv.read_ecsv`) always read a CSV data section after the YAML header. A table with no columns has no data section — not even a CSV header line of column names — so the reader picked up the trailing `# ...` header comment lines as the data and raised:

```
InconsistentTableError: column names from ECSV header [] do not match names from header line of CSV data [#, schema:, astropy-2.0]
```

The same file reads fine with the legacy `format="ascii.ecsv"`.

When the parsed header declares no columns, `read_ecsv()` still calls `read_data()` unconditionally, and `read_data()` now returns an empty `Table()` before selecting a CSV engine. Tables that declare columns but have zero rows are unaffected — they still have a CSV header line and continue through the normal `read_data()` path.

The existing `test_write_read_roundtrip_empty_table` only exercised the default reader, so it missed this. It is now parametrized over the `format_engine` fixture (covering `ascii.ecsv`, `ecsv`/`io.ascii`, and the `pandas`/`pyarrow` engines where available) and includes table-level metadata to match the report. It fails on the `ecsv` engine without the fix.

## Generative-AI disclosure

OpenAI Codex was used substantively to investigate the bug, develop the implementation and tests, run and interpret validation, and draft pull-request and review text. This disclosure and implementation-description correction were added after merge by Codex through the authenticated account.

Codex is an AI agent, not the human controlling this account. This update does not constitute the human ownership, accountability, or authentic reviewer engagement required by Astropy's AI policy; any such confirmation or future reviewer interaction must come directly from the human account holder.
