### PR TITLE
Preserve nested masks with data-mask serialization

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -691,8 +691,12 @@ def test_round_trip_masked_mixin_serialize_mask(serialize_method, format_engine)
     table2 = QTable.read(text, **format_engine)
     assert_array_equal(table2["sc"].ra.mask, table["sc"].ra.mask)
     assert_array_equal(table2["sc"].dec.mask, table["sc"].dec.mask)
-    assert_array_equal(table2["sc"].ra.unmasked, table["sc"].ra.unmasked)
-    assert_array_equal(table2["sc"].dec.unmasked, table["sc"].dec.unmasked)
+    assert quantity_allclose(
+        table2["sc"].ra.unmasked, table["sc"].ra.unmasked, rtol=1e-15
+    )
+    assert quantity_allclose(
+        table2["sc"].dec.unmasked, table["sc"].dec.unmasked, rtol=1e-15
+    )
     assert np.all(table2["sc"].obstime == table["sc"].obstime)
 
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -19,6 +19,7 @@ import yaml
 from numpy.testing import assert_array_equal
 
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.io import ascii
 from astropy.io.ascii.ecsv import DELIMITERS, InvalidEcsvDatatypeWarning
 from astropy.io.ascii.tests.common import TEST_DIR
@@ -658,6 +659,67 @@ def test_round_trip_masked_table_serialize_mask(tmp_path, format_engine):
         t[name].mask = False
         t2[name].mask = False
         assert np.all(t2[name] == t[name])
+
+
+@pytest.mark.parametrize(
+    "serialize_method",
+    ["data_mask", {"sc": "data_mask"}, {SkyCoord: "data_mask"}],
+)
+def test_round_trip_masked_mixin_serialize_mask(serialize_method, format_engine):
+    """Test that data-mask serialization propagates to masked mixin components."""
+    table = QTable()
+    table["sc"] = SkyCoord(
+        ra=Masked([1.0, 2.0, 3.0], mask=[True, False, False]),
+        dec=Masked([5.0, 6.0, 7.0], mask=[False, True, False]),
+        unit="hourangle,deg",
+        obstime=Time(["2020-01-01", "2020-01-02", "2020-01-03"]),
+    )
+
+    out = StringIO()
+    table.write(out, format="ascii.ecsv", serialize_method=serialize_method)
+    text = out.getvalue()
+    colnames = next(
+        line for line in text.splitlines() if not line.startswith("#")
+    ).split()
+
+    assert "sc.ra.mask" in colnames
+    assert "sc.dec.mask" in colnames
+    assert "sc.obstime" in colnames
+    assert "sc.obstime.jd1" not in colnames
+    assert "sc.obstime.jd2" not in colnames
+
+    table2 = QTable.read(text, **format_engine)
+    assert_array_equal(table2["sc"].ra.mask, table["sc"].ra.mask)
+    assert_array_equal(table2["sc"].dec.mask, table["sc"].dec.mask)
+    assert_array_equal(table2["sc"].ra.unmasked, table["sc"].ra.unmasked)
+    assert_array_equal(table2["sc"].dec.unmasked, table["sc"].dec.unmasked)
+    assert np.all(table2["sc"].obstime == table["sc"].obstime)
+
+
+def test_masked_mixin_serialize_method_scope():
+    """Test top-level matching and context restoration for a masked mixin."""
+    table = QTable()
+    table["sc"] = SkyCoord(
+        ra=Masked([1.0, 2.0], mask=[True, False]),
+        dec=Masked([3.0, 4.0], mask=[False, True]),
+        unit="deg",
+    )
+
+    def mask_columns_present(serialize_method):
+        out = StringIO()
+        table.write(out, format="ascii.ecsv", serialize_method=serialize_method)
+        colnames = next(
+            line for line in out.getvalue().splitlines() if not line.startswith("#")
+        ).split()
+        return "sc.ra.mask" in colnames, "sc.dec.mask" in colnames
+
+    methods = [None, {"other": "data_mask"}, {"sc": "data_mask"}, None]
+    assert [mask_columns_present(method) for method in methods] == [
+        (False, False),
+        (False, False),
+        (True, True),
+        (False, False),
+    ]
 
 
 @pytest.mark.parametrize("table_cls", (Table, QTable))

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -7,12 +7,39 @@ import os
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 from contextlib import contextmanager
+from contextvars import ContextVar
 
 import numpy as np
 
 from astropy.utils.data_info import DataInfo
 
 __all__ = ["TableInfo", "serialize_method_as", "table_info"]
