### PR TITLE
MNT: fix duplicated word in ASCII writer error message

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -56,7 +56,7 @@ def _check_multidim_table(table: Table, max_ndim: int | None) -> None:
     if nd_names:
         raise ValueError(
             f"column(s) with dimension > {max_ndim} "
-            "cannot be be written with this format, try using 'ecsv' "
+            "cannot be written with this format, try using 'ecsv' "
             "(Enhanced CSV) format"
         )
 


### PR DESCRIPTION
### Description

The `ValueError` raised by `_check_multidim_table` in `astropy/io/ascii/core.py` contains a duplicated word ("be be"):

```
ValueError: column(s) with dimension > 1 cannot be be written with this format, try using 'ecsv' (Enhanced CSV) format
```

This is user-facing output. It is raised whenever a table with a multidimensional column is written with a format that does not support one, so it is reachable from `ascii.basic` (and the other fast writers), `ascii.ipac`, and `ascii.qdp`.

This PR removes the duplicated "be". No behaviour change.

I noticed it while reading the traceback in #11148.

### Reproduction (astropy 8.0.1)

```python
import io
import numpy as np
from astropy.table import Table, Column

t = Table([Column(np.ones(3, dtype=("f", (2,))), name="R")])

for fmt in ["ascii.basic", "ascii.ipac", "ascii.qdp"]:
    try:
        t.write(io.StringIO(), format=fmt)
    except ValueError as e:
        print(f"{fmt:14s} -> {e}")
```

Before:

```
ascii.basic    -> column(s) with dimension > 1 cannot be be written with this format, try using 'ecsv' (Enhanced CSV) format
ascii.ipac     -> column(s) with dimension > 1 cannot be be written with this format, try using 'ecsv' (Enhanced CSV) format
ascii.qdp      -> column(s) with dimension > 1 cannot be be written with this format, try using 'ecsv' (Enhanced CSV) format
```

After:

```
ascii.basic    -> column(s) with dimension > 1 cannot be written with this format, try using 'ecsv' (Enhanced CSV) format
ascii.ipac     -> column(s) with dimension > 1 cannot be written with this format, try using 'ecsv' (Enhanced CSV) format
ascii.qdp      -> column(s) with dimension > 1 cannot be written with this format, try using 'ecsv' (Enhanced CSV) format
```

### Testing

No test asserts on this message — I checked the full string, the partial string, and all five call sites of `_check_multidim_table` (`core.py`, `fastbasic.py`, `html.py`, `ipac.py`, `qdp.py`).

`astropy.io.ascii` passes with the change applied:

```
1140 passed, 32 skipped, 4 xfailed in 46.66s
```

### Changelog

I have not added a changelog fragment, since this is a minor text fix with no user-visible behaviour change. Happy to add one, or to have the `no-changelog-entry-needed` label applied, whichever you prefer.
