### PR TITLE
Split (N, pixel_n_dim) inputs in WCS.pixel_to_world

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -110,7 +110,8 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         as-is (not in a tuple/list), otherwise a tuple of high-level objects is
         returned. See
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_to_world_values` for pixel
-        indexing and ordering conventions.
+        indexing and ordering conventions. A single ``(N, pixel_n_dim)`` array
+        is split into one array per pixel axis before the conversion.
         """
 
     def array_index_to_world(self, *index_arrays):
@@ -417,6 +418,14 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
     def pixel_to_world(self, *pixel_arrays):
         values, masks = MaskedNDArray._get_data_and_masks(pixel_arrays)
+        # A single (N, pixel_n_dim) array is the low-level pix2world layout.
+        # Split it into one array per axis so values_to_high_level_objects
+        # receives world axes, not rows (#19230).
+        if len(values) == 1:
+            arr = np.asanyarray(values[0])
+            nax = self.low_level_wcs.pixel_n_dim
+            if arr.ndim == 2 and arr.shape[-1] == nax:
+                values = tuple(np.moveaxis(arr, -1, 0))
         # Compute the world coordinate values
         world_values = self.low_level_wcs.pixel_to_world_values(*values)
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -1672,6 +1672,18 @@ def test_array_index_conversions_scalars_2d():
     assert isinstance(y, np.ndarray) and y.ndim == 0
 
 
+def test_pixel_to_world_accepts_nxndim_array():
+    # Regression for #19230: a single (N, pixel_n_dim) array must match
+    # passing one 1-D array per axis, not feed rows into SkyCoord.
+    wcs = WCS_SIMPLE_CELESTIAL
+    xy = np.array([[30.0, 40.0], [30.0, 40.0], [30.0, 40.0]])
+    split = wcs.pixel_to_world(xy[:, 0], xy[:, 1])
+    stacked = wcs.pixel_to_world(xy)
+    assert stacked.shape == split.shape
+    assert_allclose(stacked.ra.deg, split.ra.deg)
+    assert_allclose(stacked.dec.deg, split.dec.deg)
+
+
 class TestMaskedData:
     wcs = WCS_SIMPLE_CELESTIAL
 

--- a/docs/changes/wcs/20363.bugfix.rst
+++ b/docs/changes/wcs/20363.bugfix.rst
@@ -1,0 +1,4 @@
+``WCS.pixel_to_world`` now accepts a single ``(N, pixel_n_dim)`` pixel
+array and splits it into one array per axis, matching
+``pixel_to_world_values``. Previously those stacked inputs were unpacked
+as rows and a celestial WCS could raise in ``Latitude``.


### PR DESCRIPTION
## Description

`WCS.pixel_to_world` already accepts one array per pixel axis. Passing a single `(N, pixel_n_dim)` array (the layout `pixel_to_world_values` uses) was forwarded unchanged, so `values_to_high_level_objects` treated **rows** as world axes. For a 2D RA/Dec WCS that feeds Latitude a mixed `[ra, dec]` vector and raises.

This splits a unique 2-D array whose last axis is `pixel_n_dim` into one array per axis before the low-level transform. The documented `pixel_to_world(x, y)` path is unchanged.

Fixes #19230.

## Test plan

- [x] Local reproduction on astropy 8.0.1 with a TAN WCS: `pixel_to_world(np.zeros((5, 2)))` raised; after the split it matches `pixel_to_world(xy[:,0], xy[:,1])`.
- [x] New regression test `test_pixel_to_world_accepts_nxndim_array` on `WCS_SIMPLE_CELESTIAL`.
- [ ] CI `astropy/wcs/wcsapi/tests/test_fitswcs.py`.