### PR TITLE
Treat tables opened with mode='denywrite' as read-only instead of writing back unchanged columns on save

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -780,6 +780,15 @@ class FITS_rec(np.recarray):
                 # fields
                 converted = self._convert_other(column, field, recformat)
 
+            # If the underlying data is read-only (e.g. opened with
+            # mode='denywrite'), hand out a read-only array so that editing a
+            # scaled/logical/bit column raises rather than being silently
+            # dropped on write -- matching plain columns and image data, which
+            # are direct views of the read-only buffer.
+            if converted is not field and not field.flags.writeable:
+                with suppress(ValueError):
+                    converted.flags.writeable = False
+
             # Note: Never assign values directly into the self._converted dict;
             # always go through self._cache_field; this way self._converted is
             # only used to store arrays that are not already direct views of
@@ -1264,6 +1273,12 @@ class FITS_rec(np.recarray):
         the heap.  Currently this is only used as an optimization for
         CompImageHDU that does its own handling of the heap.
         """
+        # Read-only data (e.g. opened with mode='denywrite') cannot have been
+        # modified -- field() hands out read-only arrays -- so the raw bytes are
+        # already the correct on-disk form and must not (and cannot) be written
+        # back. We still walk the columns to recompute the heap size.
+        read_only = not self.flags.writeable
+
         # Running total for the new heap size
         heapsize = 0
 
@@ -1281,7 +1296,7 @@ class FITS_rec(np.recarray):
                 # an array of characters.
                 dtype = np.array([], dtype=recformat.dtype).dtype
 
-                if update_heap_pointers and name in self._converted:
+                if update_heap_pointers and name in self._converted and not read_only:
                     # The VLA has potentially been updated, so we need to
                     # update the array descriptors
                     raw_field[:] = 0  # reset
@@ -1297,6 +1312,11 @@ class FITS_rec(np.recarray):
                 # Even if this VLA has not been read or updated, we need to
                 # include the size of its constituent arrays in the heap size
                 # total
+
+            # Read-only data was not modified and its buffer cannot be written,
+            # so skip all the column write-back below (heap size is done above).
+            if read_only:
+                continue
 
             if isinstance(recformat, _FormatX) and name in self._converted:
                 _wrapx(self._converted[name], raw_field, recformat.repeat)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -405,6 +405,64 @@ class TestTableFunctions(FitsTestCase):
 
         a.close()
 
+    @pytest.mark.parametrize("mode", ["readonly", "denywrite", "update"])
+    def test_writeto_after_open_modes(self, tmp_path, mode):
+        """Writing a table to a new file must not fail in any open mode, even
+        though scaled (TSCALn/TZEROn), logical (``'L'``) and bit (``'X'``)
+        columns have an on-disk form that differs from their in-memory values.
+        A ``mode='denywrite'`` buffer is read-only, so nothing could have been
+        modified and ``_scale_back`` does not write it back -- this previously
+        raised "assignment destination is read-only".
+        """
+        cols = [
+            fits.Column("plain", "J", array=np.array([10, 20, 30])),
+            fits.Column(
+                "scaled", "E", array=np.array([1.0, 2.0, 3.0]), bscale=2.0, bzero=5.0
+            ),
+            fits.Column("bits", "2X", array=np.array([[1, 0], [0, 1], [1, 1]])),
+            fits.Column("flag", "L", array=np.array([True, False, True])),
+        ]
+        in_path = tmp_path / "in.fits"
+        fits.BinTableHDU.from_columns(cols).writeto(in_path)
+
+        out_path = tmp_path / "out.fits"
+        with fits.open(in_path, mode=mode) as hdul:
+            for name in hdul[1].columns.names:
+                hdul[1].data[name]
+            hdul.writeto(out_path)
+
+        with fits.open(out_path) as hdul:
+            data = hdul[1].data
+            assert data["plain"].tolist() == [10, 20, 30]
+            np.testing.assert_allclose(data["scaled"], [1.0, 2.0, 3.0])
+            assert data["bits"].tolist() == [[True, False], [False, True], [True, True]]
+            assert data["flag"].tolist() == [True, False, True]
+
+    @pytest.mark.parametrize(
+        "fmt, array, kwargs",
+        [
+            ("J", [10, 20, 30], {}),
+            ("E", [1.0, 2.0, 3.0], {"bscale": 2.0, "bzero": 5.0}),
+            ("2X", [[1, 0], [0, 1], [1, 1]], {}),
+            ("L", [True, False, True], {}),
+        ],
+        ids=["int", "scaled", "bits", "logical"],
+    )
+    def test_denywrite_columns_are_readonly(self, tmp_path, fmt, array, kwargs):
+        """A table opened with ``mode='denywrite'`` exposes every column as a
+        read-only array, including scaled / logical / bit columns whose
+        in-memory form is a freshly converted array rather than a view of the
+        raw buffer. An in-place edit therefore raises instead of being silently
+        dropped on write (consistent with plain columns and image data).
+        """
+        in_path = tmp_path / "in.fits"
+        col = fits.Column("c", fmt, array=np.array(array), **kwargs)
+        fits.BinTableHDU.from_columns([col]).writeto(in_path)
+        with fits.open(in_path, mode="denywrite") as hdul:
+            data = hdul[1].data["c"]
+            with pytest.raises(ValueError, match="read-only"):
+                data[0] = data[0]
+
     def test_endianness(self):
         x = np.ndarray((1,), dtype=object)
         channelsIn = np.array([3], dtype="uint8")

--- a/docs/changes/io.fits/19955.api.rst
+++ b/docs/changes/io.fits/19955.api.rst
@@ -1,0 +1,7 @@
+A table opened with ``mode='denywrite'`` is now read-only throughout, matching
+image data and plain (unscaled) table columns. Scaled (``TSCALn``/``TZEROn``),
+logical (``'L'``) and bit (``'X'``) columns -- whose in-memory representation is
+a converted array rather than a view of the raw buffer -- are now exposed as
+read-only arrays, so an in-place edit raises ``ValueError`` instead of being
+silently accepted. As a result, writing such a table to a new file no longer
+fails with ``assignment destination is read-only``.


### PR DESCRIPTION
This is an alternative to #19952. Close https://github.com/astropy/astropy/pull/19952

A FITS file opened with `mode='denywrite'` is memory-mapped read-only: the underlying data buffer cannot be written. For **image data** and for **plain (unscaled) table columns** this already works correctly, because they are returned as direct views of that buffer - an in-place edit raises, and the file is protected:

```pycon
>>> import numpy as np
>>> from astropy.io import fits

>>> fits.PrimaryHDU(np.arange(4).reshape(2, 2)).writeto("image.fits", overwrite=True)
>>> hdul = fits.open("image.fits", mode="denywrite")
>>> hdul[0].data[0, 0] = 99
Traceback (most recent call last):
  ...
ValueError: assignment destination is read-only
```

But **scaled** (`TSCALn`/`TZEROn`), **logical** (`'L'`) and **bit** (`'X'`) columns are different: their in-memory form is a *freshly converted* array (the unscaled values, the boolean view, the unpacked bits…), not a view of the raw buffer. On `main` those converted arrays are writeable, so the same edit is silently accepted — inconsistent with plain columns and images:

```pycon
>>> fits.BinTableHDU.from_columns([
...     fits.Column("plain", "J", array=np.array([1, 2, 3])),
...     fits.Column("scaled", "E", array=np.array([1., 2., 3.]), bscale=2.0, bzero=5.0),
... ]).writeto("table.fits", overwrite=True)

>>> hdul = fits.open("table.fits", mode="denywrite")

>>> hdul[1].data["plain"][0] = 99       # plain column: view of the read-only buffer
Traceback (most recent call last):
  ...
ValueError: assignment destination is read-only

>>> hdul[1].data["scaled"][0] = 99      # scaled column: silently accepted (!)
>>> hdul[1].data["scaled"][0]
np.float64(99.0)
```

Worse, merely *reading* a scaled/logical/bit column and then writing the table to a new file crashes, because `_scale_back` tries to rewrite the raw bytes of the read-only buffer (this is the crash #19952 set out to fix):

```pycon
>>> hdul = fits.open("table.fits", mode="denywrite")
>>> _ = hdul[1].data["scaled"]          # materialise the column (apply scaling)
>>> hdul.writeto("out.fits")
Traceback (most recent call last):
  ...
ValueError: assignment destination is read-only
```

Instead of copying the data buffer so `_scale_back` can write to it (the approach in #19952), this PR treats a `denywrite` table as genuinely read-only throughout, so every column behaves like a plain column or an image:

* `field()` returns a **read-only array** whenever the underlying buffer is read-only, so editing *any* column type raises.
* `_scale_back` **does not write columns back** for read-only data — it cannot have been modified, and the raw bytes are already the correct on-disk representati
on — so writing the table to a new file works. The heap size is still recomputed, so variable-length columns round-trip.

With these changes:

```pycon
>>> hdul = fits.open("table.fits", mode="denywrite")

>>> hdul[1].data["plain"][0] = 99
Traceback (most recent call last):
  ...
ValueError: assignment destination is read-only

>>> hdul[1].data["scaled"][0] = 99      # now consistently read-only
Traceback (most recent call last):
  ...
ValueError: assignment destination is read-only

>>> hdul.writeto("out.fits")            # writing the unchanged table works
>>> fits.open("out.fits")[1].data["scaled"].tolist()
[1.0, 2.0, 3.0]
```

Plain, scaled, logical and bit columns — and image data — now all behave the same way under `denywrite`: read-only, and safe to write back out to a new file.

I think this is a cleaner solution and makes everything consistent - what do you think @saimn? I wonder about maybe not backporting this though since it's technically an api change? (I don't think we can deprecate it though, and it was kind of a bug that we allowed values to be changed before)