### PR TITLE
Do not split LaTeX table cells on & inside braces or escaped as \&

### DIFF
--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -116,13 +116,6 @@ def _split_outside_braces(line: str, delimiter: str = "&") -> list[str]:
     do not open or close a group and ``\&`` is not a separator.  An unmatched
     ``}`` is ignored rather than driving the nesting depth negative.
     """
-    # Fast path: a plain split is correct unless the delimiter is escaped or
-    # could occur after an opening brace.
-    if "\\" + delimiter not in line:
-        first_brace = line.find("{")
-        if first_brace == -1 or line.find(delimiter, first_brace) == -1:
-            return line.split(delimiter)
-
     vals = []
     start = 0
     depth = 0

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -8,6 +8,7 @@ latex.py:
 :Author: Tom Aldcroft (aldcroft@head.cfa.harvard.edu)
 """
 
+import functools
 import re
 from collections.abc import Generator
 from re import Pattern
@@ -94,17 +95,85 @@ class LatexInputter(core.BaseInputter):
         return [lin.strip() for lin in lines]
 
 
+@functools.cache
+def _latex_split_regex(delimiter: str) -> Pattern[str]:
+    return re.compile(
+        rf"""
+        \\.                       # backslash-escaped char, consumed so it is never
+                                  # seen as a brace or delimiter below
+        | \{{                     # opening brace
+        | \}}                     # closing brace
+        | {re.escape(delimiter)}  # the column delimiter
+        """,
+        re.DOTALL | re.VERBOSE,
+    )
+
+
+def _split_outside_braces(line: str, delimiter: str = "&") -> list[str]:
+    r"""Split ``line`` on ``delimiter`` only where it is outside any ``{...}`` group.
+
+    A character preceded by a backslash is taken literally, so ``\{`` and ``\}``
+    do not open or close a group and ``\&`` is not a separator.  An unmatched
+    ``}`` is ignored rather than driving the nesting depth negative.
+    """
+    # Fast path: a plain split is correct unless the delimiter is escaped or
+    # could occur after an opening brace.
+    if "\\" + delimiter not in line:
+        first_brace = line.find("{")
+        if first_brace == -1 or line.find(delimiter, first_brace) == -1:
+            return line.split(delimiter)
+
+    vals = []
+    start = 0
+    depth = 0
+    for match in _latex_split_regex(delimiter).finditer(line):
+        # regex match: an escaped pair (\&), a brace, or the delimiter
+        text = match[0]
+        if text == "{":
+            depth += 1
+        elif text == "}":
+            depth = max(depth - 1, 0)
+        elif text == delimiter and depth == 0:
+            vals.append(line[start : match.start()])
+            start = match.end()
+    vals.append(line[start:])
+    return vals
+
+
 class LatexSplitter(core.BaseSplitter):
-    """Split LaTeX table data. Default delimiter is `&`."""
+    """Split LaTeX table data. Default delimiter is `&`.
+
+    The delimiter is only recognised outside of ``{...}`` groups and when not
+    escaped as ``\\&``, so a value such as ``\\cite{2013A&A...558A..33A}`` is
+    kept intact.
+    """
 
     delimiter = "&"
 
     def __call__(self, lines: list[str]) -> Generator[list[str], None, None]:
+        # LaTeX does not require a trailing \\ on the last row of a table, but
+        # process_line insists on it, so add one there (after dropping any
+        # trailing comment) before the lines are processed.
         last_line = RE_COMMENT.split(lines[-1])[0].strip()
         if not last_line.endswith(r"\\"):
             lines[-1] = last_line + r"\\"
 
-        return super().__call__(lines)
+        return self._split_lines(lines)
+
+    def _split_lines(self, lines: list[str]) -> Generator[list[str], None, None]:
+        """Split lines for LaTeX tables.
+
+        Same as `core.BaseSplitter.__call__` but split with `_split_outside_braces`.
+        instead of line.split(self.delimiter).
+        """
+        if self.process_line:
+            lines = (self.process_line(x) for x in lines)
+        for line in lines:
+            vals = _split_outside_braces(line, self.delimiter)
+            if self.process_val:
+                yield [self.process_val(x) for x in vals]
+            else:
+                yield vals
 
     def process_line(self, line: str) -> str:
         """Remove whitespace at the beginning or end of line. Also remove
@@ -431,7 +500,9 @@ class AASTexHeaderSplitter(LatexSplitter):
     """
 
     def __call__(self, lines: list[str]) -> Generator[list[str], None, None]:
-        return super(LatexSplitter, self).__call__(lines)
+        # Skip the trailing-\\ handling in LatexSplitter.__call__; a \tablehead
+        # line does not end with \\.
+        return self._split_lines(lines)
 
     def process_line(self, line: str) -> str:
         """extract column names from tablehead."""

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1724,6 +1724,98 @@ def test_aastex_no_trailing_backslash():
     assert np.all(dat["c"] == ["c", "d", "e"])
 
 
+def test_latex_ampersand_in_braces():
+    """
+    Ampersand inside a {...} group is not a column separator (issue #6360).
+    """
+    lines = r"""
+\begin{table}
+\begin{tabular}{ccc}
+First & Second & Ref\\
+1 & 2 & \cite{other_ref}\\
+11 & 22 & \cite{2013A&A...558A..33A}\\
+\end{tabular}
+\end{table}
+"""
+    dat = ascii.read(lines, format="latex")
+    assert dat.colnames == ["First", "Second", "Ref"]
+    assert np.all(dat["First"] == [1, 11])
+    assert np.all(dat["Second"] == [2, 22])
+    assert np.all(dat["Ref"] == [r"\cite{other_ref}", r"\cite{2013A&A...558A..33A}"])
+
+
+def test_latex_ampersand_in_braces_header_and_nested():
+    """
+    Braced ampersand in a header cell, nested braces, and a braced group that
+    spans the whole cell (outer braces are stripped as before).
+    """
+    lines = r"""
+\begin{tabular}{ccc}
+{A & B} & \textbf{\cite{A&B}} & C\\
+1 & \textbf{\cite{X&Y}} & {x & y}\\
+\end{tabular}
+"""
+    dat = ascii.read(lines, format="latex")
+    assert dat.colnames == ["A & B", r"\textbf{\cite{A&B}}", "C"]
+    assert dat[r"\textbf{\cite{A&B}}"][0] == r"\textbf{\cite{X&Y}}"
+    assert dat["C"][0] == "x & y"
+
+
+def test_aastex_ampersand_in_braces():
+    r"""
+    Braced ampersand in an AASTex \colhead{} and in a data cell.
+    """
+    lines = r"""
+\begin{deluxetable}{cc}
+\tablehead{\colhead{\cite{A&B}} & \colhead{Ref}}
+\startdata
+1 & \cite{2013A&A...558A..33A}\\
+\enddata
+\end{deluxetable}
+"""
+    dat = ascii.read(lines, format="aastex")
+    assert dat.colnames == [r"\cite{A&B}", "Ref"]
+    assert dat["Ref"][0] == r"\cite{2013A&A...558A..33A}"
+
+
+def test_latex_escaped_braces_and_ampersand():
+    r"""
+    Escaped \{ and \} do not open or close a group, and escaped \& is not a
+    separator.
+    """
+    lines = r"""
+\begin{tabular}{cc}
+a & b\\
+x \{ & y\\
+\} x & y\\
+x \& y & z\\
+\end{tabular}
+"""
+    dat = ascii.read(lines, format="latex")
+    assert dat.colnames == ["a", "b"]
+    assert np.all(dat["a"] == [r"x \{", r"\} x", r"x \& y"])
+    assert np.all(dat["b"] == ["y", "y", "z"])
+
+
+def test_latex_process_val_none_keeps_ampersand():
+    """
+    With the documented ``process_val`` hook disabled, values are the raw split
+    text with any braced ampersand intact.
+    """
+    lines = r"""
+\begin{tabular}{cc}
+a & b\\
+\cite{A&B} & xy\\
+\end{tabular}
+"""
+    reader = ascii.get_reader(reader_cls=ascii.Latex)
+    reader.data.splitter.process_val = None
+    dat = reader.read(lines)
+    assert dat.colnames == ["a", "b"]
+    assert dat["a"][0] == r"\cite{A&B} "
+    assert dat["b"][0] == " xy"
+
+
 @pytest.mark.parametrize("encoding", ["utf8", "latin1", "cp1252"])
 def test_read_with_encoding(tmp_path, encoding):
     data = {"commented_header": "# à b è \n 1 2 héllo", "csv": "à,b,è\n1,2,héllo"}

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1707,7 +1707,7 @@ a & b & c \\
     assert np.all(dat["c"] == ["c", "e"])
 
 
