### PR TITLE
Preserve mask when assigning a masked Time into an unmasked one

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1208,11 +1208,7 @@ class TimeBase(MaskableShapedLikeNDArray):
         # when nan was used internally to indicate a value was masked.
         # So this is just for backwards compatibility; we do not want to extend it.
         if value is np.ma.masked or value is np.nan:  # noqa: PLW0177, RUF100
-            if not isinstance(self._time.jd2, Masked):
-                self._time.jd1 = Masked(self._time.jd1, copy=False)
-                self._time.jd2 = Masked(
-                    self._time.jd2, mask=self._time.jd1.mask, copy=False
-                )
+            self._time._convert_to_masked()
             self._time.jd2.mask[item] = True
             return
 
@@ -1230,13 +1226,8 @@ class TimeBase(MaskableShapedLikeNDArray):
         # If the value carries a mask but we do not, we have to upgrade our
         # internal jd1/jd2 to Masked first, otherwise the mask of the value
         # would be silently dropped (gh-20173).
-        if not isinstance(self._time.jd2, Masked) and isinstance(
-            value._time.jd2, Masked
-        ):
-            self._time.jd1 = Masked(self._time.jd1, copy=False)
-            self._time.jd2 = Masked(
-                self._time.jd2, mask=self._time.jd1.mask, copy=False
-            )
+        if isinstance(value._time.jd2, Masked):
+            self._time._convert_to_masked()
 
         self._time.jd1[item] = value._time.jd1
         self._time.jd2[item] = value._time.jd2

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1208,7 +1208,7 @@ class TimeBase(MaskableShapedLikeNDArray):
         # when nan was used internally to indicate a value was masked.
         # So this is just for backwards compatibility; we do not want to extend it.
         if value is np.ma.masked or value is np.nan:  # noqa: PLW0177, RUF100
-            self._time._convert_to_masked()
+            self._time._ensure_masked()
             self._time.jd2.mask[item] = True
             return
 
@@ -1226,8 +1226,8 @@ class TimeBase(MaskableShapedLikeNDArray):
         # If the value carries a mask but we do not, we have to upgrade our
         # internal jd1/jd2 to Masked first, otherwise the mask of the value
         # would be silently dropped (gh-20173).
-        if isinstance(value._time.jd2, Masked):
-            self._time._convert_to_masked()
+        if value.masked:
+            self._time._ensure_masked()
 
         self._time.jd1[item] = value._time.jd1
         self._time.jd2[item] = value._time.jd2

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1226,6 +1226,18 @@ class TimeBase(MaskableShapedLikeNDArray):
         # Finally directly set the jd1/2 values.  Locations are known to match.
         if self.scale is not None:
             value = getattr(value, self.scale)
+
+        # If the value carries a mask but we do not, we have to upgrade our
+        # internal jd1/jd2 to Masked first, otherwise the mask of the value
+        # would be silently dropped (gh-20173).
+        if not isinstance(self._time.jd2, Masked) and isinstance(
+            value._time.jd2, Masked
+        ):
+            self._time.jd1 = Masked(self._time.jd1, copy=False)
+            self._time.jd2 = Masked(
+                self._time.jd2, mask=self._time.jd1.mask, copy=False
+            )
+
         self._time.jd1[item] = value._time.jd1
         self._time.jd2[item] = value._time.jd2
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -246,6 +246,16 @@ class TimeFormat:
         if self._jd1 is not None:
             self._jd1, self._jd2 = _broadcast_writeable(self._jd1, self._jd2)
 
+    def _convert_to_masked(self):
+        """Ensure that jd1 and jd2 are `~astropy.utils.masked.Masked` arrays.
+
+        The two share the same (initially all-`False`) mask.  This is a no-op if
+        the values are masked already.
+        """
+        if not isinstance(self.jd2, Masked):
+            self.jd1 = Masked(self.jd1, copy=False)
+            self.jd2 = Masked(self.jd2, mask=self.jd1.mask, copy=False)
+
     @classmethod
     @functools.cache
     def fill_value(cls, subfmt):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -246,7 +246,7 @@ class TimeFormat:
         if self._jd1 is not None:
             self._jd1, self._jd2 = _broadcast_writeable(self._jd1, self._jd2)
 
