### PR TITLE
Raise for fractional powers in the CDS unit format instead of emitting invalid output

### DIFF
--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -249,4 +249,14 @@ class CDS(Base, _ParsingFormatMixin):
             elif is_effectively_unity(unit.scale * 100.0):
                 return "%"
 
+        # The CDS standard only allows integer powers, so a unit with a
+        # fractional exponent has no valid CDS representation: emitting one
+        # produces a string this format's own parser cannot read back. Raise
+        # instead of writing an unparseable string.
+        if any(power != int(power) for power in getattr(unit, "powers", ())):
+            raise ValueError(
+                "The CDS format is not able to represent units with fractional "
+                f"powers, got {unit!r}."
+            )
+
         return super().to_string(unit, fraction=fraction)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -175,6 +175,15 @@ def test_cds_dimensionless():
     assert u.dimensionless_unscaled.to_string(format="cds") == "---"
 
 
+@pytest.mark.parametrize("unit", [u.solMass**1.5, u.Bi, u.V / u.Hz**0.5])
+def test_cds_fractional_power_raises(unit):
+    # The CDS standard forbids fractional exponents ("solMass_3/2_ ... cannot be
+    # a valid unit") and its parser only accepts integer powers, so writing one
+    # would emit a string that cannot be read back. It must raise instead.
+    with pytest.raises(ValueError, match="fractional powers"):
+        unit.to_string("cds")
+
+
 def test_cds_log10_dimensionless():
     assert u.Unit("[-]", format="cds") == u.dex(u.dimensionless_unscaled)
     assert u.dex(u.dimensionless_unscaled).to_string(format="cds") == "[-]"

--- a/docs/changes/units/20092.bugfix.rst
+++ b/docs/changes/units/20092.bugfix.rst
@@ -1,0 +1,2 @@
+Writing a unit with a fractional power to the ``cds`` format now raises a
+``ValueError`` instead of emitting a string that the CDS format cannot parse.


### PR DESCRIPTION
## Problem

`CDS.to_string` emits fractional exponents, which the CDS standard forbids and the CDS parser cannot read back:

```python
>>> import astropy.units as u
>>> (u.solMass**1.5).to_string("cds")
'solMass+3/2'
>>> u.Unit('solMass+3/2', format="cds")      # its own parser rejects it
ValueError: ...
>>> u.Bi.to_string("cds")
'cm+1/2.g+1/2.s-1'                            # also unparseable
>>> (u.V / u.Hz**0.5).to_string("cds")        # amplitude spectral density
'V.Hz-1/2'                                    # also unparseable
```

The [CDS "Standards for Astronomical Catalogues"](https://vizier.unistra.fr/vizier/doc/catstd-3.2.htx) states: *"Only simple power functions of physical units are accepted, which means that e.g. solMass_3/2_ (solar mass at a 3/2 power) cannot be a valid unit."* — using the exact string astropy emits as its example of an **invalid** unit. The CDS grammar agrees: `unit_with_power : UNIT INT` (integers only). So the writer produces output no CDS reader — including astropy's own — can parse.

This is reachable from the VOTable writer (`io/votable/tree.py`) and the MRT writer (`io/ascii/mrt.py`), both of which call `unit.to_string("cds")`; a column in units like `V/√Hz` is silently written with an invalid unit string.

## Fix

Raise `ValueError` when a unit has a fractional power, instead of writing a string that cannot be read back. This mirrors the existing precedent in the FITS format, which already raises `UnitScaleError` for units it cannot represent. Integer-power units are unchanged.

## Verification

- `test_cds_fractional_power_raises` (parametrized over `solMass**1.5`, `Bi`, `V/Hz**0.5`) — fails without the change (the writer silently returns invalid strings), passes with it.
- Full `astropy/units/tests/test_format.py`: **911 passed, 1 xfailed** (no regression); integer-power units still round-trip. `ruff check` / `ruff format --check` clean.

## A note on layer / scope

The two writers above will now raise for a fractional-power column rather than emitting invalid output. I put the guard in the format's `to_string` because that's where the FITS precedent lives and it protects every caller at once, but if you'd prefer it handled in the writers (or as a warning-with-fallback), I'm happy to move it — say the word.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, verified it against the CDS standard and astropy's own parser, wrote the fix and the test, and wrote this description. The human account holder reviews every change, is accountable for it, and will engage with review directly. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
