### PR TITLE
Fix missing column parent-table link on a deep-copied Table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3829,7 +3829,11 @@ class Table:
     def __deepcopy__(self, memo=None):
         out = self.copy(False)
         for name in out.colnames:
-            out.columns.__setitem__(name, deepcopy(self[name]), validated=True)
+            new_col = deepcopy(self[name])
+            out.columns.__setitem__(name, new_col, validated=True)
+            # The deep-copied column dropped its link to the original parent
+            # table, so re-link it to the copied table (#20087).
+            out._set_col_parent_table_and_mask(new_col)
         out.meta = deepcopy(self.meta)
         return out
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2483,10 +2483,15 @@ def test_deepcopy_rename_columns(masked):
 
     td = copy.deepcopy(t)
 
+    # Deep-copied columns must be linked to the copied table.
+    for name in td.colnames:
+        assert td[name].info.parent_table is td
+        assert td[name].parent_table is td
+
     td.rename_columns(["px", "py"], ["x", "y"])
     assert td.colnames == ["x", "y"]
-    assert list(td["x"]) == [1.0, 2.0]
-    assert list(td["y"]) == [3.0, 4.0]
+    assert_array_equal(td["x"].data, [1.0, 2.0])
+    assert_array_equal(td["y"].data, [3.0, 4.0])
     if masked:
         assert_array_equal(td["x"].mask, [False, True])
         assert_array_equal(td["y"].mask, [False, False])
@@ -2497,7 +2502,7 @@ def test_deepcopy_rename_columns(masked):
 
     # the original table is unaffected
     assert t.colnames == ["px", "py"]
-    assert list(t["px"]) == [1.0, 2.0]
+    assert_array_equal(t["px"].data, [1.0, 2.0])
     if masked:
         assert_array_equal(t["px"].mask, [False, True])
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2473,6 +2473,27 @@ def test_deepcopy_object_column(data):
     assert t3.meta["test"] is not t1.meta["test"]
 
 
+def test_deepcopy_rename_columns():
+    # Regression test for #20087: renaming columns of a deep-copied Table
+    # left the column mapping out of sync because the copied columns lost
+    # their link to the copied parent table.
+    t = Table({"px": [1.0, 2.0], "py": [3.0, 4.0]})
+    td = copy.deepcopy(t)
+
+    td.rename_columns(["px", "py"], ["x", "y"])
+    assert td.colnames == ["x", "y"]
+    assert list(td["x"]) == [1.0, 2.0]
+    assert list(td["y"]) == [3.0, 4.0]
+
+    # renaming via the info name setter works too
+    td["x"].info.name = "xx"
+    assert td.colnames == ["xx", "y"]
+
+    # the original table is unaffected
+    assert t.colnames == ["px", "py"]
+    assert list(t["px"]) == [1.0, 2.0]
+
+
 def test_replace_column_qtable():
     """Replace existing Quantity column with a new column in a QTable"""
     a = [1, 2, 3] * u.m

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2473,17 +2473,23 @@ def test_deepcopy_object_column(data):
     assert t3.meta["test"] is not t1.meta["test"]
 
 
-def test_deepcopy_rename_columns():
-    # Regression test for #20087: renaming columns of a deep-copied Table
-    # left the column mapping out of sync because the copied columns lost
-    # their link to the copied parent table.
-    t = Table({"px": [1.0, 2.0], "py": [3.0, 4.0]})
+@pytest.mark.parametrize("masked", [False, True], ids=["unmasked", "masked"])
+def test_deepcopy_rename_columns(masked):
+    # Regression test for #20087 for unmasked and masked tables: renaming
+    # columns of a deep-copied Table must keep column mapping in sync.
+    t = Table({"px": [1.0, 2.0], "py": [3.0, 4.0]}, masked=masked)
+    if masked:
+        t["px"].mask = [False, True]
+
     td = copy.deepcopy(t)
 
     td.rename_columns(["px", "py"], ["x", "y"])
     assert td.colnames == ["x", "y"]
     assert list(td["x"]) == [1.0, 2.0]
     assert list(td["y"]) == [3.0, 4.0]
+    if masked:
+        assert_array_equal(td["x"].mask, [False, True])
+        assert_array_equal(td["y"].mask, [False, False])
 
     # renaming via the info name setter works too
     td["x"].info.name = "xx"
@@ -2492,6 +2498,8 @@ def test_deepcopy_rename_columns():
     # the original table is unaffected
     assert t.colnames == ["px", "py"]
     assert list(t["px"]) == [1.0, 2.0]
+    if masked:
+        assert_array_equal(t["px"].mask, [False, True])
 
 
 def test_replace_column_qtable():

--- a/docs/changes/table/20088.bugfix.rst
+++ b/docs/changes/table/20088.bugfix.rst
@@ -1,3 +1,5 @@
-Fixed ``rename_columns`` (and ``info.name`` assignment) on a deep-copied
-``Table``, which previously left the column mapping out of sync because copied
-columns lost their link to the copied parent table.
+Fixed an issue when deep-copying a ``Table`` where the copied columns lost their link to
+the new parent table. This led to problems in ``rename_columns`` and ``info.name``
+assignment. Other potential problems included table-aware unit conversion/replacement in
+QTable, grouped-column linkage to table group metadata, and synchronized pprint
+include/exclude name bookkeeping on rename or delete.

--- a/docs/changes/table/20088.bugfix.rst
+++ b/docs/changes/table/20088.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``rename_columns`` (and ``info.name`` assignment) on a deep-copied
+``Table``, which previously left the column mapping out of sync because copied
+columns lost their link to the copied parent table.


### PR DESCRIPTION
### Description

This pull request fixes `rename_columns()` (and `info.name` assignment) on a deep-copied `Table`, as reported in the issue:

```python
td = deepcopy(t)
td.rename_columns(["px", "py"], ["x", "y"])
td.colnames      # was ['px', 'py'] — rename didn't stick
td["x"]          # KeyError
```

Root cause: `Table.__deepcopy__` replaces each column with a standalone `deepcopy()` of it. During that copy, the column's `parent_table` link is deliberately dropped (`_attrs_no_copy`), and `TableColumns.__setitem__` does not re-link it — so the copied columns end up with `parent_table=None` and the rename notification never reaches the copied table's column mapping. (`Table.copy()` works because it goes through the normal init path, which calls `_set_col_parent_table_and_mask`.)

Fix: re-link each copied column to the copied table inside `Table.__deepcopy__` by calling the existing `_set_col_parent_table_and_mask()`, the same method used when columns are added to a table.

Tests: new `test_deepcopy_rename_columns` in `astropy/table/tests/test_table.py` (rename via `rename_columns`, via `info.name`, and original-table-unaffected). Full `astropy/table` suite passes locally (2383 passed), plus `astropy/utils` data-info tests (18 passed).

Closes #20087