-    def _convert_to_masked(self):
+    def _ensure_masked(self):
         """Ensure that jd1 and jd2 are `~astropy.utils.masked.Masked` arrays.
 
         The two share the same (initially all-`False`) mask.  This is a no-op if

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -143,8 +143,9 @@ def test_setitem_masked_value():
 
     # An unmasked value must not clear an existing mask elsewhere, and
     # assigning over a masked element unmasks it again.
+    t[0] = np.ma.masked
     t[1:] = Time(["2002:001", "2002:002"])
-    assert np.all(t.mask == [False, False, False])
+    assert np.all(t.mask == [True, False, False])
 
 
 def test_vstack_masked():
@@ -160,8 +161,8 @@ def test_vstack_masked():
     combined = vstack([t1, t2])
     assert combined["time"].masked
     assert np.all(combined["time"].mask == [False, True, True, False])
-    assert combined["time"].unmasked[0] == t1["time"].unmasked[0]
-    assert combined["time"].unmasked[3] == t2["time"].unmasked[1]
+    assert np.all(combined["time"].unmasked[:2] == t1["time"].unmasked)
+    assert np.all(combined["time"].unmasked[2:] == t2["time"].unmasked)
 
 
 def test_str():

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -7,7 +7,7 @@ import pytest
 
 from astropy import units as u
 from astropy.coordinates import EarthLocation
-from astropy.table import Table
+from astropy.table import QTable, Table, vstack
 from astropy.time import Time, conf
 from astropy.utils import iers
 from astropy.utils.compat.optional_deps import HAS_H5PY
@@ -117,6 +117,51 @@ def test_mask_not_writeable():
     assert np.all(t.mask == [True, True])
     # Check that the mask remains shared.
     assert np.may_share_memory(t._time.jd1.mask, t._time.jd2.mask)
+
+
+def test_setitem_masked_value():
+    # Regression test for gh-20173: assigning a masked Time into an unmasked
+    # one silently dropped the mask, revealing the underlying value again.
+    t = Time(["2000:001", "2000:002", "2000:003"])
+    assert not t.masked
+
+    value = Time(["2001:001", "2001:002"])
+    value[1] = np.ma.masked
+
+    t[:2] = value
+    assert t.masked
+    assert np.all(t.mask == [False, True, False])
+    assert t.unmasked[0] == Time("2001:001")
+    assert t.unmasked[2] == Time("2000:003")
+    # jd1 and jd2 should share the mask, like they do elsewhere.
+    assert np.may_share_memory(t._time.jd1.mask, t._time.jd2.mask)
+
+    # Scalar assignment of a masked element should mask the target too.
+    t2 = Time(["2000:001", "2000:002"])
+    t2[0] = value[1]
+    assert np.all(t2.mask == [True, False])
+
+    # An unmasked value must not clear an existing mask elsewhere, and
+    # assigning over a masked element unmasks it again.
+    t[1:] = Time(["2002:001", "2002:002"])
+    assert np.all(t.mask == [False, False, False])
+
+
+def test_vstack_masked():
+    # Regression test for gh-20173: vstack dropped the mask of Time columns.
+    t1 = QTable()
+    t1["time"] = Time(["2024-01-01T01:00:00", "2024-01-01T02:00:00"])
+    t1["time"][1] = np.ma.masked
+
+    t2 = QTable()
+    t2["time"] = Time(["2024-01-02T03:00:00", "2024-01-02T04:00:00"])
+    t2["time"][0] = np.ma.masked
+
+    combined = vstack([t1, t2])
+    assert combined["time"].masked
+    assert np.all(combined["time"].mask == [False, True, True, False])
+    assert combined["time"].unmasked[0] == t1["time"].unmasked[0]
+    assert combined["time"].unmasked[3] == t2["time"].unmasked[1]
 
 
 def test_str():

--- a/docs/changes/time/20178.bugfix.rst
+++ b/docs/changes/time/20178.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``Time.__setitem__`` silently dropping the mask when a masked ``Time`` was
+assigned into an unmasked one. As a result, ``vstack`` no longer loses the mask
+on ``Time`` mixin columns.


### PR DESCRIPTION
### Description

Fixes #20173.

`vstack` was silently dropping the mask on `Time` mixin columns, but the root cause turned out to sit one level down, in `Time.__setitem__`.

The tail of `__setitem__` writes the value's `jd1`/`jd2` straight into the target's arrays:

```python
self._time.jd1[item] = value._time.jd1
self._time.jd2[item] = value._time.jd2
```

If the target `Time` is not masked yet, those are plain ndarrays. Assigning a `MaskedNDArray` into a plain ndarray keeps the data and throws the mask away, so the masked entries come back as their underlying (pre-mask) values with no error or warning.

That is exactly the path `vstack` takes. `_vstack` builds the output column with `TimeInfo.new_like`, which allocates `jd1 = np.full(shape, jd2000)` / `jd2 = np.zeros(shape)` — deliberately unmasked, since it is meant to be filled in place — and then fills it with `col[idx0:idx1] = array[name]`. The first assignment silently loses the mask.

Worth noting `join` and `hstack` are unaffected: they index the source column directly (`array[name][array_out]`) instead of round-tripping through `new_like` + setitem, so their masks survive. That is why this only showed up in `vstack`.

The fix upgrades `jd1`/`jd2` to `Masked` before the assignment when the incoming value is masked and we are not. This mirrors what the `value is np.ma.masked` branch a few lines above already does, and reuses the same `mask=self._time.jd1.mask` sharing so `jd1` and `jd2` keep a common mask.

I put the fix in `__setitem__` rather than in `new_like` or `_vstack` on purpose. Making `new_like` always return a masked `Time` would force a mask onto every join/vstack output whether or not anything is masked, and patching `_vstack` alone would leave the underlying setitem hole open — plain `t[:2] = masked_time` loses the mask too, independent of tables:

```python
t = Time(["2000:001", "2000:002", "2000:003"])
value = Time(["2001:001", "2001:002"])
value[1] = np.ma.masked
t[:2] = value
t.mask  # [False, False, False] before, [False, True, False] after
```

Unmasking still behaves as before — assigning an unmasked value over a masked element clears that element's mask, and the existing `np.ma.nomask` branch is untouched.

### How was this tested?

Two regression tests in `astropy/time/tests/test_mask.py`: `test_setitem_masked_value` covers the setitem behaviour directly (slice assignment, scalar assignment of a masked element, shared `jd1`/`jd2` mask, and that unmasking still works), and `test_vstack_masked` is the reporter's scenario from the issue.

Both fail on `main` and pass with the fix:

```
$ python -m pytest astropy/time/tests/test_mask.py::test_setitem_masked_value \
                   astropy/time/tests/test_mask.py::test_vstack_masked -q
# before: 2 failed  (assert t.masked -> AssertionError: assert False)
# after:  2 passed
```

The reproducer in the issue now prints the expected output:

```
combined mask: [False  True  True False]
```

Full suites, no regressions:

```
$ python -m pytest astropy/time/       1002 passed, 30 skipped, 9 xfailed
$ python -m pytest astropy/table/      2407 passed, 189 skipped, 14 xfailed
$ python -m pytest astropy/utils/masked/ astropy/timeseries/ astropy/io/misc/
                                       3845 passed, 269 skipped, 2 xfailed
```

Lint with the pinned ruff (`v0.15.20` from `.pre-commit-config.yaml`):

```
$ ruff check astropy/time/core.py astropy/time/tests/test_mask.py
All checks passed!
$ ruff format --check astropy/time/core.py astropy/time/tests/test_mask.py
2 files already formatted
```

I'll add the changelog fragment once this has a PR number.
