### PR TITLE
Drop the out parameter cosmology's _cosmology_not_equal does not take

### DIFF
--- a/astropy/cosmology/_src/funcs/comparison.py
+++ b/astropy/cosmology/_src/funcs/comparison.py
@@ -335,11 +335,6 @@ def _cosmology_not_equal(
         The objects to compare. Must be convertible to |Cosmology|, as specified
         by ``format``.
 
-    out : ndarray, None, optional
-        A location into which the result is stored. If provided, it must have a
-        shape that the inputs broadcast to. If not provided or None, a
-        freshly-allocated array is returned.
-
     format : bool or None or str or tuple thereof, optional keyword-only
         Whether to allow the arguments to be converted to a |Cosmology|. This
         allows, e.g. a |Table| to be given instead a Cosmology. `False`


### PR DESCRIPTION
### Description

Fixes #20208.

`_cosmology_not_equal` has the signature

```python
def _cosmology_not_equal(cosmo1: Any, cosmo2: Any, /, *, allow_equivalent: bool = False) -> bool:
```

and documents an `out` parameter, described as "a location into which the result is stored", which is not accepted here or anywhere along the `_comparison_decorator` path — the wrapper forwards `**kwargs` to the wrapped function, which would raise on `out`.

`format` in the same section stays: it is not in the signature either, but `_comparison_decorator` consumes it and its own Notes say every decorated function should document it. `out` has no such counterpart, and `cosmology_equal` directly above — same decorator, same signature — has never carried the entry.

Docstring only — no signature, call site, or behaviour is touched.

### Changelog

Not added: docstring only, and the function is private, so nothing user-visible changes. Per `CONTRIBUTING.md`, minor documentation updates do not need a fragment. Happy to add one or take the `no-changelog-entry-needed` label if you prefer.
