### PR TITLE
Fix BST index engine returning range query results in unsorted order

### DIFF
--- a/astropy/table/bst.py
+++ b/astropy/table/bst.py
@@ -451,22 +451,26 @@ class BST:
         return [x for node in nodes for x in node.data]
 
     def _range(self, lower, upper, op1, op2, node, lst):
+        # In-order traversal (left, node, right) so that matching nodes
+        # are collected in ascending key order.
+        if lower < node.key and node.left is not None:
+            self._range(lower, upper, op1, op2, node.left, lst)
         if op1(lower, node.key) and op2(upper, node.key):
             lst.append(node)
         if upper > node.key and node.right is not None:
             self._range(lower, upper, op1, op2, node.right, lst)
-        if lower < node.key and node.left is not None:
-            self._range(lower, upper, op1, op2, node.left, lst)
         return lst
 
     def _same_prefix(self, val, node, lst):
+        # In-order traversal (left, node, right) so that matching nodes
+        # are collected in ascending key order.
         prefix = node.key[: len(val)]
+        if prefix >= val and node.left is not None:
+            self._same_prefix(val, node.left, lst)
         if prefix == val:
             lst.append(node)
         if prefix <= val and node.right is not None:
             self._same_prefix(val, node.right, lst)
-        if prefix >= val and node.left is not None:
-            self._same_prefix(val, node.left, lst)
         return lst
 
     def __repr__(self):

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -1148,3 +1148,21 @@ def test_loc_range_with_duplicate_index_values(engine, table_type):
     assert sorted(t.loc[2:2]["b"].tolist()) == [20, 21, 22]
     assert sorted(t.loc[2:3]["b"].tolist()) == [20, 21, 22, 30, 31]
     assert sorted(t.loc[:]["b"].tolist()) == [10, 20, 21, 22, 30, 31]
+
+
+def test_loc_range_sorted_after_add_row(engine):
+    """Regression test: a range query must return rows in ascending key order,
+    also for rows added after the index was created.
+
+    The ``BST`` engine previously collected nodes in node-right-left order,
+    so after ``add_row`` the tree was no longer a degenerate chain and
+    ``t.loc[lower:upper]`` returned rows in scrambled order.
+    """
+    t = Table([[1, 5, 9], [10, 50, 90]], names=("a", "b"))
+    t.add_index("a", engine=engine)
+    for a, b in [(7, 70), (3, 30), (8, 80), (2, 20), (6, 60), (4, 40)]:
+        t.add_row((a, b))
+
+    assert t.loc[2:8]["a"].tolist() == [2, 3, 4, 5, 6, 7, 8]
+    assert t.loc[2:8]["b"].tolist() == [20, 30, 40, 50, 60, 70, 80]
+    assert t.loc[:]["a"].tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/docs/changes/table/19912.bugfix.rst
+++ b/docs/changes/table/19912.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a bug where a ``Table.loc[]`` range query using the ``BST`` index
+engine returned rows in scrambled order if rows had been added after the
+index was created.


### PR DESCRIPTION
Fixes #19911

`BST._range` collected matching nodes in node→right→left order, so `t.loc[lower:upper]` with the BST engine was only sorted by accident: right after `add_index` the tree is a degenerate right-chain (index data is pre-sorted), but once `add_row` makes it branch, range queries come back scrambled — e.g. `[5, 7, 8, 6, 3, 4, 2]` instead of `[2, 3, 4, 5, 6, 7, 8]`. `SortedArray` and `SCEngine` both return sorted rows, and the indexing docs show sorted output.

This switches `_range` (and `_same_prefix`, which had the same pattern) to an in-order traversal, keeping the existing pruning conditions. Added a regression test parametrized over all engines that adds rows after indexing, which is exactly the case the existing tests missed.
