### PR TITLE
DEP: loosen pytest-skip-slow requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ test = [
     "pytest-doctestplus>=1.4.0",
     "pytest-filter-subpackage>=0.2.0",
     "pytest-remotedata>=0.4.1",
-    "pytest-skip-slow==1.1.0",
+    "pytest-skip-slow>=1.1.0",
     "pytest-xdist>=3.6.0",
     "threadpoolctl>=3.0.0",
 ]


### PR DESCRIPTION
### Description

Change the `pytest-skip-slow` test dependency from an exact pin to a lower bound.

The oldest supported version remains 1.1.0, and the lowest-resolution dependency tree is unchanged.

Closes #20157.
