### PR TITLE
docs: clarify TypeError message in TimeNumeric for non-float input

### DIFF
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -540,7 +540,8 @@ class TimeNumeric(TimeFormat):
             )
         ):
             raise TypeError(
-                f"for {self.name} class, input should be doubles, string, or Decimal, "
+                f"for {self.name} class, input should be doubles "
+                "(or a first item convertible to double), "
                 "and second values are only allowed for doubles."
             )
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -541,7 +541,7 @@ class TimeNumeric(TimeFormat):
         ):
             raise TypeError(
                 f"for {self.name} class, input should be doubles "
-                "(or a first item convertible to double), "
+                "or a first item convertible to double"
                 "and second values are only allowed for doubles."
             )
 

--- a/docs/changes/time/19988.bugfix.rst
+++ b/docs/changes/time/19988.bugfix.rst
@@ -1,0 +1,1 @@
+Clarified the ``TypeError`` message raised by ``TimeNumeric`` when input cannot be converted to a float, to indicate that the first item should be convertible to double.


### PR DESCRIPTION
## Description

Clarifies the `TypeError` message raised by `TimeNumeric._check_val_type` when input cannot be converted to a float. The previous message ("input should be doubles, string, or Decimal") was misleading since string representations of floats are not accepted by numeric formats like `jyear` and `byear`.

The updated message, suggested by @mhvk, now reads:

> `for {class} class, input should be doubles (or a first item convertible to double), and second values are only allowed for doubles.`

Follows the discussion in #19988 and @taldcroft's suggestion to open a clean PR for the narrowed scope.

Fixes #19984

- [x] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.

## Testing

- `python3 -m ruff check astropy/time/formats.py`
- `git diff --check`