### PR TITLE
Fix slicing of a GroupData created from a raw array (gh-6688)

### DIFF
--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -2,6 +2,7 @@
 
 import math
 import sys
+import weakref
 
 import numpy as np
 
@@ -193,6 +194,17 @@ class GroupData(FITS_rec):
 
             self._coldefs = coldefs
             self.parnames = parnames
+
+            # Work around the same chicken-egg problem as in
+            # FITS_rec.__array_finalize__: each Column's ``array`` is lazily
+            # resolved through a weakref back to this FITS_rec.  Without this,
+            # ``col.array`` stays ``None`` (as initialised in ``Column``), so
+            # ``coldefs._arrays`` is a list of ``None`` and slicing a
+            # from-scratch GroupData (``data[:2]``) fails with
+            # "NoneType object is not subscriptable" (gh-6688).
+            for col in coldefs:
+                del col.array
+                col._parent_fits_rec = weakref.ref(self)
 
             for idx, name in enumerate(unique_parnames[:-1]):
                 column = coldefs[idx]

--- a/astropy/io/fits/tests/test_groups.py
+++ b/astropy/io/fits/tests/test_groups.py
@@ -123,6 +123,26 @@ class TestGroupsFunctions(FitsTestCase):
             assert len(s) == 2
             assert hdul[0].data.parnames == s.parnames
 
+    def test_groupdata_slice_from_scratch(self):
+        """
+        Slicing a GroupData created from a raw ndarray (not read from a file)
+        must work like slicing a loaded one.  Regression test for gh-6688,
+        where ``GroupData.__new__`` left every column's ``.array`` unset so
+        ``coldefs._arrays`` was a list of ``None`` and ``data[:2]`` raised
+        ``TypeError: 'NoneType' object is not subscriptable``.
+        """
+        imdata = np.arange(100.0).reshape((10, 1, 1, 2, 5))
+        pdata1 = np.arange(10, dtype=np.float32) + 0.1
+        x = fits.hdu.groups.GroupData(
+            imdata, parnames=["abc", "xyz"], pardata=[pdata1, 42.0], bitpix=-32
+        )
+        s = x[:2]
+        assert isinstance(s, fits.GroupData)
+        assert len(s) == 2
+        assert s.parnames == x.parnames
+        np.testing.assert_allclose(s.par("abc"), pdata1[:2])
+        np.testing.assert_allclose(s[0].data, imdata[0])
+
     def test_group_slice(self):
         """
         Tests basic slicing a single group record.

--- a/docs/changes/io.fits/20331.bugfix.rst
+++ b/docs/changes/io.fits/20331.bugfix.rst
@@ -1,0 +1,5 @@
+Slicing a `GroupData` object that was created from a raw array (rather
+than read from a FITS file) now works instead of raising a
+``TypeError``.  Constructing a `GroupData` from a raw array left each
+column's ``.array`` unset, so slicing (which reads ``coldefs._arrays``)
+failed with ``'NoneType' object is not subscriptable``.

--- a/docs/changes/io.fits/20331.bugfix.rst
+++ b/docs/changes/io.fits/20331.bugfix.rst
@@ -1,5 +1,0 @@
-Slicing a `GroupData` object that was created from a raw array (rather
-than read from a FITS file) now works instead of raising a
-``TypeError``.  Constructing a `GroupData` from a raw array left each
-column's ``.array`` unset, so slicing (which reads ``coldefs._arrays``)
-failed with ``'NoneType' object is not subscriptable``.

--- a/docs/changes/io.fits/20384.bugfix.rst
+++ b/docs/changes/io.fits/20384.bugfix.rst
@@ -1,0 +1,5 @@
+Slicing a `GroupData` object that was created from a raw array (rather
+than read from a FITS file) now works instead of raising a
+``TypeError``.  Constructing a `GroupData` from a raw array left each
+column's ``.array`` unset, so slicing (which reads ``coldefs._arrays``)
+failed with ``'NoneType' object is not subscriptable``.


### PR DESCRIPTION
Slicing a `GroupData` object that was created from a raw array (rather
than read from a FITS file) raised ``TypeError: 'NoneType' object is
not subscriptable``:

    imdata = np.arange(150.0).reshape(10, 1, 1, 3, 5)
    x = fits.GroupData(imdata, bitpix=-32, parnames=['abc', 'xyz'],
                       pardata=[np.arange(10) + 0.1, 42.0])
    x[:2]  # TypeError

When a `GroupData` is built from a raw array it does not go through
`FITS_rec.__array_finalize__`, so the chicken-egg workaround that binds
each `Column` to its parent rec via a ``_parent_fits_rec`` weakref was
never applied.  Each ``Column.array`` therefore stayed unset,
``coldefs._arrays`` was a list of ``None``, and slicing (which reads
``coldefs._arrays[i][key]``) blew up.  This applies the same workaround
in ``GroupData.__new__`` so ``Column.array`` lazily resolves to the
field, and slicing and ``writeto`` work as for a loaded group HDU.

Fixes #6688

### AI Disclosure
This PR was drafted with the assistance of an AI agent (Hermes).
The root-cause analysis, fix, and tests were developed and verified
locally against astropy 8.1.0 and main.

### Checklist
- [x] Fixes #6688
- [x] Added regression test (test_groups.py)
- [x] Added changelog fragment (docs/changes/io.fits/20331.bugfix.rst, rename to actual PR number)