### PR TITLE
Improve SkyCoord equality operator

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -347,7 +347,12 @@ class SkyCoord(MaskableShapedLikeNDArray):
         if repr1.keys() != repr2.keys():
             # A different frame type, or an attribute that is set on one of the
             # two objects but not the other, so nothing can be equal.
-            return np.zeros(np.broadcast_shapes(self.shape, value.shape), bool)[()]
+            try:
+                shape = np.broadcast_shapes(self.shape, value.shape)
+            except ValueError as err:
+                raise ValueError(f"cannot compare: {err}") from err
+
+            return np.zeros(shape, bool)[()]
 
         extra_attrs = self._extra_frameattr_names | value._extra_frameattr_names
         out = True
@@ -357,7 +362,7 @@ class SkyCoord(MaskableShapedLikeNDArray):
             except ValueError as err:
                 kind = "extra frame attribute" if attr in extra_attrs else "attribute"
                 raise ValueError(
-                    f"cannot compare: {kind} {attr!r} has shape mismatch"
+                    f"cannot compare: {kind} {attr!r} has shape mismatch: {err}"
                 ) from err
 
         return out

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -39,6 +39,25 @@ from .sky_coordinate_parsers import (
 __all__ = ["SkyCoord", "SkyCoordInfo"]
 
 
+def _item_equal(val1, val2):
+    """Compare two items of a ``SkyCoord.info._represent_as_dict()`` dict."""
+    if isinstance(val1, BaseCoordinateFrame):
+        # A coordinate frame attribute, e.g. the ``origin`` of a
+        # ``SkyOffsetFrame``.  Comparing two frames raises instead of giving
+        # False when they are not equivalent, or when only one of them has data,
+        # but for an attribute that simply means the two are not equal.
+        try:
+            return val1 == val2
+        except (TypeError, ValueError) as err:
+            # Only the frame comparison itself declining to compare, not e.g. an
+            # unrelated TypeError from within it.
+            if not str(err).startswith("cannot compare"):
+                raise
+            return False
+
+    return val1 == val2
+
+
 class SkyCoordInfo(CoordinateFrameInfo):
     # Information for a SkyCoord is almost identical to that of a frame;
     # we only need to add the name of the frame used underneath.
@@ -334,7 +353,7 @@ class SkyCoord(MaskableShapedLikeNDArray):
         out = True
         for attr, val1 in repr1.items():
             try:
-                out = out & (val1 == repr2[attr])
+                out = out & _item_equal(val1, repr2[attr])
             except ValueError as err:
                 kind = "extra frame attribute" if attr in extra_attrs else "attribute"
                 raise ValueError(

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -296,9 +296,22 @@ class SkyCoord(MaskableShapedLikeNDArray):
     def __eq__(self, value):
         """Equality operator for SkyCoord.
 
-        This implements strict equality and requires that the frames are
-        equivalent, extra frame attributes are equivalent, and that the
-        representation data are exactly equal.
+        This implements strict equality, requiring that the right object be
+        strictly consistent with the left one:
+
+        - Identical frame type
+        - Identical ``representation_type``
+        - Identical representation differentials keys
+        - Identical frame attributes
+        - Identical "extra" frame attributes (e.g. ``obstime`` for an ICRS coord)
+
+        All of these, along with the coordinate data itself, are held by
+        ``self.info._represent_as_dict()``, which is what is required to
+        reconstruct the object.  The comparison is therefore just an item by item
+        comparison of two such dicts.  Items are compared element-wise and
+        broadcast against each other, so the result has the broadcast shape of
+        everything involved.  An item defined on only one of the two objects
+        makes the comparison `False` everywhere.
         """
         if isinstance(value, BaseCoordinateFrame):
             if value._data is None:
@@ -309,17 +322,26 @@ class SkyCoord(MaskableShapedLikeNDArray):
         if not isinstance(value, SkyCoord):
             return NotImplemented
 
-        # Make sure that any extra frame attribute names are equivalent.
-        for attr in self._extra_frameattr_names | value._extra_frameattr_names:
-            if not self.frame._frameattr_equiv(
-                getattr(self, attr), getattr(value, attr)
-            ):
-                raise ValueError(
-                    f"cannot compare: extra frame attribute '{attr}' is not equivalent"
-                    " (perhaps compare the frames directly to avoid this exception)"
-                )
+        repr1 = self.info._represent_as_dict()
+        repr2 = value.info._represent_as_dict()
 
-        return self._sky_coord_frame == value._sky_coord_frame
+        if repr1.keys() != repr2.keys():
+            # A different frame type, or an attribute that is set on one of the
+            # two objects but not the other, so nothing can be equal.
+            return np.zeros(np.broadcast_shapes(self.shape, value.shape), bool)[()]
+
+        extra_attrs = self._extra_frameattr_names | value._extra_frameattr_names
+        out = True
+        for attr, val1 in repr1.items():
+            try:
+                out = out & (val1 == repr2[attr])
+            except ValueError as err:
+                kind = "extra frame attribute" if attr in extra_attrs else "attribute"
+                raise ValueError(
+                    f"cannot compare: {kind} {attr!r} has shape mismatch"
+                ) from err
+
+        return out
 
     def __ne__(self, value):
         return np.logical_not(self == value)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -317,7 +317,7 @@ class SkyCoord(MaskableShapedLikeNDArray):
             if value._data is None:
                 raise ValueError("Can only compare SkyCoord to Frame with data")
 
-            return self.frame == value
+            return self == SkyCoord(value, copy=False)
 
         if not isinstance(value, SkyCoord):
             return NotImplemented

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1689,14 +1689,15 @@ def test_frame_coord_comparison():
     assert frame == coord
     assert frame != other
     assert not (frame == other)
-    error_msg = "objects must have equivalent frames"
-    with pytest.raises(TypeError, match=error_msg):
-        frame == SkyCoord(AltAz("0d", "1d"))  # noqa: B015
+
+    # A comparison involving a SkyCoord is done by SkyCoord, which gives False
+    # rather than raising when the two are not consistent.
+    assert (frame == SkyCoord(AltAz("0d", "1d"))) is np.False_
 
     coord = SkyCoord(ra=12 * u.hourangle, dec=5 * u.deg, frame=FK5(equinox="J1950"))
     frame = FK5(ra=12 * u.hourangle, dec=5 * u.deg, equinox="J2000")
-    with pytest.raises(TypeError, match=error_msg):
-        coord == frame  # noqa: B015
+    assert (coord == frame) is np.False_
+    assert (frame == coord) is np.False_
 
     frame = ICRS()
     coord = SkyCoord(0 * u.deg, 0 * u.deg, frame=frame)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -430,6 +430,77 @@ def test_equal():
     assert not v
 
 
+def test_equal_radial_velocity_broadcasting():
+    """Test equality comparison with broadcasting of radial_velocity."""
+    sc_scalar = SkyCoord(1 * u.deg, 3 * u.deg, radial_velocity=1 * u.km / u.s)
+    sc_array = SkyCoord(
+        [1, 1] * u.deg,
+        [3, 3] * u.deg,
+        radial_velocity=[1, 20] * u.km / u.s,
+    )
+
+    eq = sc_scalar == sc_array
+    ne = sc_scalar != sc_array
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+
+    eq = sc_array == sc_scalar
+    ne = sc_array != sc_scalar
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+
+
+def test_equal_fk4_frame_attribute_mismatch():
+    """A differing primary frame attribute gives False instead of raising."""
+    sc1 = SkyCoord(1 * u.deg, 3 * u.deg, frame="fk4", equinox="B1950")
+    sc2 = SkyCoord(1 * u.deg, 3 * u.deg, frame="fk4", equinox="B1951")
+
+    assert (sc1 == sc2) is np.False_
+    assert (sc1 != sc2) is np.True_
+
+    sc3 = SkyCoord(1 * u.deg, 3 * u.deg, frame="fk5")
+    assert (sc3 == sc1) is np.False_
+
+
+def test_equal_fk4_frame_attribute_arrays_default():
+    """FK4 equality works with shape-mismatched primary frame attributes."""
+    sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, frame="fk4", equinox="B1950")
+    sc2 = SkyCoord(
+        [1, 20] * u.deg, [3, 4] * u.deg, frame="fk4", equinox=["B1950", "B1950"]
+    )
+    assert sc1.equinox.shape == ()
+    assert sc2.equinox.shape == (2,)
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+
+
+def test_equal_fk4_frame_attribute_arrays():
+    """FK4 equality works with array-valued primary frame attributes."""
+    equinox = Time(["B1950", "B1951"])
+    obstime = Time(["B1960", "B1961"])
+    sc1 = SkyCoord(
+        [1, 2] * u.deg,
+        [3, 4] * u.deg,
+        frame="fk4",
+        equinox=equinox,
+        obstime=obstime,
+    )
+    sc2 = SkyCoord(
+        [1, 20] * u.deg,
+        [3, 4] * u.deg,
+        frame="fk4",
+        equinox=equinox,
+        obstime=obstime,
+    )
+
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+
+
 def test_equal_different_type():
     sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, obstime="B1955")
     # Test equals and not equals operators against different types
