### PR TITLE
Fix comparison tests with fitsio

### DIFF
--- a/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_fitsio.py
@@ -166,7 +166,13 @@ def fitsio_compressed_file_path(
         pytest.xfail("fitsio writes these files with very large/incorrect zzero values")
 
     tmp_path = tmp_path_factory.mktemp("fitsio")
-    original_data = base_original_data.astype(dtype)
+    # fitsio corrupts non-native-endian float input to compressed HDUs (it
+    # runs a non-finite check on a byteswapped view of the values and
+    # replaces false positives, see https://github.com/esheldon/fitsio/issues/513),
+    # so always hand it native-endian data. The file on disk is identical
+    # either way, and astropy's handling of non-native input is covered by
+    # test_compress.
+    original_data = base_original_data.astype(np.dtype(dtype).newbyteorder("="))
 
     filename = tmp_path / f"{compression_type}_{dtype}.fits"
     fits = fitsio.FITS(filename, "rw")

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     image: pytest-mpl>=0.18
 
     # Some FITS tests use fitsio as a comparison
-    fitsio: fitsio
+    fitsio: fitsio>=1.4.0
 
     # Include scipy in double run to detect test pollution in scipy-only tests
     double: scipy


### PR DESCRIPTION
Pass native byte order data to fitsio when writing the compressed reference files in the comparison tests, since fitsio silently corrupts non-native float input to compressed HDUs and the resulting files are not a valid reference for the reader comparison.

To be clear, this is a bug on the fitsio side not our side.

Fixes https://github.com/astropy/astropy/issues/20030
