### PR TITLE
Fix VOTable integer columns with units being cast to float in QTable

### DIFF
--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -478,14 +478,16 @@ def test_qtable_preserves_int_datatype():
     assert qt["object_id"].dtype == np.int64
     assert qt["counts"].dtype == np.int64
     assert qt["ra"].dtype == np.float64
-    assert np.all(qt["object_id"].value == OBJECT_IDS)
+    # Compare via tolist() because a float64 column compares equal to these ints:
+    # the ints get promoted to float64, which is exactly the lossy step being tested.
+    assert qt["object_id"].value.tolist() == OBJECT_IDS
     assert qt["counts"].unit == u.count
     assert qt.preserve_quantity_dtype is True
 
     # A plain Table was never affected and is unchanged.
     t = Table.read(io.BytesIO(VOTABLE_INT_WITH_UNIT), format="votable")
     assert t["object_id"].dtype == np.int64
-    assert np.all(t["object_id"] == OBJECT_IDS)
+    assert t["object_id"].tolist() == OBJECT_IDS
 
 
 def test_qtable_preserves_int_datatype_round_trip(tmp_path):
@@ -499,7 +501,7 @@ def test_qtable_preserves_int_datatype_round_trip(tmp_path):
     qt2 = QTable.read(fn, format="votable")
 
     assert qt2["object_id"].dtype == np.int64
-    assert np.all(qt2["object_id"].value == OBJECT_IDS)
+    assert qt2["object_id"].value.tolist() == OBJECT_IDS
 
 
 def test_no_field_not_empty_table():

--- a/astropy/io/votable/tests/test_table.py
+++ b/astropy/io/votable/tests/test_table.py
@@ -18,7 +18,7 @@ from astropy.io.votable.converters import Char, UnicodeChar, get_converter
 from astropy.io.votable.exceptions import E01, E25, W39, W46, W50, VOWarning
 from astropy.io.votable.table import parse, writeto
 from astropy.io.votable.tree import Field, VOTableFile
