### PR TITLE
Fix import failure when warnings.showwarning is overridden (e.g. under pytest-cov)

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -493,11 +493,27 @@ class AstropyLogger(Logger):
         """
         Reset logger to its initial state.
         """
-        # Reset any previously installed hooks
+        # Reset any previously installed hooks. This runs at import time via
+        # ``_init_log()``, so it must not raise if another library (e.g. a
+        # coverage plugin such as pytest-cov) has replaced ``warnings.showwarning``
+        # or ``sys.excepthook`` after Astropy installed its own. In that case we
+        # relinquish Astropy's hook bookkeeping without clobbering the third
+        # party's hook, instead of letting the ``LoggingError`` propagate and
+        # make ``import astropy`` fail. See https://github.com/astropy/astropy/issues/20005
         if self.warnings_logging_enabled():
-            self.disable_warnings_logging()
+            try:
+                self.disable_warnings_logging()
+            except LoggingError:
+                # Another library overrode warnings.showwarning; leave it in
+                # place and just clear our own record of the original hook.
+                self._showwarning_orig = None
         if self.exception_logging_enabled():
-            self.disable_exception_logging()
+            try:
+                self.disable_exception_logging()
+            except LoggingError:
+                # Another library overrode sys.excepthook; leave it in place
+                # and just clear our own record of the original hook.
+                self._excepthook_orig = None
 
         # Remove all previous handlers
         for handler in self.handlers[:]:

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -65,6 +65,43 @@ def test_warnings_logging_overridden():
         log.disable_warnings_logging()
 
 
+def test_set_defaults_tolerates_overridden_showwarning():
+    # Regression test for #20005: _set_defaults() runs at import time via
+    # _init_log(). If another library (e.g. the pytest-cov coverage plugin)
+    # has replaced warnings.showwarning after Astropy installed its own, the
+    # reset must not raise LoggingError and make `import astropy` fail. The
+    # third-party hook must be left in place / recoverable rather than clobbered.
+    log.enable_warnings_logging()
+    sentinel = lambda *args, **kwargs: None
+    warnings.showwarning = sentinel
+
+    # Must not raise.
+    log._set_defaults()
+
+    # conf.log_warnings defaults to True, so _set_defaults re-installs Astropy's
+    # own handler on top, saving the third-party hook as the recoverable original.
+    assert log._showwarning_orig is sentinel
+
+
+def test_set_defaults_tolerates_overridden_excepthook():
+    # Sibling of the above for the exception-logging path (#20005). A
+    # third-party sys.excepthook installed after Astropy's must not cause
+    # _set_defaults() to raise; Astropy relinquishes its bookkeeping and leaves
+    # the third-party excepthook untouched (conf.log_exceptions defaults False).
+    log.enable_exception_logging()
+
+    def sentinel_excepthook(*args, **kwargs):
+        pass
+
+    sys.excepthook = sentinel_excepthook
+
+    # Must not raise.
+    log._set_defaults()
+
+    assert sys.excepthook is sentinel_excepthook
+    assert not log.exception_logging_enabled()
+
+
 def test_warnings_logging():
     # Without warnings logging
     with pytest.warns(AstropyUserWarning, match="This is a warning") as warn_list:

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -72,7 +72,10 @@ def test_set_defaults_tolerates_overridden_showwarning():
     # reset must not raise LoggingError and make `import astropy` fail. The
     # third-party hook must be left in place / recoverable rather than clobbered.
     log.enable_warnings_logging()
-    sentinel = lambda *args, **kwargs: None
+
+    def sentinel(*args, **kwargs):
+        pass
+
     warnings.showwarning = sentinel
 
     # Must not raise.

--- a/docs/changes/20005.bugfix.rst
+++ b/docs/changes/20005.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed a bug where ``import astropy`` could fail with a ``LoggingError`` if
+another library (such as the ``pytest-cov`` coverage plugin) had replaced
+``warnings.showwarning`` or ``sys.excepthook`` after Astropy installed its
+own. The logger reset performed at import time is now best-effort and leaves
+any third-party hook in place instead of raising.


### PR DESCRIPTION
### Description

Fixes #20005.

`import astropy` can fail outright with a `LoggingError` when another library has
replaced `warnings.showwarning` (or `sys.excepthook`) after Astropy installed its
own handler. This bites `pytest-cov` users in particular — the coverage plugin
installs its own `showwarning`, and then any package that imports Astropy at
collection time (the issue came in from astroquery.mast) crashes on import:

```
astropy/logger.py:498: in _set_defaults
    self.disable_warnings_logging()
astropy/logger.py:278: in disable_warnings_logging
    raise LoggingError(
E   astropy.logger.LoggingError: Cannot disable warnings logging: warnings.showwarning
    was not set by this logger, or has been overridden
```

**Root cause.** `_init_log()` runs at import time and calls
`AstropyLogger._set_defaults()`, which resets any previously installed hooks by
calling `disable_warnings_logging()` / `disable_exception_logging()`. Those
methods deliberately raise `LoggingError` when `warnings.showwarning` /
`sys.excepthook` no longer points at Astropy's handler — a sensible contract for a
direct caller, but fatal here, because `_set_defaults()` is a best-effort reset
that runs unconditionally during `import astropy`.

**Fix.** Make the import-time reset tolerant: `_set_defaults()` now catches the
`LoggingError` from the two disable calls, leaves the third-party hook in place
(it never clobbers someone else's `showwarning`/`excepthook`), and just clears
Astropy's own bookkeeping so the logger returns to a clean state. The public
`disable_warnings_logging()` / `disable_exception_logging()` API is unchanged —
they still raise for direct callers, so the existing contract tests
(`test_warnings_logging_overridden`, `test_exception_logging_overridden`) still
pass. Because `conf.log_warnings` defaults to `True`, `_set_defaults()` then
re-installs Astropy's own handler on top and records the third party's hook as the
recoverable original, so warning capture keeps working and the other library's
hook is restored if Astropy is later disabled.

I fixed both the `showwarning` path (the reported one) and the sibling
`sys.excepthook` path in the same method, since they make the identical
assumption.

### How was this tested?

Reproduced the exact failure first, then confirmed the fix, on a source build of
`main`:

```python
import warnings
from astropy import log
from astropy.logger import LoggingError

warnings.showwarning = lambda *a, **k: None   # stand in for pytest-cov et al.
log._set_defaults()                           # RED on main: raises LoggingError
                                              # GREEN after fix: returns cleanly
```

I also confirmed that with `warnings.showwarning` overridden *before* the import,
`import astropy` now succeeds instead of raising.

Two regression tests were added to `astropy/tests/test_logger.py`
(`test_set_defaults_tolerates_overridden_showwarning` and
`test_set_defaults_tolerates_overridden_excepthook`).

Full logger suite is green and lint is clean at the repo-pinned tool version:

```
$ python -m pytest astropy/tests/test_logger.py -q
33 passed, 1 skipped

$ ruff check astropy/logger.py astropy/tests/test_logger.py   # ruff 0.15.15
All checks passed!
$ ruff format --check astropy/logger.py astropy/tests/test_logger.py
2 files already formatted
```

A changelog fragment is included at `docs/changes/20005.bugfix.rst` (named after
the issue; happy to rename it to the PR number if preferred).
