### PR TITLE
BUG: preserve trailing dimensions in aggregate_downsample

### DIFF
--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -35,8 +35,11 @@ def nanmean_reduceat(data, indices):
         counts = np.add.reduceat(~mask, indices)
         out_mask = counts <= 0
     else:
-        # Derive counts from indices
+        # Derive counts from indices. This only accounts for the leading
+        # (bin) axis, so reshape to broadcast against any trailing
+        # dimensions of a multidimensional ``data``.
         counts = np.diff(indices, append=len(data))
+        counts = counts.reshape(counts.shape + (1,) * (unmasked.ndim - 1))
         out_mask = None
 
     result = np.add.reduceat(unmasked, indices) / np.maximum(counts, 1)
@@ -56,7 +59,7 @@ def reduceat(array, indices, function):
     It will check if the input function has a reduceat and call that if it does.
     """
     if len(indices) == 0:
-        return np.zeros_like(array, shape=(0,))
+        return np.zeros_like(array, shape=(0,) + array.shape[1:])
     elif function is nanmean_reduceat:
         return function(array, indices)
     elif hasattr(function, "reduceat"):
@@ -66,7 +69,11 @@ def reduceat(array, indices, function):
             function(array[start:stop] if start < stop else array[start])
             for start, stop in pairwise(list(indices) + [len(array)])
         ]
-        return np.block(result)
+        # np.stack (rather than np.block) is needed so that a per-bin result
+        # with trailing dimensions (e.g. from a multidimensional column) is
+        # stacked along a new leading axis instead of being concatenated
+        # into a single flat array.
+        return np.stack(result)
 
 
 def _to_relative_longdouble(time: Time, rel_base: Time) -> np.longdouble:
@@ -291,8 +298,12 @@ def aggregate_downsample(
 
         # TODO: This was written before MaskedQuantity were possible.
         # Should we return that by default, instead of using np.nan?
+        # Preserve any trailing dimensions beyond the row axis (e.g. for a
+        # column that stores a spectrum or vector per row) instead of
+        # collapsing them; only the leading (time) axis is downsampled.
+        out_shape = (n_bins,) + values.shape[1:]
         if isinstance(values, u.Quantity):
-            data = np.full_like(values, np.nan, shape=(n_bins,))
+            data = np.full_like(values, np.nan, shape=out_shape)
             # Pass ndarray (`values.value`) instead of Quantity (`values`)
             # reduceat() to avoid significant performance hit for cases
             # aggregate_func does not have optimized reduceat, e.g., np.nanmean.
@@ -300,7 +311,7 @@ def aggregate_downsample(
                 reduceat(values.value, groups, aggregate_func), values.unit, copy=False
             )
         else:
-            data = np.ma.zeros(n_bins, dtype=values.dtype)
+            data = np.ma.zeros(out_shape, dtype=values.dtype)
             data[unique_indices] = reduceat(values, groups, aggregate_func)
 
         if hasattr(data, "mask"):

--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -403,6 +403,89 @@ def test_downsample_with_masked_array(masked_cls, aggregate_func):
     assert_masked_equal(down3["m"], expected3)
 
 
+def test_reduceat_multidimensional():
+    # See gh-13225: a per-bin result with trailing dimensions must be
+    # stacked along a new leading axis, not concatenated into a flat array.
+    data = np.arange(24.0).reshape(8, 3)
+    indices = [0, 3, 5]
+
+    def median_axis0(x):
+        return np.median(np.atleast_2d(x), axis=0)
+
+    out = reduceat(data, indices, median_axis0)
+    assert out.shape == (3, 3)
+    assert_equal(out[0], np.median(data[0:3], axis=0))
+    assert_equal(out[1], np.median(data[3:5], axis=0))
+    assert_equal(out[2], np.median(data[5:8], axis=0))
+
+
+def test_nanmean_reduceat_multidimensional():
+    # See gh-13225: for a multidimensional (unmasked, no-NaN) input, the
+    # per-bin counts must broadcast against the trailing dimensions instead
+    # of only matching the number of bins.
+    data = np.arange(24.0).reshape(8, 3)
+    indices = [0, 3, 5]  # unequal bin sizes: 3, 2, 3
+
+    out = nanmean_reduceat(data, indices)
+    assert out.shape == (3, 3)
+    assert_equal(out, [data[0:3].mean(0), data[3:5].mean(0), data[5:8].mean(0)])
+
+    # Same, but now with a fully-masked bin, which takes the other branch.
+    masked = Masked(data, mask=False)
+    masked.mask[3:5] = True
+    out_masked = nanmean_reduceat(masked, indices)
+    assert out_masked.shape == (3, 3)
+    assert_equal(out_masked.unmasked[0], data[0:3].mean(0))
+    assert_equal(out_masked.mask[1], [True, True, True])
+    assert_equal(out_masked.unmasked[2], data[5:8].mean(0))
+
+
+@pytest.mark.parametrize("as_quantity", [False, True])
+def test_downsample_multidimensional_column(as_quantity):
+    # Regression test for gh-13225: a multidimensional data column (e.g. a
+    # spectrum per time sample) must only be reduced along the time axis,
+    # with the trailing dimensions preserved rather than dropped, and this
+    # must not crash for unequal bin sizes.
+    n_times, n_channels = 7, 3
+    time = INPUT_TIME[0] + np.arange(n_times) * u.s
+    values = np.arange(n_times * n_channels, dtype=float).reshape(n_times, n_channels)
+    if as_quantity:
+        values = values << u.Jy
+
+    ts = TimeSeries(time=time, data=[values], names=["flux"])
+    # 3 bins of size 3s -> unequal bins covering 3, 3, 1 samples.
+    down = aggregate_downsample(ts, time_bin_size=3 * u.s)
+
+    assert down["flux"].shape == (3, n_channels)
+    raw = values.value if as_quantity else values
+    assert_equal(
+        np.asarray(down["flux"]), [raw[0:3].mean(0), raw[3:6].mean(0), raw[6:7].mean(0)]
+    )
+
+
+def test_downsample_multidimensional_column_masked():
+    # Regression test for gh-13225: masking must work per-element for a
+    # multidimensional column, and a fully-masked bin must come back masked
+    # (with the correct shape) rather than raising.
+    time = INPUT_TIME[0] + np.arange(3) * u.s
+    data = Masked(np.arange(9.0).reshape(3, 3), mask=False)
+    data.mask[1] = True  # entire middle row masked
+
+    ts = TimeSeries(time=time, data=[data], names=["flux"])
+    down = aggregate_downsample(
+        ts,
+        time_bin_start=time,
+        time_bin_end=time + 0.5 * u.s,  # one sample per bin, non-touching
+    )
+
+    down_data, down_mask = get_data_and_mask(down["flux"])
+    orig_data, _ = get_data_and_mask(data)
+    assert down_data.shape == (3, 3)
+    assert_equal(down_mask, [[False] * 3, [True] * 3, [False] * 3])
+    assert_equal(down_data[0], orig_data[0])
+    assert_equal(down_data[2], orig_data[2])
+
+
 @pytest.mark.parametrize(
     "diff_from_base", [1 * u.year, 10 * u.year, 50 * u.year, 100 * u.year]
 )

--- a/docs/changes/timeseries/20286.bugfix.rst
+++ b/docs/changes/timeseries/20286.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``aggregate_downsample()`` dropping or, for unequal bin sizes, raising
+a ``ValueError`` on a data column with more than one dimension (e.g. a
+spectrum stored per time sample). Only the time axis is now aggregated;
+any additional axes are preserved.


### PR DESCRIPTION
Fixes #13225.

### Problem

`aggregate_downsample()` did not correctly handle a data column with more than one dimension (e.g. a spectrum or vector stored per time sample). Depending on the aggregate function and the bin sizes, this either silently collapsed the extra dimension or raised a `ValueError`:

```python
import numpy as np
from astropy import units as u
from astropy.timeseries import TimeSeries, aggregate_downsample

ts = TimeSeries(time_start="2022-01-01", time_delta=1 * u.s, n_samples=30)
ts["flux"] = np.ones((30, 3))
aggregate_downsample(ts, time_bin_size=3 * u.s)
```
```
ValueError: operands could not be broadcast together with shapes (10,3) (10,)
```

### Root cause

There were three related problems in `astropy/timeseries/downsample.py`, all stemming from the same assumption that a column only has a row axis:

1. The output column was always allocated as `shape=(n_bins,)`, dropping any trailing dimensions regardless of the aggregate function used.
2. The default aggregate function, `nanmean_reduceat`, computes per-bin counts as a 1-D array derived from the bin indices (`np.diff(indices, ...)`) and divides the reduced sum by it directly. This only broadcasts correctly by coincidence when the number of bins equals the trailing dimension size; otherwise it raises the `ValueError` above.
3. The manual fallback in `reduceat()`, used when a custom `aggregate_func` has no `.reduceat` method (e.g. `functools.partial(np.nanmedian, axis=0)`), collected one result array per bin and combined them with `np.block()`, which concatenates flat arrays instead of stacking them along a new axis — so a multidimensional per-bin result came out with the wrong shape.

### Fix

- Allocate the output column as `(n_bins,) + values.shape[1:]` so trailing dimensions are preserved.
- Reshape the count array in `nanmean_reduceat` to broadcast against those trailing dimensions.
- Use `np.stack` instead of `np.block` in the manual `reduceat()` fallback so a per-bin result with trailing dimensions is stacked correctly.
- Also preserve the trailing shape in the `len(indices) == 0` early return of `reduceat()` (empty-bin edge case).

Only the time (row) axis is aggregated; any additional axes are left alone, matching what was requested in the original report.

### Testing

Added regression tests in `astropy/timeseries/tests/test_downsample.py`:
- `test_reduceat_multidimensional` — manual fallback path preserves trailing dimensions.
- `test_nanmean_reduceat_multidimensional` — default aggregate function handles unequal bin sizes and a fully-masked bin correctly for 2-D input.
- `test_downsample_multidimensional_column` (plain ndarray and `Quantity`) — end-to-end reproduction of the reported crash, with unequal bin sizes, checked against manually computed expected values.
- `test_downsample_multidimensional_column_masked` — a fully-masked row in a multidimensional masked column comes back masked with the correct shape instead of raising.

All 5 new tests fail against the code on `main` and pass with this change. The full existing `astropy/timeseries` test suite (101 tests, excluding tests requiring network access or pandas) passes unmodified. `ruff check` and `ruff format --check` pass on both changed files.

### Impact

Existing 1-D behavior is unchanged (verified by the full pre-existing test suite passing as-is). This only changes behavior for columns with more than one dimension, which previously either crashed or silently returned incorrect (collapsed) output.
