### PR TITLE
Avoid mutating same-class coordinate representations

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -948,7 +948,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential):
                 # The default is to convert via cartesian coordinates
                 new_rep = other_class.from_cartesian(self.to_cartesian())
             else:
-                new_rep = self
+                new_rep = self.without_differentials()
 
             new_rep._differentials = self._re_represent_differentials(
                 new_rep, differential_class

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1964,6 +1964,34 @@ class TestCartesianRepresentationWithDifferential:
             rep1.represent_as("name")
         assert "use frame object" in str(excinfo.value)
 
+    def test_represent_as_same_class_does_not_modify_differential(self):
+        diff = SphericalCosLatDifferential(
+            d_lon_coslat=1 * u.mas / u.yr,
+            d_lat=2 * u.mas / u.yr,
+            d_distance=3 * u.km / u.s,
+        )
+        rep = SphericalRepresentation(
+            lon=15 * u.deg,
+            lat=30 * u.deg,
+            distance=1 * u.pc,
+            differentials=diff,
+        )
+
+        new_rep = rep.represent_as(SphericalRepresentation, SphericalDifferential)
+
+        assert new_rep is not rep
+        assert rep.differentials["s"] is diff
+        assert isinstance(new_rep.differentials["s"], SphericalDifferential)
+        assert_allclose_quantity(
+            new_rep.differentials["s"].d_lon * np.cos(rep.lat),
+            diff.d_lon_coslat,
+        )
+        assert_allclose_quantity(new_rep.differentials["s"].d_lat, diff.d_lat)
+        assert_allclose_quantity(
+            new_rep.differentials["s"].d_distance,
+            diff.d_distance,
+        )
+
     @pytest.mark.parametrize(
         "sph_diff,usph_diff",
         [

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -24,6 +24,7 @@ from astropy.coordinates import (
     Attribute,
     BaseCoordinateFrame,
     CartesianRepresentation,
+    Distance,
     EarthLocation,
     Galactic,
     Latitude,
@@ -1895,6 +1896,27 @@ def test_apply_space_motion():
 
     with pytest.raises(ValueError):
         c2.apply_space_motion(new_obstime=t2)
+
+
+def test_apply_space_motion_after_display():
+    """Regression test for source-coordinate mutation in gh-18334."""
+    coord = SkyCoord(
+        ra=66.42197 * u.deg,
+        dec=-70.003723 * u.deg,
+        distance=Distance(parallax=22.76407875 * u.mas),
+        pm_ra_cosdec=144.91354358 * u.mas / u.yr,
+        pm_dec=5.44564809 * u.mas / u.yr,
+        obstime="J2000",
+    )
+    new_obstime = Time("2027-01-01")
+    original_diff = coord.frame.data.differentials["s"]
+
+    result_before = coord.apply_space_motion(new_obstime)
+    str(coord)
+    result_after = coord.apply_space_motion(new_obstime)
+
+    assert coord.frame.data.differentials["s"] is original_diff
+    assert skycoord_equal(result_before, result_after)
 
 
 def test_custom_frame_skycoord():

--- a/docs/changes/coordinates/20095.bugfix.rst
+++ b/docs/changes/coordinates/20095.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``BaseRepresentation.represent_as`` mutating a source representation when
+converting attached differentials to another class, which could cause a repeated
+``SkyCoord.apply_space_motion`` call after displaying the coordinate to fail.


### PR DESCRIPTION
### Description

This pull request prevents same-class representation conversion from replacing the source representation's attached differentials.

Previously, `BaseRepresentation.represent_as()` reused `self` when only the differential class changed. Attaching the converted differential therefore mutated the source coordinate. In the reported case, displaying a `SkyCoord` without an explicit radial velocity changed its differential representation, and a later `apply_space_motion()` call failed.

The conversion now starts from a differential-free shallow copy before attaching the requested differential representation. The positional components remain shared, while the source differential mapping is left unchanged.

Regression tests cover both the low-level same-class conversion and repeated `apply_space_motion()` after display.

Fixes #18334

### Testing

- Focused regressions: 2 passed
- Full coordinates test suite: 1964 passed, 63 skipped, 10 xfailed
- Ruff check and format checks
- `git diff --check`

### AI assistance disclosure

OpenAI Codex was used for source inspection, test design, implementation, and automated review. The contributor has completed the final review and takes responsibility for the contribution's correctness and maintenance.

