### PR TITLE
Fix misleading TimeSeries exception when a required column is removed

### DIFF
--- a/astropy/timeseries/core.py
+++ b/astropy/timeseries/core.py
@@ -66,19 +66,28 @@ class BaseTimeSeries(QTable):
             else:
                 required_columns = self._required_columns
 
-            plural = 's' if len(required_columns) > 1 else ''
+            if self._required_columns_relax:
+                # In relax mode we only validate the prefix of columns that exist.
+                if self.colnames[:len(required_columns)] != required_columns:
+                    plural = 's' if len(required_columns) > 1 else ''
+                    raise ValueError("{} object is invalid - expected '{}' "
+                                     "as the first column{} but found '{}'"
+                                     .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
+            else:
+                # Strict mode: every required column must be present, in order,
+                # starting at the first column.
+                missing = [name for name in required_columns if name not in self.colnames]
+                if missing:
+                    plural = 's' if len(missing) > 1 else ''
+                    raise ValueError("{} object is invalid - required "
+                                     "column{} missing: {}"
+                                     .format(self.__class__.__name__, plural, missing))
 
-            if not self._required_columns_relax and len(self.colnames) == 0:
-
-                raise ValueError("{} object is invalid - expected '{}' "
-                                 "as the first column{} but time series has no columns"
-                                 .format(self.__class__.__name__, required_columns[0], plural))
-
-            elif self.colnames[:len(required_columns)] != required_columns:
-
-                raise ValueError("{} object is invalid - expected '{}' "
-                                 "as the first column{} but found '{}'"
-                                 .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
+                if self.colnames[:len(required_columns)] != required_columns:
+                    plural = 's' if len(required_columns) > 1 else ''
+                    raise ValueError("{} object is invalid - expected '{}' "
+                                     "as the first column{} but found '{}'"
+                                     .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
 
             if (self._required_columns_relax
                     and self._required_columns == self.colnames[:len(self._required_columns)]):

--- a/astropy/timeseries/tests/test_binned.py
+++ b/astropy/timeseries/tests/test_binned.py
@@ -294,6 +294,46 @@ def test_read():
     assert timeseries['B'].sum() == 1151.54
 
 
+def test_remove_required_column():
+
+    # Test that removing a required column (other than time_bin_start) reports
+    # the missing column clearly instead of a misleading first-column mismatch
+    # message.
+
+    ts = BinnedTimeSeries(time_bin_start='2016-03-22T12:30:31',
+                          time_bin_size=3 * u.s, data=[[1, 4, 3], [3, 4, 3]], names=['a', 'b'])
+    # _required_columns is a class-level list, so we work on a copy to avoid
+    # mutating the shared attribute. Note that ts.copy() reconstructs the
+    # object from the table data and resets _required_columns to the class
+    # default, so we set it explicitly on the copied instance before removing
+    # columns.
+    required_columns = ts._required_columns + ['a']
+
+    # Removing a later required column reports the missing column.
+    ts2 = ts.copy()
+    ts2._required_columns = required_columns
+    with pytest.raises(ValueError) as exc:
+        ts2.remove_column('a')
+    assert exc.value.args[0] == ("BinnedTimeSeries object is invalid - required "
+                                 "column missing: ['a']")
+
+    # Removing multiple columns reports all missing required columns.
+    ts2 = ts.copy()
+    ts2._required_columns = required_columns
+    with pytest.raises(ValueError) as exc:
+        ts2.remove_columns(['a', 'b'])
+    assert exc.value.args[0] == ("BinnedTimeSeries object is invalid - required "
+                                 "column missing: ['a']")
+
+    # Removing the time_bin_start column still reports the missing required column.
+    ts2 = ts.copy()
+    ts2._required_columns = required_columns
+    with pytest.raises(ValueError) as exc:
+        ts2.remove_column('time_bin_start')
+    assert exc.value.args[0] == ("BinnedTimeSeries object is invalid - required "
+                                 "column missing: ['time_bin_start']")
+
+
 @pytest.mark.parametrize('cls', [BoxLeastSquares, LombScargle])
 def test_periodogram(cls):
 

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -377,23 +377,63 @@ def test_required_columns():
 
     with pytest.raises(ValueError) as exc:
         ts.copy().keep_columns(['a', 'b'])
-    assert exc.value.args[0] == ("TimeSeries object is invalid - expected "
-                                 "'time' as the first column but found 'a'")
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['time']")
 
     with pytest.raises(ValueError) as exc:
         ts.copy().remove_column('time')
-    assert exc.value.args[0] == ("TimeSeries object is invalid - expected "
-                                 "'time' as the first column but found 'a'")
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['time']")
 
     with pytest.raises(ValueError) as exc:
         ts.copy().remove_columns(['time', 'a'])
-    assert exc.value.args[0] == ("TimeSeries object is invalid - expected "
-                                 "'time' as the first column but found 'b'")
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['time']")
 
     with pytest.raises(ValueError) as exc:
         ts.copy().rename_column('time', 'banana')
-    assert exc.value.args[0] == ("TimeSeries object is invalid - expected "
-                                 "'time' as the first column but found 'banana'")
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['time']")
+
+
+def test_remove_required_column():
+
+    # Test that removing a required column (other than time) reports the missing
+    # column clearly instead of a misleading first-column mismatch message.
+
+    ts = TimeSeries(time=INPUT_TIME,
+                    data=[[10, 2, 3], [4, 5, 6]],
+                    names=['a', 'b'])
+    # _required_columns is a class-level list, so we work on a copy to avoid
+    # mutating the shared attribute. Note that ts.copy() reconstructs the
+    # object from the table data and resets _required_columns to the class
+    # default, so we set it explicitly on the copied instance before removing
+    # columns.
+    required_columns = ts._required_columns + ['a']
+
+    # Removing a later required column reports the missing column.
+    ts2 = ts.copy()
+    ts2._required_columns = required_columns
+    with pytest.raises(ValueError) as exc:
+        ts2.remove_column('a')
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['a']")
+
+    # Removing multiple columns reports all missing required columns.
+    ts2 = ts.copy()
+    ts2._required_columns = required_columns
+    with pytest.raises(ValueError) as exc:
+        ts2.remove_columns(['a', 'b'])
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['a']")
+
+    # Removing the time column still reports the missing required column.
+    ts2 = ts.copy()
+    ts2._required_columns = required_columns
+    with pytest.raises(ValueError) as exc:
+        ts2.remove_column('time')
+    assert exc.value.args[0] == ("TimeSeries object is invalid - required "
+                                 "column missing: ['time']")
 
 
 @pytest.mark.parametrize('cls', [BoxLeastSquares, LombScargle])

--- a/docs/changes/timeseries/13033.bugfix.rst
+++ b/docs/changes/timeseries/13033.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed the misleading exception message when a required column is removed from a
+``TimeSeries`` (or subclass). The error now reports that a required column is
+missing, rather than appearing to complain about the ``time`` column.


### PR DESCRIPTION
### Description

When a TimeSeries object has additional required columns (in addition to time) and code mistakenly removes one of them, the exception message is misleading:



This PR fixes BaseTimeSeries._check_required_columns so that it distinguishes between:

1. A required column that is missing entirely — now raises ValueError: ... required column missing: ['flux'].
2. A genuine first-column ordering mismatch — keeps the existing message.

### Changes

- astropy/timeseries/core.py: split strict-mode validation into a missing-column check followed by the existing first-column check.
- astropy/timeseries/tests/test_sampled.py: update test_required_columns for the new message text; add test_remove_required_column regression test.
- astropy/timeseries/tests/test_binned.py: add analogous regression test for BinnedTimeSeries.
- docs/changes/timeseries/13033.bugfix.rst: add towncrier bugfix fragment.

Fixes #13033.