### PR TITLE
Add N-dimensional Tensor-like string conversion to Quantity

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -303,15 +303,17 @@ def _parse_quantity_string(
     Raises if not possible.
     """
     v = re.match(NUMBER_PATTERN, string)
-    num_str = v.group()
 
-    if "," not in num_str:
-        num_str = re.sub(rf"{SEP_SPACE}", "],[", num_str)
-        num_str = re.sub(r"\s+", ",", num_str.strip())
+    match = v.group().strip()
+    if "[" in match and "," not in match:
+        match = re.sub(rf"{SEP_SPACE}", "],[", match)
+        match = re.sub(r"\s+", ",", match)
 
-    items = ast.literal_eval(num_str)
-
-    value = np.array(items, dtype=np.float64).tolist()
+    value = (
+        np.array(ast.literal_eval(match), dtype=np.float64).tolist()
+        if "[" in match
+        else float(match)
+    )
     unit = Unit(unit_str) if (unit_str := v.string[v.end() :].strip()) else None
 
     return value, unit

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -5,6 +5,7 @@ associated units. `Quantity` objects support operations like ordinary numbers,
 but will deal with unit conversions internally.
 """
 
+import ast
 import builtins
 import numbers
 import operator
@@ -257,34 +258,62 @@ NUM: Final = r"""
     ([eE][+-]?\d+)?
     [.+-]?
 """
+
+SEP_SPACE: Final = r"""\s*\]\s*\[\s*"""
+SEP_COMMA: Final = r"""\s*\]\s*,\s*\[\s*"""
+
 # List of numbers separated by "," or whitespace.
-VECTOR_COMMA: Final = rf"""
-    \[\s*
+NUMLST_COMMA: Final = rf"""
+    \s*
     {NUM}
-    (?: (\s*,\s*){NUM})*
+    (?:(\s*,\s*){NUM})*
     (\s*,\s*)?
-    \s*\]
 """
-VECTOR_WSPACE: Final = rf"""
-    \[\s*
+NUMLST_WSPACE: Final = rf"""
+    \s*
     {NUM}
-    (?: (\s+){NUM})*
-    \s*\]
+    (?:(\s*){NUM})*
 """
-VECTOR_1D: Final = rf"{VECTOR_COMMA} | {VECTOR_WSPACE}"
-NUMBER_PATTERN: Final = re.compile(rf"\s*(?:{NUM}|{VECTOR_1D})\s*", re.VERBOSE)
+TENSOR_COMMA: Final = rf"""
+    \[+
+    \s*
+    {NUMLST_COMMA}
+    (?: {SEP_COMMA}{NUMLST_COMMA})*
+    (\s*,\s*)?
+    \]+
+"""
+TENSOR_WSPACE: Final = rf"""
+    \[+
+    \s*
+    {NUMLST_WSPACE}
+    (?: {SEP_SPACE}{NUMLST_WSPACE})*
+    \]+
+"""
+
+TENSOR: Final = rf"{TENSOR_COMMA}|{TENSOR_WSPACE}"
+NUMBER_PATTERN: Final = re.compile(rf"\s*(?:{NUM}|{TENSOR})\s*", re.VERBOSE)
 
 
-def _parse_quantity_string(string: str) -> tuple[float | list[float], Unit]:
-    """Parse a string as a number or list of numbers.
+def _parse_quantity_string(
+    string: str,
+) -> tuple[float | list[float] | list[list[float]], Unit]:
+    """Parse a string as a number or list of numbers or a list of list of numbers.
 
     Returns a tuple of value (float or array) and unit.
     Raises if not possible.
     """
     v = re.match(NUMBER_PATTERN, string)
-    items = v.group().replace(",", " ").strip().strip("[]").split()
-    value = [float(a) for a in items] if "[" in string else float(items[0])
+    num_str = v.group()
+
+    if "," not in num_str:
+        num_str = re.sub(rf"{SEP_SPACE}", "],[", num_str)
+        num_str = re.sub(r"\s+", ",", num_str.strip())
+
+    items = ast.literal_eval(num_str)
+
+    value = np.array(items, dtype=np.float64).tolist()
     unit = Unit(unit_str) if (unit_str := v.string[v.end() :].strip()) else None
+
     return value, unit
 
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -259,62 +259,48 @@ NUM: Final = r"""
     [.+-]?
 """
 
-SEP_SPACE: Final = r"""\s*\]\s*\[\s*"""
-SEP_COMMA: Final = r"""\s*\]\s*,\s*\[\s*"""
+SEP_SPACE: Final = r"""\s*\]+\s*\[+\s*"""
+SEP_COMMA: Final = r"""\s*\]+\s*,\s*\[+\s*"""
 
-# List of numbers separated by "," or whitespace.
-NUMLST_COMMA: Final = rf"""
-    \s*
-    {NUM}
-    (?:(\s*,\s*){NUM})*
-    (\s*,\s*)?
-"""
-NUMLST_WSPACE: Final = rf"""
-    \s*
-    {NUM}
-    (?:(\s*){NUM})*
-"""
-TENSOR_COMMA: Final = rf"""
-    \[+
-    \s*
-    {NUMLST_COMMA}
-    (?: {SEP_COMMA}{NUMLST_COMMA})*
-    (\s*,\s*)?
-    \]+
-"""
-TENSOR_WSPACE: Final = rf"""
-    \[+
-    \s*
-    {NUMLST_WSPACE}
-    (?: {SEP_SPACE}{NUMLST_WSPACE})*
-    \]+
-"""
-
-TENSOR: Final = rf"{TENSOR_COMMA}|{TENSOR_WSPACE}"
-NUMBER_PATTERN: Final = re.compile(rf"\s*(?:{NUM}|{TENSOR})\s*", re.VERBOSE)
+NUMBER_PATTERN: Final = re.compile(rf"\s*(?:{NUM})\s*", re.VERBOSE)
 
 
 def _parse_quantity_string(
     string: str,
-) -> tuple[float | list[float] | list[list[float]], Unit]:
+):
     """Parse a string as a number or list of numbers or a list of list of numbers.
 
     Returns a tuple of value (float or array) and unit.
     Raises if not possible.
     """
-    v = re.match(NUMBER_PATTERN, string)
+    try:
+        last_rbracket = string.rindex("]") + 1
+    except ValueError:
+        v = re.match(NUMBER_PATTERN, string)
+        value_str = string[: v.end()]
+        unit_str = string[v.end() :]
+    else:
+        value_str = string[:last_rbracket]
+        unit_str = string[last_rbracket:].strip()
 
-    match = v.group().strip()
-    if "[" in match and "," not in match:
-        match = re.sub(rf"{SEP_SPACE}", "],[", match)
-        match = re.sub(r"\s+", ",", match)
+    unit = Unit(unit_str) if unit_str else None
 
-    value = (
-        np.array(ast.literal_eval(match), dtype=np.float64).tolist()
-        if "[" in match
-        else float(match)
-    )
-    unit = Unit(unit_str) if (unit_str := v.string[v.end() :].strip()) else None
+    try:
+        if "[" in value_str:
+            value = ast.literal_eval(value_str)
+            if not isinstance(
+                value[0], str
+            ):  # prevents likes of ['158'] from getting through
+                value = np.array(value, dtype=np.float64).tolist()
+        else:
+            value = float(value_str)
+    except SyntaxError as exc:
+        if "[" in value_str and "," not in value_str:
+            repaired = re.sub(rf"{SEP_SPACE}", "],[", value_str)
+            repaired = re.sub(r"\s+", ",", repaired)
+            value = np.array(ast.literal_eval(repaired), dtype=np.float64).tolist()
+        else:
+            raise exc
 
     return value, unit
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1799,23 +1799,32 @@ def test_quantity_initialisation_from_string():
 
 @pytest.mark.parametrize("unit_str", ["", "eV", "  cm"])
 @pytest.mark.parametrize(
-    "array_str",
+    "array_str, expected",
     (
-        "[7,  8,  9]",
-        "[7,8,9]",
-        "[7,8,9,]",
-        "[7,  8,  9,]",
-        "[7. 8. 9.]",
-        "[7.  8.   9.]",
-        "[7 8 9]",
-        "[7  8  9]",
-        "[7   8     9]",
+        ("[7,  8,  9]", [7, 8, 9]),
+        ("[7,8,9]", [7, 8, 9]),
+        ("[7,8,9,]", [7, 8, 9]),
+        ("[7,  8,  9,]", [7, 8, 9]),
+        ("[7. 8. 9.]", [7, 8, 9]),
+        ("[7.  8.   9.]", [7, 8, 9]),
+        ("[7 8 9]", [7, 8, 9]),
+        ("[7  8  9]", [7, 8, 9]),
+        ("[7   8     9]", [7, 8, 9]),
+        ("[[7,  8,  9], [7,  8,  9]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7,8,9]  , [7,8,9]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7,8,9] , [7,8,9]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7,  8,  9] ,  [7,  8,  9]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7. 8. 9.]  [7. 8. 9.]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7.  8.   9.]   [7.  8.   9.]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7 8 9]   [7 8 9]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7  8  9]   [7  8  9]]", [[7, 8, 9], [7, 8, 9]]),
+        ("[[7   8     9]   [7   8     9]]", [[7, 8, 9], [7, 8, 9]]),
     ),
 )
-def test_quantity_initialisation_string_array(array_str, unit_str):
+def test_quantity_initialisation_string_array(array_str, expected, unit_str):
     q = u.Quantity(array_str + unit_str)
     assert q.unit == unit_str
-    assert_array_equal(q.value, np.array([7.0, 8.0, 9.0]))
+    assert_array_equal(q.value, np.array(expected))
 
 
 def test_unsupported():

--- a/docs/changes/units/20260.feature.rst
+++ b/docs/changes/units/20260.feature.rst
@@ -1,0 +1,1 @@
+Allow ``N-dimensional`` Tensor-like strings, with or without units, to be converted into ``Quantity``.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This adds new functionality, which allows the conversion of strings that are `N-Dimensional Tensor-like`. (eg. `[[4,5,6],[7,8,9]....[4,5,2]]` , etc.) to a `Quantity` object, which was previously possible with things like `ndarrays`. 

It is essentially an upgrade over the previously added simple vector-like strings to Quantity conversion (#19214). 


