### PR TITLE
Fix bare except clause in astropy/utils/misc.py

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -106,7 +106,7 @@ def format_exception(msg, *args, **kwargs):
 
         try:
             1/0
-        except:
+        except ZeroDivisionError:
             raise ZeroDivisionError(
                 format_except('A divide by zero occurred in {filename} at '
                               'line {lineno} of function {func}.'))


### PR DESCRIPTION
Replace bare `except:` with `except ZeroDivisionError:` in the docstring example for `format_except`.

The example demonstrates catching the exception that `1/0` raises. Since `1/0` always raises `ZeroDivisionError`, the bare `except:` should be `except ZeroDivisionError:` — making the example more precise and avoiding the bad practice of silently catching `BaseException` subclasses like `KeyboardInterrupt` and `SystemExit`.