### PR TITLE
Fix fitsinfo crash with unhandled ModuleNotFoundError

### DIFF
--- a/astropy/io/fits/scripts/fitsinfo.py
+++ b/astropy/io/fits/scripts/fitsinfo.py
@@ -48,7 +48,7 @@ def fitsinfo(filename):
     """
     try:
         fits.info(filename)
-    except OSError as e:
+    except (OSError, ModuleNotFoundError) as e:
         log.error(str(e))
 
 

--- a/astropy/io/fits/tests/test_fitsinfo.py
+++ b/astropy/io/fits/tests/test_fitsinfo.py
@@ -3,6 +3,7 @@
 import pytest
 
 from astropy import __version__ as version
+from astropy.io import fits
 from astropy.io.fits.scripts import fitsinfo
 
 from .conftest import FitsTestCase
@@ -48,3 +49,17 @@ class TestFitsinfo(FitsTestCase):
         assert out[7].startswith(
             "  1                1 TableHDU        20   5R x 2C   [E10.4, I5]"
         )
+
+    def test_uncompresspy_not_installed(self, capsys, monkeypatch):
+        """
+        Regression test for #19852: fitsinfo should log an error and
+        continue, rather than crash with an unhandled ModuleNotFoundError,
+        when the optional uncompresspy package isn't available and an LZW
+        (.Z) compressed FITS file is given.
+        """
+        monkeypatch.setattr(fits.file, "HAS_UNCOMPRESSPY", False)
+
+        fitsinfo.main([self.data("lzw.fits.Z")])
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert "uncompresspy" in err

--- a/docs/changes/io.fits/19993.bugfix.rst
+++ b/docs/changes/io.fits/19993.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``fitsinfo`` crashing with an unhandled ``ModuleNotFoundError``
+instead of printing a clean error message when given an LZW (``.Z``)
+compressed FITS file and the optional ``uncompresspy`` package is not
+installed.


### PR DESCRIPTION
## Why

`fitsinfo` crashes with an unhandled `ModuleNotFoundError` traceback instead of a clean error message when given an LZW (`.Z`) compressed FITS file and the optional `uncompresspy` package isn't installed (or, in principle, an `.xz` file without the stdlib `lzma` module). `fits.file._File`'s LZW/lzma handling raises a plain `ModuleNotFoundError`:

```python
if not HAS_UNCOMPRESSPY:
    raise ModuleNotFoundError(
        "The optional package uncompresspy is necessary for reading"
        " LZW compressed files (.Z extension)."
    )
```

`fitsinfo.fitsinfo()` only caught `OSError`:

```python
try:
    fits.info(filename)
except OSError as e:
    log.error(str(e))
```

`ModuleNotFoundError` is not an `OSError` subclass, so it propagates uncaught.

As confirmed in the issue thread, `fitscheck` already handles this gracefully (it wraps per-file processing in a broad `except Exception`). This PR brings `fitsinfo` in line.

## What about fitsdiff?

The issue speculated `fitsdiff` "probably" has the same problem, but I checked and it does not: `FITSDiff.__init__` already wraps file opening in `try: ... except Exception as exc: raise OSError(...) from exc` for both inputs, so by the time the exception reaches `fitsdiff.py`'s `except OSError:`, it's already been converted from `ModuleNotFoundError` to `OSError`. I verified this directly (see Testing) rather than assuming, and left `fitsdiff.py` unchanged since there's nothing to fix there - the existing `test_warning_unreadable_file` test already passes on `main` for this exact reason.

## Fix

`fitsinfo.fitsinfo()` now catches `(OSError, ModuleNotFoundError)`, matching the pattern already used for the equivalent `fitscheck`/`fitsdiff` cases.

## Testing

This sandbox can't build astropy's C/Cython extensions (MSVC here is missing Windows SDK headers needed by `pyconfig.h`), so I couldn't run the project's test suite via `pip install -e .` directly. Instead, I installed the published `astropy` wheel (real compiled extensions) into a venv and loaded my locally-edited `fitsinfo.py`/`fitsdiff.py` by file path against that real `astropy.io.fits` package, with `fits.file.HAS_UNCOMPRESSPY` monkeypatched to `False` (the same technique the existing `test_warning_unreadable_file` test in `test_fitsdiff.py` uses) and a real `.Z` test fixture (`lzw.fits.Z`):

- Confirmed the *unpatched* `fitsinfo.fitsinfo()` raises an unhandled `ModuleNotFoundError` in this scenario.
- Confirmed the *patched* version logs the error cleanly and returns normally.
- Confirmed `fitsdiff.main()` already returns cleanly with "Warning: failed to open ... Skipping." both with and without the (reverted) `fitsdiff.py` change, proving `fitsdiff` was never affected.
- Added `test_uncompresspy_not_installed` to `test_fitsinfo.py`, mirroring `test_fitsdiff.py`'s existing test for this exact scenario.
- Ran `ruff check` on both changed files - clean.

I'd appreciate someone with a working build confirming the new test passes in CI, given I couldn't run the actual test runner here.

Fixes #19852.