### PR TITLE
STY: extract _MAS_PER_DEG constant in ICRS<->FK5 transform

### DIFF
--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -8,15 +8,17 @@ from .fk5 import FK5
 from .icrs import ICRS
 from .utils import EQUINOX_J2000
 
+_MAS_PER_DEG = 3.6e6  # 3600 arcseconds * 1000 milliarcseconds
+
 
 def _icrs_to_fk5_matrix():
     """
     B-matrix from USNO circular 179.  Used by the ICRS->FK5 transformation
     functions.
     """
-    eta0 = -19.9 / 3600000.0
-    xi0 = 9.1 / 3600000.0
-    da0 = -22.9 / 3600000.0
+    eta0 = -19.9 / _MAS_PER_DEG
+    xi0 = 9.1 / _MAS_PER_DEG
+    da0 = -22.9 / _MAS_PER_DEG
 
     return (
         rotation_matrix(-eta0, "x")


### PR DESCRIPTION
Replace the bare 3600000.0 conversion factor in _icrs_to_fk5_matrix() with a module-level _MAS_PER_DEG named constant in scientific notation. The value (3,600 arcsec/deg * 1,000 mas/arcsec) is documented in a short side comment.

Same float, more self-documenting at the call sites. Per review suggestion from neutrinoceros on #19597.