### PR TITLE
Fix Quantity losing concrete function unit on construction (gh-6319)

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -53,6 +53,30 @@ __doctest_skip__ = ["Quantity.*"]
 _UNIT_NOT_INITIALISED = "(Unit not initialised)"
 _UFUNCS_FILTER_WARNINGS = {np.arcsin, np.arccos, np.arccosh, np.arctanh}
 
+# ``astropy.units.function`` imports from ``astropy.units``, which is still
+# being initialised when this module is loaded, so ``FunctionUnitBase`` can
+# only be resolved lazily (gh-6319).
+_FunctionUnitBase = None
+
+
+def _is_function_unit(unit):
+    """Return True if unit is a `~astropy.units.function.FunctionUnitBase`.
+
+    A concrete function unit (e.g. ``DecibelUnit``) is a ``FunctionUnitBase``
+    but not a ``UnitBase``; the reverse is true for ``RegularFunctionUnit``.
+    ``UnitBase`` and ``StructuredUnit`` are never function units, so they are
+    short-circuited before the (lazy) class lookup, which also keeps this safe
+    during the initial import of ``astropy.units`` (gh-6319).
+    """
+    if isinstance(unit, (UnitBase, StructuredUnit)):
+        return False
+    global _FunctionUnitBase
+    if _FunctionUnitBase is None:
+        from .function.core import FunctionUnitBase
+
+        _FunctionUnitBase = FunctionUnitBase
+    return isinstance(unit, _FunctionUnitBase)
+
 
 class Conf(_config.ConfigNamespace):
     """
@@ -642,7 +666,19 @@ class Quantity(np.ndarray):
                 cls = qcls
 
         value = value.view(cls)
-        value._set_unit(value_unit)
+        if (
+            _is_function_unit(value_unit)
+            and getattr(value_unit, "physical_unit", None) is dimensionless_unscaled
+        ):
+            # Keep a dimensionless concrete function unit (e.g. DecibelUnit)
+            # as is, rather than normalising it to the generic registered
+            # function unit via ``_set_unit``, which would lose the
+            # conversion to the physical unit (gh-6319).  Function units with
+            # a physical dimension still go through ``_set_unit``, which
+            # rejects them for a plain Quantity (issue #5851).
+            value._unit = value_unit
+        else:
+            value._set_unit(value_unit)
         if unit is value_unit:
             return value
         else:

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -562,6 +562,26 @@ class TestLogQuantityCreation:
             unit, "physical_unit", u.dimensionless_unscaled
         )
 
+    def test_quantity_creation_with_concrete_function_unit(self):
+        # gh-6319: a Quantity created with a concrete function unit keeps
+        # that unit (and its conversion to the physical unit), instead of
+        # being normalised to the generic registered function unit.
+        db = u.dB(u.dimensionless_unscaled)
+        arr = np.array([1.0, 3.0, 5.0])
+        q = u.Quantity(arr, db)
+        assert type(q.unit) is u.DecibelUnit
+        np.testing.assert_allclose(
+            q.to(u.dimensionless_unscaled).value,
+            (arr * db).to(u.dimensionless_unscaled).value,
+        )
+        # the generic registered function unit stays as it is
+        q2 = u.Quantity(arr, u.dB)
+        assert q2.unit is u.dB
+        # a function unit with a physical dimension is still rejected for
+        # a plain Quantity (issue #5851)
+        with pytest.raises(u.UnitTypeError):
+            u.Quantity(1.0, u.dB(u.mW))
+
     @pytest.mark.parametrize(
         "value, unit",
         (

--- a/docs/changes/units/20330.bugfix.rst
+++ b/docs/changes/units/20330.bugfix.rst
@@ -1,6 +1,0 @@
-Creating a ``Quantity`` with a concrete logarithmic unit (for example
-``u.dB(u.dimensionless_unscaled)``) now preserves that unit instead of
-silently substituting the generic registered function unit (``u.dB``).
-The generic unit does not know the logarithmic conversion, so such a
-quantity previously could not be converted to its physical unit
-(``q.to(u.dimensionless_unscaled)`` raised a ``UnitConversionError``).

--- a/docs/changes/units/20330.bugfix.rst
+++ b/docs/changes/units/20330.bugfix.rst
@@ -1,0 +1,6 @@
+Creating a ``Quantity`` with a concrete logarithmic unit (for example
+``u.dB(u.dimensionless_unscaled)``) now preserves that unit instead of
+silently substituting the generic registered function unit (``u.dB``).
+The generic unit does not know the logarithmic conversion, so such a
+quantity previously could not be converted to its physical unit
+(``q.to(u.dimensionless_unscaled)`` raised a ``UnitConversionError``).

--- a/docs/changes/units/20372.bugfix.rst
+++ b/docs/changes/units/20372.bugfix.rst
@@ -1,0 +1,6 @@
+Creating a ``Quantity`` with a concrete logarithmic unit (for example
+``u.dB(u.dimensionless_unscaled)``) now preserves that unit instead of
+silently substituting the generic registered function unit (``u.dB``).
+The generic unit does not know the logarithmic conversion, so such a
+quantity previously could not be converted to its physical unit
+(``q.to(u.dimensionless_unscaled)`` raised a ``UnitConversionError``).


### PR DESCRIPTION
When a `Quantity` is created with a concrete dimensionless logarithmic
unit, e.g.

    db = u.dB(u.dimensionless_unscaled)
    q = u.Quantity(arr, db)

the unit was silently normalised to the generic registered function
unit (`u.dB`) via a string round-trip in `Quantity._set_unit`.  The
generic unit does not carry the logarithmic conversion, so `q` could
not be converted to its physical unit:

    q.to(u.dimensionless_unscaled)  # UnitConversionError

while `arr * db` (which keeps the concrete unit) works fine.

This keeps the concrete unit as-is in `Quantity.__new__` when its
physical unit is dimensionless.  Function units with a physical
dimension (e.g. `u.dB(u.mW)`) still go through `_set_unit`, which
rejects them for a plain `Quantity` as before (issue #5851).

Fixes #6319

### AI Disclosure
This PR was drafted with the assistance of an AI agent (Hermes).
The root-cause analysis, fix, and tests were developed and verified
locally against astropy 8.1.0 and main.

### Checklist
- [x] Fixes #6319
- [x] Added regression test (test_logarithmic.py)
- [x] Added changelog fragment (docs/changes/units/20330.bugfix.rst, rename to actual PR number)