+
+_serialize_method_context = ContextVar("serialize_method", default=None)
+
+
+def _get_serialize_method(col):
+    """
+    Get the serialization method override for ``col`` in the current context.
+
+    A column-name match takes precedence over a class match.
+    """
+    serialize_method = _serialize_method_context.get()
+
+    if isinstance(serialize_method, str):
+        return serialize_method
+
+    if not serialize_method:
+        return None
+
+    if col.info.name in serialize_method:
+        return serialize_method[col.info.name]
+
+    for key in serialize_method:
+        if isinstance(key, type) and isinstance(col, key):
+            return serialize_method[key]
+
+    return None
 
 
 def table_info(tbl, option="attributes", out=""):
@@ -155,28 +182,6 @@ def serialize_method_as(tbl, serialize_method):
     -------
     None (context manager)
     """
-
-    def get_override_sm(col):
-        """
-        Determine if the ``serialize_method`` str or dict specifies an
-        override of column presets for ``col``.  Returns the matching
-        serialize_method value or ``None``.
-        """
-        # If a string then all columns match
-        if isinstance(serialize_method, str):
-            return serialize_method
-
-        # If column name then return that serialize_method
-        if col.info.name in serialize_method:
-            return serialize_method[col.info.name]
-
-        # Otherwise look for subclass matches
-        for key in serialize_method:
-            if isinstance(key, type) and isinstance(col, key):
-                return serialize_method[key]
-
-        return None
-
     # Setup for the context block.  Set individual column.info.serialize_method
     # values as appropriate and keep a backup copy.  If ``serialize_method``
     # is None or empty then don't do anything.
@@ -184,34 +189,38 @@ def serialize_method_as(tbl, serialize_method):
     # Original serialize_method dict, keyed by column name.  This only
     # gets used and set if there is an override.
     original_sms = {}
+    token = _serialize_method_context.set(serialize_method)
 
-    if serialize_method:
-        # Go through every column and if it has a serialize_method info
-        # attribute then potentially update it for the duration of the write.
-        for col in tbl.itercols():
-            if hasattr(col.info, "serialize_method"):
-                override_sm = get_override_sm(col)
-                if override_sm:
-                    # Make a reference copy of the column serialize_method
-                    # dict which maps format (e.g. 'fits') to the
-                    # appropriate method (e.g. 'data_mask').
-                    original_sms[col.info.name] = col.info.serialize_method
-
-                    # Set serialize method for *every* available format.  This is
-                    # brute force, but at this point the format ('fits', 'ecsv', etc)
-                    # is not actually known (this gets determined by the write function
-                    # in registry.py).  Note this creates a new temporary dict object
-                    # so that the restored version is the same original object.
-                    col.info.serialize_method = dict.fromkeys(
-                        col.info.serialize_method, override_sm
-                    )
-
-    # Finally yield for the context block
     try:
+        if serialize_method:
+            # Go through every column and if it has a serialize_method info
+            # attribute then potentially update it for the duration of the write.
+            for col in tbl.itercols():
+                if hasattr(col.info, "serialize_method"):
+                    override_sm = _get_serialize_method(col)
+                    if override_sm:
+                        # Make a reference copy of the column serialize_method
+                        # dict which maps format (e.g. 'fits') to the
+                        # appropriate method (e.g. 'data_mask').
+                        original_sms[col.info.name] = col.info.serialize_method
+
+                        # Set serialize method for *every* available format.  This is
+                        # brute force, but at this point the format ('fits', 'ecsv', etc)
+                        # is not actually known (this gets determined by the write
+                        # function in registry.py).  Note this creates a new temporary
+                        # dict object so that the restored version is the same original
+                        # object.
+                        col.info.serialize_method = dict.fromkeys(
+                            col.info.serialize_method, override_sm
+                        )
+
         yield
     finally:
         # Teardown (restore) for the context block.  Be sure to do this even
         # if an exception occurred.
-        if serialize_method:
-            for name, original_sm in original_sms.items():
-                tbl[name].info.serialize_method = original_sm
+        try:
+            if serialize_method:
+                for name, original_sm in original_sms.items():
+                    tbl[name].info.serialize_method = original_sm
+        finally:
+            _serialize_method_context.reset(token)

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -125,7 +125,31 @@ class SerializedColumn(dict):
         return f"{self.__class__.__name__}({super().__repr__()})"
 
 
-def _represent_mixin_as_column(col, name, new_cols, mixin_cols, exclude_classes=()):
+def _get_mixin_obj_attrs(col, serialize_method):
+    """Get the representation, applying a compatible masked-data override."""
+    original_sm = None
+    if serialize_method and hasattr(col.info, "serialize_method"):
+        current_sm = col.info.serialize_method
+        methods = current_sm.values()
+        if "data_mask" in methods and serialize_method in methods:
+            original_sm = current_sm
+            col.info.serialize_method = dict.fromkeys(current_sm, serialize_method)
+
+    try:
+        return col.info._represent_as_dict()
+    finally:
+        if original_sm is not None:
+            col.info.serialize_method = original_sm
+
+
+def _represent_mixin_as_column(
+    col,
+    name,
+    new_cols,
+    mixin_cols,
+    exclude_classes=(),
+    serialize_method=None,
+):
     """Carry out processing needed to serialize ``col`` in an output table
     consisting purely of plain ``Column`` or ``MaskedColumn`` columns.  This
     relies on the object determine if any transformation is required and may
