### PR TITLE
Fix silent rescaling of scaled CompImageHDU data on header-only update

### DIFF
--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -579,6 +579,30 @@ class CompImageHDU(ImageHDU):
                 BITPIX2DTYPE[self._orig_bitpix], blank=self._orig_blank
             )
 
+        # The image header is about to be copied into the binary table by
+        # _get_bintable_without_data().  Accessing .data returns the array
+        # already scaled and, as a side effect, strips BSCALE/BZERO from the
+        # image header -- correct bookkeeping, but it happens *after* the copy
+        # when the data was not loaded yet, leaving a stale BSCALE in the table
+        # header that is applied a second time on the next read.  That silently
+        # corrupts the data on every mode="update" that only touches the
+        # header, and does so cumulatively.
+        #
+        # Load the data now, and restore the integer representation the file
+        # was written with, so that the on-disk form is preserved as well as
+        # the values.  _add_data_to_bintable() loads the data anyway.
+        if self._bintable is not None and not self._data_loaded:
+            bscale, bzero = self._orig_bscale, self._orig_bzero
+            bitpix, blank = self._orig_bitpix, self._orig_blank
+            self.data
+            if self._data_loaded and self.data is not None and (
+                bscale not in (None, 1) or bzero not in (None, 0)
+            ):
+                self._scale_internal(
+                    BITPIX2DTYPE[bitpix], bscale=bscale, bzero=bzero,
+                    blank=blank,
+                )
+
         self._tmp_bintable = self._get_bintable_without_data()
 
         self._add_data_to_bintable(self._tmp_bintable)

