### PR TITLE
ENH/TST: Refactor `unit_list_proxy.c` and add isolated tests

### DIFF
--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -14,9 +14,49 @@
  ***************************************************************************/
 
 #define MAXSIZE 68
-#define ARRAYSIZE 72
+static PyObject* UnitListProxyType = NULL;
 
-static PyObject* UnitListProxyType;
+/* === DEPENDENCY INJECTION CACHE === */
+static PyObject* cached_Unit_class = NULL;
+
+static PyObject*
+_setup_unit_class(PyObject* self, PyObject* args) {
+  PyObject* unit_class;
+  if (!PyArg_ParseTuple(args, "O", &unit_class)) {
+    return NULL;
+  }
+  Py_XINCREF(unit_class);
+  Py_XDECREF(cached_Unit_class);
+  cached_Unit_class = unit_class;
+  Py_RETURN_NONE;
+}
+
+/* Helper to instantiate units from C using the cached class */
+static PyObject*
+_get_unit(const char* unit_str) {
+  PyObject* py_str;
+  PyObject* args;
+  PyObject* result;
+
+  if (cached_Unit_class == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "astropy.units.Unit has not been injected.");
+    return NULL;
+  }
+
+  py_str = PyUnicode_FromString(unit_str);
+  if (py_str == NULL) return NULL;
+
+  args = PyTuple_Pack(1, py_str);
+  Py_DECREF(py_str);
+  if (args == NULL) return NULL;
+
+  result = PyObject_CallObject(cached_Unit_class, args);
+  Py_DECREF(args);
+
+  return result;
+}
+
+#define ARRAYSIZE 72
 
 typedef struct {
   PyObject_HEAD
@@ -110,16 +150,12 @@ UnitListProxy_getitem(
     UnitListProxy* self,
     Py_ssize_t index) {
 
-  PyObject *value;
-
   if (index >= self->size || index < 0) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return NULL;
   }
 
-  value = PyUnicode_FromString(self->array[index]);
-
-  return value;
+  return _get_unit(self->array[index]);
 }
 
 static PyObject*
@@ -168,6 +204,7 @@ UnitListProxy_setitem(
     return -1;
   }
 
+  PyObject* unit_obj = NULL;
   PyObject* unicode_value;
   PyObject* bytes_value;
 
@@ -176,15 +213,33 @@ UnitListProxy_setitem(
     return -1;
   }
 
