### PR TITLE
PERF: Add cache for some speed-up

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -71,6 +71,8 @@ _WARNING_ACTIONS: Final[dict[str, str]] = {
     "raise": "error",
 }
 
+_CONVERTER_CACHE = {}
+
 
 class UnitBase:
     """
@@ -562,18 +564,26 @@ class UnitBase:
 
     def _get_converter(self, other, equivalencies=[]):
         # Private function of above that requires other to be a Unit.
-        # First see if it is just a scaling.
+        # Check if we have cached this -- we do this only with simple
+        # scalings, since equivalencies can come and go.
+        if (converter := _CONVERTER_CACHE.get((self, other))) is not None:
+            return converter
+        # If not cached, first see if it is just a scaling.
         try:
             scale = self._to(other)
         except UnitsError:
             pass
         else:
+            # Yes, it is a simple scaling.
             if scale == 1.0:
                 # If no conversion is necessary, returns ``unit_scale_converter``
                 # (which is used as a check in quantity helpers).
-                return unit_scale_converter
+                converter = unit_scale_converter
             else:
-                return lambda val: scale * _condition_arg(val)
+                converter = lambda val: scale * _condition_arg(val)
+            # Cache the converter before returning it.
+            _CONVERTER_CACHE[(self, other)] = converter
+            return converter
 
         # if that doesn't work, maybe we can do it with equivalencies?
         try:


### PR DESCRIPTION
Typically, a code does not that many unit conversions, but often does them multiple times (likely implicitly), so we can speed up things if we cache the converter:

```
b = np.arange(10.0)
%timeit u.km.to(u.m, b)
on main: 1.24 μs, with cache: 760 ns

q = np.arange(10.0) << u.km
q2 = 1 * u.m
%timeit q + q2
on main: 4.86 μs, with cache: 4.34 μs

q3 = 30*u.deg
%timeit np.sin(q3)
on main: 4.45 μs, with cache: 4.27 μs
```

Note that these improvements are quiet small, in part because I used relatively simple units for these examples.  A more complicated one (on a different machine):
```
unit = u.Unit("erg/(s.cm2.Hz)"
%timeit unit.to(u.Jy)
on main: 2.5 μs, with cache: 791 ns
```

p.s. I have not added a changelog entry since the performance increase for the changes here do not quite warrant that. It will become better with the next steps: to replace the lambda with a C version for further speed improvements for small arrays, and then a special numpy scaled dtype for large arrays.