### PR TITLE
DOC correct parameter names and remove stale doc entries (4 locations)

### DIFF
--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -455,8 +455,6 @@ class AstropyLogger(Logger):
 
         Parameters
         ----------
-        filename : str
-            The file to log messages to.
         filter_level : str
             If set, any log messages less important than ``filter_level`` will
             not be output to the file. Note that this is in addition to the

--- a/astropy/modeling/bounding_box.py
+++ b/astropy/modeling/bounding_box.py
@@ -816,7 +816,7 @@ class ModelBoundingBox(_BoundingDomain):
             The new model for which this will be a bounding_box
         fixed_inputs : dict
             Dictionary of inputs which have been fixed by this bounding box.
-        keep_ignored : bool
+        _keep_ignored : bool
             Keep the ignored inputs of the bounding box (internal argument only)
         """
         new = self.copy()

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -556,10 +556,6 @@ class _VariancePropagationMixin:
         numpy_op : function
             Numpy operation like `np.sum` or `np.max` to use in the collapse
 
-        subtract : bool, optional
-            If ``True``, propagate for subtraction, otherwise propagate for
-            addition.
-
         axis : tuple, optional
             Axis on which to compute collapsing operations.
         """

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -58,7 +58,7 @@ def get_auto_format_func(
 
     Parameters
     ----------
-    col_name : object, optional
+    col : object, optional
         Hashable object to identify column like id or name. Default is None.
 
     possible_string_format_functions : func, optional


### PR DESCRIPTION
This pull request is to address incorrect and stale parameter names in docstrings.

### Changes

| File | Function | Issue | Fix |
|------|----------|-------|-----|
| `astropy/logger.py` | `log_to_list()` | stale `filename` param entry (copy-paste from `log_to_file`) | removed |
| `astropy/modeling/bounding_box.py` | `fix_inputs()` | `keep_ignored` should be `_keep_ignored` | renamed |
| `astropy/nddata/nduncertainty.py` | `_propagate_collapse()` | stale `subtract` param not present in signature | removed |
| `astropy/table/pprint.py` | `get_auto_format_func()` | `col_name` should be `col` | renamed |

Docstring-only changes - no logic affected.

I'll add a CHANGES.rst entry once a PR number is assigned.