### PR TITLE
PERF: use scaler class instead of lambda for unit scale conversions

### DIFF
--- a/astropy/units/_scaler/__init__.py
+++ b/astropy/units/_scaler/__init__.py
@@ -1,0 +1,3 @@
+from .scaler import Scaler
+
+__all__ = ["Scaler"]

--- a/astropy/units/_scaler/setup_package.py
+++ b/astropy/units/_scaler/setup_package.py
@@ -1,0 +1,30 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Copied from astropy/convolution/setup_package.py
+
+import os
+
+from numpy import get_include as get_numpy_include
+from setuptools import Extension
+
+C_SCALER_PKGDIR = os.path.relpath(os.path.dirname(__file__))
+
+SRC_FILES = [os.path.join(C_SCALER_PKGDIR, filename) for filename in ["src/scaler.c"]]
+INCLUDE_FILES = [
+    os.path.join(C_SCALER_PKGDIR, filename)
+    for filename in ["src/scaler_limited_api_workarounds.h"]
+]
+
+
+def get_extensions():
+    # Add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
+    # to report missed optimizations
+    _scaler_ext = Extension(
+        name="astropy.units._scaler.scaler",
+        sources=SRC_FILES,
+        depends=INCLUDE_FILES,
+        include_dirs=[get_numpy_include()],
+        language="c",
+    )
+
+    return [_scaler_ext]

--- a/astropy/units/_scaler/src/scaler.c
+++ b/astropy/units/_scaler/src/scaler.c
@@ -304,8 +304,9 @@ static void Scaler_dealloc(PyObject *self)
 {
     PyObject_GC_UnTrack(self);
     Scaler_clear(self);
+    PyTypeObject *type = Py_TYPE(self);
     PyObject_GC_Del(self);
-    Py_DECREF(Py_TYPE(self));
+    Py_DECREF(type);
 }
 
 static PyObject *Scaler_repr(PyObject *self)

--- a/astropy/units/_scaler/src/scaler.c
+++ b/astropy/units/_scaler/src/scaler.c
@@ -249,7 +249,7 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     double factor;
     Py_ssize_t nargs = PyTuple_Size(args);
