### PR TITLE
BUG: Return a copy from single-table vstack

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -721,7 +721,7 @@ def vstack(tables, join_type="outer", metadata_conflicts="warn"):
 
     tables = _get_list_of_tables(tables)  # validates input
     if len(tables) == 1:
-        return tables[0]  # no point in stacking a single table
+        return tables[0].copy()
 
     out = _vstack(tables, join_type, metadata_conflicts)
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1540,11 +1540,23 @@ class TestVStack:
         assert out["c"].info.format == "%6s"
         assert out["c"].info.description == "t2_c"
 
-    def test_vstack_one_table(self, operation_table_type):
+    @pytest.mark.parametrize("as_list", [False, True])
+    def test_vstack_one_table(self, operation_table_type, as_list):
+        """Regression tests for issues #3313 and #18910."""
         self._setup(operation_table_type)
-        """Regression test for issue #3313"""
-        assert (self.t1 == table.vstack(self.t1)).all()
-        assert (self.t1 == table.vstack([self.t1])).all()
+        self.t1.meta["my_special_value"] = 42
+
+        tables = [self.t1] if as_list else self.t1
+        out = table.vstack(tables)
+
+        assert type(out) is type(self.t1)
+        assert out is not self.t1
+        assert (self.t1 == out).all()
+
+        out["a"][0] = 10
+        out.meta = {"my_special_value": 17}
+        assert self.t1["a"][0] == 0
+        assert self.t1.meta["my_special_value"] == 42
 
     @pytest.mark.parametrize("empty_table1", [False, True])
     @pytest.mark.parametrize("empty_table2", [False, True])

--- a/docs/changes/table/20097.bugfix.rst
+++ b/docs/changes/table/20097.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``vstack`` returning the input table itself when given a single table.
+It now returns a copy, consistent with its documented new-table behavior.

--- a/docs/changes/table/20097.bugfix.rst
+++ b/docs/changes/table/20097.bugfix.rst
@@ -1,2 +1,3 @@
-Fixed ``vstack`` returning the input table itself when given a single table.
-It now returns a copy, consistent with its documented new-table behavior.
+Fixed an issue where ``vstack`` was returning the input table itself when given 
+a single table. It now returns a copy of that table, consistent with the documented 
+behavior of always returning a new table.

--- a/docs/changes/table/20097.bugfix.rst
+++ b/docs/changes/table/20097.bugfix.rst
@@ -1,3 +1,3 @@
-Fixed an issue where ``vstack`` was returning the input table itself when given 
-a single table. It now returns a copy of that table, consistent with the documented 
+Fixed an issue where ``vstack`` was returning the input table itself when given
+a single table. It now returns a copy of that table, consistent with the documented
 behavior of always returning a new table.


### PR DESCRIPTION
### Description

This changes the single-table fast path in `vstack` to return a normal table copy instead of the input object itself. That makes the implementation match the documented new-table contract and prevents mutations to the result from silently changing the input.

The regression test covers `Table` and `QTable`, both as a direct input and a one-item list, and verifies class/value preservation plus independent data and metadata.

This targets `main` only; no behavioral backport is requested.

Fixes #18910

### Tests

- `pytest astropy/table/tests/test_operations.py` — 238 passed, 8 skipped, 11 xfailed
- `pytest astropy/table/tests` — 2382 passed, 183 skipped, 14 xfailed
- `ruff check astropy/table/operations.py astropy/table/tests/test_operations.py`
- `ruff format --check astropy/table/operations.py astropy/table/tests/test_operations.py`

### AI assistance disclosure

OpenAI Codex was used for source inspection, test design, implementation, and automated review. The contributor has completed the final review and takes responsibility for the contribution's correctness and maintenance.

