### PR TITLE
TYP: Add .pyi type stubs for the _convolve C-extension

### DIFF
--- a/astropy/convolution/_convolve.pyi
+++ b/astropy/convolution/_convolve.pyi
@@ -1,0 +1,17 @@
+from typing import TypeAlias, TypeVar
+
+import numpy as np
+
+_D1: TypeAlias = tuple[int]
+_D2: TypeAlias = tuple[int, int]
+_D3: TypeAlias = tuple[int, int, int]
+_D = TypeVar("_D", _D1, _D2, _D3)
+
+def _convolveNd_c(
+    result: np.ndarray[_D, np.dtype[np.float64]],
+    array_to_convolve: np.ndarray[_D, np.dtype[np.float64]],
+    kernel: np.ndarray[_D, np.dtype[np.float64]],
+    nan_interpolate: bool,
+    embed_result_within_padded_region: bool,
+    n_threads: int,
+) -> None: ...


### PR DESCRIPTION
## Description
Another GSoC side-quest! This PR adds the `.pyi` type stub file for `astropy.convolution._convolve` so we can get static type checking working for the low-level code callers across the library.

### Implementation Notes:
* I targeted the Cython-generated wrapper (`_convolve.pyx`) rather than the pure C engine (`src/convolve.c`) since that's where the actual Python boundary is.
* The Python-facing `_convolveNd_c` function is mapped out using `npt.NDArray[np.float64]` for the arrays (`result`, `array_to_convolve`, `kernel`), `bool` for the padding and interpolation flags, and `int` for the thread count.
* Since this extension is generated by Cython rather than a hand-written `PyArg_ParseTuple`, keyword arguments are actually supported out of the box. Because of that, I left out the positional-only markers (`/`).


**Related Issue:** Addresses #20070 

cc: @neutrinoceros 