### PR TITLE
feat(coordinates): expose get_frame_class as a public API

### DIFF
--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -23,12 +23,14 @@ from .builtin_frames import GCRS, PrecessedGeocentric
 from .builtin_frames.utils import get_jd12
 from .representation import CartesianRepresentation, SphericalRepresentation
 from .sky_coordinate import SkyCoord
+from .sky_coordinate_parsers import get_frame_class  # noqa: F401
 
 __all__ = [
     "cartesian_to_spherical",
     "concatenate",
     "concatenate_representations",
     "get_constellation",
+    "get_frame_class",
     "get_sun",
     "spherical_to_cartesian",
 ]

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -32,6 +32,7 @@ from .representation import (
 )
 from .sky_coordinate_parsers import (
     _get_frame_class,
+    get_frame_class,
     _get_frame_without_data,
     _parse_coordinate_data,
 )
@@ -459,7 +460,7 @@ class SkyCoord(MaskableShapedLikeNDArray):
         """
         # TODO! like matplotlib, do string overrides for modified methods
         new_frame = (
-            _get_frame_class(new_frame) if isinstance(new_frame, str) else new_frame
+            get_frame_class(new_frame) if isinstance(new_frame, str) else new_frame
         )
         return self.frame.is_transformable_to(new_frame)
 
@@ -506,7 +507,7 @@ class SkyCoord(MaskableShapedLikeNDArray):
 
         # Frame name (string) or frame class?  Coerce into an instance.
         try:
-            frame = _get_frame_class(frame)()
+            frame = get_frame_class(frame)()
         except Exception:
             pass
 

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -23,8 +23,11 @@ from .representation import (
 
 """
 This module contains utility functions to make the SkyCoord initializer more modular
-and maintainable. No functionality here should be in the public API, but rather used as
-part of creating SkyCoord objects.
+and maintainable.
+
+Most functions here are private implementation details of the SkyCoord initializer.
+The exception is ``get_frame_class``, which is re-exported as a public API symbol
+through ``astropy.coordinates`` (see ``funcs.py``).
 """
 
 PLUS_MINUS_RE = re.compile(r"(\+|\-)")
@@ -37,10 +40,49 @@ J_PREFIXED_RA_DEC_RE = re.compile(
 )
 
 
-def _get_frame_class(frame):
-    """
-    Get a frame class from the input `frame`, which could be a frame name
-    string, or frame class.
+def get_frame_class(frame):
+    """Return a coordinate frame class from a name string or frame class.
+
+    Accepts either a registered frame name (as a string) or a
+    `~astropy.coordinates.BaseCoordinateFrame` subclass and returns the
+    corresponding frame *class*.  This is useful for downstream packages that
+    need to validate and normalise frame inputs without instantiating a full
+    |SkyCoord| object.
+
+    Parameters
+    ----------
+    frame : str or type
+        Either the lower-case registered name of a coordinate frame (e.g.
+        ``'icrs'``, ``'fk5'``) *or* a `~astropy.coordinates.BaseCoordinateFrame`
+        **subclass** (not an instance).  Frame names are looked up in the global
+        :obj:`~astropy.coordinates.frame_transform_graph`.
+
+    Returns
+    -------
+    frame_cls : type
+        The `~astropy.coordinates.BaseCoordinateFrame` subclass corresponding to
+        the input.
+
+    Raises
+    ------
+    ValueError
+        If *frame* is a string that is not registered in
+        :obj:`~astropy.coordinates.frame_transform_graph`, or if *frame* is
+        neither a string nor a `~astropy.coordinates.BaseCoordinateFrame`
+        subclass (e.g. a frame *instance* or an unrelated object).
+
+    Examples
+    --------
+    Resolve a frame name string:
+
+    >>> from astropy.coordinates import get_frame_class, ICRS
+    >>> get_frame_class('icrs')
+    <class 'astropy.coordinates.builtin_frames.icrs.ICRS'>
+
+    Pass a frame class directly (idempotent):
+
+    >>> get_frame_class(ICRS)
+    <class 'astropy.coordinates.builtin_frames.icrs.ICRS'>
     """
     if isinstance(frame, str):
         frame_names = frame_transform_graph.get_names()
@@ -61,6 +103,9 @@ def _get_frame_class(frame):
         )
 
     return frame_cls
