### PR TITLE
Add a context manager for imposing the value of a coordinate frame attribute

### DIFF
--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -23,6 +23,7 @@ __all__ = [
     "EarthLocationAttribute",
     "QuantityAttribute",
     "TimeAttribute",
+    "impose_frame_attributes",
 ]
 
 _imposed_attributes: ContextVar[defaultdict | None] = ContextVar(

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -25,18 +25,18 @@ __all__ = [
     "TimeAttribute",
 ]
 
-_assumed_attributes: ContextVar[defaultdict | None] = ContextVar(
-    "_assumed_attributes", default=None
+_imposed_attributes: ContextVar[defaultdict | None] = ContextVar(
+    "_imposed_attributes", default=None
 )
 
 
-def _get_assumed_attributes():
+def _get_imposed_attributes():
     """A helper function so that we don't have a mutable default in ContextVar."""
-    return _assumed_attributes.get() or {}
+    return _imposed_attributes.get() or {}
 
 
 @contextmanager
-def assume_frame_attributes(**kwargs):
+def impose_frame_attributes(**kwargs):
     """
     Assume a value of one or more frame attributes.
 
@@ -51,7 +51,7 @@ def assume_frame_attributes(**kwargs):
     --------
     >>> import astropy.units as u
     >>> from astropy.coordinates import EarthLocation, SkyCoord
-    >>> from astropy.coordinates.attributes import assume_frame_attributes
+    >>> from astropy.coordinates.attributes import impose_frame_attributes
 
     >>> location = EarthLocation(-5466045*u.m, -2404388*u.m, 2242133*u.m)
 
@@ -73,22 +73,22 @@ def assume_frame_attributes(**kwargs):
     location, and you want to avoid more complex transformations or
     other effects through the transform graph, you can do this:
 
-    >>> with assume_frame_attributes(obstime="2026-01-01T00:00:00"):
+    >>> with impose_frame_attributes(obstime="2026-01-01T00:00:00"):
     ...     coord2.transform_to("icrs")
     <SkyCoord (ICRS): (ra, dec) in deg
         (36.10412254, 80.47633131)>
     """
-    # Get the current assumed attributes
-    current_attrs = _get_assumed_attributes()
+    # Get the current imposed attributes
+    current_attrs = _get_imposed_attributes()
     # Build the new set, overriding current with kwargs
     new_attrs = {**current_attrs, **kwargs}
-    # Set the new assumed attrs, but make sure it's still a defaultdict
-    token = _assumed_attributes.set(defaultdict(lambda: None, new_attrs))
+    # Set the new imposed attrs, but make sure it's still a defaultdict
+    token = _imposed_attributes.set(defaultdict(lambda: None, new_attrs))
     try:
         yield
     finally:
         # Reset to previous value using token
-        _assumed_attributes.reset(token)
+        _imposed_attributes.reset(token)
 
 
 class Attribute:
@@ -193,8 +193,8 @@ class Attribute:
             # Return the descriptor instance to enable the retrieval of the docstring
             return self
 
-        if (assumed_value := _get_assumed_attributes().get(self.name)) is not None:
-            out = assumed_value
+        if (imposed_value := _get_imposed_attributes().get(self.name)) is not None:
+            out = imposed_value
         else:
             out = getattr(instance, "_" + self.name, self.default)
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -77,6 +77,31 @@ def impose_frame_attributes(**kwargs):
     ...     coord2.transform_to("icrs")
     <SkyCoord (ICRS): (ra, dec) in deg
         (36.10412254, 80.47633131)>
+
+    Another example is computing the separation between two `~.HCRS` frames with slightly different obstimes.
+
+    >>> import astropy.units as u
+    >>> from astropy.coordinates import SkyCoord
+
+    >>> coord1 = SkyCoord(10*u.deg, 20*u.deg, frame='hcrs', obstime='2026-01-01 00:00:00')
+    >>> coord2 = SkyCoord(20*u.deg, 30*u.deg, frame='hcrs', obstime='2026-01-01 00:00:00.001')
+
+    When you try and compute the separation an error is raised because of the origin shift.
+
+    >>> print(coord1.separation(coord2))  # doctest: +SKIP
+    ...
+    astropy.units.errors.UnitsError: The input HCRS coordinates do not have length units. This probably means you created coordinates with lat/lon but no distance.  Heliocentric<->ICRS transforms cannot function in this case because there is an origin shift.
+
+    However, using this context manager:
+
+    >>> with impose_frame_attributes(obstime=coord1.obstime):
+    ...     print(coord1.separation(coord2))
+    13d28m54.20360928s
+
+    Both of these examples are trivial when constructing coordinates
+    like this, but when operating on a large number of coordinates
+    read from a file or with coordinate transforms in packages such as
+    ``reproject``, it becomes harder to make these changes manually.
     """
     # Get the current imposed attributes
     current_attrs = _get_imposed_attributes()

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -1,6 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # Dependencies
+from collections import defaultdict
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 import numpy as np
 
 # Project
@@ -20,6 +24,71 @@ __all__ = [
     "QuantityAttribute",
     "TimeAttribute",
 ]
+
+_assumed_attributes: ContextVar[defaultdict | None] = ContextVar(
+    "_assumed_attributes", default=None
+)
+
+
+def _get_assumed_attributes():
+    """A helper function so that we don't have a mutable default in ContextVar."""
+    return _assumed_attributes.get() or {}
+
+
+@contextmanager
+def assume_frame_attributes(**kwargs):
+    """
+    Assume a value of one or more frame attributes.
+
+    Parameters
+    ----------
+    kwargs
+        This function accepts any keyword arguments and will override
+        any frame attribute with a name matching that of the keyword
+        name.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from astropy.coordinates import EarthLocation, SkyCoord
+    >>> from astropy.coordinates.attributes import assume_frame_attributes
+
+    >>> location = EarthLocation(-5466045*u.m, -2404388*u.m, 2242133*u.m)
+
+    Say you have two coordinates that represent points in images which are very close in time but not exactly the same:
+
+    >>> coord1 = SkyCoord(10, 20, unit=u.deg, obstime="2026-01-01T00:00:00", location=location, frame="altaz")
+    >>> coord2 = SkyCoord(10, 20, unit=u.deg, obstime="2026-01-01T00:01:00", location=location, frame="altaz")
+
+    If you transform these to other frames, they will give slightly different results:
+
+    >>> coord1.transform_to("icrs")
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (36.10412254, 80.47633131)>
+    >>> coord2.transform_to("icrs")
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (36.35158456, 80.47671193)>
+
+    If however, you are happy to ignore this small change in observer
+    location, and you want to avoid more complex transformations or
+    other effects through the transform graph, you can do this:
+
+    >>> with assume_frame_attributes(obstime="2026-01-01T00:00:00"):
+    ...     coord2.transform_to("icrs")
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (36.10412254, 80.47633131)>
+    """
+    # Get the current assumed attributes
+    current_attrs = _get_assumed_attributes()
+    # Build the new set, overriding current with kwargs
+    new_attrs = {**current_attrs, **kwargs}
+    # Set the new assumed attrs, but make sure it's still a defaultdict
+    token = _assumed_attributes.set(defaultdict(lambda: None, new_attrs))
+    try:
+        yield
+    finally:
+        # Reset to previous value using token
+        _assumed_attributes.reset(token)
 
 
 class Attribute:
@@ -124,7 +193,11 @@ class Attribute:
             # Return the descriptor instance to enable the retrieval of the docstring
             return self
 
-        out = getattr(instance, "_" + self.name, self.default)
+        if (assumed_value := _get_assumed_attributes().get(self.name)) is not None:
+            out = assumed_value
+        else:
+            out = getattr(instance, "_" + self.name, self.default)
+
         if out is None:
             out = getattr(instance, self.secondary_attribute, self.default)
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -252,7 +252,7 @@ class Attribute:
 
                 converted = True
 
-            if converted:
+            if converted and not imposed_value:
                 setattr(instance, "_" + self.name, out)
 
         return out

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -21,7 +21,7 @@ from astropy.coordinates.attributes import (
     EarthLocationAttribute,
     QuantityAttribute,
     TimeAttribute,
-    assume_frame_attributes,
+    impose_frame_attributes,
 )
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping
 from astropy.coordinates.builtin_frames import (
@@ -106,7 +106,7 @@ def test_assume_obstime():
 
     assert coo1 != assumed_obstime
 
-    with assume_frame_attributes(obstime=assumed_obstime):
+    with impose_frame_attributes(obstime=assumed_obstime):
         assert coo1.obstime == assumed_obstime
 
 
@@ -135,7 +135,7 @@ def test_altaz_transform_with_assume_obstime():
     assert not u.allclose(out1.ra, out2.dec)
     assert not u.allclose(out1.ra, out2.dec)
 
-    with assume_frame_attributes(obstime="2026-01-01T00:00:00"):
+    with impose_frame_attributes(obstime="2026-01-01T00:00:00"):
         out_assumed = coord2.transform_to("icrs")
 
     assert not u.allclose(out2.ra, out_assumed.dec)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -21,6 +21,7 @@ from astropy.coordinates.attributes import (
     EarthLocationAttribute,
     QuantityAttribute,
     TimeAttribute,
+    assume_frame_attributes,
 )
 from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping
 from astropy.coordinates.builtin_frames import (
@@ -96,6 +97,49 @@ def test_frame_attribute_descriptor():
     with pytest.raises(AttributeError) as err:
         t.attr_none = 5
     assert "Cannot set frame attribute" in str(err.value)
+
+
+def test_assume_obstime():
+    assumed_obstime = Time("2012-01-01T00:00:00")
+
+    coo1 = GCRS(obstime="2026-01-01T00:00:00")
+
+    assert coo1 != assumed_obstime
+
+    with assume_frame_attributes(obstime=assumed_obstime):
+        assert coo1.obstime == assumed_obstime
+
+
+def test_altaz_transform_with_assume_obstime():
+    location = EarthLocation(-5466045 * u.m, -2404388 * u.m, 2242133 * u.m)
+    coord1 = SkyCoord(
+        10,
+        20,
+        unit=u.deg,
+        obstime="2026-01-01T00:00:00",
+        location=location,
+        frame="altaz",
+    )
+    coord2 = SkyCoord(
+        10,
+        20,
+        unit=u.deg,
+        obstime="2026-01-01T00:01:00",
+        location=location,
+        frame="altaz",
+    )
+
+    out1 = coord1.transform_to("icrs")
+    out2 = coord2.transform_to("icrs")
+
+    assert not u.allclose(out1.ra, out2.dec)
+    assert not u.allclose(out1.ra, out2.dec)
+
+    with assume_frame_attributes(obstime="2026-01-01T00:00:00"):
+        out_assumed = coord2.transform_to("icrs")
+
+    assert not u.allclose(out2.ra, out_assumed.dec)
+    assert not u.allclose(out2.ra, out_assumed.dec)
 
 
 def test_frame_subclass_attribute_descriptor():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -99,15 +99,16 @@ def test_frame_attribute_descriptor():
     assert "Cannot set frame attribute" in str(err.value)
 
 
-def test_impose_obstime():
+def test_impose_nested_obstime():
     imposed_obstime = Time("2012-01-01T00:00:00")
 
     coo1 = GCRS(obstime="2026-01-01T00:00:00")
 
     assert coo1 != imposed_obstime
 
-    with impose_frame_attributes(obstime=imposed_obstime):
-        assert coo1.obstime == imposed_obstime
+    with impose_frame_attributes(obstime="2020-01-01T00:00:00"):
+        with impose_frame_attributes(obstime=imposed_obstime):
+            assert coo1.obstime == imposed_obstime
 
 
 def test_altaz_transform_with_imposed_obstime():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -99,18 +99,18 @@ def test_frame_attribute_descriptor():
     assert "Cannot set frame attribute" in str(err.value)
 
 
-def test_assume_obstime():
-    assumed_obstime = Time("2012-01-01T00:00:00")
+def test_impose_obstime():
+    imposed_obstime = Time("2012-01-01T00:00:00")
 
     coo1 = GCRS(obstime="2026-01-01T00:00:00")
 
-    assert coo1 != assumed_obstime
+    assert coo1 != imposed_obstime
 
-    with impose_frame_attributes(obstime=assumed_obstime):
-        assert coo1.obstime == assumed_obstime
+    with impose_frame_attributes(obstime=imposed_obstime):
+        assert coo1.obstime == imposed_obstime
 
 
-def test_altaz_transform_with_assume_obstime():
+def test_altaz_transform_with_imposed_obstime():
     location = EarthLocation(-5466045 * u.m, -2404388 * u.m, 2242133 * u.m)
     coord1 = SkyCoord(
         10,
@@ -136,10 +136,10 @@ def test_altaz_transform_with_assume_obstime():
     assert not u.allclose(out1.ra, out2.dec)
 
     with impose_frame_attributes(obstime="2026-01-01T00:00:00"):
-        out_assumed = coord2.transform_to("icrs")
+        out_imposed = coord2.transform_to("icrs")
 
-    assert not u.allclose(out2.ra, out_assumed.dec)
-    assert not u.allclose(out2.ra, out_assumed.dec)
+    assert not u.allclose(out2.ra, out_imposed.dec)
+    assert not u.allclose(out2.ra, out_imposed.dec)
 
 
 def test_frame_subclass_attribute_descriptor():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -102,13 +102,16 @@ def test_frame_attribute_descriptor():
 def test_impose_nested_obstime():
     imposed_obstime = Time("2012-01-01T00:00:00")
 
-    coo1 = GCRS(obstime="2026-01-01T00:00:00")
+    ori_obstime = "2026-01-01T00:00:00"
+    coo1 = GCRS(obstime=ori_obstime)
 
     assert coo1 != imposed_obstime
 
     with impose_frame_attributes(obstime="2020-01-01T00:00:00"):
         with impose_frame_attributes(obstime=imposed_obstime):
             assert coo1.obstime == imposed_obstime
+
+    assert coo1.obstime == ori_obstime
 
 
 def test_altaz_transform_with_imposed_obstime():
@@ -162,6 +165,16 @@ def test_frame_subclass_attribute_descriptor():
     assert mfk4.equinox.value == "J1980.000"
     assert mfk4.obstime.value == "J1990.000"
     assert mfk4.newattr == "world"
+
+
+def test_impose_restores_frame_attribute():
+    coo = GCRS(obstime="2026-01-01T00:00:00")
+    original_obstime = coo.obstime
+
+    with impose_frame_attributes(obstime="2020-01-01T00:00:00"):
+        assert coo.obstime == Time("2020-01-01T00:00:00")
+
+    assert coo.obstime == original_obstime
 
 
 def test_frame_multiple_inheritance_attribute_descriptor():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -177,6 +177,15 @@ def test_impose_restores_frame_attribute():
     assert coo.obstime == original_obstime
 
 
+def test_invalid_attribute_value():
+    with impose_frame_attributes(obstime="2020-01-01"):
+        # no error here, as attribute validation is done on get
+        frame = GCRS(obstime="hello")
+
+    with pytest.raises(ValueError):
+        frame.obstime  # Validation happens here
+
+
 def test_frame_multiple_inheritance_attribute_descriptor():
     """
     Ensure that all attributes are accumulated in case of inheritance from

--- a/docs/changes/coordinates/20254.feature.rst
+++ b/docs/changes/coordinates/20254.feature.rst
@@ -1,0 +1,1 @@
+Add a new ``impose_frame_attributes`` context manager which overrides the value of any coordinate frame attribute.

--- a/docs/coordinates/imposing_attributes.rst
+++ b/docs/coordinates/imposing_attributes.rst
@@ -1,0 +1,31 @@
+.. _astropy-coordinates-imposing-attributes:
+
+Imposing the value of Frame Attributes
+**************************************
+
+In certain circumstances you may want to override the value of one frame attribute with another.
+Examples of when this might be useful include when you are reading a series of frames from some source and need to change an attribute for a transform or calculation, or when you are using a package such as ``reproject`` where you don't control the construction of the coordinate objects.
+
+Take this example, where you have two coordinates where the obstime difference results in a very subtly different origin of the coordinate frame.
+For this example we are constructing these coordinates explicitly::
+
+    >>> import astropy.units as u
+    >>> from astropy.coordinates import SkyCoord, impose_frame_attributes
+
+    >>> coord1 = SkyCoord(10*u.deg, 20*u.deg, frame='hcrs', obstime='2026-01-01 00:00:00')
+    >>> coord2 = SkyCoord(20*u.deg, 30*u.deg, frame='hcrs', obstime='2026-01-01 00:00:00.001')
+
+When you try and compute the separation an error is raised because of the origin shift::
+
+    >>> print(coord1.separation(coord2))  # doctest: +SKIP
+    ...
+    astropy.units.errors.UnitsError: The input HCRS coordinates do not have length units. This probably means you created coordinates with lat/lon but no distance.  Heliocentric<->ICRS transforms cannot function in this case because there is an origin shift.
+
+Given the very small difference in observer location assuming that they are equal is likely valid to a high degree of precision::
+
+    >>> with impose_frame_attributes(obstime=coord1.obstime):
+    ...     print(coord1.separation(coord2))
+    13d28m54.20360928s
+
+The `~astropy.coordinates.impose_frame_attributes` decorator accepts keyword arguments which are any attribute on any frame class.
+So in our previous example of `~astropy.coordinates.HCRS` the ``obstime`` attribute.

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -547,6 +547,7 @@ listed below.
    common_errors
    definitions
    inplace
+   imposing_attributes
    example_gallery_index
 
 In addition, another resource for the capabilities of this package is the


### PR DESCRIPTION
### Description
This PR is primarily motivated by use in sunpy (I can't think of a good example with just astropy frames, but maybe someone knows one).

In the solar frames in sunpy if you have two images taken at close to but not exactly the same time, there's a very small observer shift between the two images. If you transform a coordinate from one image to another, the sunpy coordinate frame machinery has to do a full origin shift which is expensive and also valid for points on the sun, not off disk. This functionality would allow the user to opt-in to assuming one fixed observer location for both sides of the coordinate transformation (such as the average position, or one or the other).

I have opened a sunpy implementation of this here: https://github.com/sunpy/sunpy/pull/8753 but it required reimplementing `Attribute.__get__` from astropy, hence the upstreaming.

<!-- Optional opt-out -->

- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.