### PR TITLE
Align byte-swapped table checksum chunks to 4-byte words so the datasum verifies after writing

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1554,8 +1554,14 @@ def _as_bigendian_pieces(data):
                 offset += swap_itemsize
 
     # Reordering the data by indexing makes copies, so work in pieces.
+    # Each piece except the last must span a whole number of 4-byte words:
+    # _calculate_datasum_with_heap feeds the pieces to the 32-bit FITS
+    # checksum one at a time, so a piece ending mid-word would misalign the
+    # running checksum and yield a wrong DATASUM. Rounding the row count down
+    # to a multiple of four keeps every piece length (rows * itemsize) a
+    # multiple of four bytes.
     data_bytes = data.view(np.ndarray)[..., np.newaxis].view(np.ubyte)
-    step = max(65536 // len(indices), 1)
+    step = max(65536 // len(indices) // 4 * 4, 4)
     for piece in np.split(data_bytes, range(0, len(data), step)):
         if len(piece):
             yield piece[..., indices].ravel()

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -160,6 +160,39 @@ class TestChecksumFunctions(BaseChecksumTests):
             assert "DATASUM" in hdul[1].header
             assert hdul[1].header["DATASUM"] == "1062205743"
 
+    def test_checksum_byteswapped_table_spanning_multiple_chunks(self):
+        """
+        Regression test for #19990.
+
+        For a byte-swapped (little-endian) binary table large enough to be
+        checksummed in more than one chunk, the DATASUM is accumulated one
+        chunk at a time. Each chunk must be a whole number of 4-byte words,
+        otherwise the running 32-bit checksum is misaligned and the DATASUM
+        is valid in memory but fails to verify once the file is read back.
+        """
+        nrows = 8000
+        cols = fits.ColDefs(
+            [
+                fits.Column(name="a", format="J", array=np.arange(nrows, dtype="i4")),
+                fits.Column(name="b", format="D", array=np.linspace(0, 1, nrows)),
+                # An 11A column makes the row 4 + 8 + 11 = 23 bytes, which is
+                # not a multiple of 4, so the chunk boundaries fall mid-word.
+                fits.Column(name="s", format="11A", array=np.array(["xy"] * nrows)),
+            ]
+        )
+        tbhdu = fits.BinTableHDU.from_columns(cols)
+        # The table must span more than one checksum chunk to exercise the bug.
+        assert tbhdu.data.nbytes > 65536
+        tbhdu.add_checksum()
+        assert tbhdu.verify_checksum() == 1
+        assert tbhdu.verify_datasum() == 1
+        tbhdu.writeto(self.temp("tmp.fits"), overwrite=True)
+        with fits.open(self.temp("tmp.fits"), checksum=True) as hdul:
+            assert tbhdu.data.dtype.itemsize % 4 != 0
+            assert hdul[1].verify_checksum() == 1
+            assert hdul[1].verify_datasum() == 1
+            assert comparerecords(tbhdu.data, hdul[1].data)
+
     def test_variable_length_table_data(self):
         c1 = fits.Column(
             name="var",

--- a/docs/changes/io.fits/20001.bugfix.rst
+++ b/docs/changes/io.fits/20001.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed an incorrect ``DATASUM`` (and therefore ``CHECKSUM``) being written for
+byte-swapped binary tables larger than 64 kB. The data was checksummed in
+chunks that were not aligned to 4-byte word boundaries, so the stored value was
+valid in memory but failed to verify once the file was read back.


### PR DESCRIPTION
This fixes an incorrect checksum/datasum for byte-swapped binary tables over 64kB as reported in #19990, and introduced in #19585

``BinTableHDU._calculate_datasum_with_heap`` accumulates the datasum one chunk at a time over the pieces yielded by ``_as_bigendian_pieces``. Those pieces were sized at ``65536 // itemsize`` rows, so for a byte-swapped (little-endian) table whose row size makes the chunk length not a multiple of 4, each chunk boundary fell mid-word and misaligned the running 32-bit checksum. The stored ``DATASUM``/``CHECKSUM`` were therefore valid in memory but failed to verify once the file was read back (the data itself was written correctly, which is why HDUDiff reported no difference). This only showed up for tables large enough to span more than one chunk, hence the ~64 kB threshold.

The fix rounds the chunk size down to a multiple of four rows so every piece is a whole number of 4-byte words.