### PR TITLE
Match angular_diameter_distance parameter heading to its signature

### DIFF
--- a/astropy/cosmology/_src/flrw/base.py
+++ b/astropy/cosmology/_src/flrw/base.py
@@ -956,7 +956,7 @@ class FLRW(
 
         Parameters
         ----------
-        z1, z2 : Quantity-like ['redshift'], array-like
+        z, z2 : Quantity-like ['redshift'], array-like
             Input redshifts. If one argument ``z`` is given, the distance :math:`d_A(0,
             z)` is returned. If two arguments ``z1, z2`` are given, the distance
             :math:`d_A(z_1, z_2)` is returned.


### PR DESCRIPTION
### Description

Fixes #20206.

`FLRW.angular_diameter_distance` has the signature

```python
def angular_diameter_distance(self, z: _InputT, z2: _InputT | None = None, /) -> u.Quantity:
```

but heads its `Parameters` section `z1, z2`. The first parameter is `z`, so numpydoc pairs the entry with a name the method does not have.

The issue offered two options. This takes the first — rename the heading to `z, z2` and leave the prose alone — because the two sibling methods with exactly this signature already do that:

- `comoving_distance(self, z, z2=None, /)` heads its section `z, z2`,
- `comoving_transverse_distance(self, z, z2=None, /)` heads its section `z, z2`,

and both keep explaining the two-argument form in terms of `z1, z2` in the description underneath, as this one does. So the heading matches the signature and the wording stays consistent with its neighbours.

One line, docstring only — no signature, call site, or behaviour is touched.

### Changelog

Not added: docstring only, so per `CONTRIBUTING.md` ("in general you do not need to include a changelog entry for minor documentation or test updates") this is not user-visible. Happy to add a fragment or apply `no-changelog-entry-needed`, whichever you prefer.
