### PR TITLE
fix: allow in-place arithmetic on Column with unit

### DIFF
--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -279,6 +279,54 @@ class TestColumn:
         q = [10, 100, 1000] * u.AA
         np.testing.assert_allclose(d.to(u.AA), q)
 
+    def test_inplace_arithmetic_with_quantity(self, Column):
+        """
+        Regression test for gh-20075: in-place arithmetic with a Quantity
+        should work for Column instances that carry a unit.
+        """
+        ra = Column([0.0, 1.0, 2.0], name="ra", unit=u.deg)
+        dra = np.array([0.0, 1.0, 2.0]) * u.deg
+        ra_id = id(ra)
+        ra += dra
+        assert id(ra) == ra_id
+        assert isinstance(ra, Column)
+        assert ra.unit == u.deg
+        assert_array_equal(ra, [0.0, 2.0, 4.0])
+
+        # Unit conversion of the Quantity operand must be applied.
+        ra = Column([0.0, 1.0, 2.0], name="ra", unit=u.deg)
+        ra += np.array([0.0, 3600.0, 0.0]) * u.arcsec
+        assert ra.unit == u.deg
+        np.testing.assert_allclose(ra, [0.0, 2.0, 2.0])
+
+        # Operations that change the physical dimension update Column.unit,
+        # matching Quantity's in-place behaviour.
+        # MaskedColumn inherits numpy.ma in-place helpers that do not support
+        # changing units via Quantity operands, so only exercise this for Column.
+        if not issubclass(Column, table.MaskedColumn):
+            length = Column([1.0, 2.0], name="length", unit=u.m)
+            length *= 2.0 * u.s
+            assert length.unit == u.m * u.s
+            assert_array_equal(length, [2.0, 4.0])
+
+        # Explicit out= path used by ufuncs.
+        col = Column([0.0, 0.0], unit=u.deg)
+        result = np.add(
+            np.array([1.0, 2.0]) * u.deg, np.array([3.0, 4.0]) * u.deg, out=col
+        )
+        assert result is col
+        assert_array_equal(col, [4.0, 6.0])
+        assert col.unit == u.deg
+
+        # Non-inplace arithmetic still works and preserves units.
+        ra = Column([1.0, 2.0], unit=u.deg)
+        out = ra + (1.0 * u.deg)
+        assert out.unit == u.deg
+        assert_array_equal(np.asarray(out), [2.0, 3.0])
+        if not issubclass(Column, table.MaskedColumn):
+            # Plain Column + Quantity returns a Quantity.
+            assert isinstance(out, u.Quantity)
+
     def test_item_access_type(self, Column):
         """
         Tests for #3095, which forces integer item access to always return a plain

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -750,6 +750,12 @@ class Quantity(np.ndarray):
             # for out to be ndarray and the unit to be dimensionless.)
             out._set_unit(unit)
 
+        elif unit is not None and getattr(out, "unit", None) is not None:
+            # Non-Quantity outputs that carry unit metadata (e.g. table
+            # Column).  Keep the unit in sync with the values that were just
+            # written, matching Quantity's inplace behaviour.
+            out.unit = unit
+
         return out
 
     def __quantity_subclass__(self, unit):

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -374,6 +374,26 @@ def check_output(output, unit, inputs, function=None):
         return output.view(np.ndarray)
 
     else:
+        # Not a Quantity subclass.  Still allow outputs that carry a unit
+        # attribute (most notably ``Column``), so dimensional results can be
+        # stored in-place.  The unit metadata is updated afterwards in
+        # ``Quantity._result_as_quantity`` when needed.
+        output_unit = getattr(output, "unit", None)
+        if output_unit is not None:
+            # Mirror the dtype safety check used for Quantity outputs.
+            if inputs and not getattr(output.dtype, "names", None):
+                result_type = np.result_type(*inputs)
+                if not (
+                    result_type.names
+                    or np.can_cast(result_type, output.dtype, casting="same_kind")
+                ):
+                    raise TypeError(
+                        "Arguments cannot be cast safely to inplace "
+                        f"output with dtype={output.dtype}"
+                    )
+            # Prefer a plain ndarray view so we do not re-enter array_ufunc.
+            return output.view(np.ndarray)
+
         # output is not a Quantity, so cannot obtain a unit.
         if not (unit is None or unit == dimensionless_unscaled):
             raise UnitTypeError(

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -1117,6 +1117,63 @@ class TestInplaceUfuncs:
         arr *= 1 / np.cos(0 * u.deg)
         assert arr[0] == 1
 
+    def test_unit_bearing_non_quantity_inplace(self):
+        """
+        Regression coverage for gh-20075 / gh-20076.
+
+        Non-Quantity arrays that expose a ``unit`` attribute (e.g. table
+        ``Column``) must accept dimensional Quantity results in-place, and
+        have their unit metadata updated when the physical dimension changes.
+        """
+
+        class UnitArray(np.ndarray):
+            """Minimal ndarray subclass that carries a unit attribute."""
+
+            def __new__(cls, input_array, unit=None):
+                obj = np.array(input_array, dtype=float, copy=True).view(cls)
+                obj.unit = unit
+                return obj
+
+            def __array_finalize__(self, obj):
+                if obj is None:
+                    return
+                self.unit = getattr(obj, "unit", None)
+
+        # Same-unit addition via out=.
+        out = UnitArray([0.0, 0.0], unit=u.m)
+        result = np.add(np.array([1.0, 2.0]) * u.m, np.array([3.0, 4.0]) * u.m, out=out)
+        assert result is out
+        assert_array_equal(out, [4.0, 6.0])
+        assert out.unit == u.m
+
+        # In-place operator form.
+        arr = UnitArray([1.0, 2.0], unit=u.m)
+        arr_id = id(arr)
+        arr += np.array([1.0, 1.0]) * u.m
+        assert id(arr) == arr_id
+        assert_array_equal(arr, [2.0, 3.0])
+        assert arr.unit == u.m
+
+        # Operand unit conversion.
+        arr = UnitArray([1.0, 2.0], unit=u.m)
+        arr += np.array([100.0, 0.0]) * u.cm
+        assert arr.unit == u.m
+        assert_array_equal(arr, [2.0, 2.0])
+
+        # Dimension-changing in-place multiply updates unit metadata.
+        arr = UnitArray([1.0, 2.0], unit=u.m)
+        arr *= 2.0 * u.s
+        assert arr.unit == u.m * u.s
+        assert_array_equal(arr, [2.0, 4.0])
+
+        # Unsafe dtype cast still raises (mirrors Quantity output checks).
+        out_i = UnitArray([0, 0], unit=u.m)
+        # Force integer storage.
+        out_i = out_i.astype(int)
+        out_i.unit = u.m
+        with pytest.raises(TypeError, match="cast safely"):
+            np.add(np.array([1.5, 2.5]) * u.m, np.array([0.5, 0.5]) * u.m, out=out_i)
+
 
 class TestWhere:
     """Test the where argument in ufuncs."""

--- a/docs/changes/table/20076.bugfix.rst
+++ b/docs/changes/table/20076.bugfix.rst
@@ -1,0 +1,3 @@
+In-place arithmetic between a unit-bearing ``Column`` and a ``Quantity``
+(for example ``column += quantity``) now works instead of raising
+``UnitTypeError``.


### PR DESCRIPTION
### Description

In-place arithmetic such as `Column(...) += Quantity(...)` failed with
`UnitTypeError` when the Column carried a physical unit, while the
non-in-place form `Column(...) + Quantity(...)` already worked.

`Quantity.__array_ufunc__` routes through `check_output`, which previously
treated any non-`Quantity` output as unable to hold dimensional values.
`Column` is not a `Quantity` subclass, but it does store unit metadata, so
dimensional results can be written into it in-place.

This change:

- Allows dimensional ufunc results to be stored in outputs that expose a
  non-`None` `.unit` attribute (notably `Column` / `MaskedColumn`)
- Updates that unit after the operation when needed, matching `Quantity`'s
  in-place behaviour for operations that change physical dimension
- Adds a regression test for the reported case and related paths

Fixes #20075

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
