### PR TITLE
RFC: avoid PDEP-8 deprecation warnings from pandas.DataFrame

### DIFF
--- a/astropy/table/_dataframes.py
+++ b/astropy/table/_dataframes.py
@@ -281,7 +281,7 @@ def to_df(
 
     # Pandas-like index
     if index:
-        df_native.set_index(index, inplace=True, drop=True)
+        df_native = df_native.set_index(index, drop=True)
 
     return df_native
 
@@ -315,7 +315,7 @@ def from_df(
         index_name = str(df.index.name or "index")
         while index_name in df.columns:
             index_name = "_" + index_name + "_"
-        df.reset_index(index_name, inplace=True, drop=False)
+        df = df.reset_index(index_name, drop=False)
 
     # Narwhals layer, must convert to eager
     df_nw = nw.from_native(df)

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -323,7 +323,7 @@ def test_pandas():
 
     df1 = pandas.DataFrame()
     df1["a"] = [1, 2, 3]
-    df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64), inplace=True)
+    df1 = df1.set_index(pandas.DatetimeIndex(INPUT_TIME.datetime64))
 
     ts = TimeSeries.from_pandas(df1)
     assert_equal(ts.time.isot, INPUT_TIME.isot)

--- a/docs/timeseries/pandas.rst
+++ b/docs/timeseries/pandas.rst
@@ -36,7 +36,7 @@ Consider a concise example starting from a :class:`~pandas.DataFrame`:
     >>> df = pandas.DataFrame()
     >>> df['a'] = [1, 2, 3]
     >>> times = np.array(['2015-07-04', '2015-07-05', '2015-07-06'], dtype=np.datetime64)
-    >>> df.set_index(pandas.DatetimeIndex(times), inplace=True)
+    >>> df = df.set_index(pandas.DatetimeIndex(times))
     >>> df
         a
     2015-07-04  1


### PR DESCRIPTION
### Description

Context:
- https://pandas.pydata.org/pdeps/0007-copy-on-write.html#pdep-7-history
- https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html

Quoting the relevant part from PDEP-8 as a rationale
> The inplace parameter will be removed from any method which can never update the underlying values of a pandas object inplace or which alters the shape of the object, and where the inplace=True option is only syntactic sugar for reassigning the result to the calling DataFrame/Series.


Edit: quoting my original, mislead description for posterity
> PDEP-8 explicitly state that `inplace=True` has been unnecessary and without effect since the implementation of PDEP-7, dated back to Nov 2023, while we already only support compat with pandas >=2.2.2.
> While the changelog doesn't contain explicit references to PDEP-7 (or copy-on-write), considering the entire 2.2.x series came out in 2024, it seems safe to assume that this change is purely no-op already.


### AI Disclosure
<!-- REQUIRED -->
None

<!-- REQUIRED -->
- [x] I certify that I am human and that I take full responsibility for this pull request including all interactions with reviewers.

### Merge method
<!-- Optional opt-out -->
- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
