### PR TITLE
Fix in-place quantity operations on Column with unit

### DIFF
--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -109,6 +109,46 @@ class TestColumn:
         d.convert_unit_to("km")
         assert np.all(d.data == [0.001, 0.002, 0.003])
 
+    def test_inplace_operation_with_unit(self, Column):
+        """Regression test for #20075 - in-place operations with a Quantity
+        on a Column with a unit used to raise UnitTypeError."""
+        d = Column([1.0, 2.0, 3.0], name="a", unit="deg")
+        d += np.array([0.0, 1.0, 2.0]) * u.deg
+        assert np.all(d == [1.0, 3.0, 5.0])
+        assert d.unit == u.deg
+        assert isinstance(d, Column)
+
+        # units are converted for in-place operations
+        d = Column([1.0, 2.0, 3.0], name="a", unit="deg")
+        d += np.array([0.0, 60.0, 120.0]) * u.arcmin
+        assert np.allclose(d, [1.0, 3.0, 5.0])
+        assert d.unit == u.deg
+
+        d -= np.array([1.0, 1.0, 1.0]) * u.deg
+        assert np.allclose(d, [0.0, 2.0, 4.0])
+        d *= 2.0
+        assert np.allclose(d, [0.0, 4.0, 8.0])
+        d /= 2.0
+        assert np.allclose(d, [0.0, 2.0, 4.0])
+
+        # incompatible units still raise
+        with pytest.raises(u.UnitsError):
+            d += np.array([1.0, 1.0, 1.0]) * u.m
+
+        # a plain column without unit cannot accept a quantity in-place
+        d = Column([1.0, 2.0], name="b")
+        with pytest.raises(u.UnitsError):
+            d += np.array([1.0, 1.0]) * u.deg
+
+        # a result unit that differs from the column's unit is still rejected
+        d = Column([1.0, 2.0], name="c", unit="deg")
+        with pytest.raises(u.UnitTypeError):
+            np.add(
+                np.array([60.0, 120.0]) * u.arcmin,
+                np.array([1.0, 1.0]) * u.deg,
+                out=d,
+            )
+
     def test_array_wrap(self):
         """Test that the __array_wrap__ method converts a reduction ufunc
         output that has a different shape into an ndarray view.  Without this a

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -374,8 +374,13 @@ def check_output(output, unit, inputs, function=None):
         return output.view(np.ndarray)
 
     else:
-        # output is not a Quantity, so cannot obtain a unit.
+        # output is not a Quantity, so cannot obtain a unit.  However, some
+        # ndarray subclasses (such as astropy ``Column``) do carry a ``unit``
+        # attribute; for those, storing is fine if the result unit is
+        # identical to the output's unit.
         if not (unit is None or unit == dimensionless_unscaled):
+            if unit == getattr(output, "unit", None):
+                return output.view(np.ndarray)
             raise UnitTypeError(
                 "Cannot store quantity with dimension "
                 "{}in a non-Quantity instance.".format(

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -374,13 +374,14 @@ def check_output(output, unit, inputs, function=None):
         return output.view(np.ndarray)
 
     else:
-        # output is not a Quantity, so cannot obtain a unit.  However, some
-        # ndarray subclasses (such as astropy ``Column``) do carry a ``unit``
-        # attribute; for those, storing is fine if the result unit is
-        # identical to the output's unit.
-        if not (unit is None or unit == dimensionless_unscaled):
-            if unit == getattr(output, "unit", None):
-                return output.view(np.ndarray)
+        # output is not a Quantity. Some ndarray subclasses (such as astropy
+        # ``Column``) carry a ``unit`` attribute; for those, storing is fine
+        # if the result unit is identical to the output's unit.  For anything
+        # else (like ndarray proper), we require the output to be
+        # dimensionless.
+        if not (
+            unit is None or unit == getattr(output, "unit", dimensionless_unscaled)
+        ):
             raise UnitTypeError(
                 "Cannot store quantity with dimension "
                 "{}in a non-Quantity instance.".format(

--- a/docs/changes/table/20084.bugfix.rst
+++ b/docs/changes/table/20084.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed in-place operations (such as ``col += quantity``) on a ``Column`` with a unit,
+which previously raised ``UnitTypeError``. In-place operations are now allowed when the
+result unit matches the column's unit, with unit conversion applied as usual.


### PR DESCRIPTION
### Description

This pull request fixes in-place operations on a `Column` with a unit, e.g. the example from the issue:

```python
ra = Column([0, 1, 2], name='ra', unit=u.deg)
ra += np.array([0, 1, 2]) * u.deg   # raised UnitTypeError
```

Root cause: `check_output` in `quantity_helper/converters.py` rejects any non-`Quantity` output when the result unit is not dimensionless. A `Column` is not a `Quantity`, so in-place operations always failed with "Cannot store quantity with dimension ... in a non-Quantity instance", even when the column's unit exactly matched the result.

The fix allows storing the result when the output object carries a `unit` attribute identical to the result unit — which is what in-place operations look like in practice, since the output is also the first input and `add`/`sub`/`mul`/`div` resolve the result unit to it. Mixed-unit in-place operations get the usual conversion (`deg` column += `arcmin` works, as shown in the new test). Storing into a column whose unit differs from the result unit still raises, so values cannot be silently mislabeled, and storing a non-dimensionless result into a plain (unit-less) column still raises as before.

Note: for integer columns, in-place addition with a default (float64) `Quantity` raises numpy's casting error, which matches standard numpy in-place semantics.

Tests: new `test_inplace_operation_with_unit` in `astropy/table/tests/test_column.py` (runs for both `Column` and `MaskedColumn`). Full `astropy/units` (3750 passed) and `astropy/table` (2142 passed) suites pass locally, plus `test_quantity_ufuncs.py` (276 passed).

Closes #20075
