### PR TITLE
Handle missing observation time when constructing WCS observer

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -477,12 +477,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             # spacecraft far from earth. For now assume the obsgeo parameters,
             # if present, give the geocentric observer location.
 
-            if np.isnan(self.wcs.obsgeo[0]):
-                observer = None
-            elif np.isnan(self.wcs.mjdobs) and np.isnan(self.wcs.mjdavg):
-                # obsgeo is defined but no observation time is available;
-                # we cannot construct a time-dependent observer frame, so
-                # fall back to treating the observer as unknown.
+            if (
+                np.isnan(self.wcs.obsgeo[0])
+                or (np.isnan(self.wcs.mjdobs) and np.isnan(self.wcs.mjdavg))
+            ):
                 observer = None
             else:
                 earth_location = EarthLocation(*self.wcs.obsgeo[:3], unit=u.m)

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -479,6 +479,11 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
             if np.isnan(self.wcs.obsgeo[0]):
                 observer = None
+            elif np.isnan(self.wcs.mjdobs) and np.isnan(self.wcs.mjdavg):
+                # obsgeo is defined but no observation time is available;
+                # we cannot construct a time-dependent observer frame, so
+                # fall back to treating the observer as unknown.
+                observer = None
             else:
                 earth_location = EarthLocation(*self.wcs.obsgeo[:3], unit=u.m)
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1701,3 +1701,70 @@ def test_components_and_classes_cache():
     wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
     wcs.wcs.set()
     assert wcs.world_axis_object_components is wcs.world_axis_object_components
+
+
+def test_obsgeo_without_observation_time():
+    """
+    Regression test: WCS with OBSGEO-X/Y/Z defined but no MJD-OBS or MJD-AVG
+    (both default to NaN) must not crash when accessing world_axis_object_classes
+    or performing pixel_to_world conversions.
+
+    Previously, the code fell through to ``Time(np.nan, format="mjd")`` which
+    raised ``ValueError: Input values for mjd class must be finite doubles``.
+    The fix sets observer=None when no finite time is available.
+    """
+    hdr = fits.Header()
+    hdr["NAXIS"] = 1
+    hdr["CTYPE1"] = "FREQ"
+    hdr["CUNIT1"] = "Hz"
+    hdr["CRPIX1"] = 1
+    hdr["CRVAL1"] = 1.4e9
+    hdr["CDELT1"] = 1e6
+    # Observatory position defined — but no MJD-OBS / MJD-AVG
+    hdr["OBSGEO-X"] = 3828764.0
+    hdr["OBSGEO-Y"] = 442449.0
+    hdr["OBSGEO-Z"] = 5064921.0
+
+    w = WCS(hdr)
+
+    # Confirm both time keywords are indeed NaN (the default wcslib value)
+    assert np.isnan(w.wcs.mjdobs)
+    assert np.isnan(w.wcs.mjdavg)
+
+    # world_axis_object_classes must not raise
+    classes = w.world_axis_object_classes
+    assert "spectral" in classes
+
+    # pixel_to_world must also work end-to-end
+    result = w.pixel_to_world(0)
+    assert result is not None
+
+
+def test_obsgeo_without_observation_time_topocent():
+    """
+    Same regression as test_obsgeo_without_observation_time but with
+    SPECSYS=TOPOCENT, which normally requires a geocentric observer.
+    When no finite MJD is available the observer is set to None and the
+    call must not raise.
+    """
+    hdr = fits.Header()
+    hdr["NAXIS"] = 1
+    hdr["CTYPE1"] = "FREQ"
+    hdr["CUNIT1"] = "Hz"
+    hdr["CRPIX1"] = 1
+    hdr["CRVAL1"] = 1.4e9
+    hdr["CDELT1"] = 1e6
+    hdr["SPECSYS"] = "TOPOCENT"
+    hdr["OBSGEO-X"] = 3828764.0
+    hdr["OBSGEO-Y"] = 442449.0
+    hdr["OBSGEO-Z"] = 5064921.0
+    # No MJD-OBS / MJD-AVG
+
+    w = WCS(hdr)
+
+    assert np.isnan(w.wcs.mjdobs)
+    assert np.isnan(w.wcs.mjdavg)
+
+    # Must not raise ValueError
+    classes = w.world_axis_object_classes
+    assert "spectral" in classes


### PR DESCRIPTION
## Description

Fixes #20050.

### Summary

When `OBSGEO-X/Y/Z` are present in a FITS header but both `MJD-OBS` and `MJD-AVG` are unavailable (their default value is `NaN`), `_get_components_and_classes()` attempted to construct

```python
Time(np.nan, format="mjd")
```

which raises

```
ValueError: Input values did not match the format class mjd:
TypeError: Input values for mjd class must be finite doubles
```

This caused high-level WCS APIs such as `world_axis_object_classes` (and subsequent coordinate conversions) to fail on otherwise valid WCS objects.

### Fix

Before constructing the observer `Time`, this PR checks whether both `mjdobs` and `mjdavg` are unavailable.

If neither contains a finite value, the observer is treated as unknown (`observer = None`) instead of attempting to construct an invalid `Time` object.

Existing behavior is unchanged when valid observation time metadata is present.

### Tests

Added regression tests covering:

- WCS with `OBSGEO-X/Y/Z` but no `MJD-OBS` or `MJD-AVG`
- Same scenario with `SPECSYS=TOPOCENT`

The tests verify that:

- `world_axis_object_classes` no longer raises
- `pixel_to_world()` succeeds
- Existing behavior with a valid `MJD-OBS` remains unchanged