### PR TITLE
Make hashes of units a bit more logical, guarding against unlikely cases

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -366,7 +366,11 @@ class UnitBase:
 
     @cached_property
     def _hash(self) -> int:
-        return hash((self.scale, *[x.name for x in self.bases], *map(str, self.powers)))
+        # if we're just a wrapper around another unit, let our hash be the same
+        # as that unit's.
+        if self.scale == 1 and len(self.powers) == 1 and self.powers[0] == 1:
+            return hash(self.bases[0])
+        return hash((self.scale, *self.bases, *self.powers))
 
     def __getstate__(self) -> dict[str, object]:
         # If we get pickled, we should *not* store the memoized members since
@@ -1936,6 +1940,10 @@ class IrreducibleUnit(NamedUnit):
             (self.__class__, list(self.names), self.name in registry),
             self.__getstate__(),
         )
+
+    @cached_property
+    def _hash(self) -> int:
+        return hash((self.name, self.__class__.__name__))
 
     @property
     def represents(self) -> Self:

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -1195,6 +1195,20 @@ def test_hash_represents_unit(unit, power):
     assert hash(tu2) == hash(unit)
 
 
+def test_hash_correctly_different():
+    # Bit of a test against "don't do that", but still.
+    myfoot = u.Unit("foo", 34 * u.cm)
+    yourfoot = u.Unit("foo", 25 * u.m)
+    assert str(myfoot) == str(yourfoot)  # cannot be helped
+    assert myfoot != yourfoot
+    assert hash(myfoot) != hash(yourfoot)
+    myspeed = myfoot / u.s
+    yourspeed = yourfoot / u.s
+    assert str(myspeed) == str(yourspeed)  # cannot be helped
+    assert myspeed != yourspeed
+    assert hash(myspeed) != hash(yourspeed)
+
+
 @pytest.mark.skipif(not HAS_ARRAY_API_STRICT, reason="tests array_api_strict")
 def test_array_api_strict_arrays():
     # Ensure strict array api arrays can be passed in/out of Unit.to()

--- a/docs/changes/units/20224.bugfix.rst
+++ b/docs/changes/units/20224.bugfix.rst
@@ -1,0 +1,4 @@
+The hash of units has been changed to ensure that it depends not just
+on the names of units, but also on what they mean. This should have
+no practical consequence expect if one defined multiple different
+units with the same name.


### PR DESCRIPTION
This PR aims to make a bit better effort to make hashes of units logical (and is needed for #20107, where converters are cached).
    
The basic idea is to let the hash of a composite unit depend on the hashes of the bases, instead of just their names, and
to short-circuit the case of a single base with scale=1 and power=1.
    
To make this work, the `IrredicibleUnit` gets a new hash  (arguably an improvement in itself).

p.s. This does not aim to address the difference with unit equality and hash equality.

EDIT: I see no point in backporting this.

<!-- Optional opt-out -->

- [X] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.