### PR TITLE
STY: group large int literals with PEP 515 underscores

### DIFF
--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -968,7 +968,7 @@ class TestEnvvarRegressions:
     def test_config_objs_leak(self, monkeypatch, tmp_path):
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
-        ref = 0x4D3D3D3
+        ref = 0x4D3_D3D3
         conf.max_width = ref
 
         with TemporaryDirectory() as td, set_temp_config(td):

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -125,7 +125,7 @@ def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
 
 
 def test_matching_method():
-    with NumpyRNGContext(987654321):
+    with NumpyRNGContext(987_654_321):
         cmatch = ICRS(
             np.random.rand(20) * 360.0 * u.degree,
             (np.random.rand(20) * 180.0 - 90.0) * u.degree,

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -770,7 +770,7 @@ def test_repr_altaz():
 
     expected_el_repr = "(-2309223.0, -3695529.0, -4641767.0)"
 
-    loc = EarthLocation(-2309223 * u.m, -3695529 * u.m, -4641767 * u.m)
+    loc = EarthLocation(-2_309_223 * u.m, -3_695_529 * u.m, -4_641_767 * u.m)
     time = Time("2005-03-21 00:00:00")
     sc4 = sc2.transform_to(AltAz(location=loc, obstime=time))
     assert repr(sc4).startswith(
@@ -1415,7 +1415,7 @@ def test_search_around():
     """
     from astropy.utils import NumpyRNGContext
 
-    with NumpyRNGContext(987654321):
+    with NumpyRNGContext(987_654_321):
         sc1 = SkyCoord(
             np.random.rand(20) * 360.0 * u.degree,
             (np.random.rand(20) * 180.0 - 90.0) * u.degree,
@@ -1460,7 +1460,7 @@ def test_guess_from_table():
     from astropy.utils import NumpyRNGContext
 
     tab = Table()
-    with NumpyRNGContext(987654321):
+    with NumpyRNGContext(987_654_321):
         tab.add_column(Column(data=np.random.rand(10), unit="deg", name="RA[J2000]"))
         tab.add_column(Column(data=np.random.rand(10), unit="deg", name="DEC[J2000]"))
 

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -430,7 +430,7 @@ def test_regression_15611():
     # type 3 SPICE kernel
     ephemeris_file = get_pkg_data_filename("coordinates/230965_2004XA192_nima_v6.bsp")
     # KBO 2004 XA192
-    pair = (10, 20230965)
+    pair = (10, 20_230_965)
     t = Time("2023-11-11T03:59:24")
     # get_body_barycentric should not raise an error
     get_body_barycentric([pair], t, ephemeris=ephemeris_file)

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -208,7 +208,7 @@ def test_barycorr(input_radecs):
 
 
 def test_rvcorr_multiple_obstimes_onskycoord():
-    loc = EarthLocation(-2309223 * u.m, -3695529 * u.m, -4641767 * u.m)
+    loc = EarthLocation(-2_309_223 * u.m, -3_695_529 * u.m, -4_641_767 * u.m)
     arrtime = Time("2005-03-21 00:00:00") + np.linspace(-1, 1, 10) * u.day
 
     sc = SkyCoord(1 * u.deg, 2 * u.deg, 100 * u.kpc, obstime=arrtime, location=loc)
@@ -224,7 +224,7 @@ def test_rvcorr_multiple_obstimes_onskycoord():
 
 
 def test_invalid_argument_combos():
-    loc = EarthLocation(-2309223 * u.m, -3695529 * u.m, -4641767 * u.m)
+    loc = EarthLocation(-2_309_223 * u.m, -3_695_529 * u.m, -4_641_767 * u.m)
     time = Time("2005-03-21 00:00:00")
     timel = Time("2005-03-21 00:00:00", location=loc)
 
@@ -334,7 +334,7 @@ def test_regression_10094():
     # CTIO location as used in Wright & Eastmann
     xyz = u.Quantity([1814985.3, -5213916.8, -3187738.1], u.m)
     obs = EarthLocation(*xyz)
-    times = Time(2400000, reduced_jds, format="jd")
+    times = Time(2_400_000, reduced_jds, format="jd")
     tempo2 = tempo2 * speed_of_light
     barycorr = barycorr * speed_of_light
     astropy = tauCet.radial_velocity_correction(location=obs, obstime=times)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -175,7 +175,7 @@ class MaskedConstant(np.ma.core.MaskedConstant):
     def __hash__(self):
         """All instances of this class shall have the same hash."""
         # Any large number will do.
-        return 1234567890
+        return 1_234_567_890
 
     def __copy__(self) -> Self:
         """This is a singleton so just return self."""

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -63,7 +63,7 @@ def test_ipac_read_long_columns():
 
     # assert oid, as a long column, is int64
     oid = dat["oid"]
-    assert oid[0] == 90000000000000001
+    assert oid[0] == 90_000_000_000_000_001
     assert oid.dtype.kind == "i"
     assert oid.dtype.itemsize == 8
 
@@ -90,7 +90,7 @@ num,cadence
     # assert `num`` is exactly 64bit int
     assert dat["num"].dtype.kind == "i"
     assert dat["num"].dtype.itemsize == 8
-    assert dat["num"][0] == 110000000000000001
+    assert dat["num"][0] == 110_000_000_000_000_001
 
     # assert `cadence` is exactly 64bit int, even though the values are small numbers.
     assert dat["cadence"].dtype.kind == "i"

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1459,12 +1459,12 @@ class _ValidHDU(_BaseHDU, _Verify):
                 piece = piece[:-extra]
             s += int(piece.view(">u4").sum(dtype="u8"))
             while hi := (s >> 32):
-                s = (s & 0xFFFFFFFF) + hi
+                s = (s & 0xFFFF_FFFF) + hi
         return np.uint32(s)
 
     # _MASK and _EXCLUDE used for encoding the checksum value into a character
     # string.
-    _MASK = [0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF]
+    _MASK = [0xFF00_0000, 0x00FF_0000, 0x0000_FF00, 0x0000_00FF]
 
     _EXCLUDE = [0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40,
                 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60]  # fmt: skip

--- a/astropy/io/fits/hdu/compressed/_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/_tiled_compression.py
@@ -27,7 +27,7 @@ ALGORITHMS = {
     "NOCOMPRESS": NoCompress,
 }
 
-DEFAULT_ZBLANK = -2147483648
+DEFAULT_ZBLANK = -2_147_483_648
 
 
 __all__ = [

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1507,7 +1507,7 @@ def test_reserved_keywords_stripped(tmp_path):
         tmp_path / "compressed.fits", disable_image_compression=True
     ) as hduc:
         hduc[1].header["THEAP"] = hduc[1].header["NAXIS1"] * hduc[1].header["NAXIS2"]
-        hduc[1].header["ZBLANK"] = 1231212
+        hduc[1].header["ZBLANK"] = 1_231_212
         hduc[1].header["ZSCALE"] = 2
         hduc[1].header["ZZERO"] = 10
         hduc[1].writeto(tmp_path / "compressed_with_extra.fits")
@@ -1597,7 +1597,7 @@ def test_compressed_hdu_header_order():
     """Test that the headers cards end up in the correct order for the
     compressed image HDU."""
 
-    rng = np.random.default_rng(seed=5301753)
+    rng = np.random.default_rng(seed=5_301_753)
     header = fits.Header()
     header["a"] = "b"
     header["c"] = "d"

--- a/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_tiled_compression.py
@@ -52,7 +52,7 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
         canonical_data_base_path / "compressed_with_nan.fits",
         disable_image_compression=True,
     ) as hduc:
-        assert hduc[1].header["ZBLANK"] == -2147483647
+        assert hduc[1].header["ZBLANK"] == -2_147_483_647
 
     reference = np.arange(144).reshape((12, 12)).astype(float)
     reference[1, 1] = np.nan
@@ -74,7 +74,7 @@ def test_zblank_support(canonical_data_base_path, tmp_path):
     ) as hduc:
         # The ZBLANK value is different from before as we don't preserve it,
         # instead we always write out with the default ZBLANK
-        assert hduc[1].header["ZBLANK"] == -2147483648
+        assert hduc[1].header["ZBLANK"] == -2_147_483_648
 
     with fits.open(tmp_path / "test_zblank.fits") as hdul:
         assert_equal(np.round(hdul[1].data), reference)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1657,7 +1657,7 @@ class TestStreamingFunctions(FitsTestCase):
     def test_fix_invalid_extname(self, capsys):
         phdu = fits.PrimaryHDU()
         ihdu = fits.ImageHDU()
-        ihdu.header["EXTNAME"] = 12345678
+        ihdu.header["EXTNAME"] = 12_345_678
         hdul = fits.HDUList([phdu, ihdu])
         filename = self.temp("temp.fits")
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -212,7 +212,7 @@ class TestFitsTime(FitsTestCase):
             self.time,
             format="isot",
             scale="utc",
-            location=EarthLocation(-2446354, 4237210, 4077985, unit="m"),
+            location=EarthLocation(-2_446_354, 4_237_210, 4_077_985, unit="m"),
         )
         t["b"] = Time([1, 2], format="cxcsec", scale="tt")
 
@@ -465,7 +465,11 @@ class TestFitsTime(FitsTestCase):
         )
 
         # Observatory position in ITRS Cartesian coordinates (geocentric)
-        cards = [("OBSGEO-X", -2446354), ("OBSGEO-Y", 4237210), ("OBSGEO-Z", 4077985)]
+        cards = [
+            ("OBSGEO-X", -2_446_354),
+            ("OBSGEO-Y", 4_237_210),
+            ("OBSGEO-Z", 4_077_985),
+        ]
 
         # Explicitly create a FITS Binary Table
         bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
@@ -474,9 +478,9 @@ class TestFitsTime(FitsTestCase):
         tm = table_types.read(self.temp("time.fits"), astropy_native=True)
 
         assert isinstance(tm["datetime"], Time)
-        assert tm["datetime"].location.x.value == -2446354
-        assert tm["datetime"].location.y.value == 4237210
-        assert tm["datetime"].location.z.value == 4077985
+        assert tm["datetime"].location.x.value == -2_446_354
+        assert tm["datetime"].location.y.value == 4_237_210
+        assert tm["datetime"].location.z.value == 4_077_985
 
         # Observatory position in geodetic coordinates
         cards = [("OBSGEO-L", 0), ("OBSGEO-B", 0), ("OBSGEO-H", 0)]
@@ -499,7 +503,7 @@ class TestFitsTime(FitsTestCase):
         recognized by the FITS standard but are not native to astropy.
         """
         # GPS scale column
-        gps_time = np.array([630720013, 630720014])
+        gps_time = np.array([630_720_013, 630_720_014])
         c = fits.Column(
             name="gps_time",
             format="D",

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -125,7 +125,7 @@ class TestHeaderFunctions(FitsTestCase):
     def test_long_integer_value_card(self):
         """Test Card constructor with long integer value"""
 
-        c = fits.Card("long_int", -467374636747637647347374734737437)
+        c = fits.Card("long_int", -467_374_636_747_637_647_347_374_734_737_437)
         assert str(c) == _pad("LONG_INT= -467374636747637647347374734737437")
 
     def test_floating_point_value_card(self):

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -253,7 +253,7 @@ class TestTableFunctions(FitsTestCase):
             "name": ["c1", "c2", "c3", "c4"],
             "format": ["1J", "3A", "1E", "1L"],
             "unit": ["", "", "", ""],
-            "null": [-2147483647, "", "", ""],
+            "null": [-2_147_483_647, "", "", ""],
             "bscale": ["", "", 3, ""],
             "bzero": ["", "", 0.4, ""],
             "disp": ["I11", "A3", "G15.7", "L6"],
@@ -2573,7 +2573,7 @@ class TestTableFunctions(FitsTestCase):
         c2 = fits.Column(name="c2", format="B", array=a2)
         a3 = np.array([-30000, 1, 256], dtype=np.int16)
         c3 = fits.Column(name="c3", format="I", array=a3)
-        a4 = np.array([-123123123, 1234, 123123123], dtype=np.int32)
+        a4 = np.array([-123_123_123, 1234, 123_123_123], dtype=np.int32)
         c4 = fits.Column(name="c4", format="J", array=a4)
         a5 = np.array(["a", "abc", "ab"])
         c5 = fits.Column(name="c5", format="A3", array=a5)

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -970,7 +970,7 @@ class Int(Integer):
     """
 
     format = "i4"
-    val_range = (-2147483648, 2147483647)
+    val_range = (-2_147_483_648, 2_147_483_647)
     bit_size = "32-bit"
 
     def binparse(self, read):
@@ -984,7 +984,7 @@ class Long(Integer):
     """
 
     format = "i8"
-    val_range = (-9223372036854775808, 9223372036854775807)
+    val_range = (-9_223_372_036_854_775_808, 9_223_372_036_854_775_807)
     bit_size = "64-bit"
 
     def binparse(self, read):

--- a/astropy/io/votable/tests/test_vo.py
+++ b/astropy/io/votable/tests/test_vo.py
@@ -441,7 +441,8 @@ class TestParse:
     def test_int(self):
         assert issubclass(self.array["int"].dtype.type, np.int32)
         assert_array_equal(
-            self.array["int"], [268435456, 2147483647, -268435456, 268435455, 123456789]
+            self.array["int"],
+            [268_435_456, 2_147_483_647, -268_435_456, 268_435_455, 123_456_789],
         )
         assert_array_equal(self.mask["int"], [False, False, False, False, True])
 
@@ -450,11 +451,11 @@ class TestParse:
         assert_array_equal(
             self.array["long"],
             [
-                922337203685477,
-                123456789,
-                -1152921504606846976,
-                1152921504606846975,
-                123456789,
+                922_337_203_685_477,
+                123_456_789,
+                -1_152_921_504_606_846_976,
+                1_152_921_504_606_846_975,
+                123_456_789,
             ],
         )
         assert_array_equal(self.mask["long"], [False, True, False, False, True])

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -33,7 +33,7 @@ class TestNonLinearConstraints:
         self.x = np.arange(10, 20, 0.1)
         self.y1 = self.g1(self.x)
         self.y2 = self.g2(self.x)
-        rsn = default_rng(1234567890)
+        rsn = default_rng(1_234_567_890)
         self.n = rsn.standard_normal(100)
         self.ny1 = self.y1 + 2 * self.n
         self.ny2 = self.y2 + 2 * self.n
@@ -270,7 +270,7 @@ class TestLinearConstraints:
         self.p1.window = [0.0, 9.0]
         self.x = np.arange(10)
         self.y = self.p1(self.x)
-        rsn = default_rng(1234567890)
+        rsn = default_rng(1_234_567_890)
         self.n = rsn.standard_normal(10)
         self.ny = self.y + self.n
 
@@ -588,7 +588,7 @@ def test_2d_model(fitter):
     z = gauss2d(x, y)
     w = np.ones(x.shape)
 
-    with NumpyRNGContext(1234567890):
+    with NumpyRNGContext(1_234_567_890):
         n = np.random.randn(*x.shape)
         m = fitter(gauss2d, x, y, z + 2 * n, weights=w)
         assert_allclose(m.parameters, gauss2d.parameters, rtol=0.05)

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -126,7 +126,7 @@ def test_fittable_compound(fitter):
     x = np.arange(10)
     y_real = m(x)
     dy = 0.005
-    with NumpyRNGContext(1234567):
+    with NumpyRNGContext(1_234_567):
         n = np.random.normal(0.0, dy, x.shape)
     y_noisy = y_real + n
     new_model = fitter(m, x, y_noisy)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -833,7 +833,7 @@ def test_with_bounding_box():
     """
     p = models.Polynomial2D(2) & models.Polynomial2D(2)
     m = models.Mapping((0, 1, 0, 1)) | p
-    with NumpyRNGContext(1234567):
+    with NumpyRNGContext(1_234_567):
         m.parameters = np.random.rand(12)
 
     m.bounding_box = ((3, 9), (1, 8))

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -165,7 +165,7 @@ def test_nddata_init_data_maskedarray():
     assert_array_equal(nd.data, marr.data)
     # check that they are both by reference
     marr.mask[10] = ~marr.mask[10]
-    marr.data[11] = 123456789
+    marr.data[11] = 123_456_789
     assert_array_equal(nd.mask, marr.mask)
     assert_array_equal(nd.data, marr.data)
 

--- a/astropy/table/tests/test_df.py
+++ b/astropy/table/tests/test_df.py
@@ -614,7 +614,11 @@ class TestDataFrameConversion:
         t["s"].mask = [False, True, False]
 
         # https://github.com/astropy/astropy/issues/7741
-        t["Source"] = [2584290278794471936, 2584290038276303744, 2584288728310999296]
+        t["Source"] = [
+            2_584_290_278_794_471_936,
+            2_584_290_038_276_303_744,
+            2_584_288_728_310_999_296,
+        ]
         t["Source"].mask = [False, False, False]
 
         if use_nullable_int:  # Default

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -242,7 +242,7 @@ def test_qtable_uses_masked_quantity_as_needed():
     assert isinstance(t["a"], u.Quantity)
     assert isinstance(t["b"], Column)
     assert t["a"].unit == u.m
-    assert_array_equal(t["a"], [1, 2000000] * u.m)
+    assert_array_equal(t["a"], [1, 2_000_000] * u.m)
     assert not t.masked
 
     t2 = QTable(data_ragged)
@@ -250,7 +250,7 @@ def test_qtable_uses_masked_quantity_as_needed():
     assert isinstance(t2["a"], Masked(u.Quantity))
     assert isinstance(t2["b"], MaskedColumn)
     assert t2["a"].unit == u.m
-    assert np.all(t2["a"] == [1, 2000000, 0] * u.m)
+    assert np.all(t2["a"] == [1, 2_000_000, 0] * u.m)
     assert_array_equal(t2["a"].mask, [False, False, True])
     assert_array_equal(t2["b"].mask, [False, True, False])
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -159,7 +159,7 @@ def test_io_time_write_fits_standard(tmp_path, table_types):
             [[1, 2], [3, 4]],
             format="cxcsec",
             scale=scale,
-            location=EarthLocation(-2446354, 4237210, 4077985, unit="m"),
+            location=EarthLocation(-2_446_354, 4_237_210, 4_077_985, unit="m"),
         )
         t["b" + scale] = time.Time(
             ["1999-01-01T00:00:00.123456789", "2010-01-01T00:00:00"], scale=scale
@@ -284,7 +284,7 @@ def test_io_time_write_fits_local(tmp_path, table_types):
         [[50001, 50002], [50003, 50004]],
         format="mjd",
         scale="local",
-        location=EarthLocation(-2446354, 4237210, 4077985, unit="m"),
+        location=EarthLocation(-2_446_354, 4_237_210, 4_077_985, unit="m"),
     )
     t["b_local"] = time.Time(
         ["1999-01-01T00:00:00.123456789", "2010-01-01T00:00:00"], scale="local"

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2158,7 +2158,7 @@ class TestQTableIntColumnWithUnit:
     """An integer column with a unit keeps its dtype in a QTable (#17963)."""
 
     # Integers that are not exactly representable as float64.
-    VALS = [2741100559643251862, 2733456478647137226]
+    VALS = [2_741_100_559_643_251_862, 2_733_456_478_647_137_226]
 
     def get_table(self):
         return Table(

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -784,7 +784,7 @@ class TestVal2:
             Time([0.0, 50000.0], [0.0, 1.0, 2.0], format="mjd", scale="tai")
 
     def test_broadcast_not_writable(self):
-        val = (2458000 + np.arange(3))[:, None]
+        val = (2_458_000 + np.arange(3))[:, None]
         val2 = np.linspace(0, 1, 4, endpoint=False)
         t = Time(val=val, val2=val2, format="jd", scale="tai")
         t_b = Time(val=val + 0 * val2, val2=0 * val + val2, format="jd", scale="tai")
@@ -797,7 +797,7 @@ class TestVal2:
         assert np.all(t_b == t), "behaved as expected"
 
     def test_broadcast_one_not_writable(self):
-        val = 2458000 + np.arange(3)
+        val = 2_458_000 + np.arange(3)
         val2 = np.arange(1)
         t = Time(val=val, val2=val2, format="jd", scale="tai")
         t_b = Time(val=val + 0 * val2, val2=0 * val + val2, format="jd", scale="tai")
@@ -1181,7 +1181,7 @@ class TestSubFormat:
         # the header of the observations and gPhoton processing.
         t3 = Time("2004-01-21 16:33:57")
         assert allclose_sec(t3.galexsec, 758738037.0)
-        assert allclose_sec(t3.galexsec, t3.unix - 315964800)
+        assert allclose_sec(t3.galexsec, t3.unix - 315_964_800)
 
         # Round trip through epoch time
         for scale in ("utc", "tt"):
@@ -1539,7 +1539,7 @@ class TestCopyReplicate:
         jds = np.array([2450000.5], dtype=np.double)
         t = Time(jds, format="jd", scale="tai")
         assert allclose_jd(t.jd, jds)
-        jds[0] = 2458654
+        jds[0] = 2_458_654
         assert not allclose_jd(t.jd, jds)
 
         mjds = np.array([50000.0], dtype=np.double)
@@ -2955,8 +2955,8 @@ def test_linspace_fmts():
     from different formats/systems.
     """
     t1 = Time(["2020-01-01 00:00:00", "2020-01-02 00:00:00"])
-    t2 = Time(2458850, format="jd")
-    t3 = Time(1578009600, format="unix")
+    t2 = Time(2_458_850, format="jd")
+    t3 = Time(1_578_009_600, format="unix")
     atol = 2 * np.finfo(float).eps * abs(t1 - Time([t2, t3])).max()
 
     ts = np.linspace(t1, t2, 3)

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -829,7 +829,7 @@ def test_quantity_str_out_subfmt_from_non_quantity_str():
 
 def test_quantity_str_internal_precision():
     dt = TimeDelta("100000000d 1.0123456789012345s")
-    assert dt.jd1 == 100000000
+    assert dt.jd1 == 100_000_000
     assert allclose_sec(dt.jd2 * 86400, 1.0123456789012345)
 
 

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -115,7 +115,7 @@ mjd0 = Time(0, format="mjd")
 
 
 def reasonable_ordinary_jd():
-    return tuples(floats(2440000, 2470000), floats(-0.5, 0.5))
+    return tuples(floats(2_440_000, 2_470_000), floats(-0.5, 0.5))
 
 
 @composite
@@ -489,8 +489,8 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
             t2_scale2 = getattr(t2, scale2)
             assert t_scale2 < t2_scale2
     except iers.IERSRangeError:  # UT1 conversion needs IERS data
-        assume(scale1 != "ut1" or 2440000 < jd1 + jd2 < 2458000)
-        assume(scale2 != "ut1" or 2440000 < jd1 + jd2 < 2458000)
+        assume(scale1 != "ut1" or 2_440_000 < jd1 + jd2 < 2_458_000)
+        assume(scale2 != "ut1" or 2_440_000 < jd1 + jd2 < 2_458_000)
         raise
     except ErfaError:
         # If the generated date is too early to compute a UTC julian date,
@@ -563,7 +563,7 @@ def test_jd_add_subtract_round_trip(scale, jds, delta):
             t3 = t2 - delta * u.day
             assert_almost_equal(t3, t, atol=thresh, rtol=0)
     except ErfaError:
-        assume(scale != "utc" or 2440000 < jd1 + jd2 < 2460000)
+        assume(scale != "utc" or 2_440_000 < jd1 + jd2 < 2_460_000)
         raise
 
 
@@ -612,7 +612,10 @@ def test_timedelta_full_precision(scale, jds_a, jds_b):
     jd1_b, jd2_b = jds_b
     assume(
         scale != "utc"
-        or (2440000 < jd1_a + jd2_a < 2460000 and 2440000 < jd1_b + jd2_b < 2460000)
+        or (
+            2_440_000 < jd1_a + jd2_a < 2_460_000
+            and 2_440_000 < jd1_b + jd2_b < 2_460_000
+        )
     )
     if scale == "utc":
         # UTC subtraction implies a scale change, so possible rounding errors.
@@ -658,8 +661,8 @@ def test_timedelta_full_precision_arithmetic(scale, jds_a, jds_b, x, y):
             assume(
                 scale != "utc"
                 or (
-                    2440000 < jd1_a + jd2_a < 2460000
-                    and 2440000 < jd1_b + jd2_b < 2460000
+                    2_440_000 < jd1_a + jd2_a < 2_460_000
+                    and 2_440_000 < jd1_b + jd2_b < 2_460_000
                 )
             )
             raise
@@ -716,7 +719,7 @@ def test_datetime_difference_agrees_with_timedelta(scale, dt1, dt2):
 
 @given(
     days=integers(-3000 * 365, 3000 * 365),
-    microseconds=integers(0, 24 * 60 * 60 * 1000000),
+    microseconds=integers(0, 24 * 60 * 60 * 1_000_000),
 )
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_to_timedelta(scale, days, microseconds):
@@ -728,7 +731,7 @@ def test_datetime_to_timedelta(scale, days, microseconds):
 
 @given(
     days=integers(-3000 * 365, 3000 * 365),
-    microseconds=integers(0, 24 * 60 * 60 * 1000000),
+    microseconds=integers(0, 24 * 60 * 60 * 1_000_000),
 )
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_timedelta_roundtrip(scale, days, microseconds):
@@ -738,7 +741,7 @@ def test_datetime_timedelta_roundtrip(scale, days, microseconds):
 
 @given(days=integers(-3000 * 365, 3000 * 365), day_frac=floats(0, 1))
 @example(days=262144, day_frac=2.314815006343452e-11)
-@example(days=1048576, day_frac=1.157407503171726e-10)
+@example(days=1_048_576, day_frac=1.157407503171726e-10)
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_timedelta_datetime_roundtrip(scale, days, day_frac):
     td = TimeDelta(days, day_frac, format="jd", scale=scale)
@@ -778,13 +781,13 @@ def test_datetime_difference_agrees_with_timedelta_no_hypothesis():
 )
 @example(dt=datetime(2000, 1, 1, 0, 0), td=timedelta(days=-397683, microseconds=2))
 @example(dt=datetime(2179, 1, 1, 0, 0), td=timedelta(days=-795365, microseconds=53))
-@example(dt=datetime(2000, 1, 1, 0, 0), td=timedelta(days=1590729, microseconds=10))
+@example(dt=datetime(2000, 1, 1, 0, 0), td=timedelta(days=1_590_729, microseconds=10))
 @example(
-    dt=datetime(4357, 1, 1, 0, 0), td=timedelta(days=-1590729, microseconds=107770)
+    dt=datetime(4357, 1, 1, 0, 0), td=timedelta(days=-1_590_729, microseconds=107770)
 )
 @example(
     dt=datetime(4357, 1, 1, 0, 0, 0, 29),
-    td=timedelta(days=-1590729, microseconds=746292),
+    td=timedelta(days=-1_590_729, microseconds=746292),
 )
 @pytest.mark.parametrize("scale", _utc_bad)
 def test_datetime_timedelta_sum(scale, dt, td):

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -465,7 +465,7 @@ def test_distr_view_different_dtype2():
     # Viewing with a new dtype should follow the same rules as for a
     # regular array with the same dtype.
     uint32 = Distribution(
-        np.array([[0x01020304, 0x05060708], [0x11121314, 0x15161718]], dtype="u4")
+        np.array([[0x0102_0304, 0x0506_0708], [0x1112_1314, 0x1516_1718]], dtype="u4")
     )
     uint8 = uint32.view("4u1")
     assert uint8.shape == uint32.shape + (4,)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1112,21 +1112,21 @@ class TestQuantityDisplay:
                 id="zero_padding",
             ),
             pytest.param(
-                u.Quantity(1234567, "m"),
+                u.Quantity(1_234_567, "m"),
                 None,
                 ",",
                 "1,234,567.0 m",
                 id="thousands_separator",
             ),
             pytest.param(
-                u.Quantity(137000000, "lyr"),
+                u.Quantity(137_000_000, "lyr"),
                 None,
                 ">+30,.2e",
                 "                     +1.37e+08 lyr",
                 id="large_number_complex_format",
             ),
             pytest.param(
-                u.Quantity(1234567, "m"),
+                u.Quantity(1_234_567, "m"),
                 None,
                 "_",
                 "1_234_567.0 m",
@@ -1204,7 +1204,7 @@ class TestQuantityDisplay:
                 id="complex_number_latex_positive_alignment",
             ),
             pytest.param(
-                u.Quantity(137000000, "lyr"),
+                u.Quantity(137_000_000, "lyr"),
                 None,
                 ">+30,.2e",
                 "latex",
@@ -1252,7 +1252,7 @@ class TestQuantityDisplay:
                 id="scientific_notation_inline_latex_format",
             ),
             pytest.param(
-                u.Quantity(1239999123, "m/s"),
+                u.Quantity(1_239_999_123, "m/s"),
                 None,
                 None,
                 "latex",
@@ -2142,7 +2142,7 @@ class TestQuantityConvertIntToFloat:
     """Test the ``quantity_convert_int_to_float`` configuration item."""
 
     # Integers that are not exactly representable as float64.
-    VALS = [2741100559643251862, 2733456478647137226]
+    VALS = [2_741_100_559_643_251_862, 2_733_456_478_647_137_226]
 
     @pytest.mark.parametrize("value", ["default", "always"])
     def test_int_is_converted_to_float(self, value):

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -189,7 +189,7 @@ def test_human_time(seconds, string):
 @pytest.mark.parametrize(
     ("size", "string"),
     [
-        (8640882, "8.6M"),
+        (8_640_882, "8.6M"),
         (187213, "187k"),
         (3905, "3.9k"),
         (64, " 64 "),

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -89,8 +89,8 @@ hglt_obs: -6.820544""".lstrip()
 
 def test_solar_aux_get():
     w = WCS(HEADER_SOLAR)
-    assert_allclose(w.wcs.aux.rsun_ref, 696000000)
-    assert_allclose(w.wcs.aux.dsun_obs, 147724815128)
+    assert_allclose(w.wcs.aux.rsun_ref, 696_000_000)
+    assert_allclose(w.wcs.aux.dsun_obs, 147_724_815_128)
     assert_allclose(w.wcs.aux.crln_obs, 22.814522)
     assert_allclose(w.wcs.aux.hgln_obs, 8.431123)
     assert_allclose(w.wcs.aux.hglt_obs, -6.820544)
@@ -112,11 +112,11 @@ hglt_obs: 40.000000""".lstrip()
 def test_solar_aux_set():
     w = WCS(HEADER_SOLAR)
 
-    w.wcs.aux.rsun_ref = 698000000
-    assert_allclose(w.wcs.aux.rsun_ref, 698000000)
+    w.wcs.aux.rsun_ref = 698_000_000
+    assert_allclose(w.wcs.aux.rsun_ref, 698_000_000)
 
-    w.wcs.aux.dsun_obs = 140000000000
-    assert_allclose(w.wcs.aux.dsun_obs, 140000000000)
+    w.wcs.aux.dsun_obs = 140_000_000_000
+    assert_allclose(w.wcs.aux.dsun_obs, 140_000_000_000)
 
     w.wcs.aux.crln_obs = 10.0
     assert_allclose(w.wcs.aux.crln_obs, 10.0)
@@ -130,8 +130,8 @@ def test_solar_aux_set():
     assert str(w.wcs.aux) == STR_EXPECTED_SET
 
     header = w.to_header()
-    assert_allclose(header["RSUN_REF"], 698000000)
-    assert_allclose(header["DSUN_OBS"], 140000000000)
+    assert_allclose(header["RSUN_REF"], 698_000_000)
+    assert_allclose(header["DSUN_OBS"], 140_000_000_000)
     assert_allclose(header["CRLN_OBS"], 10.0)
     assert_allclose(header["HGLN_OBS"], 30.0)
     assert_allclose(header["HGLT_OBS"], 40.0)
@@ -140,11 +140,11 @@ def test_solar_aux_set():
 def test_set_aux_on_empty():
     w = WCS(naxis=2)
 
-    w.wcs.aux.rsun_ref = 698000000
-    assert_allclose(w.wcs.aux.rsun_ref, 698000000)
+    w.wcs.aux.rsun_ref = 698_000_000
+    assert_allclose(w.wcs.aux.rsun_ref, 698_000_000)
 
-    w.wcs.aux.dsun_obs = 140000000000
-    assert_allclose(w.wcs.aux.dsun_obs, 140000000000)
+    w.wcs.aux.dsun_obs = 140_000_000_000
+    assert_allclose(w.wcs.aux.dsun_obs, 140_000_000_000)
 
     w.wcs.aux.crln_obs = 10.0
     assert_allclose(w.wcs.aux.crln_obs, 10.0)
@@ -158,8 +158,8 @@ def test_set_aux_on_empty():
     assert str(w.wcs.aux) == STR_EXPECTED_SET
 
     header = w.to_header()
-    assert_allclose(header["RSUN_REF"], 698000000)
-    assert_allclose(header["DSUN_OBS"], 140000000000)
+    assert_allclose(header["RSUN_REF"], 698_000_000)
+    assert_allclose(header["DSUN_OBS"], 140_000_000_000)
     assert_allclose(header["CRLN_OBS"], 10.0)
     assert_allclose(header["HGLN_OBS"], 30.0)
     assert_allclose(header["HGLT_OBS"], 40.0)

--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -44,7 +44,7 @@ def test_dist():
         s = pickle.dumps(wcs1)
         wcs2 = pickle.loads(s)
 
-        with NumpyRNGContext(123456789):
+        with NumpyRNGContext(123_456_789):
             x = np.random.rand(2**16, wcs1.wcs.naxis)
             world1 = wcs1.all_pix2world(x, 1)
             world2 = wcs2.all_pix2world(x, 1)
@@ -63,7 +63,7 @@ def test_sip():
         s = pickle.dumps(wcs1)
         wcs2 = pickle.loads(s)
 
-        with NumpyRNGContext(123456789):
+        with NumpyRNGContext(123_456_789):
             x = np.random.rand(2**16, wcs1.wcs.naxis)
             world1 = wcs1.all_pix2world(x, 1)
             world2 = wcs2.all_pix2world(x, 1)
@@ -82,7 +82,7 @@ def test_sip2():
         s = pickle.dumps(wcs1)
         wcs2 = pickle.loads(s)
 
-        with NumpyRNGContext(123456789):
+        with NumpyRNGContext(123_456_789):
             x = np.random.rand(2**16, wcs1.wcs.naxis)
             world1 = wcs1.all_pix2world(x, 1)
             world2 = wcs2.all_pix2world(x, 1)
@@ -101,7 +101,7 @@ def test_wcs():
     s = pickle.dumps(wcs1)
     wcs2 = pickle.loads(s)
 
-    with NumpyRNGContext(123456789):
+    with NumpyRNGContext(123_456_789):
         x = np.random.rand(2**16, wcs1.wcs.naxis)
         world1 = wcs1.all_pix2world(x, 1)
         world2 = wcs2.all_pix2world(x, 1)

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -41,7 +41,7 @@ def test_map(filename):
     header = get_pkg_data_contents(os.path.join("data/maps", filename))
     wcsobj = wcs.WCS(header)
 
-    with NumpyRNGContext(123456789):
+    with NumpyRNGContext(123_456_789):
         x = np.random.rand(2**12, wcsobj.wcs.naxis)
         wcsobj.wcs_pix2world(x, 1)
         wcsobj.wcs_world2pix(x, 1)
@@ -73,7 +73,7 @@ def test_spectrum(filename):
         wcsobj = wcs.WCS(header)
     for w in warning_lines:
         assert issubclass(w.category, FITSFixedWarning)
-    with NumpyRNGContext(123456789):
+    with NumpyRNGContext(123_456_789):
         x = np.random.rand(2**16, wcsobj.wcs.naxis)
         wcsobj.wcs_pix2world(x, 1)
         wcsobj.wcs_world2pix(x, 1)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -277,7 +277,7 @@ def test_extra_kwarg():
     Issue #444
     """
     w = wcs.WCS()
-    with NumpyRNGContext(123456789):
+    with NumpyRNGContext(123_456_789):
         data = np.random.rand(100, 2)
         with pytest.raises(TypeError):
             w.wcs_pix2world(data, origin=1)
@@ -288,7 +288,7 @@ def test_3d_shapes():
     Issue #444
     """
     w = wcs.WCS(naxis=3)
-    with NumpyRNGContext(123456789):
+    with NumpyRNGContext(123_456_789):
         data = np.random.rand(100, 3)
         result = w.wcs_pix2world(data, 1)
         assert result.shape == (100, 3)
@@ -608,7 +608,7 @@ def test_all_world2pix():
     )[0]
 
     # Generate random data (in image coordinates):
-    with NumpyRNGContext(123456789):
+    with NumpyRNGContext(123_456_789):
         rnd_pix = np.random.rand(25_000, ncoord)
 
     # Scale random data to cover the central part of the image
@@ -2224,7 +2224,7 @@ class TestPreserveUnits:
         self.header = fits.Header.fromstring(HEADER_WITH_NON_SI_UNITS, sep="\n")
         self.wcs_default = wcs.WCS(self.header)
         self.wcs_preserve = wcs.WCS(self.header, preserve_units=True)
-        rsn = default_rng(1234567890)
+        rsn = default_rng(1_234_567_890)
         self.coords = rsn.uniform(-10, 10, (100, 5))
         self.scale = np.array([1 / 3600, 1e9, 1 / 3600, 1e-9, 1])
 
@@ -2726,7 +2726,7 @@ RADESYS = 'ICRS'               / Equatorial coordinate system
         wcs_default = wcs.WCS(hdul[0].header, hdul)
         wcs_preserve = wcs.WCS(hdul[0].header, hdul, preserve_units=True)
 
-        rsn = default_rng(1234567890)
+        rsn = default_rng(1_234_567_890)
         pixel = rsn.uniform(1, 99, 3)
         world = rsn.uniform(4000, 5000, 3)
 

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -153,10 +153,10 @@ def test_colnum():
     assert w.colnum == 42
 
     with pytest.raises(OverflowError):
-        w.colnum = 0xFFFFFFFFFFFFFFFFFFFF
+        w.colnum = 0xFFFF_FFFF_FFFF_FFFF_FFFF
 
     with pytest.raises(OverflowError):
-        w.colnum = 0xFFFFFFFF
+        w.colnum = 0xFFFF_FFFF
 
     with pytest.raises(TypeError):
         del w.colnum

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -594,32 +594,34 @@ def test_time_1d_values(header_time_1d, scale):
     # scales, and formats.
 
     header_time_1d["CTYPE1"] = scale.upper()
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, scale, "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, scale, "mjd")
 
 
 def test_time_1d_values_gps(header_time_1d):
     # Special treatment for GPS scale
     header_time_1d["CTYPE1"] = "GPS"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + (7 + 19) / 3600 / 24, "tai", "mjd")
+    assert_time_at(
+        header_time_1d, 1, 2_450_003, 0.1 + (7 + 19) / 3600 / 24, "tai", "mjd"
+    )
 
 
 def test_time_1d_values_deprecated(header_time_1d):
     # Deprecated (in FITS) scales
     header_time_1d["CTYPE1"] = "TDT"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, "tt", "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, "tt", "mjd")
     header_time_1d["CTYPE1"] = "IAT"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, "tai", "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, "tai", "mjd")
     header_time_1d["CTYPE1"] = "GMT"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, "utc", "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, "utc", "mjd")
     header_time_1d["CTYPE1"] = "ET"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, "tt", "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, "tt", "mjd")
 
 
 def test_time_1d_values_time(header_time_1d):
     header_time_1d["CTYPE1"] = "TIME"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, "utc", "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, "utc", "mjd")
     header_time_1d["TIMESYS"] = "TAI"
-    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, "tai", "mjd")
+    assert_time_at(header_time_1d, 1, 2_450_003, 0.1 + 7 / 3600 / 24, "tai", "mjd")
 
 
 @pytest.mark.remote_data


### PR DESCRIPTION
### Description

This is a split of #19597 to change only using pep515 on int (more consensual than other proposals). floats can have a lot of reason to not be normalized, whereas no other alternative to make big int easier to read than pep 515 exists.

I evolved the pylint checker accordingly with three messages: bad-float-notation (disabled by default, scientific/engineering/pep615 allowed by default), bad-integer-notation and bad-float-precision instead of the initial bad-float-notation raising for bad-float-precision and with an option to parse int too.

Let me know if you'd rather I split this by subpackages.
