### PR TITLE
Fix ECSV reading with names, include_names or exclude_names for mixin columns

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1467,15 +1467,25 @@ class BaseReader(metaclass=MetaBaseReader):
         if hasattr(self.header, "table_meta"):
             self.meta["table"].update(self.header.table_meta)
 
-        _apply_include_exclude_names(
-            self.header, self.names, self.include_names, self.exclude_names
-        )
+        self._filter_header_cols()
         self.data.masks(cols)
 
         table = self.outputter(self.header.cols, self.meta)
         self.cols = self.header.cols
 
         return table
+
+    def _filter_header_cols(self) -> None:
+        """
+        Apply ``names``, ``include_names`` and ``exclude_names`` to ``self.header``.
+
+        This is a hook that format-specific readers can override when the column
+        names in the file differ from the column names in the output table (e.g.
+        ECSV files with serialized mixin columns).
+        """
+        _apply_include_exclude_names(
+            self.header, self.names, self.include_names, self.exclude_names
+        )
 
     def inconsistent_handler(self, str_vals: list[str], ncols: int) -> list[str]:
         """

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -154,6 +154,12 @@ class EcsvHeader(basic.BasicHeader):
         in get_cols() for this reader.
         """
 
+    def check_column_names(self, names, strict_names, guessing):
+        # Not applicable to ECSV since the format has a well-defined header, and
+        # ``names`` applies to the output table columns which differ from the
+        # file columns for mixin columns. See ``Ecsv.read()``.
+        pass
+
     def get_cols(self, lines):
         """
         READ: Initialize the header Column objects from the table ``lines``.
@@ -548,6 +554,28 @@ class Ecsv(basic.Basic):
     outputter_class = EcsvOutputter
 
     max_ndim = None  # No limit on column dimensionality
+
+    def _filter_header_cols(self):
+        # ``names``, ``include_names`` and ``exclude_names`` all apply to the
+        # output table columns, so nothing is done here (see ``read()``).
+        pass
+
+    def read(self, table):
+        out = super().read(table)
+
+        # Mixin columns are stored in the file as one or more data columns (e.g.
+        # ``tm.jd1`` and ``tm.jd2`` for a Time column ``tm``), so ``names``,
+        # ``include_names`` and ``exclude_names`` are applied to the output table
+        # after the mixin columns are constructed (see gh-12237).
+        if self.names is not None and len(self.names) != len(out.colnames):
+            raise core.InconsistentTableError(
+                f"Length of names argument ({len(self.names)}) does not match "
+                f"number of table columns ({len(out.colnames)})"
+            )
+        core._apply_include_exclude_names(
+            out, self.names, self.include_names, self.exclude_names
+        )
+        return out
 
     def update_table_data(self, table):
         """

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -606,6 +606,63 @@ def test_ecsv_mixins_per_column(table_cls, name_col, ndim, format_engine):
         assert t2[name]._time.jd2.__class__ is np.ndarray
 
 
