### PR TITLE
BUG: ensure we do not cache parsed unit strings if warnings were emitted

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2096,9 +2096,23 @@ class _UnitMetaClass(type):
                 if (unit := _parsed_units.get(s)) is not None:
                     return unit
 
-            else:
-                # Signal that we do not want to cache the unit below.
-                _parsed_units = None
+                # Recurse, recording warnings, as we want to cache the result
+                # only if none are emitted (otherwise, on a next invocation we
+                # would use the cache and bypass the warnings machinery).
+                with _WARNING_LOCK, warnings.catch_warnings(record=True) as w:
+                    unit = cls(s, format="generic")
+                # Sadly, one cannot record without silencing, so replay any warnings.
+                for w_ in w:
+                    warnings.warn_explicit(
+                        message=w_.message,
+                        category=w_.category,
+                        filename=w_.filename,
+                        lineno=w_.lineno,
+                        source=w_.source,
+                    )
+                if not w:
+                    _parsed_units[s] = unit
+                return unit
 
             from .format import Generic, get_format
 
@@ -2111,77 +2125,54 @@ class _UnitMetaClass(type):
                 raise err
 
             try:
-                unit = f._validate_unit(s)  # Try a shortcut
+                return f._validate_unit(s)  # Try a shortcut
             except (AttributeError, KeyError):
                 # No `f._validate_unit()` (AttributeError)
                 # or `s` was a composite unit (KeyError).
-                try:
-                    # We not only check for parser warnings following
-                    # parse_strict, but record all others, since we want to
-                    # avoid caching the string if any are emitted.
-                    with (
-                        _WARNING_LOCK,
-                        warnings.catch_warnings(
-                            action="always", record=True
-                        ) as captured_warnings,
-                        warnings.catch_warnings(
-                            action=_WARNING_ACTIONS[parse_strict],
-                            category=UnitParserWarning,
-                        ),
-                    ):
-                        unit = f.parse(s)
-                except NotImplementedError:
+                pass
+
+            try:
+                with (
+                    _WARNING_LOCK,
+                    warnings.catch_warnings(
+                        action=_WARNING_ACTIONS[parse_strict],
+                        category=UnitParserWarning,
+                    ),
+                ):
+                    return f.parse(s)
+            except NotImplementedError:
+                raise
+            except UnitParserWarning as err:
+                new_err = ValueError(err)
+                new_err.add_note(
+                    "If you cannot change the unit string then try specifying the "
+                    "'parse_strict' argument."
+                )
+                raise new_err from err
+            except KeyError as err:
+                if parse_strict in _WARNING_ACTIONS:
                     raise
