### PR TITLE
Add new QTable kwarg and attribute preserve_quantity_dtype

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -907,7 +907,7 @@ class Table:
         # Set table meta.  If copy=True then deepcopy meta otherwise use the
         # user-supplied meta directly.  This is done before the real initialization
         # since a TableAttribute stored in meta can change how the columns get
-        # converted (e.g. the QTable ``preserve_quantity_dtype`` attribute).
+        # converted (e.g. the QTable ``quantity_convert_keep_int`` attribute).
         if meta is not None:
             self.meta = deepcopy(meta) if copy else meta
 
@@ -4388,16 +4388,17 @@ class QTable(Table):
         List or dict of units to apply to columns.
     descriptions : list, dict, optional
         List or dict of descriptions to apply to columns.
-    preserve_quantity_dtype : bool, optional
-        If `True`, always preserve the dtype of input data with units when converting to
-        `~astropy.units.Quantity`. By default, integer types are converted to float,
-        following the behavior of `~astropy.units.Quantity`.
+    quantity_convert_keep_int : bool, optional
+        If `True`, an integer column with a unit keeps its ``dtype`` when it is
+        converted to `~astropy.units.Quantity`. By default such a column is cast to
+        float, following the behavior of `~astropy.units.Quantity`. Columns that are
+        already float or complex are unaffected either way.
     **kwargs : dict, optional
         Additional keyword args when converting table-like object.
 
     """
 
-    preserve_quantity_dtype = TableAttribute()
+    quantity_convert_keep_int = TableAttribute()
 
     def _is_mixin_for_table(self, col):
         """
@@ -4416,7 +4417,7 @@ class QTable(Table):
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
             # Quantity casts integer data to float unless dtype=None is supplied.
-            kwargs = {"dtype": None} if self.preserve_quantity_dtype else {}
+            kwargs = {"dtype": None} if self.quantity_convert_keep_int else {}
             try:
                 qcol = q_cls(col.data, col.unit, copy=None, subok=True, **kwargs)
             except Exception as exc:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -904,11 +904,10 @@ class Table:
 
         self._check_names_dtype(names, dtype, n_cols)
 
-        # Finally do the real initialization
-        init_func(data, names, dtype, n_cols, copy)
-
         # Set table meta.  If copy=True then deepcopy meta otherwise use the
-        # user-supplied meta directly.
+        # user-supplied meta directly.  This is done before the real initialization
+        # since a TableAttribute stored in meta can change how the columns get
+        # converted (e.g. the QTable ``preserve_quantity_dtype`` attribute).
         if meta is not None:
             self.meta = deepcopy(meta) if copy else meta
 
@@ -917,6 +916,9 @@ class Table:
         if meta_table_attrs:
             for attr, value in meta_table_attrs.items():
                 setattr(self, attr, value)
+
+        # Finally do the real initialization
+        init_func(data, names, dtype, n_cols, copy)
 
         # Whatever happens above, the masked property should be set to a boolean
         if self.masked not in (None, True, False):
@@ -4386,10 +4388,16 @@ class QTable(Table):
         List or dict of units to apply to columns.
     descriptions : list, dict, optional
         List or dict of descriptions to apply to columns.
+    preserve_quantity_dtype : bool, optional
+        If `True`, always preserve the dtype of input data with units when converting to
+        `~astropy.units.Quantity`. By default, integer types are converted to float,
+        following the behavior of `~astropy.units.Quantity`.
     **kwargs : dict, optional
         Additional keyword args when converting table-like object.
 
     """
+
+    preserve_quantity_dtype = TableAttribute()
 
     def _is_mixin_for_table(self, col):
         """
@@ -4407,8 +4415,10 @@ class QTable(Table):
             # We need to turn the column into a quantity; use subok=True to allow
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
+            # Quantity casts integer data to float unless dtype=None is supplied.
+            kwargs = {"dtype": None} if self.preserve_quantity_dtype else {}
             try:
-                qcol = q_cls(col.data, col.unit, copy=None, subok=True)
+                qcol = q_cls(col.data, col.unit, copy=None, subok=True, **kwargs)
             except Exception as exc:
                 warnings.warn(
                     f"column {col.info.name} has a unit but is kept as "

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -31,6 +31,7 @@ from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.masked import Masked
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
 
 from .conftest import MaskedTable
@@ -2149,6 +2150,71 @@ class TestQTableColumnConversionCornerCases:
         with pytest.warns(AstropyUserWarning, match="convert it to Quantity failed"):
             t["a"] = Column(["a"], unit=u.m)
         assert isinstance(t["a"], Column)
+
+
+class TestPreserveQuantityDtype:
+    """Test the QTable ``preserve_quantity_dtype`` attribute (#17963)."""
+
+    # Integers that are not exactly representable as float64.
+    VALS = [2741100559643251862, 2733456478647137226]
+
+    def get_table(self):
+        return Table(
+            [
+                Column(self.VALS, name="a", unit="m"),
+                MaskedColumn(self.VALS, name="b", unit="", mask=[False, True]),
+            ]
+        )
+
+    def test_default_is_not_set(self):
+        """By default integer columns with a unit are cast to float."""
+        t = QTable(self.get_table())
+        assert t.preserve_quantity_dtype is None
+        # The unset attribute does not clutter the table meta.
+        assert t.meta == {}
+        assert t["a"].dtype.kind == "f"
+        assert t["b"].dtype.kind == "f"
+
+    def test_init_kwarg(self):
+        t = QTable(self.get_table(), preserve_quantity_dtype=True)
+        assert t.preserve_quantity_dtype is True
+        assert t["a"].dtype == np.int64
+        assert t["b"].dtype == np.int64
+        assert np.all(t["a"].value == self.VALS)
+        assert isinstance(t["a"], u.Quantity)
+        assert isinstance(t["b"], Masked)
+        assert t["a"].unit == u.m
+        assert np.all(t["b"].mask == [False, True])
+
+    def test_set_attribute_then_add_column(self):
+        t = QTable()
+        t.preserve_quantity_dtype = True
+        t["a"] = Column(self.VALS, unit="m")
+        assert t["a"].dtype == np.int64
+        assert np.all(t["a"].value == self.VALS)
+
+    def test_attribute_persists(self):
+        """The attribute is stored in meta so it survives slicing and copying."""
+        t = QTable(self.get_table(), preserve_quantity_dtype=True)
+        assert t.meta["__attributes__"] == {"preserve_quantity_dtype": True}
+        for t2 in (t[:1], t.copy(), QTable(t), QTable(Table(t))):
+            assert t2.preserve_quantity_dtype is True
+            assert t2["a"].dtype == np.int64
+
+    def test_kwarg_takes_precedence_over_meta(self):
+        t = QTable(self.get_table(), preserve_quantity_dtype=True)
+        t2 = QTable(Table(t), preserve_quantity_dtype=False)
+        assert t2.preserve_quantity_dtype is False
+        assert t2["a"].dtype.kind == "f"
+
+    def test_float_column_unaffected(self):
+        vals = [1.5, 2.5]
+        t = QTable(
+            [Column(vals, name="a", unit="m", dtype=np.float32)],
+            preserve_quantity_dtype=True,
+        )
+        assert t["a"].dtype == np.float32
+        assert np.all(t["a"].value == vals)
 
 
 class Test__Astropy_Table__:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2161,7 +2161,7 @@ class TestQuantityConvertKeepInt:
     def get_table(self):
         return Table(
             [
-                Column(self.VALS, name="a", unit="m"),
+                Column(self.VALS, name="a", unit="ct"),
                 MaskedColumn(self.VALS, name="b", unit="", mask=[False, True]),
             ]
         )
@@ -2183,7 +2183,7 @@ class TestQuantityConvertKeepInt:
         assert np.all(t["a"].value == self.VALS)
         assert isinstance(t["a"], u.Quantity)
         assert isinstance(t["b"], Masked)
-        assert t["a"].unit == u.m
+        assert t["a"].unit == u.ct
         assert np.all(t["b"].mask == [False, True])
         # Values are exact under the mask as well as outside it.
         assert np.all(t["b"].unmasked.value == self.VALS)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2152,8 +2152,8 @@ class TestQTableColumnConversionCornerCases:
         assert isinstance(t["a"], Column)
 
 
-class TestPreserveQuantityDtype:
-    """Test the QTable ``preserve_quantity_dtype`` attribute (#17963)."""
+class TestQuantityConvertKeepInt:
+    """Test the QTable ``quantity_convert_keep_int`` attribute (#17963)."""
 
     # Integers that are not exactly representable as float64.
     VALS = [2741100559643251862, 2733456478647137226]
@@ -2169,15 +2169,15 @@ class TestPreserveQuantityDtype:
     def test_default_is_not_set(self):
         """By default integer columns with a unit are cast to float."""
         t = QTable(self.get_table())
-        assert t.preserve_quantity_dtype is None
+        assert t.quantity_convert_keep_int is None
         # The unset attribute does not clutter the table meta.
         assert t.meta == {}
         assert t["a"].dtype.kind == "f"
         assert t["b"].dtype.kind == "f"
 
     def test_init_kwarg(self):
-        t = QTable(self.get_table(), preserve_quantity_dtype=True)
-        assert t.preserve_quantity_dtype is True
+        t = QTable(self.get_table(), quantity_convert_keep_int=True)
+        assert t.quantity_convert_keep_int is True
         assert t["a"].dtype == np.int64
         assert t["b"].dtype == np.int64
         assert np.all(t["a"].value == self.VALS)
@@ -2188,30 +2188,30 @@ class TestPreserveQuantityDtype:
 
     def test_set_attribute_then_add_column(self):
         t = QTable()
-        t.preserve_quantity_dtype = True
+        t.quantity_convert_keep_int = True
         t["a"] = Column(self.VALS, unit="m")
         assert t["a"].dtype == np.int64
         assert np.all(t["a"].value == self.VALS)
 
     def test_attribute_persists(self):
         """The attribute is stored in meta so it survives slicing and copying."""
-        t = QTable(self.get_table(), preserve_quantity_dtype=True)
-        assert t.meta["__attributes__"] == {"preserve_quantity_dtype": True}
+        t = QTable(self.get_table(), quantity_convert_keep_int=True)
+        assert t.meta["__attributes__"] == {"quantity_convert_keep_int": True}
         for t2 in (t[:1], t.copy(), QTable(t), QTable(Table(t))):
-            assert t2.preserve_quantity_dtype is True
+            assert t2.quantity_convert_keep_int is True
             assert t2["a"].dtype == np.int64
 
     def test_kwarg_takes_precedence_over_meta(self):
-        t = QTable(self.get_table(), preserve_quantity_dtype=True)
-        t2 = QTable(Table(t), preserve_quantity_dtype=False)
-        assert t2.preserve_quantity_dtype is False
+        t = QTable(self.get_table(), quantity_convert_keep_int=True)
+        t2 = QTable(Table(t), quantity_convert_keep_int=False)
+        assert t2.quantity_convert_keep_int is False
         assert t2["a"].dtype.kind == "f"
 
     def test_float_column_unaffected(self):
         vals = [1.5, 2.5]
         t = QTable(
             [Column(vals, name="a", unit="m", dtype=np.float32)],
-            preserve_quantity_dtype=True,
+            quantity_convert_keep_int=True,
         )
         assert t["a"].dtype == np.float32
         assert np.all(t["a"].value == vals)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2185,6 +2185,8 @@ class TestQuantityConvertKeepInt:
         assert isinstance(t["b"], Masked)
         assert t["a"].unit == u.m
         assert np.all(t["b"].mask == [False, True])
+        # Values are exact under the mask as well as outside it.
+        assert np.all(t["b"].unmasked.value == self.VALS)
 
     def test_set_attribute_then_add_column(self):
         t = QTable()

--- a/docs/changes/table/20247.feature.rst
+++ b/docs/changes/table/20247.feature.rst
@@ -1,5 +1,5 @@
 Added a new ``QTable`` keyword argument and attribute ``preserve_quantity_dtype``. When
-set to `True`, a integer column with a unit keeps its ``dtype`` when it is converted to
+set to `True`, an integer column with a unit keeps its ``dtype`` when it is converted to
 a ``Quantity`` instead of being cast to float. This avoids silently losing precision for
 integer columns such as source identifiers, which are commonly read from VOTable or FITS
 files with a unit defined.

--- a/docs/changes/table/20247.feature.rst
+++ b/docs/changes/table/20247.feature.rst
@@ -1,0 +1,5 @@
+Added a new ``QTable`` keyword argument and attribute ``preserve_quantity_dtype``. When
+set to `True`, a integer column with a unit keeps its ``dtype`` when it is converted to
+a ``Quantity`` instead of being cast to float. This avoids silently losing precision for
+integer columns such as source identifiers, which are commonly read from VOTable or FITS
+files with a unit defined.

--- a/docs/changes/table/20247.feature.rst
+++ b/docs/changes/table/20247.feature.rst
@@ -1,4 +1,4 @@
-Added a new ``QTable`` keyword argument and attribute ``preserve_quantity_dtype``. When
+Added a new ``QTable`` keyword argument and attribute ``quantity_convert_keep_int``. When
 set to `True`, an integer column with a unit keeps its ``dtype`` when it is converted to
 a ``Quantity`` instead of being cast to float. This avoids silently losing precision for
 integer columns such as source identifiers, which are commonly read from VOTable or FITS

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -192,8 +192,6 @@ Example::
    file written from a `~astropy.table.QTable`, is still converted to `float` when it is
    read back.
 
-.. EXAMPLE END
-
 .. _mixin_attributes:
 
 Mixin Attributes

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -146,10 +146,11 @@ You can conveniently convert |Table| to |QTable| and vice-versa::
 Quantity and Integer Columns
 ============================
 
-When a column of ``int`` ``dtype`` has a defined unit and is converted to
-`~astropy.units.Quantity`, its ``dtype`` is converted to `float` by default. This
-situation is common when reading VOtable or FITS data tables that have integer count
-data or source IDs with defined units.
+When a `~astropy.table.Column` or `~astropy.table.MaskedColumn` with a defined unit is
+added to a `~astropy.table.QTable`, it is converted to `~astropy.units.Quantity`. By
+default, an `int` ``dtype`` is converted to `float`, following the normal behavior of
+`~astropy.units.Quantity`. A common example is integer count data with a ``count`` or
+``ct`` unit.
 
 You can change this behavior and keep the integer ``dtype`` by providing
 ``quantity_convert_keep_int=True`` when creating the `~astropy.table.QTable`. You can

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -141,15 +141,56 @@ You can conveniently convert |Table| to |QTable| and vice-versa::
    ordinary `~astropy.table.Table` then it gets converted to an ordinary
    `~astropy.table.Column` with the corresponding ``unit`` attribute.
 
-.. attention::
+.. EXAMPLE END
 
-   When a column of ``int`` ``dtype`` is converted to `~astropy.units.Quantity`,
-   its ``dtype`` is converted to ``float``.
+Quantity and Integer Columns
+============================
 
-   For example, for a quality flag column of ``int``, if it is
-   assigned with the :ref:`dimensionless unit <doc_dimensionless_unit>`, it will still
-   be converted to ``float``. Therefore such columns typically should not be
-   assigned with any unit.
+When a column of ``int`` ``dtype`` has a defined unit and is converted to
+`~astropy.units.Quantity`, its ``dtype`` is converted to `float` by default. This
+situation is common when reading VOtable or FITS data tables that have integer count
+data or source IDs with defined units.
+
+You can change this behavior and preserve the original ``dtype``  by providing
+``preserve_quantity_dtype=True`` when creating the `~astropy.table.QTable`. You can also
+change this behavior for an existing `~astropy.table.QTable` by setting the
+``preserve_quantity_dtype`` attribute to `True`. This attribute is stored in the table
+``meta`` so it is preserved through table operations such as copying, slicing, and
+pickling, as well as writing to ECSV.
+
+Example::
+
+    >>> from astropy.table import Column
+    >>> source = Column([2741100559643251862, 2733456478647137226], unit="")
+    >>> counts = Column([401, 15023], unit="count")
+    >>> QTable({"source": source, "counts": counts})
+    <QTable length=2>
+            source          counts
+                              ct
+          float64          float64
+    ---------------------- -------
+    2.7411005596432517e+18   401.0
+    2.7334564786471373e+18 15023.0
+    >>> qt_int = QTable({"source": source, "counts": counts}, preserve_quantity_dtype=True)
+    >>> qt_int
+    <QTable length=2>
+           source        counts
+                           ct
+          int64          int64
+    ------------------- ------
+    2741100559643251862    401
+    2733456478647137226  15023
+    >>> qt_int.preserve_quantity_dtype
+    True
+
+.. note::
+
+   When reading a file into a `~astropy.table.QTable`, the ``dtype`` is preserved only
+   if the file stores the data as a plain column with a unit *and* the
+   ``preserve_quantity_dtype`` attribute is in the table ``meta``. A column that was
+   written as a serialized `~astropy.units.Quantity` column, for instance in an ECSV
+   file written from a `~astropy.table.QTable`, is still converted to `float` when it is
+   read back.
 
 .. EXAMPLE END
 

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -151,10 +151,10 @@ When a column of ``int`` ``dtype`` has a defined unit and is converted to
 situation is common when reading VOtable or FITS data tables that have integer count
 data or source IDs with defined units.
 
-You can change this behavior and preserve the original ``dtype``  by providing
-``preserve_quantity_dtype=True`` when creating the `~astropy.table.QTable`. You can also
-change this behavior for an existing `~astropy.table.QTable` by setting the
-``preserve_quantity_dtype`` attribute to `True`. This attribute is stored in the table
+You can change this behavior and keep the integer ``dtype`` by providing
+``quantity_convert_keep_int=True`` when creating the `~astropy.table.QTable`. You can
+also change this behavior for an existing `~astropy.table.QTable` by setting the
+``quantity_convert_keep_int`` attribute to `True`. This attribute is stored in the table
 ``meta`` so it is preserved through table operations such as copying, slicing, and
 pickling, as well as writing to ECSV.
 
@@ -171,7 +171,7 @@ Example::
     ---------------------- -------
     2.7411005596432517e+18   401.0
     2.7334564786471373e+18 15023.0
-    >>> qt_int = QTable({"source": source, "counts": counts}, preserve_quantity_dtype=True)
+    >>> qt_int = QTable({"source": source, "counts": counts}, quantity_convert_keep_int=True)
     >>> qt_int
     <QTable length=2>
            source        counts
@@ -180,14 +180,14 @@ Example::
     ------------------- ------
     2741100559643251862    401
     2733456478647137226  15023
-    >>> qt_int.preserve_quantity_dtype
+    >>> qt_int.quantity_convert_keep_int
     True
 
 .. note::
 
-   When reading a file into a `~astropy.table.QTable`, the ``dtype`` is preserved only
-   if the file stores the data as a plain column with a unit *and* the
-   ``preserve_quantity_dtype`` attribute is in the table ``meta``. A column that was
+   When reading a file into a `~astropy.table.QTable`, the integer ``dtype`` is kept
+   only if the file stores the data as a plain column with a unit *and* the
+   ``quantity_convert_keep_int`` attribute is in the table ``meta``. A column that was
    written as a serialized `~astropy.units.Quantity` column, for instance in an ECSV
    file written from a `~astropy.table.QTable`, is still converted to `float` when it is
    read back.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

`QTable` converts any `Column` that has a unit into a `Quantity`, and `Quantity` defaults to `dtype=np.inexact`. An integer column with a unit is therefore always cast to float64, which silently changes values above 2\*\*53. This hits on source identifiers, which routinely exceed that: a VOTable with `datatype="long"` and `unit="NA"` reads into `Table` as exact int64 and into `QTable` as a wrong float, with no warning (#17963).

```python
>>> t = Table({"source_id": Column([2741100559643251862], unit="")})
>>> QTable(t)["source_id"][0]
<Quantity 2.74110056e+18>                # main: value is off by 6

>>> QTable(t, preserve_quantity_dtype=True)["source_id"][0]
<Quantity 2741100559643251862>           # this branch: exact
```

This PR adds an optional `QTable` keyword argument and attribute `preserve_quantity_dtype`. When it is true the `Quantity` is built with `dtype=None`, which keeps whatever dtype the input column had. The default behavior is unchanged.

Fixes #17963. This is the `table` side only — the `io.votable` behavior of treating `unit="NA"` or `unit=""` as a real unit, which is what routes these ID columns into `Quantity` in the first place, is left for a separate change.

This supersedes and thus closes #12505. I believe that using a proper `TableAttribute` that survives copy/pickle/slice/serialize is the right approach.

### AI disclosure

Much of this PR is AI-generated using Claude Opus 5, but I did make substantive changes to the initial outputs. I have examined the code and fully understand the changes in `table.py` and the tests.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Add a `QTable.preserve_quantity_dtype` table attribute that keeps the column dtype when converting to `Quantity`**

### 1. Where the dtype is lost

`QTable._convert_col_for_table()` is the single place where a `Column` with a unit becomes a `Quantity`:

```python
qcol = q_cls(col.data, col.unit, copy=None, subok=True)
```

`Quantity.__new__` has `dtype=np.inexact`, so int64 in gives float64 out. Nothing else in the chain is lossy — the ECSV/FITS/VOTable readers all hand `QTable` an exact integer column, and `Table` keeps it exact. Passing `dtype=None` instead makes `Quantity` keep the input dtype.

### 2. Implementation

All of it is in `astropy/table/table.py`.

**The attribute.** `preserve_quantity_dtype = TableAttribute()` on `QTable`, so the value lives in `meta['__attributes__']` and travels with the table through slicing, copying, pickling and ECSV.

It is declared with the default `None` rather than `default=False` on purpose. `MetaAttribute.__get__` copies any non-`None` default into `meta['__attributes__']` the first time the attribute is read, so `TableAttribute(default=False)` would give *every* `QTable` a `meta` of `{'__attributes__': {'preserve_quantity_dtype': False}}` and write that block into every ECSV file. With the `None` default the getter short-circuits and `meta` stays empty until the attribute is explicitly set. This is the same reason `Table._hidden_columns` defaults to `None`.

**The conversion.**

```python
 q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
+# Quantity casts integer data to float unless dtype=None is supplied.
+kwargs = {"dtype": None} if self.preserve_quantity_dtype else {}
 try:
-    qcol = q_cls(col.data, col.unit, copy=None, subok=True)
+    qcol = q_cls(col.data, col.unit, copy=None, subok=True, **kwargs)
```

Passing the kwarg conditionally rather than `dtype=np.inexact` in the false branch keeps the default path from hardcoding a default that belongs to `Quantity`.

**One reorder in `Table.__init__`.** Table attributes were applied *after* `init_func()`, which is what builds and converts the columns. An attribute supplied as an init kwarg could therefore never affect the conversion — `QTable(data, preserve_quantity_dtype=True)` would have cast the columns to float and only then recorded the attribute. The `self.meta` assignment and the kwarg loop now run before `init_func()`:

```python
 self._check_names_dtype(names, dtype, n_cols)

-# Finally do the real initialization
-init_func(data, names, dtype, n_cols, copy)
-
 # Set table meta.  If copy=True then deepcopy meta otherwise use the
-# user-supplied meta directly.
+# user-supplied meta directly.  This is done before the real initialization
+# since a TableAttribute stored in meta can change how the columns get
+# converted (e.g. the QTable ``preserve_quantity_dtype`` attribute).
 if meta is not None:
     self.meta = deepcopy(meta) if copy else meta

 # Update meta with TableAttributes supplied as kwargs in Table init.
 # This takes precedence over previously-defined meta.
 if meta_table_attrs:
     for attr, value in meta_table_attrs.items():
         setattr(self, attr, value)

+# Finally do the real initialization
+init_func(data, names, dtype, n_cols, copy)
```

Setting `meta` first is what also makes the attribute work when it arrives *in* the input meta rather than as a kwarg, which is the ECSV read path. Precedence is unchanged: the kwarg loop still runs last and still wins over the meta value.

This reorder is safe because no init function reads or writes `self.meta` — the only `self.meta` references between `__init__` and `_new_from_slice` are in `__getstate__` and `_new_from_slice` itself. Verified against `table`, `io.ascii`, `io.misc`, `io.votable`, `units`, `utils` and `nddata`, whose `MetaAttribute`/`meta` handling would be the first thing to break.

### 3. Testing

`TestPreserveQuantityDtype` in `astropy/table/tests/test_table.py`, six tests using `[2741100559643251862, 2733456478647137226]` — real Euclid-style IDs, neither of which survives a float64 round trip. It covers the default (dtype cast to float, `meta` left empty), the init kwarg, setting the attribute on an existing table before adding a column, persistence through slice/copy/`QTable(t)`/`QTable(Table(t))`, kwarg precedence over a value already in `meta`, and a float32 column being left alone rather than upcast.

Also checked by hand:

| case | result |
|---|---|
| masked int column with a unit | `MaskedQuantity`, int64, mask intact |
| `u.mag()` unit with `subok=True` | `<Magnitude [1, 2] mag>`, int64 |
| pickle round trip | attribute and int64 preserved |
| default `QTable(...)` | `meta == {}`, no `__attributes__` block |
| `copy=False` with user meta | `qt.meta is` the caller's dict, as before |
| user meta plus the kwarg | `{'x': 1, '__attributes__': {...}}`, neither clobbers the other |
| ECSV written from a `Table` (plain column + unit, attribute in meta) | `QTable.read()` gives exact int64 |

`astropy/table`, `io/ascii`, `io/misc`, `io/votable`, `units`, `utils`, `nddata`: 11775 passed, 200 skipped, 29 xfailed. `docs/table` and `docs/io` doctests: 35 passed, 6 skipped.

### 4. Known limitations

The attribute governs `_convert_col_for_table()`, so it only applies to columns that reach `QTable` as a `Column` with a unit. Two read paths bypass it, both documented in the new docs note:

- A column written as a *serialized* `Quantity` mixin column — what `QTable.write()` produces for ECSV and parquet — is rebuilt by `table/serialize.py` through `QuantityInfo._construct_from_dict()`, which calls `Quantity(value, unit)` with the default float cast. The attribute round-trips correctly but has no effect on those columns. This is a pre-existing bug in its own right (any int64 `Quantity` loses its dtype through ECSV, with or without this PR) and the fix belongs in `astropy.units`, so it is not included here.
- FITS drops the attribute entirely: `__attributes__` is a dict and `Header` refuses it with *"Attribute `__attributes__` of type <class 'dict'> cannot be added to FITS Header - skipping"*. The int64 data itself is written correctly (`TFORM = 'K'`); only the attribute is lost.

`QTable.read(..., preserve_quantity_dtype=True)` is also not supported — the unified I/O layer passes unknown kwargs to the reader, not to the table class. The working idiom for now is `QTable(Table.read(...), preserve_quantity_dtype=True)`.

### 5. Backwards compatibility

No behavior changes unless the new attribute is explicitly set. With it unset, `_convert_col_for_table()` calls `Quantity` with exactly the arguments it did before, `QTable.preserve_quantity_dtype` reads back as `None`, and `meta` is untouched. The `Table.__init__` reorder is not observable — attribute precedence, meta identity under `copy=False`, and deepcopy semantics under `copy=True` are all unchanged.

A `docs/changes/table/20247.feature.rst` fragment is included, and `docs/table/mixin_columns.rst` gains a "Quantity and Integer Columns" section replacing the `.. attention::` block that previously documented the float cast as unavoidable.

</details>
