### PR TITLE
Support masked Time in aggregate_downsample; mask BLS transit_time only if needed

### DIFF
--- a/astropy/timeseries/downsample.py
+++ b/astropy/timeseries/downsample.py
@@ -78,7 +78,14 @@ def _to_relative_longdouble(time: Time, rel_base: Time) -> np.longdouble:
     # Relative time in seconds with np.longdouble type is used to:
     # - a consistent format for search, irrespective of the format/scale of the inputs,
     # - retain the best precision possible
-    return (time - rel_base).to_value(format="sec", subfmt="long")
+    rel = (time - rel_base).to_value(format="sec", subfmt="long")
+    # `np.searchsorted` does not support masked arrays, so for a masked ``time``
+    # return a plain ndarray. Callers ensure that no element is actually masked,
+    # but just in case, use NaN for masked elements: all comparisons with NaN are
+    # False, so such elements would not fall in any bin.
+    if isinstance(rel, Masked):
+        rel = rel.filled(np.nan)
+    return rel
 
 
 def aggregate_downsample(
@@ -150,6 +157,10 @@ def aggregate_downsample(
     if time_bin_end is not None and not isinstance(time_bin_end, (Time, TimeDelta)):
         time_bin_end = Time(time_bin_end)
 
+    # Rows with a masked time cannot be assigned to any bin, so drop them.
+    if time_series.time.masked and np.any(time_series.time.mask):
+        time_series = time_series[~time_series.time.mask]
+
     # Use the table sorted by time
     ts_sorted = time_series.iloc[:]
 
@@ -216,6 +227,9 @@ def aggregate_downsample(
     # Start and end times of the binned timeseries
     bin_start = binned.time_bin_start
     bin_end = binned.time_bin_end
+    for name, bin_edge in (("time_bin_start", bin_start), ("time_bin_end", bin_end)):
+        if bin_edge.masked and np.any(bin_edge.mask):
+            raise ValueError(f"'{name}' must not contain masked values")
 
     # Set `n_bins` to match the length of `time_bin_start` if
     # `n_bins` is unspecified or if `time_bin_start` is an iterable

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -392,7 +392,11 @@ class BoxLeastSquares(BasePeriodogram):
             reset = np.abs(times.to_value(u.year)) > 100000
             times[reset] = 0
             times = self._tstart + times
-            times[reset] = np.nan
+            # Setting to NaN masks the elements, which turns ``times`` into a
+            # masked Time. Only do so if there is something to mask, so that
+            # the result is masked only if it needs to be.
+            if np.any(reset):
+                times[reset] = np.nan
         return times
 
     def model(self, t_model, period, duration, transit_time):

--- a/astropy/timeseries/periodograms/bls/tests/test_bls.py
+++ b/astropy/timeseries/periodograms/bls/tests/test_bls.py
@@ -510,3 +510,27 @@ def test_transit_time_in_range(data):
     assert np.all(results1.transit_time <= t.max())
     assert np.all(results2.transit_time >= t2.min())
     assert np.all(results2.transit_time <= t2.max())
+
+
+def test_absolute_times_masked_only_if_needed(data):
+    # Transit times far off from the present are masked. When nothing needs
+    # masking, the result should not be a masked Time (gh-20291).
+    t, y, dy, params = data
+    start = Time("2019-05-04T12:34:56")
+    bls = BoxLeastSquares(t * u.day + start, y * u.mag, dy * u.mag)
+
+    results = bls.autopower(0.16 * u.day)
+    assert isinstance(results.transit_time, Time)
+    assert not results.transit_time.masked
+
+    # Directly check the conversion to absolute times, both without and with
+    # an out-of-range value. Relative times are with respect to the first time.
+    tstart = bls.t[0]
+    times = bls._as_absolute_time_if_needed("transit_time", [1.0, 2.0] * u.day)
+    assert not times.masked
+    assert_allclose((times - tstart).to_value(u.day), [1.0, 2.0])
+
+    times = bls._as_absolute_time_if_needed("transit_time", [1.0, 1e9] * u.day)
+    assert times.masked
+    assert_equal(times.mask, [False, True])
+    assert_allclose((times[0] - tstart).to_value(u.day), 1.0)

--- a/astropy/timeseries/tests/test_downsample.py
+++ b/astropy/timeseries/tests/test_downsample.py
@@ -434,3 +434,55 @@ def test_time_precision_limit(diff_from_base):
     # ensure in the converted relative time,
     # t2 and t3 can still be correctly compared
     assert r_t3 > r_t2
+
+
+@pytest.mark.parametrize(
+    "bin_kwargs",
+    [
+        dict(time_bin_start=INPUT_TIME[:-1:2], time_bin_end=INPUT_TIME[1::2]),
+        dict(time_bin_size=2 * u.s),
+    ],
+    ids=["explicit_bins", "auto_bins"],
+)
+@pytest.mark.parametrize(
+    "masked_index", [None, 0, 2, -1], ids=["nomask", "first", "mid", "last"]
+)
+def test_downsample_with_masked_time(masked_index, bin_kwargs):
+    """Downsampling works for a masked ``time`` column.
+
+    Rows with a masked time must not fall in any bin, nor affect the automatic
+    bin edges. A masked ``Time`` in which nothing is actually masked gives the
+    same result as a plain ``Time``.
+    """
+    mask = np.zeros(len(INPUT_TIME), dtype=bool)
+    if masked_index is not None:
+        mask[masked_index] = True
+    # Setting elements to np.ma.masked gives a masked Time, even if the
+    # index selects nothing (this is how BoxLeastSquares ends up returning
+    # a masked transit_time in which nothing is masked).
+    time = INPUT_TIME.copy()
+    time[mask] = np.ma.masked
+    assert time.masked
+    assert_equal(time.mask, mask)
+
+    values = np.arange(len(INPUT_TIME), dtype=float)
+    ts = TimeSeries(time=time, data=[values], names=["a"])
+    down = aggregate_downsample(ts, **bin_kwargs)
+
+    # Reference result from the same data with the masked row removed.
+    ts_ref = TimeSeries(time=INPUT_TIME[~mask], data=[values[~mask]], names=["a"])
+    down_ref = aggregate_downsample(ts_ref, **bin_kwargs)
+    assert len(down) == len(down_ref)
+    assert_masked_equal(down["a"], down_ref["a"])
+    assert_equal(down.time_bin_start.jd, down_ref.time_bin_start.jd)
+    assert_equal(down.time_bin_size, down_ref.time_bin_size)
+
+
+def test_downsample_with_masked_bin_edges():
+    ts = TimeSeries(time=INPUT_TIME, data=[np.ones(len(INPUT_TIME))], names=["a"])
+    time_bin_start = INPUT_TIME[:-1:2].copy()
+    time_bin_start[1] = np.ma.masked
+    with pytest.raises(ValueError, match="'time_bin_start' must not contain masked"):
+        aggregate_downsample(
+            ts, time_bin_start=time_bin_start, time_bin_end=INPUT_TIME[1::2]
+        )

--- a/docs/changes/timeseries/20319.bugfix.rst
+++ b/docs/changes/timeseries/20319.bugfix.rst
@@ -1,0 +1,6 @@
+``aggregate_downsample`` now works for a time series with a masked ``time``
+column, including one obtained by folding on a ``transit_time`` from a
+``BoxLeastSquares`` periodogram. Rows with a masked time are excluded from all
+bins, and masked bin edges raise ``ValueError``. In addition, the
+``transit_time`` in ``BoxLeastSquares`` results is no longer masked when none
+of the values need to be masked.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

#20291 revealed a bug in TimeSeries masked array handling by way of a failing RTD build. This PR fixes that.

`aggregate_downsample` fails for a `TimeSeries` whose `time` column is a masked `Time`, because it passes the relative times to `np.searchsorted`, which has no implementation for `Masked` arrays. This is an existing bug but it has gone unnoticed because masked `Time` columns are rare and, in the one place the docs produce one, the mask was silently dropped again.

`BoxLeastSquares` returns a `transit_time` that is masked with nothing actually masked, and `TimeSeries.fold` on such an epoch currently gives an unmasked result only because `TimeDelta` discards an all-`False` mask on input. #20291 changes that so masked input always gives a masked `Time`, and the `timeseries` docs example (`BoxLeastSquares` -> `fold` -> `aggregate_downsample`) then fails its Read the Docs build. That PR needs this one merged first.

```python
>>> t = Time([1.0, 2.0, 3.0], format="mjd")
>>> t[[False, True, False]] = np.ma.masked
>>> ts = TimeSeries(time=t, data={"a": [1.0, 2.0, 3.0]})
>>> aggregate_downsample(ts, time_bin_size=1 * u.day)["a"].tolist()
TypeError: no implementation found for 'numpy.searchsorted' ...   # main
[1.0, 3.0]              # this branch: 2 bins covering the two unmasked times
```

Two things are changed. `aggregate_downsample` now drops rows with a masked time before binning, rejects masked bin edges with a `ValueError`, and hands plain `ndarray` values to `np.searchsorted`. `BoxLeastSquares` now only masks its absolute transit times when some value actually needs masking, so a result is masked only if it has to be. `LombScargle` is not affected because it never assigns into a `Time`.

### AI disclosure

This PR includes AI-generated content using Claude Fable 5.1. I have reviewed the content and somewhat understand the changes within narrow context, but I'll be honest and say that this needs an expert to review. I'm not very familiar with TimeSeries.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Make `aggregate_downsample` work with a masked `Time` column, and stop `BoxLeastSquares` from masking its transit times when nothing needs masking**

### 1. `aggregate_downsample` — no support for masked times

`_to_relative_longdouble` converts times to relative seconds, and the result is a `MaskedNDArray` whenever the input `Time` is masked. Everything up to `np.searchsorted` copes with that, but `np.searchsorted` is in the deliberately unsupported list for `Masked` and raises `TypeError`. With a `Time` that has masked elements there is a second problem: those elements sort to the end, so `ts_sorted.time[-1]` is a masked value and the automatic number of bins computed from the total duration is meaningless (25773 bins for a 6-point series in one probe).

### 2. `BoxLeastSquares._as_absolute_time_if_needed` — masks unconditionally

The method masks transit times more than 100,000 years from the reference epoch by doing `times[reset] = np.nan`. `Time.__setitem__` treats assignment of `np.nan` as "mask these elements" and calls `_ensure_masked()` before indexing, so the `Time` becomes masked even when `reset` is all `False`. Every `transit_time` for absolute input times therefore has `masked=True`, normally with no masked elements.

### Implementation

`astropy/timeseries/downsample.py`

- `aggregate_downsample`: right after the input validation, if `time_series.time` is masked and any element is masked, replace `time_series` by `time_series[~time_series.time.mask]`. Rows with a masked time cannot belong to any bin, and dropping them keeps the sorted first and last times, and hence the automatic bin edges, correct.
- `aggregate_downsample`: after the `BinnedTimeSeries` is built, raise `ValueError("'time_bin_start' must not contain masked values")` (or `time_bin_end`) if a bin edge has a masked element. Previously this ended in the same `TypeError` from `np.searchsorted`.
- `_to_relative_longdouble`: if the relative times come back as `Masked`, return `rel.filled(np.nan)`. After the row filtering no element is actually masked, so this only strips the mask; the NaN fill is a guard so that any masked element would compare `False` against every bin edge.

`astropy/timeseries/periodograms/bls/core.py`

- `_as_absolute_time_if_needed`: only execute `times[reset] = np.nan` when `np.any(reset)`. The out-of-range masking behaviour is unchanged.

Tests

- `test_downsample.py::test_downsample_with_masked_time`: parametrized over no masked element and a masked element at the first, middle and last position, with both explicit bin edges and automatic bins from `time_bin_size`. The result must equal downsampling the same series with the masked row removed. The masked `Time` is made by assigning `np.ma.masked` through a boolean index on a copy of the input times, which gives a masked `Time` even when the index selects nothing, exactly as happens in `BoxLeastSquares`.
- `test_downsample.py::test_downsample_with_masked_bin_edges`: masked `time_bin_start` raises the new `ValueError`.
- `test_bls.py::test_absolute_times_masked_only_if_needed`: `autopower` on absolute times gives an unmasked `transit_time`; `_as_absolute_time_if_needed` gives an unmasked result for in-range values and a `Time` with mask `[False, True]` when one value is out of range.

Verification

- The 10 new test cases: `10 passed in 0.13s` with this branch. With `main`'s `downsample.py` and `bls/core.py` temporarily swapped in: `10 failed in 0.21s`, all of them.
- `pytest astropy/timeseries docs/timeseries`: `2875 passed, 5 skipped in 25.97s`.
- The `timeseries` docs example was run end to end against the Kepler sample file on top of #20291 with these changes: `transit_time` unmasked, `ts_folded.time` unmasked, downsample gives 74 bins as in the doctest. `tox -e build_docs -- -j 1` on that combination: `build succeeded`, and the two `Exception occurred in plotting` warnings for `docs/timeseries/index.rst` from the RTD log are gone.

### Backwards compatibility

No public API changes. For an unmasked `time` column the code path is bit-for-bit the same as before: the new row filter and bin-edge check are skipped, and `_to_relative_longdouble` returns the same `ndarray`. What changes:

- A `TimeSeries` with masked times can now be downsampled; masked rows are excluded from every bin. Previously this raised `TypeError`.
- Masked bin edges raise `ValueError` instead of `TypeError`.
- `BoxLeastSquaresResults.transit_time` for absolute input times is an unmasked `Time` unless some value is out of range. Previously it was always masked. Values are identical.

Changelog fragment: `docs/changes/timeseries/20319.bugfix.rst`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
