### PR TITLE
Fix CCDData unit state after failed arithmetic

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -57,9 +57,12 @@ def _arithmetic(op):
         def inner(self, operand, operand2=None, **kwargs):
             global _config_ccd_requires_unit
             _config_ccd_requires_unit = False
-            result = self._prepare_then_do_arithmetic(op, operand, operand2, **kwargs)
+            try:
+                result = self._prepare_then_do_arithmetic(op, operand, operand2, **kwargs)
+            finally:
+                # Restore the unit check even when arithmetic raises.
+                _config_ccd_requires_unit = True
             # Wrap it again as CCDData so it checks the final unit.
-            _config_ccd_requires_unit = True
             return result.__class__(result)
 
         inner.__doc__ = f"See `astropy.nddata.NDArithmeticMixin.{func.__name__}`."

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -58,7 +58,9 @@ def _arithmetic(op):
             global _config_ccd_requires_unit
             _config_ccd_requires_unit = False
             try:
-                result = self._prepare_then_do_arithmetic(op, operand, operand2, **kwargs)
+                result = self._prepare_then_do_arithmetic(
+                    op, operand, operand2, **kwargs
+                )
             finally:
                 # Restore the unit check even when arithmetic raises.
                 _config_ccd_requires_unit = True

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -473,6 +473,21 @@ def test_arithmetic_overload_fails():
         ccd_data.subtract("five")
 
 
+def test_arithmetic_error_restores_unit_requirement():
+    ccd_adu = CCDData(np.ones((2, 2)), unit="adu")
+    ccd_electron = CCDData(np.ones((2, 2)), unit="electron")
+
+    with pytest.raises(u.UnitConversionError):
+        ccd_adu.add(ccd_electron)
+
+    # A failed operation must not disable this process-wide validation.
+    from astropy.nddata import ccddata
+
+    assert ccddata._config_ccd_requires_unit is True
+    with pytest.raises(ValueError, match="a unit for CCDData must be specified"):
+        CCDData(np.ones((2, 2)))
+
+
 def test_arithmetic_no_wcs_compare():
     ccd = CCDData(np.ones((10, 10)), unit="")
     assert ccd.add(ccd, compare_wcs=None).wcs is None

--- a/docs/changes/nddata/20268.bugfix.rst
+++ b/docs/changes/nddata/20268.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure the ``CCDData`` unit requirement is restored when an arithmetic operation raises an exception.


### PR DESCRIPTION
This PR fixes a small state leak in CCDData arithmetic.

`_arithmetic` temporarily disables the unit requirement while it builds the result. If `_prepare_then_do_arithmetic` raises—for example, when adding incompatible `adu` and `electron` data—the old path did not restore the flag. After that failure, an unrelated `CCDData(...)` could be created without a unit.

The change moves the restoration into `finally` and adds a regression test that exercises the incompatible-unit path and checks that the next unitless construction still raises. I also added the nddata changelog fragment.

Validation so far:
- `python3 -m compileall` on changed Python files
- `git diff --check`

I have not run the Astropy test suite yet because the local Python 3.9 environment cannot install the current development build dependencies. I'm keeping this PR as a draft until I can run the targeted test in a supported environment.

Fixes #20268