### PR TITLE
Fix latex reader splitting on `&` inside braced arguments like `\cite{...}` (#6360)

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -46,6 +46,32 @@ latexdicts = {
 
 RE_COMMENT: Final[Pattern[str]] = re.compile(r"(?<!\\)%")  # % character but not \%
 
+# Sentinel used to shield ``&`` characters that occur inside braced arguments
+# (e.g. ``\cite{Smith&Jones}``) so that they are not treated as column
+# separators when splitting a LaTeX table (#6360).  The sentinel is inserted in
+# ``LatexSplitter.process_line`` and restored in ``LatexSplitter.process_val``.
+AMPERSAND_MASK = "\x1f"
+
+
+def _mask_ampersands_in_braces(line: str) -> str:
+    """Replace ``&`` characters that appear inside braced ``{...}`` groups with
+    ``AMPERSAND_MASK``.
+
+    A ``&`` inside braces is cell content (e.g. a bib code in ``\cite``) rather
+    than a column delimiter, while an unbraced ``&`` keeps its role as the
+    LaTeX column separator.
+    """
+    out = []
+    depth = 0
+    for ch in line:
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth = max(depth - 1, 0)
+        out.append(AMPERSAND_MASK if ch == "&" and depth > 0 else ch)
+    return "".join(out)
+
+
 
 def add_dictval_to_list(adict, key, alist):
     """
@@ -115,14 +141,14 @@ class LatexSplitter(core.BaseSplitter):
             raise core.InconsistentTableError(
                 r"Lines in LaTeX table have to end with \\"
             )
-        return line.removesuffix(r"\\")
+        return _mask_ampersands_in_braces(line.removesuffix(r"\\"))
 
     def process_val(self, val: str) -> str:
         """Remove whitespace and {} at the beginning or end of value."""
         val = val.strip()
         if val and (val[0] == "{") and (val[-1] == "}"):
             val = val[1:-1]
-        return val
+        return val.replace(AMPERSAND_MASK, "&")
 
     def join(self, vals: list[str]) -> str:
         """Join values together and add a few extra spaces for readability."""

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -54,7 +54,7 @@ AMPERSAND_MASK = "\x1f"
 
 
 def _mask_ampersands_in_braces(line: str) -> str:
-    """Replace ``&`` characters that appear inside braced ``{...}`` groups with
+    r"""Replace ``&`` characters that appear inside braced ``{...}`` groups with
     ``AMPERSAND_MASK``.
 
     A ``&`` inside braces is cell content (e.g. a bib code in ``\cite``) rather
@@ -70,7 +70,6 @@ def _mask_ampersands_in_braces(line: str) -> str:
             depth = max(depth - 1, 0)
         out.append(AMPERSAND_MASK if ch == "&" and depth > 0 else ch)
     return "".join(out)
-
 
 
 def add_dictval_to_list(adict, key, alist):

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1707,6 +1707,26 @@ a & b & c \\
     assert np.all(dat["c"] == ["c", "e"])
 
 
+def test_latex_cite_with_ampersand():
+    """
+    A ``&`` inside a braced argument (e.g. a bib code in ``\cite{...}``) is
+    cell content, not a column separator, so the table must read (#6360).
+    """
+    lines = r"""
+\begin{table}
+\begin{tabular}{ccc}
+First & Second & Ref\\
+1 & 2 & \cite{other_ref}\\
+11 & 22 & \cite{2013A&A...558A..33A}\\
+\end{tabular}
+\end{table}
+"""
+    dat = ascii.read(lines, format="latex")
+    assert dat.colnames == ["First", "Second", "Ref"]
+    assert len(dat) == 2
+    assert np.all(dat["Ref"] == [r"\cite{other_ref}", r"\cite{2013A&A...558A..33A}"])
+
+
 def text_aastex_no_trailing_backslash():
     lines = r"""
 \begin{deluxetable}{ccc}

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1708,7 +1708,7 @@ a & b & c \\
 
 
 def test_latex_cite_with_ampersand():
-    """
+    r"""
     A ``&`` inside a braced argument (e.g. a bib code in ``\cite{...}``) is
     cell content, not a column separator, so the table must read (#6360).
     """

--- a/docs/changes/io.ascii/20324.bugfix.rst
+++ b/docs/changes/io.ascii/20324.bugfix.rst
@@ -1,0 +1,1 @@
+The LaTeX table reader no longer treats an ampersand (``&``) that occurs inside a braced ``{...}`` argument (such as a bib code in ``\cite{...}``) as a column separator, so tables with a reference column now read as expected (see #6360).


### PR DESCRIPTION
Fixes #6360.

LaTeX tables in papers often have a reference column containing bib codes such as `\cite{2013A&A...558A..33A}`.  The unescaped `&` inside the braced argument was treated as a column separator, so the table failed to read with `InconsistentTableError`.

## What changed
- `astropy/io/ascii/latex.py`: a small helper masks `&` characters that occur inside braced `{...}` groups (a sentinel inserted in `LatexSplitter.process_line`, restored in `LatexSplitter.process_val`).  Unbraced `&` keeps its role as the column separator, so existing behaviour is unchanged.
- Regression test `test_latex_cite_with_ampersand` in `tests/test_read.py` using the example from the issue.

## Validation
- reproduces on pristine code (red), fixed version passes (green)
- full `test_read.py` (168 passed) and `test_write.py` (156 passed), no regressions

Will add the `docs/changes` changelog fragment with the PR number.


### AI Disclosure
An AI coding agent assisted with this pull request: it helped diagnose the issue from the linked report, draft the code fix and the regression test, and write this PR description. The change was validated locally against the project's own test suite (red/green runs plus full-module regression) before submission.