### PR TITLE
Fix misleading exception when required TimeSeries columns are missing

### DIFF
--- a/astropy/timeseries/core.py
+++ b/astropy/timeseries/core.py
@@ -70,15 +70,32 @@ class BaseTimeSeries(QTable):
 
             if not self._required_columns_relax and len(self.colnames) == 0:
 
-                raise ValueError("{} object is invalid - expected '{}' "
-                                 "as the first column{} but time series has no columns"
-                                 .format(self.__class__.__name__, required_columns[0], plural))
+                raise ValueError("{} object is invalid - time series has no columns, "
+                                 "expected required column{}: {}"
+                                 .format(self.__class__.__name__, plural,
+                                         ', '.join(required_columns)))
 
-            elif self.colnames[:len(required_columns)] != required_columns:
+            elif self.colnames[0] != required_columns[0]:
 
                 raise ValueError("{} object is invalid - expected '{}' "
                                  "as the first column{} but found '{}'"
                                  .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
+
+            elif self.colnames[:len(required_columns)] != required_columns:
+
+                missing = [name for name in required_columns
+                           if name not in self.colnames[:len(required_columns)]]
+
+                if len(required_columns) == 1:
+                    raise ValueError("{} object is invalid - expected '{}' "
+                                     "as the first column{} but found '{}'"
+                                     .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
+                else:
+                    raise ValueError("{} object is invalid - expected '{}' "
+                                     "as the first column{} but found '{}', "
+                                     "missing required column{}: {}"
+                                     .format(self.__class__.__name__, required_columns[0], plural,
+                                             self.colnames[0], plural, ', '.join(missing)))
 
             if (self._required_columns_relax
                     and self._required_columns == self.colnames[:len(self._required_columns)]):

--- a/astropy/timeseries/tests/test_binned.py
+++ b/astropy/timeseries/tests/test_binned.py
@@ -31,6 +31,25 @@ def test_empty_initialization_invalid():
                                  "'time_bin_start' as the first column but found 'flux'")
 
 
+def test_required_columns_missing():
+
+    # Regression test for misleading error message when a required column
+    # other than the first one is missing.
+
+    ts = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
+                          time_bin_size=3 * u.s, data=[[1, 4, 3], [3, 4, 3]],
+                          names=['flux', 'other'])
+    ts._required_columns = ['time_bin_start', 'time_bin_size', 'flux']
+
+    with pytest.raises(ValueError) as exc:
+        ts.remove_column('flux')
+    assert "missing required column" in exc.value.args[0]
+    assert "flux" in exc.value.args[0]
+    assert exc.value.args[0] == ("BinnedTimeSeries object is invalid - expected "
+                                 "'time_bin_start' as the first columns but found "
+                                 "'time_bin_start', missing required columns: flux")
+
+
 def test_initialization_time_bin_invalid():
 
     # Make sure things crash when time_bin_* is passed incorrectly.

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -396,6 +396,25 @@ def test_required_columns():
                                  "'time' as the first column but found 'banana'")
 
 
+def test_required_columns_missing():
+
+    # Regression test for misleading error message when a required column
+    # other than the first one is missing.
+
+    ts = TimeSeries(time=INPUT_TIME,
+                    data=[[10, 2, 3], [4, 5, 6]],
+                    names=['flux', 'other'])
+    ts._required_columns = ['time', 'flux']
+
+    with pytest.raises(ValueError) as exc:
+        ts.remove_column('flux')
+    assert "missing required column" in exc.value.args[0]
+    assert "flux" in exc.value.args[0]
+    assert exc.value.args[0] == ("TimeSeries object is invalid - expected "
+                                 "'time' as the first columns but found 'time', "
+                                 "missing required columns: flux")
+
+
 @pytest.mark.parametrize('cls', [BoxLeastSquares, LombScargle])
 def test_periodogram(cls):
 

--- a/docs/changes/timeseries/13033.bugfix.rst
+++ b/docs/changes/timeseries/13033.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed misleading error message in ``TimeSeries`` and ``BinnedTimeSeries`` when
+required columns other than the first one were missing.


### PR DESCRIPTION
This PR fixes the confusing error message raised when a `TimeSeries` (or `BinnedTimeSeries`) subclass declares required columns beyond the first and an operation removes one of them.\n\nPreviously, removing a later required column produced:\n\n```\nValueError: TimeSeries object is invalid - expected 'time' as the first columns but found 'time'\n```\n\n`BaseTimeSeries._check_required_columns()` now distinguishes between a wrong first column, missing later required columns, and an empty table, and reports which required columns are actually missing.\n\nFixes #13033\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)