### PR TITLE
Set Table primary key when copied indices are attached

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1523,6 +1523,13 @@ class Table:
                 else:
                     index_dict[names] = index
 
+        # Columns that were copied from an indexed table carry their indices
+        # along (e.g. ``t[["a", "b"]]`` or ``Table([t["a"]])``), but nothing has
+        # set the primary key yet.  Follow ``add_index()`` and make the first
+        # index the primary one so that ``loc``, ``iloc`` etc. work.
+        if self.primary_key is None and index_dict:
+            self.primary_key = next(iter(index_dict))
+
     def _new_from_slice(self, slice_):
         """Create a new table as a referenced slice from self."""
         table = self.__class__(masked=self.masked)
@@ -2118,6 +2125,10 @@ class Table:
                 out, indices=self.groups._indices, keys=self.groups._keys
             )
             out.meta = self.meta.copy()  # Shallow copy for meta
+            # Keep the primary key if its index survived the slice, otherwise
+            # the first remaining index (if any) has been made primary.
+            if self.primary_key in [index.id for index in out.indices]:
+                out.primary_key = self.primary_key
             return out
         elif (isinstance(item, np.ndarray) and item.size == 0) or (
             isinstance(item, (tuple, list)) and not item

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -1176,3 +1176,38 @@ def test_loc_range_sorted_after_add_row(engine):
     assert t.loc[2:8]["a"].tolist() == [2, 3, 4, 5, 6, 7, 8]
     assert t.loc[2:8]["b"].tolist() == [20, 30, 40, 50, 60, 70, 80]
     assert t.loc[:]["a"].tolist() == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_primary_key_from_copied_indices():
+    """Test that a table built from indexed columns gets a primary key.
+
+    Column slices and ``Table([col])`` copy the indices of the input columns
+    but did not set ``primary_key``, so ``loc``/``iloc`` failed with a
+    TypeError (see #20297).
+    """
+    t = Table({"a": [3, 1, 2], "b": [4, 5, 6]})
+    t.add_index("a")
+
+    t2 = t[["a", "b"]]
+    assert [index.id for index in t2.indices] == [("a",)]
+    assert t2.primary_key == ("a",)
+    assert t2.loc[1]["b"] == 5
+    assert list(t2.iloc[:]["a"]) == [1, 2, 3]
+
+    # No index survives when the indexed column is dropped
+    t3 = t[["b"]]
+    assert len(t3.indices) == 0
+    assert t3.primary_key is None
+
+    t4 = Table([t["a"]])
+    assert t4.primary_key == ("a",)
+    assert t4.loc[2]["a"] == 2
+    assert repr(t4.loc) == f"<TableLoc index_id='a' id(table)={id(t4)}>"
+
+    # A column slice keeps the primary key of the parent table if that index
+    # survived; otherwise the first remaining index becomes primary as in
+    # add_index().
+    t.add_index("b")
+    assert t[["b", "a"]].primary_key == ("a",)
+    assert t[["b"]].primary_key == ("b",)
+    assert Table([t["b"], t["a"]]).primary_key == ("b",)

--- a/docs/changes/table/20362.bugfix.rst
+++ b/docs/changes/table/20362.bugfix.rst
@@ -1,0 +1,5 @@
+A table built from columns that carry an index, such as a column-name slice
+``t[["a", "b"]]`` or ``Table([t["a"]])``, now gets that index as its primary key,
+so that ``loc`` and ``iloc`` work as they do on the original table. As a
+consequence, ``to_pandas`` on such a table uses the primary key column as the
+``DataFrame`` index by default, as it already did for the original table.


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

A `Table` built from columns that already carry an index, most commonly a column-name slice like `t[["a", "b"]]`, keeps the index but has no primary key. Every consumer of `primary_key` then fails on it: `.loc`, `.iloc`, `.loc_indices`, `repr(t.loc)`, and `write(..., write_indices=True)`. The slice looks fully indexed (`t2.indices` is populated), so the failure is surprising and the error message points nowhere useful.

```python
>>> t = Table({"a": [3, 1, 2], "b": [4, 5, 6]})
>>> t.add_index("a")
>>> t2 = t[["a", "b"]]
>>> t2.indices
[<SlicedIndex ...>]                                                 # both: the index is there
>>> t2.primary_key
None                                                                # main
('a',)                                                              # this branch
>>> t2.loc[1]
TypeError: list indices must be integers or slices, not NoneType   # main
<Row index=1> a b -> 1 5                                            # this branch
```

The cause is that `primary_key` is set only by `add_index()`, while `Table.__init__` attaches copied indices to the new columns without ever setting it. This PR sets the primary key where those copied indices are attached, following the same "first index is primary" rule as `add_index()`, and additionally keeps the parent's primary key on a column slice when that index survived the slice. Row slices (`t[1:]`, `t[mask]`) were never affected, since `_new_from_slice` already copies `primary_key`.

This is the `astropy.table` half of the fix for #20297; the `astropy.timeseries` half is #20361. The two are independent and either one alone fixes the `aggregate_downsample` example in that issue.

Related to #20297. Supersedes the `astropy.table` part of #20354.

### AI disclosure

This PR includes AI-generated content using Claude Fable 5.1. I have carefully reviewed the content and fully understand the changes in `astropy/table/table.py` and `astropy/table/tests/test_index.py`.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Set `primary_key` whenever a new `Table` receives copied indices**

### 1. How a table gets indices without a primary key

`col_copy(col, copy_indices=True)` deep-copies a column's `SlicedIndex` objects and re-points them at the new column, so `Table([t["a"]])` and `t[["a", "b"]]` (which goes through the same constructor) produce columns with live, valid indices. `Table._init_from_cols` already walks these to deduplicate index objects shared between columns of a multi-column index, but nothing sets `self.primary_key`, which `Table.__init__` initialised to `None`. Only `add_index()` sets it, and only when the table has no indices yet.

`TableLoc._get_index_id_and_item` uses `self.table.primary_key` as the index id, so `None` reaches `TableIndices.__getitem__`, which falls through to `list.__getitem__(None)`.

### 2. Implementation

`Table._init_from_cols`, after the existing deduplication loop that fills `index_dict` (keyed by index id in column order):

```python
if self.primary_key is None and index_dict:
    self.primary_key = next(iter(index_dict))
```

The first index in column order becomes primary, matching `add_index()`. This covers `Table([indexed_col])`, `QTable(table_with_indices)`, and any other constructor path that copies indices. When the input is a `Table`, `__init__` has already copied `data.primary_key`, so this only fills in a missing key and never overrides one.

`Table.__getitem__`, in the list-of-column-names branch:

```python
if self.primary_key in [index.id for index in out.indices]:
    out.primary_key = self.primary_key
```

A reordered slice such as `t[["b", "a"]]` on a table with indices on both columns would otherwise get `("b",)` from the rule above; this keeps the parent's `("a",)`. The membership test against the slice's actual indices means a stale key (one whose index was dropped by the slice, or one left behind by `remove_indices`, see below) is never propagated. `None in [...]` is `False`, so an unindexed parent is unaffected.

### 3. Things deliberately left alone

- A multi-column index whose other column is dropped by the slice (`t.add_index(["a", "b"]); t[["a", "c"]]`) now becomes the primary key. `.loc[1]` on it raises `IndexError: tuple index out of range`, but the unsliced `t.loc[1]` raises the identical error for a composite index, so this is consistent rather than a regression. Filtering such indices out would be a separate policy change.
- `Table.remove_indices` promises in its docstring to reassign the primary key when the primary index is removed but never does, leaving a stale key. That is pre-existing and not touched here; the `__getitem__` guard above just avoids spreading it.
- `Table(t, copy_indices=False)` already gives a table with a `primary_key` but no indices. Unchanged.

### 4. Tests

`test_index.py::test_primary_key_from_copied_indices` (fails on `main`, passes here) checks: `t[["a", "b"]]` has one index and `primary_key == ("a",)` with working `.loc` and `.iloc`; `t[["b"]]` has no index and no key; `Table([t["a"]])` has a working `.loc` and `repr(t4.loc)` no longer raises; with a second index on `b`, `t[["b", "a"]]` keeps `("a",)`, `t[["b"]]` gets `("b",)`, and `Table([t["b"], t["a"]])` gets `("b",)`.

`python -m pytest astropy/table/tests/test_index.py astropy/table/tests/test_df.py docs/table/indexing.rst` on this branch: `710 passed, 56 skipped`. The full `astropy/table`, `astropy/io/misc` and ECSV suites were run with this change applied together with #20361 (`6949 passed, 89 skipped, 23 xfailed`), not separately. `pre-commit run --files` on all changed files passes.

### 5. Backwards compatibility

No API change, but one visible behavior change: `to_pandas()` (and `to_df()`) use a single-column primary key as the `DataFrame` index by default, so `t[["a", "b"]].to_pandas()` now returns a frame indexed by `a` with only `b` as a column, where on `main` `a` stayed a regular column with a `RangeIndex`. That is what the unsliced `t.to_pandas()` already did, and `to_pandas(index=False)` restores the old output. Tables without indices, row slices, and tables built through `add_index()` are bit-for-bit unchanged.

Changelog fragment: `docs/changes/table/20362.bugfix.rst`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
