### PR TITLE
MNT: fix duplicated words in two user-facing strings

### DIFF
--- a/astropy/coordinates/representation/base.py
+++ b/astropy/coordinates/representation/base.py
@@ -153,7 +153,7 @@ class BaseRepresentationOrDifferential(MaskableShapedLikeNDArray):
     """Name of the representation or differential.
 
     When a subclass is defined, by default, the name is the lower-cased name of the
-    class with with any trailing 'representation' or 'differential' removed. (E.g.,
+    class with any trailing 'representation' or 'differential' removed. (E.g.,
     'spherical' for `~astropy.coordinates.SphericalRepresentation` or
     `~astropy.coordinates.SphericalDifferential`.)
 

--- a/astropy/uncertainty/distributions.py
+++ b/astropy/uncertainty/distributions.py
@@ -61,7 +61,7 @@ def normal(
         if std is None:
             std = np.asanyarray(ivar) ** -0.5
         else:
-            raise ValueError("normal cannot take both ivar and and std or var")
+            raise ValueError("normal cannot take both ivar and std or var")
     if std is None:
         raise ValueError("normal requires one of std, var, or ivar")
     else:


### PR DESCRIPTION
### Description

Two duplicated words in user-facing text.

**1. `astropy/uncertainty/distributions.py`, the `normal()` error message**

```python
raise ValueError("normal cannot take both ivar and and std or var")
```

Besides the repeated "and", the extra word makes the sentence hard to parse, since "and and std" reads as though a keyword named `and` were involved. The neighbouring message four lines above uses the plainer phrasing this one was presumably meant to follow:

```python
raise ValueError("normal cannot take both std and var")
```

It is reachable from any call passing `ivar` together with `std` or `var`:

```python
>>> from astropy.uncertainty import normal
>>> normal(1.0, n_samples=10, ivar=1.0, std=1.0)
ValueError: normal cannot take both ivar and and std or var
>>> normal(1.0, n_samples=10, ivar=1.0, var=1.0)
ValueError: normal cannot take both ivar and and std or var
```

After:

```
ValueError: normal cannot take both ivar and std or var
```

**2. `astropy/coordinates/representation/base.py`, the `name` attribute docstring**

> the lower-cased name of the class with with any trailing 'representation' or 'differential' removed

This one renders in the API docs for every representation and differential class.

### Testing

Neither string is asserted on anywhere in the test suite (checked both, plus `cannot take both`).

With both changes applied:

```
astropy.uncertainty + astropy.coordinates
2109 passed, 65 skipped, 10 xfailed in 48.40s
```

### Changelog

No fragment added, since neither change affects behaviour. Happy to add one, or to have the `no-changelog-entry-needed` label applied, whichever you prefer.

I found these by scanning string literals for repeated words, which is also how I found the one in #20146. Kept separate from that PR since it touches different subpackages.
