### PR TITLE
Fix silent corruption of large masked ints in to_pandas/to_df

### DIFF
--- a/astropy/table/_dataframes.py
+++ b/astropy/table/_dataframes.py
@@ -35,13 +35,24 @@ PANDAS_LIKE: PandasLikeSentinel = PandasLikeSentinel(object())
 INTEGER_DTYPE_KINDS = frozenset({"u", "i"})
 
 
-def _numpy_to_pandas_dtype(dtype: np.dtype) -> str:
-    """Convert a numpy dtype to a pandas dtype string, handling nullable integers."""
-    dtype_name = dtype.name
-    # Special case needed for uint -> UInt
-    if dtype_name.startswith("uint"):
-        return "UInt" + dtype_name.removeprefix("uint")
-    return dtype.name.title()
+def _pandas_nullable_int_array(data, mask):
+    """Make a pandas nullable integer array from integer ``data`` and ``mask``.
+
+    The obvious ways of getting a masked integer column into pandas (letting
+    pandas apply the mask and then casting to a nullable dtype, or passing a
+    masked array to ``Series(..., dtype="Int64")``) both go through a float64
+    intermediate.  That silently corrupts integers which are not exactly
+    representable as float64, i.e. those above 2**53, such as Gaia source ids
+    (gh-14442).  Building the nullable array from the integer values and the
+    mask directly avoids the float intermediate entirely.
+    """
+    from pandas.arrays import IntegerArray
+
+    data = np.asarray(data)
+    if not data.dtype.isnative:
+        data = data.byteswap().view(data.dtype.newbyteorder("="))
+    # copy=True since ``data`` and ``mask`` are generally views on the table.
+    return IntegerArray(data, np.asarray(mask), copy=True)
 
 
 def _encode_mixins(tbl: Table) -> Table:
