### PR TITLE
BUG: keep empty VLA entries as (0,) when the column has a TDIM/dim

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -943,8 +943,12 @@ class FITS_rec(np.recarray):
                 dt = np.dtype(recformat.dtype)
                 arr_len = count * dt.itemsize
                 dummy[idx] = raw_data[offset : offset + arr_len].view(dt)
-                if column.dim and len(vla_shape) > 1:
-                    # The VLA is reshaped consistently with TDIM instructions
+                if column.dim and len(vla_shape) > 1 and count > 0:
+                    # The VLA is reshaped consistently with TDIM instructions.
+                    # Empty entries (count == 0) are skipped: per the FITS
+                    # standard the TDIMn keyword is not applicable when the VLA
+                    # descriptor has a size of zero, so such entries keep their
+                    # natural ``(0,)`` shape instead of being reshaped.
                     if vla_shape[0] == 1:
                         dummy[idx] = dummy[idx].reshape(1, len(dummy[idx]))
                     else:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3809,6 +3809,36 @@ class TestVLATables(FitsTestCase):
                     hdu[1].data["empty"][i], np.array([], dtype=np.int32)
                 )
 
+    def test_empty_vla_entry_with_dim(self):
+        """
+        Regression test for
+        https://github.com/astropy/astropy/issues/15105
+
+        A variable-length array column may set a ``dim`` (TDIMn) so that its
+        non-empty entries are reshaped multidimensionally.  An entry with zero
+        elements must still be read back with the natural ``(0,)`` shape: per
+        the FITS standard the TDIMn keyword is not applicable when the VLA
+        descriptor has a size of zero.  Previously the empty entry was reshaped
+        using the column dimension and came back with a spurious shape such as
+        ``(0, 5)``.
+        """
+
+        array = np.array([np.arange(20).reshape((4, 5)), np.array([])], dtype=object)
+        col = fits.Column(name="col", format="PI", array=array, dim="(5, 4)")
+        fits.BinTableHDU.from_columns([col]).writeto(self.temp("empty_dim_vla.fits"))
+        with fits.open(self.temp("empty_dim_vla.fits")) as hdus:
+            # The non-empty entry is still reshaped according to TDIM ...
+            assert hdus[1].data["col"][0].shape == (4, 5)
+            # ... while the empty entry keeps its natural (0,) shape.
+            assert hdus[1].data["col"][1].shape == (0,)
+
+        # Same expectation for the Q (64-bit descriptor) variant.
+        col_q = fits.Column(name="qcol", format="QI", array=array, dim="(5, 4)")
+        fits.BinTableHDU.from_columns([col_q]).writeto(self.temp("empty_dim_qvla.fits"))
+        with fits.open(self.temp("empty_dim_qvla.fits")) as hdus:
+            assert hdus[1].data["qcol"][0].shape == (4, 5)
+            assert hdus[1].data["qcol"][1].shape == (0,)
+
     def test_multidim_VLA_tables(self):
         """
         Check if multidimensional VLF are correctly write and read.

--- a/docs/changes/io.fits/20128.bugfix.rst
+++ b/docs/changes/io.fits/20128.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug in :class:`~astropy.io.fits.FITS_rec` where an empty entry in a
+variable-length array column that has a ``TDIM`` (``dim``) set was reshaped
+using the column dimension, producing a spurious shape such as ``(0, 5)``
+instead of the natural ``(0,)`` required by the FITS standard.


### PR DESCRIPTION
### Description

Fixes #15105 (the empty-entry-with-`dim` sub-case).

When a variable-length array (VLA) column has a `dim` (TDIM) set, its
non-empty entries are reshaped multidimensionally on read. The reshape was
also being applied to entries containing **zero** elements, so an empty entry
came back with a spurious shape such as `(0, 5)` instead of the natural `(0,)`.

The FITS standard (§7.3.5) states that the `TDIMn` keyword is not applicable
when the VLA descriptor has a size of zero, so a zero-length entry should keep
its `(0,)` shape regardless of the column's `dim`.

The fix guards the TDIM reshape in `FITS_rec._convert_p` with `count > 0`, so
empty entries skip the reshape entirely while non-empty entries are unaffected.

### How was this tested?

Added a regression test, `TestVLATables::test_empty_vla_entry_with_dim`, that
writes a `PI`/`QI` VLA column with `dim="(5, 4)"` where the first row is a
`(4, 5)` array and the second row is empty, then reads it back and asserts the
non-empty entry still reshapes to `(4, 5)` while the empty entry returns `(0,)`.

Before the fix the new test fails with:

```
assert hdus[1].data["col"][1].shape == (0,)
E   assert (0, 5) == (0,)
```

After the fix:

- The new test passes.
- `astropy/io/fits/tests/test_table.py` — 219 passed, 3 skipped.
- All VLA tests (`-k "vla or VLA"`) — 28 passed.
- `test_connect.py` + `test_fitsdiff.py` — 195 passed, 9 skipped.
- `ruff check` / `ruff format --check` (pinned v0.15.20) — clean.

A changelog fragment will be added once the PR number is assigned.

This is a draft pending a final review pass.
