### PR TITLE
BUG: allow unit.get_converter to take unit-like objects

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -553,6 +553,10 @@ class UnitBase:
         different units. Note that the function returned takes
         and returns values, not quantities.
         """
+        return self._get_converter(Unit(other), equivalencies=equivalencies)
+
+    def _get_converter(self, other, equivalencies=[]):
+        # Private function of above that requires other to be a Unit.
         # First see if it is just a scaling.
         try:
             scale = self._to(other)
@@ -579,7 +583,7 @@ class UnitBase:
                 for funit, tunit, _, b in other.equivalencies:
                     if other is funit:
                         try:
-                            converter = self.get_converter(tunit, equivalencies)
+                            converter = self._get_converter(tunit, equivalencies)
                         except Exception:
                             pass
                         else:
@@ -656,7 +660,7 @@ class UnitBase:
         if other is self and value is UNITY:
             return UNITY
         else:
-            return self.get_converter(Unit(other), equivalencies)(value)
+            return self.get_converter(other, equivalencies)(value)
 
     @deprecated(since="7.0", alternative="to()")
     def in_units(self, other, value=1.0, equivalencies=[]):

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -269,7 +269,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
         Parameters
         ----------
-        other : `~astropy.units.Unit` or `~astropy.units.FunctionUnitBase`
+        other : unit-like
             The unit to convert to.
 
         equivalencies : list of tuple
@@ -296,6 +296,10 @@ class FunctionUnitBase(metaclass=ABCMeta):
         different units. Note that the function returned takes
         and returns values, not quantities.
         """
+        return self._get_converter(Unit(other), equivalencies=equivalencies)
+
+    def _get_converter(self, other, equivalencies=[]):
+        # Private function of above that requires other to be a (Function)Unit.
         # conversion to one's own physical unit should be fastest
         if other is self.physical_unit:
             return self.to_physical

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -36,7 +36,7 @@ def get_converter(from_unit, to_unit):
     i.e., if the inferred scale is unity.
     """
     try:
-        converter = from_unit.get_converter(to_unit)
+        converter = from_unit._get_converter(to_unit)
     except AttributeError as exc:
         # Check for lack of unit only now, to avoid delay for cases where a unit
         # was present. Note that cases where dimensionless is expected are
@@ -45,7 +45,7 @@ def get_converter(from_unit, to_unit):
         if from_unit is not None:  # pragma: no cover
             raise
         try:
-            converter = dimensionless_unscaled.get_converter(to_unit)
+            converter = dimensionless_unscaled._get_converter(to_unit)
         except UnitsError:
             exc.add_note(
                 "Input without a 'unit' attribute? Such input is treated "

--- a/astropy/units/structured.py
+++ b/astropy/units/structured.py
@@ -360,6 +360,12 @@ class StructuredUnit:
         if not isinstance(other, type(self)):
             other = self.__class__(other, names=self)
 
+        return self._get_converter(other, equivalencies=equivalencies)
+
+    get_converter.__doc__ = UnitBase.get_converter.__doc__
+
+    def _get_converter(self, other, equivalencies=[]):
+        # Private function of above that requires other to be a StructuredUnit.
         converters = [
             self_part.get_converter(other_part, equivalencies=equivalencies)
             for (self_part, other_part) in zip(self.values(), other.values())
@@ -375,8 +381,6 @@ class StructuredUnit:
             return result if result.shape else result[()]
 
         return converter
-
-    get_converter.__doc__ = UnitBase.get_converter.__doc__
 
     def to(self, other, value=np._NoValue, equivalencies=[]):
         """Return values converted to the specified unit.

--- a/astropy/units/tests/test_quantity_erfa_ufuncs.py
+++ b/astropy/units/tests/test_quantity_erfa_ufuncs.py
@@ -134,7 +134,7 @@ class TestPVUfuncs:
         with pytest.raises(
             AttributeError,
             match=(
-                "'NoneType' object has no attribute 'get_converter'"
+                "'NoneType' object has no attribute '_get_converter'"
                 ".*\n.*treated as dimensionless"
             ),
         ):
@@ -647,7 +647,7 @@ class TestGeodetic:
         """Test unit errors when dimensionless parameters are used"""
 
         msg = (
-            "'NoneType' object has no attribute 'get_converter'"
+            "'NoneType' object has no attribute '_get_converter'"
             ".*\n.*treated as dimensionless"
         )
         with pytest.raises(AttributeError, match=msg):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -332,7 +332,7 @@ class TestQuantityTrigonometricFuncs:
         with pytest.raises(
             AttributeError,
             match=(
-                "'NoneType' object has no attribute 'get_converter'"
+                "'NoneType' object has no attribute '_get_converter'"
                 ".*\n.*treated as dimensionless"
             ),
         ):

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -97,8 +97,9 @@ def test_convert(original, expectation):
 
 
 def test_convert_roundtrip():
-    c1 = u.cm.get_converter(u.m)
-    c2 = u.m.get_converter(u.cm)
+    # Use strings here to check get_converter can take those.
+    c1 = u.cm.get_converter("m")
+    c2 = u.m.get_converter("cm")
     assert_allclose(c1(c2(10.0)), c2(c1(10.0)), rtol=1e-15, atol=0)
 
 
@@ -106,6 +107,11 @@ def test_convert_roundtrip_with_equivalency():
     c1 = u.arcsec.get_converter(u.pc, u.parallax())
     c2 = u.pc.get_converter(u.arcsec, u.parallax())
     assert_allclose(c1(c2(10.0)), c2(c1(10.0)), rtol=1e-15, atol=0)
+
+
+def test_get_converter_bad_unit():
+    with pytest.raises(ValueError, match="did not parse as unit"):
+        u.m.get_converter("this is not a unit")
 
 
 def test_convert_fail():

--- a/docs/changes/units/20106.bugfix.rst
+++ b/docs/changes/units/20106.bugfix.rst
@@ -1,0 +1,3 @@
+The ``get_converter`` method of units now takes any argument that can
+be converted to a unit (like a string), making it consistent with what
+was advertised in its docstring.


### PR DESCRIPTION
A small fix, further preparation for caching of converters (which is easiest done if one can guarantee `other` is a unit -- but when writing it, I realized that was assumed, while the docstring stated any unit-like was OK).

I don't think it should be backported, though, since that would mean someone writing something for the next point release would not work on 8.0.0. 