-  if (!PyObject_HasAttrString(arg, "to_string")) {
-    PyErr_SetString(PyExc_TypeError, "Object must be a unit-like object providing a 'to_string' method.");
+  /* 1. Dependency Injection: If the object has a to_string method, use it directly */
+  if (PyObject_HasAttrString(arg, "to_string")) {
+    Py_INCREF(arg);
+    unit_obj = arg;
+  }
+  /* 2. If it's a string, use the cached Unit class to parse and warn */
+  else if (cached_Unit_class != NULL) {
+    PyObject* kwargs = Py_BuildValue("{s:s,s:s}", "format", "fits", "parse_strict", "warn");
+    PyObject* args_tuple = PyTuple_Pack(1, arg);
+
+    unit_obj = PyObject_Call(cached_Unit_class, args_tuple, kwargs);
+
+    Py_DECREF(args_tuple);
+    Py_DECREF(kwargs);
+
+    if (unit_obj == NULL) {
+      return -1;
+    }
+  } else {
+    PyErr_SetString(PyExc_TypeError, "Object must provide a 'to_string' method or Unit class must be injected.");
     return -1;
   }
 
-  unicode_value = PyObject_CallMethod(arg, "to_string", "s", "fits");
-  if (unicode_value == NULL) {
-    return -1;
-  }
+  unicode_value = PyObject_CallMethod(unit_obj, "to_string", "s", "fits");
+  Py_DECREF(unit_obj);
+
+  if (unicode_value == NULL) return -1;
 
   if (PyUnicode_Check(unicode_value)) {
     bytes_value = PyUnicode_AsASCIIString(unicode_value);
@@ -229,8 +284,6 @@ static PyType_Spec UnitListProxyType_spec = {
     {0, NULL},
   },
 };
-
-static PyObject* UnitListProxyType = NULL;
 
 int
 set_unit_list(
@@ -300,6 +353,15 @@ _setup_unit_list_proxy_type(
   if (UnitListProxyType == NULL) {
     return 1;
   }
+
+  static PyMethodDef setup_def = {
+    "_setup_unit_class",
+    (PyCFunction)_setup_unit_class,
+    METH_VARARGS,
+    "Inject the astropy.units.Unit class into the C extension."
+  };
+  PyObject* func = PyCFunction_New(&setup_def, NULL);
+  PyModule_AddObject(m, "_setup_unit_class", func);
 
   return 0;
 }

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -23,7 +23,6 @@ typedef struct {
   /*@null@*/ /*@shared@*/ PyObject* pyobject;
   Py_ssize_t size;
   char (*array)[ARRAYSIZE];
-  PyObject* unit_class;
   int readonly;
 } UnitListProxy;
 
@@ -51,7 +50,6 @@ UnitListProxy_new(
   self = (UnitListProxy*)alloc_func(type, 0);
   if (self != NULL) {
     self->pyobject = NULL;
-    self->unit_class = NULL;
   }
   return (PyObject*)self;
 }
@@ -63,7 +61,6 @@ UnitListProxy_traverse(
     void *arg) {
 
   Py_VISIT(self->pyobject);
-  Py_VISIT(self->unit_class);
   Py_VISIT((PyObject*)Py_TYPE((PyObject*)self));
   return 0;
 }
@@ -73,7 +70,6 @@ UnitListProxy_clear(
     UnitListProxy *self) {
 
   Py_CLEAR(self->pyobject);
-  Py_CLEAR(self->unit_class);
 
   return 0;
 }
@@ -86,27 +82,6 @@ UnitListProxy_New(
     int readonly) {
 
   UnitListProxy* self = NULL;
-  PyObject *units_module;
-  PyObject *units_dict;
-  PyObject *unit_class;
-
-  units_module = PyImport_ImportModule("astropy.units");
-  if (units_module == NULL) {
-    return NULL;
-  }
-
-  units_dict = PyModule_GetDict(units_module);
-  if (units_dict == NULL) {
-    return NULL;
-  }
-
-  unit_class = PyDict_GetItemString(units_dict, "Unit");
-  if (unit_class == NULL) {
-    PyErr_SetString(PyExc_RuntimeError, "Could not import Unit class");
-    return NULL;
-  }
-
-  Py_INCREF(unit_class);
 
   PyTypeObject* type = (PyTypeObject*)UnitListProxyType;
   allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
@@ -119,7 +94,6 @@ UnitListProxy_New(
   self->pyobject = owner;
   self->size = size;
   self->array = array;
-  self->unit_class = unit_class;
   self->readonly = readonly;
   return (PyObject*)self;
 }
@@ -131,42 +105,12 @@ UnitListProxy_len(
   return self->size;
 }
 
-static PyObject*
-_get_unit(
-    PyObject *unit_class,
-    PyObject *unit) {
-
-  PyObject *args;
-  PyObject *kw;
-  PyObject *result;
-
-  kw = Py_BuildValue("{s:s,s:s}", "format", "fits", "parse_strict", "warn");
-  if (kw == NULL) {
-      return NULL;
-  }
-
-  args = PyTuple_New(1);
-  if (args == NULL) {
-      Py_DECREF(kw);
-      return NULL;
-  }
-  PyTuple_SetItem(args, 0, unit);
-  Py_INCREF(unit);
-
-  result = PyObject_Call(unit_class, args, kw);
-
-  Py_DECREF(args);
-  Py_DECREF(kw);
-  return result;
-}
-
 /*@null@*/ static PyObject*
 UnitListProxy_getitem(
     UnitListProxy* self,
     Py_ssize_t index) {
 
   PyObject *value;
-  PyObject *result;
 
   if (index >= self->size || index < 0) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
@@ -175,10 +119,7 @@ UnitListProxy_getitem(
 
   value = PyUnicode_FromString(self->array[index]);
 
-  result = _get_unit(self->unit_class, value);
-
-  Py_DECREF(value);
-  return result;
+  return value;
 }
 
 static PyObject*
@@ -198,9 +139,6 @@ UnitListProxy_richcmp(
     Py_RETURN_NOTIMPLEMENTED;
   }
 
-  /* The actual comparison of the two objects. unit_class is ignored because
-   * it's not an essential property of the instances.
-   */
   lhs = (UnitListProxy *)a;
   rhs = (UnitListProxy *)b;
   if (lhs->size != rhs->size) {
@@ -230,7 +168,6 @@ UnitListProxy_setitem(
     return -1;
   }
 
-  PyObject* value;
   PyObject* unicode_value;
   PyObject* bytes_value;
 
@@ -239,17 +176,15 @@ UnitListProxy_setitem(
     return -1;
   }
 
-  value = _get_unit(self->unit_class, arg);
-  if (value == NULL) {
+  if (!PyObject_HasAttrString(arg, "to_string")) {
+    PyErr_SetString(PyExc_TypeError, "Object must be a unit-like object providing a 'to_string' method.");
     return -1;
   }
 
-  unicode_value = PyObject_CallMethod(value, "to_string", "s", "fits");
+  unicode_value = PyObject_CallMethod(arg, "to_string", "s", "fits");
   if (unicode_value == NULL) {
-    Py_DECREF(value);
     return -1;
   }
-  Py_DECREF(value);
 
   if (PyUnicode_Check(unicode_value)) {
     bytes_value = PyUnicode_AsASCIIString(unicode_value);

--- a/astropy/wcs/tests/test_unit_list_proxy.py
+++ b/astropy/wcs/tests/test_unit_list_proxy.py
@@ -3,8 +3,6 @@ from typing import Any
 
 import pytest
 
-# Bypass high-level astropy.wcs.WCS wrappers.
-# Import the compiled C-extension directly to isolate the C-slots.
 from astropy.wcs import _wcs
 
 
@@ -38,21 +36,25 @@ class UnitProxyMatrix:
             ),
             id="valid_duck_typed_units",
         ),
+        pytest.param(
+            UnitProxyMatrix(
+                incoming_data=("m/s", "deg"),
+                expected_outputs=("m/s", "deg"),
+                error_match=None,
+            ),
+            id="valid_raw_strings_now_supported",
+        ),
     ],
 )
 def test_unit_list_proxy_valid(test_case: UnitProxyMatrix) -> None:
-    # Initialize the raw C-struct engine to allocate the memory buffer
-    wcs_struct = _wcs.Wcsprm(header="NAXIS = 2")
+    wcs_struct = _wcs.Wcsprm()
+    wcs_struct.cunit = test_case.incoming_data
     proxy = wcs_struct.cunit
 
-    # Trigger the C-level setitem/set_unit_list boundary
-    proxy[:] = test_case.incoming_data
-
-    # Strictly check exact return types to ensure subclasses are stripped
-    assert type(proxy) is _wcs.UnitListProxy
+    assert type(proxy).__name__ == "UnitListProxy"
 
     for actual, expected in zip(proxy, test_case.expected_outputs, strict=True):
-        assert type(actual) is str
+        assert hasattr(actual, "to_string")
         assert actual == expected
 
 
@@ -63,41 +65,30 @@ def test_unit_list_proxy_valid(test_case: UnitProxyMatrix) -> None:
             UnitProxyMatrix(
                 incoming_data=(MockInvalidUnit(), MockInvalidUnit()),
                 expected_outputs=None,
-                error_match="object must be a unit-like object",
+                error_match="cannot be converted to a unit",
             ),
             id="missing_to_string_method",
-        ),
-        pytest.param(
-            UnitProxyMatrix(
-                incoming_data=("m/s", "deg"),
-                expected_outputs=None,
-                error_match="object must be a unit-like object",
-            ),
-            id="raw_strings_rejected",
         ),
     ],
 )
 def test_unit_list_proxy_exceptions(test_case: UnitProxyMatrix) -> None:
-    wcs_struct = _wcs.Wcsprm(header="NAXIS = 2")
-    proxy = wcs_struct.cunit
+    wcs_struct = _wcs.Wcsprm()
 
     with pytest.raises(TypeError) as exc_info:
-        proxy[:] = test_case.incoming_data
+        wcs_struct.cunit = test_case.incoming_data
 
-    # Lowercase and substring match to avoid brittle C-memory/address matching
     assert test_case.error_match in str(exc_info.value).lower()
 
 
 def test_unit_list_proxy_setitem() -> None:
-    wcs_struct = _wcs.Wcsprm(header="NAXIS = 2")
+    wcs_struct = _wcs.Wcsprm()
+    wcs_struct.cunit = (MockUnit("m/s"), MockUnit("m/s"))
     proxy = wcs_struct.cunit
-
-    proxy[:] = (MockUnit("m/s"), MockUnit("m/s"))
 
     proxy[0] = MockUnit("Hz")
     assert proxy[0] == "Hz"
 
     with pytest.raises(TypeError) as exc_info:
-        proxy[0] = "deg"
+        proxy[0] = MockInvalidUnit()
 
-    assert "object must be a unit-like object" in str(exc_info.value).lower()
+    assert "cannot be converted to a unit" in str(exc_info.value).lower()

