### PR TITLE
Convert UT1 via TAI to fix one-second errors at leap seconds

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -79,22 +79,26 @@ TIME_TYPES = {
     scale: scales for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales
 }
 TIME_SCALES = STANDARD_TIME_SCALES + LOCAL_SCALES
+# Intermediate scales needed for transformations between non-adjacent scales.
+# Note that UT1 is attached to TAI rather than UTC: UT1 - TAI is continuous
+# across leap seconds, while UT1 - UTC and TAI - UTC both jump, so going via
+# UTC is ambiguous right at leap seconds (see gh-13517).
 MULTI_HOPS = {
     ("tai", "tcb"): ("tt", "tdb"),
     ("tai", "tcg"): ("tt",),
-    ("tai", "ut1"): ("utc",),
     ("tai", "tdb"): ("tt",),
     ("tcb", "tcg"): ("tdb", "tt"),
     ("tcb", "tt"): ("tdb",),
-    ("tcb", "ut1"): ("tdb", "tt", "tai", "utc"),
+    ("tcb", "ut1"): ("tdb", "tt", "tai"),
     ("tcb", "utc"): ("tdb", "tt", "tai"),
     ("tcg", "tdb"): ("tt",),
-    ("tcg", "ut1"): ("tt", "tai", "utc"),
+    ("tcg", "ut1"): ("tt", "tai"),
     ("tcg", "utc"): ("tt", "tai"),
-    ("tdb", "ut1"): ("tt", "tai", "utc"),
+    ("tdb", "ut1"): ("tt", "tai"),
     ("tdb", "utc"): ("tt", "tai"),
-    ("tt", "ut1"): ("tai", "utc"),
+    ("tt", "ut1"): ("tai",),
     ("tt", "utc"): ("tai",),
+    ("ut1", "utc"): ("tai",),
 }
 GEOCENTRIC_SCALES = ("tai", "tt", "tcg")
 BARYCENTRIC_SCALES = ("tcb", "tdb")
@@ -796,9 +800,9 @@ class TimeBase(MaskableShapedLikeNDArray):
                 f"Scale {scale!r} is not in the allowed scales {sorted(self.SCALES)}"
             )
 
-        if scale == "utc" or self.scale == "utc":
-            # If doing a transform involving UTC then check that the leap
-            # seconds table is up to date.
+        if {"utc", "ut1"} & {scale, self.scale}:
+            # If doing a transform involving UTC or UT1 (which needs TAI - UTC)
+            # then check that the leap seconds table is up to date.
             _check_leapsec()
 
         # Determine the chain of scale transformations to get from the current
@@ -2548,41 +2552,75 @@ class Time(TimeBase):
         return iers_table.ut1_utc(self.utc, return_status=return_status)
 
     # Property for ERFA DUT arg = UT1 - UTC
-    def _get_delta_ut1_utc(self, jd1=None, jd2=None):
+    def _get_delta_ut1_utc(self):
         """
-        Get ERFA DUT arg = UT1 - UTC.  This getter takes optional jd1 and
-        jd2 args because it gets called that way when converting time scales.
-        If delta_ut1_utc is not yet set, this will interpolate them from the
-        the IERS table.
+        Get ERFA DUT arg = UT1 - UTC.  If delta_ut1_utc has not been set,
+        this interpolates it from the IERS table at the UTC of ``self`` and
+        stores the result.
         """
         # Sec. 4.3.1: the arg DUT is the quantity delta_UT1 = UT1 - UTC in
         # seconds. It is obtained from tables published by the IERS.
         if not hasattr(self, "_delta_ut1_utc"):
