### PR TITLE
BUG: Improve error for FITS tables with too many columns

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -24,6 +24,7 @@ from .convenience import table_to_hdu
 from .hdu.hdulist import FITS_SIGNATURE
 from .hdu.hdulist import fitsopen as fits_open
 from .util import first
+from .verify import VerifyError
 
 # Keywords to remove for all tables that are read in
 REMOVE_KEYWORDS = [
@@ -505,6 +506,11 @@ def write_table_fits(input, output, overwrite=False, append=False, name=None):
     """
     # Encode any mixin columns into standard Columns.
     input = _encode_mixins(input)
+
+    if (n_columns := len(input.columns)) > 999:
+        raise VerifyError(
+            f"FITS tables cannot contain more than 999 columns (got {n_columns})"
+        )
 
     table_hdu = table_to_hdu(input, character_as_bytes=True, name=name)
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -84,6 +84,18 @@ class TestSingleTable:
         t2 = Table.read(buff)
         assert equal_data(t2, t)
 
+    def test_write_maximum_number_of_columns(self):
+        table = Table({f"col{idx}": [idx] for idx in range(999)})
+        table.write(BytesIO(), format="fits")
+
+    def test_write_too_many_columns(self):
+        table = Table({f"col{idx}": [idx] for idx in range(1000)})
+        with pytest.raises(
+            fits.VerifyError,
+            match=r"FITS tables cannot contain more than 999 columns \(got 1000\)",
+        ):
+            table.write(BytesIO(), format="fits")
+
     def test_simple(self, tmp_path):
         filename = tmp_path / "test_simple.fts"
         t1 = Table(self.data)

--- a/docs/changes/io.fits/20234.bugfix.rst
+++ b/docs/changes/io.fits/20234.bugfix.rst
@@ -1,0 +1,3 @@
+Writing an `~astropy.table.Table` with more than 999 columns to FITS now raises
+a clear error explaining the FITS limit instead of reporting a generic invalid
+``TFIELDS`` value.

--- a/docs/changes/io.fits/20234.bugfix.rst
+++ b/docs/changes/io.fits/20234.bugfix.rst
@@ -1,3 +1,3 @@
-Writing an `~astropy.table.Table` with more than 999 columns to FITS now raises
+Writing an astropy Table with more than 999 columns to FITS now raises
 a clear error explaining the FITS limit instead of reporting a generic invalid
 ``TFIELDS`` value.


### PR DESCRIPTION
### Description

FITS binary tables are limited to 999 columns. Writing a larger `Table` currently reaches HDU construction before that limit is reported, which can emit non-standard `TTYPE1000`/`TFORM1000` warnings before ending with the generic message that `TFIELDS` is invalid.

This change checks the encoded table's physical column count before constructing the HDU and raises a specific `VerifyError`. The check happens after mixin encoding so expanded mixin columns are included.

The regression tests cover both sides of the boundary: 999 columns still write successfully, while 1000 columns raise the clear error.

Fixes #19236

### Validation

- `python -m pytest astropy/io/fits/tests/test_connect.py -q` (176 passed, 8 skipped)
- `python -m pytest astropy/io/fits -q -n 4` (1661 passed, 39 skipped, 100 xfailed)
- `python -m pre_commit run --files astropy/io/fits/connect.py astropy/io/fits/tests/test_connect.py`
- Built a Windows CPython 3.13 wheel and installed it into a clean virtual environment
- From that installed wheel, wrote and read back a 999-column FITS file; a 1000-column write raised the new `VerifyError` and left no output file

### AI disclosure

OpenAI Codex assisted with issue triage, implementation, and local validation. The contributor remains responsible for the submitted content and will engage with review feedback.

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
