### PR TITLE
TST: Add direct C-boundary tests for LombScargle cython_impl

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_cython_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_cython_impl.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from astropy.timeseries.periodograms.lombscargle.implementations.cython_impl import (
+    lombscargle_cython,
+)
+
+_F64Array: TypeAlias = npt.NDArray[np.float64]
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class SyntheticSignal:
+    t: _F64Array
+    y: _F64Array
+    dy: _F64Array
+    true_frequency: float
+    frequency_grid: _F64Array
+
+
+@pytest.fixture
+def perfect_sine_wave() -> SyntheticSignal:
+    """Generates a synthetic sine wave signal with a known period to verify power recovery."""
+    t = np.linspace(0, 10, 101, dtype=np.float64)
+    true_frequency = 0.5
+
+    y = np.sin(2 * np.pi * true_frequency * t)
+    dy = np.ones_like(t)
+
+    # We tune the frequency grid to exactly 91 steps so the peak frequency (0.5)
+    # lands perfectly on a discrete float coordinate. This avoids false-negative
+    # Cython interpolation errors when comparing the recovered peak.
+    frequency_grid = np.linspace(0.1, 1.0, 91, dtype=np.float64)
+
+    return SyntheticSignal(
+        t=t, y=y, dy=dy, true_frequency=true_frequency, frequency_grid=frequency_grid
+    )
+
+
+def test_cython_lombscargle_exact_recovery(perfect_sine_wave: SyntheticSignal):
+    """Validates the Cython Lomb-Scargle engine mathematically recovers a known signal."""
+    power = lombscargle_cython(
+        perfect_sine_wave.t,
+        perfect_sine_wave.y,
+        perfect_sine_wave.dy,
+        perfect_sine_wave.frequency_grid,
+        normalization="standard",
+        fit_mean=False,
+        center_data=False,
+        assume_regular_frequency=True,
+    )
+
+    assert type(power) is np.ndarray
+    assert power.dtype == np.float64
+
+    # Ensure the C-engine successfully allocated the memory and returned valid numbers
+    # across the entire grid without overflowing into NaNs or infinities.
+    assert np.all(np.isfinite(power))
+    assert power.shape == perfect_sine_wave.frequency_grid.shape
+
+    peak_idx = np.argmax(power)
+    recovered_frequency = perfect_sine_wave.frequency_grid[peak_idx]
+
+    assert np.isclose(recovered_frequency, perfect_sine_wave.true_frequency, rtol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "norm_type",
+    [
+        pytest.param("standard", id="norm_standard"),
+        pytest.param("model", id="norm_model"),
+        pytest.param("log", id="norm_log"),
+        pytest.param("psd", id="norm_psd"),
+    ],
+)
+def test_cython_lombscargle_normalizations(
+    perfect_sine_wave: SyntheticSignal, norm_type: str
+):
+    """Validates that the C-engine successfully calculates all normalizations."""
+    power = lombscargle_cython(
+        perfect_sine_wave.t,
+        perfect_sine_wave.y,
+        perfect_sine_wave.dy,
+        perfect_sine_wave.frequency_grid,
+        normalization=norm_type,
+    )
+
+    assert type(power) is np.ndarray
+    assert np.all(np.isfinite(power))
+
+
+def test_cython_lombscargle_exceptions(perfect_sine_wave: SyntheticSignal):
+    """Triggers C-level validation exceptions to ensure dimensions are strictly enforced."""
+    t_2d = np.ones((10, 2), dtype=np.float64)
+    freq_2d = np.ones((10, 2), dtype=np.float64)
+
+    with pytest.raises(ValueError, match="t, y, dy should be one dimensional"):
+        lombscargle_cython(t_2d, t_2d, t_2d, perfect_sine_wave.frequency_grid)
+
+    with pytest.raises(ValueError, match="frequency should be one-dimensional"):
+        lombscargle_cython(
+            perfect_sine_wave.t, perfect_sine_wave.y, perfect_sine_wave.dy, freq_2d
+        )
+
+    with pytest.raises(ValueError, match="normalization='invalid' not recognized"):
+        lombscargle_cython(
+            perfect_sine_wave.t,
+            perfect_sine_wave.y,
+            perfect_sine_wave.dy,
+            perfect_sine_wave.frequency_grid,
+            normalization="invalid",
+        )

--- a/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_cython_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/tests/test_cython_impl.py
@@ -67,15 +67,7 @@ def test_cython_lombscargle_exact_recovery(perfect_sine_wave: SyntheticSignal):
     assert np.isclose(recovered_frequency, perfect_sine_wave.true_frequency, rtol=1e-4)
 
 
-@pytest.mark.parametrize(
-    "norm_type",
-    [
-        pytest.param("standard", id="norm_standard"),
-        pytest.param("model", id="norm_model"),
-        pytest.param("log", id="norm_log"),
-        pytest.param("psd", id="norm_psd"),
-    ],
-)
+@pytest.mark.parametrize("norm_type", ["standard", "model", "log", "psd"])
 def test_cython_lombscargle_normalizations(
     perfect_sine_wave: SyntheticSignal, norm_type: str
 ):


### PR DESCRIPTION
Hi everyone! This PR tackles the LombScargle Cython extension testing for my GSoC project.

Instead of routing through the high-level LombScargle API, this suite hits the Cython wrapper (`lombscargle_cython`) directly to ensure the math and memory allocations hold up in complete isolation.

**Key additions:**

- Fed strictly-typed `np.float64` memory buffers directly into the C-boundary.
- Built a `SyntheticSignal` fixture to mathematically verify the C-engine accurately recovers the period and power from a planted sine wave. *(Note: I tuned the frequency grid to exactly 91 steps so the peak frequency lands perfectly on a discrete float point, avoiding false-negative Cython interpolation errors.)*
- Used strict `type(power) is np.ndarray` assertions to guarantee the boundary returns a raw array and strips any unintended subclasses.
- Added isolated tests for the C-level dimensionality trapdoors. *(Note: I deliberately passed 2D arrays that can successfully broadcast against each other to bypass NumPy's early `broadcast_arrays` panic, ensuring the error is actually caught by the `ndim != 1` check inside the Cython wrapper.)*

cc: @neutrinoceros