-            from astropy.utils.iers import earth_orientation_table
-
-            iers_table = earth_orientation_table.get()
-            # jd1, jd2 are normally set (see above), except if delta_ut1_utc
-            # is access directly; ensure we behave as expected for that case
-            if jd1 is None:
-                self_utc = self.utc
-                jd1, jd2 = self_utc._time.jd1, self_utc._time.jd2
-                scale = "utc"
-            else:
-                scale = self.scale
-            # interpolate UT1-UTC in IERS table
-            delta = iers_table.ut1_utc(jd1, jd2)
-            # if we interpolated using UT1 jds, we may be off by one
-            # second near leap seconds (and very slightly off elsewhere)
-            if scale == "ut1":
-                # calculate UTC using the offset we got; the ERFA routine
-                # is tolerant of leap seconds, so will do this right
-                jd1_utc, jd2_utc = erfa.ut1utc(jd1, jd2, delta.to_value(u.s))
-                # calculate a better estimate using the nearly correct UTC
-                delta = iers_table.ut1_utc(jd1_utc, jd2_utc)
-
-            self._set_delta_ut1_utc(delta)
+            self_utc = self.utc
+            self._set_delta_ut1_utc(
+                self._interpolate_delta_ut1_utc(self_utc._time.jd1, self_utc._time.jd2)
+            )
 
         return self._delta_ut1_utc
+
+    @staticmethod
+    def _interpolate_delta_ut1_utc(utc1, utc2):
+        """Interpolate UT1 - UTC in seconds from the IERS table at the given UTC."""
+        from astropy.utils.iers import earth_orientation_table
+
+        iers_table = earth_orientation_table.get()
+        return iers_table.ut1_utc(utc1, utc2).to_value(u.s)
+
+    # ERFA DTA arg = UT1 - TAI, used in the TAI <-> UT1 scale transformation
+    def _get_delta_ut1_tai(self, jd1, jd2):
+        """
+        Get ERFA DTA arg = UT1 - TAI.  This getter takes jd1 and jd2 args
+        because it gets called that way when converting time scales.  These
+        are in the UT1 scale if ``self.scale`` is ``'ut1'`` and otherwise in
+        the TAI scale (UT1 is an end point of any chain of transformations, so
+        the TAI <-> UT1 step is the first or the last one).
+
+        UT1 - TAI is evaluated as (UT1 - UTC) - (TAI - UTC) with both terms
+        taken at the same UTC.  Since both terms jump by the same amount at a
+        leap second, their difference is continuous, which avoids the
+        leap-second ambiguities of transforming via UTC (see gh-13517).
+
+        If ``delta_ut1_utc`` has been set explicitly, its sign is used to decide
+        whether it is the value from before or after a nearby leap second (see
+        `_get_delta_tai_utc_for_dut1`).  Otherwise, UT1 - UTC is interpolated
+        from the IERS table and the result is stored in ``delta_ut1_utc``.
+        """
+        if hasattr(self, "_delta_ut1_utc"):
+            dut1 = self._delta_ut1_utc
+            if self.scale == "ut1":
+                # UTC up to the labelling of leap seconds, which is all that
+                # is needed to determine TAI - UTC given UT1 - UTC.
+                utc1, utc2 = jd1, jd2 - dut1 / erfa.DAYSEC
+            else:
+                utc1, utc2 = erfa.taiutc(jd1, jd2)
+            return dut1 - _get_delta_tai_utc_for_dut1(utc1, utc2, dut1)
+
+        if self.scale == "ut1":
+            # UTC is not yet known, but since |UT1 - UTC| < 1 s, the UT1 jds
+            # are a good approximation to it for evaluating both offsets (right
+            # at a leap second one may end up on the other side, but the
+            # offsets are then still consistent with each other).  Use the
+            # resulting estimate of UT1 - TAI to get the actual UTC.
+            dta = self._interpolate_delta_ut1_utc(jd1, jd2) - _get_delta_tai_utc(
+                jd1, jd2
+            )
+            utc1, utc2 = erfa.taiutc(*erfa.ut1tai(jd1, jd2, dta))
+        else:
+            utc1, utc2 = erfa.taiutc(jd1, jd2)
+
+        dut1 = self._interpolate_delta_ut1_utc(utc1, utc2)
+        self._set_delta_ut1_utc(dut1)
+        return dut1 - _get_delta_tai_utc(utc1, utc2)
 
     def _set_delta_ut1_utc(self, val):
         del self.cache