+
+
+_get_frame_class = get_frame_class
 
 
 _conflict_err_msg = (

--- a/astropy/coordinates/tests/test_sky_coordinate_parsers.py
+++ b/astropy/coordinates/tests/test_sky_coordinate_parsers.py
@@ -1,0 +1,177 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Tests for `~astropy.coordinates.get_frame_class`.
+
+Covers:
+- Resolution of registered frame name strings to frame classes.
+- Acceptance of ``BaseCoordinateFrame`` subclasses (idempotent pass-through).
+- Rejection of frame *instances* (must be a class, not an object).
+- Rejection of unrecognised string names.
+- Rejection of unrelated object types.
+- Public import path ``astropy.coordinates.get_frame_class``.
+- Backward-compatibility alias ``_get_frame_class``.
+"""
+
+import pytest
+
+import astropy.coordinates as coord
+from astropy.coordinates import (
+    FK4,
+    FK5,
+    GCRS,
+    ICRS,
+    BaseCoordinateFrame,
+    Galactic,
+)
+from astropy.coordinates.sky_coordinate_parsers import (
+    _get_frame_class,
+    get_frame_class,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: all frames expected to round-trip through their registered name
+# ---------------------------------------------------------------------------
+NAMED_FRAME_CASES = [
+    ("icrs", ICRS),
+    ("fk5", FK5),
+    ("fk4", FK4),
+    ("galactic", Galactic),
+    ("gcrs", GCRS),
+]
+
+
+class TestGetFrameClassStringInput:
+    """``get_frame_class`` called with a frame name string."""
+
+    @pytest.mark.parametrize("name,expected_cls", NAMED_FRAME_CASES)
+    def test_known_frame_names(self, name, expected_cls):
+        """Registered name strings resolve to the correct class."""
+        result = get_frame_class(name)
+        assert result is expected_cls
+
+    def test_unknown_frame_name_raises(self):
+        """An unregistered string raises ``ValueError``."""
+        with pytest.raises(ValueError, match="not a known coordinate frame"):
+            get_frame_class("completely_unknown_frame_xyz")
+
+    def test_empty_string_raises(self):
+        """An empty string is not a registered name and must raise."""
+        with pytest.raises(ValueError, match="not a known coordinate frame"):
+            get_frame_class("")
+
+    def test_case_sensitive(self):
+        """Frame names are case-sensitive; 'ICRS' should not resolve."""
+        with pytest.raises(ValueError, match="not a known coordinate frame"):
+            get_frame_class("ICRS")
+
+
+class TestGetFrameClassClassInput:
+    """``get_frame_class`` called with a frame *class* (idempotent)."""
+
+    @pytest.mark.parametrize("frame_cls", [ICRS, FK5, FK4, Galactic, GCRS])
+    def test_frame_class_returns_itself(self, frame_cls):
+        """A ``BaseCoordinateFrame`` subclass is returned unchanged."""
+        result = get_frame_class(frame_cls)
+        assert result is frame_cls
+
+    def test_base_coordinate_frame_itself_is_accepted(self):
+        """``BaseCoordinateFrame`` itself (the abstract base) is a valid class input."""
+        result = get_frame_class(BaseCoordinateFrame)
+        assert result is BaseCoordinateFrame
+
+    def test_custom_frame_subclass(self):
+        """A user-defined ``BaseCoordinateFrame`` subclass is accepted."""
+        class MyCustomFrame(BaseCoordinateFrame):
+            default_representation = coord.SphericalRepresentation
+
+        result = get_frame_class(MyCustomFrame)
+        assert result is MyCustomFrame
+
+
+class TestGetFrameClassInvalidInput:
+    """``get_frame_class`` must raise ``ValueError`` for invalid inputs."""
+
+    def test_frame_instance_raises(self):
+        """A frame *instance* (not class) must raise ``ValueError``."""
+        instance = ICRS()
+        with pytest.raises(ValueError, match="Coordinate frame must be a frame name or frame class"):
+            get_frame_class(instance)
+
+    def test_none_raises(self):
+        """``None`` is not a valid frame specifier."""
+        with pytest.raises(ValueError, match="Coordinate frame must be a frame name or frame class"):
+            get_frame_class(None)
+
+    def test_integer_raises(self):
+        """An integer is not a valid frame specifier."""
+        with pytest.raises(ValueError, match="Coordinate frame must be a frame name or frame class"):
+            get_frame_class(42)
+
+    def test_list_raises(self):
+        """A list is not a valid frame specifier."""
+        with pytest.raises(ValueError, match="Coordinate frame must be a frame name or frame class"):
+            get_frame_class(["icrs"])
+
+    def test_unrelated_class_raises(self):
+        """A class unrelated to ``BaseCoordinateFrame`` must raise."""
+        with pytest.raises(ValueError, match="Coordinate frame must be a frame name or frame class"):
+            get_frame_class(int)
+
+
+class TestGetFrameClassPublicAPI:
+    """Verify the public import path works correctly."""
+
+    def test_importable_from_astropy_coordinates(self):
+        """``get_frame_class`` must be importable from ``astropy.coordinates``."""
+        from astropy.coordinates import get_frame_class as _gfc  # noqa: F401
+        assert callable(_gfc)
+
+    def test_top_level_namespace_symbol(self):
+        """``astropy.coordinates.get_frame_class`` is the correct public symbol."""
+        assert hasattr(coord, "get_frame_class")
+        assert coord.get_frame_class is get_frame_class
+
+    def test_public_api_resolves_icrs(self):
+        """End-to-end: the top-level public API resolves 'icrs' to ICRS."""
+        result = coord.get_frame_class("icrs")
+        assert result is ICRS
+
+    def test_public_api_accepts_class(self):
+        """End-to-end: the top-level public API accepts a frame class."""
+        result = coord.get_frame_class(FK5)
+        assert result is FK5
+
+
+class TestGetFrameClassBackwardCompatAlias:
+    """Verify the private backward-compatibility alias ``_get_frame_class`` still works."""
+
+    def test_private_alias_is_same_function(self):
+        """``_get_frame_class`` is the same object as ``get_frame_class``."""
+        assert _get_frame_class is get_frame_class
+
+    def test_private_alias_resolves_icrs(self):
+        """``_get_frame_class('icrs')`` still works via the alias."""
+        result = _get_frame_class("icrs")
+        assert result is ICRS
+
+    def test_private_alias_raises_on_invalid(self):
+        """``_get_frame_class`` raises on invalid input, same as the public name."""
+        with pytest.raises(ValueError):
+            _get_frame_class("nonexistent_frame_xyz")
+
+
+class TestGetFrameClassReturnType:
+    """Verify the return value is always a class, never an instance."""
+
+    @pytest.mark.parametrize("name,expected_cls", NAMED_FRAME_CASES)
+    def test_returns_class_not_instance(self, name, expected_cls):
+        """Return value must be a class (``type``), not an object."""
+        result = get_frame_class(name)
+        assert isinstance(result, type)
+        assert issubclass(result, BaseCoordinateFrame)
+
+    def test_class_can_be_instantiated(self):
+        """The returned class is directly instantiable."""
+        cls = get_frame_class("fk5")
+        instance = cls()
+        assert isinstance(instance, BaseCoordinateFrame)

--- a/docs/changes/coordinates/19711.feature.rst
+++ b/docs/changes/coordinates/19711.feature.rst
@@ -1,0 +1,1 @@
+Added `get_frame_class` as a new public function in `astropy.coordinates`. It accepts a frame name string (e.g. `'icrs'`) or a `BaseCoordinateFrame` subclass and returns the corresponding frame class, making it easier for downstream packages to validate and normalise coordinate frame inputs without constructing a full |SkyCoord|.


### PR DESCRIPTION
## Summary

This PR addresses Issue #19711 by exposing the existing frame resolution helper as a public API.

The implementation introduces `astropy.coordinates.get_frame_class`, allowing downstream packages to validate and normalize coordinate frame inputs without duplicating Astropy's internal logic.

The existing implementation is reused; this change primarily makes the functionality available through Astropy's public interface while preserving current behavior.

---

## Motivation

The `astropy-regions` package currently requires functionality equivalent to `_get_frame_class()` in order to normalize frame inputs such as:

- registered frame names (e.g. `"icrs"`, `"fk5"`)
- `BaseCoordinateFrame` subclasses

Because the helper is private, downstream packages must either duplicate the implementation or depend on a private API.

Making this functionality public provides a supported mechanism for frame normalization and avoids code duplication.

---

## Implementation

### Public API

Added:

```python
from astropy.coordinates import get_frame_class