+def test_ecsv_include_exclude_names_time_jd1_jd2():
+    """Exact scenario from gh-12237: Time columns serialized as jd1/jd2."""
+    t = Table()
+    t["a"] = Time([1, 2], format="cxcsec")
+    t["b"] = Time([3, 4], format="cxcsec")
+    out = StringIO()
+    t.write(out, format="ascii.ecsv", serialize_method="jd1_jd2")
+    txt = out.getvalue()
+
+    t2 = Table.read(txt, format="ascii.ecsv", include_names=["a"])
+    assert t2.colnames == ["a"]
+    assert isinstance(t2["a"], Time)
+    assert_array_equal(t2["a"].jd, t["a"].jd)
+
+    t2 = Table.read(txt, format="ascii.ecsv", exclude_names=["a"])
+    assert t2.colnames == ["b"]
+    assert isinstance(t2["b"], Time)
+    assert_array_equal(t2["b"].jd, t["b"].jd)
+
+
+def test_ecsv_names_refer_to_output_columns():
+    """The names, include_names and exclude_names refer to output table columns.
+
+    The data column names in the file for a mixin column (e.g. ``a.jd1``) are not
+    output column names and so are ignored for ``include_names`` and
+    ``exclude_names``, and ``names`` renames the output columns.
+    """
+    t = Table()
+    t["a"] = Time([1, 2], format="cxcsec")
+    t["b"] = [3, 4]
+    out = StringIO()
+    t.write(out, format="ascii.ecsv", serialize_method="jd1_jd2")
+    txt = out.getvalue()
+
+    t2 = Table.read(txt, format="ascii.ecsv", include_names=["a.jd1", "b"])
+    assert t2.colnames == ["b"]
+
+    t2 = Table.read(txt, format="ascii.ecsv", exclude_names=["a.jd2"])
+    assert t2.colnames == ["a", "b"]
+    assert isinstance(t2["a"], Time)
+
+    t2 = Table.read(txt, format="ascii.ecsv", names=["x", "y"])
+    assert t2.colnames == ["x", "y"]
+    assert isinstance(t2["x"], Time)
+    assert_array_equal(t2["x"].jd, t["a"].jd)
+
+    t2 = Table.read(txt, format="ascii.ecsv", names=["x", "y"], include_names=["y"])
+    assert t2.colnames == ["y"]
+
+    with pytest.raises(
+        ascii.InconsistentTableError,
+        match=r"Length of names argument \(3\) does not match number of table "
+        r"columns \(2\)",
+    ):
+        Table.read(txt, format="ascii.ecsv", names=["x", "y", "z"])
+
+
 def test_round_trip_masked_table_default(tmp_path):
     """Test (mostly) round-trip of MaskedColumn through ECSV using default serialization
     that uses an empty string "" to mark NULL values.  Note:

--- a/docs/changes/io.ascii/20366.bugfix.rst
+++ b/docs/changes/io.ascii/20366.bugfix.rst
@@ -1,0 +1,5 @@
+Reading an ECSV file with ``names``, ``include_names`` or ``exclude_names`` using the
+``io.ascii`` reader now works for mixin columns (e.g. ``Time`` or ``SkyCoord``). These
+arguments now refer to the column names in the output table. Previously naming such a
+column raised ``ValueError`` for ``names`` and ``include_names`` and had no effect for
+``exclude_names``.

--- a/docs/io/ascii/ecsv.rst
+++ b/docs/io/ascii/ecsv.rst
@@ -60,6 +60,11 @@ Apart from the delimiter, the only other applicable write arguments are
 ``names``, ``include_names``, and ``exclude_names``. All other arguments will be
 either ignored or raise an error.
 
+When reading, ``names``, ``include_names`` and ``exclude_names`` refer to the
+column names in the output table. A mixin column such as a `~astropy.time.Time`
+column ``tm`` that is stored in the file as multiple data columns (``tm.jd1`` and
+``tm.jd2``) is renamed, selected or excluded as the single column ``tm``.
+
 Simple Table
 ------------
 ..


### PR DESCRIPTION
<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

### Summary

Reading an ECSV file with `include_names` or `exclude_names` does not work for mixin columns such as `Time` or `SkyCoord`. These are stored in the file as several plain data columns (a `Time` column `a` becomes `a.jd1` and `a.jd2`) and are only combined back into one column at the end of the read.

```python
>>> t = Table({"a": Time([1, 2], format="cxcsec"), "b": Time([3, 4], format="cxcsec")})
>>> t.write("t.ecsv", serialize_method="jd1_jd2")
>>> Table.read("t.ecsv", include_names=["a"]).colnames
ValueError: 'a.jd1' is not in list    # main
['a']                                 # this branch
>>> Table.read("t.ecsv", exclude_names=["a"]).colnames
['a', 'b']                            # main: no effect
['b']                                 # this branch
>>> Table.read("t.ecsv", names=["x", "y"]).colnames
InconsistentTableError: Length of names argument (2) does not match number of table columns (3)    # main
['x', 'y']                            # this branch
```

This PR makes the ECSV reader apply `names`, `include_names` and `exclude_names` to the finished output table, after the mixin columns are constructed, instead of to the header columns. All three arguments now refer to the column names in the output table. No other `io.ascii` format is affected. The separate `format="ecsv"` reader in `astropy.io.misc.ecsv` does not accept these arguments at all and is not touched.

The approach in this PR does have a memory cost of temporarily creating new mixin columns that might not end up in the table. I think this is acceptable given that the code change ends up being considerably simpler than the alternatives e.g. #20334.

Fixes #12237.

### AI disclosure

This PR includes AI-generated content using Claude Fable 5.1. I have carefully reviewed the content and fully understand the changes in `core.py`, `ecsv.py`, `test_ecsv.py` and the docs.

- [x] I certify that I am human and take responsibility for the code and interactions with reviewers.

### Details

<details>
<summary>Click to expand</summary>

**Filter ECSV output columns after mixin construction rather than filtering file columns in the header**

### 1. Why the header-stage filtering cannot work for ECSV

`BaseReader.read()` in `core.py` applies `names`, `include_names` and `exclude_names` to `self.header` after the data lines are collected and before the outputter converts them to a `Table`. For every other format the header columns and the output columns are the same thing, so this is the right place and it also avoids converting columns that will be discarded.

For ECSV, the outputter runs `serialize._construct_mixins_from_columns()` afterwards, which uses the `__serialized_columns__` block in the table meta to pull columns like `a.jd1` and `a.jd2` out of the table and replace them with a single `Time` column `a`. The user-facing name `a` never exists at the header stage, and removing any of its data columns there makes the reconstruction fail with `ValueError: 'a.jd1' is not in list`. The `names` argument hit a related check: `BaseHeader.check_column_names()` requires `len(names)` to equal the number of file columns, which for a table with mixins is larger than the number of output columns.

### 2. Implementation

`astropy/io/ascii/core.py`

- `BaseReader.read()`: the direct call to `_apply_include_exclude_names(self.header, ...)` is replaced by `self._filter_header_cols()`.
- New `BaseReader._filter_header_cols()`: contains exactly that call. It exists only as an override point; the behaviour of every reader that does not override it is unchanged.

`astropy/io/ascii/ecsv.py`

- `EcsvHeader.check_column_names()`: now a no-op. The strict-name and guessing checks in the base method are for formats whose header has to be inferred, which does not apply to ECSV, and the `names` length check moves to `Ecsv.read()`.
- `Ecsv._filter_header_cols()`: now a no-op, so all file columns reach the outputter.
- New `Ecsv.read()`: calls the base `read()` to get the full output table with mixins constructed, checks that `len(names)` matches the number of output columns (raising the same `InconsistentTableError` with the same message as the base class), then calls the existing `core._apply_include_exclude_names()` on the output table. That function already accepts a `Table` because the write path uses it this way, so no new filtering code is needed.

The cost of this approach is that an excluded mixin column is constructed and then dropped, so a read with `exclude_names` briefly holds the full table in memory. An earlier version of this branch instead expanded each mixin name into its serialized data column names by walking the `__serialized_columns__` structure and rewrote the meta afterwards. That kept the header-stage filtering but needed about 60 lines of ECSV-specific logic; it was replaced by the current approach to keep the code simple.

### 3. Tests

Two tests added to `astropy/io/ascii/tests/test_ecsv.py`:

- `test_ecsv_include_exclude_names_time_jd1_jd2`: the exact scenario from the issue, checking that `include_names` and `exclude_names` select and drop a `Time` column serialized as `jd1`/`jd2` and that the surviving column round-trips exactly.
- `test_ecsv_names_refer_to_output_columns`: file-level names such as `a.jd1` are ignored by `include_names` and `exclude_names`; `names` renames the output columns; `names` combined with `include_names` works; a `names` list of the wrong length raises `InconsistentTableError` with the output column count.

Run from the branch:

```text
$ python -m pytest astropy/io/ascii astropy/table/tests/test_mixin.py docs/io/ascii/ecsv.rst -n 4
1934 passed, 19 skipped, 2 xfailed in 8.09s
```

`pre-commit run --files` on the changed files passes.

### 4. Backwards compatibility

For ECSV files without mixin columns nothing changes: the file columns are the output columns, so filtering them after the read gives the same table as filtering them before.

For ECSV files with mixin columns, `include_names` and `exclude_names` previously either raised or had no effect when given a mixin name, so any code that worked before keeps working. The one behaviour change is for `names`: it previously had to be sized to the number of file columns, and could only succeed if it left every serialized data column name unchanged (for example `names=["a.jd1", "a.jd2", "e"]` to rename a plain column `d` next to a `Time` column `a`). That form now raises `InconsistentTableError` because `names` must be sized to the output columns, and the equivalent call is `names=["a", "e"]`.

Readers for every other `io.ascii` format are unchanged. The `format="ecsv"` reader in `astropy.io.misc.ecsv` does not take these arguments and is out of scope here.

A short paragraph in `docs/io/ascii/ecsv.rst` documents that the three arguments refer to output table columns. Changelog fragment: `docs/changes/io.ascii/20366.bugfix.rst`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
