### PR TITLE
fix(wcs): gracefully deep-copy a 0-d WCS produced by WCS.sub

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -893,6 +893,25 @@ def test_sub_3d_with_sip():
     assert w.naxis == 2
 
 
+def test_sub_0d_deepcopy():
+    # Regression test for #16298: deep-copying a 0-d WCS (produced by
+    # ``WCS.sub`` dropping all axes) raised an obscure "NULL error object
+    # in wcslib" RuntimeError because a ``Wcsprm`` with no axes cannot be
+    # deep-copied by wcslib. The 0-d ``Wcsprm`` is now passed through by
+    # reference (it holds no axis data, so this is equivalent).
+    w = wcs.WCS(naxis=2)
+    w_sub = w.sub([wcs.WCSSUB_SPECTRAL])
+    assert w_sub.naxis == 0
+    w_copy = w_sub.deepcopy()
+    assert w_copy.naxis == 0
+    assert w_copy is not w_sub
+    # sanity: a regular N-d deepcopy is unaffected
+    w2 = wcs.WCS(naxis=2)
+    w2_copy = w2.deepcopy()
+    assert w2_copy.naxis == 2
+    assert w2_copy is not w2
+
+
 def test_printwcs(capsys):
     """
     Just make sure that it runs

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -736,11 +736,20 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         new_copy = self.__class__()
         new_copy.naxis = deepcopy(self.naxis, memo)
+        if self.naxis == 0:
+            # A 0-d WCS (e.g. produced by ``WCS.sub``) has an underlying
+            # ``Wcsprm`` with no axes, whose C structure wcslib cannot
+            # deep-copy (it raises "NULL error object in wcslib"). Since it
+            # holds no axis data, passing the ``Wcsprm`` by reference is
+            # equivalent to a deep copy here.
+            wcs_copy = self.wcs
+        else:
+            wcs_copy = deepcopy(self.wcs, memo)
         WCSBase.__init__(
             new_copy,
             deepcopy(self.sip, memo),
             (deepcopy(self.cpdis1, memo), deepcopy(self.cpdis2, memo)),
-            deepcopy(self.wcs, memo),
+            wcs_copy,
             (deepcopy(self.det2im1, memo), deepcopy(self.det2im2, memo)),
         )
         for key, val in self.__dict__.items():

--- a/docs/changes/wcs/20321.bugfix.rst
+++ b/docs/changes/wcs/20321.bugfix.rst
@@ -1,0 +1,4 @@
+Deep-copying a 0-d ``WCS`` (for example one produced by ``WCS.sub``) no longer
+raises ``RuntimeError: NULL error object in wcslib``. The underlying
+``Wcsprm`` of a 0-d ``WCS`` holds no per-axis data, so it is now passed
+through by reference instead of being deep-copied by wcslib.


### PR DESCRIPTION
## Problem

Deep-copying a 0-d WCS raises an obscure `RuntimeError: NULL error object in
wcslib`. A 0-d WCS is easy to produce: `WCS(naxis=2).sub([WCSSUB_SPECTRAL])`
drops all axes and yields an object with `naxis == 0`. Calling `.deepcopy()` on
it then blows up with a C-level wcslib error that gives no hint about the real
cause.

Reproduce (before fix):

```python
from astropy.wcs import WCS, WCSSUB_SPECTRAL
w = WCS(naxis=2).sub([WCSSUB_SPECTRAL])   # naxis == 0
w.deepcopy()   # RuntimeError: NULL error object in wcslib
```

## Root cause

`WCS.__deepcopy__` unconditionally deep-copies the underlying `Wcsprm`
(`deepcopy(self.wcs, memo)`). For a 0-d WCS the `Wcsprm` has `naxis == 0` and a
C structure that wcslib cannot deep-copy — it reports a NULL error object. The
0-d `Wcsprm` holds no axis data at all (all per-axis arrays are empty), so it
cannot be meaningfully deep-copied, and it also cannot be reconstructed via the
public `Wcsprm(naxis=...)` constructor (which rejects `naxis=0`).

## Fix

In `WCS.__deepcopy__`, when `self.naxis == 0` pass the underlying `Wcsprm`
through **by reference** instead of deep-copying it (equivalent, since a 0-d
`Wcsprm` carries no per-axis buffers). All other axes keep the existing
deep-copy path, so non-0-d behavior is unchanged.

This matches the "gracefully deep copy the 0-d WCS" option suggested in the
issue, and is backward compatible: `WCS.sub` behavior is untouched, and a 0-d
WCS can now be deep-copied as well as any other WCS.

## Test

Adds `test_sub_0d_deepcopy` in `astropy/wcs/tests/test_wcs.py`:
- a 0-d WCS produced by `WCS.sub` deep-copies cleanly (`naxis == 0`, distinct object);
- a regular 2-d `deepcopy` sanity check (unaffected, still a distinct object).

Verified red/green: the new test raises `RuntimeError: NULL error object in
wcslib` on the unpatched code and passes on the patched code. Existing
`sub`/`copy`/`deepcopy`/`pickle` tests in `test_wcs.py` and `test_pickle.py`
still pass (no regression).

Fixes #16298


### AI Disclosure
An AI coding agent assisted with this pull request: it helped diagnose the issue from the linked report, draft the code fix and the regression test, and write this PR description. The change was validated locally against the project's own test suite (red/green runs plus full-module regression) before submission.