### PR TITLE
Make astropy.wcs.get_include raise an exception when astropy was built against system WCSLIB

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -153,6 +153,9 @@ jobs:
           env: |
             ARCH_ON_CI: ${{ env.ARCH_ON_CI }}
             IS_CRON: ${{ env.IS_CRON }}
+            # Exported for the whole run, not just the build, so that the
+            # tests that need the bundled WCSLIB headers know to skip.
+            ASTROPY_USE_SYSTEM_ALL: 1
 
           install: |
             apt-get update -q -y
@@ -186,7 +189,7 @@ jobs:
             # cython and pyerfa versions in ubuntu repos are too old currently
             pip install -U cython setuptools packaging
             pip install -U --no-build-isolation pyerfa
-            ASTROPY_USE_SYSTEM_ALL=1 pip install -v --no-build-isolation -e .[test]
+            pip install -v --no-build-isolation -e .[test]
             pip list
             # A fresh CI runner has no ~/.astropy directory, but developer
             # machines usually do. Create empty cache and config directories

--- a/astropy/wcs/__init__.py
+++ b/astropy/wcs/__init__.py
@@ -29,9 +29,25 @@ from .wcs import *
 from .wcs import InvalidTabularParametersError  # just for docs
 
 
+class NoWcslibHeadersError(Exception):
+    """
+    Raised by `~astropy.wcs.get_include` when the header files needed to build
+    extensions against the ``astropy.wcs`` C API are not included in the
+    installed version of astropy, which is the case when astropy was built
+    against a system installation of WCSLIB.
+    """
+
+
 def get_include():
     """
     Get the path to astropy.wcs's C header files.
+
+    Raises
+    ------
+    NoWcslibHeadersError
+        If astropy was built against a system installation of WCSLIB, in
+        which case the WCSLIB headers needed to build extensions against the
+        ``astropy.wcs`` C API are not included.
 
     .. note::
         The C API exposed through these headers is provided only for backward
@@ -43,4 +59,17 @@ def get_include():
     """
     import os
 
-    return os.path.join(os.path.dirname(__file__), "include")
+    include_dir = os.path.join(os.path.dirname(__file__), "include")
+    for required in (
+        os.path.join("astropy_wcs", "wcsconfig.h"),
+        os.path.join("wcslib", "wcs.h"),
+    ):
+        if not os.path.exists(os.path.join(include_dir, required)):
+            raise NoWcslibHeadersError(
+                "This installation of astropy was built against a system "
+                "installation of WCSLIB, so the header files needed to build "
+                "extensions against the astropy.wcs C API are not included. "
+                "Use an installation of astropy built with the bundled WCSLIB "
+                "(such as a wheel from PyPI) instead."
+            )
+    return include_dir

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -22,10 +22,22 @@ from astropy.wcs import WCS, NoWcslibHeadersError, get_include
 
 HERE = os.path.dirname(__file__)
 
-pytestmark = pytest.mark.skipif(
-    not os.path.exists(os.path.join(sysconfig.get_path("include"), "Python.h")),
-    reason="CPython development headers are required to build the test extension",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.path.exists(os.path.join(sysconfig.get_path("include"), "Python.h")),
+        reason="CPython development headers are required to build the test extension",
+    ),
+    # Environments that build astropy against a system WCSLIB (the same
+    # condition setup_package.py checks) must opt out explicitly: such builds
+    # do not ship the headers needed to compile the extension.  Anywhere else,
+    # missing headers are a packaging bug and the build failure below is real.
+    pytest.mark.skipif(
+        int(os.environ.get("ASTROPY_USE_SYSTEM_WCSLIB", "0"))
+        or int(os.environ.get("ASTROPY_USE_SYSTEM_ALL", "0")),
+        reason="astropy was built against a system WCSLIB, which does not ship "
+        "the headers needed to build extensions against the astropy.wcs C API",
+    ),
+]
 
 # Built at test time against the headers published by astropy.wcs.get_include(),
 # with the same include directories a downstream package such as drizzlepac uses.
@@ -69,13 +81,6 @@ setup(
 
 @pytest.fixture(scope="module")
 def wcsapi_test(tmp_path_factory):
-    try:
-        get_include()
-    except NoWcslibHeadersError as exc:
-        # astropy was built against a system WCSLIB, so the headers needed to
-        # build the extension are not available.
-        pytest.skip(str(exc))
-
     # Build the extension in a scratch directory so we don't leave artifacts in
     # the source tree.
     build_dir = tmp_path_factory.mktemp("wcsapi_test")

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -18,7 +18,7 @@ import warnings
 
 import pytest
 
-from astropy.wcs import WCS
+from astropy.wcs import WCS, NoWcslibHeadersError, get_include
 
 HERE = os.path.dirname(__file__)
 
@@ -69,6 +69,13 @@ setup(
 
 @pytest.fixture(scope="module")
 def wcsapi_test(tmp_path_factory):
+    try:
+        get_include()
+    except NoWcslibHeadersError as exc:
+        # astropy was built against a system WCSLIB, so the headers needed to
+        # build the extension are not available.
+        pytest.skip(str(exc))
+
     # Build the extension in a scratch directory so we don't leave artifacts in
     # the source tree.
     build_dir = tmp_path_factory.mktemp("wcsapi_test")
@@ -161,3 +168,11 @@ def test_deprecated_slot_warns(wcsapi_test):
     # A deprecated member of the table (pipeline_clear) warns when used.
     with pytest.warns(DeprecationWarning, match="pipeline_clear"):
         wcsapi_test.call_deprecated()
+
+
+def test_get_include_missing_headers(monkeypatch):
+    # Simulate an installation built against a system WCSLIB, which does not
+    # ship wcsconfig.h or the WCSLIB headers.
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+    with pytest.raises(NoWcslibHeadersError, match="system installation of WCSLIB"):
+        get_include()

--- a/docs/changes/wcs/20048.api.rst
+++ b/docs/changes/wcs/20048.api.rst
@@ -1,0 +1,4 @@
+``astropy.wcs.get_include()`` now raises the new
+``astropy.wcs.NoWcslibHeadersError`` exception if astropy was built against a
+system installation of WCSLIB, in which case the header files needed to build
+extensions against the ``astropy.wcs`` C API are not included.


### PR DESCRIPTION
When astropy it built against system WCSLIB, we don't include all the header files so ``get_include()`` doesn't work properly. This has never worked, so it makes sense to just raise an exception rather than try and find a way to make it work.

Fixes https://github.com/astropy/astropy/issues/20045 (to be clear this is not a new issue/regression, it's just that we were not testing it before)