@@ -437,19 +508,88 @@ def test_equal_different_type():
     assert not (sc1 == "a string")
 
 
-def test_equal_exceptions():
-    sc1 = SkyCoord(1 * u.deg, 2 * u.deg, obstime="B1955")
-    sc2 = SkyCoord(1 * u.deg, 2 * u.deg)
+def test_equal_extra_frame_attributes():
+    """Extra frame attributes contribute element-wise to equality results."""
+    obstime = Time(["B1955", "B1956"])
+    sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, obstime=obstime)
+    sc2 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, obstime="B1955")
+
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+
+    sc3 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+    eq = sc1 == sc3
+    ne = sc1 != sc3
+    assert np.all(eq == [False, False])
+    assert np.all(ne == [True, True])
+
+
+def test_equal_extra_frame_attribute_broadcasting_mismatch():
+    """Broadcast extra frame attributes to SkyCoord shape before comparison."""
+    sc1 = SkyCoord(
+        [[1, 2], [1, 2]] * u.deg,
+        [[3, 4], [3, 4]] * u.deg,
+        obstime=Time([["B1955"], ["B1956"]]),
+    )
+    sc2 = SkyCoord(
+        [[1, 2], [1, 2]] * u.deg,
+        [[3, 4], [3, 4]] * u.deg,
+        obstime="B1955",
+    )
+
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [[True, True], [False, False]])
+    assert np.all(ne == [[False, False], [True, True]])
+
+
+def test_equal_extra_frame_attribute_larger_than_coord_shape():
+    """Extra frame attributes are not broadcast against the data when they are set.
+
+    So unlike a frame attribute, an extra frame attribute can have a shape that
+    does not fit within the SkyCoord shape, and the comparison broadcasts against
+    it, giving a result larger than either input.
+    """
+    sc1 = SkyCoord(
+        [1, 2] * u.deg,
+        [3, 4] * u.deg,
+        obstime=Time([["B1955"], ["B1956"]]),
+    )
+    sc2 = SkyCoord(
+        [1, 2] * u.deg,
+        [3, 4] * u.deg,
+        obstime="B1955",
+    )
+    assert sc1.shape == (2,)
+    assert sc1.obstime.shape == (2, 1)
+
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [[True, True], [False, False]])
+    assert np.all(ne == [[False, False], [True, True]])
+
+    # A scalar SkyCoord carrying an array-valued extra frame attribute can be
+    # compared, giving the shape of the attribute.
+    sc3 = SkyCoord(1 * u.deg, 3 * u.deg, obstime=Time(["B1955", "B1956"]))
+    sc4 = SkyCoord(1 * u.deg, 3 * u.deg, obstime=Time(["B1955", "B1957"]))
+    assert sc3.shape == ()
+    assert np.all((sc3 == sc4) == [True, False])
+
+
+def test_equal_extra_frame_attribute_shape_mismatch():
+    """Raise when an extra frame attribute cannot broadcast to comparison shape."""
+    sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, obstime=Time(["B1955", "B1956"]))
+    sc2 = SkyCoord(
+        [1, 2] * u.deg, [3, 4] * u.deg, obstime=Time(["B1955", "B1956", "B1957"])
+    )
+
     with pytest.raises(
         ValueError,
-        match=(
-            "cannot compare: extra frame attribute 'obstime' is not equivalent"
-            r" \(perhaps compare the frames directly to avoid this exception\)"
-        ),
+        match="cannot compare: extra frame attribute 'obstime' has shape mismatch",
     ):
         sc1 == sc2  # noqa: B015
