### PR TITLE
Backport of PR 20265 onto v7.2.x (Merged Fix MaskedColumn TypeError from stale fill_value after dtype-changing ufuncs)

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -9,7 +9,12 @@ import numpy as np
 from numpy import ma
 
 from astropy.units import Quantity, StructuredUnit, Unit
-from astropy.utils.compat import COPY_IF_NEEDED, NUMPY_LT_2_0, NUMPY_LT_2_5
+from astropy.utils.compat import (
+    COPY_IF_NEEDED,
+    NUMPY_LT_2_0,
+    NUMPY_LT_2_5,
+    NUMPY_LT_2_6,
+)
 from astropy.utils.console import color_print
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.metadata import MetaData
@@ -1687,6 +1692,31 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             out.info = self.info
 
         return out
+
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
+        out_arr = super().__array_wrap__(out_arr, context, return_scalar)
+
+        if NUMPY_LT_2_6:
+            # Workaround for a numpy.ma bug, fixed upstream by
+            # https://github.com/numpy/numpy/pull/32423: MaskedArray's
+            # _update_from copied the input's raw `_fill_value` into the
+            # output without checking it was still valid for the output's
+            # dtype.  Mirror the fix numpy made to _update_from here.
+            fill_value = getattr(out_arr, "_fill_value", None)
+            out_dtype = getattr(out_arr, "dtype", None)
+            if (
+                fill_value is not None
+                and out_dtype is not None
+                and out_dtype != self.dtype
+            ):
+                try:
+                    out_arr._fill_value = ma.core._check_fill_value(
+                        fill_value, out_dtype
+                    )
+                except (TypeError, ValueError, OverflowError):
+                    out_arr._fill_value = None
+
+        return out_arr
 
     @property
     def fill_value(self):

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -454,6 +454,25 @@ class TestColumn:
         with pytest.raises(ValueError):
             c1 = c.insert(1, [100, 200], mask=[True, False, True])
 
+    def test_masked_string_ufunc_dtype_change_fill_value(self):
+        """
+        Regression test for a ufunc that changes the dtype of a
+        MaskedColumn (e.g. np.strings.find applied to a string column,
+        which returns an int array).
+        See https://github.com/astropy/astropy/issues/20257
+        """
+        col = table.MaskedColumn(
+            ["foo", "bar", "baz"], mask=False, fill_value="N/A", dtype="U3"
+        )
+        assert col.fill_value == "N/A"
+        assert col.dtype.kind == "U"
+        # The following used to blow up with TypeError
+        result = np.strings.find(col, "foo")
+
+        assert result.fill_value != "N/A"
+        assert result.dtype.kind == "i"
+        assert result[0] == 0  # "foo" is found at index 0
+
     def test_mask_on_non_masked_table(self):
         """
         When table is not masked and trying to set mask on column then

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -467,9 +467,11 @@ class TestColumn:
         assert col.fill_value == "N/A"
         assert col.dtype.kind == "U"
         # The following used to blow up with TypeError
-        result = np.strings.find(col, "foo")
-
-        assert result.fill_value != "N/A"
+        if NUMPY_LT_2_0:
+            result = np.char.find(col, "foo")
+        else:
+            result = np.strings.find(col, "foo")
+            assert result.fill_value != "N/A"
         assert result.dtype.kind == "i"
         assert result[0] == 0  # "foo" is found at index 0
 

--- a/docs/changes/table/20265.bugfix.rst
+++ b/docs/changes/table/20265.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed a bug where a numpy function used on a ``MaskedColumn`` produced output
+with a different dtype than the input (e.g., ``np.strings.find``), which would
+later lead to a ``TypeError`` from a stale ``fill_value`` dtype. Now, when
+the fill_value is no longer valid for the output dtype, fall back to the
+default fill_value for that dtype instead of propagating the stale value.
+This can now raise a castings warnings following standard numpy casting rules.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->

This pull request is to manually backport #20265 onto v7.2.x because auto backport failed.

### AI Disclosure
<!-- REQUIRED -->
*If AI tools were used to develop this pull request, describe the tools, how they were used, and what content is AI generated. Otherwise enter "N/A".*

N/A

<!-- REQUIRED -->
- [x] I certify that I am human and that I take full responsibility for this pull request including all interactions with reviewers.

### Merge method
<!-- Optional opt-out -->
- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
