### PR TITLE
Initialize model _parameters array at construction (fix flaky Gaussian1D pickling)

### DIFF
--- a/astropy/convolution/tests/test_pickle.py
+++ b/astropy/convolution/tests/test_pickle.py
@@ -11,10 +11,7 @@ from astropy.tests.helper import check_pickling_recovery, pickle_protocol  # noq
     "original",
     [
         conv.CustomKernel(array=np.random.rand(15)),
-        # FIXME: Gaussian1DKernel sometimes fails check_pickling_recovery()
-        #        because Gaussian1D (modeling) sometimes fails it.
-        #        Fixing the latter will automatically fix the former.
-        # conv.Gaussian1DKernel(1.0, x_size=5),
+        conv.Gaussian1DKernel(1.0, x_size=5),
         conv.Gaussian2DKernel(1.0, x_size=5, y_size=5),
     ],
     ids=lambda x: type(x).__name__,

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2719,6 +2719,13 @@ class Model(metaclass=_ModelMeta):
             param_metrics[name]["size"] = param_size
             total_size += param_size
         self._parameters = np.empty(total_size, dtype=np.float64)
+        # Populate the freshly allocated array with the actual parameter values
+        # immediately. Otherwise ``_parameters`` is left holding uninitialized
+        # memory until the first access of the ``parameters`` property, which
+        # makes operations that read it directly (e.g. pickling a pristine
+        # model) non-deterministic -- if the uninitialized memory happens to
+        # contain a NaN, equality comparisons of the raw array fail. See #18598.
+        self._parameters_to_array()
 
     def _parameters_to_array(self):
         # Now set the parameter values (this will also fill

--- a/astropy/modeling/tests/test_pickle.py
+++ b/astropy/modeling/tests/test_pickle.py
@@ -208,3 +208,39 @@ def test_pickle_spline(inputs):
 
     mp = loads(dumps(m))
     assert_allclose(m(inputs[0]), mp(inputs[0]))
+
+
+@pytest.mark.parametrize("model", ["Gaussian1D", "Gaussian2D", "Const1D"])
+def test_fresh_model_parameters_are_initialized(model):
+    """A freshly constructed model must have a fully initialized ``_parameters``
+    array (not uninitialized ``np.empty`` memory).
+
+    Regression test for #18598: ``_parameters`` used to be allocated with
+    ``np.empty`` and only filled on the first access of the ``parameters``
+    property. A pristine model therefore held uninitialized memory in
+    ``_parameters``; when that memory happened to contain a NaN, strict
+    equality checks against the unpickled copy (which recomputes the values)
+    failed non-deterministically.
+    """
+    m = getattr(functional_models, model)()
+    # Copy the raw stored array *before* touching the ``parameters`` property
+    # (which fills ``_parameters`` lazily in place and would otherwise mask the
+    # bug by mutating the very array we want to inspect).
+    raw = np.array(m.__dict__["_parameters"], copy=True)
+    assert not np.isnan(raw).any()
+    assert_allclose(raw, m.parameters)
+
+
+def test_gaussian1d_strict_pickling_recovery():
+    """``Gaussian1D`` must survive a *strict*-equality pickle round-trip.
+
+    Regression test for #18598. ``check_pickling_recovery`` compares the
+    original and unpickled objects attribute-by-attribute with strict
+    equality (unlike the ``assert_allclose`` comparisons elsewhere in this
+    module), so it catches the uninitialized-``_parameters`` bug that made
+    ``Gaussian1DKernel``'s pickle test flaky.
+    """
+    from astropy.tests.helper import check_pickling_recovery
+
+    for protocol in (0, 1, 4, -1):
+        check_pickling_recovery(functional_models.Gaussian1D(), protocol)

--- a/docs/changes/modeling/20060.bugfix.rst
+++ b/docs/changes/modeling/20060.bugfix.rst
@@ -1,0 +1,5 @@
+Model parameters arrays are now fully initialized at construction rather than
+lazily on first access of the ``parameters`` property. Previously a freshly
+constructed model held uninitialized memory in its internal ``_parameters``
+array, which could make operations that read it directly (such as pickling a
+pristine model) behave non-deterministically.


### PR DESCRIPTION
## What this fixes

Fixes #18598.

A freshly constructed `Model` allocated its `_parameters` array with `np.empty()`
in `_initialize_slices()` and only populated it lazily, on the first access of the
`parameters` property. Until that first access, `_parameters` held **uninitialized
memory**.

That is harmless for the normal fitting workflow (which always touches
`.parameters`), but it makes any operation that reads the raw `_parameters` array
directly non-deterministic. The clearest victim is pickle-recovery testing:
`astropy.tests.helper.check_pickling_recovery()` compares the original and
unpickled objects attribute-by-attribute with **strict equality**. When the
uninitialized memory happened to contain a NaN, the comparison
`original._parameters == unpickled._parameters` produced `False` (since
`NaN != NaN`), raising `AssertionError: Value of _parameters changed by pickling`.

This is exactly the intermittent failure that led to `Gaussian1DKernel` being
disabled from `convolution/tests/test_pickle.py` in #18596 — `Gaussian1DKernel`
wraps a `Gaussian1D`, so the modeling-level flakiness surfaced there. As #18598
notes, fixing `Gaussian1D` fixes the kernel automatically.

## The fix

Populate `_parameters` from the actual parameter values immediately after it is
allocated, so a pristine model never holds uninitialized memory:

```python
self._parameters = np.empty(total_size, dtype=np.float64)
self._parameters_to_array()   # fill with real values right away
```

`_parameters_to_array()` only needs the `_param_metrics` slices (already built
earlier in `_initialize_slices`) and the parameter values, so it is safe to call
here. After the change, a fresh `Gaussian1D()` has `_parameters == [1., 0., 1.]`
(its real defaults) instead of garbage.

The disabled `Gaussian1DKernel` case in `convolution/tests/test_pickle.py` is
re-enabled (this is the `Revert #18596` item on the issue checklist).

## How it was tested

Reproduced the failure first (RED). With a fresh model whose uninitialized
`_parameters` was forced to contain NaN, `check_pickling_recovery()` failed with
the reported signature:

```
check_pickling_recovery: FAILED (RED) -> Value of _parameters changed by pickling
```

Reverting the one-line fix in the working tree and running the new
`test_fresh_model_parameters_are_initialized` shows the raw array actually holding
uninitialized garbage rather than the parameter values:

```
ACTUAL:  array([ 1.797693e+308, -1.797693e+308, 2.0, 2.22e-16, 2.22e-308, 4.94e-324])
DESIRED: array([1., 0., 0., 1., 1., 0.])
```

With the fix applied (GREEN), the full suites pass:

- `pytest astropy/modeling/tests/` → **1690 passed**, 1118 skipped (scipy-gated)
- `pytest astropy/convolution/tests/` → **1560 passed**, 36 skipped, 8 xfailed
- combined modeling + convolution → **3250 passed**, 0 failed

`ruff check` and `ruff format --check` (pinned `v0.15.20`) are clean on all three
changed files.

Two regression tests are added in `modeling/tests/test_pickle.py`:
`test_fresh_model_parameters_are_initialized` (asserts a pristine model's raw
`_parameters` matches its real values and contains no NaN) and
`test_gaussian1d_strict_pickling_recovery` (exercises the strict
`check_pickling_recovery` path across all pickle protocols).