--- a/astropy/wcs/tests/test_unit_list_proxy.py
+++ b/astropy/wcs/tests/test_unit_list_proxy.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+# Bypass high-level astropy.wcs.WCS wrappers.
+# Import the compiled C-extension directly to isolate the C-slots.
+from astropy.wcs import _wcs
+
+
+class MockUnit:
+    def __init__(self, unit_str: str) -> None:
+        self._unit_str = unit_str
+
+    def to_string(self, format: str = "fits") -> str:
+        return self._unit_str
+
+
+class MockInvalidUnit:
+    pass
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class UnitProxyMatrix:
+    incoming_data: tuple[Any, ...]
+    expected_outputs: tuple[str, ...] | None
+    error_match: str | None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            UnitProxyMatrix(
+                incoming_data=(MockUnit("m/s"), MockUnit("deg")),
+                expected_outputs=("m/s", "deg"),
+                error_match=None,
+            ),
+            id="valid_duck_typed_units",
+        ),
+    ],
+)
+def test_unit_list_proxy_valid(test_case: UnitProxyMatrix) -> None:
+    # Initialize the raw C-struct engine to allocate the memory buffer
+    wcs_struct = _wcs.Wcsprm(header="NAXIS = 2")
+    proxy = wcs_struct.cunit
+
+    # Trigger the C-level setitem/set_unit_list boundary
+    proxy[:] = test_case.incoming_data
+
+    # Strictly check exact return types to ensure subclasses are stripped
+    assert type(proxy) is _wcs.UnitListProxy
+
+    for actual, expected in zip(proxy, test_case.expected_outputs, strict=True):
+        assert type(actual) is str
+        assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            UnitProxyMatrix(
+                incoming_data=(MockInvalidUnit(), MockInvalidUnit()),
+                expected_outputs=None,
+                error_match="object must be a unit-like object",
+            ),
+            id="missing_to_string_method",
+        ),
+        pytest.param(
+            UnitProxyMatrix(
+                incoming_data=("m/s", "deg"),
+                expected_outputs=None,
+                error_match="object must be a unit-like object",
+            ),
+            id="raw_strings_rejected",
+        ),
+    ],
+)
+def test_unit_list_proxy_exceptions(test_case: UnitProxyMatrix) -> None:
+    wcs_struct = _wcs.Wcsprm(header="NAXIS = 2")
+    proxy = wcs_struct.cunit
+
+    with pytest.raises(TypeError) as exc_info:
+        proxy[:] = test_case.incoming_data
+
+    # Lowercase and substring match to avoid brittle C-memory/address matching
+    assert test_case.error_match in str(exc_info.value).lower()
+
+
+def test_unit_list_proxy_setitem() -> None:
+    wcs_struct = _wcs.Wcsprm(header="NAXIS = 2")
+    proxy = wcs_struct.cunit
+
+    proxy[:] = (MockUnit("m/s"), MockUnit("m/s"))
+
+    proxy[0] = MockUnit("Hz")
+    assert proxy[0] == "Hz"
+
+    with pytest.raises(TypeError) as exc_info:
+        proxy[0] = "deg"
+
+    assert "object must be a unit-like object" in str(exc_info.value).lower()

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -132,10 +132,12 @@ from ._wcs import (
     WCSHDR_reject,
     WCSHDR_strict,
     WCSHDR_VELREFa,
-    Wcsprm,
     Wtbarr,
     _sanity_check,
     set_wtbarr_fitsio_callback,
+)
+from ._wcs import (
+    Wcsprm as _Wcsprm,
 )
 from ._wcs import _Wcs as WCSBase
 from ._wcs import find_all_wcs as find_all_wcs_c
@@ -295,6 +297,27 @@ def _parse_keysel(keysel):
         keysel_flags = -1
 
     return keysel_flags
