### PR TITLE
Stop preserving NULL once a logical column is read as a bool array (without logical_as_bytes)

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -167,6 +167,9 @@ class FITS_rec(np.recarray):
     _character_as_bytes = False
     _logical_as_bytes = False
     _load_variable_length_data = True
+    # True while ``from_columns`` materializes columns internally, so a logical
+    # column's bool conversion is not counted as a user-facing read.
+    _converting_internally = False
 
     def __new__(cls, input):
         """
@@ -212,6 +215,7 @@ class FITS_rec(np.recarray):
 
         for attrs in [
             "_converted",
+            "_logical_null_coerced",
             "_heapoffset",
             "_heapsize",
             "_tbsize",
@@ -244,6 +248,7 @@ class FITS_rec(np.recarray):
 
         if isinstance(obj, FITS_rec) and obj.dtype == self.dtype:
             self._converted = obj._converted
+            self._logical_null_coerced = obj._logical_null_coerced
             self._heapoffset = obj._heapoffset
             self._heapsize = obj._heapsize
             self._tbsize = obj._tbsize
@@ -257,6 +262,7 @@ class FITS_rec(np.recarray):
             # just other FITS_rec objects
             self._nfields = len(self.dtype.fields)
             self._converted = {}
+            self._logical_null_coerced = set()
 
             self._heapoffset = getattr(obj, "_heapoffset", 0)
             self._heapsize = getattr(obj, "_heapsize", 0)
@@ -281,6 +287,9 @@ class FITS_rec(np.recarray):
         """Initializes internal attributes specific to FITS-isms."""
         self._nfields = 0
         self._converted = {}
+        # Logical columns whose NULL (b'\x00') was coerced to False by a bool
+        # read; written back as b'T'/b'F' only (see _scale_back).
+        self._logical_null_coerced = set()
         self._heapoffset = 0
         self._heapsize = 0
         self._tbsize = 0
@@ -508,14 +517,20 @@ class FITS_rec(np.recarray):
         # ``_convert_p`` during this internal plumbing: the user has not yet
         # accessed the data, so a warning issued here would be spurious. The
         # warning is still emitted the next time the user reads the column.
+        # ``_converting_internally`` also stops ``_convert_other`` marking these
+        # NULLs as coerced, so |S1-supplied NULL bytes survive the round-trip.
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
                 message=r".*[Cc]olumn '.*' contains NULL",
                 category=AstropyUserWarning,
             )
-            for idx in range(len(columns)):
-                columns._arrays[idx] = data.field(idx)
+            data._converting_internally = True
+            try:
+                for idx in range(len(columns)):
+                    columns._arrays[idx] = data.field(idx)
+            finally:
+                data._converting_internally = False
 
         return data
 
@@ -591,6 +606,7 @@ class FITS_rec(np.recarray):
         out._coldefs = ColDefs(self._coldefs)
         arrays = []
         out._converted = {}
+        out._logical_null_coerced = set(self._logical_null_coerced)
         for idx, name in enumerate(self._coldefs.names):
             #
             # Store the new arrays for the _coldefs object
@@ -1126,7 +1142,7 @@ class FITS_rec(np.recarray):
             else:
                 # Check for NULL values (0x00) before converting
                 null_mask = field == 0
-                if np.any(null_mask):
+                if np.any(null_mask) and not self._converting_internally:
                     warnings.warn(
                         f"Column '{column.name}' contains NULL (undefined) values "
                         "which will be converted to False. To preserve NULL "
@@ -1135,6 +1151,10 @@ class FITS_rec(np.recarray):
                         "b'T' (True), and b'F' (False).",
                         AstropyUserWarning,
                     )
+                    # The user saw the lossy bool view (which can't represent
+                    # NULL), so record the column: _scale_back then writes
+                    # b'T'/b'F' for every row, collapsing NULL to match the warning.
+                    self._logical_null_coerced.add(column.name)
                 field = np.equal(field, ord("T"))
         elif _str:
             if not self._character_as_bytes:
@@ -1368,18 +1388,29 @@ class FITS_rec(np.recarray):
 
             # ASCII table does not have Boolean type
             elif _bool and name in self._converted:
-                choices = (
-                    np.array([ord("F")], dtype=np.int8)[0],
-                    np.array([ord("T")], dtype=np.int8)[0],
-                )
-                # Only overwrite raw bytes where the cached bool disagrees
-                # with the raw byte's implied bool value (b'T'==True,
-                # anything else==False). This preserves NULL (b'\x00') and
-                # other non-T/F raw bytes where the user has not modified
-                # the corresponding boolean value.
-                current_as_bool = raw_field == ord("T")
-                needs_update = field != current_as_bool
-                raw_field[needs_update] = np.choose(field[needs_update], choices)
+                if field.dtype.kind == "S":
+                    # logical_as_bytes=True: ``field`` holds the raw L wire bytes
+                    # (b'T'/b'F'/b'\x00'); copy verbatim so NULL is preserved.
+                    raw_field[:] = field.view(np.int8)
+                else:
+                    choices = (
+                        np.array([ord("F")], dtype=np.int8)[0],
+                        np.array([ord("T")], dtype=np.int8)[0],
+                    )
+                    if name in self._logical_null_coerced:
+                        # Read as bool (warned): that view can't represent NULL,
+                        # so write b'T'/b'F' for every row -- NULL collapses to
+                        # False and an explicit False is stored as b'F', not NULL.
+                        raw_field[:] = np.choose(field, choices)
+                    else:
+                        # No lossy bool read (e.g. built from a |S1 array with
+                        # explicit NULL): only rewrite rows where the cached bool
+                        # disagrees with the raw byte, preserving genuine NULL.
+                        current_as_bool = raw_field == ord("T")
+                        needs_update = field != current_as_bool
+                        raw_field[needs_update] = np.choose(
+                            field[needs_update], choices
+                        )
 
             # Validate the on-disk bytes of a fixed-length logical ('L')
             # column: only b'T', b'F', and b'\x00' are legal. This catches

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3000,6 +3000,61 @@ class TestTableFunctions(FitsTestCase):
                 with pytest.raises(ValueError, match="only b'T', b'F'"):
                     hdul.writeto(tmp_path / f"bad_{bad}.fits")
 
+    def test_logical_null_collapses_on_bool_write(self, tmp_path):
+        """Reading a logical ('L') column without ``logical_as_bytes`` is a
+        lossy view (NULL -> False, with a warning); writing it back stores only
+        b'T'/b'F', never NULL. NULL survives only via ``logical_as_bytes=True``.
+        """
+        # Source file with a genuine NULL in row 1 (raw bytes b'T', NUL, b'F').
+        src = np.array([b"T", b"\x00", b"F"], dtype="S1")
+        src_path = tmp_path / "src.fits"
+        fits.BinTableHDU.from_columns([fits.Column("flag", "L", array=src)]).writeto(
+            src_path
+        )
+
+        # Explicitly assigning False to the formerly-NULL row stores b'F'.
+        with pytest.warns(AstropyUserWarning, match="contains NULL"):
+            with fits.open(src_path) as hdul:
+                hdul[1].data["flag"][1] = False
+                out = tmp_path / "explicit_false.fits"
+                hdul.writeto(out)
+        with fits.open(out, logical_as_bytes=True) as hdul:
+            assert hdul[1].data["flag"].tobytes() == b"TFF"
+
+        # Merely reading the column as bool (no modification) and writing back
+        # also collapses NULL to b'F'.
+        with pytest.warns(AstropyUserWarning, match="contains NULL"):
+            with fits.open(src_path) as hdul:
+                list(hdul[1].data["flag"])
+                collapsed = tmp_path / "collapsed.fits"
+                hdul.writeto(collapsed)
+        with fits.open(collapsed, logical_as_bytes=True) as hdul:
+            assert hdul[1].data["flag"].tobytes() == b"TFF"
+
+        # logical_as_bytes is the documented way to preserve NULL on write.
+        with fits.open(src_path, logical_as_bytes=True) as hdul:
+            hdul[1].data["flag"][0] = b"\x00"
+            preserved = tmp_path / "preserved.fits"
+            hdul.writeto(preserved)
+        with fits.open(preserved, logical_as_bytes=True) as hdul:
+            assert hdul[1].data["flag"].tobytes() == b"\x00\x00F"
+
+        # A column that is never accessed as bool is written through verbatim,
+        # so its NULL survives even when another column is modified.
+        two_path = tmp_path / "two.fits"
+        fits.BinTableHDU.from_columns(
+            [
+                fits.Column("flag", "L", array=src),
+                fits.Column("num", "J", array=np.array([1, 2, 3])),
+            ]
+        ).writeto(two_path)
+        with fits.open(two_path) as hdul:
+            hdul[1].data["num"][0] = 99
+            untouched = tmp_path / "untouched.fits"
+            hdul.writeto(untouched)
+        with fits.open(untouched, logical_as_bytes=True) as hdul:
+            assert hdul[1].data["flag"].tobytes() == b"T\x00F"
+
     def test_missing_tnull(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/197"""
 

