### PR TITLE
Fix CompoundModel.input_units to be independent of operand order

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3897,7 +3897,9 @@ class CompoundModel(Model):
         # ``inputs_map`` only records the left one. Fill in the units of any
         # input that the left operand does not constrain from the right operand
         # so the result does not depend on the operand order (GH #17040).
-        if self.op in ("+", "-", "*", "/", "**"):
+        if self.op in ("+", "-", "*", "/", "**") and any(
+            key not in input_units_dict for key in self.inputs
+        ):
             right_units = self.right.input_units
             if right_units:
                 for left_key, right_key in zip(self.inputs, self.right.inputs):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3893,6 +3893,16 @@ class CompoundModel(Model):
             for key, (mod, orig_key) in inputs_map.items()
             if inputs_map[key][0].input_units is not None
         }
+        # For arithmetic operators the inputs are shared by both operands, but
+        # ``inputs_map`` only records the left one. Fill in the units of any
+        # input that the left operand does not constrain from the right operand
+        # so the result does not depend on the operand order (GH #17040).
+        if self.op in ("+", "-", "*", "/", "**"):
+            right_units = self.right.input_units
+            if right_units:
+                for left_key, right_key in zip(self.inputs, self.right.inputs):
+                    if left_key not in input_units_dict and right_key in right_units:
+                        input_units_dict[left_key] = right_units[right_key]
         if input_units_dict:
             return input_units_dict
         return None

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -140,3 +140,23 @@ def test_read_only(m):
         m.input_units_allow_dimensionless = {}
     with pytest.raises(AttributeError):
         m.input_units_strict = {}
+
+
+def test_compound_input_units_operand_order():
+    """input_units of an arithmetic compound model should not depend on the
+    order of the operands. Regression test for
+    https://github.com/astropy/astropy/issues/17040
+    """
+    gauss = models.Gaussian1D(mean=976.8 * u.AA, amplitude=4 * u.DN, stddev=1 * u.AA)
+    const = models.Const1D(amplitude=1 * u.DN)
+
+    expected = {"x": u.AA}
+    assert (const + gauss).input_units == expected
+    assert (gauss + const).input_units == expected
+
+    # other arithmetic operators behave the same way
+    assert (const * gauss).input_units == expected
+    assert (const - gauss).input_units == expected
+
+    # if neither operand constrains the units the result is still None
+    assert (const + models.Const1D(amplitude=1 * u.DN)).input_units is None

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -158,6 +158,6 @@ def test_compound_input_units_operand_order():
     assert (const * gauss).input_units == expected
     assert (const - gauss).input_units == expected
     assert (const / gauss).input_units == expected
-    assert (const ** gauss).input_units == expected
+    assert (const**gauss).input_units == expected
     # if neither operand constrains the units the result is still None
     assert (const + models.Const1D(amplitude=1 * u.DN)).input_units is None

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -157,6 +157,7 @@ def test_compound_input_units_operand_order():
     # other arithmetic operators behave the same way
     assert (const * gauss).input_units == expected
     assert (const - gauss).input_units == expected
-
+    assert (const / gauss).input_units == expected
+    assert (const ** gauss).input_units == expected
     # if neither operand constrains the units the result is still None
     assert (const + models.Const1D(amplitude=1 * u.DN)).input_units is None

--- a/docs/changes/modeling/20020.bugfix.rst
+++ b/docs/changes/modeling/20020.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``CompoundModel.input_units`` returning a result that depended on the
+order of the operands for arithmetic operators. The units of an input that the
+left operand does not constrain are now taken from the right operand, so e.g.
+``Const1D() + Gaussian1D()`` and ``Gaussian1D() + Const1D()`` report the same
+input units.


### PR DESCRIPTION
### Description

This pull request fixes `CompoundModel.input_units` returning a result that depends on the operand order for arithmetic operators.

Fixes #17040.

For arithmetic operators (`+ - * / **`) the inputs are shared by both operands, but `inputs_map()` only records the *left* operand. `input_units` therefore never consulted the right operand, so an expression whose left operand has no input units (e.g. `Const1D`) returned `None`, while the reversed order returned the correct units:

```python
import astropy.units as u
import astropy.modeling.models as m
g = m.Gaussian1D(mean=976.8 * u.AA, amplitude=4 * u.DN, stddev=1 * u.AA)
c = m.Const1D(amplitude=1 * u.DN)
(c + g).input_units   # was None      -> now {'x': Unit("Angstrom")}
(g + c).input_units   # {'x': Unit("Angstrom")}
```

The fix fills in the units of any input the left operand does not constrain from the right operand, so the result is independent of operand order. If neither operand constrains the units the result is still `None`. Composition (`|`) and join (`&`) are unaffected.

A regression test is added in `astropy/modeling/tests/test_quantities_model.py`. The `astropy/modeling` test suite passes locally.

<sub>Note: this change was prepared with the assistance of Claude Code; it has been reviewed and tested locally by the submitter.</sub>
