### PR TITLE
Disallow masked values in modeling inputs

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -30,6 +30,7 @@ from astropy.table import Table
 from astropy.units import Quantity, UnitsError, dimensionless_unscaled
 from astropy.utils import find_current_module, metadata, sharedmethod
 from astropy.utils.codegen import make_function_with_signature
+from astropy.utils.masked import get_data_and_mask
 
 from .bounding_box import CompoundBoundingBox, ModelBoundingBox
 from .parameters import InputParameterError, Parameter, _tofloat, param_repr_oneline
@@ -2104,7 +2105,14 @@ class Model(metaclass=_ModelMeta):
             model_set_axis = self.model_set_axis
 
         params = [getattr(self, name) for name in self.param_names]
-        inputs = [np.asanyarray(_input, dtype=float) for _input in inputs]
+        arrays = [np.asanyarray(_input, dtype=float) for _input in inputs]
+        # Ensure inputs are unmasked arrays
+        inputs = []
+        for array in arrays:
+            data, mask = get_data_and_mask(array)
+            if mask is not None and np.any(mask):
+                raise ValueError("models do not accept masked values.")
+            inputs.append(data)
 
         self._validate_input_shapes(inputs, self.inputs, model_set_axis)
 

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -127,10 +127,9 @@ class RotationSequence3D(Model):
         """
         if x.shape != y.shape or x.shape != z.shape:
             raise ValueError("Expected input arrays to have the same shape")
-        xyz = np.stack([x, y, z], axis=-1)
-        rotmat = _create_matrix(angles[0], self.axes_order)
-        rxyz = np.einsum("...j,ij->...i", xyz, rotmat)
-        return tuple(rxyz.T)
+        inarr = np.stack([x, y, z], axis=-2)
+        result = np.matmul(_create_matrix(angles[0], self.axes_order), inarr)
+        return tuple(np.moveaxis(result, -2, 0))
 
 
 class SphericalRotationSequence(RotationSequence3D):

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -393,7 +393,9 @@ def test_masked_column_rotation(model):
     mdl = model([0, 0, 0], axes_order=["x", "y", "z"])
     col = MaskedColumn([1, 2])
     truth = (np.array([1, 2]),)
-    if model is rotations.RotationSequence3D:
-        assert_allclose(mdl(col, col, col), truth * 3)
-    else:
-        assert_allclose(mdl(col, col), truth * 2)
+    assert_allclose(mdl(*((col,) * mdl.n_inputs)), truth * mdl.n_inputs)
+
+    # TODO: move this test for masked inputs to a more general place.
+    col2 = MaskedColumn([1, 2], mask=[False, True])
+    with pytest.raises(ValueError, match="do not accept masked"):
+        mdl(*((col2,) * mdl.n_inputs))

--- a/docs/changes/modeling/20062.api.rst
+++ b/docs/changes/modeling/20062.api.rst
@@ -1,0 +1,5 @@
+Model inputs should not contain masks, but previously this was not
+explicitly checked, resulting sometimes in obscure problems and other
+times in the mask being silently stripped. Now, for mask inputs, if
+any value is masked, an error is raised, and it is ensure that the
+outputs are always unmasked.


### PR DESCRIPTION
This is a follow-up or possible alternative to #20054, trying to treat the more general problem, that an assumption underlying modeling is that Model inputs should not contain masks, but previously this was not explicitly checked, resulting sometimes in obscure problems and other times in the mask being silently stripped. This PR ensures that for mask inputs, if any value is masked, an error is raised, and otherwise the mask is stripped, so that outputs are always unmasked.

I'm not quite sure how to deal with this, since at some level this is both a bugfix and an API change. 

p.s. Please feel free to push to or even take over this PR! In particular, the test for masked values could probably be in a better place, but I don't know modeling well `enough (and` am too short on time right now...)  to find it.

Related

* #20054
* #20052
* close #20056