-    if (nargs != 1 || kwds != NULL) {
+    if (nargs != 1 || (kwds != NULL && PyDict_Size(kwds) > 0)) {
         // Use parser to give error message.
         char *kwlist[] = {"", NULL};
         PyArg_ParseTupleAndKeywords(args, kwds, "d:Scaler", kwlist, &factor);

--- a/astropy/units/_scaler/src/scaler.c
+++ b/astropy/units/_scaler/src/scaler.c
@@ -26,7 +26,7 @@ typedef struct {
     PyObject *unity_scaler; // Singleton for scale=1.0
     PyObject *np_multiply;  // Reference to multiply, for holding on to loops.
     // Float and double multiply loops, filled in on initialization.
-    PyUFuncGenericFunction loops[2];
+    PyUFuncGenericFunction loops[6];
 } scaler_state;
 
 // Forward definition.
@@ -36,7 +36,9 @@ typedef struct {
     PyObject_HEAD
     vectorcallfunc vectorcall;
     double factor;
+    double factor_imag; // So factor can be treated as complex; always 0.
     float factor_f;
+    float factor_f_imag;
     PyObject *O_factor;
     PyObject *A_factor;
     PyObject *A_factor_f;
@@ -68,20 +70,9 @@ static inline PyObject *use_contiguous_loop(PyObject *self, PyArrayObject *arr, 
     if (n == 0) {
         return (PyObject *)res; // Nothing to do.
     }
-    PyUFuncGenericFunction loop;
-    npy_intp strides[3];
+    PyUFuncGenericFunction loop = state->loops[type_num - NPY_FLOAT];
+    npy_intp strides[3] = {PyArray_ITEMSIZE(arr), 0, PyArray_ITEMSIZE(res)};
     char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA(res)};
-    if (type_num == NPY_DOUBLE || type_num == NPY_FLOAT) {
-        strides[0] = PyArray_ITEMSIZE(arr);
-        loop = state->loops[type_num - NPY_FLOAT];
-    }
-    else { // For complex, with real factor, we can use real loop.
-        strides[0] = PyArray_ITEMSIZE(arr) / 2;
-        n *= 2;
-        loop = state->loops[type_num - NPY_CFLOAT];
-    }
-    strides[1] = 0;
-    strides[2] = strides[0];
     PyUFunc_clearfperr();
     NPY_BEGIN_THREADS_DEF;
     NPY_BEGIN_THREADS_THRESHOLDED(n);
@@ -136,31 +127,38 @@ static PyObject *Scaler_vectorcall(
     if (PyFloat_CheckExact(obj)) {
         return PyFloat_FromDouble(PyFloat_AsDouble(obj) * scaler->factor);
     }
-    // Fast path for plain ndarray, with special care for contiguous data.
+    // Fast path for plain real or complex ndarray, with special care for contiguous data.
     if (PyArray_CheckExact(obj)) {
         PyArrayObject *const arr = (PyArrayObject *)obj;
+        PyObject *O_factor; // becomes A_factor or O_factor in slow paths.
         const int type_num = PyArray_TYPE(arr);
         npy_bool needs_float = type_num == NPY_FLOAT || type_num == NPY_CFLOAT;
         npy_bool supported_fast_type =
             (needs_float || type_num == NPY_DOUBLE || type_num == NPY_CDOUBLE);
-        char *f_ptr = needs_float ? (char *)&scaler->factor_f : (char *)&scaler->factor;
-        // Pass contiguous float or complex arrays directly to multiply loop,
-        // bypassing ufunc setup.
-        if (supported_fast_type && PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr)) {
-            return use_contiguous_loop(self, arr, f_ptr);
-        }
-        // If not, convert factor to array here, since that makes ufunc
-        // call substantially faster.  Use cached version if available.
-        PyObject **A_factor = needs_float ? &scaler->A_factor_f : &scaler->A_factor;
-        if (*A_factor == NULL) {
-            const npy_intp dims[1] = {0};
-            *A_factor =
-                PyArray_SimpleNewFromData(0, dims, needs_float ? NPY_FLOAT : NPY_DOUBLE, f_ptr);
-            if (*A_factor == NULL) {
-                return NULL;
+        if (supported_fast_type) {
+            char *f_ptr = needs_float ? (char *)&scaler->factor_f : (char *)&scaler->factor;
+            // Pass contiguous real or complex arrays directly to multiply loop,
+            // bypassing ufunc setup.
+            if (PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr) && PyArray_ISALIGNED(arr)) {
+                return use_contiguous_loop(self, arr, f_ptr);
             }
+            // If not, convert factor to array here, since that makes ufunc
+            // call substantially faster.  Use cached version if available.
+            PyObject **A_factor = needs_float ? &scaler->A_factor_f : &scaler->A_factor;
+            if (*A_factor == NULL) {
+                const npy_intp dims[1] = {0};
+                *A_factor =
+                    PyArray_SimpleNewFromData(0, dims, needs_float ? NPY_FLOAT : NPY_DOUBLE, f_ptr);
+            }
+            O_factor = *A_factor;
         }
-        return PyNumber_Multiply(obj, *A_factor);
+        else {
+            O_factor = get_o_factor(scaler);
+        }
+        if (O_factor == NULL) {
+            return NULL;
+        }
+        return PyNumber_Multiply(O_factor, obj);
     }
 // Fast paths for numpy double and float scalars; particularly useful for
 // float32, where it avoids double->float conversion.
@@ -200,8 +198,8 @@ static PyObject *Scaler_vectorcall(
     if (O_factor == NULL) {
         return NULL;
     }
-    // If a known type of object, like a subclass, or something that has
-    // a dtype or supports the Array API, just run multiply.
+    // If a known type of object, like an ndarray subclass, or something that
+    // has a dtype or supports the Array API, just run multiply.
     if (PyFloat_Check(obj) || PyComplex_Check(obj) || PyLong_Check(obj) || PyArray_Check(obj) ||
         PyObject_HasAttrString(obj, "dtype") ||
         PyObject_HasAttrString(obj, "__array_namespace__")) {
@@ -364,7 +362,7 @@ static PyMethodDef Scaler_methods[] = {
 };
 
 static PyType_Slot Scaler_slots[] = {
-    {Py_tp_doc, Scaler_doc},
+    {Py_tp_doc, (char *)Scaler_doc},
     {Py_tp_new, (newfunc)Scaler_new},
     {Py_tp_traverse, (traverseproc)Scaler_traverse},
     {Py_tp_clear, (inquiry)Scaler_clear},
@@ -403,7 +401,10 @@ static int get_multiply_loops(scaler_state *state)
     }
     // Unfortunately, new-style loops are not exposed, so get legacy ones.
     PyUFuncObject *multiply = (PyUFuncObject *)state->np_multiply;
-    for (int k = 0; k < 2; k++) {
+    for (int k = 0; k < 5; k++) {
+        if (k == 2) {
+            continue; // no support for long doubles (or complex)
+        }
         char type = (char)(k + NPY_FLOAT);
         const char *types = multiply->types;
         for (int i = 0; i < multiply->ntypes; i++) {
@@ -462,8 +463,9 @@ static int scaler_module_clear(PyObject *m)
     Py_CLEAR(state->Scaler);
     Py_CLEAR(state->unity_scaler);
     Py_CLEAR(state->np_multiply);
-    state->loops[0] = NULL;
-    state->loops[1] = NULL;
+    for (int k = 0; k < 6; k++) {
+        state->loops[k] = NULL;
+    }
     return 0;
 }
 

--- a/astropy/units/_scaler/src/scaler.c
+++ b/astropy/units/_scaler/src/scaler.c
@@ -1,5 +1,5 @@
-#define NPY_TARGET_VERSION NPY_2_0_API_VERSION // For PyUFunc_GiveFloatingpointErrors
-#define Py_LIMITED_API 0x030B0000
+// Licensed under a 3-clause BSD style license - see LICENSE.rst
+
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <numpy/arrayobject.h>
@@ -8,56 +8,7 @@
 #include <numpy/ufuncobject.h>
 #include <stddef.h> // for offsetof()
 
-// Once we're at 3.12, move SCALER_TP_FLAGS to its use, and remove this whole block.
-#if Py_LIMITED_API + 0 >= 0x030C0000
-#define SCALER_TP_FLAGS \
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE
-#else                     // work-arounds for python 3.11 limited API
-#include <structmember.h> // for PyMemberDef
-#define PyType_GetModuleByDef(type, unused) PyType_GetModule(type) // hence, cannot subclass
-#define vectorcallfunc void *
-#define Py_TPFLAGS_HAVE_VECTORCALL (1UL << 11)
-#define SCALER_TP_FLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC
-#ifndef Py_T_DOUBLE
-// Most of these are macros whose availability depends on which python we're compiling on,
-// but which do not influence support in different versions (tested by compiling on
-// 3.11 and running tests on 3.14 with the resulting .so file).
-// But more annoyingly, we also need to define our own PyVectorcall_Call;
-// Note that what is below is specific to our class; it cannot be used generally!
-#define Py_T_DOUBLE T_DOUBLE
-#define Py_READONLY READONLY
-#define Py_T_PYSSIZET T_PYSSIZET
-#define PY_VECTORCALL_ARGUMENTS_OFFSET (_Py_STATIC_CAST(size_t, 1) << (8 * sizeof(size_t) - 1))
-#define PyVectorcall_NARGS(nargsf) (Py_ssize_t)(nargsf & ~PY_VECTORCALL_ARGUMENTS_OFFSET)
-static PyObject *Scaler_vectorcall(
-    PyObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
-);
-static PyObject *PyVectorcall_Call(PyObject *self, PyObject *tuple, PyObject *dict)
-{
-    if (dict != NULL && PyDict_Size(dict) > 0) {
-        Py_ssize_t pos = 0;
-        PyObject *key, *value;
-        PyDict_Next(dict, &pos, &key, &value);
-        PyErr_Format(PyExc_TypeError, "scaler() got an unexpected keyword argument %R", key);
-        return NULL;
-    }
-    if (PyTuple_Size(tuple) != 1) {
-        PyErr_Format(
-            PyExc_TypeError,
-            "scaler() takes 1 positional argument but %d were given",
-            PyTuple_Size(tuple)
-        );
-        return NULL;
-    }
-    PyObject *args[1];
-    args[0] = PyTuple_GetItem(tuple, 0);
-    if (args[0] == NULL) {
-        return NULL;
-    }
-    return Scaler_vectorcall(self, args, 1, NULL);
-}
-#endif
-#endif
+#include "scaler_limited_api_workarounds.h"
 
 PyDoc_STRVAR(scaler_module_doc, "Compiled module providing the inspectable Scaler class.");
 PyDoc_STRVAR(
@@ -74,7 +25,7 @@ typedef struct {
     PyTypeObject *Scaler;   // The class
     PyObject *unity_scaler; // Singleton for scale=1.0
     PyObject *np_multiply;  // Reference to multiply, for holding on to loops.
-    // Double and float multiply loops, filled in on initialization.
+    // Float and double multiply loops, filled in on initialization.
     PyUFuncGenericFunction loops[2];
 } scaler_state;
 
@@ -302,7 +253,7 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     Py_ssize_t nargs = PyTuple_Size(args);
     if (nargs != 1 || kwds != NULL) {
         // Use parser to give error message.
-        char *const kwlist[] = {"", NULL};
+        char *kwlist[] = {"", NULL};
         PyArg_ParseTupleAndKeywords(args, kwds, "d:Scaler", kwlist, &factor);
         return NULL;
     }

--- a/astropy/units/_scaler/src/scaler.c
+++ b/astropy/units/_scaler/src/scaler.c
@@ -427,7 +427,7 @@ static PyType_Slot Scaler_slots[] = {
 };
 
 static PyType_Spec Scaler_spec = {
-    .name = "scaler.Scaler",
+    .name = "astropy.units._scaler.Scaler",
     .basicsize = sizeof(ScalerObject),
     .flags = SCALER_TP_FLAGS,
     .slots = Scaler_slots,

--- a/astropy/units/_scaler/src/scaler.c
+++ b/astropy/units/_scaler/src/scaler.c
@@ -91,12 +91,11 @@ static inline PyObject *use_contiguous_loop(PyObject *self, PyArrayObject *arr, 
 // Get the factor as a PyFloat, caching it as needed.
 static inline PyObject *get_o_factor(ScalerObject *scaler)
 {
+    Py_BEGIN_CRITICAL_SECTION(scaler);
     if (scaler->O_factor == NULL) {
         scaler->O_factor = PyFloat_FromDouble(scaler->factor);
-        if (scaler->O_factor == NULL) {
-            return NULL;
-        }
     }
+    Py_END_CRITICAL_SECTION();
     return scaler->O_factor;
 }
 
@@ -144,6 +143,7 @@ static PyObject *Scaler_vectorcall(
             }
             // If not, convert factor to array here, since that makes ufunc
             // call substantially faster.  Use cached version if available.
+            Py_BEGIN_CRITICAL_SECTION(scaler);
             PyObject **A_factor = needs_float ? &scaler->A_factor_f : &scaler->A_factor;
             if (*A_factor == NULL) {
                 const npy_intp dims[1] = {0};
@@ -151,6 +151,7 @@ static PyObject *Scaler_vectorcall(
                     PyArray_SimpleNewFromData(0, dims, needs_float ? NPY_FLOAT : NPY_DOUBLE, f_ptr);
             }
             O_factor = *A_factor;
+            Py_END_CRITICAL_SECTION();
         }
         else {
             O_factor = get_o_factor(scaler);
@@ -288,7 +289,7 @@ static int Scaler_traverse(PyObject *self, visitproc visit, void *arg)
     return 0;
 }
 
-// Clear internal references; called from finalize and dealloc.
+// Clear internal references; called from dealloc.
 static int Scaler_clear(PyObject *self)
 {
     ScalerObject *scaler = (ScalerObject *)self;
@@ -425,6 +426,9 @@ static int get_multiply_loops(scaler_state *state)
 static int scaler_module_exec(PyObject *m)
 {
     scaler_state *state = PyModule_GetState(m);
+    if (state == NULL) {
+        return -1;
+    }
     state->Scaler = (PyTypeObject *)PyType_FromModuleAndSpec(m, &Scaler_spec, NULL);
     if (state->Scaler == NULL) {
         return -1;

--- a/astropy/units/_scaler/src/scaler_limited_api_workarounds.h
+++ b/astropy/units/_scaler/src/scaler_limited_api_workarounds.h
@@ -1,0 +1,64 @@
+// Licensed under a 3-clause BSD style license - see LICENSE.rst
+#ifndef _SCALER_LIMITED_API_WORKAROUNDS_H
+#define _SCALER_LIMITED_API_WORKAROUNDS_H
+
+// Once we're at 3.13, move SCALER_TP_FLAGS to its use in scaler.c,
+// and remove this include file.
+#if defined(Py_LIMITED_API) && Py_LIMITED_API + 0 >= 0x030D0000
+#define SCALER_TP_FLAGS \
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE
+#else
+// PyType_GetModuleByDef is part of the limited API only since 3.13.
+// Its definition is rather long so we use a nearly good enough substitute,
+// the only downside of which is that one cannot subclass (hence the adjustment
+// to the flags). Not that important really, since it should not be needed
+// in normal use, but we might as well allow it once we can.
+#define PyType_GetModuleByDef(type, unused) PyType_GetModule(type)
+#define SCALER_TP_FLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC
+#endif // defined(Py_LIMITED_API) && Py_LIMITED_API + 0 >= 0x030D0000
+
+// Larger changes needed for python 3.11, with our without limited API.
+#if PY_VERSION_HEX < 0x030C0000
+#include <structmember.h> // For PyMemberDef, included by default only for >=3.12
+#define vectorcallfunc void *
+#define Py_TPFLAGS_HAVE_VECTORCALL (1UL << 11)
+#define Py_T_DOUBLE T_DOUBLE
+#define Py_READONLY READONLY
+#define Py_T_PYSSIZET T_PYSSIZET
+#define PY_VECTORCALL_ARGUMENTS_OFFSET (_Py_STATIC_CAST(size_t, 1) << (8 * sizeof(size_t) - 1))
+#define PyVectorcall_NARGS(nargsf) (Py_ssize_t)(nargsf & ~PY_VECTORCALL_ARGUMENTS_OFFSET)
+#ifdef Py_LIMITED_API
+// If python 3.11, PyVectorcall_Call was available only outside of limited API.
+// A simple substitution here that just calls our own vectorcall implementation
+// (hence the forward definition).
+static PyObject *Scaler_vectorcall(
+    PyObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
+);
+static PyObject *PyVectorcall_Call(PyObject *self, PyObject *tuple, PyObject *dict)
+{
+    if (dict != NULL && PyDict_Size(dict) > 0) {
+        Py_ssize_t pos = 0;
+        PyObject *key, *value;
+        PyDict_Next(dict, &pos, &key, &value);
+        PyErr_Format(PyExc_TypeError, "scaler() got an unexpected keyword argument %R", key);
+        return NULL;
+    }
+    if (PyTuple_Size(tuple) != 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "scaler() takes 1 positional argument but %d were given",
+            PyTuple_Size(tuple)
+        );
+        return NULL;
+    }
+    PyObject *args[1];
+    args[0] = PyTuple_GetItem(tuple, 0);
+    if (args[0] == NULL) {
+        return NULL;
+    }
+    return Scaler_vectorcall(self, args, 1, NULL);
+}
+#endif // Py_LIMITED_API
+#endif // Py_VERSION_HEX < 0x030C000
+
+#endif // _SCALER_PY311_WORKAROUNDS_H

--- a/astropy/units/_scaler/src/scaler_limited_api_workarounds.h
+++ b/astropy/units/_scaler/src/scaler_limited_api_workarounds.h
@@ -2,8 +2,14 @@
 #ifndef _SCALER_LIMITED_API_WORKAROUNDS_H
 #define _SCALER_LIMITED_API_WORKAROUNDS_H
 
-// Once we're at 3.13, move SCALER_TP_FLAGS to its use in scaler.c,
+// Once we're at 3.13, move SCALER_TP_FLAGS to its use in scaler.c
 // and remove this whole include file.
+
+#if PY_VERSION_HEX < 0x030D00B3
+#define Py_BEGIN_CRITICAL_SECTION(op) {
+#define Py_END_CRITICAL_SECTION() }
+#endif
+
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API + 0 >= 0x030D0000
 #define SCALER_TP_FLAGS \
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE

--- a/astropy/units/_scaler/src/scaler_limited_api_workarounds.h
+++ b/astropy/units/_scaler/src/scaler_limited_api_workarounds.h
@@ -3,34 +3,19 @@
 #define _SCALER_LIMITED_API_WORKAROUNDS_H
 
 // Once we're at 3.13, move SCALER_TP_FLAGS to its use in scaler.c,
-// and remove this include file.
-#if defined(Py_LIMITED_API) && Py_LIMITED_API + 0 >= 0x030D0000
+// and remove this whole include file.
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API + 0 >= 0x030D0000
 #define SCALER_TP_FLAGS \
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE
-#else
-// PyType_GetModuleByDef is part of the limited API only since 3.13.
-// Its definition is rather long so we use a nearly good enough substitute,
-// the only downside of which is that one cannot subclass (hence the adjustment
-// to the flags). Not that important really, since it should not be needed
-// in normal use, but we might as well allow it once we can.
-#define PyType_GetModuleByDef(type, unused) PyType_GetModule(type)
-#define SCALER_TP_FLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC
-#endif // defined(Py_LIMITED_API) && Py_LIMITED_API + 0 >= 0x030D0000
-
-// Larger changes needed for python 3.11, with our without limited API.
-#if PY_VERSION_HEX < 0x030C0000
-#include <structmember.h> // For PyMemberDef, included by default only for >=3.12
-#define vectorcallfunc void *
+#else // Limited API 3.12 or 3.11
+#if Py_LIMITED_API + 0 < 0x030C0000
+// Some vectorcall stuff was not yet part of the limited API in 3.11
+// Includes a simple substitution for PyVectorcall_Call that is specific
+// to our own vectorcall implementation (hence the forward definition).
 #define Py_TPFLAGS_HAVE_VECTORCALL (1UL << 11)
-#define Py_T_DOUBLE T_DOUBLE
-#define Py_READONLY READONLY
-#define Py_T_PYSSIZET T_PYSSIZET
 #define PY_VECTORCALL_ARGUMENTS_OFFSET (_Py_STATIC_CAST(size_t, 1) << (8 * sizeof(size_t) - 1))
 #define PyVectorcall_NARGS(nargsf) (Py_ssize_t)(nargsf & ~PY_VECTORCALL_ARGUMENTS_OFFSET)
-#ifdef Py_LIMITED_API
-// If python 3.11, PyVectorcall_Call was available only outside of limited API.
-// A simple substitution here that just calls our own vectorcall implementation
-// (hence the forward definition).
+#define vectorcallfunc void *
 static PyObject *Scaler_vectorcall(
     PyObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
 );
@@ -58,7 +43,22 @@ static PyObject *PyVectorcall_Call(PyObject *self, PyObject *tuple, PyObject *di
     }
     return Scaler_vectorcall(self, args, 1, NULL);
 }
-#endif // Py_LIMITED_API
-#endif // Py_VERSION_HEX < 0x030C000
+#endif // Py_LIMITED_API + 0 < 0x030C0000
+// PyType_GetModuleByDef is part of the limited API only since 3.13.
+// Its definition is rather long so we use a nearly good enough substitute,
+// the only downside of which is that one cannot subclass (hence the adjustment
+// to the flags). Not that important really, since it should not be needed
+// in normal use, but we might as well allow it once we can.
+#define PyType_GetModuleByDef(type, unused) PyType_GetModule(type)
+#define SCALER_TP_FLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC
+#endif // defined(Py_LIMITED_API) && Py_LIMITED_API + 0 >= 0x030D0000
 
-#endif // _SCALER_PY311_WORKAROUNDS_H
+// Other changes needed for python 3.11, with our without limited API.
+#if PY_VERSION_HEX < 0x030C0000
+#include <structmember.h> // For PyMemberDef, included by default only for >=3.12
+#define Py_T_DOUBLE T_DOUBLE
+#define Py_READONLY READONLY
+#define Py_T_PYSSIZET T_PYSSIZET
+#endif // PY_VERSION_HEX < 0x030C0000
+
+#endif // _SCALER_LIMITED_API_WORKAROUNDS_H

--- a/astropy/units/_scaler/tests/test_scaler.py
+++ b/astropy/units/_scaler/tests/test_scaler.py
@@ -95,37 +95,38 @@ def test_scale_attribute():
     assert sc.factor == 10.0
 
 
-def test_init_errors():
-    with pytest.raises(TypeError, match=r"exactly 1 positional.*\(0 given\)"):
-        Scaler()
-    with pytest.raises(TypeError, match=r"exactly 1 positional.*\(0 given\)"):
-        Scaler(b=20.0)
-    with pytest.raises(TypeError, match=r"at most 1 argument \(2 given\)"):
-        Scaler(10.0, 20.0)
-    with pytest.raises(TypeError, match=r"at most 1 argument \(2 given\)"):
-        Scaler(10.0, b=20.0)
-    with pytest.raises(TypeError, match=r"at most 1 argument \(3 given\)"):
-        Scaler(10.0, 20.0, b=20.0)
-    with pytest.raises(TypeError, match=r"at most 1 argument \(3 given\)"):
-        Scaler(10.0, b=20.0, c=20.0)
-    with pytest.raises(TypeError, match="must be real number, not"):
-        Scaler(1 + 1j)
-    with pytest.raises(TypeError, match="must be real number, not"):
-        Scaler({})
+@pytest.mark.parametrize(
+    "args, kwargs, expected_msg",
+    [
+        ((), {}, r"exactly 1 positional.*\(0 given\)"),
+        ((), {"b": 20.0}, r"exactly 1 positional.*\(0 given\)"),
+        ((10.0, 20.0), {}, r"at most 1 argument \(2 given\)"),
+        ((10.0,), {"b": 20.0}, r"at most 1 argument \(2 given\)"),
+        ((10.0, 20.0), {"b": 20.0}, r"at most 1 argument \(3 given\)"),
+        ((10.0, 20.0), {"b": 20.0, "c": 20.0}, r"at most 1 argument \(4 given\)"),
+        ((1 + 1j,), {}, r"must be real number, not"),
+        (({},), {}, r"must be real number, not"),
+    ],
+)
+def test_init_errors(args, kwargs, expected_msg):
+    with pytest.raises(TypeError, match=expected_msg):
+        Scaler(*args, **kwargs)
 
 
-def test_call_errors():
+@pytest.mark.parametrize(
+    "args, kwargs, expected_msg",
+    [
+        ((), {}, r"takes 1 positional.*but 0 were given"),
+        ((10.0, 20.0), {}, r"takes 1 positional.*but 2 were given"),
+        ((), {"b": 20.0}, r"got an unexpected.*'b'"),
+        ((10.0,), {"b": 20.0}, r"got an unexpected.*'b'"),
+        ((10.0, 20.0), {"b": 20.0}, r"got an unexpected.*'b'"),
+    ],
+)
+def test_call_errors(args, kwargs, expected_msg):
     sc = Scaler(10.0)
-    with pytest.raises(TypeError, match="takes 1 positional.*0 were given"):
-        sc()
-    with pytest.raises(TypeError, match="takes 1 positional.*2 were given"):
-        sc(10.0, 20.0)
-    with pytest.raises(TypeError, match="got an unexpected.*'b'"):
-        sc(b=20.0)
-    with pytest.raises(TypeError, match="got an unexpected.*'b'"):
-        sc(10.0, b=20.0)
-    with pytest.raises(TypeError, match="got an unexpected.*'b'"):
-        sc(10.0, 20.0, b=20.0)
+    with pytest.raises(TypeError, match=expected_msg):
+        sc(*args, **kwargs)
 
 
 def test_unity_scaler_is_singleton():

--- a/astropy/units/_scaler/tests/test_scaler.py
+++ b/astropy/units/_scaler/tests/test_scaler.py
@@ -5,8 +5,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from scaler import Scaler
-
+from astropy.units._scaler import Scaler
 
 NUMPY_SCALAR_TYPES = [np.float32, np.float64, np.complex64, np.complex128]
 SCALAR_TYPES = NUMPY_SCALAR_TYPES + [float, complex, int, np.int32, np.uint64]

--- a/astropy/units/_scaler/tests/test_scaler.py
+++ b/astropy/units/_scaler/tests/test_scaler.py
@@ -152,6 +152,10 @@ def test_init_errors(args, kwargs, expected_msg):
         Scaler(*args, **kwargs)
 
 
+def test_init_empty_kwargs_ok():
+    Scaler(10.0, **{})  # noqa: PIE804
+
+
 @pytest.mark.parametrize(
     "args, kwargs, expected_msg",
     [

--- a/astropy/units/_scaler/tests/test_scaler.py
+++ b/astropy/units/_scaler/tests/test_scaler.py
@@ -41,38 +41,77 @@ class TestScalar:
 
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("swapbyteorder", [False, True])
+@pytest.mark.parametrize("aligned", [False, True])
 class TestArray:
     def get_dtype(self, dtype, swapbyteorder):
         dtype = np.dtype(dtype)
         return dtype.newbyteorder() if swapbyteorder else dtype
 
-    def get_array(self, data, dtype, order, imag=-4j):
+    def get_array(self, data, dtype, order="C", aligned=True, imag=-4j):
         if dtype.kind == "c":
             data = np.asanyarray(data) + np.asanyarray(imag)
         data = np.array(data).astype(dtype, order=order)
         assert data.dtype == dtype
+        if not aligned:
+            new_dt = np.dtype([("c", "S1"), ("v", dtype)])
+            new = np.zeros(data.shape, new_dt)
+            new["v"] = data
+            data = new["v"]
         return data
 
     @pytest.mark.parametrize("dtype", DTYPES)
-    def test_array(self, dtype, swapbyteorder, order):
+    def test_array(self, dtype, swapbyteorder, order, aligned):
         dtype = self.get_dtype(dtype, swapbyteorder)
-        a = self.get_array(np.arange(10).reshape(2, 5), dtype, order)
-        if order == "C":
-            assert a.flags["C_CONTIGUOUS"] and not a.flags["F_CONTIGUOUS"]
+        a = self.get_array(np.arange(10).reshape(2, 5), dtype, order, aligned)
+        if aligned:
+            if order == "C":
+                assert a.flags["C_CONTIGUOUS"] and not a.flags["F_CONTIGUOUS"]
+            else:
+                assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
         else:
-            assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
+            assert not a.flags["ALIGNED"]
+            assert not a.flags["C_CONTIGUOUS"] and not a.flags["F_CONTIGUOUS"]
         scaler = Scaler(10.0)
         got = scaler(a)
         exp = a * 10.0
         assert_array_equal(got, exp, strict=True)
 
     @pytest.mark.parametrize("dtype", FLOATING_DTYPES)
-    def test_array_overflow(self, dtype, swapbyteorder, order):
+    def test_array_overflow(self, dtype, swapbyteorder, order, aligned):
         dtype = self.get_dtype(dtype, swapbyteorder)
-        a = self.get_array([1.0, np.finfo(dtype).max], dtype, order)
+        a = self.get_array([1.0, np.finfo(dtype).max], dtype, order, aligned)
         scaler = Scaler(1000.0)
         with pytest.warns(RuntimeWarning, match="overflow.*multiply"):
-            scaler(a)
+            got = scaler(a)
+        with pytest.warns(RuntimeWarning, match="overflow.*multiply"):
+            exp = a * 1000.0
+        assert_array_equal(got, exp, strict=True)
+
+    @pytest.mark.parametrize("dtype", FLOATING_DTYPES)
+    def test_array_inf_nan(self, dtype, swapbyteorder, order, aligned):
+        dtype = self.get_dtype(dtype, swapbyteorder)
+        data_r = [1.0, np.nan, 0.0, np.inf, 0.0]
+        data_i = [1.0, 0.0, np.nan, 0.0, np.inf]
+        a = self.get_array(data_r, dtype, order, aligned, imag=data_i)
+        scaler = Scaler(1000.0)
+        if dtype.kind == "c":
+            with pytest.warns(RuntimeWarning, match="invalid.*multiply"):
+                got = scaler(a)
+            with pytest.warns(RuntimeWarning, match="invalid.*multiply"):
+                exp = a * 1000.0
+        else:
+            got = scaler(a)
+            exp = a * 1000.0
+        assert_array_equal(got, exp, strict=True)
+
+
+def test_float16_array():
+    scaler = Scaler(10.0)
+    a = np.arange(10.0, dtype="f2")
+    got = scaler(a)
+    assert got.dtype == a.dtype
+    exp = a * 10.0
+    assert_array_equal(got, exp, strict=True)
 
 
 def test_with_list():

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -21,6 +21,7 @@ import numpy as np
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 
+from ._scaler import Scaler
 from .errors import UnitConversionError, UnitParserWarning, UnitsError, UnitsWarning
 from .typing import (
     PhysicalTypeID,
@@ -487,8 +488,13 @@ class UnitBase:
         """
 
         def make_converter(scale1, func, scale2):
+            # We need to do func(v / scale1) * scale2, so we need two scalers.
+            # The first we cannot omit, since it also does the sanity checks on input.
+            scaler1 = Scaler(1 / scale1)
+            scaler2 = Scaler(scale2) if scale2 != 1.0 else lambda x: x
+
             def convert(v):
-                return func(_condition_arg(v) / scale1) * scale2
+                return scaler2(func(scaler1(v)))
 
             return convert
 
@@ -574,15 +580,7 @@ class UnitBase:
         except UnitsError:
             pass
         else:
-            # Yes, it is a simple scaling.
-            if scale == 1.0:
-                # If no conversion is necessary, returns ``unit_scale_converter``
-                # (which is used as a check in quantity helpers).
-                converter = unit_scale_converter
-            else:
-                converter = lambda val: scale * _condition_arg(val)
-            # Cache the converter before returning it.
-            _CONVERTER_CACHE[(self, other)] = converter
+            converter = _CONVERTER_CACHE[(self, other)] = Scaler(scale)
             return converter
 
         # if that doesn't work, maybe we can do it with equivalencies?
@@ -2767,54 +2765,12 @@ def def_unit(
     return result
 
 
-KNOWN_GOOD = np.ndarray | float | int | complex
+unit_scale_converter = Scaler(1.0)
+"""Callable that just multiplies the value by unity.
 
-
-def _condition_arg(value):
-    """Validate value is acceptable for conversion purposes.
-
-    Will convert into an array if not a scalar or array-like, where scalars
-    and arrays can be python and numpy types, anything that defines
-    ``__array_namespace__`` or anything that has a ``.dtype`` attribute.
-
-    Parameters
-    ----------
-    value : scalar or array-like
-
-    Returns
-    -------
-    Scalar value or array
-
-    Raises
-    ------
-    ValueError
-        If value is not as expected
-
-    """
-    if (
-        isinstance(value, KNOWN_GOOD)
-        or hasattr(value, "dtype")
-        or hasattr(value, "__array_namespace__")
-    ):
-        return value
-
-    value = np.array(value)
-    if value.dtype.kind not in "ifc":
-        raise ValueError(
-            "Value not scalar compatible or convertible to "
-            "an int, float, or complex array"
-        )
-    return value
-
-
-def unit_scale_converter(val):
-    """Function that just multiplies the value by unity.
-
-    This is a separate function so it can be recognized and
-    discarded in unit conversion.
-    """
-    return 1.0 * _condition_arg(val)
-
+This is a singleton and defined here so it can be recognized and
+discarded in unit conversion.
+"""
 
 dimensionless_unscaled: Final[CompositeUnit] = CompositeUnit(
     1, [], [], _error_check=False

--- a/docs/changes/units/20183.perf.rst
+++ b/docs/changes/units/20183.perf.rst
@@ -1,0 +1,5 @@
+Astropy unit conversions have been sped up by about 10% for scalars and small
+arrays with the introduction of a C-based class that does the actual scale
+conversion.  ``Unit.get_converter()`` now produces instances of this class
+when no equivalencies are involved. E.g., the ``repr`` of
+``u.km.get_converter(u.m)`` is ``Scaler(1000.0)``.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ class EditableInstallWithStubs(editable_wheel):
 # Specify the minimum version for the Numpy C-API
 for ext in ext_modules:
     if ext.include_dirs and "numpy" in ext.include_dirs[0]:
-        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_1_25_API_VERSION"))
+        ext.define_macros.append(("NPY_TARGET_VERSION", "NPY_2_0_API_VERSION"))
         ext.define_macros.append(("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"))
 
 setup(

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -38,8 +38,8 @@ static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr
             Py_DECREF(res);
             return NULL;
         }
-        return res;
     }
+    return res;
 }
 
 static PyObject *Scaler_vectorcall(
@@ -90,25 +90,49 @@ static PyObject *Scaler_vectorcall(
     if (self->O_factor == NULL) {
         self->O_factor = PyFloat_FromDouble(self->factor);
         if (self->O_factor == NULL) {
-            self->O_factor = PyFloat_FromDouble(self->factor);
-            if (self->O_factor == NULL) {
-                return NULL;
-            }
+            return NULL;
         }
     }
-    // Fast path, go directly for the slot, to avoid PyNumber call.
-    if (Py_TYPE(obj)->tp_as_number != NULL) {
-        binaryfunc slotv = Py_TYPE(obj)->tp_as_number->nb_multiply;
-        if (slotv != NULL) {
-            PyObject *res = slotv(obj, self->O_factor);
-            if (res != Py_NotImplemented) {
-                return res;
+    // If a known type of object, like a subclass, or something that has
+    // a dtype or supports the Array API, just run multiply.
+    if (PyFloat_Check(obj) || PyComplex_Check(obj) || PyLong_Check(obj) || PyArray_Check(obj) ||
+        PyObject_HasAttrString(obj, "dtype") ||
+        PyObject_HasAttrString(obj, "__array_namespace__")) {
+        // Generally, should be possible to go directly for the slot.
+        if (Py_TYPE(obj)->tp_as_number != NULL) {
+            binaryfunc slotv = Py_TYPE(obj)->tp_as_number->nb_multiply;
+            if (slotv != NULL) {
+                PyObject *res = slotv(obj, self->O_factor);
+                if (res != Py_NotImplemented) {
+                    return res;
+                }
+                // Fall back to slow path, which will likely raise,
+                // thus giving a reasonable error message.
+                Py_DECREF(res);
             }
-            // Fall back to slow path, which will almost certainly raise.
-            Py_DECREF(res);
         }
         return PyNumber_Multiply(obj, self->O_factor);
     }
+    // If not a known type, try converting to an array.
+    PyObject *arr = PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
+    if (arr == NULL) {
+        return NULL;
+    }
+    PyObject *res = NULL;
+    if (PyArray_ISNUMBER((PyArrayObject *)arr)) {
+        // Re-enter to use the array path.
+        res = Scaler_vectorcall(self, &arr, 1, NULL);
+    }
+    else {
+        // If not numeric, same error message as in _condition_arg.
+        PyErr_SetString(
+            PyExc_ValueError,
+            "Value not scalar compatible or convertible to "
+            "an int, float, or complex array"
+        );
+    }
+    Py_DECREF(arr);
+    return res;
 }
 
 static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -42,6 +42,17 @@ static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr
     return res;
 }
 
+static inline PyObject *get_o_factor(ScalerObject *self)
+{
+    if (self->O_factor == NULL) {
+        self->O_factor = PyFloat_FromDouble(self->factor);
+        if (self->O_factor == NULL) {
+            return NULL;
+        }
+    }
+    return self->O_factor;
+}
+
 static PyObject *Scaler_vectorcall(
     ScalerObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
 )
@@ -85,13 +96,10 @@ static PyObject *Scaler_vectorcall(
         }
         return PyFloat_FromDouble(d * self->factor);
     }
-    // For cases without special treatment, we need the float object;
-    // construct it if not done already.
-    if (self->O_factor == NULL) {
-        self->O_factor = PyFloat_FromDouble(self->factor);
-        if (self->O_factor == NULL) {
-            return NULL;
-        }
+    // For cases without special treatment, we need the float object.
+    PyObject *O_factor = get_o_factor(self);
+    if (O_factor == NULL) {
+        return NULL;
     }
     // If a known type of object, like a subclass, or something that has
     // a dtype or supports the Array API, just run multiply.
@@ -102,7 +110,7 @@ static PyObject *Scaler_vectorcall(
         if (Py_TYPE(obj)->tp_as_number != NULL) {
             binaryfunc slotv = Py_TYPE(obj)->tp_as_number->nb_multiply;
             if (slotv != NULL) {
-                PyObject *res = slotv(obj, self->O_factor);
+                PyObject *res = slotv(obj, O_factor);
                 if (res != Py_NotImplemented) {
                     return res;
                 }
@@ -111,7 +119,7 @@ static PyObject *Scaler_vectorcall(
                 Py_DECREF(res);
             }
         }
-        return PyNumber_Multiply(obj, self->O_factor);
+        return PyNumber_Multiply(obj, O_factor);
     }
     // If not a known type, try converting to an array.
     PyObject *arr = PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
@@ -173,6 +181,34 @@ static PyObject *Scaler_repr(ScalerObject *self)
     return PyUnicode_FromFormat("Scaler(%S)", PyFloat_FromDouble(self->factor));
 }
 
+static PyObject *Scaler_richcompare(PyObject *self, PyObject *other, int op)
+{
+    if (op != Py_EQ && op != Py_NE) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+    npy_bool same =
+        (Py_TYPE(other) == Py_TYPE(self) &&
+         (((ScalerObject *)other)->factor == ((ScalerObject *)self)->factor));
+    PyObject *res = (op == Py_EQ) ^ same ? Py_False : Py_True;
+    Py_INCREF(res);
+    return res;
+}
+
+Py_hash_t Scaler_hash(PyObject *self)
+{
+    PyObject *O_factor = get_o_factor((ScalerObject *)self);
+    if (O_factor == NULL) {
+        return -1;
+    }
+    return (PyObject_Hash((PyObject *)Py_TYPE(self)) ^ PyObject_Hash(O_factor));
+}
+
+static PyObject *Scaler___reduce__(ScalerObject *self)
+{
+    return Py_BuildValue("(O(d))", Py_TYPE(self), self->factor);
+}
+
 static PyMemberDef Scaler_members[] = {
     {"factor",
      Py_T_DOUBLE,
@@ -182,8 +218,13 @@ static PyMemberDef Scaler_members[] = {
     {NULL},
 };
 
+static PyMethodDef Scaler_methods[] = {
+    {"__reduce__", (PyCFunction)Scaler___reduce__, METH_NOARGS, NULL},
+    {NULL, NULL, 0, NULL},
+};
+
 static PyTypeObject ScalerType = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Scaler",
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "scaler.Scaler",
     .tp_doc = PyDoc_STR("Multiplies input by the given scale factor."),
     .tp_basicsize = sizeof(ScalerObject),
     .tp_itemsize = 0,
@@ -194,6 +235,9 @@ static PyTypeObject ScalerType = {
     .tp_vectorcall_offset = offsetof(ScalerObject, vectorcall),
     .tp_call = &PyVectorcall_Call,
     .tp_members = Scaler_members,
+    .tp_methods = Scaler_methods,
+    .tp_richcompare = Scaler_richcompare,
+    .tp_hash = Scaler_hash,
 };
 
 static int get_multiply_loops(PyUFuncGenericFunction loops[6])

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -1,7 +1,10 @@
-#define NPY_TARGET_VERSION NPY_2_0_API_VERSION
+#define NPY_TARGET_VERSION NPY_2_0_API_VERSION // For PyUFunc_GiveFloatingpointErrors
 #define PY_SSIZE_T_CLEAN
-#include "numpy/arrayobject.h"
 #include <Python.h>
+#if Py_Version < 0x03120000
+#include <structmember.h> // for PyMemberDef, not in Python.h for python <= 3.11
+#endif
+#include <numpy/arrayobject.h>
 #include <numpy/arrayscalars.h>
 #include <numpy/ndarrayobject.h>
 #include <numpy/ufuncobject.h>
@@ -305,9 +308,15 @@ static PyObject *Scaler___reduce__(ScalerObject *self)
 
 static PyMemberDef Scaler_members[] = {
     {"factor",
+#if Py_Version < 0x03120000
+     T_DOUBLE,
+     offsetof(ScalerObject, factor),
+     READONLY,
+#else
      Py_T_DOUBLE,
      offsetof(ScalerObject, factor),
      Py_READONLY,
+#endif
      "Factor with which input is multiplied."},
     {NULL},
 };
@@ -389,8 +398,9 @@ static int scaler_module_exec(PyObject *m)
 
 static PyModuleDef_Slot scaler_module_slots[] = {
     {Py_mod_exec, scaler_module_exec},
-    // Just use this while using static types
+#if Py_Version >= 0x03120000
     {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
+#endif
     {0, NULL}
 };
 

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -10,35 +10,34 @@ typedef struct {
     PyObject_HEAD
     /* Type-specific fields go here. */
     double factor;
+    double factor_imag; // always set to 0, to have complex factor.
+    float factor_f;
+    float factor_f_imag; // always set to 0.
     PyObject *O_factor;
     PyObject *A_factor;
+    PyObject *A_factor_f;
     vectorcallfunc vectorcall;
 } ScalerObject;
 
 static PyUFuncObject *multiply = NULL;
 
-static PyObject *use_contiguous_loop(PyArrayObject *arr, double *factor)
+static PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
 {
-    static PyUFuncGenericFunction loop = NULL; // [NPY_CDOUBLE] = {NULL};
-    const char type_num = PyArray_DESCR(arr)->type_num;
+    static PyUFuncGenericFunction loops[6] = {NULL};
+    const char type_num = PyArray_TYPE(arr);
+    PyUFuncGenericFunction loop = loops[(int)(type_num - NPY_FLOAT)];
     if (loop == NULL) {
         // Unfortunately, new-style loops are not exposed, so get legacy one.
         int nargs = multiply->nargs;
         const char *types = multiply->types;
-        int i, j;
-        for (i = 0; i < multiply->ntypes; ++i) {
-            for (j = 0; j < nargs; ++j) {
-                if (types[j] != type_num) {
-                    break;
-                }
-            }
-            if (j == nargs) {
-                loop = multiply->functions[i];
+        for (int i = 0; i < multiply->ntypes; i++) {
+            if (types[0] == type_num && types[1] == type_num && types[2] == type_num) {
+                loop = loops[(int)(type_num - NPY_FLOAT)] = multiply->functions[i];
                 break;
             }
             types += nargs;
         }
-        if (i == multiply->ntypes) {
+        if (loop == NULL) {
             PyErr_SetString(PyExc_RuntimeError, "could not find loop");
             return NULL;
         }
@@ -46,7 +45,7 @@ static PyObject *use_contiguous_loop(PyArrayObject *arr, double *factor)
     // do it!
     PyObject *res =
         PyArray_EMPTY(PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr));
-    char *data[3] = {PyArray_DATA(arr), (char *)factor, PyArray_DATA((PyArrayObject *)res)};
+    char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA((PyArrayObject *)res)};
     npy_intp n = PyArray_SIZE(arr);
     npy_intp strides[3] = {PyArray_ITEMSIZE(arr), 0, PyArray_ITEMSIZE(arr)};
     PyUFunc_clearfperr();
@@ -78,22 +77,24 @@ static PyObject *Scaler_vectorcall(
     }
     else if (PyArray_CheckExact(obj)) {
         PyArrayObject *const arr = (PyArrayObject *)obj;
-        if (PyArray_DESCR(arr)->type_num == NPY_FLOAT64 && PyArray_ISONESEGMENT(arr)) {
-            // speed up over ufunc by using strided loop directly.
-            return use_contiguous_loop(arr, &self->factor);
+        char type_num = PyArray_TYPE(arr);
+        npy_bool needs_float = type_num == NPY_FLOAT || type_num == NPY_CFLOAT;
+        char *f_ptr = needs_float ? (char *)&self->factor_f : (char *)&self->factor;
+        // Pass contiguous float or complex arrays directly to multiply loop,
+        // bypassing ufunc setup.
+        if (PyArray_ISONESEGMENT(arr) &&
+            (type_num == NPY_DOUBLE || type_num == NPY_CDOUBLE || needs_float)) {
+            return use_contiguous_loop(arr, f_ptr);
         }
-        if (self->A_factor == NULL) {
-            npy_intp const dims[0];
-            self->A_factor = PyArray_SimpleNewFromData(0, dims, NPY_FLOAT64, &self->factor);
-            if (self->A_factor == NULL) {
-                npy_intp const dims[0];
-                self->A_factor = PyArray_SimpleNewFromData(0, dims, NPY_FLOAT64, &self->factor);
-                if (self->A_factor == NULL) {
-                    return NULL;
-                }
-            }
-            return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, self->A_factor);
+        // If not, convert factor to array here, since that makes ufunc
+        // call substantially faster.
+        PyObject **A_factor = needs_float ? &self->A_factor_f : &self->A_factor;
+        if (*A_factor == NULL) {
+            const npy_intp dims[1] = {0};
+            *A_factor =
+                PyArray_SimpleNewFromData(0, dims, needs_float ? NPY_FLOAT : NPY_DOUBLE, f_ptr);
         }
+        return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, *A_factor);
     }
     else if (PyLong_CheckExact(obj)) {
         double d = PyLong_AsDouble(obj);
@@ -102,15 +103,18 @@ static PyObject *Scaler_vectorcall(
         }
         return PyFloat_FromDouble(d * self->factor);
     }
-    // For cases without special treatment, we need the float object, so
-    // construct it ahead of time.
+    // For cases without special treatment, we need the float object;
+    // construct it if not done already.
     if (self->O_factor == NULL) {
         self->O_factor = PyFloat_FromDouble(self->factor);
         if (self->O_factor == NULL) {
-            return NULL;
+            self->O_factor = PyFloat_FromDouble(self->factor);
+            if (self->O_factor == NULL) {
+                return NULL;
+            }
         }
     }
-    // fast path, go directly for the slot, to avoid PyNumber call.
+    // Fast path, go directly for the slot, to avoid PyNumber call.
     if (Py_TYPE(obj)->tp_as_number != NULL) {
         binaryfunc slotv = Py_TYPE(obj)->tp_as_number->nb_multiply;
         if (slotv != NULL) {
@@ -121,8 +125,8 @@ static PyObject *Scaler_vectorcall(
             // Fall back to slow path, which will almost certainly raise.
             Py_DECREF(res);
         }
+        return PyNumber_Multiply(obj, self->O_factor);
     }
-    return PyNumber_Multiply(obj, self->O_factor);
 }
 
 static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
@@ -140,8 +144,12 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     self->factor = factor;
-    self->O_factor = NULL;
+    self->factor_imag = 0; // allows using &self->factor for complex.
+    self->factor_f = (float)factor;
+    self->factor_f_imag = 0;
+    self->O_factor = NULL; // following initialized only if needed in call.
     self->A_factor = NULL;
+    self->A_factor_f = NULL;
     self->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
     return (PyObject *)self;
 }
@@ -150,6 +158,7 @@ static void Scaler_dealloc(ScalerObject *self)
 {
     Py_XDECREF(self->O_factor);
     Py_XDECREF(self->A_factor);
+    Py_XDECREF(self->A_factor_f);
     Py_TYPE(self)->tp_free(self);
 }
 
@@ -158,13 +167,13 @@ static PyMemberDef Scaler_members[] = {
      Py_T_DOUBLE,
      offsetof(ScalerObject, factor),
      Py_READONLY,
-     "factor with which input is multiplied"},
+     "Factor with which input is multiplied."},
     {NULL},
 };
 
 static PyTypeObject ScalerType = {
     .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Scaler",
-    .tp_doc = PyDoc_STR("Multiplies input by the given scale factor"),
+    .tp_doc = PyDoc_STR("Multiplies input by the given scale factor."),
     .tp_basicsize = sizeof(ScalerObject),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
@@ -180,11 +189,9 @@ static int scaler_module_exec(PyObject *m)
     if (PyType_Ready(&ScalerType) < 0) {
         return -1;
     }
-
     if (PyModule_AddObjectRef(m, "Scaler", (PyObject *)&ScalerType) < 0) {
         return -1;
     }
-
     return 0;
 }
 
@@ -198,7 +205,7 @@ static PyModuleDef_Slot scaler_module_slots[] = {
 static PyModuleDef scaler_module = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "scaler",
-    .m_doc = "Example module that creates an extension type.",
+    .m_doc = "Provides the inspectable Scaler class.",
     .m_size = 0,
     .m_slots = scaler_module_slots,
 };

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -20,6 +20,14 @@ PyDoc_STRVAR(
     "    The scale factor with which, when called, an argument will be multiplied.\n"
 );
 
+// Module state
+typedef struct {
+    PyTypeObject *Scaler;
+    PyObject *unity_scaler;
+} scaler_state;
+
+// Forward definition.
+static PyModuleDef scaler_module;
 
 typedef struct {
     PyObject_HEAD
@@ -33,8 +41,6 @@ typedef struct {
 
 // Double and float multiply loops, filled in on initialization.
 static PyUFuncGenericFunction loops[2] = {NULL, NULL};
-// Unity scaler, which is kept unique, filled in on initialization.
-static PyObject *unity_scaler = NULL;
 
 // Multiply a contiguous array directly with the factor, using np.multiply's
 // loop function.
@@ -253,8 +259,16 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (factor == -1.0 && PyErr_Occurred()) {
         return NULL;
     }
-    if (factor == 1.0) { // Use singleton.
-        return Py_NewRef(unity_scaler);
+    if (factor == 1.0) { // Get singleton from module state.
+        PyObject *m = PyType_GetModuleByDef(type, &scaler_module);
+        if (m == NULL) {
+            return NULL;
+        }
+        scaler_state *state = PyModule_GetState(m);
+        if (state == NULL) {
+            return NULL;
+        }
+        return Py_NewRef(state->unity_scaler);
     }
     return Scaler_from_factor(type, factor);
 }
@@ -414,21 +428,50 @@ static int get_multiply_loops(PyUFuncGenericFunction loops[2])
 
 static int scaler_module_exec(PyObject *m)
 {
-    PyTypeObject *Scaler = (PyTypeObject *)PyType_FromModuleAndSpec(m, &Scaler_spec, NULL);
-    if (Scaler == NULL) {
+    scaler_state *state = PyModule_GetState(m);
+    state->Scaler = (PyTypeObject *)PyType_FromModuleAndSpec(m, &Scaler_spec, NULL);
+    if (state->Scaler == NULL) {
         return -1;
     }
-    if (PyModule_AddType(m, Scaler) < 0) {
+    if (PyModule_AddType(m, state->Scaler) < 0) {
         return -1;
     }
-    unity_scaler = Scaler_from_factor(Scaler, 1.0);
-    if (unity_scaler == NULL) {
+    state->unity_scaler = Scaler_from_factor(state->Scaler, 1.0);
+    if (state->unity_scaler == NULL) {
         return -1;
     }
     if (get_multiply_loops(loops) < 0) {
         return -1;
     }
     return 0;
+}
+
+static int scaler_module_traverse(PyObject *m, visitproc visit, void *arg)
+{
+    scaler_state *state = PyModule_GetState(m);
+    if (state == NULL) {
+        return 0;
+    }
+    Py_VISIT(state->Scaler);
+    Py_VISIT(state->unity_scaler);
+    return 0;
+}
+
+static int scaler_module_clear(PyObject *m)
+{
+    scaler_state *state = PyModule_GetState(m);
+    if (state == NULL) {
+        return 0;
+    }
+    Py_CLEAR(state->Scaler);
+    Py_CLEAR(state->unity_scaler);
+    return 0;
+}
+
+static void scaler_module_free(PyObject *m)
+{
+    // allow scaler_modexec to omit calling scaler_clear on error
+    scaler_module_clear(m);
 }
 
 static PyModuleDef_Slot scaler_module_slots[] = {
@@ -443,7 +486,10 @@ static PyModuleDef scaler_module = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "scaler",
     .m_doc = scaler_module_doc,
-    .m_size = 0,
+    .m_size = sizeof(scaler_state),
+    .m_traverse = (traverseproc)scaler_module_traverse,
+    .m_clear = (inquiry)scaler_module_clear,
+    .m_free = (freefunc)scaler_module_free,
     .m_slots = scaler_module_slots,
 };
 

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -8,17 +8,16 @@
 
 typedef struct {
     PyObject_HEAD
+    vectorcallfunc vectorcall;
     double factor;
-    double factor_imag; // always set to 0, to have complex factor.
     float factor_f;
-    float factor_f_imag; // always set to 0.
     PyObject *O_factor;
     PyObject *A_factor;
     PyObject *A_factor_f;
-    vectorcallfunc vectorcall;
 } ScalerObject;
 
-static PyUFuncGenericFunction loops[6] = {NULL};
+// Double and float multiply loops, filled in on initialization.
+static PyUFuncGenericFunction loops[2] = {NULL, NULL};
 
 // Multiply a contiguous array directly with the factor, using np.multiply's
 // loop function.
@@ -35,9 +34,20 @@ static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr
     if (n == 0) {
         return (PyObject *)res; // Nothing to do.
     }
-    PyUFuncGenericFunction loop = loops[type_num - NPY_FLOAT];
-    npy_intp strides[3] = {PyArray_ITEMSIZE(arr), 0, PyArray_ITEMSIZE(arr)};
+    PyUFuncGenericFunction loop;
+    npy_intp strides[3];
     char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA(res)};
+    if (type_num == NPY_DOUBLE || type_num == NPY_FLOAT) {
+        strides[0] = PyArray_ITEMSIZE(arr);
+        loop = loops[type_num - NPY_FLOAT];
+    }
+    else { // For complex, with real factor, we can use real loop.
+        strides[0] = PyArray_ITEMSIZE(arr) / 2;
+        n *= 2;
+        loop = loops[type_num - NPY_CFLOAT];
+    }
+    strides[1] = 0;
+    strides[2] = strides[0];
     PyUFunc_clearfperr();
     NPY_BEGIN_THREADS_DEF;
     NPY_BEGIN_THREADS_THRESHOLDED(n);
@@ -178,8 +188,6 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->factor = factor;
     self->factor_f = (float)factor;
     // No need to explicitly set to zero, since zeroed by tp_alloc.
-    // self->factor_imag = 0;  // allows using &self->factor for complex.
-    // self->factor_f_imag = 0;
     // self->O_factor = NULL;  // initialized as needed in call.
     // self->A_factor = NULL;
     // self->A_factor_f = NULL;
@@ -265,9 +273,9 @@ static PyTypeObject ScalerType = {
 };
 
 // Get and cache multiplication loops for use with plain ndarray.
-// Only gets float, double, complex float and complex double,
-// not the long double ones.
-static int get_multiply_loops(PyUFuncGenericFunction loops[6])
+// Only gets double and float loops, since those can be used for
+// complex too. We ignore long double for our fast path.
+static int get_multiply_loops(PyUFuncGenericFunction loops[2])
 {
     PyObject *mod = PyImport_ImportModule("numpy");
     if (mod == NULL) {
@@ -279,11 +287,8 @@ static int get_multiply_loops(PyUFuncGenericFunction loops[6])
         return -1;
     }
     // Unfortunately, new-style loops are not exposed, so get legacy ones.
-    for (int k = 0; k < 5; k++) {
+    for (int k = 0; k < 2; k++) {
         char type = (char)(k + NPY_FLOAT);
-        if (type == NPY_LONGDOUBLE) {
-            continue;
-        }
         const char *types = multiply->types;
         for (int i = 0; i < multiply->ntypes; i++) {
             if (types[0] == type && types[1] == type && types[2] == type) {

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -1,14 +1,63 @@
 #define NPY_TARGET_VERSION NPY_2_0_API_VERSION // For PyUFunc_GiveFloatingpointErrors
+#define Py_LIMITED_API 0x030B0000
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-#if Py_Version < 0x03120000
-#include <structmember.h> // for PyMemberDef, not in Python.h for python <= 3.11
-#endif
 #include <numpy/arrayobject.h>
 #include <numpy/arrayscalars.h>
 #include <numpy/ndarrayobject.h>
 #include <numpy/ufuncobject.h>
 #include <stddef.h> // for offsetof()
+
+// Once we're at 3.12, move SCALER_TP_FLAGS to its use, and remove this whole block.
+#if Py_LIMITED_API + 0 >= 0x030C0000
+#define SCALER_TP_FLAGS \
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE
+#else                     // work-arounds for python 3.11 limited API
+#include <structmember.h> // for PyMemberDef
+#define PyType_GetModuleByDef(type, unused) PyType_GetModule(type) // hence, cannot subclass
+#define vectorcallfunc void *
+#define Py_TPFLAGS_HAVE_VECTORCALL (1UL << 11)
+#define SCALER_TP_FLAGS Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC
+#ifndef Py_T_DOUBLE
+// Most of these are macros whose availability depends on which python we're compiling on,
+// but which do not influence support in different versions (tested by compiling on
+// 3.11 and running tests on 3.14 with the resulting .so file).
+// But more annoyingly, we also need to define our own PyVectorcall_Call;
+// Note that what is below is specific to our class; it cannot be used generally!
+#define Py_T_DOUBLE T_DOUBLE
+#define Py_READONLY READONLY
+#define Py_T_PYSSIZET T_PYSSIZET
+#define PY_VECTORCALL_ARGUMENTS_OFFSET (_Py_STATIC_CAST(size_t, 1) << (8 * sizeof(size_t) - 1))
+#define PyVectorcall_NARGS(nargsf) (Py_ssize_t)(nargsf & ~PY_VECTORCALL_ARGUMENTS_OFFSET)
+static PyObject *Scaler_vectorcall(
+    PyObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
+);
+static PyObject *PyVectorcall_Call(PyObject *self, PyObject *tuple, PyObject *dict)
+{
+    if (dict != NULL && PyDict_Size(dict) > 0) {
+        Py_ssize_t pos = 0;
+        PyObject *key, *value;
+        PyDict_Next(dict, &pos, &key, &value);
+        PyErr_Format(PyExc_TypeError, "scaler() got an unexpected keyword argument %R", key);
+        return NULL;
+    }
+    if (PyTuple_Size(tuple) != 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "scaler() takes 1 positional argument but %d were given",
+            PyTuple_Size(tuple)
+        );
+        return NULL;
+    }
+    PyObject *args[1];
+    args[0] = PyTuple_GetItem(tuple, 0);
+    if (args[0] == NULL) {
+        return NULL;
+    }
+    return Scaler_vectorcall(self, args, 1, NULL);
+}
+#endif
+#endif
 
 PyDoc_STRVAR(scaler_module_doc, "Compiled module providing the inspectable Scaler class.");
 PyDoc_STRVAR(
@@ -45,9 +94,7 @@ typedef struct {
 
 // Multiply a contiguous array directly with the factor, using np.multiply's
 // loop function.
-static inline PyObject *use_contiguous_loop(
-    ScalerObject *self, PyArrayObject *arr, char *factor_ptr
-)
+static inline PyObject *use_contiguous_loop(PyObject *self, PyArrayObject *arr, char *factor_ptr)
 {
     // Get loops from module state.
     PyObject *m = PyType_GetModuleByDef(Py_TYPE(self), &scaler_module);
@@ -100,27 +147,27 @@ static inline PyObject *use_contiguous_loop(
 }
 
 // Get the factor as a PyFloat, caching it as needed.
-static inline PyObject *get_o_factor(ScalerObject *self)
+static inline PyObject *get_o_factor(ScalerObject *scaler)
 {
-    if (self->O_factor == NULL) {
-        self->O_factor = PyFloat_FromDouble(self->factor);
-        if (self->O_factor == NULL) {
+    if (scaler->O_factor == NULL) {
+        scaler->O_factor = PyFloat_FromDouble(scaler->factor);
+        if (scaler->O_factor == NULL) {
             return NULL;
         }
     }
-    return self->O_factor;
+    return scaler->O_factor;
 }
 
 // Scale the input with the factor, using shortcuts where possible.
 static PyObject *Scaler_vectorcall(
-    ScalerObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
+    PyObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
 )
 {
-    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
+    if (kwnames != NULL && PyTuple_Size(kwnames) > 0) {
         PyErr_Format(
             PyExc_TypeError,
             "scaler() got an unexpected keyword argument %R",
-            PyTuple_GET_ITEM(kwnames, 0)
+            PyTuple_GetItem(kwnames, 0)
         );
         return NULL;
     }
@@ -132,11 +179,11 @@ static PyObject *Scaler_vectorcall(
         );
         return NULL;
     }
-
+    ScalerObject *scaler = (ScalerObject *)self;
     PyObject *const obj = args[0];
     // Fast paths for python double.
     if (PyFloat_CheckExact(obj)) {
-        return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
+        return PyFloat_FromDouble(PyFloat_AsDouble(obj) * scaler->factor);
     }
     // Fast path for plain ndarray, with special care for contiguous data.
     if (PyArray_CheckExact(obj)) {
@@ -145,7 +192,7 @@ static PyObject *Scaler_vectorcall(
         npy_bool needs_float = type_num == NPY_FLOAT || type_num == NPY_CFLOAT;
         npy_bool supported_fast_type =
             (needs_float || type_num == NPY_DOUBLE || type_num == NPY_CDOUBLE);
-        char *f_ptr = needs_float ? (char *)&self->factor_f : (char *)&self->factor;
+        char *f_ptr = needs_float ? (char *)&scaler->factor_f : (char *)&scaler->factor;
         // Pass contiguous float or complex arrays directly to multiply loop,
         // bypassing ufunc setup.
         if (supported_fast_type && PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr)) {
@@ -153,7 +200,7 @@ static PyObject *Scaler_vectorcall(
         }
         // If not, convert factor to array here, since that makes ufunc
         // call substantially faster.  Use cached version if available.
-        PyObject **A_factor = needs_float ? &self->A_factor_f : &self->A_factor;
+        PyObject **A_factor = needs_float ? &scaler->A_factor_f : &scaler->A_factor;
         if (*A_factor == NULL) {
             const npy_intp dims[1] = {0};
             *A_factor =
@@ -162,30 +209,32 @@ static PyObject *Scaler_vectorcall(
                 return NULL;
             }
         }
-        return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, *A_factor);
+        return PyNumber_Multiply(obj, *A_factor);
     }
 // Fast paths for numpy double and float scalars; particularly useful for
 // float32, where it avoids double->float conversion.
-// Note: keep PyArray_VAL and ASSIGN where they are: they prevent the compiler
+// Note: keep the PyArray_Scalar* calls where they are: they prevent the compiler
 // from reordering the multiplication with the fperr calls.
 #define FAST_PATH_NUMPY_SCALAR(obj, Type, npy_type, factor) \
     if (PyArray_IsScalar(obj, Type)) { \
-        PyObject *res = PyArrayScalar_New(Type); \
+        npy_type out; \
+        PyUFunc_clearfperr(); \
+        PyArray_ScalarAsCtype(obj, (char *)&out); \
+        out *= factor; \
+        PyArray_Descr *dtype = PyArray_DescrFromScalar(obj); \
+        PyObject *res = PyArray_Scalar((char *)&out, dtype, NULL); \
+        Py_DECREF(dtype); \
         if (res == NULL) { \
             return NULL; \
         } \
-        PyUFunc_clearfperr(); \
-        npy_type x = PyArrayScalar_VAL(obj, Type); \
-        npy_type out = x * factor; \
-        PyArrayScalar_ASSIGN(res, Type, out); \
         int fpe_errors = PyUFunc_getfperr(); \
         if (fpe_errors && PyUFunc_GiveFloatingpointErrors("scalar multiply", fpe_errors) < 0) { \
             Py_CLEAR(res); \
         } \
         return res; \
     }
-    FAST_PATH_NUMPY_SCALAR(obj, Double, npy_double, self->factor);
-    FAST_PATH_NUMPY_SCALAR(obj, Float, npy_float, self->factor_f);
+    FAST_PATH_NUMPY_SCALAR(obj, Double, npy_double, scaler->factor);
+    FAST_PATH_NUMPY_SCALAR(obj, Float, npy_float, scaler->factor_f);
 #undef FAST_PATH_NUMPY_SCALAR
     // Fast path for python integers.
     if (PyLong_CheckExact(obj)) {
@@ -193,10 +242,10 @@ static PyObject *Scaler_vectorcall(
         if (d == -1.0 && PyErr_Occurred()) {
             return NULL;
         }
-        return PyFloat_FromDouble(d * self->factor);
+        return PyFloat_FromDouble(d * scaler->factor);
     }
     // For cases without special treatment, we need the float object.
-    PyObject *O_factor = get_o_factor(self);
+    PyObject *O_factor = get_o_factor(scaler);
     if (O_factor == NULL) {
         return NULL;
     }
@@ -206,18 +255,6 @@ static PyObject *Scaler_vectorcall(
         PyObject_HasAttrString(obj, "dtype") ||
         PyObject_HasAttrString(obj, "__array_namespace__")) {
         // Generally, should be possible to go directly for the slot.
-        if (Py_TYPE(obj)->tp_as_number != NULL) {
-            binaryfunc slotv = Py_TYPE(obj)->tp_as_number->nb_multiply;
-            if (slotv != NULL) {
-                PyObject *res = slotv(obj, O_factor);
-                if (res != Py_NotImplemented) {
-                    return res;
-                }
-                // Fall back to slow path, which will likely raise,
-                // thus giving a reasonable error message.
-                Py_DECREF(res);
-            }
-        }
         return PyNumber_Multiply(obj, O_factor);
     }
     // If obj is not a known type, try converting it to an array.
@@ -244,31 +281,32 @@ static PyObject *Scaler_vectorcall(
 
 static inline PyObject *Scaler_from_factor(PyTypeObject *type, double factor)
 {
-    ScalerObject *self = (ScalerObject *)type->tp_alloc(type, 0);
+    PyObject *self = PyType_GenericAlloc(type, 0);
     if (self == NULL) {
         return NULL;
     }
-    self->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
-    self->factor = factor;
-    self->factor_f = (float)factor;
+    ScalerObject *scaler = (ScalerObject *)self;
+    scaler->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
+    scaler->factor = factor;
+    scaler->factor_f = (float)factor;
     // No need to explicitly set to zero, since zeroed by tp_alloc.
-    // self->O_factor = NULL;  // initialized as needed in call.
-    // self->A_factor = NULL;
-    // self->A_factor_f = NULL;
-    return (PyObject *)self;
+    // scaler->O_factor = NULL;  // initialized as needed in call.
+    // scaler->A_factor = NULL;
+    // scaler->A_factor_f = NULL;
+    return self;
 }
 
 static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     double factor;
-    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+    Py_ssize_t nargs = PyTuple_Size(args);
     if (nargs != 1 || kwds != NULL) {
         // Use parser to give error message.
         char *const kwlist[] = {"", NULL};
         PyArg_ParseTupleAndKeywords(args, kwds, "d:Scaler", kwlist, &factor);
         return NULL;
     }
-    factor = PyFloat_AsDouble(PyTuple_GET_ITEM(args, 0));
+    factor = PyFloat_AsDouble(PyTuple_GetItem(args, 0));
     if (factor == -1.0 && PyErr_Occurred()) {
         return NULL;
     }
@@ -288,39 +326,40 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 // traverse: Visit all references from an object, including its type
 // (since we're a heap type, which can get deallocated).
-static int Scaler_traverse(ScalerObject *self, visitproc visit, void *arg)
+static int Scaler_traverse(PyObject *self, visitproc visit, void *arg)
 {
     // Visit the type
     Py_VISIT(Py_TYPE(self));
 
     // Visit attributes that may hold references.
-    Py_VISIT(self->O_factor);
-    Py_VISIT(self->A_factor);
-    Py_VISIT(self->A_factor_f);
+    ScalerObject *scaler = (ScalerObject *)self;
+    Py_VISIT(scaler->O_factor);
+    Py_VISIT(scaler->A_factor);
+    Py_VISIT(scaler->A_factor_f);
     return 0;
 }
 
 // Clear internal references; called from finalize and dealloc.
-static int Scaler_clear(ScalerObject *self)
+static int Scaler_clear(PyObject *self)
 {
-    Py_CLEAR(self->O_factor);
-    Py_CLEAR(self->A_factor);
-    Py_CLEAR(self->A_factor_f);
+    ScalerObject *scaler = (ScalerObject *)self;
+    Py_CLEAR(scaler->O_factor);
+    Py_CLEAR(scaler->A_factor);
+    Py_CLEAR(scaler->A_factor_f);
     return 0;
 }
 
-static void Scaler_dealloc(ScalerObject *self)
+static void Scaler_dealloc(PyObject *self)
 {
     PyObject_GC_UnTrack(self);
     Scaler_clear(self);
-    PyTypeObject *type = Py_TYPE(self);
-    type->tp_free(self);
-    Py_DECREF(type);
+    PyObject_GC_Del(self);
+    Py_DECREF(Py_TYPE(self));
 }
 
-static PyObject *Scaler_repr(ScalerObject *self)
+static PyObject *Scaler_repr(PyObject *self)
 {
-    PyObject *O_factor = get_o_factor(self);
+    PyObject *O_factor = get_o_factor((ScalerObject *)self);
     if (O_factor == NULL) {
         return NULL;
     }
@@ -352,27 +391,18 @@ static Py_hash_t Scaler_hash(PyObject *self)
     return (PyObject_Hash((PyObject *)Py_TYPE(self)) ^ PyObject_Hash(O_factor));
 }
 
-static PyObject *Scaler___reduce__(ScalerObject *self)
+static PyObject *Scaler___reduce__(PyObject *self)
 {
-    return Py_BuildValue("(O(d))", Py_TYPE(self), self->factor);
+    return Py_BuildValue("(O(d))", Py_TYPE(self), ((ScalerObject *)self)->factor);
 }
 
 static PyMemberDef Scaler_members[] = {
-#if Py_Version < 0x03120000
-    {"factor",
-     T_DOUBLE,
-     offsetof(ScalerObject, factor),
-     READONLY,
-     "Factor with which input is multiplied."},
-    {"__vectorcalloffset__", T_PYSSIZET, offsetof(ScalerObject, vectorcall), READONLY},
-#else
     {"factor",
      Py_T_DOUBLE,
      offsetof(ScalerObject, factor),
      Py_READONLY,
      "Factor with which input is multiplied."},
     {"__vectorcalloffset__", Py_T_PYSSIZET, offsetof(ScalerObject, vectorcall), Py_READONLY},
-#endif
     {NULL},
 };
 
@@ -399,8 +429,7 @@ static PyType_Slot Scaler_slots[] = {
 static PyType_Spec Scaler_spec = {
     .name = "scaler.Scaler",
     .basicsize = sizeof(ScalerObject),
-    .flags =
-        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
+    .flags = SCALER_TP_FLAGS,
     .slots = Scaler_slots,
 };
 
@@ -494,11 +523,7 @@ static void scaler_module_free(PyObject *m)
 
 static PyModuleDef_Slot scaler_module_slots[] = {
     {Py_mod_exec, scaler_module_exec},
-#if Py_Version >= 0x03120000
-    // Just use this while using static types
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED},
-#endif
-    {0, NULL}
+    {0, NULL},
 };
 
 static PyModuleDef scaler_module = {

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -22,8 +22,11 @@ PyDoc_STRVAR(
 
 // Module state
 typedef struct {
-    PyTypeObject *Scaler;
-    PyObject *unity_scaler;
+    PyTypeObject *Scaler;   // The class
+    PyObject *unity_scaler; // Singleton for scale=1.0
+    PyObject *np_multiply;  // Reference to multiply, for holding on to loops.
+    // Double and float multiply loops, filled in on initialization.
+    PyUFuncGenericFunction loops[2];
 } scaler_state;
 
 // Forward definition.
@@ -39,13 +42,23 @@ typedef struct {
     PyObject *A_factor_f;
 } ScalerObject;
 
-// Double and float multiply loops, filled in on initialization.
-static PyUFuncGenericFunction loops[2] = {NULL, NULL};
 
 // Multiply a contiguous array directly with the factor, using np.multiply's
 // loop function.
-static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
+static inline PyObject *use_contiguous_loop(
+    ScalerObject *self, PyArrayObject *arr, char *factor_ptr
+)
 {
+    // Get loops from module state.
+    PyObject *m = PyType_GetModuleByDef(Py_TYPE(self), &scaler_module);
+    if (m == NULL) {
+        return NULL;
+    }
+    scaler_state *state = PyModule_GetState(m);
+    if (state == NULL) {
+        return NULL;
+    }
+    // Create result array.
     const int type_num = PyArray_TYPE(arr);
     PyArrayObject *res = (PyArrayObject *)PyArray_EMPTY(
         PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr)
@@ -62,12 +75,12 @@ static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr
     char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA(res)};
     if (type_num == NPY_DOUBLE || type_num == NPY_FLOAT) {
         strides[0] = PyArray_ITEMSIZE(arr);
-        loop = loops[type_num - NPY_FLOAT];
+        loop = state->loops[type_num - NPY_FLOAT];
     }
     else { // For complex, with real factor, we can use real loop.
         strides[0] = PyArray_ITEMSIZE(arr) / 2;
         n *= 2;
-        loop = loops[type_num - NPY_CFLOAT];
+        loop = state->loops[type_num - NPY_CFLOAT];
     }
     strides[1] = 0;
     strides[2] = strides[0];
@@ -136,7 +149,7 @@ static PyObject *Scaler_vectorcall(
         // Pass contiguous float or complex arrays directly to multiply loop,
         // bypassing ufunc setup.
         if (supported_fast_type && PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr)) {
-            return use_contiguous_loop(arr, f_ptr);
+            return use_contiguous_loop(self, arr, f_ptr);
         }
         // If not, convert factor to array here, since that makes ufunc
         // call substantially faster.  Use cached version if available.
@@ -394,35 +407,36 @@ static PyType_Spec Scaler_spec = {
 // Get and cache multiplication loops for use with plain ndarray.
 // Only gets double and float loops, since those can be used for
 // complex too. We ignore long double for our fast path.
-static int get_multiply_loops(PyUFuncGenericFunction loops[2])
+static int get_multiply_loops(scaler_state *state)
 {
     PyObject *mod = PyImport_ImportModule("numpy");
     if (mod == NULL) {
         return -1;
     }
-    PyUFuncObject *multiply = (PyUFuncObject *)PyObject_GetAttrString(mod, "multiply");
+    // Keep reference to multiply since we are using its loops
+    // (not that it will ever disappear...).
+    state->np_multiply = PyObject_GetAttrString(mod, "multiply");
     Py_DECREF(mod);
-    if (multiply == NULL) {
+    if (state->np_multiply == NULL) {
         return -1;
     }
     // Unfortunately, new-style loops are not exposed, so get legacy ones.
+    PyUFuncObject *multiply = (PyUFuncObject *)state->np_multiply;
     for (int k = 0; k < 2; k++) {
         char type = (char)(k + NPY_FLOAT);
         const char *types = multiply->types;
         for (int i = 0; i < multiply->ntypes; i++) {
             if (types[0] == type && types[1] == type && types[2] == type) {
-                loops[k] = multiply->functions[i];
+                state->loops[k] = multiply->functions[i];
                 break;
             }
             types += 3;
         }
-        if (loops[k] == NULL) { // Should never happen.
+        if (state->loops[k] == NULL) { // Should never happen.
             PyErr_SetString(PyExc_RuntimeError, "could not find loop");
             return -1;
         }
     }
-    // Keep reference to multiply since we are using its loops
-    // (not that it will ever disappear...).
     return 0;
 }
 
@@ -440,7 +454,7 @@ static int scaler_module_exec(PyObject *m)
     if (state->unity_scaler == NULL) {
         return -1;
     }
-    if (get_multiply_loops(loops) < 0) {
+    if (get_multiply_loops(state) < 0) {
         return -1;
     }
     return 0;
@@ -454,6 +468,7 @@ static int scaler_module_traverse(PyObject *m, visitproc visit, void *arg)
     }
     Py_VISIT(state->Scaler);
     Py_VISIT(state->unity_scaler);
+    Py_VISIT(state->np_multiply);
     return 0;
 }
 
@@ -465,6 +480,9 @@ static int scaler_module_clear(PyObject *m)
     }
     Py_CLEAR(state->Scaler);
     Py_CLEAR(state->unity_scaler);
+    Py_CLEAR(state->np_multiply);
+    state->loops[0] = NULL;
+    state->loops[1] = NULL;
     return 0;
 }
 
@@ -477,7 +495,8 @@ static void scaler_module_free(PyObject *m)
 static PyModuleDef_Slot scaler_module_slots[] = {
     {Py_mod_exec, scaler_module_exec},
 #if Py_Version >= 0x03120000
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
+    // Just use this while using static types
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED},
 #endif
     {0, NULL}
 };

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -7,6 +7,17 @@
 #include <numpy/ufuncobject.h>
 #include <stddef.h> // for offsetof()
 
+PyDoc_STRVAR(scaler_module_doc, "Compiled module providing the inspectable Scaler class.");
+PyDoc_STRVAR(
+    Scaler_doc,
+    "Multiplies input by the given scale factor.\n\n"
+    "Parameters\n"
+    "----------\n"
+    "factor : float, positional only\n"
+    "    The scale factor with which, when called, an argument will be multiplied.\n"
+);
+
+
 typedef struct {
     PyObject_HEAD
     vectorcallfunc vectorcall;
@@ -308,7 +319,7 @@ static PyMethodDef Scaler_methods[] = {
 
 static PyTypeObject ScalerType = {
     .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "scaler.Scaler",
-    .tp_doc = PyDoc_STR("When called, multiplies input by the given scale factor."),
+    .tp_doc = Scaler_doc,
     .tp_basicsize = sizeof(ScalerObject),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
@@ -386,7 +397,7 @@ static PyModuleDef_Slot scaler_module_slots[] = {
 static PyModuleDef scaler_module = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "scaler",
-    .m_doc = "Compiled module providing the inspectable Scaler class.",
+    .m_doc = scaler_module_doc,
     .m_size = 0,
     .m_slots = scaler_module_slots,
 };

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -259,12 +259,36 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return Scaler_from_factor(type, factor);
 }
 
+// traverse: Visit all references from an object, including its type
+// (since we're a heap type, which can get deallocated).
+static int Scaler_traverse(ScalerObject *self, visitproc visit, void *arg)
+{
+    // Visit the type
+    Py_VISIT(Py_TYPE(self));
+
+    // Visit attributes that may hold references.
+    Py_VISIT(self->O_factor);
+    Py_VISIT(self->A_factor);
+    Py_VISIT(self->A_factor_f);
+    return 0;
+}
+
+// Clear internal references; called from finalize and dealloc.
+static int Scaler_clear(ScalerObject *self)
+{
+    Py_CLEAR(self->O_factor);
+    Py_CLEAR(self->A_factor);
+    Py_CLEAR(self->A_factor_f);
+    return 0;
+}
+
 static void Scaler_dealloc(ScalerObject *self)
 {
-    Py_XDECREF(self->O_factor);
-    Py_XDECREF(self->A_factor);
-    Py_XDECREF(self->A_factor_f);
-    Py_TYPE(self)->tp_free(self);
+    PyObject_GC_UnTrack(self);
+    Scaler_clear(self);
+    PyTypeObject *type = Py_TYPE(self);
+    type->tp_free(self);
+    Py_DECREF(type);
 }
 
 static PyObject *Scaler_repr(ScalerObject *self)
@@ -307,17 +331,21 @@ static PyObject *Scaler___reduce__(ScalerObject *self)
 }
 
 static PyMemberDef Scaler_members[] = {
-    {"factor",
 #if Py_Version < 0x03120000
+    {"factor",
      T_DOUBLE,
      offsetof(ScalerObject, factor),
      READONLY,
+     "Factor with which input is multiplied."},
+    {"__vectorcalloffset__", T_PYSSIZET, offsetof(ScalerObject, vectorcall), READONLY},
 #else
+    {"factor",
      Py_T_DOUBLE,
      offsetof(ScalerObject, factor),
      Py_READONLY,
-#endif
      "Factor with which input is multiplied."},
+    {"__vectorcalloffset__", Py_T_PYSSIZET, offsetof(ScalerObject, vectorcall), Py_READONLY},
+#endif
     {NULL},
 };
 
@@ -326,21 +354,27 @@ static PyMethodDef Scaler_methods[] = {
     {NULL, NULL, 0, NULL},
 };
 
-static PyTypeObject ScalerType = {
-    .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "scaler.Scaler",
-    .tp_doc = Scaler_doc,
-    .tp_basicsize = sizeof(ScalerObject),
-    .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
-    .tp_new = Scaler_new,
-    .tp_repr = (reprfunc)Scaler_repr,
-    .tp_dealloc = (destructor)Scaler_dealloc,
-    .tp_vectorcall_offset = offsetof(ScalerObject, vectorcall),
-    .tp_call = &PyVectorcall_Call,
-    .tp_members = Scaler_members,
-    .tp_methods = Scaler_methods,
-    .tp_richcompare = Scaler_richcompare,
-    .tp_hash = Scaler_hash,
+static PyType_Slot Scaler_slots[] = {
+    {Py_tp_doc, Scaler_doc},
+    {Py_tp_new, (newfunc)Scaler_new},
+    {Py_tp_traverse, (traverseproc)Scaler_traverse},
+    {Py_tp_clear, (inquiry)Scaler_clear},
+    {Py_tp_dealloc, (destructor)Scaler_dealloc},
+    {Py_tp_repr, (reprfunc)Scaler_repr},
+    {Py_tp_richcompare, (richcmpfunc)Scaler_richcompare},
+    {Py_tp_hash, (hashfunc)Scaler_hash},
+    {Py_tp_call, &PyVectorcall_Call},
+    {Py_tp_members, Scaler_members},
+    {Py_tp_methods, Scaler_methods},
+    {0, NULL},
+};
+
+static PyType_Spec Scaler_spec = {
+    .name = "scaler.Scaler",
+    .basicsize = sizeof(ScalerObject),
+    .flags =
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_BASETYPE,
+    .slots = Scaler_slots,
 };
 
 // Get and cache multiplication loops for use with plain ndarray.
@@ -380,13 +414,14 @@ static int get_multiply_loops(PyUFuncGenericFunction loops[2])
 
 static int scaler_module_exec(PyObject *m)
 {
-    if (PyType_Ready(&ScalerType) < 0) {
+    PyTypeObject *Scaler = (PyTypeObject *)PyType_FromModuleAndSpec(m, &Scaler_spec, NULL);
+    if (Scaler == NULL) {
         return -1;
     }
-    if (PyModule_AddObjectRef(m, "Scaler", (PyObject *)&ScalerType) < 0) {
+    if (PyModule_AddType(m, Scaler) < 0) {
         return -1;
     }
-    unity_scaler = Scaler_from_factor(&ScalerType, 1.0);
+    unity_scaler = Scaler_from_factor(Scaler, 1.0);
     if (unity_scaler == NULL) {
         return -1;
     }

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -19,6 +19,8 @@ typedef struct {
 
 // Double and float multiply loops, filled in on initialization.
 static PyUFuncGenericFunction loops[2] = {NULL, NULL};
+// Unity scaler, which is kept unique, filled in on initialization.
+static PyObject *unity_scaler = NULL;
 
 // Multiply a contiguous array directly with the factor, using np.multiply's
 // loop function.
@@ -196,16 +198,8 @@ static PyObject *Scaler_vectorcall(
     return res;
 }
 
-static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static inline PyObject *Scaler_from_factor(PyTypeObject *type, double factor)
 {
-    if (kwds != NULL || PyTuple_Size(args) != 1) {
-        PyErr_SetString(PyExc_TypeError, "Scaler takes exactly 1 positional argument.");
-        return NULL;
-    }
-    double factor = PyFloat_AsDouble(PyTuple_GET_ITEM(args, 0));
-    if (factor == -1.0 && PyErr_Occurred()) {
-        return NULL;
-    }
     ScalerObject *self = (ScalerObject *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;
@@ -218,6 +212,22 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     // self->A_factor = NULL;
     // self->A_factor_f = NULL;
     return (PyObject *)self;
+}
+
+static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    if (kwds != NULL || PyTuple_GET_SIZE(args) != 1) {
+        PyErr_SetString(PyExc_TypeError, "Scaler takes exactly 1 positional argument.");
+        return NULL;
+    }
+    double factor = PyFloat_AsDouble(PyTuple_GET_ITEM(args, 0));
+    if (factor == -1.0 && PyErr_Occurred()) {
+        return NULL;
+    }
+    if (factor == 1.0) { // Use singleton.
+        return Py_NewRef(unity_scaler);
+    }
+    return Scaler_from_factor(type, factor);
 }
 
 static void Scaler_dealloc(ScalerObject *self)
@@ -339,6 +349,10 @@ static int scaler_module_exec(PyObject *m)
         return -1;
     }
     if (PyModule_AddObjectRef(m, "Scaler", (PyObject *)&ScalerType) < 0) {
+        return -1;
+    }
+    unity_scaler = Scaler_from_factor(&ScalerType, 1.0);
+    if (unity_scaler == NULL) {
         return -1;
     }
     if (get_multiply_loops(loops) < 0) {

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -4,11 +4,10 @@
 #include <Python.h>
 #include <numpy/ndarrayobject.h>
 #include <numpy/ufuncobject.h>
-#include <stddef.h> /* for offsetof() */
+#include <stddef.h> // for offsetof()
 
 typedef struct {
     PyObject_HEAD
-    /* Type-specific fields go here. */
     double factor;
     double factor_imag; // always set to 0, to have complex factor.
     float factor_f;
@@ -21,15 +20,18 @@ typedef struct {
 
 static PyUFuncGenericFunction loops[6] = {NULL};
 
+// Multiply a contiguous array directly with the factor, using np.multiply's
+// loop function.
 static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
 {
-    const char type_num = PyArray_TYPE(arr);
-    PyUFuncGenericFunction loop = loops[(int)(type_num - NPY_FLOAT)];
-    PyObject *res =
-        PyArray_EMPTY(PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr));
-    char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA((PyArrayObject *)res)};
+    const int type_num = PyArray_TYPE(arr);
+    PyUFuncGenericFunction loop = loops[type_num - NPY_FLOAT];
+    PyArrayObject *res = (PyArrayObject *)PyArray_EMPTY(
+        PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr)
+    );
     npy_intp n = PyArray_SIZE(arr);
     npy_intp strides[3] = {PyArray_ITEMSIZE(arr), 0, PyArray_ITEMSIZE(arr)};
+    char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA(res)};
     PyUFunc_clearfperr();
     loop(data, &n, strides, NULL);
     int fpe_errors = PyUFunc_getfperr();
@@ -39,9 +41,10 @@ static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr
             return NULL;
         }
     }
-    return res;
+    return (PyObject *)res;
 }
 
+// Get the factor as a PyFloat, caching it as needed.
 static inline PyObject *get_o_factor(ScalerObject *self)
 {
     if (self->O_factor == NULL) {
@@ -53,43 +56,48 @@ static inline PyObject *get_o_factor(ScalerObject *self)
     return self->O_factor;
 }
 
+// Scale the input with the factor, using shortcuts where possible.
 static PyObject *Scaler_vectorcall(
     ScalerObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
 )
 {
-    PyObject *const obj = args[0];
     if (PyVectorcall_NARGS(len_args) != 1) {
         PyErr_Format(
             PyExc_TypeError, "scaler() takes 1 argument, not %d", PyVectorcall_NARGS(len_args)
         );
         return NULL;
     }
+    PyObject *const obj = args[0];
     // fastest paths: special-case known objects.
     if (PyFloat_CheckExact(obj)) {
         return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
     }
-    else if (PyArray_CheckExact(obj)) {
+    if (PyArray_CheckExact(obj)) {
         PyArrayObject *const arr = (PyArrayObject *)obj;
-        char type_num = PyArray_TYPE(arr);
+        const int type_num = PyArray_TYPE(arr);
         npy_bool needs_float = type_num == NPY_FLOAT || type_num == NPY_CFLOAT;
+        npy_bool supported_fast_type =
+            (needs_float || type_num == NPY_DOUBLE || type_num == NPY_CDOUBLE);
         char *f_ptr = needs_float ? (char *)&self->factor_f : (char *)&self->factor;
         // Pass contiguous float or complex arrays directly to multiply loop,
         // bypassing ufunc setup.
-        if (PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr) &&
-            (type_num == NPY_DOUBLE || type_num == NPY_CDOUBLE || needs_float)) {
+        if (supported_fast_type && PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr)) {
             return use_contiguous_loop(arr, f_ptr);
         }
         // If not, convert factor to array here, since that makes ufunc
-        // call substantially faster.
+        // call substantially faster.  Use cached version if available.
         PyObject **A_factor = needs_float ? &self->A_factor_f : &self->A_factor;
         if (*A_factor == NULL) {
             const npy_intp dims[1] = {0};
             *A_factor =
                 PyArray_SimpleNewFromData(0, dims, needs_float ? NPY_FLOAT : NPY_DOUBLE, f_ptr);
+            if (*A_factor == NULL) {
+                return NULL;
+            }
         }
         return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, *A_factor);
     }
-    else if (PyLong_CheckExact(obj)) {
+    if (PyLong_CheckExact(obj)) {
         double d = PyLong_AsDouble(obj);
         if (d == -1.0 && PyErr_Occurred()) {
             return NULL;
@@ -121,7 +129,7 @@ static PyObject *Scaler_vectorcall(
         }
         return PyNumber_Multiply(obj, O_factor);
     }
-    // If not a known type, try converting to an array.
+    // If obj is not a known type, try converting it to an array.
     PyObject *arr = PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
     if (arr == NULL) {
         return NULL;
@@ -157,14 +165,15 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (self == NULL) {
         return NULL;
     }
-    self->factor = factor;
-    self->factor_imag = 0; // allows using &self->factor for complex.
-    self->factor_f = (float)factor;
-    self->factor_f_imag = 0;
-    self->O_factor = NULL; // following initialized only if needed in call.
-    self->A_factor = NULL;
-    self->A_factor_f = NULL;
     self->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
+    self->factor = factor;
+    self->factor_f = (float)factor;
+    // No need to explicitly set to zero, since zeroed by tp_alloc.
+    // self->factor_imag = 0;  // allows using &self->factor for complex.
+    // self->factor_f_imag = 0;
+    // self->O_factor = NULL;  // initialized as needed in call.
+    // self->A_factor = NULL;
+    // self->A_factor_f = NULL;
     return (PyObject *)self;
 }
 
@@ -178,24 +187,30 @@ static void Scaler_dealloc(ScalerObject *self)
 
 static PyObject *Scaler_repr(ScalerObject *self)
 {
-    return PyUnicode_FromFormat("Scaler(%S)", PyFloat_FromDouble(self->factor));
+    PyObject *O_factor = get_o_factor(self);
+    if (O_factor == NULL) {
+        return NULL;
+    }
+    return PyUnicode_FromFormat("Scaler(%S)", O_factor);
 }
 
 static PyObject *Scaler_richcompare(PyObject *self, PyObject *other, int op)
 {
     if (op != Py_EQ && op != Py_NE) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+        Py_RETURN_NOTIMPLEMENTED;
     }
     npy_bool same =
         (Py_TYPE(other) == Py_TYPE(self) &&
          (((ScalerObject *)other)->factor == ((ScalerObject *)self)->factor));
-    PyObject *res = (op == Py_EQ) ^ same ? Py_False : Py_True;
-    Py_INCREF(res);
-    return res;
+    if ((op == Py_EQ) ^ same) {
+        Py_RETURN_FALSE;
+    }
+    else {
+        Py_RETURN_TRUE;
+    }
 }
 
-Py_hash_t Scaler_hash(PyObject *self)
+static Py_hash_t Scaler_hash(PyObject *self)
 {
     PyObject *O_factor = get_o_factor((ScalerObject *)self);
     if (O_factor == NULL) {
@@ -225,7 +240,7 @@ static PyMethodDef Scaler_methods[] = {
 
 static PyTypeObject ScalerType = {
     .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "scaler.Scaler",
-    .tp_doc = PyDoc_STR("Multiplies input by the given scale factor."),
+    .tp_doc = PyDoc_STR("When called, multiplies input by the given scale factor."),
     .tp_basicsize = sizeof(ScalerObject),
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
@@ -240,9 +255,11 @@ static PyTypeObject ScalerType = {
     .tp_hash = Scaler_hash,
 };
 
+// Get and cache multiplication loops for use with plain ndarray.
+// Only gets float, double, complex float and complex double,
+// not the long double ones.
 static int get_multiply_loops(PyUFuncGenericFunction loops[6])
 {
-    // Get and cache multiplication loops for use with plain ndarray.
     PyObject *mod = PyImport_ImportModule("numpy");
     if (mod == NULL) {
         return -1;
@@ -254,7 +271,7 @@ static int get_multiply_loops(PyUFuncGenericFunction loops[6])
     }
     // Unfortunately, new-style loops are not exposed, so get legacy ones.
     for (int k = 0; k < 5; k++) {
-        char type = (char)(k + (int)NPY_FLOAT);
+        char type = (char)(k + NPY_FLOAT);
         if (type == NPY_LONGDOUBLE) {
             continue;
         }
@@ -266,7 +283,7 @@ static int get_multiply_loops(PyUFuncGenericFunction loops[6])
             }
             types += 3;
         }
-        if (loops[k] == NULL) {
+        if (loops[k] == NULL) { // Should never happen.
             PyErr_SetString(PyExc_RuntimeError, "could not find loop");
             return -1;
         }
@@ -300,7 +317,7 @@ static PyModuleDef_Slot scaler_module_slots[] = {
 static PyModuleDef scaler_module = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "scaler",
-    .m_doc = "Provides the inspectable Scaler class.",
+    .m_doc = "Compiled module providing the inspectable Scaler class.",
     .m_size = 0,
     .m_slots = scaler_module_slots,
 };

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -28,6 +28,13 @@ PyObject *Scaler_vectorcall(
         return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
     }
     else if (PyArray_CheckExact(obj)) {
+        if (self->A_factor == NULL) {
+            npy_intp const dims[0];
+            self->A_factor = PyArray_SimpleNewFromData(0, dims, NPY_FLOAT64, &self->factor);
+            if (self->A_factor == NULL) {
+                return NULL;
+            }
+        }
         return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, self->A_factor);
     }
     else if (PyLong_CheckExact(obj)) {
@@ -36,6 +43,14 @@ PyObject *Scaler_vectorcall(
             return NULL;
         }
         return PyFloat_FromDouble(d * self->factor);
+    }
+    // For cases without special treatment, we need the float object, so
+    // construct it ahead of time.
+    if (self->O_factor == NULL) {
+        self->O_factor = PyFloat_FromDouble(self->factor);
+        if (self->O_factor == NULL) {
+            return NULL;
+        }
     }
     // fast path, go directly for the slot, to avoid PyNumber call.
     if (Py_TYPE(obj)->tp_as_number != NULL) {
@@ -54,31 +69,21 @@ PyObject *Scaler_vectorcall(
 
 static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    ScalerObject *self;
-    self = (ScalerObject *)type->tp_alloc(type, 0);
+    if (kwds != NULL || PyTuple_Size(args) != 1) {
+        PyErr_SetString(PyExc_TypeError, "Scaler takes exactly 1 positional argument.");
+        return NULL;
+    }
+    double factor = PyFloat_AsDouble(PyTuple_GET_ITEM(args, 0));
+    if (factor == -1.0 && PyErr_Occurred()) {
+        return NULL;
+    }
+    ScalerObject *self = (ScalerObject *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;
     }
-    static char *kwlist[] = {"factor", NULL};
-    int res = PyArg_ParseTupleAndKeywords(args, kwds, "d", kwlist, &self->factor);
-    if (!res) {
-        Py_DECREF(self);
-        return NULL;
-    }
-    // For cases without special treatment, we need the float object, so
-    // construct it ahead of time.
-    self->O_factor = PyFloat_FromDouble(self->factor);
-    if (self->O_factor == NULL) {
-        Py_DECREF(self);
-        return NULL;
-    }
-    PyArray_Descr *dtype = PyArray_DescrFromType(NPY_FLOAT64); // cannot fail;
-    self->A_factor = PyArray_FromAny(self->O_factor, dtype, 0, 0, 0, NULL);
-    if (self->A_factor == NULL) {
-        Py_DECREF(self);
-        Py_DECREF(self->O_factor);
-        return NULL;
-    }
+    self->factor = factor;
+    self->O_factor = NULL;
+    self->A_factor = NULL;
     self->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
     return (PyObject *)self;
 }

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -5,8 +5,47 @@
 typedef struct {
     PyObject_HEAD
     /* Type-specific fields go here. */
-    PyObject *factor;
+    double factor;
+    PyObject *O_factor;
+    vectorcallfunc vectorcall;
 } ScalerObject;
+
+PyObject *Scaler_vectorcall(
+    ScalerObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
+)
+{
+    PyObject *obj = args[0];
+    if (PyVectorcall_NARGS(len_args) != 1) {
+        PyErr_Format(
+            PyExc_TypeError, "scaler() takes 1 argument, not %d", PyVectorcall_NARGS(len_args)
+        );
+        return NULL;
+    }
+    // fastest paths: special-case known objects.
+    if (PyFloat_CheckExact(obj)) {
+        return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
+    }
+    else if (PyLong_CheckExact(obj)) {
+        double d = PyLong_AsDouble(obj);
+        if (d == -1.0 && PyErr_Occurred()) {
+            return NULL;
+        }
+        return PyFloat_FromDouble(d * self->factor);
+    }
+    // fast path, go directly for the slot, to avoid PyNumber call.
+    if (Py_TYPE(obj)->tp_as_number != NULL) {
+        binaryfunc slotv = Py_TYPE(obj)->tp_as_number->nb_multiply;
+        if (slotv != NULL) {
+            PyObject *res = slotv(obj, self->O_factor);
+            if (res != Py_NotImplemented) {
+                return res;
+            }
+            // Fall back to slow path, which will almost certainly raise.
+            Py_DECREF(res);
+        }
+    }
+    return PyNumber_Multiply(obj, self->O_factor);
+}
 
 static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
@@ -16,58 +55,32 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     static char *kwlist[] = {"factor", NULL};
-    double factor;
-    int res = PyArg_ParseTupleAndKeywords(args, kwds, "d", kwlist, &factor);
+    int res = PyArg_ParseTupleAndKeywords(args, kwds, "d", kwlist, &self->factor);
     if (!res) {
         Py_DECREF(self);
         return NULL;
     }
-    self->factor = PyFloat_FromDouble(factor);
-    if (self->factor == NULL) {
+    // For cases without special treatment, we need the float object, so
+    // construct it ahead of time.
+    self->O_factor = PyFloat_FromDouble(self->factor);
+    if (self->O_factor == NULL) {
         Py_DECREF(self);
         return NULL;
     }
+    self->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
     return (PyObject *)self;
 }
 
 static void Scaler_dealloc(ScalerObject *self)
 {
-    Py_XDECREF(self->factor);
+    Py_XDECREF(self->O_factor);
     Py_TYPE(self)->tp_free(self);
-}
-
-PyObject *Scaler_call(ScalerObject *self, PyObject *args, PyObject *kwds)
-{
-    PyObject *obj, *mul, *res;
-    static char *kwlist[] = {"x", NULL};
-    if (PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &obj) < 0) {
-        return NULL;
-    }
-    mul = PyObject_GetAttrString(obj, "__mul__");
-    if (mul == NULL) {
-        return NULL;
-    }
-    res = PyObject_CallOneArg(mul, self->factor);
-    Py_DECREF(mul);
-    if (res == Py_NotImplemented) {
-        // Fairly unlikely to happen, but int cannot multiply with float.
-        Py_DECREF(res);
-        mul = PyObject_GetAttrString(self->factor, "__rmul__");
-        res = PyObject_CallOneArg(mul, obj);
-        Py_DECREF(mul);
-        if (res == Py_NotImplemented) { // Not sure I can hit this.
-            Py_DECREF(res);
-            PyErr_Format(PyExc_TypeError, "cannot scale type '%T'", obj);
-            res = NULL;
-        }
-    }
-    return res;
 }
 
 static PyMemberDef Scaler_members[] = {
     {"factor",
      Py_T_OBJECT_EX,
-     offsetof(ScalerObject, factor),
+     offsetof(ScalerObject, O_factor),
      Py_READONLY,
      "factor with which input is multiplied"},
     {NULL},
@@ -78,10 +91,11 @@ static PyTypeObject ScalerType = {
     .tp_doc = PyDoc_STR("Multiplies input by the given scale factor"),
     .tp_basicsize = sizeof(ScalerObject),
     .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_new = Scaler_new,
     .tp_dealloc = (destructor)Scaler_dealloc,
-    .tp_call = (ternaryfunc)Scaler_call,
+    .tp_vectorcall_offset = offsetof(ScalerObject, vectorcall),
+    .tp_call = &PyVectorcall_Call,
     .tp_members = Scaler_members,
 };
 

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -83,12 +83,23 @@ static PyObject *Scaler_vectorcall(
     ScalerObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
 )
 {
-    if (PyVectorcall_NARGS(len_args) != 1) {
+    if (kwnames != NULL && PyTuple_GET_SIZE(kwnames) > 0) {
         PyErr_Format(
-            PyExc_TypeError, "scaler() takes 1 argument, not %d", PyVectorcall_NARGS(len_args)
+            PyExc_TypeError,
+            "scaler() got an unexpected keyword argument %R",
+            PyTuple_GET_ITEM(kwnames, 0)
         );
         return NULL;
     }
+    if (PyVectorcall_NARGS(len_args) != 1) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "scaler() takes 1 positional argument but %d were given",
+            PyVectorcall_NARGS(len_args)
+        );
+        return NULL;
+    }
+
     PyObject *const obj = args[0];
     // Fast paths for python double.
     if (PyFloat_CheckExact(obj)) {
@@ -216,11 +227,15 @@ static inline PyObject *Scaler_from_factor(PyTypeObject *type, double factor)
 
 static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    if (kwds != NULL || PyTuple_GET_SIZE(args) != 1) {
-        PyErr_SetString(PyExc_TypeError, "Scaler takes exactly 1 positional argument.");
+    double factor;
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+    if (nargs != 1 || kwds != NULL) {
+        // Use parser to give error message.
+        char *const kwlist[] = {"", NULL};
+        PyArg_ParseTupleAndKeywords(args, kwds, "d:Scaler", kwlist, &factor);
         return NULL;
     }
-    double factor = PyFloat_AsDouble(PyTuple_GET_ITEM(args, 0));
+    factor = PyFloat_AsDouble(PyTuple_GET_ITEM(args, 0));
     if (factor == -1.0 && PyErr_Occurred()) {
         return NULL;
     }

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -25,15 +25,24 @@ static PyUFuncGenericFunction loops[6] = {NULL};
 static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
 {
     const int type_num = PyArray_TYPE(arr);
-    PyUFuncGenericFunction loop = loops[type_num - NPY_FLOAT];
     PyArrayObject *res = (PyArrayObject *)PyArray_EMPTY(
         PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr)
     );
+    if (res == NULL) {
+        return NULL;
+    }
     npy_intp n = PyArray_SIZE(arr);
+    if (n == 0) {
+        return (PyObject *)res; // Nothing to do.
+    }
+    PyUFuncGenericFunction loop = loops[type_num - NPY_FLOAT];
     npy_intp strides[3] = {PyArray_ITEMSIZE(arr), 0, PyArray_ITEMSIZE(arr)};
     char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA(res)};
     PyUFunc_clearfperr();
+    NPY_BEGIN_THREADS_DEF;
+    NPY_BEGIN_THREADS_THRESHOLDED(n);
     loop(data, &n, strides, NULL);
+    NPY_END_THREADS;
     int fpe_errors = PyUFunc_getfperr();
     if (fpe_errors) {
         if (PyUFunc_GiveFloatingpointErrors("multiply", fpe_errors) < 0) {

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -19,30 +19,12 @@ typedef struct {
     vectorcallfunc vectorcall;
 } ScalerObject;
 
-static PyUFuncObject *multiply = NULL;
+static PyUFuncGenericFunction loops[6] = {NULL};
 
-static PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
+static inline PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
 {
-    static PyUFuncGenericFunction loops[6] = {NULL};
     const char type_num = PyArray_TYPE(arr);
     PyUFuncGenericFunction loop = loops[(int)(type_num - NPY_FLOAT)];
-    if (loop == NULL) {
-        // Unfortunately, new-style loops are not exposed, so get legacy one.
-        int nargs = multiply->nargs;
-        const char *types = multiply->types;
-        for (int i = 0; i < multiply->ntypes; i++) {
-            if (types[0] == type_num && types[1] == type_num && types[2] == type_num) {
-                loop = loops[(int)(type_num - NPY_FLOAT)] = multiply->functions[i];
-                break;
-            }
-            types += nargs;
-        }
-        if (loop == NULL) {
-            PyErr_SetString(PyExc_RuntimeError, "could not find loop");
-            return NULL;
-        }
-    }
-    // do it!
     PyObject *res =
         PyArray_EMPTY(PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr));
     char *data[3] = {PyArray_DATA(arr), factor_ptr, PyArray_DATA((PyArrayObject *)res)};
@@ -56,8 +38,8 @@ static PyObject *use_contiguous_loop(PyArrayObject *arr, char *factor_ptr)
             Py_DECREF(res);
             return NULL;
         }
+        return res;
     }
-    return res;
 }
 
 static PyObject *Scaler_vectorcall(
@@ -184,12 +166,51 @@ static PyTypeObject ScalerType = {
     .tp_members = Scaler_members,
 };
 
+static int get_multiply_loops(PyUFuncGenericFunction loops[6])
+{
+    // Get and cache multiplication loops for use with plain ndarray.
+    PyObject *mod = PyImport_ImportModule("numpy");
+    if (mod == NULL) {
+        return -1;
+    }
+    PyUFuncObject *multiply = (PyUFuncObject *)PyObject_GetAttrString(mod, "multiply");
+    Py_DECREF(mod);
+    if (multiply == NULL) {
+        return -1;
+    }
+    // Unfortunately, new-style loops are not exposed, so get legacy ones.
+    for (int k = 0; k < 5; k++) {
+        char type = (char)(k + (int)NPY_FLOAT);
+        if (type == NPY_LONGDOUBLE) {
+            continue;
+        }
+        const char *types = multiply->types;
+        for (int i = 0; i < multiply->ntypes; i++) {
+            if (types[0] == type && types[1] == type && types[2] == type) {
+                loops[k] = multiply->functions[i];
+                break;
+            }
+            types += 3;
+        }
+        if (loops[k] == NULL) {
+            PyErr_SetString(PyExc_RuntimeError, "could not find loop");
+            return -1;
+        }
+    }
+    // Keep reference to multiply since we are using its loops
+    // (not that it will ever disappear...).
+    return 0;
+}
+
 static int scaler_module_exec(PyObject *m)
 {
     if (PyType_Ready(&ScalerType) < 0) {
         return -1;
     }
     if (PyModule_AddObjectRef(m, "Scaler", (PyObject *)&ScalerType) < 0) {
+        return -1;
+    }
+    if (get_multiply_loops(loops) < 0) {
         return -1;
     }
     return 0;
@@ -216,14 +237,6 @@ PyMODINIT_FUNC PyInit_scaler(void)
         return NULL;
     }
     if (PyArray_ImportNumPyAPI() < 0) {
-        return NULL;
-    }
-    PyObject *mod = PyImport_ImportModule("numpy");
-    if (mod != NULL) {
-        multiply = (PyUFuncObject *)PyObject_GetAttrString(mod, "multiply");
-        Py_DECREF(mod);
-    }
-    if (multiply == NULL) {
         return NULL;
     }
     return PyModuleDef_Init(&scaler_module);

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -168,6 +168,11 @@ static void Scaler_dealloc(ScalerObject *self)
     Py_TYPE(self)->tp_free(self);
 }
 
+static PyObject *Scaler_repr(ScalerObject *self)
+{
+    return PyUnicode_FromFormat("Scaler(%S)", PyFloat_FromDouble(self->factor));
+}
+
 static PyMemberDef Scaler_members[] = {
     {"factor",
      Py_T_DOUBLE,
@@ -184,6 +189,7 @@ static PyTypeObject ScalerType = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL,
     .tp_new = Scaler_new,
+    .tp_repr = (reprfunc)Scaler_repr,
     .tp_dealloc = (destructor)Scaler_dealloc,
     .tp_vectorcall_offset = offsetof(ScalerObject, vectorcall),
     .tp_call = &PyVectorcall_Call,

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -2,6 +2,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "numpy/arrayobject.h"
 #include <Python.h>
+#include <numpy/arrayscalars.h>
 #include <numpy/ndarrayobject.h>
 #include <numpy/ufuncobject.h>
 #include <stddef.h> // for offsetof()
@@ -87,10 +88,11 @@ static PyObject *Scaler_vectorcall(
         return NULL;
     }
     PyObject *const obj = args[0];
-    // fastest paths: special-case known objects.
+    // Fast paths for python double.
     if (PyFloat_CheckExact(obj)) {
         return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
     }
+    // Fast path for plain ndarray, with special care for contiguous data.
     if (PyArray_CheckExact(obj)) {
         PyArrayObject *const arr = (PyArrayObject *)obj;
         const int type_num = PyArray_TYPE(arr);
@@ -116,6 +118,30 @@ static PyObject *Scaler_vectorcall(
         }
         return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, *A_factor);
     }
+// Fast paths for numpy double and float scalars; particularly useful for
+// float32, where it avoids double->float conversion.
+// Note: keep PyArray_VAL and ASSIGN where they are: they prevent the compiler
+// from reordering the multiplication with the fperr calls.
+#define FAST_PATH_NUMPY_SCALAR(obj, Type, npy_type, factor) \
+    if (PyArray_IsScalar(obj, Type)) { \
+        PyObject *res = PyArrayScalar_New(Type); \
+        if (res == NULL) { \
+            return NULL; \
+        } \
+        PyUFunc_clearfperr(); \
+        npy_type x = PyArrayScalar_VAL(obj, Type); \
+        npy_type out = x * factor; \
+        PyArrayScalar_ASSIGN(res, Type, out); \
+        int fpe_errors = PyUFunc_getfperr(); \
+        if (fpe_errors && PyUFunc_GiveFloatingpointErrors("scalar multiply", fpe_errors) < 0) { \
+            Py_CLEAR(res); \
+        } \
+        return res; \
+    }
+    FAST_PATH_NUMPY_SCALAR(obj, Double, npy_double, self->factor);
+    FAST_PATH_NUMPY_SCALAR(obj, Float, npy_float, self->factor_f);
+#undef FAST_PATH_NUMPY_SCALAR
+    // Fast path for python integers.
     if (PyLong_CheckExact(obj)) {
         double d = PyLong_AsDouble(obj);
         if (d == -1.0 && PyErr_Occurred()) {

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -1,0 +1,119 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stddef.h> /* for offsetof() */
+
+typedef struct {
+    PyObject_HEAD
+    /* Type-specific fields go here. */
+    PyObject *factor;
+} ScalerObject;
+
+static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    ScalerObject *self;
+    self = (ScalerObject *)type->tp_alloc(type, 0);
+    if (self == NULL) {
+        return NULL;
+    }
+    static char *kwlist[] = {"factor", NULL};
+    double factor;
+    int res = PyArg_ParseTupleAndKeywords(args, kwds, "d", kwlist, &factor);
+    if (!res) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    self->factor = PyFloat_FromDouble(factor);
+    if (self->factor == NULL) {
+        Py_DECREF(self);
+        return NULL;
+    }
+    return (PyObject *)self;
+}
+
+static void Scaler_dealloc(ScalerObject *self)
+{
+    Py_XDECREF(self->factor);
+    Py_TYPE(self)->tp_free(self);
+}
+
+PyObject *Scaler_call(ScalerObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *obj, *mul, *res;
+    static char *kwlist[] = {"x", NULL};
+    if (PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &obj) < 0) {
+        return NULL;
+    }
+    mul = PyObject_GetAttrString(obj, "__mul__");
+    if (mul == NULL) {
+        return NULL;
+    }
+    res = PyObject_CallOneArg(mul, self->factor);
+    Py_DECREF(mul);
+    if (res == Py_NotImplemented) {
+        // Fairly unlikely to happen, but int cannot multiply with float.
+        Py_DECREF(res);
+        mul = PyObject_GetAttrString(self->factor, "__rmul__");
+        res = PyObject_CallOneArg(mul, obj);
+        Py_DECREF(mul);
+        if (res == Py_NotImplemented) { // Not sure I can hit this.
+            Py_DECREF(res);
+            PyErr_Format(PyExc_TypeError, "cannot scale type '%T'", obj);
+            res = NULL;
+        }
+    }
+    return res;
+}
+
+static PyMemberDef Scaler_members[] = {
+    {"factor",
+     Py_T_OBJECT_EX,
+     offsetof(ScalerObject, factor),
+     Py_READONLY,
+     "factor with which input is multiplied"},
+    {NULL},
+};
+
+static PyTypeObject ScalerType = {
+    .ob_base = PyVarObject_HEAD_INIT(NULL, 0).tp_name = "Scaler",
+    .tp_doc = PyDoc_STR("Multiplies input by the given scale factor"),
+    .tp_basicsize = sizeof(ScalerObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_new = Scaler_new,
+    .tp_dealloc = (destructor)Scaler_dealloc,
+    .tp_call = (ternaryfunc)Scaler_call,
+    .tp_members = Scaler_members,
+};
+
+static int scaler_module_exec(PyObject *m)
+{
+    if (PyType_Ready(&ScalerType) < 0) {
+        return -1;
+    }
+
+    if (PyModule_AddObjectRef(m, "Scaler", (PyObject *)&ScalerType) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static PyModuleDef_Slot scaler_module_slots[] = {
+    {Py_mod_exec, scaler_module_exec},
+    // Just use this while using static types
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
+    {0, NULL}
+};
+
+static PyModuleDef scaler_module = {
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "scaler",
+    .m_doc = "Example module that creates an extension type.",
+    .m_size = 0,
+    .m_slots = scaler_module_slots,
+};
+
+PyMODINIT_FUNC PyInit_scaler(void)
+{
+    return PyModuleDef_Init(&scaler_module);
+}

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -64,7 +64,7 @@ static PyObject *Scaler_vectorcall(
         char *f_ptr = needs_float ? (char *)&self->factor_f : (char *)&self->factor;
         // Pass contiguous float or complex arrays directly to multiply loop,
         // bypassing ufunc setup.
-        if (PyArray_ISONESEGMENT(arr) &&
+        if (PyArray_ISONESEGMENT(arr) && PyArray_ISNOTSWAPPED(arr) &&
             (type_num == NPY_DOUBLE || type_num == NPY_CDOUBLE || needs_float)) {
             return use_contiguous_loop(arr, f_ptr);
         }

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -1,4 +1,5 @@
 #define PY_SSIZE_T_CLEAN
+#include "numpy/arrayobject.h"
 #include <Python.h>
 #include <stddef.h> /* for offsetof() */
 
@@ -7,6 +8,7 @@ typedef struct {
     /* Type-specific fields go here. */
     double factor;
     PyObject *O_factor;
+    PyObject *A_factor;
     vectorcallfunc vectorcall;
 } ScalerObject;
 
@@ -24,6 +26,9 @@ PyObject *Scaler_vectorcall(
     // fastest paths: special-case known objects.
     if (PyFloat_CheckExact(obj)) {
         return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
+    }
+    else if (PyArray_CheckExact(obj)) {
+        return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, self->A_factor);
     }
     else if (PyLong_CheckExact(obj)) {
         double d = PyLong_AsDouble(obj);
@@ -67,6 +72,13 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(self);
         return NULL;
     }
+    PyArray_Descr *dtype = PyArray_DescrFromType(NPY_FLOAT64); // cannot fail;
+    self->A_factor = PyArray_FromAny(self->O_factor, dtype, 0, 0, 0, NULL);
+    if (self->A_factor == NULL) {
+        Py_DECREF(self);
+        Py_DECREF(self->O_factor);
+        return NULL;
+    }
     self->vectorcall = (vectorcallfunc)&Scaler_vectorcall;
     return (PyObject *)self;
 }
@@ -74,6 +86,7 @@ static PyObject *Scaler_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static void Scaler_dealloc(ScalerObject *self)
 {
     Py_XDECREF(self->O_factor);
+    Py_XDECREF(self->A_factor);
     Py_TYPE(self)->tp_free(self);
 }
 
@@ -129,5 +142,6 @@ static PyModuleDef scaler_module = {
 
 PyMODINIT_FUNC PyInit_scaler(void)
 {
+    import_array();
     return PyModuleDef_Init(&scaler_module);
 }

--- a/src/scaler.c
+++ b/src/scaler.c
@@ -1,6 +1,9 @@
+#define NPY_TARGET_VERSION NPY_2_0_API_VERSION
 #define PY_SSIZE_T_CLEAN
 #include "numpy/arrayobject.h"
 #include <Python.h>
+#include <numpy/ndarrayobject.h>
+#include <numpy/ufuncobject.h>
 #include <stddef.h> /* for offsetof() */
 
 typedef struct {
@@ -12,11 +15,57 @@ typedef struct {
     vectorcallfunc vectorcall;
 } ScalerObject;
 
-PyObject *Scaler_vectorcall(
+static PyUFuncObject *multiply = NULL;
+
+static PyObject *use_contiguous_loop(PyArrayObject *arr, double *factor)
+{
+    static PyUFuncGenericFunction loop = NULL; // [NPY_CDOUBLE] = {NULL};
+    const char type_num = PyArray_DESCR(arr)->type_num;
+    if (loop == NULL) {
+        // Unfortunately, new-style loops are not exposed, so get legacy one.
+        int nargs = multiply->nargs;
+        const char *types = multiply->types;
+        int i, j;
+        for (i = 0; i < multiply->ntypes; ++i) {
+            for (j = 0; j < nargs; ++j) {
+                if (types[j] != type_num) {
+                    break;
+                }
+            }
+            if (j == nargs) {
+                loop = multiply->functions[i];
+                break;
+            }
+            types += nargs;
+        }
+        if (i == multiply->ntypes) {
+            PyErr_SetString(PyExc_RuntimeError, "could not find loop");
+            return NULL;
+        }
+    }
+    // do it!
+    PyObject *res =
+        PyArray_EMPTY(PyArray_NDIM(arr), PyArray_DIMS(arr), type_num, PyArray_ISFORTRAN(arr));
+    char *data[3] = {PyArray_DATA(arr), (char *)factor, PyArray_DATA((PyArrayObject *)res)};
+    npy_intp n = PyArray_SIZE(arr);
+    npy_intp strides[3] = {PyArray_ITEMSIZE(arr), 0, PyArray_ITEMSIZE(arr)};
+    PyUFunc_clearfperr();
+    loop(data, &n, strides, NULL);
+    int fpe_errors = PyUFunc_getfperr();
+    if (fpe_errors) {
+        if (PyUFunc_GiveFloatingpointErrors("multiply", fpe_errors) < 0) {
+            Py_DECREF(res);
+            return NULL;
+        }
+    }
+    return res;
+}
+
+static PyObject *Scaler_vectorcall(
     ScalerObject *self, PyObject *const *args, size_t len_args, PyObject *kwnames
 )
 {
-    PyObject *obj = args[0];
+    PyObject *const obj = args[0];
     if (PyVectorcall_NARGS(len_args) != 1) {
         PyErr_Format(
             PyExc_TypeError, "scaler() takes 1 argument, not %d", PyVectorcall_NARGS(len_args)
@@ -28,14 +77,23 @@ PyObject *Scaler_vectorcall(
         return PyFloat_FromDouble(PyFloat_AS_DOUBLE(obj) * self->factor);
     }
     else if (PyArray_CheckExact(obj)) {
+        PyArrayObject *const arr = (PyArrayObject *)obj;
+        if (PyArray_DESCR(arr)->type_num == NPY_FLOAT64 && PyArray_ISONESEGMENT(arr)) {
+            // speed up over ufunc by using strided loop directly.
+            return use_contiguous_loop(arr, &self->factor);
+        }
         if (self->A_factor == NULL) {
             npy_intp const dims[0];
             self->A_factor = PyArray_SimpleNewFromData(0, dims, NPY_FLOAT64, &self->factor);
             if (self->A_factor == NULL) {
-                return NULL;
+                npy_intp const dims[0];
+                self->A_factor = PyArray_SimpleNewFromData(0, dims, NPY_FLOAT64, &self->factor);
+                if (self->A_factor == NULL) {
+                    return NULL;
+                }
             }
+            return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, self->A_factor);
         }
-        return Py_TYPE(obj)->tp_as_number->nb_multiply(obj, self->A_factor);
     }
     else if (PyLong_CheckExact(obj)) {
         double d = PyLong_AsDouble(obj);
@@ -97,8 +155,8 @@ static void Scaler_dealloc(ScalerObject *self)
 
 static PyMemberDef Scaler_members[] = {
     {"factor",
-     Py_T_OBJECT_EX,
-     offsetof(ScalerObject, O_factor),
+     Py_T_DOUBLE,
+     offsetof(ScalerObject, factor),
      Py_READONLY,
      "factor with which input is multiplied"},
     {NULL},
@@ -147,6 +205,19 @@ static PyModuleDef scaler_module = {
 
 PyMODINIT_FUNC PyInit_scaler(void)
 {
-    import_array();
+    if (PyUFunc_ImportUFuncAPI() < 0) {
+        return NULL;
+    }
+    if (PyArray_ImportNumPyAPI() < 0) {
+        return NULL;
+    }
+    PyObject *mod = PyImport_ImportModule("numpy");
+    if (mod != NULL) {
+        multiply = (PyUFuncObject *)PyObject_GetAttrString(mod, "multiply");
+        Py_DECREF(mod);
+    }
+    if (multiply == NULL) {
+        return NULL;
+    }
     return PyModuleDef_Init(&scaler_module);
 }

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -29,6 +29,7 @@ def test_with_scalar(dtype):
 
 
 @pytest.mark.parametrize("order", ["C", "F"])
+@pytest.mark.parametrize("swapbyteorder", [False, True])
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -40,10 +41,13 @@ def test_with_scalar(dtype):
         np.uint64,
     ],
 )
-def test_with_array(dtype, order):
+def test_with_array(dtype, swapbyteorder, order):
+    dtype = np.dtype(dtype)
+    if swapbyteorder:
+        dtype = dtype.newbyteorder()
     a = np.arange(10, dtype=dtype).reshape(2, 5)
-    if issubclass(dtype, np.complexfloating):
-        a = a - 4.0j
+    if dtype.kind == "c":
+        a -= 4.0j
     a = a.copy(order=order)
 
     assert a.dtype == dtype
@@ -53,8 +57,7 @@ def test_with_array(dtype, order):
         assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
     got = Scaler(10.0)(a)
     exp = a * 10.0
-    assert got.dtype == exp.dtype
-    assert_array_equal(got, exp)
+    assert_array_equal(got, exp, strict=True)
 
 
 def test_with_list():

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -28,6 +28,7 @@ def test_with_scalar(dtype):
     assert Scaler(10.0)(a) == a * 10.0
 
 
+@pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -39,12 +40,17 @@ def test_with_scalar(dtype):
         np.uint64,
     ],
 )
-def test_with_array(dtype):
-    a = np.arange(10, dtype=dtype)
+def test_with_array(dtype, order):
+    a = np.arange(10, dtype=dtype).reshape(2, 5)
     if issubclass(dtype, np.complexfloating):
         a = a - 4.0j
+    a = a.copy(order=order)
 
     assert a.dtype == dtype
+    if order == "C":
+        assert a.flags["C_CONTIGUOUS"] and not a.flags["F_CONTIGUOUS"]
+    else:
+        assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
     got = Scaler(10.0)(a)
     exp = a * 10.0
     assert_array_equal(got, exp)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -91,6 +91,16 @@ def test_with_wrong_items(item):
         sc(item)
 
 
+def test_unity_scaler_is_singleton():
+    sc1a = Scaler(1.0)
+    sc2a = Scaler(2.0)
+    sc1b = Scaler(1.0)
+    sc2b = Scaler(2.0)
+    assert sc1a is sc1b
+    assert sc1a is not sc2a
+    assert sc2b is not sc2a
+
+
 def test_repr():
     sc = Scaler(10.0)
     assert repr(sc) == "Scaler(10.0)"

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -91,6 +91,44 @@ def test_with_wrong_items(item):
         sc(item)
 
 
+def test_scale_attribute():
+    sc = Scaler(10.0)
+    assert sc.factor == 10.0
+
+
+def test_init_errors():
+    with pytest.raises(TypeError, match=r"exactly 1 positional.*\(0 given\)"):
+        Scaler()
+    with pytest.raises(TypeError, match=r"exactly 1 positional.*\(0 given\)"):
+        Scaler(b=20.0)
+    with pytest.raises(TypeError, match=r"at most 1 argument \(2 given\)"):
+        Scaler(10.0, 20.0)
+    with pytest.raises(TypeError, match=r"at most 1 argument \(2 given\)"):
+        Scaler(10.0, b=20.0)
+    with pytest.raises(TypeError, match=r"at most 1 argument \(3 given\)"):
+        Scaler(10.0, 20.0, b=20.0)
+    with pytest.raises(TypeError, match=r"at most 1 argument \(3 given\)"):
+        Scaler(10.0, b=20.0, c=20.0)
+    with pytest.raises(TypeError, match="must be real number, not"):
+        Scaler(1 + 1j)
+    with pytest.raises(TypeError, match="must be real number, not"):
+        Scaler({})
+
+
+def test_call_errors():
+    sc = Scaler(10.0)
+    with pytest.raises(TypeError, match="takes 1 positional.*0 were given"):
+        sc()
+    with pytest.raises(TypeError, match="takes 1 positional.*2 were given"):
+        sc(10.0, 20.0)
+    with pytest.raises(TypeError, match="got an unexpected.*'b'"):
+        sc(b=20.0)
+    with pytest.raises(TypeError, match="got an unexpected.*'b'"):
+        sc(10.0, b=20.0)
+    with pytest.raises(TypeError, match="got an unexpected.*'b'"):
+        sc(10.0, 20.0, b=20.0)
+
+
 def test_unity_scaler_is_singleton():
     sc1a = Scaler(1.0)
     sc2a = Scaler(2.0)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -95,7 +95,7 @@ def test_equality():
     sc1 = Scaler(10.0)
     sc1_2 = Scaler(10.0)
     assert sc1_2 == sc1
-    assert not (sc1_2 != sc1)
+    assert not (sc1_2 != sc1)  # noqa: SIM202
     sc2 = Scaler(20.0)
     assert sc1 != sc2
     assert not (sc1 == sc2)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -53,4 +53,5 @@ def test_with_array(dtype, order):
         assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
     got = Scaler(10.0)(a)
     exp = a * 10.0
+    assert got.dtype == exp.dtype
     assert_array_equal(got, exp)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -55,3 +55,18 @@ def test_with_array(dtype, order):
     exp = a * 10.0
     assert got.dtype == exp.dtype
     assert_array_equal(got, exp)
+
+
+def test_with_list():
+    a = [[1.0, 2.0], [3.0, 4.0]]
+    got = Scaler(10.0)(a)
+    exp = np.array(a) * 10.0
+    assert got.dtype == exp.dtype
+    assert_array_equal(got, exp)
+
+
+@pytest.mark.parametrize("item", [["abc"], [{}]])
+def test_with_wrong_items(item):
+    sc = Scaler(10.0)
+    with pytest.raises(ValueError, match="compatible.*convertible"):
+        sc(item)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -70,3 +70,8 @@ def test_with_wrong_items(item):
     sc = Scaler(10.0)
     with pytest.raises(ValueError, match="compatible.*convertible"):
         sc(item)
+
+
+def test_repr():
+    sc = Scaler(10.0)
+    assert repr(sc) == "Scaler(10.0)"

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1,3 +1,6 @@
+import operator
+import pickle
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -78,3 +81,37 @@ def test_with_wrong_items(item):
 def test_repr():
     sc = Scaler(10.0)
     assert repr(sc) == "Scaler(10.0)"
+
+
+def test_pickle():
+    sc = Scaler(10.0)
+    p = pickle.dumps(sc)
+    got = pickle.loads(p)
+    assert type(got) is Scaler
+    assert got.factor == sc.factor
+
+
+def test_equality():
+    sc1 = Scaler(10.0)
+    sc1_2 = Scaler(10.0)
+    assert sc1_2 == sc1
+    assert not (sc1_2 != sc1)
+    sc2 = Scaler(20.0)
+    assert sc1 != sc2
+    assert not (sc1 == sc2)
+
+
+def test_hash():
+    sc1 = Scaler(10.0)
+    assert hash(sc1) != hash(10.0)
+    sc1_2 = Scaler(10.0)
+    assert hash(sc1_2) == hash(sc1)
+    sc2 = Scaler(20.0)
+    assert hash(sc2) != hash(sc1)
+
+
+@pytest.mark.parametrize("op", [operator.lt, operator.le, operator.gt, operator.ge])
+def test_comparison_impossible(op):
+    sc = Scaler(10.0)
+    with pytest.raises(TypeError, match="not supported"):
+        op(sc, sc)

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -8,59 +8,72 @@ from numpy.testing import assert_array_equal
 from scaler import Scaler
 
 
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        float,
-        np.float32,
-        np.float64,
-        complex,
-        np.complex64,
-        np.complex128,
-        int,
-        np.int32,
-        np.uint64,
-    ],
-)
-def test_with_scalar(dtype):
-    a = dtype(5)
-    if issubclass(dtype, (complex, np.complexfloating)):
-        a = a - 4.0j
+NUMPY_SCALAR_TYPES = [np.float32, np.float64, np.complex64, np.complex128]
+SCALAR_TYPES = NUMPY_SCALAR_TYPES + [float, complex, int, np.int32, np.uint64]
 
-    assert isinstance(a, dtype)
-    assert Scaler(10.0)(a) == a * 10.0
+FLOATING_DTYPES = ["f4", "f8", "c8", "c16"]
+DTYPES = FLOATING_DTYPES + ["i4", "u8"]
+
+
+class TestScalar:
+    @pytest.mark.parametrize("scalar_type", SCALAR_TYPES)
+    def test_scalar(self, scalar_type):
+        a = scalar_type(5)
+        if issubclass(scalar_type, (complex, np.complexfloating)):
+            a = a - 4.0j
+
+        assert isinstance(a, scalar_type)
+        scaler = Scaler(10.0)
+        got = scaler(a)
+        exp = a * 10.0
+        assert got == exp
+
+    @pytest.mark.parametrize("scalar_type", NUMPY_SCALAR_TYPES)
+    def test_scalar_overflow(self, scalar_type):
+        a = scalar_type(np.finfo(scalar_type).max)
+        if issubclass(scalar_type, (complex, np.complexfloating)):
+            a = a - 4.0j
+
+        assert isinstance(a, scalar_type)
+        scaler = Scaler(1000.0)
+        with pytest.warns(RuntimeWarning, match="overflow.*scalar multiply"):
+            scaler(a)
 
 
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("swapbyteorder", [False, True])
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        np.float32,
-        np.float64,
-        np.complex64,
-        np.complex128,
-        np.int32,
-        np.uint64,
-    ],
-)
-def test_with_array(dtype, swapbyteorder, order):
-    dtype = np.dtype(dtype)
-    if swapbyteorder:
-        dtype = dtype.newbyteorder()
-    a = np.arange(10, dtype=dtype).reshape(2, 5)
-    if dtype.kind == "c":
-        a -= 4.0j
-    a = a.copy(order=order)
+class TestArray:
+    def get_dtype(self, dtype, swapbyteorder):
+        dtype = np.dtype(dtype)
+        return dtype.newbyteorder() if swapbyteorder else dtype
 
-    assert a.dtype == dtype
-    if order == "C":
-        assert a.flags["C_CONTIGUOUS"] and not a.flags["F_CONTIGUOUS"]
-    else:
-        assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
-    got = Scaler(10.0)(a)
-    exp = a * 10.0
-    assert_array_equal(got, exp, strict=True)
+    def get_array(self, data, dtype, order, imag=-4j):
+        if dtype.kind == "c":
+            data = np.asanyarray(data) + np.asanyarray(imag)
+        data = np.array(data).astype(dtype, order=order)
+        assert data.dtype == dtype
+        return data
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_array(self, dtype, swapbyteorder, order):
+        dtype = self.get_dtype(dtype, swapbyteorder)
+        a = self.get_array(np.arange(10).reshape(2, 5), dtype, order)
+        if order == "C":
+            assert a.flags["C_CONTIGUOUS"] and not a.flags["F_CONTIGUOUS"]
+        else:
+            assert a.flags["F_CONTIGUOUS"] and not a.flags["C_CONTIGUOUS"]
+        scaler = Scaler(10.0)
+        got = scaler(a)
+        exp = a * 10.0
+        assert_array_equal(got, exp, strict=True)
+
+    @pytest.mark.parametrize("dtype", FLOATING_DTYPES)
+    def test_array_overflow(self, dtype, swapbyteorder, order):
+        dtype = self.get_dtype(dtype, swapbyteorder)
+        a = self.get_array([1.0, np.finfo(dtype).max], dtype, order)
+        scaler = Scaler(1000.0)
+        with pytest.warns(RuntimeWarning, match="overflow.*multiply"):
+            scaler(a)
 
 
 def test_with_list():

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from scaler import Scaler
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        float,
+        np.float32,
+        np.float64,
+        complex,
+        np.complex64,
+        np.complex128,
+        int,
+        np.int32,
+        np.uint64,
+    ],
+)
+def test_with_scalar(dtype):
+    a = dtype(5)
+    if issubclass(dtype, (complex, np.complexfloating)):
+        a = a - 4.0j
+
+    assert isinstance(a, dtype)
+    assert Scaler(10.0)(a) == a * 10.0
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float32,
+        np.float64,
+        np.complex64,
+        np.complex128,
+        np.int32,
+        np.uint64,
+    ],
+)
+def test_with_array(dtype):
+    a = np.arange(10, dtype=dtype)
+    if issubclass(dtype, np.complexfloating):
+        a = a - 4.0j
+
+    assert a.dtype == dtype
+    got = Scaler(10.0)(a)
+    exp = a * 10.0
+    assert_array_equal(got, exp)


### PR DESCRIPTION
This PR introduces a C-based scaler class, which has two advantages over the lambda that is currently used in unit conversions: it is inspectable, and it is faster, with in particular nice optimizations for scalars and contiguous arrays:
```
import astropy.units as u
import numpy as np

c = u.km.get_converter(u.m)
%timeit c(10.0)
# 45.7 ns -> 17.6 ns (14.1 ns w/o limited API)

b = np.arange(10.0)
%timeit c(b)
# 392 ns -> 86 ns (84 ns w/o limited API)
```
(With the static type one gets an ~10 ns extra speed-up, but that does not seem worth it in the scheme of things.)

Note that while this propagates to `Quantity` operations, the effect is only at the 10% level since there are other quite large overheads:
```
q1 = 1 * u.m
q2 = np.arange(10.0) << u.km
%timeit q1 + q2
# 4.19 μs -> 3.66 μs
# EDIT: with cached scaler now in main: 2.98 μs

q3 = np.arange(30.0)*u.deg
%timeit np.sin(q3)
# 4.12 μs -> 3.55 μs
# EDIT: with cached scaler now in main: 2.96 μs
```

Also: time needed for construction of the scaler does not change (for that, would need to do caching):
```
%timeit u.km.get_converter(u.m)
# 704 ns -> 704 ns
# EDIT: now changed with caching: 272 ns
```

Finally, @neutrinoceros - I developed the class separately from astropy, and kept its source and the tests separate here, to help the eventual move of C based code outside of astropy.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