-                except UnitParserWarning as err:
-                    new_err = ValueError(err)
-                    new_err.add_note(
-                        "If you cannot change the unit string then try "
-                        "specifying the 'parse_strict' argument."
+                raise ValueError(
+                    "'parse_strict' must be 'warn', 'raise' or 'silent'"
+                ) from None
+            except Exception as e:
+                if parse_strict != "silent":
+                    # Deliberately not issubclass here. Subclasses
+                    # should use their name.
+                    format_clause = "" if f is Generic else f.name + " "
+                    msg = (
+                        f"'{s}' did not parse as {format_clause}unit: {e} "
+                        "If this is meant to be a custom unit, "
+                        "define it with 'u.def_unit'. To have it "
+                        "recognized inside a file reader or other code, "
+                        "enable it with 'u.add_enabled_units'. "
+                        "For details, see "
+                        "https://docs.astropy.org/en/latest/units/combining_and_defining.html"
                     )
-                    raise new_err from err
-                except KeyError as err:
-                    if parse_strict in _WARNING_ACTIONS:
-                        raise
-                    raise ValueError(
-                        "'parse_strict' must be 'warn', 'raise' or 'silent'"
-                    ) from None
-                except Exception as e:
-                    if parse_strict != "silent":
-                        # Deliberately not issubclass here. Subclasses
-                        # should use their name.
-                        format_clause = "" if f is Generic else f.name + " "
-                        msg = (
-                            f"'{s}' did not parse as {format_clause}unit: {e} "
-                            "If this is meant to be a custom unit, "
-                            "define it with 'u.def_unit'. To have it "
-                            "recognized inside a file reader or other code, "
-                            "enable it with 'u.add_enabled_units'. "
-                            "For details, see "
-                            "https://docs.astropy.org/en/latest/units/combining_and_defining.html"
-                        )
-                        if parse_strict == "raise":
-                            raise ValueError(msg) from None
-                        warnings.warn(msg, UnitsWarning)
-                    return UnrecognizedUnit(s)
-
-                # We parsed without raising an exception, including any from
-                # parse_raise="strict". If warnings were captured, replay them,
-                # and just return the unit, not falling through to cache it.
-                if captured_warnings:
-                    for w in captured_warnings:
-                        warnings.warn_explicit(
-                            message=w.message,
-                            category=w.category,
-                            filename=w.filename,
-                            lineno=w.lineno,
-                            source=w.source,
-                        )
-                    return unit
-
-            if _parsed_units is not None:
-                _parsed_units[s] = unit
-
-            return unit
+                    if parse_strict == "raise":
+                        raise ValueError(msg) from None
+                    warnings.warn(msg, UnitsWarning)
+                return UnrecognizedUnit(s)
 
         if isinstance(s, bytes):
             # Recurse.  We do it here so we do not slow down the str case.

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2116,8 +2116,14 @@ class _UnitMetaClass(type):
                 # No `f._validate_unit()` (AttributeError)
                 # or `s` was a composite unit (KeyError).
                 try:
+                    # We not only check for parser warnings following
+                    # parse_strict, but record all others, since we want to
+                    # avoid caching the string if any are emitted.
                     with (
                         _WARNING_LOCK,
+                        warnings.catch_warnings(
+                            action="always", record=True
+                        ) as captured_warnings,
                         warnings.catch_warnings(
                             action=_WARNING_ACTIONS[parse_strict],
                             category=UnitParserWarning,
@@ -2154,9 +2160,23 @@ class _UnitMetaClass(type):
                             "https://docs.astropy.org/en/latest/units/combining_and_defining.html"
                         )
                         if parse_strict == "raise":
-                            raise ValueError(msg)
+                            raise ValueError(msg) from None
                         warnings.warn(msg, UnitsWarning)
                     return UnrecognizedUnit(s)
+
+                # We parsed without raising an exception, including any from
+                # parse_raise="strict". If warnings were captured, replay them,
+                # and just return the unit, not falling through to cache it.
+                if captured_warnings:
+                    for w in captured_warnings:
+                        warnings.warn_explicit(
+                            message=w.message,
+                            category=w.category,
+                            filename=w.filename,
+                            lineno=w.lineno,
+                            source=w.source,
+                        )
+                    return unit
 
             if _parsed_units is not None:
                 _parsed_units[s] = unit

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -213,9 +213,18 @@ def test_multiple_solidus():
     ):
         assert u.Unit("m/s/kg").to_string() == "m / (kg s)"
 
+    # Check we always warn, not just the first time.
+    with pytest.warns(
+        u.UnitsWarning,
+        match="'m/s/kg' contains multiple slashes, which is discouraged",
+    ):
+        assert u.Unit("m/s/kg").to_string() == "m / (kg s)"
+
     with pytest.raises(ValueError, match="contains multiple slashes"):
         u.Unit("m/s/kg", format="vounit")
 
+
+def test_multiple_solidus_in_exponent_is_ok():
     # Regression test for #9000: solidi in exponents do not count towards this.
     x = u.Unit("kg(3/10) * m(5/2) / s", format="vounit")
     assert x.to_string() == "m(5/2) kg(3/10) / s"


### PR DESCRIPTION
Follow-up on #20090, which brought up via the double-test CI run that strings were cached even if a warning was emited, causing no warning to be emitted the next time. It is rather unclear why this was not seen before (only a change in python version, from 3.11 to 3.12), but I could confirm it easily.

This adjusts the test so that the problem is obvious also in regular test runs, and fixes the problem. 

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.