### PR TITLE
Added a workflow to close AI PRs with no/little human engagement

### DIFF
--- a/.github/workflows/close-on-label.yml
+++ b/.github/workflows/close-on-label.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.label.name == 'close-ai'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/close-on-label.yml
+++ b/.github/workflows/close-on-label.yml
@@ -1,0 +1,29 @@
+name: Close PR on label
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close:
+    if: github.event.label.name == 'close-ai'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number,
+              body: "This PR is being closed as it has been determined that it does not pass the threshold of demonstrating sufficient human engagement (see [our AI policy](https://github.com/astropy/astropy-project/blob/main/policies/ai-policy.md)). While we do not forbid the use of AI tools in preparing pull requests, our policy makes it clear that we expect to be interacting with humans who show a good understanding of the proposed changes."
+            });
+
+            await github.rest.pulls.update({
+              owner, repo, pull_number: issue_number,
+              state: "closed"
+            });


### PR DESCRIPTION
### Description

This adds a simple workflow so that we can just label PRs ``close-ai`` and it will close with the following message

_This PR is being closed as it has been determined that it does not pass the threshold of demonstrating sufficient human engagement (see [our AI policy](https://github.com/astropy/astropy-project/blob/main/policies/ai-policy.md)). While we do not forbid the use of AI tools in preparing pull requests, our policy makes it clear that we expect to be interacting with humans who show a good understanding of the proposed changes._

Tested [here](https://github.com/astrofrog/astropy/pull/154#issuecomment-5645546357)

### AI Disclosure

I asked Claude to give me a starting template for the action workflow then edited/adjusted it by hand to get what I needed.

### Merge method
<!-- Optional opt-out -->
- [ ] By checking this box, the PR author has requested that maintainers do **NOT** use the "Squash and Merge" button. Maintainers should respect this when possible; however, the final decision is at the discretion of the maintainer that merges the PR.