--- a/docs/changes/io.fits/19941.bugfix.rst
+++ b/docs/changes/io.fits/19941.bugfix.rst
@@ -1,0 +1,10 @@
+Fixed a bug where a logical (``'L'``) column read without ``logical_as_bytes=True``
+did not round-trip the boolean array it returned. Although reading the column
+warned that its NULL (``b'\x00'``) values would be converted to ``False``,
+``_scale_back`` preserved the original NULL bytes on write, so explicitly
+assigning ``False`` to a row that was NULL on disk was silently dropped and the
+``contains NULL`` warning kept firing on every read. Once a logical column
+containing NULL has been read as a bool array, it is now written back as
+``b'T'``/``b'F'``, matching the warning. NULL is still preserved when the column
+is accessed with ``logical_as_bytes=True``, supplied as a ``|S1`` array, or
+never read as bool.


### PR DESCRIPTION
_This is one last fix which is again also arguably a bug fix which I'd like to include in 8.0.1 to fix some of the behavior with the new logical NULL functionality introduced in 8.0.0._

Reading a FITS logical column without `logical_as_bytes=True` returns a bool array in which NULL (`b'\x00'`) is coerced to `False`, and warns that it has done so. But on write-back the original NULL bytes are currently *preserved* rather than converted, so the bool array users read and edit does not round-trip to disk: explicitly assigning `False` to a row that was NULL is silently dropped, and the column keeps emitting the `contains NULL` warning on every read even after every value has been set. In other words the warning is not correctly reflecting the truth.

