### PR TITLE
Fix minor ticks being dropped when tick values are set explicitly

### DIFF
--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -135,7 +135,17 @@ class BaseFormatterLocator:
 
     def minor_locator(self, spacing, frequency, value_min, value_max):
         if self.values is not None:
-            return [] * self._unit
+            # There is no global spacing to subdivide, so place minor ticks
+            # by subdividing the intervals between consecutive tick values.
+            values = np.sort(self.values.to_value(self._unit))
+            if len(values) < 2 or frequency < 2:
+                return [] * self._unit
+            fractions = np.arange(1, frequency) / frequency
+            intervals = np.diff(values)
+            minor = (
+                values[:-1, None] + intervals[:, None] * fractions[None, :]
+            ).ravel()
+            return minor * self._unit
 
         minor_spacing = spacing.value / frequency
         values = self._locate_values(value_min, value_max, minor_spacing)

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -131,6 +131,26 @@ class TestAngleFormatterLocator:
 
         minor_values = fl.minor_locator(spacing, 2, 34.3, 55.4)
 
+        assert_almost_equal(minor_values.to_value(u.degree), [0.55, 7.5])
+
+    def test_minor_locator_with_explicit_values(self):
+        # gh-19529: minor ticks used to be dropped entirely when the major
+        # tick values were specified explicitly
+        fl = AngleFormatterLocator(values=np.arange(25, 33) * u.degree)
+
+        values, spacing = fl.locator(24.0, 33.0)
+
+        minor_values = fl.minor_locator(spacing, 4, 24.0, 33.0)
+
+        expected = (np.arange(25, 32)[:, None] + np.array([0.25, 0.5, 0.75])).ravel()
+        assert_almost_equal(minor_values.to_value(u.degree), expected)
+
+        # a single tick value or a frequency of 1 gives no minor ticks
+        minor_values = fl.minor_locator(spacing, 1, 24.0, 33.0)
+        assert_almost_equal(minor_values.to_value(u.degree), [])
+
+        fl.values = [30.0] * u.degree
+        minor_values = fl.minor_locator(spacing, 4, 24.0, 33.0)
         assert_almost_equal(minor_values.to_value(u.degree), [])
 
     @pytest.mark.parametrize(
@@ -579,7 +599,7 @@ class TestScalarFormatterLocator:
 
         minor_values = fl.minor_locator(spacing, 2, 34.3, 55.4)
 
-        assert_almost_equal(minor_values.value, [])
+        assert_almost_equal(minor_values.value, [0.55, 7.5])
 
     @pytest.mark.parametrize(
         ("format", "string"),

--- a/docs/changes/visualization/20018.bugfix.rst
+++ b/docs/changes/visualization/20018.bugfix.rst
@@ -1,0 +1,1 @@
+Minor ticks are no longer dropped when major tick values are specified explicitly with ``set_ticks(values=...)``; they are now placed by subdividing the intervals between consecutive values.


### PR DESCRIPTION
Fixes #19529

Setting explicit tick values with set_ticks(values=...) dropped minor ticks entirely, even with display_minor_ticks(True): BaseFormatterLocator.minor_locator returns an empty list for the explicit-values case, because the auto path derives minor positions from the major spacing and explicit values have none. This subdivides the intervals between consecutive explicit values instead, placing frequency-1 minor ticks per interval, which also handles unevenly spaced values. A single value or a frequency of 1 still gives no minor ticks.

The previous behavior was pinned by test_minor_locator in both the Angle and Scalar variants (asserting an empty result for the values case), so those assertions are updated, plus a new test for the evenly spaced case from the issue. No image tests combine explicit values with minor ticks, so no reference images change.