@@ -256,14 +267,17 @@ def to_df(
     # Convert to dataframe
     df_native = df_nw.to_native()
 
-    # Fix pandas-like nullable integers
+    # Fix pandas-like nullable integers.  These are rebuilt from the original
+    # integer data and mask rather than cast from the masked (hence float64)
+    # column in ``df_native``, which would corrupt values above 2**53.
     if backend_impl.is_pandas_like() and tbl.has_masked_columns and use_nullable_int:
         for name in masked_cols:
-            dtype = array[name].dtype
-            if (dtype := array[name].dtype).kind not in INTEGER_DTYPE_KINDS:
+            if array[name].dtype.kind not in INTEGER_DTYPE_KINDS:
                 continue
 
-            df_native[name] = df_native[name].astype(_numpy_to_pandas_dtype(dtype))
+            df_native[name] = _pandas_nullable_int_array(
+                array[name].data, array[name].mask
+            )
 
     # Pandas-like index
     if index:
@@ -424,18 +438,15 @@ def to_pandas(
 
         if isinstance(column, MaskedColumn) and np.any(column.mask):
             if column.dtype.kind in ["i", "u"]:
-                pd_dtype = column.dtype.name
-                if use_nullable_int:
-                    # Convert int64 to Int64, uint32 to UInt32, etc for nullable types
-                    pd_dtype = pd_dtype.replace("i", "I").replace("u", "U")
-                else:
+                if not use_nullable_int:
                     from pandas.errors import IntCastingNaNError
 
                     raise IntCastingNaNError(
                         "Cannot convert masked integer columns to DataFrame without using nullable integers. "
                         f"Set use_nullable_int=True or remove the offending column: {name}."
                     )
-                out[name] = Series(out[name], dtype=pd_dtype)
+                # Convert int64 to Int64, uint32 to UInt32, etc for nullable types
+                out[name] = Series(_pandas_nullable_int_array(out[name], column.mask))
 
             elif column.dtype.kind not in ["f", "c"]:
                 out[name] = column.astype(object).filled(np.nan)

--- a/astropy/table/tests/test_df.py
+++ b/astropy/table/tests/test_df.py
@@ -454,6 +454,28 @@ class TestDataFrameConversion:
         assert_array_equal(t2["col0"].mask, [False, True])
         assert_array_equal(t2["col0"], c)
 
+    @pytest.mark.parametrize("unsigned", ["u", ""])
+    def test_nullable_int_no_float_intermediate(
+        self, backend, use_legacy_pandas_api, unsigned
+    ):
+        """Masked 64-bit ints above 2**53 must not be converted via float64.
+
+        Regression test for gh-14442, where masked Gaia source ids came back
+        from ``to_pandas()`` silently rounded to the nearest float64.
+        """
+        np_dtype = f"{unsigned}int64"
+        # Values that a float64 (53-bit mantissa) cannot represent exactly.
+        values = [np.iinfo(np_dtype).max, 2**62 + 1, 3]
+        c = MaskedColumn(np.array(values, dtype=np_dtype), mask=[False, False, True])
+        t = Table([c])
+
+        df = self._to_dataframe(t, backend, use_legacy_pandas_api)
+
+        t2 = self._from_dataframe(df, backend, use_legacy_pandas_api)
+        assert str(t2["col0"].dtype) == np_dtype
+        assert_array_equal(t2["col0"].mask, [False, False, True])
+        assert_array_equal(t2["col0"][:2], values[:2])
+
     @pytest.mark.parametrize("ndim", [1, 2, 3])
     def test_nd_columns(self, backend, use_legacy_pandas_api, ndim):
         """Test handling of multidimensional columns."""

--- a/docs/changes/table/20240.bugfix.rst
+++ b/docs/changes/table/20240.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed ``Table.to_pandas()`` and ``Table.to_df()`` silently corrupting masked
+integer columns whose values are too large to be represented exactly as a
+float64, e.g. Gaia source ids. The nullable integer column is now built
+directly from the integer data and the mask instead of via a float64
+intermediate. Only the pandas backend was affected; polars and pyarrow already
+round-tripped these values exactly.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

`Table.to_pandas()` and `Table.to_df()` silently corrupt masked integer columns whose values are too large to be represented exactly as a float64, such as Gaia `source_id` values. The destination dtype and the mask are both correct — only the values are quietly wrong, which is why this has gone unnoticed since 2023.

```python
>>> big = 2**62 + 1
>>> t = Table({"source_id": MaskedColumn([big, 123], mask=[False, True])})
>>> t.to_pandas()["source_id"][0]
4611686018427387904          # main: off by one, no warning
4611686018427387905          # this branch: exact
```

The cause is a float64 intermediate on the way to the pandas nullable integer dtype. This PR builds the nullable array directly from the integer data and the mask, so no float is ever involved. Only pandas was affected; the polars and pyarrow backends of `to_df()` already round-tripped these values exactly.

Fixes #14442.

### AI disclosure

This PR is entirely AI-generated using Claude Opus 5. I have examined the code and fully understand the changes in `_dataframes.py` and the tests.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Build pandas nullable integer columns without a float64 intermediate**

float64 has a 53-bit mantissa, so any integer above 2\*\*53 that passes through a float is silently rounded. Both dataframe export paths introduced the mask into an integer column by way of such a float, but for different reasons — one is an upstream pandas bug and the other is ordinary numpy dtype behaviour.

### 1. `to_pandas()` — an upstream pandas bug

The masked-integer branch did:

```python
out[name] = Series(masked_column, dtype="Int64")
```

Both endpoints here are int64: an int64 masked array in, `Int64` requested out. pandas nevertheless materializes the masked array as float64-with-NaN and then casts, so the value is destroyed before the cast happens. Reduced to pure pandas:

```python
import numpy as np, pandas as pd

big = 2**62 + 1
ma = np.ma.MaskedArray([big, 123], mask=[False, True])
s = pd.Series(ma, dtype="Int64")

s.dtype      # Int64                          <- destination dtype is right
s[0] == big  # False
s[0]         # 4611686018427387904
```

This is [pandas#56566](https://github.com/pandas-dev/pandas/issues/56566), *"BUG: Inconsistent behavior while constructing a Series with large integers in a int64 masked array"* — open since Dec 2023, labeled `Bug` / `Dtype Conversions` / `Constructors` / `NA - MaskedArrays`. "Inconsistent" is the operative word: every other route to the same destination is exact.

```python
pd.Series(pd.arrays.IntegerArray(data, mask))     # exact
pd.array([big, None], dtype="Int64")              # exact
pd.Series(data).astype("Int64").mask(mask)        # exact  (cast first, then mask)
```

### 2. `to_df()` — not a pandas bug

The narwhals path applies the mask with `nw.when(~mask).then(col)` and then casts the result to the nullable dtype. On a numpy-backed int64 column the masking step *must* widen to float64, because numpy int64 has no NA value:

```python
pd.Series(data).mask(mask).dtype               # float64   <- precision lost here
pd.Series(data).mask(mask).astype("Int64")     # 4611686018427387904
```

That is documented, longstanding behaviour, not a bug; the subsequent `.astype("Int64")` is only cleaning up after a lossy step. polars and pyarrow use native nullable integers with no float detour, which is why they were already correct.

### 3. Implementation

All of it is in `astropy/table/_dataframes.py`.

- New `_pandas_nullable_int_array(data, mask)` helper constructing `pandas.arrays.IntegerArray` straight from the integer values and the boolean mask. It normalizes byte order and copies, so the DataFrame does not alias the table.
- `to_pandas()` uses it in place of `Series(..., dtype=pd_dtype)`. With the dtype string no longer needed (`IntegerArray` derives `Int64`/`UInt32`/… itself), the `use_nullable_int=False` branch becomes a plain early raise.
- `to_df()` uses it to rebuild the column from `array[name].data` and `array[name].mask`, instead of casting the already-masked (hence float64) column in `df_native`.
- `_numpy_to_pandas_dtype()` is removed; it had no remaining callers.

The explicit byteswap in `to_pandas()` is left in place — it serves every column, not just masked integers. `to_df()` has no equivalent because `Table.as_array()` already normalizes byte order via its `keep_byteorder=False` default. The byte-order guard inside the new helper is therefore redundant for both current callers, and is kept deliberately: `IntegerArray.__init__` validates only `dtype.kind in "iu"`, so it accepts a non-native array silently and then fails later with `KeyError: dtype('>i8')` on first dtype access.

### 4. Testing

`test_nullable_int_no_float_intermediate` in `astropy/table/tests/test_df.py`, sitting next to the existing `test_nullable_int` and parametrized the same way — signed and unsigned, across all four backend/API combinations. It uses `iinfo(dtype).max` and `2**62 + 1`, neither of which survives a float64 round trip. Without the fix it fails on all four pandas variants (legacy and generic API, signed and unsigned) and passes for polars and pyarrow.

Also checked by hand:

| case | result |
|---|---|
| all 8 int dtypes, `iinfo` max/min | exact values, dtype preserved (`Int8`…`UInt64`) |
| big-endian masked int column | exact, mask preserved |
| `to_pandas(index=...)` | unchanged |
| `use_nullable_int=False` | still raises `IntCastingNaNError` |
| mutating the returned DataFrame | no longer writes through to the table |

`astropy/table` + `astropy/io/misc`: 2992 passed, 83 skipped, 23 xfailed. `docs/table` doctests pass.

### 5. Backwards compatibility

No API change. Dtypes, masks, and every value at or below 2\*\*53 are bit-for-bit identical to before; only the previously-corrupted large values change, and they change to the correct answer. A `docs/changes/table/20240.bugfix.rst` fragment is included.

</details>

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