-from astropy.table import Column, Table
+from astropy.table import Column, QTable, Table
 from astropy.table.table_helpers import simple_table
 from astropy.utils.compat.optional_deps import HAS_PYARROW
 from astropy.utils.data import (
@@ -446,6 +446,60 @@ def test_empty_table():
     votable = parse(get_pkg_data_filename("data/empty_table.xml"))
     table = votable.get_first_table()
     table.to_table()
+
+
+VOTABLE_INT_WITH_UNIT = b"""<?xml version='1.0'?>
+<VOTABLE version="1.2" xmlns="http://www.ivoa.net/xml/VOTable/v1.2">
+<RESOURCE><TABLE nrows="2">
+<FIELD ID="object_id" datatype="long" name="object_id" unit="NA">
+<VALUES null='-9223372036854775808'/>
+</FIELD>
+<FIELD ID="counts" datatype="long" name="counts" unit="ct"/>
+<FIELD ID="ra" datatype="double" name="ra" unit="deg"/>
+<DATA><TABLEDATA>
+  <TR><TD>2741100559643251862</TD><TD>401</TD><TD>274.11005599493853</TD></TR>
+  <TR><TD>2733456478647137226</TD><TD>15023</TD><TD>273.34564786062185</TD></TR>
+</TABLEDATA></DATA>
+</TABLE></RESOURCE></VOTABLE>
+"""
+
+# Object IDs that are not exactly representable as float64.
+OBJECT_IDS = [2741100559643251862, 2733456478647137226]
+
+
+def test_qtable_preserves_int_datatype():
+    """The FIELD datatype must survive the conversion to Quantity.
+
+    Reading a ``long`` column that also has a unit used to give a float64 QTable
+    column, silently changing values above 2**53.  See #17963.
+    """
+    qt = QTable.read(io.BytesIO(VOTABLE_INT_WITH_UNIT), format="votable")
+
+    assert qt["object_id"].dtype == np.int64
+    assert qt["counts"].dtype == np.int64
+    assert qt["ra"].dtype == np.float64
+    assert np.all(qt["object_id"].value == OBJECT_IDS)
+    assert qt["counts"].unit == u.count
+    assert qt.preserve_quantity_dtype is True
+
+    # A plain Table was never affected and is unchanged.
+    t = Table.read(io.BytesIO(VOTABLE_INT_WITH_UNIT), format="votable")
+    assert t["object_id"].dtype == np.int64
+    assert np.all(t["object_id"] == OBJECT_IDS)
+
+
+def test_qtable_preserves_int_datatype_round_trip(tmp_path):
+    """Writing and re-reading keeps the exact integer values."""
+    qt = QTable.read(io.BytesIO(VOTABLE_INT_WITH_UNIT), format="votable")
+
+    fn = tmp_path / "int_with_unit.xml"
+    # W50: "NA" is not a valid VOUnit, so writing it back out warns.
+    with pytest.warns(W50, match="Invalid unit string 'NA'"):
+        qt.write(fn, format="votable")
+    qt2 = QTable.read(fn, format="votable")
+
+    assert qt2["object_id"].dtype == np.int64
+    assert np.all(qt2["object_id"].value == OBJECT_IDS)
 
 
 def test_no_field_not_empty_table():

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3535,6 +3535,12 @@ class TableElement(
         else:
             names = [field.ID for field in self.fields]
 
+        # The FIELD ``datatype`` attribute is authoritative, so an integer column that
+        # also has a unit must not be silently cast to float when this table is
+        # converted to a `~astropy.table.QTable`. This sets the QTable
+        # ``preserve_quantity_dtype`` table attribute, which is stored in the meta.
+        meta["__attributes__"] = {"preserve_quantity_dtype": True}
+
         table = Table(self.array, names=names, meta=meta)
 
         for name, field in zip(names, self.fields):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -904,11 +904,10 @@ class Table:
 
         self._check_names_dtype(names, dtype, n_cols)
 
-        # Finally do the real initialization
-        init_func(data, names, dtype, n_cols, copy)
-
         # Set table meta.  If copy=True then deepcopy meta otherwise use the
-        # user-supplied meta directly.
+        # user-supplied meta directly.  This is done before the real initialization
+        # since a TableAttribute stored in meta can change how the columns get
+        # converted (e.g. the QTable ``preserve_quantity_dtype`` attribute).
         if meta is not None:
             self.meta = deepcopy(meta) if copy else meta
 
@@ -917,6 +916,9 @@ class Table:
         if meta_table_attrs:
             for attr, value in meta_table_attrs.items():
                 setattr(self, attr, value)
+
+        # Finally do the real initialization
+        init_func(data, names, dtype, n_cols, copy)
 
         # Whatever happens above, the masked property should be set to a boolean
         if self.masked not in (None, True, False):
@@ -4386,10 +4388,16 @@ class QTable(Table):
         List or dict of units to apply to columns.
     descriptions : list, dict, optional
         List or dict of descriptions to apply to columns.
+    preserve_quantity_dtype : bool, optional
+        If `True`, always preserve the dtype of input data with units when converting to
+        `~astropy.units.Quantity`. By default, integer types are converted to float,
+        following the behavior of `~astropy.units.Quantity`.
     **kwargs : dict, optional
         Additional keyword args when converting table-like object.
 
     """
+
+    preserve_quantity_dtype = TableAttribute()
 
     def _is_mixin_for_table(self, col):
         """
@@ -4407,8 +4415,10 @@ class QTable(Table):
             # We need to turn the column into a quantity; use subok=True to allow
             # Quantity subclasses identified in the unit (such as u.mag()).
             q_cls = Masked(Quantity) if isinstance(col, MaskedColumn) else Quantity
+            # Quantity casts integer data to float unless dtype=None is supplied.
+            kwargs = {"dtype": None} if self.preserve_quantity_dtype else {}
             try:
-                qcol = q_cls(col.data, col.unit, copy=None, subok=True)
+                qcol = q_cls(col.data, col.unit, copy=None, subok=True, **kwargs)
             except Exception as exc:
                 warnings.warn(
                     f"column {col.info.name} has a unit but is kept as "

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -31,6 +31,7 @@ from astropy.tests.helper import assert_follows_unicode_guidelines
 from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.masked import Masked
 from astropy.utils.metadata.tests.test_metadata import MetaBaseTest
 
 from .conftest import MaskedTable
@@ -2149,6 +2150,71 @@ class TestQTableColumnConversionCornerCases:
         with pytest.warns(AstropyUserWarning, match="convert it to Quantity failed"):
             t["a"] = Column(["a"], unit=u.m)
         assert isinstance(t["a"], Column)
+
+
+class TestPreserveQuantityDtype:
+    """Test the QTable ``preserve_quantity_dtype`` attribute (#17963)."""
+
+    # Integers that are not exactly representable as float64.
+    VALS = [2741100559643251862, 2733456478647137226]
+
+    def get_table(self):
+        return Table(
+            [
+                Column(self.VALS, name="a", unit="m"),
+                MaskedColumn(self.VALS, name="b", unit="", mask=[False, True]),
+            ]
+        )
+
+    def test_default_is_not_set(self):
+        """By default integer columns with a unit are cast to float."""
+        t = QTable(self.get_table())
+        assert t.preserve_quantity_dtype is None
+        # The unset attribute does not clutter the table meta.
+        assert t.meta == {}
+        assert t["a"].dtype.kind == "f"
+        assert t["b"].dtype.kind == "f"
+
+    def test_init_kwarg(self):
+        t = QTable(self.get_table(), preserve_quantity_dtype=True)
+        assert t.preserve_quantity_dtype is True
+        assert t["a"].dtype == np.int64
+        assert t["b"].dtype == np.int64
+        assert np.all(t["a"].value == self.VALS)
+        assert isinstance(t["a"], u.Quantity)
+        assert isinstance(t["b"], Masked)
+        assert t["a"].unit == u.m
+        assert np.all(t["b"].mask == [False, True])
+
+    def test_set_attribute_then_add_column(self):
+        t = QTable()
+        t.preserve_quantity_dtype = True
+        t["a"] = Column(self.VALS, unit="m")
+        assert t["a"].dtype == np.int64
+        assert np.all(t["a"].value == self.VALS)
+
+    def test_attribute_persists(self):
+        """The attribute is stored in meta so it survives slicing and copying."""
+        t = QTable(self.get_table(), preserve_quantity_dtype=True)
+        assert t.meta["__attributes__"] == {"preserve_quantity_dtype": True}
+        for t2 in (t[:1], t.copy(), QTable(t), QTable(Table(t))):
+            assert t2.preserve_quantity_dtype is True
+            assert t2["a"].dtype == np.int64
+
+    def test_kwarg_takes_precedence_over_meta(self):
+        t = QTable(self.get_table(), preserve_quantity_dtype=True)
+        t2 = QTable(Table(t), preserve_quantity_dtype=False)
+        assert t2.preserve_quantity_dtype is False
+        assert t2["a"].dtype.kind == "f"
+
+    def test_float_column_unaffected(self):
+        vals = [1.5, 2.5]
+        t = QTable(
+            [Column(vals, name="a", unit="m", dtype=np.float32)],
+            preserve_quantity_dtype=True,
+        )
+        assert t["a"].dtype == np.float32
+        assert np.all(t["a"].value == vals)
 
 
 class Test__Astropy_Table__:

--- a/docs/changes/io.votable/20248.api.rst
+++ b/docs/changes/io.votable/20248.api.rst
@@ -1,0 +1,11 @@
+Reading a VOTable into a ``QTable`` now gives an integer column for a ``FIELD`` with an
+integer ``datatype`` and a unit, where previously such a column was converted to a float
+``Quantity``. Code that relied on getting a float column will now get an integer
+``Quantity``, for which true division and in-place assignment of float values behave as
+they do for any integer array. Reading into a plain ``Table`` is unchanged.
+
+In addition, the ``meta`` of a table returned by
+``astropy.io.votable.tree.TableElement.to_table()``, and therefore by
+``Table.read(..., format='votable')``, now always contains an ``__attributes__`` entry
+holding the ``QTable`` ``preserve_quantity_dtype`` attribute. This is written out by file
+formats that preserve table ``meta``, such as ECSV.

--- a/docs/changes/io.votable/20248.bugfix.rst
+++ b/docs/changes/io.votable/20248.bugfix.rst
@@ -1,0 +1,4 @@
+Reading a VOTable into a ``QTable`` now respects the ``FIELD`` ``datatype``. Previously
+an integer column that also had a unit, for instance an object identifier, was silently
+cast to float, which changes values that are too large to be represented exactly as a
+float64.

--- a/docs/changes/table/20247.feature.rst
+++ b/docs/changes/table/20247.feature.rst
@@ -1,5 +1,5 @@
 Added a new ``QTable`` keyword argument and attribute ``preserve_quantity_dtype``. When
-set to `True`, a integer column with a unit keeps its ``dtype`` when it is converted to
+set to `True`, an integer column with a unit keeps its ``dtype`` when it is converted to
 a ``Quantity`` instead of being cast to float. This avoids silently losing precision for
 integer columns such as source identifiers, which are commonly read from VOTable or FITS
 files with a unit defined.

--- a/docs/changes/table/20247.feature.rst
+++ b/docs/changes/table/20247.feature.rst
@@ -1,0 +1,5 @@
+Added a new ``QTable`` keyword argument and attribute ``preserve_quantity_dtype``. When
+set to `True`, a integer column with a unit keeps its ``dtype`` when it is converted to
+a ``Quantity`` instead of being cast to float. This avoids silently losing precision for
+integer columns such as source identifiers, which are commonly read from VOTable or FITS
+files with a unit defined.

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -192,8 +192,6 @@ Example::
    file written from a `~astropy.table.QTable`, is still converted to `float` when it is
    read back.
 
-.. EXAMPLE END
-
 .. _mixin_attributes:
 
 Mixin Attributes

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -141,15 +141,56 @@ You can conveniently convert |Table| to |QTable| and vice-versa::
    ordinary `~astropy.table.Table` then it gets converted to an ordinary
    `~astropy.table.Column` with the corresponding ``unit`` attribute.
 
-.. attention::
+.. EXAMPLE END
 
-   When a column of ``int`` ``dtype`` is converted to `~astropy.units.Quantity`,
-   its ``dtype`` is converted to ``float``.
+Quantity and Integer Columns
+============================
 
-   For example, for a quality flag column of ``int``, if it is
-   assigned with the :ref:`dimensionless unit <doc_dimensionless_unit>`, it will still
-   be converted to ``float``. Therefore such columns typically should not be
-   assigned with any unit.
+When a column of ``int`` ``dtype`` has a defined unit and is converted to
+`~astropy.units.Quantity`, its ``dtype`` is converted to `float` by default. This
+situation is common when reading VOtable or FITS data tables that have integer count
+data or source IDs with defined units.
+
+You can change this behavior and preserve the original ``dtype``  by providing
+``preserve_quantity_dtype=True`` when creating the `~astropy.table.QTable`. You can also
+change this behavior for an existing `~astropy.table.QTable` by setting the
+``preserve_quantity_dtype`` attribute to `True`. This attribute is stored in the table
+``meta`` so it is preserved through table operations such as copying, slicing, and
+pickling, as well as writing to ECSV.
+
+Example::
+
+    >>> from astropy.table import Column
+    >>> source = Column([2741100559643251862, 2733456478647137226], unit="")
+    >>> counts = Column([401, 15023], unit="count")
+    >>> QTable({"source": source, "counts": counts})
+    <QTable length=2>
+            source          counts
+                              ct
+          float64          float64
+    ---------------------- -------
+    2.7411005596432517e+18   401.0
+    2.7334564786471373e+18 15023.0
+    >>> qt_int = QTable({"source": source, "counts": counts}, preserve_quantity_dtype=True)
+    >>> qt_int
+    <QTable length=2>
+           source        counts
+                           ct
+          int64          int64
+    ------------------- ------
+    2741100559643251862    401
+    2733456478647137226  15023
+    >>> qt_int.preserve_quantity_dtype
+    True
+
+.. note::
+
+   When reading a file into a `~astropy.table.QTable`, the ``dtype`` is preserved only
+   if the file stores the data as a plain column with a unit *and* the
+   ``preserve_quantity_dtype`` attribute is in the table ``meta``. A column that was
+   written as a serialized `~astropy.units.Quantity` column, for instance in an ECSV
+   file written from a `~astropy.table.QTable`, is still converted to `float` when it is
+   read back.
 
 .. EXAMPLE END
 


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

A VOTable `FIELD` declares its `datatype` explicitly, but reading one into a `QTable` threw that away for any integer column that also carried a unit: the column was converted to `Quantity`, which casts to float64, silently changing every value above 2\*\*53. Object identifiers are routinely that large, so the reported Euclid `object_id` column came back with wrong values and no warning, while the same file read into a plain `Table` was exact.

```python
>>> QTable.read("euclid.vot")["object_id"][0]
<MaskedQuantity 2.74110056e+18 NA>       # main: not the value in the file

>>> QTable.read("euclid.vot")["object_id"][0]
<MaskedQuantity 2741100559643251862 NA>  # this branch: exact
```

`TableElement.to_table()` now sets the `QTable` `preserve_quantity_dtype` attribute added in #20247, so the declared `datatype` survives the conversion to `Quantity`. A `long` column with `unit="ct"` becomes an integer `Quantity` in counts rather than a float one, which is the behavior discussed in the issue.

Fixes #17963.

Based on #20247 — the first commit here is that PR, so this one should be merged after it. Only the second commit is new.

#### Backwards compatibility

Reading a VOTable into a `QTable` changes the dtype of integer columns that have a unit, from float64 to the declared integer type. That is the bug being fixed, and it is the only value-level change: everything else, including plain `Table` reads, is untouched. Code that assumed a float column there will now see an integer one — an integer `Quantity` supports the same operations, but true division and in-place float assignment behave as they do for any integer array.

The other visible change is the extra `__attributes__` entry in the meta of every table produced by `to_table()`, as described above.

### AI disclosure

This PR is AI-generated using Claude Opus 5. I have examined the code and fully understand the changes in `tree.py` and the tests.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Set the `preserve_quantity_dtype` table attribute when converting a VOTable to an astropy table**

### 1. Where the cast happens

`io.votable` itself was never lossy. `TableElement.to_table()` returns a `Table` whose columns hold the exact integer values from the file. The cast happens afterwards, in `QTable._convert_col_for_table()`, which turns any `Column` with a unit into a `Quantity` — and `Quantity.__new__` defaults to `dtype=np.inexact`. Since the reader is registered for `Table`, the unified I/O layer produces the `QTable` itself, with `out = cls(out, copy=False)` in `table/connect.py`, well after the reader has returned.

That is why the fix cannot be a change to the values or dtypes the reader produces — they are already right. What the reader has to do is tell the eventual `QTable` conversion to leave the dtype alone, and the only channel that survives from the reader to that conversion is the table `meta`.

### 2. Implementation

Four lines in `TableElement.to_table()`, in `astropy/io/votable/tree.py`:

```python
+# The FIELD ``datatype`` attribute is authoritative, so an integer column that
+# also has a unit must not be silently cast to float when this table is
+# converted to a `~astropy.table.QTable`. This sets the QTable
+# ``preserve_quantity_dtype`` table attribute, which is stored in the meta.
+meta["__attributes__"] = {"preserve_quantity_dtype": True}
+
 table = Table(self.array, names=names, meta=meta)
```

`preserve_quantity_dtype` is the `TableAttribute` added in #20247; like every `TableAttribute` its value lives in `meta['__attributes__']`, which is documented behavior of `TableAttribute` rather than an internal detail being poked at.

This goes in `to_table()` rather than in `connect.py::read_table_votable()` so that it also covers code that goes through the votable API directly:

```python
t = parse(fileobj).get_first_table().to_table()
QTable(t)["object_id"].dtype     # int64
```

That is the path `pyvo` and `astroquery` use — `DALResultsTable.to_qtable()` in the issue report — so fixing only the unified-I/O entry point would have left the reporter's actual call broken.

### 3. Testing

Two tests in `astropy/io/votable/tests/test_table.py`, built on a `VOTABLE_INT_WITH_UNIT` sample modeled on the file in the issue: `object_id` is `datatype="long" unit="NA"` with a `VALUES null`, `counts` is `datatype="long" unit="ct"`, `ra` is `datatype="double" unit="deg"`.

- `test_qtable_preserves_int_datatype` — `object_id` and `counts` are int64 and `ra` is float64; the `object_id` values compare equal to the exact Python ints; `counts` keeps `u.count`; the attribute reads back as `True`; and a plain `Table` read of the same bytes is unchanged, since it was never affected.
- `test_qtable_preserves_int_datatype_round_trip` — writing the `QTable` back to VOTable and re-reading keeps int64 and the exact values.

Two things worth knowing if you touch these tests: reading `unit="NA"` emits nothing, but *writing* it back does emit `W50: Invalid unit string 'NA'`, so only the write is wrapped in `pytest.warns`. And `unit="count"` is not valid VOUnit — it parses to `UnrecognizedUnit`, so the sample uses `ct`.

Also checked by hand against the file from the issue:

| case | result |
|---|---|
| `long` + `unit="NA"` | int64 `MaskedQuantity`, exact, unit `NA` |
| `long` + `unit="ct"` | int64 `MaskedQuantity` in counts |
| `double` + `unit="deg"` | float64, unchanged |
| `parse().get_first_table().to_table()` then `QTable(...)` | int64 |
| VOTable write then read | int64, values exact |
| plain `Table.read` | unchanged in every case |

`astropy/io/votable`, `table`, `io/ascii`, `io/misc`, `units`, `utils`, plus `docs/table` and `docs/io` doctests: 10522 passed, 206 skipped, 29 xfailed.

### 4. Trade-offs and what is not addressed

**Every** table from `to_table()` now carries `meta['__attributes__'] = {'preserve_quantity_dtype': True}`, whether or not it has an integer column with a unit. This is visible in `t.meta` and propagates to formats that preserve meta — an ECSV written from a VOTable-read table gains a `__attributes__: {preserve_quantity_dtype: true}` line. Writing back to VOTable drops it, since `TableElement.from_table()` reads only the `ID`/`name`/`ref`/`ucd`/`utype`/`description` keys.

The alternative is to set it only when a column actually is an integer with a unit, which keeps `meta` clean in the common case. I went with the unconditional form because the guarantee comes from the format — VOTable always declares `datatype` — rather than from the contents of a particular file. Easy to change if reviewers prefer the narrower version.

Not addressed here, from the issue discussion:

- `unit="NA"` still parses to an `UnrecognizedUnit` and the column still becomes a `Quantity`. The suggestion of skipping the `Quantity` conversion entirely for `UnrecognizedUnit` columns is a `table` change with wider consequences, and is independent of the dtype question — with this PR the values are correct either way.
- No warning is emitted when a unit string fails to parse on read. That behavior is unchanged.

</details>
