### PR TITLE
Fix two rounding errors in Angle.to_string

### DIFF
--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -423,16 +423,19 @@ def _decimal_to_sexagesimal_string(
     # Builtin round, not NumPy's, which disagrees with the formatting on ties.
     ndp = 8 if precision is None else precision
 
-    if fields == 3 and round(float(values[2]), ndp) >= 60.0:
-        values[2] = 0.0
-        values[1] += 1.0
-    elif fields < 3 and values[2] >= 30.0:
-        values[1] += 1.0
+    if fields == 3:
+        if round(float(values[2]), ndp) >= 60.0:
+            values[2] = 0.0
+            values[1] += 1.0
+    elif fields == 2:
+        if values[2] >= 30.0:
+            values[1] += 1.0
+    # Rounding the seconds into the minutes here too would round twice.
+    elif values[1] + values[2] / 60.0 >= 30.0:
+        values[0] += 1.0
 
     if fields >= 2 and values[1] >= 60.0:
         values[1] = 0.0
-        values[0] += 1.0
-    elif fields < 2 and values[1] >= 30.0:
         values[0] += 1.0
 
     literal = f"{np.copysign(values[0], sign):0{pad}.0f}{sep[0]}"

--- a/astropy/coordinates/angles/formats.py
+++ b/astropy/coordinates/angles/formats.py
@@ -420,9 +420,10 @@ def _decimal_to_sexagesimal_string(
     # example, if the seconds will round up to 60, we should convert
     # it to 0 and carry upwards.  If the field is hidden (by the
     # fields kwarg) we round up around the middle, 30.0.
-    rounding_thresh = 60.0 - (10.0 ** -(8 if precision is None else precision))
+    # Builtin round, not NumPy's, which disagrees with the formatting on ties.
+    ndp = 8 if precision is None else precision
 
-    if fields == 3 and values[2] >= rounding_thresh:
+    if fields == 3 and round(float(values[2]), ndp) >= 60.0:
         values[2] = 0.0
         values[1] += 1.0
     elif fields < 3 and values[2] >= 30.0:

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -171,6 +171,23 @@ def test_sexagesimal_seconds_round_at_half_a_unit(angle, precision, expected):
     assert Angle(angle).to_string(precision=precision) == expected
 
 
+@pytest.mark.parametrize(
+    "angle, expected",
+    [
+        # Below half a degree of the next one: no carry.  The seconds must not
+        # be rounded into the minutes first, or these would round twice.
+        ("285d29m41.76s", "285d"),
+        ("285d29m59.9s", "285d"),
+        ("-285d29m41.76s", "-285d"),
+        # Half a degree or more: carry.
+        ("285d30m", "286d"),
+        ("285d30m00.1s", "286d"),
+    ],
+)
+def test_sexagesimal_degrees_round_once(angle, expected):
+    assert Angle(angle).to_string(fields=1) == expected
+
+
 def test_to_string_scalar():
     a = Angle(1.113355, unit=u.deg)
     assert isinstance(a.to_string(), str)

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -152,6 +152,25 @@ def test_sexagesimal_rounding_up():
     assert a.to_string(fields=1, precision=5) == "4d"
 
 
+@pytest.mark.parametrize(
+    "angle, precision, expected",
+    [
+        # Just below half a unit in the last digit shown: no carry.
+        ("1d2m59.49999s", 0, "1d02m59s"),
+        ("1d2m59.94s", 1, "1d02m59.9s"),
+        ("1d2m59.994s", 2, "1d02m59.99s"),
+        # At or above it: the seconds carry into the minutes, and on into
+        # the degrees.
+        ("1d2m59.5s", 0, "1d03m00s"),
+        ("1d2m59.96s", 1, "1d03m00.0s"),
+        ("1d59m59.5s", 0, "2d00m00s"),
+        ("-1d2m59.49999s", 0, "-1d02m59s"),
+    ],
+)
+def test_sexagesimal_seconds_round_at_half_a_unit(angle, precision, expected):
+    assert Angle(angle).to_string(precision=precision) == expected
+
+
 def test_to_string_scalar():
     a = Angle(1.113355, unit=u.deg)
     assert isinstance(a.to_string(), str)

--- a/docs/changes/coordinates/20227.bugfix.rst
+++ b/docs/changes/coordinates/20227.bugfix.rst
@@ -1,3 +1,6 @@
-Fixed ``Angle.to_string`` rounding the seconds up to the next minute half a
-unit too early, so that, e.g., ``Angle("1d2m59.49999s").to_string(precision=0)``
-gave ``1d03m00s`` instead of ``1d02m59s``.
+Fixed two rounding errors in ``Angle.to_string``. The seconds were carried into
+the next minute half a unit too early, so that, e.g.,
+``Angle("1d2m59.49999s").to_string(precision=0)`` gave ``1d03m00s`` instead of
+``1d02m59s``. And with ``fields=1`` the seconds were rounded into the minutes
+before the minutes were rounded into the degrees, rounding twice, so that, e.g.,
+``Angle("285d29m41.76s").to_string(fields=1)`` gave ``286d`` instead of ``285d``.

--- a/docs/changes/coordinates/20227.bugfix.rst
+++ b/docs/changes/coordinates/20227.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``Angle.to_string`` rounding the seconds up to the next minute half a
+unit too early, so that, e.g., ``Angle("1d2m59.49999s").to_string(precision=0)``
+gave ``1d03m00s`` instead of ``1d02m59s``.


### PR DESCRIPTION
Split out of #20130, where @mhvk spotted the first of these.

The seconds carry into the minutes too early:

```
>>> Angle("1d2m59.49999s").to_string(precision=0)
'1d03m00s'          # should be 1d02m59s
```

The threshold sat a whole unit in the last digit shown below 60 instead of half of one. As @mhvk suggested it now rounds the seconds and compares against 60, so there is no threshold left. It does need the builtin `round` on a float, since numpy's scales by ten and back and calls 59.995 at precision 2 a carry where the formatting gives 59.99.

And with `fields=1` the angle is rounded twice, seconds into minutes and then minutes into degrees:

```
>>> Angle("285d29m41.76s").to_string(fields=1)
'286d'              # should be 285d
```

The degrees are now rounded on the minutes and seconds together.

Over 40,000 angles per case this moves 295 for `fields=1`, and 365 and 19 for `fields=3` at precision 0 and 1. Nothing else changes. Tests for both, checked to fail against the current code.
