### PR TITLE
feat: new method to init wcs with center and fov

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -561,6 +561,11 @@ def test_celestial_frame_to_wcs():
         celestial_frame_to_wcs(frame)
 
     frame = ICRS()
+    projection = "ABC"
+    with pytest.raises(ValueError, match="Must specify valid projection code*"):
+        celestial_frame_to_wcs(frame, projection)
+
+    frame = ICRS()
     mywcs = celestial_frame_to_wcs(frame)
     mywcs.wcs.set()
     assert tuple(mywcs.wcs.ctype) == ("RA---TAN", "DEC--TAN")

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -7,7 +7,14 @@ from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 from packaging.version import Version
 
 from astropy import units as u
-from astropy.coordinates import ITRS, BaseCoordinateFrame, EarthLocation, SkyCoord
+from astropy.coordinates import (
+    ITRS,
+    Angle,
+    BaseCoordinateFrame,
+    EarthLocation,
+    Galactic,
+    SkyCoord,
+)
 from astropy.coordinates.representation import SphericalRepresentation
 from astropy.coordinates.representation.geodetic import (
     BaseBodycentricRepresentation,
@@ -45,6 +52,7 @@ from astropy.wcs.utils import (
     pixel_to_pixel,
     pixel_to_skycoord,
     proj_plane_pixel_scales,
+    skycoord_to_celestial_wcs,
     skycoord_to_pixel,
     wcs_to_celestial_frame,
 )
@@ -621,6 +629,69 @@ def test_celestial_frame_to_wcs():
     assert tuple(mywcs.wcs.ctype) == ("TLON-CAR", "TLAT-CAR")
     assert mywcs.wcs.radesys == "ITRS"
     assert mywcs.wcs.dateobs == Time("J2000").utc.fits
+
+
+def test_skycoord_to_celestial_wcs():
+    # default values
+    center = SkyCoord(266.4, -29, unit="deg")
+    fov = Angle([4, 4], unit="arcmin")
+    pixel_scale = Angle(1, unit="arcmin")
+    wcs_default = skycoord_to_celestial_wcs(center, fov=fov, pixel_scale=pixel_scale)
+    assert wcs_default.naxis == 2
+    assert wcs_default.wcs.ctype[0] == "RA---TAN"
+    assert wcs_default.wcs.ctype[1] == "DEC--TAN"
+    expected_cdelt = 1 / 60.0
+    assert_allclose(wcs_default.wcs.cdelt, [-expected_cdelt, expected_cdelt])
+    assert_allclose(wcs_default.wcs.crval, [266.4, -29.0])
+    expected_naxis = 4
+    assert_allclose(wcs_default.array_shape, [expected_naxis, expected_naxis])
+    expected_crpix = expected_naxis / 2.0 + 0.5
+    assert_allclose(wcs_default.wcs.crpix, [expected_crpix, expected_crpix])
+
+    # all optional
+    center = SkyCoord(0, 0, unit="deg", frame="galactic")
+    data_shape = [150, 90]
+    wcs_optional = skycoord_to_celestial_wcs(
+        center,
+        shape=data_shape,
+        pixel_scale=Angle([-0.01, 0.02], unit="deg"),
+        reference_pixel=[15, 10],
+        frame=Galactic(),
+        projection="TAN",
+        rotation=Angle(90, unit="deg"),
+    )
+    assert_allclose(wcs_optional.wcs.cdelt, [-0.01, 0.02])
+    assert wcs_optional.wcs.ctype[0] == "GLON-TAN"
+    assert wcs_optional.wcs.ctype[1] == "GLAT-TAN"
+    assert_allclose(wcs_optional.wcs.crval, [0.0, 0.0])
+    assert_allclose(wcs_optional.array_shape, [150, 90])
+    assert_allclose(wcs_optional.wcs.crpix, [11, 16])
+    assert_allclose(wcs_optional.wcs.pc, [[0, 2], [-0.5, 0]], atol=1e-10)
+
+
+def test_skycoord_to_celestial_wcs_errors():
+    center = SkyCoord(0, 0, unit="deg", frame="galactic")
+    fov = Angle([8, 4], unit="deg")
+    pixel_scale = Angle(1, unit="deg")
+    shape = (100, 200)
+
+    with pytest.raises(ValueError, match="'reference_position' should be scalar*"):
+        center_non_scalar = SkyCoord([0, 0], [0, 0], unit="deg", frame="galactic")
+        skycoord_to_celestial_wcs(
+            center_non_scalar, shape=shape, pixel_scale=pixel_scale
+        )
+
+    with pytest.raises(ValueError, match="Missing 'fov' or 'shape'"):
+        skycoord_to_celestial_wcs(center, pixel_scale=pixel_scale)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        skycoord_to_celestial_wcs(center, fov=fov, shape=shape, pixel_scale=pixel_scale)
+
+    with pytest.raises(ValueError, match="'reference_pixel' should be of length 2"):
+        scalar_ref_pixel = [10]  # Only 1 element
+        skycoord_to_celestial_wcs(
+            center, fov=fov, pixel_scale=pixel_scale, reference_pixel=scalar_ref_pixel
+        )
 
 
 def test_body_to_wcs_frame():

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 
 from astropy import units as u
 from astropy.coordinates import (
+    ICRS,
     ITRS,
     Angle,
     BaseCoordinateFrame,
@@ -692,6 +693,34 @@ def test_skycoord_to_celestial_wcs_errors():
         skycoord_to_celestial_wcs(
             center, fov=fov, pixel_scale=pixel_scale, reference_pixel=scalar_ref_pixel
         )
+
+
+def test_crota_vs_pc_in_skycoord_to_celestial_wcs():
+    # see https://github.com/astropy/astropy/pull/19985#discussion_r3596900938
+    center = SkyCoord(0, 0, unit="deg")
+    shape = (100, 200)
+    pixel_scale = Angle([1, 0.5], unit="arcmin")
+    rotation = Angle(30, unit="deg")
+
+    wcs_pc = skycoord_to_celestial_wcs(
+        center, shape=shape, pixel_scale=pixel_scale, rotation=rotation
+    )
+
+    wcs_crota = celestial_frame_to_wcs(frame=ICRS(), projection="TAN")
+    wcs_crota.wcs.cdelt[0] = float(pixel_scale[0].to_value("deg"))
+    wcs_crota.wcs.cdelt[1] = float(pixel_scale[1].to_value("deg"))
+    wcs_crota.wcs.crval = [0, 0]
+    wcs_crota.array_shape = shape
+    wcs_crota.wcs.crpix = [50.5, 100.5]
+    wcs_crota.wcs.crota = 0, 30
+
+    x = np.arange(100)
+    y = np.arange(0, 200, 2)
+    pixel_pc = pixel_to_skycoord(x, y, wcs=wcs_pc)
+    pixel_crota = pixel_to_skycoord(x, y, wcs=wcs_crota)
+
+    assert_allclose(pixel_pc.data.lon.value, pixel_crota.data.lon.value)
+    assert_allclose(pixel_pc.data.lat.value, pixel_crota.data.lat.value)
 
 
 def test_body_to_wcs_frame():

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -707,15 +707,13 @@ def test_crota_vs_pc_in_skycoord_to_celestial_wcs():
     )
 
     wcs_crota = celestial_frame_to_wcs(frame=ICRS(), projection="TAN")
-    wcs_crota.wcs.cdelt[0] = float(pixel_scale[0].to_value("deg"))
-    wcs_crota.wcs.cdelt[1] = float(pixel_scale[1].to_value("deg"))
+    wcs_crota.wcs.cdelt = pixel_scale.to_value("deg")
     wcs_crota.wcs.crval = [0, 0]
     wcs_crota.array_shape = shape
     wcs_crota.wcs.crpix = [50.5, 100.5]
     wcs_crota.wcs.crota = 0, 30
 
-    x = np.arange(100)
-    y = np.arange(0, 200, 2)
+    y, x = np.mgrid[0:200:20, 0:100:10]
     pixel_pc = pixel_to_skycoord(x, y, wcs=wcs_pc)
     pixel_crota = pixel_to_skycoord(x, y, wcs=wcs_crota)
 

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -523,8 +523,7 @@ def skycoord_to_celestial_wcs(
         pixel_scale_in_deg = float(pixel_scale.to_value("deg"))
         wcs.wcs.cdelt = [-pixel_scale_in_deg, pixel_scale_in_deg]
     elif len(pixel_scale) == 2:
-        wcs.wcs.cdelt[0] = float(pixel_scale[0].to_value("deg"))
-        wcs.wcs.cdelt[1] = float(pixel_scale[1].to_value("deg"))
+        wcs.wcs.cdelt = pixel_scale.to_value("deg")
     else:
         raise ValueError(
             f"'pixel_scale' should be of length 1 or 2 but is {len(pixel_scale)}."

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import astropy.units as u
 from astropy.coordinates import (
+    ICRS,
     ITRS,
     BaseBodycentricRepresentation,
     BaseCoordinateFrame,
@@ -34,6 +35,7 @@ __all__ = [
     "pixel_to_skycoord",
     "proj_plane_pixel_area",
     "proj_plane_pixel_scales",
+    "skycoord_to_celestial_wcs",
     "skycoord_to_pixel",
     "wcs_to_celestial_frame",
 ]
@@ -411,6 +413,152 @@ def celestial_frame_to_wcs(frame, projection="TAN"):
     raise ValueError(
         "Could not determine WCS corresponding to the specified coordinate frame."
     )
+
+
+def skycoord_to_celestial_wcs(
+    reference_position,
+    *,
+    fov=None,
+    shape=None,
+    pixel_scale,
+    reference_pixel=None,
+    frame=None,
+    projection="TAN",
+    rotation=None,
+):
+    """Create a sky WCS from a reference position and a field of view.
+
+    Parameters
+    ----------
+    reference_position : `~astropy.coordinates.SkyCoord` of length 1
+        The coordinates of the center of the WCS. It should be scalar.
+    fov : `~astropy.coordinates.Angle` of length 2
+        The field of view in physical units. ``fov`` and ``shape`` are mutually
+        exclusive and one of them must be provided.
+    shape : Sequence[int, int]
+        The image size in pixels (NAXIS). ``fov`` and ``shape`` are mutually exclusive
+        and one of them must be provided.
+    pixel_scale : `~astropy.coordinates.Angle` of length 1 or 2
+        The pixel scale along the x and y axis. It is either of length 2 for each axis
+        or of length 1. Then ``cdelt`` will be set to ``[-pixel_scale, pixel_scale]``
+    reference_pixel : Sequence[int, int], optional
+        Reference pixel for the projection. In zero-indexed (Python convention) numpy
+        order (swapped with respect to the WCS convention). If ``None``, it will be set
+        to the center of the view.
+    frame : `~astropy.coordinates.BaseCoordinateFrame`, optional
+        An instance of `~astropy.coordinates.BaseCoordinateFrame` or subclass.
+        Defaults to `~astropy.coordinates.ICRS`.
+    projection : str, optional
+        Any valid WCS projection code (see the list with ``from astropy.wcs
+        import PRJ_CODES``), by default "TAN"
+    rotation : `~astropy.coordinates.Angle`, optional
+        The angle of rotation. It will be converted to a ``PC_ij`` matrix. By
+        default no rotation.
+
+    Returns
+    -------
+    `~astropy.wcs.WCS`
+        A celestial WCS object.
+
+    Examples
+    --------
+    >>> from astropy.wcs.utils import skycoord_to_celestial_wcs
+    >>> from astropy.coordinates import Angle, SkyCoord
+    >>> center = SkyCoord(266.4, -29, unit="deg")
+    >>> fov = Angle([8, 4], unit="deg")
+    >>> wcs = skycoord_to_celestial_wcs(center, fov=fov,
+    ...                                 pixel_scale=Angle([-0.1, 0.1], unit="deg"))
+    >>> print(wcs)
+    WCS Keywords
+    <BLANKLINE>
+    Number of WCS axes: 2
+    CTYPE : 'RA---TAN' 'DEC--TAN'
+    CUNIT : '' ''
+    CRVAL : 266.4 -29.0
+    CRPIX : 40.5 20.5
+    PC1_1 PC1_2  : 1.0 0.0
+    PC2_1 PC2_2  : 0.0 1.0
+    CDELT : -0.1 0.1
+    NAXIS : 40  80
+
+    You can also use ``shape`` instead of ``fov``:
+    >>> shape = (80, 40)
+    >>> wcs = skycoord_to_celestial_wcs(center, shape=shape,
+    ...                                 pixel_scale=Angle([-0.1, 0.1], unit="deg"))
+    >>> print(wcs)
+    WCS Keywords
+    <BLANKLINE>
+    Number of WCS axes: 2
+    CTYPE : 'RA---TAN' 'DEC--TAN'
+    CUNIT : '' ''
+    CRVAL : 266.4 -29.0
+    CRPIX : 40.5 20.5
+    PC1_1 PC1_2  : 1.0 0.0
+    PC2_1 PC2_2  : 0.0 1.0
+    CDELT : -0.1 0.1
+    NAXIS : 40  80
+    """
+    if not reference_position.isscalar:
+        raise ValueError(
+            "'reference_position' should be scalar, "
+            f"but is of length {len(reference_position)}"
+        )
+
+    if fov is None and shape is None:
+        raise ValueError(
+            "Missing 'fov' or 'shape'. The extent of the wcs must be provided either as"
+            " 'fov (an 'astropy.coordinates.Angle') or as 'shape' (two integers)."
+        )
+    if fov is not None and shape is not None:
+        raise ValueError(
+            "Conflicting parameters: 'fov' and 'shape' are mutually exclusive. "
+            "Provide one or the other."
+        )
+
+    if frame is None:
+        frame = ICRS()
+    wcs = celestial_frame_to_wcs(frame=frame, projection=projection)
+
+    if pixel_scale.isscalar:
+        pixel_scale_in_deg = float(pixel_scale.to_value("deg"))
+        wcs.wcs.cdelt = [-pixel_scale_in_deg, pixel_scale_in_deg]
+    elif len(pixel_scale) == 2:
+        wcs.wcs.cdelt[0] = float(pixel_scale[0].to_value("deg"))
+        wcs.wcs.cdelt[1] = float(pixel_scale[1].to_value("deg"))
+    else:
+        raise ValueError(
+            f"'pixel_scale' should be of length 1 or 2 but is {len(pixel_scale)}."
+        )
+
+    coo_for_frame = reference_position.transform_to(frame)
+    wcs.wcs.crval = [coo_for_frame.data.lon.deg, coo_for_frame.data.lat.deg]
+
+    if fov is not None:  # field of view as an Angle or quantity
+        wcs.array_shape = [
+            abs(round(angle.to_value("deg") / cdelt))
+            for angle, cdelt in zip(fov, wcs.wcs.cdelt)
+        ]
+    else:  # image size
+        wcs.array_shape = shape
+
+    if reference_pixel is not None:
+        if len(reference_pixel) != 2:
+            raise ValueError(
+                f"'reference_pixel' should be of length 2 but is {len(reference_pixel)}."
+            )
+        wcs.wcs.crpix = [reference_pixel[1] + 1, reference_pixel[0] + 1]
+    else:
+        wcs.wcs.crpix = [wcs.array_shape[0] / 2.0 + 0.5, wcs.array_shape[1] / 2.0 + 0.5]
+
+    if rotation is not None:
+        theta = rotation.radian
+        ratio = wcs.wcs.cdelt[1] / wcs.wcs.cdelt[0]  # case of rectangular pixels
+        wcs.wcs.pc = [
+            [np.cos(theta), -ratio * np.sin(theta)],
+            [np.sin(theta) / ratio, np.cos(theta)],
+        ]
+
+    return wcs
 
 
 def proj_plane_pixel_scales(wcs):

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -16,7 +16,7 @@ from astropy.coordinates import (
 )
 from astropy.utils import unbroadcast
 
-from .wcs import WCS, WCSSUB_LATITUDE, WCSSUB_LONGITUDE
+from .wcs import PRJ_CODES, WCS, WCSSUB_LATITUDE, WCSSUB_LONGITUDE
 
 __doctest_skip__ = ["wcs_to_celestial_frame", "celestial_frame_to_wcs"]
 
@@ -398,6 +398,11 @@ def celestial_frame_to_wcs(frame, projection="TAN"):
         ...     celestial_frame_to_wcs(...)
 
     """
+    if projection not in PRJ_CODES:
+        raise ValueError(
+            "Must specify valid projection code from list of supported types: ",
+            ", ".join(PRJ_CODES),
+        )
     for mapping_set in FRAME_WCS_MAPPINGS:
         for func in mapping_set:
             wcs = func(frame, projection=projection)
@@ -1149,41 +1154,7 @@ def fit_wcs_from_points(
     if not use_center_as_proj_point:
         assert proj_point.size == 1
 
-    proj_codes = [
-        "AZP",
-        "SZP",
-        "TAN",
-        "STG",
-        "SIN",
-        "ARC",
-        "ZEA",
-        "AIR",
-        "CYP",
-        "CEA",
-        "CAR",
-        "MER",
-        "SFL",
-        "PAR",
-        "MOL",
-        "AIT",
-        "COP",
-        "COE",
-        "COD",
-        "COO",
-        "BON",
-        "PCO",
-        "TSC",
-        "CSC",
-        "QSC",
-        "HPX",
-        "XPH",
-    ]
     if type(projection) == str:
-        if projection not in proj_codes:
-            raise ValueError(
-                "Must specify valid projection code from list of supported types: ",
-                ", ".join(proj_codes),
-            )
         # empty wcs to fill in with fit values
         wcs = celestial_frame_to_wcs(frame=world_coords.frame, projection=projection)
     else:  # if projection is not string, should be wcs object. use as template.

--- a/docs/changes/wcs/19985.feature.rst
+++ b/docs/changes/wcs/19985.feature.rst
@@ -1,0 +1,2 @@
+Added ``skycoord_to_celestial_wcs`` method to ``WCS`` to instantiate a sky WCS from a center
+position and a field of view or image shape.

--- a/docs/visualization/wcsaxes/initializing_axes.rst
+++ b/docs/visualization/wcsaxes/initializing_axes.rst
@@ -65,6 +65,35 @@ same functions/methods as for a normal Matplotlib plot:
 .. note:: If you use the pyplot interface, you can also replace ``ax.set_xlim`` and
           ``ax.set_ylim`` by ``plt.xlim`` and ``plt.ylim``.
 
+
+Initialization from a center and field of view
+**********************************************
+
+When displaying artificial data, we can use
+:func:`~astropy.wcs.WCS.skycoord_to_celestial_wcs` to inittialize a WCS from a center and
+a field of view.
+
+.. plot::
+   :context: reset
+   :include-source:
+   :align: center
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from astropy.wcs import WCS
+    from astropy.coordinates import Angle, SkyCoord
+
+    center = SkyCoord(266.4, -29, unit="deg")
+    fov = Angle([0.4, 0.2], unit="deg")
+    wcs = WCS.skycoord_to_celestial_wcs(center, fov=fov, pixel_size=0.005)
+
+    data = np.random.rand(40, 80)
+
+    fig, ax = plt.subplots(subplot_kw=dict(projection=wcs))
+    plt.imshow(data, origin="lower")
+
+
 Alternative methods
 *******************
 

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -114,6 +114,7 @@ Examples creating a WCS programmatically
    Example of Cube WCS <example_cube_wcs.rst>
    Example of a Planetary WCS <creating_planetary_wcs.rst>
    Loading From a FITS File <loading_from_fits.rst>
+   Creating a celestial WCS from a center and field of view <skycoord_to_celestial_wcs.rst>
 
 WCS Tools
 =========

--- a/docs/wcs/skycoord_to_celestial_wcs.rst
+++ b/docs/wcs/skycoord_to_celestial_wcs.rst
@@ -1,0 +1,14 @@
+.. _example_skycoord_to_celestial_wcs:
+
+Create a WCS from a center and field of view
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This example demonstrate how a WCS can be instantiated with a center coordinate
+and field of view values:
+
+>>> from astropy.coordinates import Angle, SkyCoord
+>>> from astropy.wcs.utils import skycoord_to_celestial_wcs
+>>> center = SkyCoord(266.4, -29, unit="deg")
+>>> fov = Angle([0.4, 0.2], unit="deg")
+>>> wcs = skycoord_to_celestial_wcs(center, fov=fov,
+...                                 pixel_scale=Angle([-0.005, 0.005], unit="deg"))

--- a/docs/whatsnew/8.1.rst
+++ b/docs/whatsnew/8.1.rst
@@ -14,6 +14,7 @@ In particular, this release includes:
 
 * :ref:`whatsnew-8.1-time-string-formats`
 * :ref:`whatsnew-8.1-faster-table-joins`
+* :ref:`whatsnew-8.1-wcs-init`
 
 In addition to these major changes, Astropy v8.1 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -58,6 +59,37 @@ if it is available and otherwise falls back to the built-in astropy join impleme
 
 In addition, the built-in astropy join was sped up by a factor of ~2x for the common
 case of a single join column.
+
+.. _whatsnew-8.1-wcs-init:
+
+New method to initialize a WCS without a FITS file
+==================================================
+
+A new method :func:`~astropy.wcs.WCS.skycoord_to_celestial_wcs` now allows to instantiate a
+WCS instance with a center coordinate and a field of view:
+
+>>> import numpy as np
+>>> import astropy.units as u
+>>> from astropy.coordinates import Angle, SkyCoord
+>>> from astropy.wcs.utils import skycoord_to_celestial_wcs
+>>> # Initialize a celestial WCS instance without a FITS file
+>>> center = SkyCoord(266.4, -29, unit="deg")
+>>> fov = Angle([0.4, 0.2], unit="deg")
+>>> wcs = skycoord_to_celestial_wcs(center, fov=fov, pixel_scale=[-0.005, 0.005] * u.deg)
+
+Alternatively, for finer grain control, one can also instantiate with an image shape
+rather than with the desired field of view:
+
+>>> import numpy as np
+>>> import astropy.units as u
+>>> from astropy.coordinates import Angle, SkyCoord
+>>> from astropy.wcs.utils import skycoord_to_celestial_wcs
+>>> # Initialize a celestial WCS instance without a FITS file
+>>> center = SkyCoord(266.4, -29, unit="deg")
+>>> image_shape = [80, 40]
+>>> wcs = skycoord_to_celestial_wcs(center, shape=image_shape,
+...                                 pixel_scale=[-0.005, 0.005] * u.deg)
+
 
 Contributors to the 8.1 release
 ===============================


### PR DESCRIPTION
### Description

This PR adds a new convenience method to instantiate a celestial WCS with physical parameters. So far, the center and a field of view are mandatory. I'm open to all suggestions for parameters names &/or API 

I think that this solves #12830 and that the feature is relevant here in astropy because a number of affiliated packages end up writing something similar for their users (GammaPy and SunPy are cited in the issue, I know of ligo.skymap, I maintain an other version in MOCPy, and there are surely others).

CC @smcguire-cmu & @bsipocz with whom we discussed this change


--- 
<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.