Here is a minimal example to demonstrate the bug:

```pycon
>>> import numpy as np
>>> from astropy.io import fits

>>> # build a file whose logical column has a NULL in row 1 (raw bytes b'T', b'\x00', b'F')
>>> col = fits.Column("flag", "L", array=np.array([b"T", b"\x00", b"F"], dtype="S1"))
>>> fits.BinTableHDU.from_columns([col]).writeto("flags.fits", overwrite=True)

>>> hdul = fits.open("flags.fits")
>>> flag = hdul[1].data["flag"]          # materialize the column as a bool array
WARNING: Column 'flag' contains NULL (undefined) values which will be converted to False. To preserve NULL information, reopen the file with logical_as_bytes=True and check for bytes values of b'\x00' (NULL), b'T' (True), and b'F' (False). [astropy.io.fits.fitsrec]
>>> flag
array([ True, False, False])
>>> flag[0] = False                      # row 0 was True  -> changes to b'F'
>>> flag[1] = False                      # row 1 was NULL  -> *should* change to b'F'
>>> flag[2] = True                       # row 2 was False -> changes to b'T'
>>> hdul.writeto("out.fits", overwrite=True)
>>> hdul.close()

>>> # before this PR: rows 0 and 2 changed, but row 1 is still NULL
>>> fits.open("out.fits", logical_as_bytes=True)[1].data["flag"].tobytes()
b'F\x00T'
```

The issue here is that `_scale_back` decides which raw bytes to rewrite with `raw_field == ord("T")`, which is `False` for both a NULL byte and a `b'F'` byte. The cached `False` therefore "matches" the NULL byte and the byte is left untouched. The selective write was added with the 8.0 NULL support to preserve genuine NULLs, but it cannot distinguish an explicit `False` from a `False` produced by coercing a NULL.

The cleanest way I've found to fix it is that once a NULL-containing logical column has been materialized as a bool array (the lossy view the warning is about), write it back as `b'T'`/`b'F'`. With this PR the same edit gives:

```pycon
>>> hdul = fits.open("flags.fits")
>>> hdul[1].data["flag"][1] = False
WARNING: Column 'flag' contains NULL (undefined) values which will be converted to False. ... [astropy.io.fits.fitsrec]
>>> hdul.writeto("out.fits", overwrite=True)
>>> hdul.close()
>>> fits.open("out.fits", logical_as_bytes=True)[1].data["flag"].tobytes()
b'TFF'
```

There are two side effects of this, which I think/hope we can live with:

1. Conversion is lazy and per-column, so whether NULL survives a copy depends on whether you touched the column. If you read a file and never access the column, NULLs are preserved on disk even if you opened with ``logical_as_bytes=False`` - we have to do this because data access is lazy, so we can't go through all the data at open time and convert all the data over to bool preemptively.

2. Operations that access *every* column -- `repr`/printing the table, `Table.read`, iterating rows -- count as reading the logical column, so they too cause its NULLs to be written as `False` on a later write:

```pycon
>>> hdul = fits.open("flags.fits")
>>> _ = repr(hdul[1].data)              # converts all columns
WARNING: Column 'flag' contains NULL (undefined) values which will be converted to False. ... [astropy.io.fits.fitsrec]
>>> hdul.writeto("copy2.fits", overwrite=True)
>>> hdul.close()
>>> fits.open("copy2.fits", logical_as_bytes=True)[1].data["flag"].tobytes()
b'TFF'
```

The same rule applies under `mode='update'`: reading a NULL logical column and letting the file flush on close rewrites those NULLs as `False` in place. To read or edit NULL deliberately in any of these situations, use `logical_as_bytes=True`.

To be clear though, the most important here is that the warning and behavior are consistent. If a warning is emitted, then the data will be changed when the file is written (which is not the case currently). If a user opens a file in update mode just to update the header, the logical data won't be touched.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