-    # Note that this exception is the only one raised directly in SkyCoord.
-    # All others come from lower-level classes and are tested in test_frames.py.
 
 
 def test_attr_inheritance():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -27,9 +27,11 @@ from astropy.coordinates import (
     Distance,
     EarthLocation,
     Galactic,
+    Galactocentric,
     Latitude,
     RepresentationMapping,
     SkyCoord,
+    SkyOffsetFrame,
     SphericalRepresentation,
     UnitSphericalRepresentation,
     frame_transform_graph,
@@ -38,6 +40,7 @@ from astropy.coordinates.representation import (
     DUPLICATE_REPRESENTATIONS,
     REPRESENTATION_CLASSES,
 )
+from astropy.coordinates.sky_coordinate import _item_equal
 from astropy.coordinates.tests.helper import skycoord_equal
 from astropy.coordinates.transformations import FunctionTransform
 from astropy.io import fits
@@ -622,6 +625,48 @@ def test_equal_frame():
         ValueError, match="Can only compare SkyCoord to Frame with data"
     ):
         sc == ICRS()  # noqa: B015
+
+
+def test_equal_coordinate_frame_attribute():
+    """A frame-valued attribute that cannot be compared is simply not equal.
+
+    Comparing two frames that are not equivalent, or one that has data with one
+    that does not, raises rather than giving `False`, so equality of a coordinate
+    frame attribute such as ``SkyOffsetFrame.origin`` has to allow for that.
+    """
+    origin1 = FK5(1 * u.deg, 2 * u.deg, equinox="J2000")
+    origin2 = FK5(1 * u.deg, 2 * u.deg, equinox="J1999")
+    # Comparing the two origins directly would raise.
+    with pytest.raises(TypeError, match="must have equivalent frames"):
+        origin1 == origin2  # noqa: B015
+
+    data = ICRS(3 * u.deg, 4 * u.deg).data
+    offset = lambda origin: SkyCoord(SkyOffsetFrame(origin=origin).realize_frame(data))
+    assert (offset(origin1) == offset(origin2)) is np.False_
+
+    # An equivalent origin still compares equal, and the data still matters.
+    assert (offset(origin1) == offset(FK5(1 * u.deg, 2 * u.deg))) is np.True_
+    other = SkyCoord(
+        SkyOffsetFrame(origin=origin1).realize_frame(ICRS(9 * u.deg, 4 * u.deg).data)
+    )
+    assert (offset(origin1) == other) is np.False_
+
+    # An error that is not the frame comparison declining to compare is not
+    # swallowed.
+    class Boom(FK5):
+        def __eq__(self, other):
+            raise TypeError("something else entirely")
+
+    with pytest.raises(TypeError, match="something else entirely"):
+        _item_equal(Boom(1 * u.deg, 2 * u.deg), origin1)
+
+    # Likewise when only one of the two attributes has data.
+    galcen = lambda coord: SkyCoord(
+        Galactocentric(
+            [1, 2] * u.kpc, [0, 0] * u.kpc, [0, 0] * u.kpc, galcen_coord=coord
+        )
+    )
+    assert np.all((galcen(ICRS(1 * u.deg, 2 * u.deg)) == galcen(ICRS())) == [False] * 2)
 
 
 def test_attr_inheritance():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -592,6 +592,38 @@ def test_equal_extra_frame_attribute_shape_mismatch():
         sc1 == sc2  # noqa: B015
 
 
