### PR TITLE
DOC: rst syntax, no space before :: in directive.

### DIFF
--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -362,7 +362,7 @@ doc_footer = """
         plane. Unless you really know what this means, you probably should
         not change this!
 
-    .. versionchanged :: 8.0
+    .. versionchanged:: 8.0
        ``galcen_v_sun`` is now a `~astropy.coordinates.CartesianRepresentation`
        rather than a `~astropy.coordinates.CartesianDifferential`.
 

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -33,7 +33,7 @@ doc_footer_lsr = """
         The velocity of the solar system barycenter with respect to the LSR, in
         Galactic cartesian velocity components.
 
-    .. versionchanged :: 8.0
+    .. versionchanged:: 8.0
        ``v_bary`` is now a `~astropy.coordinates.CartesianRepresentation`
        rather than a `~astropy.coordinates.CartesianDifferential`.
 """


### PR DESCRIPTION
Docutils is lenient on that, but is not the only rst parser. This makes sure the rst syntax is correct.