-def text_aastex_no_trailing_backslash():
+def test_aastex_no_trailing_backslash():
     lines = r"""
 \begin{deluxetable}{ccc}
 \tablehead{\colhead{a} & \colhead{b} & \colhead{c}}
@@ -1720,8 +1720,8 @@ def text_aastex_no_trailing_backslash():
 """
     dat = ascii.read(lines, format="aastex")
     assert dat.colnames == ["a", "b", "c"]
-    assert np.all(dat["a"] == ["1", r"3\%"])
-    assert np.all(dat["c"] == ["c", "e"])
+    assert np.all(dat["a"] == ["1", "2", r"3\%"])
+    assert np.all(dat["c"] == ["c", "d", "e"])
 
 
 @pytest.mark.parametrize("encoding", ["utf8", "latin1", "cp1252"])

--- a/docs/changes/io.ascii/20333.bugfix.rst
+++ b/docs/changes/io.ascii/20333.bugfix.rst
@@ -1,0 +1,4 @@
+The ``latex`` and ``aastex`` readers no longer treat an ampersand inside a
+braced ``{...}`` group or an escaped ``\&`` as a column separator, so tables
+with a reference column such as ``\cite{2013A&A...558A..33A}`` now read
+correctly.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

The `latex` and `aastex` readers split every data line on `&`, with no regard for LaTeX grouping. A cell such as `\cite{2013A&A...558A..33A}`, which is the normal way to reference an A&A paper in a table, therefore yields an extra column and the whole table fails to read. The same happens for a `\&` in a cell, which is how LaTeX writes a literal ampersand.

```python
>>> lines = r"""
... \begin{tabular}{ccc}
... First & Second & Ref\\
... 11 & 22 & \cite{2013A&A...558A..33A}\\
... \end{tabular}
... """
>>> ascii.read(lines, format="latex")["Ref"][0]
InconsistentTableError: Number of header columns (3) inconsistent with data columns (4)   # main
'\\cite{2013A&A...558A..33A}'                                                           # this branch
```

The cause is that `LatexSplitter` inherits the plain `line.split("&")` of `core.BaseSplitter.__call__`. This PR replaces that step with a split that only recognises `&` at brace depth zero and skips any backslash-escaped character, so `\{`, `\}` and `\&` are taken literally. The AASTex `\tablehead{\colhead{...} & ...}` line goes through the same split. The writer is unchanged: it never escaped `&` in values, and a table written with `\cite{A&B}` in a cell now round-trips.

Fixes #6360. Supersedes #20324, whose sentinel-character approach regresses on escaped braces; its test case for the issue example is reused here.

### AI disclosure

This PR includes AI-generated content using Claude Fable 5.1. I have carefully reviewed the content and fully understand the changes in `latex.py` and `test_read.py`.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Split LaTeX table lines on `&` only outside `{...}` groups and only when not escaped**

### 1. Why a sentinel character was not used