@@ -147,7 +171,7 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols, exclude_classes=
     to imply serialization.  Starting with version 3.1, the non-mixin
     ``MaskedColumn`` can also be serialized.
     """
-    obj_attrs = col.info._represent_as_dict()
+    obj_attrs = _get_mixin_obj_attrs(col, serialize_method)
 
     # If serialization is not required (see function docstring above)
     # or explicitly specified as excluded, then treat as a normal column.
@@ -221,7 +245,13 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols, exclude_classes=
         # a Mixin column, a structured Column, a MaskedColumn for which mask is
         # stored, etc.), it will define obj_attrs[new_name]. Otherwise, it will
         # just add to new_cols and all we have to do is to link to the new name.
-        _represent_mixin_as_column(data, new_name, new_cols, obj_attrs)
+        _represent_mixin_as_column(
+            data,
+            new_name,
+            new_cols,
+            obj_attrs,
+            serialize_method=serialize_method,
+        )
         obj_attrs[data_attr] = SerializedColumn(
             obj_attrs.pop(new_name, {"name": new_name})
         )
@@ -306,9 +336,16 @@ def represent_mixins_as_columns(tbl, exclude_classes=()):
 
     # Go through table columns and represent each column as one or more
     # plain Column objects (in new_cols) + metadata (in mixin_cols).
+    from .info import _get_serialize_method
+
     for col in tbl.itercols():
         _represent_mixin_as_column(
-            col, col.info.name, new_cols, mixin_cols, exclude_classes=exclude_classes
+            col,
+            col.info.name,
+            new_cols,
+            mixin_cols,
+            exclude_classes=exclude_classes,
+            serialize_method=_get_serialize_method(col),
         )
 
     # If no metadata was created then just return the original table.

--- a/docs/changes/table/20094.bugfix.rst
+++ b/docs/changes/table/20094.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``serialize_method="data_mask"`` to preserve masks and underlying data
+in masked components nested inside mixin columns such as
+`~astropy.coordinates.SkyCoord`.


### PR DESCRIPTION
### Description

This pull request makes `Table.write(..., serialize_method="data_mask")` propagate the selected mask serialization into compatible masked components nested inside mixin columns.

For a masked `SkyCoord`, this writes separate `sc.ra.mask` and `sc.dec.mask` columns, preserving both independently masked components and their underlying values. Selector matching remains at the original table-column level for string, column-name, and column-class forms. Nested serializers that do not support masked-data methods, such as a `Time` stored in `SkyCoord.obstime`, retain their existing serialization.

The regression uses disjoint coordinate masks and distinct underlying data, and also checks default behavior, a nonmatching selector, context restoration, and nested `Time`.

Fixes #18704

### Validation

- Targeted nested-mask regression: 7 passed
- `pytest -q astropy/table/tests astropy/io/ascii/tests/test_ecsv.py astropy/utils/masked/tests/test_table.py` — 2,930 passed, 183 skipped, 14 xfailed
- `pytest -q astropy/io/fits/tests/test_connect.py astropy/io/misc/tests/test_hdf5.py` — 175 passed, 123 skipped
- Full pre-commit suite on the four changed files, including pinned Ruff check/format, codespell, repository review, and Sphinx lint
- `git range-diff` confirms that rebasing onto current `main` did not change either patch

### AI assistance

I used OpenAI Codex and Anthropic Claude Code as development and review assistants, with human direction and review throughout. I have reviewed and understand the submitted implementation and tests, take responsibility for all submitted content and licensing compliance, and will engage directly with reviewer questions and feedback.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button.