+def test_equal_frame():
+    """Comparing to a bare frame goes through the same comparison as a SkyCoord.
+
+    A frame carries no "extra" frame attributes, so a |SkyCoord| that has any is
+    never equal to one.
+    """
+    frame = ICRS([1, 2] * u.deg, [3, 4] * u.deg)
+    sc = SkyCoord([1, 20] * u.deg, [3, 4] * u.deg)
+
+    assert np.all((sc == frame) == [True, False])
+    assert np.all((frame == sc) == [True, False])
+    assert np.all((sc != frame) == [False, True])
+
+    # An extra frame attribute makes the SkyCoord unequal to any bare frame.
+    sc_obstime = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg, obstime="B1955")
+    assert np.all((sc_obstime == frame) == [False, False])
+    assert np.all((frame == sc_obstime) == [False, False])
+
+    # A differing frame attribute or frame class gives False, not an exception.
+    assert (
+        SkyCoord(1 * u.deg, 2 * u.deg, frame="fk5", equinox="J1950")
+        == FK5(1 * u.deg, 2 * u.deg, equinox="J2000")
+    ) is np.False_
+    assert (SkyCoord(1 * u.deg, 2 * u.deg) == FK5(1 * u.deg, 2 * u.deg)) is np.False_
+
+    # But a frame without data cannot be compared at all.
+    with pytest.raises(
+        ValueError, match="Can only compare SkyCoord to Frame with data"
+    ):
+        sc == ICRS()  # noqa: B015
+
+
 def test_attr_inheritance():
     """
     When initializing from an existing coord the representation attrs like

--- a/docs/changes/coordinates/20266.api.rst
+++ b/docs/changes/coordinates/20266.api.rst
@@ -1,0 +1,7 @@
+Equality comparison of ``SkyCoord`` objects now compares the frame attributes and the
+"extra" frame attributes element-wise, in the same way as the coordinate data, instead
+of requiring them to be equivalent. Array-valued attributes that agree for only some
+elements now give a partially `True` result, and a mismatch gives `False` rather than
+raising ``TypeError`` or ``ValueError``. The same attribute is treated the same way
+whether or not it belongs to the coordinate's own frame, so ``obstime`` on an ICRS
+coordinate now behaves like ``obstime`` on an FK4 one.

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1149,15 +1149,18 @@ For example, when comparing, e.g., two |SkyCoord| objects::
 
     >>> left_skycoord == right_skycoord  # doctest: +SKIP
 
-the right object must be strictly consistent with the left object for
-comparison:
+Two |SkyCoord| objects are equal where all of the following are identical:
 
-- Identical class
-- Equivalent frames (`~astropy.coordinates.BaseCoordinateFrame.is_equivalent_frame`)
-- Identical representation_types
-- Identical representation differentials keys
-- Identical frame attributes
-- Identical "extra" frame attributes (e.g., ``obstime`` for an ICRS coord)
+- Class
+- Frame type
+- Representation type
+- Representation differentials keys
+- Representation component data (which may include velocities)
+- Frame attributes (e.g., ``equinox`` for an FK5 coord)
+- "Extra" frame attributes (e.g., ``obstime`` for an ICRS coord)
+
+All of these are compared element-wise, so array-valued inputs give an
+array-valued result.
 
 In the first example we show simple comparisons using array-valued coordinates::
 
@@ -1173,30 +1176,66 @@ In the first example we show simple comparisons using array-valued coordinates::
   >>> sc1 != sc2  # Not equal
   array([False,  True])
 
-In addition to numerically comparing the representation component data (which
-may include velocities), the equality comparison includes strict tests that all
-of the frame attributes like ``equinox`` or ``obstime`` are exactly equal.  Any
-mismatch in attributes will result in an exception being raised.  For example::
+The frame attributes are compared in the same way as the component data, so a
+difference in ``equinox`` or ``obstime`` makes the coordinates unequal even where
+the components themselves agree::
 
-  >>> sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
-  >>> sc2 = SkyCoord([1, 20]*u.deg, [3, 4]*u.deg, obstime='2020-01-01')
-  >>> sc1 == sc2  # doctest: +SKIP
-  ...
-  ValueError: cannot compare: extra frame attribute 'obstime' is not equivalent
-   (perhaps compare the frames directly to avoid this exception)
+  >>> from astropy.time import Time
+  >>> obstime = Time(['2020-01-01', '2021-01-01'])
+  >>> sc3 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, frame='fk4', obstime=obstime)
+  >>> sc4 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, frame='fk4', obstime='2020-01-01')
+  >>> sc3 == sc4
+  array([ True, False])
 
-In this example the ``obstime`` attribute is a so-called "extra" frame attribute
-that does not apply directly to the ICRS coordinate frame. So we could compare
-with the following, this time using the ``!=`` operator for variety::
+This applies just the same to an attribute that is not part of the coordinate's
+own frame. Such an "extra" frame attribute is carried along by the |SkyCoord| so
+that it survives a transformation to a frame that does use it, and it counts
+towards equality in exactly the same way::
 
-  >>> sc1.frame != sc2.frame
-  array([False, True])
+  >>> sc5 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime=obstime)  # ICRS
+  >>> sc6 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime='2020-01-01')
+  >>> sc5 == sc6
+  array([ True, False])
+
+An attribute that is set on one of the two objects but not on the other, or a
+different frame type, means that nothing can be equal::
+
+  >>> sc5 == SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)  # no obstime at all
+  array([False, False])
+  >>> SkyCoord(1*u.deg, 2*u.deg) == SkyCoord(1*u.deg, 2*u.deg, frame='fk5')
+  np.False_
+
+Comparing with a low-level frame (:doc:`frames`) works the same way. Since a
+frame never carries extra frame attributes, a |SkyCoord| that has one is not
+equal to any frame::
+
+  >>> sc2 == ICRS([1, 2]*u.deg, [3, 4]*u.deg)
+  array([ True, False])
+  >>> sc5 == ICRS([1, 2]*u.deg, [3, 4]*u.deg)  # sc5 has an obstime
+  array([False, False])
+
+.. note::
+
+  Comparing two low-level frames directly is stricter than comparing two
+  |SkyCoord| objects. It requires that the frames be *equivalent*
+  (`~astropy.coordinates.BaseCoordinateFrame.is_equivalent_frame`) and raises if
+  they are not, so a frame attribute that differs in even one element makes the
+  whole comparison raise instead of giving an element-wise answer::
+
+    >>> FK4([1, 2]*u.deg, [3, 4]*u.deg, obstime=obstime) == FK4([1, 2]*u.deg, [3, 4]*u.deg, obstime='2020-01-01')
+    Traceback (most recent call last):
+    ...
+    TypeError: cannot compare: objects must have equivalent frames: ...
+
+  ``is_equivalent_frame()`` is also what governs whether operations such as item
+  assignment or :func:`~astropy.coordinates.concatenate` are allowed. Those are
+  all-or-nothing and require that *every* element of *every* frame attribute
+  matches.
 
 One slightly special case is comparing two frames that both have no data, where
 the return value is the same as ``frame1.is_equivalent_frame(frame2)``. For
 example::
 
-  >>> from astropy.coordinates import FK4
   >>> FK4() == FK4(obstime='2020-01-01')
   False
 


### PR DESCRIPTION
### Summary

This PR updates `SkyCoord` equality to use a single item-by-item comparison of `self.info._represent_as_dict()`, the dict that already holds everything needed to reconstruct a `SkyCoord`. Comparing two of those dicts gives the documented definition of equality directly, and because the items are compared with plain `==` the result broadcasts like any other array operation.

The goal is that equality always succeeds and returns a result consistent with the broadcasted shape of the two sides. The only time an exception is raised is if the shapes are not broadcastable.

This addresses a long-time issue of inconsistency in behavior, e.g.:
```python
>>> obstime = Time(["2020-01-01", "2021-01-01"])
>>> sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime=obstime)
>>> sc2 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime="2020-01-01")
>>> sc1 == sc2
ValueError: cannot compare: extra frame attribute 'obstime' is not equivalent    # main
array([ True, False])                                                            # this branch

>>> f1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, frame="fk4", obstime=obstime)
>>> f2 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, frame="fk4", obstime="2020-01-01")
>>> f1 == f2
TypeError: cannot compare: objects must have equivalent frames: ...              # main
array([ True, False])                                                            # this branch
```
### AI disclosure

The code in this PR is largely AI-generated using Claude Opus 5. I planned the Claude prompts carefully and I have examined the code and fully understand the changes in `sky_coordinate.py` and the tests.

- [x] I certify that I am human and take responsibility for the code and interactions
with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Compare the two `info._represent_as_dict()` dicts item by item instead of routing
through frame equality**

### 1. Why the primary/extra split existed

A `SkyCoord` can carry any attribute registered in `frame_transform_graph`, not just
those of its own frame, so that a round trip through another frame preserves them.
`SkyCoord.__setattr__` files anything that is not an attribute of `self.frame` into
`self._extra_frameattr_names` and stores it as `self._<name>`.

The two kinds then diverge in one way that matters here. A frame broadcasts its own
attributes against the data at construction (`BaseCoordinateFrame.__init__` folds their
shapes into `self._shape`, and `Attribute.__get__` broadcasts on access), whereas
`SkyCoord.__getattr__` returns the raw stored value. So a frame attribute always has the
frame's shape, and an extra frame attribute can have any shape at all — including one
larger than the coordinate it is attached to.

`_represent_as_dict()` erases the distinction: it does
`attrs.extend(frame_transform_graph.frame_attributes.keys())` and then
`getattr(self._parent, key, None)` for each, which for a `SkyCoord` picks up both kinds
identically. Values keep their natural shapes, so the broadcasting difference above is
handled by numpy rather than by explicit shape code.

### 2. Why `False` and not an exception

`_represent_as_dict()` skips items whose value is `None`, so an unset attribute is
simply an absent key, and the frame name, `representation_type` and `differential_type`
are present as plain strings. Every one of the five conditions in the documented
definition of equality is therefore either a differing key or a differing value:

| condition | how it shows up |
| --- | --- |
| identical frame type | `frame` key differs, and usually the component names too |
| identical `representation_type` | `representation_type` key differs |
| identical differentials keys | `differential_type` present on one side only |
| identical frame attributes | attribute key differs in value |
| identical extra frame attributes | same, no separate handling |

None of these has any reason to raise — they are all just "not equal". A differing key
short-circuits to all-`False`, since there is nothing to compare element-wise.

### 3. Implementation

`SkyCoord.__eq__` is now, in full:

- Frame on the right-hand side: `return self == SkyCoord(value, copy=False)`, so the
  frame goes through the same comparison. The `value._data is None` guard stays ahead of
  it, otherwise the message would come from the `SkyCoord` constructor instead.
- Not a `SkyCoord`: `return NotImplemented`, unchanged.
- `repr1.keys() != repr2.keys()`: return `np.zeros(shape, bool)[()]` where `shape` is
  `np.broadcast_shapes(self.shape, value.shape)`. The `[()]` is what makes a scalar
  comparison return `np.False_` rather than a 0-d array.
- Otherwise `out = out & _item_equal(val1, repr2[attr])` over the items, starting from
  `True`. The output shape falls out of the broadcasting rather than being computed;
  it has to, because an extra frame attribute can make the result larger than either
  input (see the test below).

`_item_equal()` is a module-level helper for one case: an attribute whose value is
itself a frame, such as `SkyOffsetFrame.origin`. Comparing two frames raises rather than
returning `False` when they are not equivalent, or when only one of them has data, so
for an attribute that has to be translated into "not equal". The catch is narrowed two
ways — the value must be a `BaseCoordinateFrame`, and the message must start with
`cannot compare`, which is the prefix used by all five raise sites in
`baseframe.py` and `representation/base.py`. Anything else propagates.

`BaseCoordinateFrame._frameattr_equiv` is left in place; it is still used by
`is_equivalent_frame()` and by `SkyCoord.__setitem__`.

Shape-mismatch messages now name the offending item and carry numpy's detail, and all
of them use the `cannot compare:` prefix already used elsewhere in the subpackage:

```
cannot compare: extra frame attribute 'obstime' has shape mismatch: operands could not
be broadcast together with shapes (2,) (3,)
```

### 4. Testing

New and rewritten tests in `astropy/coordinates/tests/test_sky_coord.py`:

| test | covers |
| --- | --- |
| `test_equal_fk4_frame_attribute_mismatch` | scalar attribute mismatch gives `np.False_`; different frame class likewise, in both directions |
| `test_equal_fk4_frame_attribute_arrays` | array-valued `equinox`/`obstime` compared element-wise |
| `test_equal_fk4_frame_attribute_arrays_default` | scalar attribute against an array-valued one |
| `test_equal_extra_frame_attributes` | extra `obstime`, and the case where it is set on only one side |
| `test_equal_extra_frame_attribute_broadcasting_mismatch` | `(2, 1)` attribute against `(2, 2)` coordinates |
| `test_equal_extra_frame_attribute_larger_than_coord_shape` | `(2, 1)` attribute on `(2,)` coordinates gives a `(2, 2)` result; array attribute on scalar coordinates |
| `test_equal_extra_frame_attribute_shape_mismatch` | attributes that do not broadcast still raise |
| `test_equal_radial_velocity_broadcasting` | scalar against array with velocities |
| `test_equal_frame` | comparison against a bare frame, including that extra frame attributes are now counted |
| `test_equal_coordinate_frame_attribute` | `SkyOffsetFrame.origin` with non-equivalent origins; `galcen_coord` with data on one side only; an unrelated `TypeError` still propagates |

`test_equal_exceptions` is removed — the exceptions it asserted no longer exist. In
`test_frames.py`, `test_frame_coord_comparison` had two `pytest.raises(TypeError)` blocks
for comparisons involving a `SkyCoord`; both now assert `np.False_`, and the reflected
direction was added.

Attribute types exercised by the above: `TimeAttribute`, `QuantityAttribute`,
`EarthLocationAttribute`, `CartesianRepresentationAttribute`, `DifferentialAttribute`
and `CoordinateAttribute`, plus masked data.

```
$ python -m pytest astropy/coordinates
2051 passed, 48 skipped, 10 xfailed in 7.44s

$ python -m pytest astropy/coordinates/tests/test_sky_coord.py -k equal
12 passed, 426 deselected in 0.13s

$ python -m pytest docs/coordinates
24 passed in 1.50s

$ python -m pytest astropy docs
32303 passed, 439 skipped, 265 xfailed in 177.70s
```

The full-suite figure is from an earlier run of this branch, before the shape-mismatch
message change in the final commit; the coordinates and docs figures above are current.

### 5. Backwards compatibility

`SkyCoord.__eq__` and `SkyCoord.__ne__` are the only changed API. Comparisons that
succeeded before return the same values; what changes is that comparisons which raised
now return `False` or an array containing `False`. Code that relies on catching the
exception will stop working, hence the changelog fragment at
`docs/changes/coordinates/20266.api.rst`.

Two behaviour changes worth calling out beyond "stops raising":

- Comparing a `SkyCoord` to a `BaseCoordinateFrame` previously ignored the extra frame
  attributes entirely, because it delegated to `self.frame == value`. It no longer does,
  so a `SkyCoord` carrying an `obstime` is not equal to a bare `ICRS` frame. The old
  behaviour made equality non-transitive: `sc(obstime=A) == fr` and `sc(obstime=B) == fr`
  were both `True` while `sc(obstime=A) != sc(obstime=B)`.
- Comparing coordinates in different frame classes returns `False` instead of raising
  `TypeError`.

`BaseCoordinateFrame` is unmodified, so frame-to-frame equality, `is_equivalent_frame()`,
`__setitem__`, `concatenate()` and the transformation machinery are bit-for-bit
unchanged.

The `docs/coordinates/skycoord.rst` "Exact Equality" section still describes the old
raising behaviour and needs updating; that is not in this PR yet.

</details>