@@ -2591,8 +2629,6 @@ class Time(TimeBase):
         val = self._match_shape(val)
         self._delta_ut1_utc = val
 
-    # Note can't use @property because _get_delta_tdb_tt is explicitly
-    # called with the optional jd1 and jd2 args.
     delta_ut1_utc = property(_get_delta_ut1_utc, _set_delta_ut1_utc)
     """UT1 - UTC time scale offset"""
 
@@ -3388,6 +3424,43 @@ class OperandTypeError(TypeError):
             f"Unsupported operand type(s){op_string}: '{type(left).__name__}' "
             f"and '{type(right).__name__}'"
         )
+
+
+def _get_delta_tai_utc(utc1, utc2):
+    """Get TAI - UTC in seconds at the given two-part UTC (quasi-)julian dates."""
+    return erfa.dat(*erfa.jd2cal(utc1, utc2))
+
+
+def _get_delta_tai_utc_for_dut1(utc1, utc2, dut1):
+    """Get TAI - UTC in seconds for given UTC julian dates and UT1 - UTC.
+
+    Near a leap second, TAI - UTC depends on whether ``dut1`` is the value from
+    before or after the leap second.  Like ``erfa.ut1utc``, this uses that a
+    positive leap second increases UT1 - UTC by one second, while |UT1 - UTC|
+    is always less than 0.9 s, so UT1 - UTC is negative before and positive
+    after a positive leap second (and vice versa for a negative one).  Hence,
+    on the day that ends with a leap second, a ``dut1`` with the same sign as
+    the jump in TAI - UTC (or zero) is taken to be the value from after the leap
+    second, and TAI - UTC of the next day is returned.  Conversely, on the day
+    after a leap second, a ``dut1`` with the opposite sign is taken to be the
+    value from before, and TAI - UTC of the previous day is returned.
+
+    The UTC only needs to be approximate to within the labelling of the leap
+    second (e.g., UT1 - dut1 is fine).
+    """
+    iy, im, id, fd = erfa.jd2cal(utc1, utc2)
+    dat = erfa.dat(iy, im, id, fd)
+    dat_prev = erfa.dat(*erfa.jd2cal(utc1 - 1.0, utc2))
+    dat_next = erfa.dat(*erfa.jd2cal(utc1 + 1.0, utc2))
+    # Jumps in TAI - UTC at the start and end of the day (the fractional
+    # changes before 1972 are ignored).
+    ddat_prev = dat - dat_prev
+    ddat_next = dat_next - dat
+    is_after_next = (np.abs(ddat_next) >= 0.5) & (dut1 * ddat_next >= 0)
+    is_before_prev = (np.abs(ddat_prev) >= 0.5) & (dut1 * ddat_prev < 0)
+    dat = np.where(is_after_next, dat_next, dat)
+    dat = np.where(is_before_prev, dat_prev, dat)
+    return dat
 
 
 def _check_leapsec():

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -506,12 +506,7 @@ def test_conversion_never_loses_precision(iers_b, scale1, scale2, jds):
         # consistently; this can cause trouble on day boundaries for UTC to
         # UT1; it is not clear whether this will ever be resolved (and is
         # unlikely ever to matter).
-        # Furthermore, exactly at leap-second boundaries, it is possible to
-        # get the wrong leap-second correction due to rounding errors.
-        # The latter is xfail'd for now, but should be fixed; see gh-13517.
         if "ut1" in (scale1, scale2):
-            if abs(t_scale2 - t2_scale2 - 1 * u.s) < 1 * u.ms:
-                pytest.xfail()
             assume(t.jd > 2441317.5 or t.jd2 < 0.4999999)
         raise
 

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -4,6 +4,7 @@ import functools
 import numpy as np
 import pytest
 
