### PR TITLE
Fixed deprecated use of shape setting in test_open_scaled_in_update_mode_compressed

### DIFF
--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -305,7 +305,7 @@ class TestCompressedImage(FitsTestCase):
 
         # Try reshaping the data, then closing and reopening the file; let's
         # see if all the changes are preserved properly
-        hdul[1].data.shape = (42, 10)
+        hdul[1].data = hdul[1].data.reshape(42, 10)
         hdul.close()
 
         hdul = fits.open(self.temp("scale.fits"))


### PR DESCRIPTION
This will hopefully unfail the v7.2.x and v8.0.x CI

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.