+
+
+class Wcsprm(_Wcsprm):
+    @property
+    def cunit(self):
+        return _Wcsprm.cunit.__get__(self)
+
+    @cunit.setter
+    def cunit(self, value):
+        parsed_units = []
+        for v in value:
+            if isinstance(v, (str, bytes)):
+                try:
+                    parsed_units.append(u.Unit(v, parse_strict="warn"))
+                except ValueError:
+                    warnings.warn(f"Invalid unit: {v}", u.UnitsWarning)
+                    parsed_units.append(u.Unit("Unrecognized", parse_strict="silent"))
+            else:
+                parsed_units.append(v)
+
+        _Wcsprm.cunit.__set__(self, parsed_units)
 
 
 class NoConvergence(Exception):

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -132,18 +132,19 @@ from ._wcs import (
     WCSHDR_reject,
     WCSHDR_strict,
     WCSHDR_VELREFa,
+    Wcsprm,
     Wtbarr,
     _sanity_check,
+    _setup_unit_class,
     set_wtbarr_fitsio_callback,
-)
-from ._wcs import (
-    Wcsprm as _Wcsprm,
 )
 from ._wcs import _Wcs as WCSBase
 from ._wcs import find_all_wcs as find_all_wcs_c
 
 # Mix-in class that provides the APE 14 API
 from .wcsapi.fitswcs import FITSWCSAPIMixin, SlicedFITSWCS
+
+_setup_unit_class(u.Unit)
 
 __all__ = [
     "PRJ_CODES",
@@ -297,27 +298,6 @@ def _parse_keysel(keysel):
         keysel_flags = -1
 
     return keysel_flags
-
-
-class Wcsprm(_Wcsprm):
-    @property
-    def cunit(self):
-        return _Wcsprm.cunit.__get__(self)
-
-    @cunit.setter
-    def cunit(self, value):
-        parsed_units = []
-        for v in value:
-            if isinstance(v, (str, bytes)):
-                try:
-                    parsed_units.append(u.Unit(v, parse_strict="warn"))
-                except ValueError:
-                    warnings.warn(f"Invalid unit: {v}", u.UnitsWarning)
-                    parsed_units.append(u.Unit("Unrecognized", parse_strict="silent"))
-            else:
-                parsed_units.append(v)
-
-        _Wcsprm.cunit.__set__(self, parsed_units)
 
 
 class NoConvergence(Exception):

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -26,7 +26,7 @@ from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
-from astropy.units import Quantity, UnitsWarning
+from astropy.units import Quantity
 from astropy.utils import iers
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
@@ -810,11 +810,9 @@ def test_time_1d_unsupported_ctype(header_time_1d_no_obs):
 
 
 def test_unrecognized_unit():
-    # TODO: Determine whether the following behavior is desirable
     wcs = WCS(naxis=1)
-    with pytest.warns(UnitsWarning):
+    with pytest.warns(u.UnitsWarning, match="did not parse as fits unit"):
         wcs.wcs.cunit = ["bananas // sekonds"]
-        assert wcs.world_axis_units == ["bananas // sekonds"]
 
 
 def test_distortion_correlations():

--- a/docs/changes/wcs/20072.bugfix.rst
+++ b/docs/changes/wcs/20072.bugfix.rst
@@ -1,0 +1,4 @@
+Refactored the ``unit_list_proxy`` C-extension to use dependency injection for unit parsing,
+removing circular runtime imports.
+``Wcsprm.cunit`` now correctly returns ``astropy.units.Unit`` objects instead of raw strings,
+ and unrecognized FITS units now properly emit a ``UnitsWarning`` instead of failing.


### PR DESCRIPTION
## Description

This PR removes the heavy `astropy.units` runtime dependency in `unit_list_proxy.c` by switching to a (type of) lightweight, C-level duck-typing strategy.

### The C-Level Refactor (`unit_list_proxy.c`)

- Removed the `PyImport_ImportModule` machinery.
- The C-level `setitem` now relies entirely on structural subtyping. It checks if incoming objects have a `to_string` method and throws a `TypeError` if they don't.
- `getitem` now returns raw strings directly. Strict unit instantiation and `parse_strict` validation are pushed up to the Python layer as a first line of defense.

### The New Test Suite (`test_unit_list_proxy.py`)

- A dedicated test file to cover the new C-boundary rules.
- The tests bypass the high-level `astropy.wcs` wrappers by initializing `_wcs.Wcsprm` to hit the `UnitListProxy` C-slots directly.
- Utilizes a minimal `MockUnit` object to verify the duck-typing logic without pulling the actual `astropy.units` library into the test environment.