+import astropy.units as u
 from astropy.time import Time
 from astropy.utils.iers import conf as iers_conf
 from astropy.utils.iers import iers  # used in testing
@@ -118,14 +119,113 @@ class TestTimeUT1:
     def test_empty_ut1(self):
         """Testing for a zero-length Time object from UTC to UT1
         when an empty array is passed"""
-        from astropy import units as u
-
         with iers_conf.set_temp("auto_download", False):
             t = Time(["2012-06-30 12:00:00"]) + np.arange(24) * u.hour
             t_empty = t[[]].ut1
             assert isinstance(t_empty, Time)
             assert t_empty.scale == "ut1"
             assert t_empty.size == 0
+
+    @pytest.mark.parametrize(
+        "jd1",
+        [2441498.5, 2456108.5],  # Leap seconds of 1972-07-01 and 2012-07-01
+    )
+    @pytest.mark.parametrize("scale", ["tai", "utc", "tt", "tcb"])
+    def test_ut1_conversion_at_leap_second(self, jd1, scale):
+        """Regression test for gh-13517: right at a leap second, conversion
+        from UT1 (then via UTC) could be off by a second due to rounding."""
+        jd2 = np.array([0.9999999999999999, 1.0, 1.0000000000000002])
+        # Use the bundled IERS-B table, which has data for 1972 as well.
+        with iers.earth_orientation_table.set(iers.IERS_B.open()):
+            t = Time(jd1, jd2, format="jd", scale="ut1")
+            t2 = getattr(t, scale)
+            assert t2[0] < t2[1] < t2[2]
+            assert (t2[2] - t2[0]).sec < 1e-9
+            # Round trip back to UT1.
+            assert np.all(np.abs((t2.ut1 - t).sec) < 1e-9)
+            # And the same for the other direction, i.e., starting with the
+            # other scale, going to UT1 and back (the way back uses the
+            # UT1 - UTC stored in the intermediate UT1 time, which needs care
+            # within the leap second).
+            t3 = Time(jd1, jd2, format="jd", scale=scale)
+            t3_ut1 = t3.ut1
+            assert t3_ut1[0] < t3_ut1[1] < t3_ut1[2]
+            assert (t3_ut1[2] - t3_ut1[0]).sec < 1e-9
+            assert np.all(np.abs((getattr(t3_ut1, scale) - t3).sec) < 1e-9)
+
+    def test_ut1_tai_continuous_across_leap_second(self):
+        """UT1 - TAI is continuous through a leap second, unlike UT1 - UTC
+        and TAI - UTC (gh-13517)."""
+        with iers_conf.set_temp("auto_download", False):
+            t = Time("2012-07-01 00:00:00", scale="ut1") + np.arange(-20, 21) * (
+                0.1 * u.s
+            )
+            tai = t.tai
+            assert np.allclose((tai[1:] - tai[:-1]).sec, 0.1, rtol=0, atol=1e-8)
+            # The leap second is present in UTC (UT1 - UTC is about -0.59 s
+            # before it and +0.41 s after), i.e., UT1 - UTC jumps by 1 s.
+            utc = t.utc
+            assert utc.iso[20] == "2012-06-30 23:59:60.587"
+            assert utc.iso[24] == "2012-06-30 23:59:60.987"
+            assert utc.iso[25] == "2012-07-01 00:00:00.087"
+            assert np.all(utc.delta_ut1_utc[:25] < 0)
+            assert np.all(utc.delta_ut1_utc[25:] > 0)
+            assert np.allclose(
+                utc.delta_ut1_utc[25:] - utc.delta_ut1_utc[24], 1.0, atol=1e-6
+            )
+            assert np.all(np.abs((utc.ut1 - t).sec) < 1e-9)
+
+    def test_ut1_to_utc_explicit_delta_at_leap_second(self):
+        """With an explicitly set delta_ut1_utc, its sign is used to determine
+        whether it is the value from before or after a nearby leap second
+        (like in erfa.ut1utc): a positive leap second increases UT1 - UTC by
+        one second, so UT1 - UTC is negative before and positive after it."""
+        t = Time(
+            ["2012-06-30 23:59:59", "2012-07-01 00:00:00", "2012-07-01 00:00:01"],
+            scale="ut1",
+        )
+        # A non-negative value is the value from after the leap second, i.e.,
+        # UT1 - UTC = -1 before it.
+        t.delta_ut1_utc = 0.0
+        assert np.all(
+            t.utc.iso
+            == [
+                "2012-06-30 23:59:60.000",
+                "2012-07-01 00:00:00.000",
+                "2012-07-01 00:00:01.000",
+            ]
+        )
+        # UT1 - UTC = -0.5 before the leap second and thus +0.5 after it, or,
+        # equivalently, +0.5 after and -0.5 before, so both give the same.
+        expected = [
+            "2012-06-30 23:59:59.500",
+            "2012-06-30 23:59:60.500",
+            "2012-07-01 00:00:00.500",
+        ]
+        t.delta_ut1_utc = -0.5
+        assert np.all(t.utc.iso == expected)
+        t.delta_ut1_utc = 0.5
+        assert np.all(t.utc.iso == expected)
+        # Going to other scales gives consistent results.
+        assert np.all(t.utc.tai.iso == t.tai.iso)
+        assert np.all(t.tai.ut1.iso == t.iso)
+        # UTC in and around the leap second, going to UT1 and back.
+        t_utc = Time(
+            ["2012-06-30 23:59:59.5", "2012-06-30 23:59:60.5", "2012-07-01 00:00:00.5"],
+            scale="utc",
+        )
+        t_utc.delta_ut1_utc = -0.25
+        assert np.all(
+            t_utc.ut1.iso
+            == [
+                "2012-06-30 23:59:59.250",
+                "2012-07-01 00:00:00.250",
+                "2012-07-01 00:00:01.250",
+            ]
+        )
+        assert np.all(t_utc.ut1.utc.iso == t_utc.iso)
+        t_utc.delta_ut1_utc = 0.75  # Same as -0.25 before the leap second.
+        assert np.all(t_utc.ut1.utc.iso == t_utc.iso)
 
     def test_delta_ut1_utc(self):
         """Accessing delta_ut1_utc should try to get it from IERS

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -308,8 +308,15 @@ class IERS(QTable):
         except Exception:
             pass
 
-        mjd = np.floor(jd1 - MJD_ZERO + jd2)
-        utc = jd1 - (MJD_ZERO + mjd) + jd2
+        mjd1 = jd1 - MJD_ZERO
+        mjd = np.floor(mjd1 + jd2)
+        utc = (mjd1 - mjd) + jd2
+        # Right at a day boundary, rounding in the sum above can put mjd one
+        # day off relative to the exact two-part jd; correct for that so that
+        # 0 <= utc < 1 (this matters for consistency with the leap seconds).
+        utc_floor = np.floor(utc)
+        mjd = mjd + utc_floor
+        utc = utc - utc_floor
         return mjd, utc
 
     def ut1_utc(self, jd1, jd2=0.0, return_status=False):

--- a/docs/changes/time/20327.bugfix.rst
+++ b/docs/changes/time/20327.bugfix.rst
@@ -1,0 +1,9 @@
+Fixed a bug where converting a ``Time`` in the ``ut1`` scale to another scale
+could give a result that was off by one second right at a leap second.
+Conversions to and from ``ut1`` now go via ``tai`` rather than ``utc``, using
+UT1 - TAI, which is continuous across leap seconds.  As part of this, an
+explicitly set ``delta_ut1_utc`` is now interpreted consistently in both
+directions near a leap second: as in ``erfa.ut1utc``, on the day ending with a
+positive leap second a non-negative value is taken to be the value from after
+the leap second, and on the day after a negative value is taken to be the value
+from before it.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1113,6 +1113,14 @@ UT1 - UTC and TDB - TT, respectively. As an example::
   >>> t.ut1.iso    # ISO representation of time in UT1 scale
   '2010-01-01 00:00:00.334'
 
+.. note:: A positive leap second increases UT1 - UTC by one second, while
+   |UT1 - UTC| is always less than 0.9 s.  Hence, following ``erfa.ut1utc``, an
+   explicitly set :attr:`~astropy.time.Time.delta_ut1_utc` that is non-negative
+   is taken to be the value from *after* the leap second on the day that ends
+   with a leap second (so that before the leap second UT1 - UTC is one second
+   less), and a negative value on the day after a leap second is taken to be
+   the value from *before* it.
+
 For the UT1 to UTC offset, you have to interpolate the observed values provided
 by the `International Earth Rotation and Reference Systems (IERS) Service
 <https://www.iers.org>`_. ``astropy`` will automatically download and use values


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->
### AI disclosure

This PR was AI-generated using Claude Fable 5.1.

**This is presented as a candidate fix for discussion. I have not fully reviewed or understood the fixes as the details are honestly beyond my abilities.**

@mhvk - it is up to you if you want to verify this fix. I'm OK with closing this and leaving #13517 open.

- [x] I certify that I am human and take responsibility for ~~the code and~~ interactions with reviewers.

### Summary

Converting a `Time` in the `ut1` scale to any other scale can be off by exactly one second when the time falls right at a leap second. Two UT1 times that differ by 10 picoseconds come out a full second apart in TAI, with the later input giving the earlier output. This only bites for a two-part JD whose fractional part rounds across a day boundary, which is why it was only ever caught by `hypothesis`.

```python
>>> Time(2441498.5, 0.9999999999999999, format="jd", scale="ut1").tai.isot
'1972-07-01T00:00:11.192'   # main: one second later than the next line
'1972-07-01T00:00:09.192'   # this branch
>>> Time(2441498.5, 1.0, format="jd", scale="ut1").tai.isot
'1972-07-01T00:00:10.192'   # main
'1972-07-01T00:00:09.192'   # this branch
```

The cause is that all UT1 conversions went through UTC, using `erfa.ut1utc`, which locates the leap-second day by adding whole days to the fractional part of the two-part JD; for a fraction like `0.9999999999999999` that sum rounds to the next day and the leap second is missed. This PR attaches UT1 to TAI instead of UTC in the scale graph and evaluates UT1 - TAI as (UT1 - UTC) - (TAI - UTC) at one consistent UTC, as suggested in the issue. UT1 - TAI is continuous across leap seconds, so no ambiguity arises. Conversions between the other scales are untouched, and conversions to and from UT1 away from leap seconds change at the 10 picosecond level at most.

Fixes #13517.

### Details

<details>
<summary>Click to expand</summary>

**Route all UT1 conversions through TAI, using UT1 - TAI evaluated at a single UTC**

### 1. `erfa.ut1utc` misidentifies the leap-second day for fractions that round

`eraUt1utc` scans `d2 = u2 + i` for `i = -1..3` to find the day on which TAI - UTC changes. With `u2 = 0.9999999999999999`, `u2 + 1` is exactly `2.0` in double precision, so the scan sees July 2 where it should see July 1, concludes the UT1 is before the start of the leap-second day, and skips the ramp that produces ERFA's quasi-JD UTC for that day. The resulting UTC is `1972-07-01T00:00:00.192` instead of `1972-06-30T23:59:60.192`, and `utctai` then adds 11 s instead of 10 s. Passing the normalized two-part JD that `Time` uses internally (`jd1` integer, `|jd2| <= 0.5`) does not help, since `0.4999999999999999 + 1` rounds the same way.

Going via UTC is fragile in principle for this conversion: both UT1 - UTC and TAI - UTC jump at a leap second, and a UT1 instant does not tell you which side of the jump its UTC is on. UT1 - TAI has no jump.

### 2. `IERS.mjd_utc` put times just before midnight into the next day

The IERS table interpolation computed `mjd = floor(jd1 - MJD_ZERO + jd2)` on the rounded single-float sum, so a UTC of `2012-06-30 23:59:59.99999999999` was interpolated in the interval starting at `2012-07-01`, giving the post-leap value of UT1 - UTC while `erfa.jd2cal` on the same two-part JD correctly reports June 30. In the new scheme the two lookups have to agree on the day, otherwise UT1 - TAI is off by one second for the first estimate and the refined UTC lands a second away from the true one, which showed up as a 1 ns non-monotonicity in the converted times.

### 3. A stored `delta_ut1_utc` within the leap second

After `t_utc.ut1`, the result carries the UT1 - UTC that was used, and `.utc` on it converts back with that value fixed. For a UTC inside the leap second the stored value is the pre-leap one, but the UT1 date is already the next day, so a naive `erfa.dat` at the UT1 date gives the post-leap TAI - UTC and the round trip is off by one second. Deciding by comparing `UT1 - delta_ut1_utc` against midnight is not robust either: a UTC of exactly `00:00:00` on the day after a leap second round trips to a picosecond before midnight and flips the day.

The fix follows the convention `erfa.ut1utc` uses: a positive leap second raises UT1 - UTC by one second while |UT1 - UTC| < 0.9 s, so the value is negative before and positive after a positive leap second. On the day that ends with a leap second, a non-negative `delta_ut1_utc` is the post-leap value and the next day's TAI - UTC applies; on the day after, a negative value is the pre-leap value and the previous day's TAI - UTC applies. This is insensitive to rounding on either side of midnight. I checked the convention against the bundled IERS-B table: for all 27 leap seconds in its range the tabulated value is negative on the day before and positive on the day after (the only sign violation is 1972-01-01, a 0.1 s step that the code ignores since only jumps of 0.5 s or more are treated as leap seconds).

### Implementation

`astropy/time/core.py`

- `MULTI_HOPS`: `("tai", "ut1")` is now a direct hop, `("ut1", "utc")` goes via `("tai",)`, and every other route to `ut1` ends in `tai` rather than `tai, utc`.
- `_set_scale`: `_check_leapsec()` now also runs when either scale is `ut1`, since the conversion needs TAI - UTC. Previously a `tai` to `ut1` conversion ran `erfa.utcut1` without this check.
- New `_get_delta_ut1_tai(jd1, jd2)`, picked up by the existing `_get_delta_{sys1}_{sys2}` lookup in `_set_scale`. `jd1`, `jd2` are UT1 if `self.scale == "ut1"` and TAI otherwise, which holds because UT1 is a leaf in the scale graph, so the TAI/UT1 step is always first or last. When `delta_ut1_utc` is set it returns `dut1 - _get_delta_tai_utc_for_dut1(utc, dut1)` with `utc` either `erfa.taiutc(tai)` or `ut1 - dut1`. Otherwise, from TAI it interpolates the IERS table at the exact UTC; from UT1 it first evaluates both offsets at the UT1 jds as approximate UTC (consistent with each other even if on the wrong side of a leap second), converts to TAI and back to UTC, and evaluates both offsets there. The interpolated UT1 - UTC is stored in `delta_ut1_utc` as before.
- `_get_delta_ut1_utc` no longer takes `jd1`, `jd2` (it was only called that way from `_set_scale`, which now uses the UT1 - TAI getter) and no longer calls `erfa.ut1utc`. The interpolation is factored into a `_interpolate_delta_ut1_utc` staticmethod.
- Module-level `_get_delta_tai_utc(utc1, utc2)` (`erfa.dat` at `erfa.jd2cal`) and `_get_delta_tai_utc_for_dut1(utc1, utc2, dut1)` implementing the sign rule from section 3 by comparing `erfa.dat` for the day, the day before and the day after.

`astropy/utils/iers/iers.py`

- `IERS.mjd_utc`: subtract `MJD_ZERO` and the floored MJD from `jd1` before adding `jd2`, then fold `floor(utc)` back into `mjd` so that `0 <= utc < 1`. For inputs away from a day boundary the result is unchanged.

`docs/time/index.rst`: a note under "Transformation Offsets" stating the sign convention for an explicitly set `delta_ut1_utc` near a leap second.

Not changed: `docs/time/time_scale_conversion.png` still draws UT1 attached to UTC through `delta_ut1_utc`, which remains the offset a user supplies.

### Tests

`astropy/time/tests/test_precision.py`: the `pytest.xfail()` for gh-13517 in `test_conversion_never_loses_precision` is removed; the existing `@example(scale1="ut1", scale2="tai", jds=(2441498.5, 0.9999999999999999))` is the case from the issue.

`astropy/time/tests/test_ut1.py`, using the bundled IERS-B table so that 1972 has real data:

- `test_ut1_conversion_at_leap_second`: for the 1972-07-01 and 2012-07-01 leap seconds and each of `tai`, `utc`, `tt`, `tcb`, three UT1 inputs straddling midnight by one ULP convert monotonically, span under 1 ns, and round trip to within 1 ns; the same starting from the other scale, going to UT1 and back (16 cases).
- `test_ut1_tai_continuous_across_leap_second`: 41 UT1 times at 0.1 s steps through the 2012 leap second give TAI steps of 0.1 s to within 1e-8 s, UTC shows `23:59:60.587` and `23:59:60.987` before `00:00:00.087`, and the stored UT1 - UTC jumps by 1 s.
- `test_ut1_to_utc_explicit_delta_at_leap_second`: the sign convention for `delta_ut1_utc` of `0.0`, `-0.5`, `0.5`, `-0.25` and `0.75` on the leap-second day, including that `-0.5` and `+0.5` give identical UTC and that UTC in the leap second round trips through UT1.

The existing `TestERFATestCases.setup_class` in `test_sidereal.py` fakes a 65 s `delta_ut1_utc` at 2006-01-01 assuming `time_ut1.tt` is linear in it across the 2005-12-31 leap second; the sign convention makes this hold, so that file is unchanged.

Beyond the test suite I ran a `hypothesis` script with 4000 examples drawing UT1 or TAI/UTC/TT/TDB/TCB/TCG times on and around every leap-second day in the IERS-B range (including fractions one ULP either side of midnight), checking that ordering is preserved for a 2 ULP step and that the conversion round trips to within 1 ns; it passes on this branch.

```text
$ python -m pytest astropy/time astropy/utils/iers astropy/coordinates docs/time -n 4
3136 passed, 76 skipped, 12 xfailed in 6.49s
```

### Backwards compatibility

No public API changes. `delta_ut1_utc` keeps its meaning and its getter still interpolates the IERS table at the UTC of the time on first access. Conversions not involving `ut1` are untouched. Conversions involving `ut1` with IERS-derived offsets change at the 1e-11 s level away from leap seconds, and by one second only in the cases that were wrong.

For an explicitly set `delta_ut1_utc` the UT1 to UTC direction reproduces what `erfa.ut1utc` gave before on the leap-second day and the day after (it differs from ERFA's 3-day look-ahead on the two days before a leap second, where ERFA also applied the "after" interpretation). The UTC to UT1 direction is the behavior change: on `main` it applied the value literally, so on the day ending with a leap second `delta_ut1_utc = 0` gave UT1 = UTC while the reverse conversion gave UTC = UT1 + 1 s. Now both directions use the same interpretation and are exact inverses, which means UTC to UT1 with a non-negative value on that day is one second earlier than before. Changelog fragment: `docs/changes/time/20327.bugfix.rst`.

</details>