The obvious fix (#20324) rewrites a braced `&` to an unused character such as `\x1f` in `process_line`, splits on the remaining `&`, and swaps the sentinel back in `process_val`. Checking that branch against a set of edge cases turned up several problems with any variant of that design:

- `\{` and `\}` are counted as group delimiters, so a row `x \{ & y\\` that reads on `main` raises `InconsistentTableError` on that branch.
- `process_val` is documented in `docs/io/ascii/read.rst` as a hook the user may replace. Setting it to `None` leaks the sentinel into table values.
- `\x1f` is whitespace to `str.strip()`, and `process_val` strips before restoring, so a cell ending in a braced `&` silently loses it.
- Any literal U+001F in the input is rewritten to `&`.
- The AASTex header splitter does not call the masking step, so `\colhead{\cite{A&B}}` still splits.

Doing the brace tracking in the split itself avoids all of these, and leaves `process_line` and `process_val` with their documented meanings.

### 2. Implementation

`astropy/io/ascii/latex.py`:

- New module-level `_split_outside_braces(line, delimiter)`. A cached `re.VERBOSE` pattern with four alternatives (`\\.`, `\{`, `\}`, the escaped delimiter) is iterated with `finditer`. Matching `\\.` as a unit is what makes an escaped brace or ampersand invisible to the other alternatives. Brace depth is tracked and the delimiter only splits at depth zero. An unmatched `}` is clamped at zero rather than going negative; an unmatched `{` swallows the rest of the line, which is malformed input either way.
- `LatexSplitter.__call__` keeps its trailing-`\\` fixup of the last line (now with a comment explaining why it exists) and then calls a new `_split_lines` method, which is the loop body of `core.BaseSplitter.__call__` with the split step replaced.
- `AASTexHeaderSplitter.__call__` previously called `super(LatexSplitter, self).__call__` to bypass the trailing-`\\` fixup. It now calls `_split_lines` directly, so the same bypass is kept and the `\tablehead` line gets the brace-aware split.
- The `LatexSplitter` docstring notes the new behaviour.

`astropy/io/ascii/tests/test_read.py`, five new tests next to `test_latex_no_trailing_backslash`:

- `test_latex_ampersand_in_braces`: the issue example, format `latex`.
- `test_latex_ampersand_in_braces_header_and_nested`: braced `&` in a header cell, nested `\textbf{\cite{A&B}}`, and a cell wrapped entirely in braces (outer braces still stripped by `process_val` as before).
- `test_aastex_ampersand_in_braces`: `\colhead{\cite{A&B}}` in a `\tablehead` and `\cite{...&...}` in a data cell.
- `test_latex_escaped_braces_and_ampersand`: `\{`, `\}` and `\&` in cells are literal.
- `test_latex_process_val_none_keeps_ampersand`: with `process_val = None` the raw split text keeps the braced `&`.

A separate first commit renames `text_aastex_no_trailing_backslash` to `test_aastex_no_trailing_backslash`. The typo meant pytest never collected it, and its expected values covered two of the three data rows. It passes with the corrected expectations.

### 3. Performance

Every line now goes through the regex loop instead of `str.split`. Reading a 100k-row, 3-column table, minimum of three runs on the same machine:

| rows | `main` | this branch |
|---|---|---|
| numeric, no braces | 0.170 s | 0.251 s |
| `3\%` in every row | 0.179 s | 0.266 s |
| `\cite{ref}` in the last column | 0.201 s | 0.305 s |
| `\cite{ref}` in the first column | 0.206 s | 0.313 s |

That is about 1 µs per row. An earlier revision had a `str.split` fast path for lines with no `\&` and no `&` after an opening brace, which kept the first three cases within noise of `main`; it was removed for simplicity, since LaTeX tables are small and reading them is not speed critical.

### 4. Backwards compatibility

No API change. A line with no `\&` and no `&` inside braces splits exactly as before, which covers every table that read correctly on `main`. Tables that previously raised `InconsistentTableError` because of a braced or escaped `&` now read. The one observable change for a table that did read before is a row like `\multicolumn{2}{c}{x & y} & z`, which happened to yield three cells by splitting inside the braces and now correctly yields two; `\multicolumn` is not otherwise supported by the reader.

Changelog fragment: `docs/changes/io.ascii/20333.bugfix.rst`.

### 5. Testing

```text
$ python -m pytest astropy/io/ascii docs/io/ascii -q -n 4
1698 passed, 13 skipped, 2 xfailed in 6.73s
```

`pre-commit run --files` on the changed files is clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
