### PR TITLE
MNT: upgrade zizmor pre-commit hook to 1.30.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
             cextern/expat/lib/xmlparse.c|\
             cextern/wcslib/C/flexed/.*|\
             CHANGES.rst|\
-        )$"
+          )$"
         # Prevent giant files from being committed.
       - id: check-case-conflict
         # Check for files with names that would conflict on a case-insensitive
@@ -59,7 +59,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.29.0
+    rev: v1.30.1
     hooks:
     - id: zizmor
 


### PR DESCRIPTION
### Description
This upgrade is *almost* no-op but not quite, because zizmor 1.30 introduced audits for `.pre-commit-config.yaml`, and current versions choke on ours, supposedly because it slightly violates yaml syntax. I'm fixing this violation in the same PR, and I also reported the "regression" (TBD) upstream at https://github.com/zizmorcore/zizmor/issues/2379

### AI Disclosure
None

<!-- REQUIRED -->
- [x] I certify that I am human and that I take full responsibility for this pull request including all interactions with reviewers.

### Merge method
<!-- Optional opt-out -->
- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
