### PR TITLE
Preserve masks in Time.insert

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1186,6 +1186,19 @@ class TimeBase(MaskableShapedLikeNDArray):
         out._time.jd1[idx0 + n_values :] = self._time.jd1[idx0:]
         out._time.jd2[idx0 + n_values :] = self._time.jd2[idx0:]
 
+        # The assignments above copy only the data, so any mask on ``self`` or
+        # on ``values`` is dropped (gh-20230); carry the masks over explicitly.
+        values_mask = values.mask if isinstance(values, self.__class__) else False
+        if self.masked or np.any(values_mask):
+            if not out.masked:
+                out._time.jd1 = Masked(out._time.jd1, copy=False)
+                out._time.jd2 = Masked(
+                    out._time.jd2, mask=out._time.jd1.mask, copy=False
+                )
+            out._time.jd2.mask[:idx0] = self.mask[:idx0]
+            out._time.jd2.mask[idx0 : idx0 + n_values] = values_mask
+            out._time.jd2.mask[idx0 + n_values :] = self.mask[idx0:]
+
         return out
 
     def __setitem__(self, item, value):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2489,6 +2489,48 @@ def test_insert_time():
     assert np.all(tm2 == Time([10, 20, 1, 2], format="unix"))
 
 
+def test_insert_time_masked():
+    """Insert must preserve masks on self and on the inserted values (gh-20230)."""
+    tm = Time([1, 2, 3], format="unix")
+    tm[0] = np.ma.masked
+    tm[2] = np.ma.masked
+
+    # Mask on self survives an unmasked scalar insert.
+    tm2 = tm.insert(1, Time(60, format="unix"))
+    assert tm2.masked
+    assert np.all(tm2.mask == [True, False, False, True])
+    assert np.all(tm2.unmasked == Time([1, 60, 2, 3], format="unix").unmasked)
+
+    # Also at the end, where only the head copy runs.
+    tm2 = tm.insert(3, Time(60, format="unix"))
+    assert np.all(tm2.mask == [True, False, True, False])
+
+    # Masked values inserted into an unmasked Time promote the result.
+    tm_plain = Time([1, 2], format="unix")
+    masked_value = Time([60], format="unix")
+    masked_value[0] = np.ma.masked
+    tm2 = tm_plain.insert(1, masked_value)
+    assert tm2.masked
+    assert np.all(tm2.mask == [False, True, False])
+
+    # Both sides masked.
+    tm2 = tm.insert(1, masked_value)
+    assert np.all(tm2.mask == [True, True, False, True])
+
+    # Fully unmasked stays unmasked.
+    tm2 = tm_plain.insert(1, Time(60, format="unix"))
+    assert not tm2.masked
+
+
+def test_insert_timedelta_masked():
+    """TimeDelta shares Time.insert; masks must survive there too (gh-20230)."""
+    td = TimeDelta([1.0, 2.0, 3.0], format="jd")
+    td[1] = np.ma.masked
+    td2 = td.insert(0, TimeDelta(9.0, format="jd"))
+    assert td2.masked
+    assert np.all(td2.mask == [False, False, True, False])
+
+
 def test_insert_time_out_subfmt():
     # Check insert() with out_subfmt set
     T = Time(["1999-01-01", "1999-01-02"], out_subfmt="date")

--- a/docs/changes/time/20258.bugfix.rst
+++ b/docs/changes/time/20258.bugfix.rst
@@ -1,0 +1,3 @@
+``Time.insert`` now preserves masks: the mask on the time being inserted
+into is carried over to the result, and inserting masked values promotes
+the result to masked.


### PR DESCRIPTION
Fixes #20230.

`Time.insert` copies `jd1`/`jd2` data directly and uses setitem for the inserted values, so the mask on `self` was dropped (the issue's report), and a masked `Time` passed as `values` lost its mask the same way. The fix carries both masks over explicitly after the data copies, promoting the result to masked only when either side actually carries a mask, using the same shared-mask promotion `Time.__setitem__` uses.

Verified against the issue's reproduction plus five more cases (insert at the end so only the head copy runs, masked values into an unmasked `Time`, both sides masked, fully unmasked stays unmasked, and the `TimeDelta` path), all added as tests in `test_basic.py`.

One related observation kept out of scope here: `Time.__setitem__` with a masked `Time` **value** (e.g. `t[0] = masked_time[0]`) also drops the value's mask, since the promotion at the top of `__setitem__` only triggers on the `np.ma.masked` sentinel. Happy to file that separately.

A changelog fragment will follow named for this PR's number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)