### PR TITLE
Vectorize string output for Angle.to_string

### DIFF
--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -341,15 +341,46 @@ class Angle(SpecificTypeQuantity):
         if format == "latex_inline":
             format = "latex"
 
-        # Create an iterator so we can format each element of what
-        # might be an array.
-        is_sexagesimal = not decimal and (unit == u.degree or unit == u.hourangle)
-        if is_sexagesimal:
+        # Convert Quantity to value in the requested unit so we can format it.
+        values = self.to_value(unit)
+
+        # For sexagmesimal formatting, try using a vectorized path for non-small arrays,
+        # otherwise fall back to a per-element loop by defining a formatting function.
+        if not decimal and (unit == u.degree or unit == u.hourangle):
             # Sexagesimal.
             if sep == "fromunit":
                 if format not in separators:
                     raise ValueError(f"Unknown format '{format}'")
                 sep = separators[format][unit]
+
+            # Fast path: build the whole sexagesimal array with NumPy string operations
+            # instead of looping ``do_format`` over the elements. The helper returns
+            # ``None`` for cases it cannot handle (very old NumPy or out-of-range
+            # degrees), in which case we fall through to the per-element path below. The
+            # vectorized path carries a fixed setup cost, so for a scalar or just a
+            # handful of values the plain loop is quicker.
+            if values.size > _VECTORIZE_MIN_SIZE:
+                result = formats._decimal_to_sexagesimal_string_array(
+                    values, precision=precision, sep=sep, pad=pad, fields=fields
+                )
+                if result is not None:
+                    if alwayssign:
+                        result = np.where(
+                            np.strings.startswith(result, "-"),
+                            result,
+                            np.strings.add("+", result),
+                        )
+                    if format == "latex":
+                        result = np.strings.add("$", np.strings.add(result, "$"))
+                    is_nan = np.isnan(values)
+                    if is_nan.any():
+                        result = np.where(is_nan, "nan", result)
+                    # NumPy string ops can collapse a scalar to a 0-d string; make
+                    # sure we return a bare Python string in that case, as before.
+                    result = np.asarray(result)
+                    return result if result.ndim else result[()]
+
+            # Cannot do vectorized formatting, continue on with per-element formatting
             func = functools.partial(
                 formats._decimal_to_sexagesimal_string,
                 precision=precision,
@@ -387,35 +418,6 @@ class Angle(SpecificTypeQuantity):
             if alwayssign and not s.startswith("-"):
                 s = "+" + s
             return f"${s}$" if format == "latex" else s
-
-        values = self.to_value(unit)
-
-        # Fast path: build the whole sexagesimal array with NumPy string
-        # operations instead of looping ``do_format`` over the elements. The
-        # helper returns ``None`` for cases it cannot handle (very old NumPy or
-        # out-of-range degrees), in which case we fall through to the per-element
-        # path below. The vectorized path carries a fixed setup cost, so for a
-        # scalar or just a handful of values the plain loop is quicker.
-        if is_sexagesimal and values.size > _VECTORIZE_MIN_SIZE:
-            result = formats._decimal_to_sexagesimal_string_array(
-                values, precision=precision, sep=sep, pad=pad, fields=fields
-            )
-            if result is not None:
-                if alwayssign:
-                    result = np.where(
-                        np.strings.startswith(result, "-"),
-                        result,
-                        np.strings.add("+", result),
-                    )
-                if format == "latex":
-                    result = np.strings.add("$", np.strings.add(result, "$"))
-                is_nan = np.isnan(values)
-                if is_nan.any():
-                    result = np.where(is_nan, "nan", result)
-                # NumPy string ops can collapse a scalar to a 0-d string; make
-                # sure we return a bare Python string in that case, as before.
-                result = np.asarray(result)
-                return result if result.ndim else result[()]
 
         format_ufunc = np.vectorize(do_format, otypes=["U"])
         result = format_ufunc(values)

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -17,6 +17,11 @@ from . import formats
 
 __all__ = ["Angle", "Latitude", "Longitude"]
 
+# Minimum number of values for which the vectorized sexagesimal formatter in
+# ``Angle.to_string`` beats the per-element loop; below this its setup cost
+# dominates (see the crossover measured around a handful of elements).
+_VECTORIZE_MIN_SIZE = 8
+
 
 # these are used by the `hms` and `dms` attributes
 class hms_tuple(NamedTuple):
@@ -338,7 +343,8 @@ class Angle(SpecificTypeQuantity):
 
         # Create an iterator so we can format each element of what
         # might be an array.
-        if not decimal and (unit == u.degree or unit == u.hourangle):
+        is_sexagesimal = not decimal and (unit == u.degree or unit == u.hourangle)
+        if is_sexagesimal:
             # Sexagesimal.
             if sep == "fromunit":
                 if format not in separators:
@@ -382,8 +388,37 @@ class Angle(SpecificTypeQuantity):
                 s = "+" + s
             return f"${s}$" if format == "latex" else s
 
+        values = self.to_value(unit)
+
+        # Fast path: build the whole sexagesimal array with NumPy string
+        # operations instead of looping ``do_format`` over the elements. The
+        # helper returns ``None`` for cases it cannot handle (very old NumPy or
+        # out-of-range degrees), in which case we fall through to the per-element
+        # path below. The vectorized path carries a fixed setup cost, so for a
+        # scalar or just a handful of values the plain loop is quicker.
+        if is_sexagesimal and values.size > _VECTORIZE_MIN_SIZE:
+            result = formats._decimal_to_sexagesimal_string_array(
+                values, precision=precision, sep=sep, pad=pad, fields=fields
+            )
+            if result is not None:
+                if alwayssign:
+                    result = np.where(
+                        np.strings.startswith(result, "-"),
+                        result,
+                        np.strings.add("+", result),
+                    )
+                if format == "latex":
+                    result = np.strings.add("$", np.strings.add(result, "$"))
+                is_nan = np.isnan(values)
+                if is_nan.any():
+                    result = np.where(is_nan, "nan", result)
+                # NumPy string ops can collapse a scalar to a 0-d string; make
+                # sure we return a bare Python string in that case, as before.
+                result = np.asarray(result)
+                return result if result.ndim else result[()]
+
         format_ufunc = np.vectorize(do_format, otypes=["U"])
-        result = format_ufunc(self.to_value(unit))
+        result = format_ufunc(values)
         return result if result.ndim else result[()]
 
     def _wrap_at(self, wrap_angle):

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -371,13 +371,11 @@ class Angle(SpecificTypeQuantity):
                 if result is not None:
                     if format == "latex":
                         result = "$" + result + "$"
-                    is_nan = np.isnan(values)
-                    if is_nan.any():
-                        result = np.where(is_nan, "nan", result)
-                    # NumPy string ops can collapse a scalar to a 0-d string; make
-                    # sure we return a bare Python string in that case, as before.
-                    result = np.asarray(result)
-                    return result if result.ndim else result[()]
+                    # A non-finite value was formatted as "inf", which is right
+                    # for the infinities but not for NaN.  There is room for
+                    # the shorter string, so this can be done in place.
+                    result[np.isnan(values)] = "nan"
+                    return result
 
             # Cannot do vectorized formatting, continue on with per-element formatting
             func = functools.partial(

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -370,7 +370,7 @@ class Angle(SpecificTypeQuantity):
                 )
                 if result is not None:
                     if format == "latex":
-                        result = np.strings.add("$", np.strings.add(result, "$"))
+                        result = "$" + result + "$"
                     is_nan = np.isnan(values)
                     if is_nan.any():
                         result = np.where(is_nan, "nan", result)

--- a/astropy/coordinates/angles/core.py
+++ b/astropy/coordinates/angles/core.py
@@ -361,15 +361,14 @@ class Angle(SpecificTypeQuantity):
             # handful of values the plain loop is quicker.
             if values.size > _VECTORIZE_MIN_SIZE:
                 result = formats._decimal_to_sexagesimal_string_array(
-                    values, precision=precision, sep=sep, pad=pad, fields=fields
+                    values,
+                    precision=precision,
+                    sep=sep,
+                    pad=pad,
+                    fields=fields,
+                    alwayssign=alwayssign,
                 )
                 if result is not None:
-                    if alwayssign:
-                        result = np.where(
-                            np.strings.startswith(result, "-"),
-                            result,
-                            np.strings.add("+", result),
-                        )
                     if format == "latex":
                         result = np.strings.add("$", np.strings.add(result, "$"))
                     is_nan = np.isnan(values)

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -22,7 +22,9 @@ from warnings import warn
 import numpy as np
 
 from astropy import units as u
+from astropy.time.formats import _write_decimal
 from astropy.utils import parsing
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_1
 
 from .errors import (
     IllegalHourError,
@@ -450,3 +452,117 @@ def _decimal_to_sexagesimal_string(
             last_value = "0" + last_value
         literal += f"{last_value}{sep[2]}"
     return literal
+
+
+def _fixed_width_decimal(values, width):
+    """Zero-padded, fixed-``width`` decimal strings for non-negative integers.
+
+    The digits are written with plain integer arithmetic (via
+    `~astropy.time.formats._write_decimal`), which is several times faster than
+    ``values.astype("U")`` or ``np.strings.mod("%d", ...)`` because those format
+    each element through a Python string conversion.
+    """
+    values = np.asarray(values)
+    buf = np.empty(values.shape + (width,), dtype=np.uint32)
+    _write_decimal(buf, values, width, False)
+    return buf.view(f"U{width}").reshape(values.shape)
+
+
+def _decimal_to_sexagesimal_string_array(
+    angle, precision=None, pad=False, sep=(":",), fields=3
+):
+    """Vectorized equivalent of `_decimal_to_sexagesimal_string`.
+
+    Formats a whole array of angles at once with NumPy string operations,
+    which is much faster than looping `_decimal_to_sexagesimal_string` over the
+    elements.  The output is identical to formatting each element on its own.
+
+    Returns ``None`` when the array cannot be handled this way -- currently on
+    NumPy < 2.1 (where ``np.strings.zfill`` is buggy) or for degree values too
+    large for a 64-bit integer -- so the caller can fall back to the
+    per-element path.
+    """
+    if NUMPY_LT_2_1:
+        return None
+
+    if fields < 1 or fields > 3:
+        raise ValueError("fields must be 1, 2, or 3")
+
+    angle = np.asarray(angle, dtype=float)
+    d, m, s = _decimal_to_sexagesimal(angle)
+    # The sign is carried on the degrees; work with magnitudes and put it back
+    # at the end, matching `_decimal_to_sexagesimal_string`.
+    sign = np.copysign(1.0, d)
+    d, m, s = np.abs(d), np.abs(m), np.abs(s)
+
+    # Normalize the separators exactly as the per-element version does.
+    if not isinstance(sep, tuple):
+        sep = tuple(sep)
+    if not sep:
+        sep = ("", "", "")
+    elif len(sep) == 1:
+        if fields == 3:
+            sep = sep + (sep[0], "")
+        elif fields == 2:
+            sep = sep + ("", "")
+        else:
+            sep = ("", "", "")
+    elif len(sep) == 2:
+        sep = sep + ("",)
+    elif len(sep) != 3:
+        raise ValueError(
+            "Invalid separator specification for converting angle to string."
+        )
+
+    # Carry rounding upwards through the fields, as in the per-element version.
+    rounding_thresh = 60.0 - (10.0 ** -(8 if precision is None else precision))
+    if fields == 3:
+        carry = s >= rounding_thresh
+        s = np.where(carry, 0.0, s)
+        m = np.where(carry, m + 1.0, m)
+    else:
+        m = np.where(s >= 30.0, m + 1.0, m)
+    if fields >= 2:
+        carry = m >= 60.0
+        m = np.where(carry, 0.0, m)
+        d = np.where(carry, d + 1.0, d)
+    else:
+        d = np.where(m >= 30.0, d + 1.0, d)
+
+    # Degrees have a variable number of digits, so size the buffer from the
+    # largest finite value.  Infinities render as "inf" like the per-element
+    # path; NaNs are dealt with by the caller.
+    finite = np.isfinite(d)
+    dmax = int(d[finite].max()) if finite.any() else 0
+    if dmax >= 10**18:
+        # Would overflow the int64 buffer below; leave it to the slow path.
+        return None
+    degrees = _fixed_width_decimal(
+        np.where(finite, d, 0.0).astype(np.int64), max(1, len(str(dmax)))
+    )
+    degrees = np.strings.lstrip(degrees, "0")
+    if pad:
+        degrees = np.strings.zfill(degrees, 2)
+    else:
+        degrees = np.where(degrees == "", "0", degrees)
+    if not finite.all():
+        degrees = np.where(finite, degrees, "inf")
+    degrees = np.where(sign < 0, np.strings.add("-", degrees), degrees)
+
+    # Zero out non-finite entries before the integer cast (their strings are
+    # replaced by "inf"/"nan" elsewhere), so it does not raise on inf/NaN.
+    m = np.where(finite, m, 0.0)
+
+    out = np.strings.add(degrees, sep[0])
+    if fields >= 2:
+        minutes = _fixed_width_decimal(m.astype(np.int64), 2)
+        out = np.strings.add(out, np.strings.add(minutes, sep[1]))
+    if fields == 3:
+        if precision is None:
+            seconds = np.strings.mod("%011.8f", s)
+            seconds = np.strings.rstrip(np.strings.rstrip(seconds, "0"), ".")
+        else:
+            width = precision + 3 if precision else 2
+            seconds = np.strings.mod(f"%0{width}.{precision}f", s)
+        out = np.strings.add(out, np.strings.add(seconds, sep[2]))
+    return out

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -19,10 +19,11 @@ of data to another.
 import threading
 from warnings import warn
 
+import erfa
 import numpy as np
 
 from astropy import units as u
-from astropy.time.formats import _write_decimal
+from astropy.time.formats import _format_template
 from astropy.utils import parsing
 from astropy.utils.compat.numpycompat import NUMPY_LT_2_1
 
@@ -377,12 +378,52 @@ def _decimal_to_sexagesimal(a, /):
     return np.floor(sign * d), sign * np.floor(m), sign * s
 
 
+# ERFA's fields are 32-bit, so it cannot take more than 9 decimals of a second
+# nor an angle past this many degrees or hours.
+_ERFA_MAX_FIELD = 2**31
+
+# ERFA resolves to ``ndp`` decimals of a second, and negative values give
+# coarser resolutions: -2 is a whole minute and -4 a whole degree or hour,
+# which is what the hidden fields need.
+_COARSE_RESOLUTION = {2: -2, 1: -4}
+
+
 def _decimal_to_sexagesimal_string(
     angle, precision=None, pad=False, sep=(":",), fields=3
 ):
     """
     Given a floating point angle, convert it to string
     """
+    if fields < 1 or fields > 3:
+        raise ValueError("fields must be 1, 2, or 3")
+
+    sep = _normalize_sep(sep, fields)
+    ndp = 8 if precision is None else precision
+
+    # ERFA does the decomposition, the rounding and the carrying between the
+    # fields.  It cannot handle more than 9 decimals of a second or angles too
+    # large for its 32-bit fields, and its integer fields have no room for the
+    # non-finite values, all of which are left to the slower code below.
+    if 0 <= ndp <= 9 and abs(angle) < _ERFA_MAX_FIELD:
+        _, parts = erfa.d2tf(_COARSE_RESOLUTION.get(fields, ndp), angle / 24.0)
+        d, m, s, f = (int(parts[name]) for name in ("h", "m", "s", "f"))
+        # The sign comes from the angle rather than from ERFA, so that a
+        # negative zero keeps the "-" it has always been given.
+        sign = "-" if np.signbit(angle) else ""
+        literal = f"{sign}{d:0{2 if pad else 1}d}{sep[0]}"
+        if fields >= 2:
+            literal += f"{m:02d}{sep[1]}"
+        if fields == 3:
+            literal += f"{s:02d}"
+            if precision is None:
+                fraction = f"{f:08d}".rstrip("0")
+                if fraction:
+                    literal += f".{fraction}"
+            elif precision:
+                literal += f".{f:0{precision}d}"
+            literal += sep[2]
+        return literal
+
     values = _decimal_to_sexagesimal(angle)
     # Check to see if values[0] is negative, using np.copysign to handle -0
     sign = np.copysign(1.0, values[0])
@@ -395,28 +436,6 @@ def _decimal_to_sexagesimal_string(
         pad = 3 if sign == -1 else 2
     else:
         pad = 0
-
-    if not isinstance(sep, tuple):
-        sep = tuple(sep)
-
-    if fields < 1 or fields > 3:
-        raise ValueError("fields must be 1, 2, or 3")
-
-    if not sep:  # empty string, False, or None, etc.
-        sep = ("", "", "")
-    elif len(sep) == 1:
-        if fields == 3:
-            sep = sep + (sep[0], "")
-        elif fields == 2:
-            sep = sep + ("", "")
-        else:
-            sep = ("", "", "")
-    elif len(sep) == 2:
-        sep = sep + ("",)
-    elif len(sep) != 3:
-        raise ValueError(
-            "Invalid separator specification for converting angle to string."
-        )
 
     # Simplify the expression based on the requested precision.  For
     # example, if the seconds will round up to 60, we should convert
@@ -454,18 +473,25 @@ def _decimal_to_sexagesimal_string(
     return literal
 
 
-def _fixed_width_decimal(values, width):
-    """Zero-padded, fixed-``width`` decimal strings for non-negative integers.
-
-    The digits are written with plain integer arithmetic (via
-    `~astropy.time.formats._write_decimal`), which is several times faster than
-    ``values.astype("U")`` or ``np.strings.mod("%d", ...)`` because those format
-    each element through a Python string conversion.
-    """
-    values = np.asarray(values)
-    buf = np.empty(values.shape + (width,), dtype=np.uint32)
-    _write_decimal(buf, values, width, False)
-    return buf.view(f"U{width}").reshape(values.shape)
+def _normalize_sep(sep, fields):
+    """Expand ``sep`` to the three separators that follow each field."""
+    if not isinstance(sep, tuple):
+        sep = tuple(sep)
+    if not sep:  # empty string, False, or None, etc.
+        return ("", "", "")
+    if len(sep) == 1:
+        if fields == 3:
+            return sep + (sep[0], "")
+        if fields == 2:
+            return sep + ("", "")
+        return ("", "", "")
+    if len(sep) == 2:
+        return sep + ("",)
+    if len(sep) != 3:
+        raise ValueError(
+            "Invalid separator specification for converting angle to string."
+        )
+    return sep
 
 
 def _decimal_to_sexagesimal_string_array(
@@ -473,14 +499,15 @@ def _decimal_to_sexagesimal_string_array(
 ):
     """Vectorized equivalent of `_decimal_to_sexagesimal_string`.
 
-    Formats a whole array of angles at once with NumPy string operations,
-    which is much faster than looping `_decimal_to_sexagesimal_string` over the
-    elements.  The output is identical to formatting each element on its own.
+    The sexagesimal fields come from ERFA, which rounds them and carries
+    between them, and the strings are then assembled from a format template
+    with array operations.  This is much faster than looping
+    `_decimal_to_sexagesimal_string` over the elements.
 
-    Returns ``None`` when the array cannot be handled this way -- currently on
-    NumPy < 2.1 (where ``np.strings.zfill`` is buggy) or for degree values too
-    large for a 64-bit integer -- so the caller can fall back to the
-    per-element path.
+    Returns ``None`` when the array cannot be handled this way, so that the
+    caller can fall back to the per-element path: on NumPy < 2.1 (where
+    ``np.strings.zfill`` is buggy), for a precision beyond the 9 digits ERFA
+    can give, and for angles too large for its 32-bit fields.
     """
     if NUMPY_LT_2_1:
         return None
@@ -488,80 +515,56 @@ def _decimal_to_sexagesimal_string_array(
     if fields < 1 or fields > 3:
         raise ValueError("fields must be 1, 2, or 3")
 
+    sep = _normalize_sep(sep, fields)
+    ndp = 8 if precision is None else precision
+    if ndp > 9 or ndp < 0:
+        return None
+
     angle = np.asarray(angle, dtype=float)
-    # Infinities cannot pass the integer casts below, so zero them here and
-    # restore their strings at the end.  The sign is taken first, so that -inf
-    # keeps it.
+    negative = np.signbit(angle)
     finite = np.isfinite(angle)
-    sign = np.copysign(1.0, angle)
     if not finite.all():
         angle = np.where(finite, angle, 0.0)
-
-    # np.array, not np.asarray: the fields are updated in place below.
-    d, m, s = (np.array(part) for part in _decimal_to_sexagesimal(np.abs(angle)))
-
-    # Normalize the separators exactly as the per-element version does.
-    if not isinstance(sep, tuple):
-        sep = tuple(sep)
-    if not sep:
-        sep = ("", "", "")
-    elif len(sep) == 1:
-        if fields == 3:
-            sep = sep + (sep[0], "")
-        elif fields == 2:
-            sep = sep + ("", "")
-        else:
-            sep = ("", "", "")
-    elif len(sep) == 2:
-        sep = sep + ("",)
-    elif len(sep) != 3:
-        raise ValueError(
-            "Invalid separator specification for converting angle to string."
-        )
-
-    # Carry rounding upwards through the fields, as in the per-element version.
-    rounding_thresh = 60.0 - (10.0 ** -(8 if precision is None else precision))
-    if fields == 3:
-        carry = s >= rounding_thresh
-        s[carry] = 0.0
-        m[carry] += 1.0
-    else:
-        m[s >= 30.0] += 1.0
-    if fields >= 2:
-        carry = m >= 60.0
-        m[carry] = 0.0
-        d[carry] += 1.0
-    else:
-        d[m >= 30.0] += 1.0
-
-    # Degrees have a variable number of digits, so size the buffer from the
-    # largest value.
-    dmax = int(d.max()) if d.size else 0
-    if dmax >= 10**18:
-        # Would overflow the int64 buffer below; leave it to the slow path.
+    if angle.size and np.abs(angle).max() >= _ERFA_MAX_FIELD:
         return None
-    degrees = _fixed_width_decimal(d.astype(np.int64), max(1, len(str(dmax))))
+
+    _, parts = erfa.d2tf(_COARSE_RESOLUTION.get(fields, ndp), angle / 24.0)
+
+    # The leading field has a variable number of digits, so it is written to
+    # its own column and stripped, rather than going into the template.
+    degrees = parts["h"]
+    width = len(str(int(degrees.max()))) if degrees.size else 1
+    out = _format_template(f"{{deg:0{width}d}}", {"deg": degrees}, degrees.shape)
     # np.asarray: the string operations give a scalar for 0-d input.
-    degrees = np.asarray(np.strings.lstrip(degrees, "0"))
+    out = np.asarray(np.strings.lstrip(out, "0"))
     if pad:
-        degrees = np.strings.zfill(degrees, 2)
+        # A minimum width of two digits, not a fixed one, so that larger
+        # values keep all of theirs.
+        out = np.strings.zfill(out, 2)
     else:
-        degrees[degrees == ""] = "0"
+        out[out == ""] = "0"
     if not finite.all():
         # Not in place: "inf" needs a wider dtype.
-        degrees = np.where(finite, degrees, "inf")
-    degrees = np.where(sign < 0, "-", "") + degrees
+        out = np.where(finite, out, "inf")
+    out = np.where(negative, "-", "") + out
 
-    out = degrees + sep[0]
+    template = sep[0]
     if fields >= 2:
-        minutes = _fixed_width_decimal(m.astype(np.int64), 2)
-        out = out + minutes + sep[1]
+        template += "{min:02d}" + sep[1]
+    if fields == 3:
+        template += "{sec:02d}"
+        if ndp:
+            template += f".{{frac:0{ndp}d}}"
+    tail = _format_template(
+        template,
+        {"min": parts["m"], "sec": parts["s"], "frac": parts["f"]},
+        degrees.shape,
+    )
     if fields == 3:
         if precision is None:
-            seconds = np.strings.mod("%011.8f", s)
-            seconds = np.strings.rstrip(np.strings.rstrip(seconds, "0"), ".")
-        else:
-            width = precision + 3 if precision else 2
-            seconds = np.strings.mod(f"%0{width}.{precision}f", s)
-        out = out + seconds + sep[2]
-    return out
+            # Drop trailing zeros of the fraction, and the point if all of them
+            # went.  This cannot eat into the seconds, since the strip stops at
+            # the point.
+            tail = np.strings.rstrip(np.strings.rstrip(tail, "0"), ".")
+        tail = tail + sep[2]
+    return out + tail

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -489,11 +489,16 @@ def _decimal_to_sexagesimal_string_array(
         raise ValueError("fields must be 1, 2, or 3")
 
     angle = np.asarray(angle, dtype=float)
-    d, m, s = _decimal_to_sexagesimal(angle)
-    # The sign is carried on the degrees; work with magnitudes and put it back
-    # at the end, matching `_decimal_to_sexagesimal_string`.
-    sign = np.copysign(1.0, d)
-    d, m, s = np.abs(d), np.abs(m), np.abs(s)
+    # Infinities cannot pass the integer casts below, so zero them here and
+    # restore their strings at the end.  The sign is taken first, so that -inf
+    # keeps it.
+    finite = np.isfinite(angle)
+    sign = np.copysign(1.0, angle)
+    if not finite.all():
+        angle = np.where(finite, angle, 0.0)
+
+    # np.array, not np.asarray: the fields are updated in place below.
+    d, m, s = (np.array(part) for part in _decimal_to_sexagesimal(np.abs(angle)))
 
     # Normalize the separators exactly as the per-element version does.
     if not isinstance(sep, tuple):
@@ -518,45 +523,39 @@ def _decimal_to_sexagesimal_string_array(
     rounding_thresh = 60.0 - (10.0 ** -(8 if precision is None else precision))
     if fields == 3:
         carry = s >= rounding_thresh
-        s = np.where(carry, 0.0, s)
-        m = np.where(carry, m + 1.0, m)
+        s[carry] = 0.0
+        m[carry] += 1.0
     else:
-        m = np.where(s >= 30.0, m + 1.0, m)
+        m[s >= 30.0] += 1.0
     if fields >= 2:
         carry = m >= 60.0
-        m = np.where(carry, 0.0, m)
-        d = np.where(carry, d + 1.0, d)
+        m[carry] = 0.0
+        d[carry] += 1.0
     else:
-        d = np.where(m >= 30.0, d + 1.0, d)
+        d[m >= 30.0] += 1.0
 
     # Degrees have a variable number of digits, so size the buffer from the
-    # largest finite value.  Infinities render as "inf" like the per-element
-    # path; NaNs are dealt with by the caller.
-    finite = np.isfinite(d)
-    dmax = int(d[finite].max()) if finite.any() else 0
+    # largest value.
+    dmax = int(d.max()) if d.size else 0
     if dmax >= 10**18:
         # Would overflow the int64 buffer below; leave it to the slow path.
         return None
-    degrees = _fixed_width_decimal(
-        np.where(finite, d, 0.0).astype(np.int64), max(1, len(str(dmax)))
-    )
-    degrees = np.strings.lstrip(degrees, "0")
+    degrees = _fixed_width_decimal(d.astype(np.int64), max(1, len(str(dmax))))
+    # np.asarray: the string operations give a scalar for 0-d input.
+    degrees = np.asarray(np.strings.lstrip(degrees, "0"))
     if pad:
         degrees = np.strings.zfill(degrees, 2)
     else:
-        degrees = np.where(degrees == "", "0", degrees)
+        degrees[degrees == ""] = "0"
     if not finite.all():
+        # Not in place: "inf" needs a wider dtype.
         degrees = np.where(finite, degrees, "inf")
-    degrees = np.where(sign < 0, np.strings.add("-", degrees), degrees)
+    degrees = np.where(sign < 0, "-", "") + degrees
 
-    # Zero out non-finite entries before the integer cast (their strings are
-    # replaced by "inf"/"nan" elsewhere), so it does not raise on inf/NaN.
-    m = np.where(finite, m, 0.0)
-
-    out = np.strings.add(degrees, sep[0])
+    out = degrees + sep[0]
     if fields >= 2:
         minutes = _fixed_width_decimal(m.astype(np.int64), 2)
-        out = np.strings.add(out, np.strings.add(minutes, sep[1]))
+        out = out + minutes + sep[1]
     if fields == 3:
         if precision is None:
             seconds = np.strings.mod("%011.8f", s)
@@ -564,5 +563,5 @@ def _decimal_to_sexagesimal_string_array(
         else:
             width = precision + 3 if precision else 2
             seconds = np.strings.mod(f"%0{width}.{precision}f", s)
-        out = np.strings.add(out, np.strings.add(seconds, sep[2]))
+        out = out + seconds + sep[2]
     return out

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -22,7 +22,9 @@ from warnings import warn
 import numpy as np
 
 from astropy import units as u
+from astropy.time.formats import _write_decimal
 from astropy.utils import parsing
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_1
 
 from .errors import (
     IllegalHourError,
@@ -446,3 +448,117 @@ def _decimal_to_sexagesimal_string(
             last_value = "0" + last_value
         literal += f"{last_value}{sep[2]}"
     return literal
+
+
+def _fixed_width_decimal(values, width):
+    """Zero-padded, fixed-``width`` decimal strings for non-negative integers.
+
+    The digits are written with plain integer arithmetic (via
+    `~astropy.time.formats._write_decimal`), which is several times faster than
+    ``values.astype("U")`` or ``np.strings.mod("%d", ...)`` because those format
+    each element through a Python string conversion.
+    """
+    values = np.asarray(values)
+    buf = np.empty(values.shape + (width,), dtype=np.uint32)
+    _write_decimal(buf, values, width, False)
+    return buf.view(f"U{width}").reshape(values.shape)
+
+
+def _decimal_to_sexagesimal_string_array(
+    angle, precision=None, pad=False, sep=(":",), fields=3
+):
+    """Vectorized equivalent of `_decimal_to_sexagesimal_string`.
+
+    Formats a whole array of angles at once with NumPy string operations,
+    which is much faster than looping `_decimal_to_sexagesimal_string` over the
+    elements.  The output is identical to formatting each element on its own.
+
+    Returns ``None`` when the array cannot be handled this way -- currently on
+    NumPy < 2.1 (where ``np.strings.zfill`` is buggy) or for degree values too
+    large for a 64-bit integer -- so the caller can fall back to the
+    per-element path.
+    """
+    if NUMPY_LT_2_1:
+        return None
+
+    if fields < 1 or fields > 3:
+        raise ValueError("fields must be 1, 2, or 3")
+
+    angle = np.asarray(angle, dtype=float)
+    d, m, s = _decimal_to_sexagesimal(angle)
+    # The sign is carried on the degrees; work with magnitudes and put it back
+    # at the end, matching `_decimal_to_sexagesimal_string`.
+    sign = np.copysign(1.0, d)
+    d, m, s = np.abs(d), np.abs(m), np.abs(s)
+
+    # Normalize the separators exactly as the per-element version does.
+    if not isinstance(sep, tuple):
+        sep = tuple(sep)
+    if not sep:
+        sep = ("", "", "")
+    elif len(sep) == 1:
+        if fields == 3:
+            sep = sep + (sep[0], "")
+        elif fields == 2:
+            sep = sep + ("", "")
+        else:
+            sep = ("", "", "")
+    elif len(sep) == 2:
+        sep = sep + ("",)
+    elif len(sep) != 3:
+        raise ValueError(
+            "Invalid separator specification for converting angle to string."
+        )
+
+    # Carry rounding upwards through the fields, as in the per-element version.
+    rounding_thresh = 60.0 - (10.0 ** -(8 if precision is None else precision))
+    if fields == 3:
+        carry = s >= rounding_thresh
+        s = np.where(carry, 0.0, s)
+        m = np.where(carry, m + 1.0, m)
+    else:
+        m = np.where(s >= 30.0, m + 1.0, m)
+    if fields >= 2:
+        carry = m >= 60.0
+        m = np.where(carry, 0.0, m)
+        d = np.where(carry, d + 1.0, d)
+    else:
+        d = np.where(m >= 30.0, d + 1.0, d)
+
+    # Degrees have a variable number of digits, so size the buffer from the
+    # largest finite value.  Infinities render as "inf" like the per-element
+    # path; NaNs are dealt with by the caller.
+    finite = np.isfinite(d)
+    dmax = int(d[finite].max()) if finite.any() else 0
+    if dmax >= 10**18:
+        # Would overflow the int64 buffer below; leave it to the slow path.
+        return None
+    degrees = _fixed_width_decimal(
+        np.where(finite, d, 0.0).astype(np.int64), max(1, len(str(dmax)))
+    )
+    degrees = np.strings.lstrip(degrees, "0")
+    if pad:
+        degrees = np.strings.zfill(degrees, 2)
+    else:
+        degrees = np.where(degrees == "", "0", degrees)
+    if not finite.all():
+        degrees = np.where(finite, degrees, "inf")
+    degrees = np.where(sign < 0, np.strings.add("-", degrees), degrees)
+
+    # Zero out non-finite entries before the integer cast (their strings are
+    # replaced by "inf"/"nan" elsewhere), so it does not raise on inf/NaN.
+    m = np.where(finite, m, 0.0)
+
+    out = np.strings.add(degrees, sep[0])
+    if fields >= 2:
+        minutes = _fixed_width_decimal(m.astype(np.int64), 2)
+        out = np.strings.add(out, np.strings.add(minutes, sep[1]))
+    if fields == 3:
+        if precision is None:
+            seconds = np.strings.mod("%011.8f", s)
+            seconds = np.strings.rstrip(np.strings.rstrip(seconds, "0"), ".")
+        else:
+            width = precision + 3 if precision else 2
+            seconds = np.strings.mod(f"%0{width}.{precision}f", s)
+        out = np.strings.add(out, np.strings.add(seconds, sep[2]))
+    return out

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -495,14 +495,16 @@ def _normalize_sep(sep, fields):
 
 
 def _decimal_to_sexagesimal_string_array(
-    angle, precision=None, pad=False, sep=(":",), fields=3
+    angle, precision=None, pad=False, sep=(":",), fields=3, alwayssign=False
 ):
     """Vectorized equivalent of `_decimal_to_sexagesimal_string`.
 
     The sexagesimal fields come from ERFA, which rounds them and carries
     between them, and the strings are then assembled from a format template
     with array operations.  This is much faster than looping
-    `_decimal_to_sexagesimal_string` over the elements.
+    `_decimal_to_sexagesimal_string` over the elements.  The sign comes from
+    ERFA along with the fields, so ``alwayssign`` is dealt with here rather
+    than with another pass over the strings.
 
     Returns ``None`` when the array cannot be handled this way, so that the
     caller can fall back to the per-element path: on NumPy < 2.1 (where
@@ -528,7 +530,12 @@ def _decimal_to_sexagesimal_string_array(
     if angle.size and np.abs(angle).max() >= _ERFA_MAX_FIELD:
         return None
 
-    _, parts = erfa.d2tf(_COARSE_RESOLUTION.get(fields, ndp), angle / 24.0)
+    sign, parts = erfa.d2tf(_COARSE_RESOLUTION.get(fields, ndp), angle / 24.0)
+    sign = np.asarray(sign).astype("U1")
+    # ERFA gives "+" for a negative zero, which has always been given a "-".
+    sign[negative] = "-"
+    if not alwayssign:
+        sign[sign == "+"] = ""
 
     # The leading field has a variable number of digits, so it is written to
     # its own column and stripped, rather than going into the template.
@@ -546,7 +553,7 @@ def _decimal_to_sexagesimal_string_array(
     if not finite.all():
         # Not in place: "inf" needs a wider dtype.
         out = np.where(finite, out, "inf")
-    out = np.where(negative, "-", "") + out
+    out = sign + out
 
     template = sep[0]
     if fields >= 2:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -894,13 +894,16 @@ class SkyCoord(MaskableShapedLikeNDArray):
                 f" {sph_coord.lat.to_string(**latargs)}"
             )
         else:
-            coord_string = []
-            for lonangle, latangle in zip(sph_coord.lon.ravel(), sph_coord.lat.ravel()):
-                coord_string += [
-                    f"{lonangle.to_string(**lonargs)} {latangle.to_string(**latargs)}"
-                ]
+            # Format both angles for the whole array at once and join them,
+            # rather than looping element by element, so large coordinate
+            # arrays benefit from the vectorized Angle.to_string.
+            lon_string = np.asarray(sph_coord.lon.to_string(**lonargs)).ravel()
+            lat_string = np.asarray(sph_coord.lat.to_string(**latargs)).ravel()
+            coord_string = np.char.add(np.char.add(lon_string, " "), lat_string)
             if len(sph_coord.shape) > 1:
-                coord_string = np.array(coord_string).reshape(sph_coord.shape)
+                coord_string = coord_string.reshape(sph_coord.shape)
+            else:
+                coord_string = coord_string.tolist()
 
         return coord_string
 

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -5,9 +5,11 @@ test_sky_coord
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from astropy import units as u
 from astropy.coordinates import Angle
+from astropy.coordinates.angles import formats
 
 
 def test_to_string_precision():
@@ -180,3 +182,119 @@ def test_to_string_fields_colon():
     assert a.to_string(fields=2, sep=":") == "1:07"
     assert a.to_string(fields=3, sep=":") == "1:06:48.078"
     assert a.to_string(fields=1, sep=":") == "1"
+
+
+# A spread of angles that exercises the sign, the carrying between fields, the
+# rounding and the non-finite handling of the vectorized formatter.  Kept well
+# above the size threshold so that ``to_string`` takes the fast array path.
+TO_STRING_ANGLES = np.array(
+    [
+        0.0,
+        -0.0,
+        5.25,
+        -5.25,
+        12.3456789,
+        -12.3456789,
+        59.9999999,
+        359.9999999,
+        90.0,
+        -90.0,
+        123.4567,
+        0.5 / 3600,
+        1e-9,
+        720.0,
+        np.nan,
+        np.inf,
+        -np.inf,
+    ]
+)
+
+# Representative keyword combinations covering every option that changes the
+# output: separators, padding, number of fields, precision, sign and format.
+TO_STRING_KWARGS = [
+    {},
+    {"sep": ":"},
+    {"sep": "dms"},
+    {"sep": ("-", ":")},
+    {"sep": ""},
+    {"pad": True},
+    {"pad": True, "sep": ":"},
+    {"fields": 1},
+    {"fields": 2},
+    {"fields": 2, "sep": ":"},
+    {"precision": 0},
+    {"precision": 4},
+    {"precision": 8},
+    {"precision": 0, "fields": 2},
+    {"alwayssign": True},
+    {"alwayssign": True, "pad": True},
+    {"format": "latex"},
+    {"format": "latex", "alwayssign": True},
+    {"format": "latex_inline"},
+    {"format": "unicode"},
+    {"precision": 2, "pad": True, "alwayssign": True, "sep": ":"},
+]
+
+
+@pytest.mark.parametrize("unit", [u.degree, u.hourangle])
+@pytest.mark.parametrize("kwargs", TO_STRING_KWARGS)
+def test_to_string_vectorized_matches_per_element(monkeypatch, unit, kwargs):
+    """The fast array formatting of ``to_string`` matches the per-element path.
+
+    The same call is run twice: once normally, and once with the vectorized
+    helper disabled so it falls back to looping over the elements.  The two
+    results must be identical.
+    """
+    angle = Angle(TO_STRING_ANGLES, unit=unit)
+    fast = np.asarray(angle.to_string(**kwargs))
+
+    monkeypatch.setattr(
+        formats, "_decimal_to_sexagesimal_string_array", lambda *args, **kw: None
+    )
+    per_element = np.asarray(angle.to_string(**kwargs))
+
+    assert_array_equal(fast, per_element)
+
+
+@pytest.mark.parametrize("sep", [(":",), ("d", "m", "s"), ("-", ":"), ()])
+@pytest.mark.parametrize("fields", [1, 2, 3])
+@pytest.mark.parametrize("precision", [None, 0, 2, 5])
+@pytest.mark.parametrize("pad", [False, True])
+def test_decimal_to_sexagesimal_string_array(sep, fields, precision, pad):
+    """The array formatter matches ``_decimal_to_sexagesimal_string`` per value.
+
+    NaN is handled by ``Angle.to_string`` itself, so it is excluded here.
+    """
+    values = np.array(
+        [0.0, -0.0, 5.25, -5.25, 59.9999999, 12.3456789, 123.456, np.inf, -np.inf]
+    )
+    got = formats._decimal_to_sexagesimal_string_array(
+        values, precision=precision, sep=sep, pad=pad, fields=fields
+    )
+    ref = np.array(
+        [
+            formats._decimal_to_sexagesimal_string(
+                v, precision=precision, sep=sep, pad=pad, fields=fields
+            )
+            for v in values
+        ]
+    )
+    assert_array_equal(got, ref)
+
+
+def test_to_string_array_falls_back_for_huge_degrees():
+    """Degrees too large for the int64 buffer defer to the per-element path."""
+    values = np.array([1e19, 2e19, 3e19])
+    assert formats._decimal_to_sexagesimal_string_array(values) is None
+    # ``to_string`` still returns the correct result via the fallback.
+    angle = Angle(values, unit=u.degree)
+    expected = np.array(
+        [formats._decimal_to_sexagesimal_string(v, sep=("d", "m", "s")) for v in values]
+    )
+    assert_array_equal(np.asarray(angle.to_string(sep="dms")), expected)
+
+
+def test_to_string_array_falls_back_on_old_numpy(monkeypatch):
+    """The vectorized helper defers to the per-element path on NumPy < 2.1."""
+    monkeypatch.setattr(formats, "NUMPY_LT_2_1", True)
+    assert formats._decimal_to_sexagesimal_string_array(np.arange(10.0)) is None

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.coordinates.angles import formats
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_1
 
 
 def test_to_string_precision():
@@ -250,22 +251,15 @@ TO_STRING_ANGLES = np.array(
 TO_STRING_KWARGS = [
     {},
     {"sep": ":"},
-    {"sep": "dms"},
     {"sep": ("-", ":")},
     {"sep": ""},
     {"pad": True},
-    {"pad": True, "sep": ":"},
     {"fields": 1},
     {"fields": 2},
-    {"fields": 2, "sep": ":"},
     {"precision": 0},
-    {"precision": 4},
     {"precision": 8},
-    {"precision": 0, "fields": 2},
     {"alwayssign": True},
-    {"alwayssign": True, "pad": True},
     {"format": "latex"},
-    {"format": "latex", "alwayssign": True},
     {"format": "latex_inline"},
     {"format": "unicode"},
     {"precision": 2, "pad": True, "alwayssign": True, "sep": ":"},
@@ -292,32 +286,37 @@ def test_to_string_vectorized_matches_per_element(monkeypatch, unit, kwargs):
     assert_array_equal(fast, per_element)
 
 
-@pytest.mark.parametrize("sep", [(":",), ("d", "m", "s"), ("-", ":"), ()])
-@pytest.mark.parametrize("fields", [1, 2, 3])
-@pytest.mark.parametrize("precision", [None, 0, 2, 5])
-@pytest.mark.parametrize("pad", [False, True])
-def test_decimal_to_sexagesimal_string_array(sep, fields, precision, pad):
+@pytest.mark.skipif(NUMPY_LT_2_1, reason="vectorized formatter requires NumPy >= 2.1")
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"sep": ("d", "m", "s")},
+        {"sep": ("-", ":"), "pad": True},
+        {"fields": 1},
+        {"fields": 2, "precision": 0},
+        {"precision": 5},
+        {"sep": (), "precision": 2},
+    ],
+)
+def test_decimal_to_sexagesimal_string_array(kwargs):
     """The array formatter matches ``_decimal_to_sexagesimal_string`` per value.
 
-    NaN is handled by ``Angle.to_string`` itself, so it is excluded here.
+    ``Angle.to_string`` handles NaN itself, so it is excluded here. The broad
+    option coverage lives in ``test_to_string_vectorized_matches_per_element``;
+    this just checks the helper directly for a few representative cases.
     """
     values = np.array(
         [0.0, -0.0, 5.25, -5.25, 59.9999999, 12.3456789, 123.456, np.inf, -np.inf]
     )
-    got = formats._decimal_to_sexagesimal_string_array(
-        values, precision=precision, sep=sep, pad=pad, fields=fields
-    )
+    got = formats._decimal_to_sexagesimal_string_array(values, **kwargs)
     ref = np.array(
-        [
-            formats._decimal_to_sexagesimal_string(
-                v, precision=precision, sep=sep, pad=pad, fields=fields
-            )
-            for v in values
-        ]
+        [formats._decimal_to_sexagesimal_string(v, **kwargs) for v in values]
     )
     assert_array_equal(got, ref)
 
 
+@pytest.mark.skipif(NUMPY_LT_2_1, reason="vectorized formatter requires NumPy >= 2.1")
 def test_to_string_array_falls_back_for_huge_degrees():
     """Degrees too large for the int64 buffer defer to the per-element path."""
     values = np.array([1e19, 2e19, 3e19])

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.coordinates.angles import formats
+from astropy.utils.compat.numpycompat import NUMPY_LT_2_1
 
 
 def test_to_string_precision():
@@ -214,22 +215,15 @@ TO_STRING_ANGLES = np.array(
 TO_STRING_KWARGS = [
     {},
     {"sep": ":"},
-    {"sep": "dms"},
     {"sep": ("-", ":")},
     {"sep": ""},
     {"pad": True},
-    {"pad": True, "sep": ":"},
     {"fields": 1},
     {"fields": 2},
-    {"fields": 2, "sep": ":"},
     {"precision": 0},
-    {"precision": 4},
     {"precision": 8},
-    {"precision": 0, "fields": 2},
     {"alwayssign": True},
-    {"alwayssign": True, "pad": True},
     {"format": "latex"},
-    {"format": "latex", "alwayssign": True},
     {"format": "latex_inline"},
     {"format": "unicode"},
     {"precision": 2, "pad": True, "alwayssign": True, "sep": ":"},
@@ -256,32 +250,37 @@ def test_to_string_vectorized_matches_per_element(monkeypatch, unit, kwargs):
     assert_array_equal(fast, per_element)
 
 
-@pytest.mark.parametrize("sep", [(":",), ("d", "m", "s"), ("-", ":"), ()])
-@pytest.mark.parametrize("fields", [1, 2, 3])
-@pytest.mark.parametrize("precision", [None, 0, 2, 5])
-@pytest.mark.parametrize("pad", [False, True])
-def test_decimal_to_sexagesimal_string_array(sep, fields, precision, pad):
+@pytest.mark.skipif(NUMPY_LT_2_1, reason="vectorized formatter requires NumPy >= 2.1")
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"sep": ("d", "m", "s")},
+        {"sep": ("-", ":"), "pad": True},
+        {"fields": 1},
+        {"fields": 2, "precision": 0},
+        {"precision": 5},
+        {"sep": (), "precision": 2},
+    ],
+)
+def test_decimal_to_sexagesimal_string_array(kwargs):
     """The array formatter matches ``_decimal_to_sexagesimal_string`` per value.
 
-    NaN is handled by ``Angle.to_string`` itself, so it is excluded here.
+    ``Angle.to_string`` handles NaN itself, so it is excluded here. The broad
+    option coverage lives in ``test_to_string_vectorized_matches_per_element``;
+    this just checks the helper directly for a few representative cases.
     """
     values = np.array(
         [0.0, -0.0, 5.25, -5.25, 59.9999999, 12.3456789, 123.456, np.inf, -np.inf]
     )
-    got = formats._decimal_to_sexagesimal_string_array(
-        values, precision=precision, sep=sep, pad=pad, fields=fields
-    )
+    got = formats._decimal_to_sexagesimal_string_array(values, **kwargs)
     ref = np.array(
-        [
-            formats._decimal_to_sexagesimal_string(
-                v, precision=precision, sep=sep, pad=pad, fields=fields
-            )
-            for v in values
-        ]
+        [formats._decimal_to_sexagesimal_string(v, **kwargs) for v in values]
     )
     assert_array_equal(got, ref)
 
 
+@pytest.mark.skipif(NUMPY_LT_2_1, reason="vectorized formatter requires NumPy >= 2.1")
 def test_to_string_array_falls_back_for_huge_degrees():
     """Degrees too large for the int64 buffer defer to the per-element path."""
     values = np.array([1e19, 2e19, 3e19])

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -5,9 +5,11 @@ test_sky_coord
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from astropy import units as u
 from astropy.coordinates import Angle
+from astropy.coordinates.angles import formats
 
 
 def test_to_string_precision():
@@ -216,3 +218,119 @@ def test_to_string_fields_colon():
     assert a.to_string(fields=2, sep=":") == "1:07"
     assert a.to_string(fields=3, sep=":") == "1:06:48.078"
     assert a.to_string(fields=1, sep=":") == "1"
+
+
+# A spread of angles that exercises the sign, the carrying between fields, the
+# rounding and the non-finite handling of the vectorized formatter.  Kept well
+# above the size threshold so that ``to_string`` takes the fast array path.
+TO_STRING_ANGLES = np.array(
+    [
+        0.0,
+        -0.0,
+        5.25,
+        -5.25,
+        12.3456789,
+        -12.3456789,
+        59.9999999,
+        359.9999999,
+        90.0,
+        -90.0,
+        123.4567,
+        0.5 / 3600,
+        1e-9,
+        720.0,
+        np.nan,
+        np.inf,
+        -np.inf,
+    ]
+)
+
+# Representative keyword combinations covering every option that changes the
+# output: separators, padding, number of fields, precision, sign and format.
+TO_STRING_KWARGS = [
+    {},
+    {"sep": ":"},
+    {"sep": "dms"},
+    {"sep": ("-", ":")},
+    {"sep": ""},
+    {"pad": True},
+    {"pad": True, "sep": ":"},
+    {"fields": 1},
+    {"fields": 2},
+    {"fields": 2, "sep": ":"},
+    {"precision": 0},
+    {"precision": 4},
+    {"precision": 8},
+    {"precision": 0, "fields": 2},
+    {"alwayssign": True},
+    {"alwayssign": True, "pad": True},
+    {"format": "latex"},
+    {"format": "latex", "alwayssign": True},
+    {"format": "latex_inline"},
+    {"format": "unicode"},
+    {"precision": 2, "pad": True, "alwayssign": True, "sep": ":"},
+]
+
+
+@pytest.mark.parametrize("unit", [u.degree, u.hourangle])
+@pytest.mark.parametrize("kwargs", TO_STRING_KWARGS)
+def test_to_string_vectorized_matches_per_element(monkeypatch, unit, kwargs):
+    """The fast array formatting of ``to_string`` matches the per-element path.
+
+    The same call is run twice: once normally, and once with the vectorized
+    helper disabled so it falls back to looping over the elements.  The two
+    results must be identical.
+    """
+    angle = Angle(TO_STRING_ANGLES, unit=unit)
+    fast = np.asarray(angle.to_string(**kwargs))
+
+    monkeypatch.setattr(
+        formats, "_decimal_to_sexagesimal_string_array", lambda *args, **kw: None
+    )
+    per_element = np.asarray(angle.to_string(**kwargs))
+
+    assert_array_equal(fast, per_element)
+
+
+@pytest.mark.parametrize("sep", [(":",), ("d", "m", "s"), ("-", ":"), ()])
+@pytest.mark.parametrize("fields", [1, 2, 3])
+@pytest.mark.parametrize("precision", [None, 0, 2, 5])
+@pytest.mark.parametrize("pad", [False, True])
+def test_decimal_to_sexagesimal_string_array(sep, fields, precision, pad):
+    """The array formatter matches ``_decimal_to_sexagesimal_string`` per value.
+
+    NaN is handled by ``Angle.to_string`` itself, so it is excluded here.
+    """
+    values = np.array(
+        [0.0, -0.0, 5.25, -5.25, 59.9999999, 12.3456789, 123.456, np.inf, -np.inf]
+    )
+    got = formats._decimal_to_sexagesimal_string_array(
+        values, precision=precision, sep=sep, pad=pad, fields=fields
+    )
+    ref = np.array(
+        [
+            formats._decimal_to_sexagesimal_string(
+                v, precision=precision, sep=sep, pad=pad, fields=fields
+            )
+            for v in values
+        ]
+    )
+    assert_array_equal(got, ref)
+
+
+def test_to_string_array_falls_back_for_huge_degrees():
+    """Degrees too large for the int64 buffer defer to the per-element path."""
+    values = np.array([1e19, 2e19, 3e19])
+    assert formats._decimal_to_sexagesimal_string_array(values) is None
+    # ``to_string`` still returns the correct result via the fallback.
+    angle = Angle(values, unit=u.degree)
+    expected = np.array(
+        [formats._decimal_to_sexagesimal_string(v, sep=("d", "m", "s")) for v in values]
+    )
+    assert_array_equal(np.asarray(angle.to_string(sep="dms")), expected)
+
+
+def test_to_string_array_falls_back_on_old_numpy(monkeypatch):
+    """The vectorized helper defers to the per-element path on NumPy < 2.1."""
+    monkeypatch.setattr(formats, "NUMPY_LT_2_1", True)
+    assert formats._decimal_to_sexagesimal_string_array(np.arange(10.0)) is None

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -747,6 +747,29 @@ def test_to_string():
         assert with_kwargs == wrap("+01h02m03.000s +01d02m03.000s")
 
 
+@pytest.mark.parametrize("style", ["decimal", "dms", "hmsdms"])
+def test_to_string_array(style):
+    """Array ``to_string`` matches formatting each coordinate on its own.
+
+    This covers the vectorized code path, which formats both angles for the
+    whole array at once instead of looping over the elements.
+    """
+    rng = np.random.default_rng(12345)
+    ra = rng.uniform(0, 360, 25)
+    dec = rng.uniform(-90, 90, 25)
+    sc = SkyCoord(ra, dec, unit="deg")
+
+    result = sc.to_string(style)
+    expected = [SkyCoord(r, d, unit="deg").to_string(style) for r, d in zip(ra, dec)]
+    assert result == expected
+
+    # And the shape is preserved for a multidimensional coordinate.
+    sc2d = sc[:24].reshape(4, 6)
+    result2d = sc2d.to_string(style)
+    assert result2d.shape == sc2d.shape
+    assert np.all(result2d.ravel() == np.array(expected[:24]))
+
+
 def test_repr():
     sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame="icrs")
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame="icrs", distance=1 * u.kpc)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -748,6 +748,29 @@ def test_to_string():
         assert with_kwargs == wrap("+01h02m03.000s +01d02m03.000s")
 
 
+@pytest.mark.parametrize("style", ["decimal", "dms", "hmsdms"])
+def test_to_string_array(style):
+    """Array ``to_string`` matches formatting each coordinate on its own.
+
+    This covers the vectorized code path, which formats both angles for the
+    whole array at once instead of looping over the elements.
+    """
+    rng = np.random.default_rng(12345)
+    ra = rng.uniform(0, 360, 25)
+    dec = rng.uniform(-90, 90, 25)
+    sc = SkyCoord(ra, dec, unit="deg")
+
+    result = sc.to_string(style)
+    expected = [SkyCoord(r, d, unit="deg").to_string(style) for r, d in zip(ra, dec)]
+    assert result == expected
+
+    # And the shape is preserved for a multidimensional coordinate.
+    sc2d = sc[:24].reshape(4, 6)
+    result2d = sc2d.to_string(style)
+    assert result2d.shape == sc2d.shape
+    assert np.all(result2d.ravel() == np.array(expected[:24]))
+
+
 def test_repr():
     sc1 = SkyCoord(0 * u.deg, 1 * u.deg, frame="icrs")
     sc2 = SkyCoord(1 * u.deg, 1 * u.deg, frame="icrs", distance=1 * u.kpc)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1663,7 +1663,9 @@ def _format_template(template, fields, shape):
             buf[..., col : col + len(value)] = [ord(char) for char in value]
             col += len(value)
         else:
-            _write_decimal(buf[..., col : col + value_width], value, value_width, signed)
+            _write_decimal(
+                buf[..., col : col + value_width], value, value_width, signed
+            )
             col += value_width
 
     return buf.view(f"U{width}").reshape(shape)
@@ -1926,7 +1928,6 @@ class TimeString(TimeUnique):
         but subclasses can add to this.
         """
         return str_fmt.format(**kwargs)
-
 
     def _value_fast(self, str_fmt):
         """Build the output strings for ``str_fmt`` with array operations.

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1546,6 +1546,129 @@ def _write_decimal(out, values, width, signed):
         out[..., 0] = np.where(negative, ord("-"), ord("+"))
 
 
+def _field_width(spec, values):
+    """Fixed character width of an integer format ``spec`` over ``values``.
+
+    Returns ``(width, signed)``, or ``(None, None)`` when the field cannot
+    be built as a fixed-width column (e.g. a bare ``d`` whose values do not
+    all have the same number of digits), signalling that the caller should
+    fall back to formatting element by element.
+
+    Parameters
+    ----------
+    spec : str
+        The format spec portion of a ``{name:spec}`` replacement field,
+        e.g. ``"d"``, ``"02d"``, or ``"+06d"``.
+    values : ndarray of int
+        The integer values that will be formatted under this spec.
+
+    Returns
+    -------
+    width : int or None
+        Fixed character width of the field, or ``None`` if the field
+        cannot be rendered at a uniform width by this function.
+    signed : bool or None
+        ``True`` if the first character is an explicit ``'+'``/``'-'``
+        sign, ``False`` if the field is unsigned, or ``None`` when
+        ``width`` is ``None``.
+    """
+    match = _INT_SPEC.fullmatch(spec)
+    if match is None:
+        return None, None
+    sign, zero, digits = match.group(1, 2, 3)
+    if digits:
+        # We build columns by zero-padding, so a fixed width without the
+        # "0" flag (which pads with spaces) is left to the per-element path.
+        # And "real" formatting widens the field when a value does not fit,
+        # so a value needing more characters than ``width`` would be silently
+        # truncated in our fixed-width column; fall back in that (rare) case
+        # too -- e.g. a year past 9999 in the signed FITS ``{year:+06d}``.
+        width = int(digits)
+        signed = sign == "+"
+        fits = zero
+        if zero and values.size:
+            n_sign = 1 if signed or int(values.min()) < 0 else 0
+            fits = len(str(int(np.abs(values).max()))) + n_sign <= width
+        return (width, signed) if fits else (None, None)
+    # A bare "d" has no field width, so the width follows the values and we
+    # can only pre-size the column if they share a digit count and need no
+    # sign (a forced "+" or a negative value would make the width vary too).
+    if values.size == 0:
+        return 1, False
+    low = int(values.min())
+    lo = len(str(low))
+    hi = len(str(int(values.max())))
+    if sign or low < 0 or lo != hi:
+        return None, None
+    return hi, False
+
+
+def _format_template(template, fields, shape):
+    """Render ``template`` for arrays of integer ``fields``.
+
+    `TimeString` uses this to build its output from the subformat templates,
+    and `astropy.coordinates` to build sexagesimal angles from the separators
+    given to ``Angle.to_string``.
+
+    Parameters
+    ----------
+    template : str
+        Format string of literal text and ``{name:spec}`` replacement fields,
+        e.g. ``"{deg:d}d{min:02d}m{sec:02d}s"``. Every ``spec`` must be an
+        integer one that `_field_width` can size.
+    fields : dict of str to ndarray of int
+        Values for the replacement fields, broadcastable to ``shape``.
+    shape : tuple of int
+        Shape of the result.
+
+    Returns
+    -------
+    out : ndarray of str, or None
+        The rendered strings, or `None` if any field cannot be rendered at a
+        fixed width, in which case the caller should format element by element.
+    """
+    # Split the template into literal text and replacement fields, recording
+    # the fixed width of each piece so the whole row fits one buffer.
+    pieces = []
+    width = 0
+    pos = 0
+    for match in _SUBFMT_FIELD.finditer(template):
+        if match.start() > pos:
+            literal = template[pos : match.start()]
+            pieces.append((literal, None, None))
+            width += len(literal)
+        name, spec = match.group(1, 2)
+        if name not in fields:
+            return None
+        value_width, signed = _field_width(spec, fields[name])
+        if value_width is None:
+            return None
+        pieces.append((fields[name], value_width, signed))
+        width += value_width
+        pos = match.end()
+    if pos < len(template):
+        literal = template[pos:]
+        pieces.append((literal, None, None))
+        width += len(literal)
+
+    if width == 0:
+        return np.zeros(shape, dtype="U1")
+
+    # Write each piece into its slice of a single code-point buffer, then
+    # reinterpret the rows as fixed-width unicode strings.
+    buf = np.empty(shape + (width,), dtype=np.uint32)
+    col = 0
+    for value, value_width, signed in pieces:
+        if value_width is None:  # literal text
+            buf[..., col : col + len(value)] = [ord(char) for char in value]
+            col += len(value)
+        else:
+            _write_decimal(buf[..., col : col + value_width], value, value_width, signed)
+            col += value_width
+
+    return buf.view(f"U{width}").reshape(shape)
+
+
 class TimeString(TimeUnique):
     """
     Base class for string-like time representations.
@@ -1804,62 +1927,6 @@ class TimeString(TimeUnique):
         """
         return str_fmt.format(**kwargs)
 
-    @staticmethod
-    def _field_width(spec, values):
-        """Fixed character width of an integer format ``spec`` over ``values``.
-
-        Returns ``(width, signed)``, or ``(None, None)`` when the field cannot
-        be built as a fixed-width column (e.g. a bare ``d`` whose values do not
-        all have the same number of digits), signalling that the caller should
-        fall back to formatting element by element.
-
-        Parameters
-        ----------
-        spec : str
-            The format spec portion of a ``{name:spec}`` replacement field,
-            e.g. ``"d"``, ``"02d"``, or ``"+06d"``.
-        values : ndarray of int
-            The integer values that will be formatted under this spec.
-
-        Returns
-        -------
-        width : int or None
-            Fixed character width of the field, or ``None`` if the field
-            cannot be rendered at a uniform width by this function.
-        signed : bool or None
-            ``True`` if the first character is an explicit ``'+'``/``'-'``
-            sign, ``False`` if the field is unsigned, or ``None`` when
-            ``width`` is ``None``.
-        """
-        match = _INT_SPEC.fullmatch(spec)
-        if match is None:
-            return None, None
-        sign, zero, digits = match.group(1, 2, 3)
-        if digits:
-            # We build columns by zero-padding, so a fixed width without the
-            # "0" flag (which pads with spaces) is left to the per-element path.
-            # And "real" formatting widens the field when a value does not fit,
-            # so a value needing more characters than ``width`` would be silently
-            # truncated in our fixed-width column; fall back in that (rare) case
-            # too -- e.g. a year past 9999 in the signed FITS ``{year:+06d}``.
-            width = int(digits)
-            signed = sign == "+"
-            fits = zero
-            if zero and values.size:
-                n_sign = 1 if signed or int(values.min()) < 0 else 0
-                fits = len(str(int(np.abs(values).max()))) + n_sign <= width
-            return (width, signed) if fits else (None, None)
-        # A bare "d" has no field width, so the width follows the values and we
-        # can only pre-size the column if they share a digit count and need no
-        # sign (a forced "+" or a negative value would make the width vary too).
-        if values.size == 0:
-            return 1, False
-        low = int(values.min())
-        lo = len(str(low))
-        hi = len(str(int(values.max())))
-        if sign or low < 0 or lo != hi:
-            return None, None
-        return hi, False
 
     def _value_fast(self, str_fmt):
         """Build the output strings for ``str_fmt`` with array operations.
@@ -1898,45 +1965,7 @@ class TimeString(TimeUnique):
         if "{yday:" in str_fmt:
             fields["yday"] = _day_of_year(fields["year"], fields["mon"], fields["day"])
 
-        # Split the template into literal text and replacement fields, recording
-        # the fixed width of each piece so the whole row fits one buffer.
-        pieces = []
-        width = 0
-        pos = 0
-        for match in _SUBFMT_FIELD.finditer(str_fmt):
-            if match.start() > pos:
-                literal = str_fmt[pos : match.start()]
-                pieces.append((literal, None, None))
-                width += len(literal)
-            name, spec = match.group(1, 2)
-            if name not in fields:
-                return None
-            field_width, signed = self._field_width(spec, fields[name])
-            if field_width is None:
-                return None
-            pieces.append((fields[name], field_width, signed))
-            width += field_width
-            pos = match.end()
-        if pos < len(str_fmt):
-            literal = str_fmt[pos:]
-            pieces.append((literal, None, None))
-            width += len(literal)
-
-        # Write each piece into its slice of a single code-point buffer, then
-        # reinterpret the rows as fixed-width unicode strings.
-        buf = np.empty(fields["year"].shape + (width,), dtype=np.uint32)
-        col = 0
-        for value, field_width, signed in pieces:
-            if field_width is None:  # literal text
-                buf[..., col : col + len(value)] = [ord(char) for char in value]
-                col += len(value)
-            else:
-                _write_decimal(
-                    buf[..., col : col + field_width], value, field_width, signed
-                )
-                col += field_width
-
-        return buf.view(f"U{width}").reshape(self.jd1.shape)
+        return _format_template(str_fmt, fields, self.jd1.shape)
 
     @property
     def value(self):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1044,26 +1044,28 @@ class TestSubFormat:
 
     def test_string_field_width(self):
         """Integer specs that can/can't be built as a fixed-width column."""
+        from astropy.time.formats import _field_width
+
         vals = np.array([2003, 2004])
         # Specs used by the built-in templates take the fast path when the
         # values fit in the field.
-        assert TimeString._field_width("d", vals) == (4, False)
-        assert TimeString._field_width("02d", np.array([1, 12])) == (2, False)
-        assert TimeString._field_width("+06d", vals) == (6, True)
-        assert TimeString._field_width("d", np.array([], dtype=int)) == (1, False)
+        assert _field_width("d", vals) == (4, False)
+        assert _field_width("02d", np.array([1, 12])) == (2, False)
+        assert _field_width("+06d", vals) == (6, True)
+        assert _field_width("d", np.array([], dtype=int)) == (1, False)
         # Anything we would format wrongly by zero-padding is left to the loop:
         # space padding, a bare width that varies, negatives, or a sign with no
         # width, as well as non-integer specs.
-        assert TimeString._field_width("6d", vals) == (None, None)
-        assert TimeString._field_width("d", np.array([99, 2003])) == (None, None)
-        assert TimeString._field_width("d", np.array([-5, 5])) == (None, None)
-        assert TimeString._field_width("+d", vals) == (None, None)
-        assert TimeString._field_width(".3f", vals) == (None, None)
+        assert _field_width("6d", vals) == (None, None)
+        assert _field_width("d", np.array([99, 2003])) == (None, None)
+        assert _field_width("d", np.array([-5, 5])) == (None, None)
+        assert _field_width("+d", vals) == (None, None)
+        assert _field_width(".3f", vals) == (None, None)
         # A value too wide for its zero-padded field would be truncated, so it
         # falls back too rather than silently dropping digits.
-        assert TimeString._field_width("02d", np.array([1, 100])) == (None, None)
-        assert TimeString._field_width("04d", np.array([12345])) == (None, None)
-        assert TimeString._field_width("+06d", np.array([100002])) == (None, None)
+        assert _field_width("02d", np.array([1, 100])) == (None, None)
+        assert _field_width("04d", np.array([12345])) == (None, None)
+        assert _field_width("+06d", np.array([100002])) == (None, None)
 
     def test_string_fits_very_large_years(self, monkeypatch):
         """A year too wide for the FITS ``+06d`` field falls back and stays correct."""

--- a/docs/changes/coordinates/20130.perf.rst
+++ b/docs/changes/coordinates/20130.perf.rst
@@ -1,0 +1,6 @@
+``Angle.to_string`` (and hence ``Longitude``, ``Latitude`` and
+``SkyCoord.to_string``) now builds sexagesimal strings with array operations
+instead of a Python loop over the elements. This makes it roughly ten times
+faster for large arrays, and ``SkyCoord.to_string`` faster still since it no
+longer formats the two angles one element at a time. This speeds up printing
+coordinates and writing them to a text table.

--- a/docs/whatsnew/8.1.rst
+++ b/docs/whatsnew/8.1.rst
@@ -14,6 +14,7 @@ In particular, this release includes:
 
 * :ref:`whatsnew-8.1-time-string-formats`
 * :ref:`whatsnew-8.1-faster-table-joins`
+* :ref:`whatsnew-8.1-angle-to-string`
 
 In addition to these major changes, Astropy v8.1 includes a large number of
 smaller improvements and bug fixes, which are described in the :ref:`changelog`.
@@ -58,6 +59,20 @@ if it is available and otherwise falls back to the built-in astropy join impleme
 
 In addition, the built-in astropy join was sped up by a factor of ~2x for the common
 case of a single join column.
+
+.. _whatsnew-8.1-angle-to-string:
+
+Faster Angle and SkyCoord string formatting
+===========================================
+
+Formatting an :class:`~astropy.coordinates.Angle` (and therefore a
+:class:`~astropy.coordinates.Longitude`, :class:`~astropy.coordinates.Latitude`
+or :class:`~astropy.coordinates.SkyCoord`) into a sexagesimal string with
+:meth:`~astropy.coordinates.Angle.to_string` now assembles the strings with
+array operations rather than looping over the elements. For large arrays this
+is roughly ten times faster, and :meth:`~astropy.coordinates.SkyCoord.to_string`
+is faster still since it no longer formats the coordinates one at a time. This
+noticeably speeds up printing catalogues and writing them to text tables.
 
 Contributors to the 8.1 release
 ===============================

--- a/docs/whatsnew/8.1.rst
+++ b/docs/whatsnew/8.1.rst
@@ -14,6 +14,7 @@ In particular, this release includes:
 
 * :ref:`whatsnew-8.1-time-string-formats`
 * :ref:`whatsnew-8.1-faster-table-joins`
+* :ref:`whatsnew-8.1-angle-to-string`
 * :ref:`whatsnew-8.1-quantity-int-config`
 * :ref:`whatsnew-8.1-qtable-int-columns`
 * :ref:`whatsnew-8.1-reading-int-columns`
@@ -61,6 +62,20 @@ if it is available and otherwise falls back to the built-in astropy join impleme
 
 In addition, the built-in astropy join was sped up by a factor of ~2x for the common
 case of a single join column.
+
+.. _whatsnew-8.1-angle-to-string:
+
+Faster Angle and SkyCoord string formatting
+===========================================
+
+Formatting an :class:`~astropy.coordinates.Angle` (and therefore a
+:class:`~astropy.coordinates.Longitude`, :class:`~astropy.coordinates.Latitude`
+or :class:`~astropy.coordinates.SkyCoord`) into a sexagesimal string with
+:meth:`~astropy.coordinates.Angle.to_string` now assembles the strings with
+array operations rather than looping over the elements. For large arrays this
+is roughly ten times faster, and :meth:`~astropy.coordinates.SkyCoord.to_string`
+is faster still since it no longer formats the coordinates one at a time. This
+noticeably speeds up printing catalogues and writing them to text tables.
 
 .. _whatsnew-8.1-quantity-int-config:
 


### PR DESCRIPTION
Fixes #19992.

`Angle.to_string` formats each element with a Python loop
(`np.vectorize(do_format)` calling `_decimal_to_sexagesimal_string`), so every
value pays the full Python overhead even though the underlying arithmetic in
`_decimal_to_sexagesimal` is already vectorized. This is the coordinates
analogue of the `Time` string work in #19942, and following @mhvk's suggestion
on the issue I reused the same approach here.

### What this does

- Adds `_decimal_to_sexagesimal_string_array`, which builds the whole array of
  sexagesimal strings with NumPy string operations. The integer degree and
  minute fields are written with a small fixed-width code-point buffer (reusing
  `_write_decimal` from `astropy.time.formats`), and the fractional seconds go
  through `np.strings.mod` so the rounding matches the per-element output
  exactly. It returns `None` for the cases it cannot handle (NumPy < 2.1, where
  `np.strings.zfill` is buggy, and degrees too large for `int64`), so
  `Angle.to_string` transparently falls back to the existing per-element path.
- `Angle.to_string` takes the fast path only above a handful of elements, since
  the vectorized version has a fixed setup cost; scalars and tiny arrays keep
  using the plain loop.
- `SkyCoord.to_string` no longer loops over the coordinates calling
  `Angle.to_string` on each scalar; it formats both angles for the whole array
  at once and joins them, keeping the previous return types (a list for 1-D
  input, an array for higher dimensions).

### Benchmarks

On NumPy 2.4.6, for 1,000,000 elements:

| call | before | after |
| --- | --- | --- |
| `Angle.to_string(sep="dms")` | ~4.25 s | ~0.43 s |
| `SkyCoord.to_string("hmsdms")` | ~23 s | ~0.9 s |

### Correctness

The output is identical to the per-element formatting. Added tests compare
`to_string` against the per-element path (disabled with a monkeypatch) over a
spread of separators, padding, field counts, precisions, signs and formats,
including `NaN` and the infinities; test `_decimal_to_sexagesimal_string_array`
directly against the scalar formatter; and check that out-of-range degrees and
old NumPy fall back correctly. `SkyCoord.to_string` is checked against
per-element output for the `decimal`, `dms` and `hmsdms` styles.

Changelog and a What's New entry are included.