--- a/astropy/io/fits/hdu/compressed/compressed.py
+++ b/astropy/io/fits/hdu/compressed/compressed.py
@@ -24,6 +24,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from .header import (
     _bintable_header_to_image_header,
     _image_header_to_empty_bintable,
+    _update_bintable_header_from_image_header,
 )
 from .section import CompImageSection
 from .settings import (
@@ -565,14 +566,25 @@ class CompImageHDU(ImageHDU):
         bintable.data = data
 
     def _prewriteto(self, inplace=False):
-        if (
-            self._bintable is not None
-            and not self._has_data
-            and not self.header._modified
-        ):
-            self._tmp_bintable = self._bintable
-            self._tmp_bintable._output_checksum = self._output_checksum
-            return self._tmp_bintable._prewriteto(inplace=inplace)
+        if self._bintable is not None and not self._has_data:
+            # The data was never loaded, so it cannot have changed: the stored
+            # binary table can be reused as-is, and a header-only change is
+            # propagated card by card into the table header.  This avoids the
+            # decompression + recompression cycle, which is not only wasted
+            # work: with scaled integer data it corrupted the values (the
+            # stale-BSCALE ordering problem described below), and with
+            # quantized floating-point data it would requantize the data at
+            # every header-only update.  If a change involves a structural or
+            # translated keyword the propagation refuses, and we fall through
+            # to the full rebuild below.
+            if not self.header._modified or (
+                _update_bintable_header_from_image_header(
+                    self.header, self._bintable.header
+                )
+            ):
+                self._tmp_bintable = self._bintable
+                self._tmp_bintable._output_checksum = self._output_checksum
+                return self._tmp_bintable._prewriteto(inplace=inplace)
 
         if self._scale_back:
             self._scale_internal(
@@ -584,22 +596,26 @@ class CompImageHDU(ImageHDU):
         # already scaled and, as a side effect, strips BSCALE/BZERO from the
         # image header -- correct bookkeeping, but it happens *after* the copy
         # when the data was not loaded yet, leaving a stale BSCALE in the table
-        # header that is applied a second time on the next read.  That silently
-        # corrupts the data on every mode="update" that only touches the
-        # header, and does so cumulatively.
-        #
-        # Load the data now, and restore the integer representation the file
-        # was written with, so that the on-disk form is preserved as well as
-        # the values.  _add_data_to_bintable() loads the data anyway.
-        if self._bintable is not None and not self._data_loaded:
+        # header that is applied a second time on the next read.  Load the
+        # data now, and restore the integer representation the file was
+        # written with, so that both the values and the on-disk form are
+        # preserved.  _add_data_to_bintable() loads the data anyway.  With
+        # do_not_scale_image_data the data is loaded raw and the header is
+        # left alone, so there is nothing to restore.
+        if (
+            self._bintable is not None
+            and not self._data_loaded
+            and not self._do_not_scale_image_data
+        ):
             bscale, bzero = self._orig_bscale, self._orig_bzero
             bitpix, blank = self._orig_bitpix, self._orig_blank
-            self.data
-            if self._data_loaded and self.data is not None and (
+            if self.data is not None and (
                 bscale not in (None, 1) or bzero not in (None, 0)
             ):
                 self._scale_internal(
-                    BITPIX2DTYPE[bitpix], bscale=bscale, bzero=bzero,
+                    BITPIX2DTYPE[bitpix],
+                    bscale=bscale,
+                    bzero=bzero,
                     blank=blank,
                 )
 

--- a/astropy/io/fits/hdu/compressed/header.py
+++ b/astropy/io/fits/hdu/compressed/header.py
@@ -29,6 +29,7 @@ __all__ = [
     "CompImageHeader",
     "_bintable_header_to_image_header",
     "_image_header_to_empty_bintable",
+    "_update_bintable_header_from_image_header",
 ]
 
 ZDEF_RE = re.compile(r"(?P<label>^[Zz][a-zA-Z]*)(?P<num>[1-9][0-9 ]*$)?")
@@ -235,6 +236,159 @@ def _bintable_header_to_image_header(bintable_header):
         image_header.append()
 
     return image_header
+
+
+def _update_bintable_header_from_image_header(image_header, bintable_header):
+    """
+    Propagate header-only changes from ``image_header`` to the header of an
+    existing compressed binary table, without touching the compressed data.
+
+    ``image_header`` is the header the user sees and may have modified; the
+    unmodified baseline is recomputed from ``bintable_header`` with
+    ``_bintable_header_to_image_header``, which is the same translation that
+    produced the image header when the HDU was read in.  The differences are
+    then applied to ``bintable_header`` in place.
+
+    Returns `True` if every difference could be propagated.  Returns `False`,
+    leaving ``bintable_header`` unchanged, if a difference involves a keyword
+    that is structural, translated (e.g. ``BITPIX`` -> ``ZBITPIX``) or
+    otherwise tied to the compressed data: in that case the caller has to
+    rebuild the binary table, recompressing the data.
+
+    Added cards are inserted after the counterpart of the card they follow in
+    the image header, so that their position survives the round trip back to
+    an image header.
+    """
+    original = _bintable_header_to_image_header(bintable_header)
+
+    # Regular (non-commentary, non-blank) cards, by keyword.  A duplicated
+    # regular keyword has no reliable one-to-one diff, so refuse.
+    def _regular_cards(header):
+        cards = {}
+        for card in header.cards:
+            if card.keyword in ("", "COMMENT", "HISTORY"):
+                continue
+            if card.keyword in cards:
+                return None
+            cards[card.keyword] = card
+        return cards
+
+    new_cards = _regular_cards(image_header)
+    old_cards = _regular_cards(original)
+    if new_cards is None or old_cards is None:
+        return False
+
+    def _propagatable(keyword):
+        # CHECKSUM/DATASUM are owned by the checksum machinery at write time
+        # and are never propagated (nor a reason to refuse).  BLANK is tied
+        # to the compressed representation through ZBLANK, so a change to it
+        # requires a rebuild, as do the translated and reserved keywords.
+        return not (
+            _is_reserved_keyword(keyword)
+            or keyword in REMAPPED_KEYWORDS
+            or keyword == "BLANK"
+            or re.match(r"NAXIS[0-9]*$", keyword)
+        )
+
+    changes = {}
+    deletions = []
+
+    for keyword, card in new_cards.items():
+        old = old_cards.pop(keyword, None)
+        if old is not None and old.value == card.value and old.comment == card.comment:
+            continue
+        if keyword in ("CHECKSUM", "DATASUM"):
+            continue
+        if not _propagatable(keyword):
+            return False
+        changes[keyword] = (card.value, card.comment, old is None)
+
+    for keyword in old_cards:
+        if keyword in ("CHECKSUM", "DATASUM"):
+            continue
+        if not _propagatable(keyword):
+            return False
+        deletions.append(keyword)
+
+    # Commentary cards are compared as ordered value lists and, when they
+    # differ, replaced wholesale.  Blank cards are synchronized in _writeto.
+    commentary = []
+    for keyword in ("COMMENT", "HISTORY"):
+        new_values = list(image_header[keyword]) if keyword in image_header else []
+        old_values = list(original[keyword]) if keyword in original else []
+        if new_values != old_values:
+            commentary.append((keyword, new_values))
+
+    # Nothing vetoed the propagation: apply it.  Deletions and wholesale
+    # commentary removals first, then a single forward walk over the image
+    # header that changes cards in place and inserts added and commentary
+    # cards right after the counterpart of the card they follow, so that
+    # their position survives the round trip back to an image header.  The
+    # insertions use the useblanks default, consuming the trailing padding:
+    # inserting *after* it (e.g. with append(..., end=True)) would turn the
+    # padding into interior blank cards and grow the header spuriously once
+    # _writeto restores the padding to the image header count.
+    for keyword in deletions:
+        del bintable_header[keyword]
+
+    redo_commentary = {keyword for keyword, _ in commentary}
+    for keyword in redo_commentary:
+        if keyword in bintable_header:
+            del bintable_header[keyword]
+
+    position = None
+
+    def _position_before_next_anchor():
+        # No verbatim card precedes the one being inserted in the image
+        # header, so insert before the counterpart of the first verbatim
+        # card instead; `None` if there is none at all.
+        for other in image_header.cards:
+            if (
+                other.keyword not in ("", "COMMENT", "HISTORY", "CHECKSUM", "DATASUM")
+                and _propagatable(other.keyword)
+                and other.keyword in bintable_header
+            ):
+                return bintable_header.index(other.keyword)
+        return None
+
+    for card in image_header.cards:
+        keyword = card.keyword
+
+        if keyword == "" or keyword in ("CHECKSUM", "DATASUM"):
+            # Blank cards are synchronized in _writeto; the checksum cards
+            # are owned by the checksum machinery.
+            continue
+
+        if keyword in ("COMMENT", "HISTORY"):
+            if keyword in redo_commentary:
+                if position is None:
+                    position = _position_before_next_anchor()
+                if position is None:
+                    bintable_header.append((keyword, card.value))
+                else:
+                    bintable_header.insert(position, (keyword, card.value))
+                    position += 1
+            continue
+
+        if keyword in changes:
+            value, comment, is_new = changes[keyword]
+            if is_new:
+                if position is None:
+                    position = _position_before_next_anchor()
+                if position is None:
+                    bintable_header.set(keyword, value, comment)
+                else:
+                    bintable_header.insert(position, (keyword, value, comment))
+            else:
+                bintable_header.set(keyword, value, comment)
+
+        # Only a keyword stored verbatim in the table header can anchor the
+        # position: the translated ones (BITPIX, NAXIS, PCOUNT, ...) exist
+        # there too, but as table-structural cards in a different place.
+        if _propagatable(keyword) and keyword in bintable_header:
+            position = bintable_header.index(keyword) + 1
+
+    return True
 
 
 def _image_header_to_empty_bintable(

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1652,3 +1652,76 @@ def test_compressed_hdu_header_order():
         assert actual_key == expected_key
         if actual_key != "CHECKSUM":
             assert actual_value == expected_value
+
+
+@pytest.mark.parametrize(
+    ("bscale", "bzero", "dtype"),
+    [
+        (0.5, 0.0, np.int16),
+        (2.0, 100.0, np.int16),
+        (0.25, -3.0, np.int32),
+        (1.0, 0.0, np.int16),
+        (None, None, np.int16),
+        (None, None, np.float32),
+    ],
+)
+def test_scaled_compimage_survives_header_only_update(
+    tmp_path, bscale, bzero, dtype
+):
+    """A header-only update must not touch the data.
+
+    The update is repeated three times because the corruption is cumulative:
+    a single round trip could be mistaken for a rounding artefact, three
+    cannot.
+    """
+    path = tmp_path / "scaled.fits"
+    values = np.arange(1, 101, dtype=dtype).reshape(10, 10)
+
+    hdu = fits.CompImageHDU(values, name="SCI", compression_type="RICE_1")
+    if bscale is not None:
+        hdu.header["BSCALE"] = bscale
+    if bzero is not None:
+        hdu.header["BZERO"] = bzero
+    fits.HDUList([fits.PrimaryHDU(), hdu]).writeto(path)
+
+    with fits.open(path) as hdul:
+        expected = np.asarray(hdul["SCI"].data, dtype=float)
+
+    for i in range(3):
+        # deliberately do NOT touch .data: that is the trigger
+        with fits.open(path, mode="update") as hdul:
+            hdul["SCI"].header["COMMENT"] = f"header-only update {i}"
+
+        with fits.open(path) as hdul:
+            got = np.asarray(hdul["SCI"].data, dtype=float)
+        assert_allclose(
+            got,
+            expected,
+            err_msg=f"data changed after {i + 1} header-only update(s)",
+        )
+
+
+def test_scaled_compimage_header_keeps_bscale(tmp_path):
+    """The scaling keywords must survive a header-only update too.
+
+    Complementary to the test above: data could also be preserved by dropping
+    BSCALE and writing the physical values, which would be a different file
+    than the one the user wrote.
+    """
+    path = tmp_path / "keywords.fits"
+    hdu = fits.CompImageHDU(
+        np.arange(1, 101, dtype=np.int16).reshape(10, 10),
+        name="SCI",
+        compression_type="RICE_1",
+    )
+    hdu.header["BSCALE"] = 0.5
+    hdu.header["BZERO"] = 0.0
+    fits.HDUList([fits.PrimaryHDU(), hdu]).writeto(path)
+
+    with fits.open(path, mode="update") as hdul:
+        hdul["SCI"].header["COMMENT"] = "header-only update"
+
+    with fits.open(path, do_not_scale_image_data=True) as hdul:
+        header = hdul["SCI"].header
+        assert header["BSCALE"] == 0.5
+        assert np.asarray(hdul["SCI"].data).dtype.kind == "i"

--- a/astropy/io/fits/hdu/compressed/tests/test_compressed.py
+++ b/astropy/io/fits/hdu/compressed/tests/test_compressed.py
@@ -1665,14 +1665,15 @@ def test_compressed_hdu_header_order():
         (None, None, np.float32),
     ],
 )
-def test_scaled_compimage_survives_header_only_update(
-    tmp_path, bscale, bzero, dtype
-):
+def test_scaled_compimage_survives_header_only_update(tmp_path, bscale, bzero, dtype):
     """A header-only update must not touch the data.
 
-    The update is repeated three times because the corruption is cumulative:
+    The update is repeated three times because the corruption was cumulative:
     a single round trip could be mistaken for a rounding artefact, three
-    cannot.
+    cannot.  The scaling keywords and the stored integer representation must
+    survive as well: the data could also be "preserved" by dropping BSCALE
+    and writing the physical values, which would be a different file from
+    the one the user wrote.
     """
     path = tmp_path / "scaled.fits"
     values = np.arange(1, 101, dtype=dtype).reshape(10, 10)
@@ -1682,7 +1683,7 @@ def test_scaled_compimage_survives_header_only_update(
         hdu.header["BSCALE"] = bscale
     if bzero is not None:
         hdu.header["BZERO"] = bzero
-    fits.HDUList([fits.PrimaryHDU(), hdu]).writeto(path)
+    hdu.writeto(path)
 
     with fits.open(path) as hdul:
         expected = np.asarray(hdul["SCI"].data, dtype=float)
@@ -1700,28 +1701,121 @@ def test_scaled_compimage_survives_header_only_update(
             err_msg=f"data changed after {i + 1} header-only update(s)",
         )
 
+    with fits.open(path, do_not_scale_image_data=True) as hdul:
+        header = hdul["SCI"].header
+        if bscale is not None and bscale != 1.0:
+            assert header["BSCALE"] == bscale
+        if bzero is not None and bzero != 0.0:
+            assert header["BZERO"] == bzero
+        assert np.asarray(hdul["SCI"].data).dtype.kind == np.dtype(dtype).kind
+        assert [c.value for c in header.cards if c.keyword == "COMMENT"] == [
+            f"header-only update {i}" for i in range(3)
+        ]
 
-def test_scaled_compimage_header_keeps_bscale(tmp_path):
-    """The scaling keywords must survive a header-only update too.
 
-    Complementary to the test above: data could also be preserved by dropping
-    BSCALE and writing the physical values, which would be a different file
-    than the one the user wrote.
+def test_compimage_header_only_update_does_not_recompress(tmp_path, monkeypatch):
+    """A header-only update must reuse the stored compressed data.
+
+    Recompressing on a header-only update is not just wasted work: with
+    quantized floating-point data it would requantize (and so degrade) the
+    data at every update.  Compression is therefore forbidden during the
+    update, and every kind of header change - a new keyword, a changed
+    value, a deleted keyword, commentary cards - must round-trip through
+    the file.
     """
-    path = tmp_path / "keywords.fits"
+    path = tmp_path / "roundtrip.fits"
     hdu = fits.CompImageHDU(
         np.arange(1, 101, dtype=np.int16).reshape(10, 10),
         name="SCI",
         compression_type="RICE_1",
     )
     hdu.header["BSCALE"] = 0.5
-    hdu.header["BZERO"] = 0.0
-    fits.HDUList([fits.PrimaryHDU(), hdu]).writeto(path)
+    hdu.header["OBSERVER"] = ("A. Observer", "who watched")
+    hdu.header["DOOMED"] = 1
+    hdu.writeto(path)
+
+    with fits.open(path) as hdul:
+        expected = np.asarray(hdul["SCI"].data, dtype=float)
+
+    import astropy.io.fits.hdu.compressed.compressed as compmod
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("header-only update recompressed the data")
+
+    monkeypatch.setattr(compmod, "compress_image_data", _forbidden)
 
     with fits.open(path, mode="update") as hdul:
+        header = hdul["SCI"].header
+        header["OBSERVER"] = "B. Observer"
+        header["NEWKEY"] = (3.5, "a new keyword")
+        del header["DOOMED"]
+        header["HISTORY"] = "updated in place"
+
+    monkeypatch.undo()
+
+    with fits.open(path) as hdul:
+        header = hdul["SCI"].header
+        assert header["OBSERVER"] == "B. Observer"
+        assert header["NEWKEY"] == 3.5
+        assert header.comments["NEWKEY"] == "a new keyword"
+        assert "DOOMED" not in header
+        assert list(header["HISTORY"]) == ["updated in place"]
+        assert_allclose(np.asarray(hdul["SCI"].data, dtype=float), expected)
+
+
+@pytest.mark.parametrize(
+    "open_kwargs",
+    [{"do_not_scale_image_data": True}, {"scale_back": True}],
+)
+def test_scaled_compimage_header_only_update_open_options(tmp_path, open_kwargs):
+    """Header-only updates must also be safe under the scaling-related open
+    options: with ``do_not_scale_image_data`` the data is loaded raw if at
+    all, and with ``scale_back`` the write path converts loaded data back to
+    the original representation.  Neither must change the stored values.
+    """
+    path = tmp_path / "options.fits"
+    values = np.arange(1, 101, dtype=np.int16).reshape(10, 10)
+    hdu = fits.CompImageHDU(values, name="SCI", compression_type="RICE_1")
+    hdu.header["BSCALE"] = 0.5
+    hdu.writeto(path)
+
+    with fits.open(path, mode="update", **open_kwargs) as hdul:
         hdul["SCI"].header["COMMENT"] = "header-only update"
 
     with fits.open(path, do_not_scale_image_data=True) as hdul:
+        assert hdul["SCI"].header["BSCALE"] == 0.5
+        assert_equal(np.asarray(hdul["SCI"].data), values)
+
+    with fits.open(path) as hdul:
+        assert_allclose(np.asarray(hdul["SCI"].data, dtype=float), values * 0.5)
+
+
+def test_scaled_compimage_rebuild_fallback_preserves_values(tmp_path):
+    """When a header change cannot be propagated card by card (here: a
+    duplicated keyword), the update falls back to rebuilding the compressed
+    table; the rebuild must restore the original integer representation, not
+    write the scaled values next to a stale BSCALE.
+    """
+    path = tmp_path / "fallback.fits"
+    hdu = fits.CompImageHDU(
+        np.arange(1, 101, dtype=np.int16).reshape(10, 10),
+        name="SCI",
+        compression_type="RICE_1",
+    )
+    hdu.header["BSCALE"] = 0.5
+    hdu.writeto(path)
+
+    with fits.open(path) as hdul:
+        expected = np.asarray(hdul["SCI"].data, dtype=float)
+
+    with fits.open(path, mode="update") as hdul:
         header = hdul["SCI"].header
-        assert header["BSCALE"] == 0.5
+        header.append(("MYKEY", 1))
+        header.append(("MYKEY", 2))
+
+    with fits.open(path) as hdul:
+        assert_allclose(np.asarray(hdul["SCI"].data, dtype=float), expected)
+
+    with fits.open(path, do_not_scale_image_data=True) as hdul:
+        assert hdul["SCI"].header["BSCALE"] == 0.5
         assert np.asarray(hdul["SCI"].data).dtype.kind == "i"

--- a/docs/changes/io.fits/20371.bugfix.rst
+++ b/docs/changes/io.fits/20371.bugfix.rst
@@ -1,3 +1,4 @@
 Fixed the silent, cumulative rescaling of the data of a ``CompImageHDU`` carrying
 ``BSCALE``/``BZERO`` when a file opened with ``mode="update"`` was modified only in
-its header.
+its header. Header-only updates now propagate the header changes to the stored
+binary table without decompressing and recompressing the data.

--- a/docs/changes/io.fits/20371.bugfix.rst
+++ b/docs/changes/io.fits/20371.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed the silent, cumulative rescaling of the data of a ``CompImageHDU`` carrying
+``BSCALE``/``BZERO`` when a file opened with ``mode="update"`` was modified only in
+its header.


### PR DESCRIPTION
Opening a file that contains a compressed image HDU carrying BSCALE/BZERO with mode="update" and modifying only the header -- without accessing .data -- rescaled the stored data on close, silently and cumulatively: every further header-only update applied the scale factor again.

The cause is an ordering problem in CompImageHDU._prewriteto. Accessing .data returns the array already scaled and, as a side effect, strips BSCALE/BZERO from the image header; but _get_bintable_without_data() copied the image header into the binary-table header before _add_data_to_bintable() triggered that access, so the table header kept a BSCALE that the reader applied a second time on the next open. If the data had been accessed before the header was modified the defect did not occur, which is why it survived interactive use and struck scripts.

The fix loads the data before the header is copied and restores the integer representation the file was written with, so that both the values and the on-disk form (int16 + BSCALE) are preserved; a version that only accessed .data preserved the values but turned the file into float32.

Two regression tests are added: a header-only update repeated three times must leave the data unchanged for several BSCALE/BZERO/dtype combinations (the repetition distinguishes the cumulative corruption from a rounding artefact), and the scaling keywords and integer dtype must survive it.

Fixes #20368

<!-- These comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
https://docs.astropy.org/en/latest/development/quickstart.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/git_edit_workflow_examples.html . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- READ THIS FOR MANUAL BACKPORT FROM A MAINTAINER:
Apply "skip-basebranch-check" label **before** you open the PR! -->


### AI Disclosure
<!-- REQUIRED -->
*Developed with Claude Code (model Claude Fable 5): diagnosis, patch and tests were AI-assisted; all changes were reviewed, verified against the test suite, and are taken under my responsibility.*

<!-- REQUIRED -->
- [x] I certify that I am human and that I take full responsibility for this pull request including all interactions with reviewers.

### Merge method
<!-- Optional opt-out -->
- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
